### PR TITLE
Show computer name and project in session tabs

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1770,9 +1770,10 @@ body {
 .pill-name {
     font-size: 0.85rem;
     color: var(--text-primary);
-    max-width: 150px;
+    max-width: 200px;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .pill-delete {


### PR DESCRIPTION
## Summary
- Added `format_session_display()` helper function to parse session names
- Session pills now show "hostname: project_folder" format instead of raw "hostname-YYYYMMDD-HHMMSS"
- Session view headers also use the new formatted display
- Added tooltips showing full session name and path on hover
- Increased pill-name max-width from 150px to 200px

Example: `meawoppl-blade-20260111-150741` with path `/home/user/repos/cc-proxy` 
→ displays as `meawoppl-blade: cc-proxy`

Closes #11

## Test plan
- [ ] Verify session pills show "hostname: project" format
- [ ] Verify tooltips appear on hover showing full names
- [ ] Verify session view header shows formatted name
- [ ] Test with sessions that have no working_directory (should show just hostname)

🤖 Generated with [Claude Code](https://claude.com/claude-code)