### PR TITLE
Skip download if binary already installed

### DIFF
--- a/backend/src/handlers/downloads.rs
+++ b/backend/src/handlers/downloads.rs
@@ -60,6 +60,7 @@ echo "  3. Start a session: claude-proxy"
         r##"#!/bin/bash
 # CC-Proxy Installer
 # This script downloads and installs the claude-proxy binary
+# If already installed, skips download and just runs init
 
 set -e
 
@@ -71,6 +72,14 @@ DOWNLOAD_URL="{base_url}/api/download/proxy"
 echo "CC-Proxy Installer"
 echo "=================="
 echo ""
+
+# Check if binary already exists
+if [ -x "${{BIN_PATH}}" ]; then
+    echo "claude-proxy is already installed at: ${{BIN_PATH}}"
+    echo ""
+{init_section}
+    exit 0
+fi
 
 # Create config directory
 mkdir -p "${{CONFIG_DIR}}"


### PR DESCRIPTION
## Summary
- If `claude-proxy` binary already exists at `~/.config/cc-proxy/claude-proxy`, skip the download and install steps
- Just run the `--init` command with the provided token URL to configure the session for the current working directory
- This allows quickly setting up new sessions from different directories without re-downloading

## Use case
When a user has already installed `claude-proxy` on a machine and runs the install script again (e.g., from a different project directory), they just want to configure a new session, not re-download the binary.

## Test plan
- [ ] Run install script on fresh machine - should download and install
- [ ] Run install script again with token URL - should skip download, just run init
- [ ] Verify session is configured for current directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)