### PR TITLE
Add GitHub Action to build and push container to GHCR

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,61 @@
+name: Build and Push Container
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and Push Container
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "container-build"
+
+      - name: Install trunk
+        run: cargo install trunk --locked
+
+      - name: Build frontend
+        run: cd frontend && trunk build
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that builds and pushes the Docker container to GitHub Container Registry on every push to main.

## Workflow steps
1. Build frontend with trunk (WASM)
2. Build Docker image using `backend/Dockerfile`
3. Push to `ghcr.io/meawoppl/cc-proxy` with tags:
   - `latest` - always points to most recent main
   - `<sha>` - commit SHA for pinning specific versions

## Usage
After merge, the container will be available at:
```
ghcr.io/meawoppl/cc-proxy:latest
ghcr.io/meawoppl/cc-proxy:<commit-sha>
```

## Closes
Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)