### PR TITLE
Add diff rendering for Edit tool in frontend

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1119,6 +1119,152 @@ body {
     padding: 0;
 }
 
+/* Edit Tool Diff Styling */
+.edit-tool {
+    background: rgba(99, 102, 241, 0.05);
+}
+
+.edit-tool .tool-use-header {
+    flex-wrap: wrap;
+}
+
+.edit-file-path {
+    color: var(--text-primary);
+    font-weight: 500;
+    word-break: break-all;
+}
+
+.edit-replace-all {
+    color: var(--warning);
+    font-size: 0.75rem;
+    padding: 0.1rem 0.4rem;
+    background: rgba(245, 158, 11, 0.15);
+    border-radius: 3px;
+}
+
+.diff-container {
+    margin-top: 0.5rem;
+    border-radius: 4px;
+    overflow: hidden;
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.diff-view {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    line-height: 1.5;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+.diff-line {
+    display: flex;
+    padding: 0 0.5rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+.diff-line.context {
+    background: transparent;
+    color: var(--text-secondary);
+}
+
+.diff-line.removed {
+    background: rgba(239, 68, 68, 0.2);
+    color: #fca5a5;
+}
+
+.diff-line.added {
+    background: rgba(34, 197, 94, 0.2);
+    color: #86efac;
+}
+
+.diff-marker {
+    flex-shrink: 0;
+    width: 1.5rem;
+    text-align: center;
+    user-select: none;
+    color: var(--text-muted);
+}
+
+.diff-line.removed .diff-marker {
+    color: #f87171;
+}
+
+.diff-line.added .diff-marker {
+    color: #4ade80;
+}
+
+.diff-content {
+    flex: 1;
+    min-width: 0;
+}
+
+/* Write Tool Styling */
+.write-tool {
+    background: rgba(99, 102, 241, 0.05);
+}
+
+.write-tool .tool-use-header {
+    flex-wrap: wrap;
+}
+
+.write-file-path {
+    color: var(--text-primary);
+    font-weight: 500;
+    word-break: break-all;
+}
+
+.write-size {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.write-preview {
+    margin-top: 0.5rem;
+    border-radius: 4px;
+    overflow: hidden;
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.write-content {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    line-height: 1.5;
+    max-height: 300px;
+    overflow-y: auto;
+    margin: 0;
+    padding: 0.5rem;
+}
+
+.write-line {
+    display: flex;
+}
+
+.write-line .line-number {
+    flex-shrink: 0;
+    width: 3rem;
+    text-align: right;
+    padding-right: 0.75rem;
+    color: var(--text-muted);
+    user-select: none;
+}
+
+.write-line .line-content {
+    flex: 1;
+    white-space: pre-wrap;
+    word-break: break-all;
+    color: var(--text-secondary);
+}
+
+.write-truncated {
+    padding: 0.5rem;
+    text-align: center;
+    color: var(--text-muted);
+    font-style: italic;
+    border-top: 1px solid var(--border-color);
+}
+
 /* Thinking Block Styling */
 .thinking-block {
     padding: 0.5rem 0.75rem;


### PR DESCRIPTION
## Summary

- Implements proper diff display for file edits in the web frontend
- Shows added lines in green with + marker, removed lines in red with - marker
- Uses LCS (longest common subsequence) based diff algorithm for accurate line matching
- Displays file path prominently in tool header
- Also adds improved Write tool display showing file content preview with line numbers

## Before
Edit tool results were shown as raw text, truncated at 500 characters, with no visual diff formatting.

## After
- Edit tool shows a visual diff with:
  - Red background for removed lines with `-` marker
  - Green background for added lines with `+` marker  
  - Context lines showing unchanged content
  - File path displayed in header
  - Indicator when `replace_all` is used

- Write tool shows:
  - File path in header
  - Line count and byte size
  - First 20 lines of content with line numbers
  - Truncation indicator for longer files

## Test plan
- [ ] Build frontend: `cargo build -p frontend`
- [ ] Run clippy: `cargo clippy -p frontend`
- [ ] Start dev server and create a session with Claude
- [ ] Have Claude edit a file and verify diff is displayed with colors
- [ ] Have Claude write a new file and verify preview is shown

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)