### PR TITLE
Fix UTF-8 panics when truncating multi-byte characters

### DIFF
--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -427,7 +427,7 @@ fn log_claude_output(output: &ClaudeOutput) {
                             .map(|c| {
                                 let s = format!("{:?}", c);
                                 if s.len() > 60 {
-                                    format!("{}...", &s[..60])
+                                    format!("{}...", truncate(&s, 60))
                                 } else {
                                     s
                                 }


### PR DESCRIPTION
## Summary

- Fixes panic when truncating strings containing multi-byte UTF-8 characters
- The proxy panicked when byte index fell inside a multi-byte char (like `→`)

## Root Cause

Unsafe byte slicing like `&s[..60]` panics if index 60 is inside a multi-byte character. The arrow `→` is 3 bytes (59-61), so slicing at byte 60 causes:

```
byte index 60 is not a char boundary; it is inside '→' (bytes 59..62)
```

## Fix

- **proxy/src/session.rs**: Use the existing safe `truncate()` function that finds valid UTF-8 boundaries
- **frontend/src/components/message_renderer.rs**: Updated `truncate_str()` to check `is_char_boundary()` before slicing

## Test plan

- [ ] Build: `cargo build -p claude-proxy -p frontend`
- [ ] Clippy: `cargo clippy -p claude-proxy -p frontend`
- [ ] Test with content containing multi-byte chars (arrows, emoji, etc.)

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)