### PR TITLE
Handle missing local Claude sessions gracefully

### DIFF
--- a/proxy/src/ui.rs
+++ b/proxy/src/ui.rs
@@ -174,6 +174,21 @@ pub fn print_init_complete(email: &str, backend_url: &str) {
     );
 }
 
+/// Print session not found message (when resuming a session that doesn't exist locally)
+pub fn print_session_not_found(session_id: &str) {
+    println!();
+    println!(
+        "  {} Previous session {} not found locally",
+        "⚠".bright_yellow(),
+        session_id[..8].bright_cyan()
+    );
+    println!(
+        "  {} Starting a fresh session instead...",
+        "→".bright_blue()
+    );
+    println!();
+}
+
 /// Print update complete message
 pub fn print_update_complete() {
     println!();


### PR DESCRIPTION
## Summary
- Detect "No conversation found" error in Claude stderr when resuming a session
- Automatically restart with a fresh session instead of exiting
- Update directory_sessions config with the new session ID

## Problem
When running `claude-proxy` on a different computer than where a session was originally created, the proxy attempted to resume the session but failed because Claude Code sessions are stored locally per-machine. This caused the proxy to exit immediately.

## Solution
The proxy now monitors Claude's stderr for the "No conversation found" message. When detected while attempting to resume, it:
1. Shuts down the failing Claude process
2. Creates a new session UUID
3. Updates the local config with the new session
4. Restarts Claude with a fresh session

Closes #9

## Test plan
- [ ] Run proxy with a session ID that doesn't exist locally and verify it auto-recovers
- [ ] Verify the directory_sessions config is updated with the new session ID
- [ ] Verify the UI shows appropriate messages about the session not being found

🤖 Generated with [Claude Code](https://claude.com/claude-code)