### PR TITLE
Add click/touch support for permission approval options

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2313,6 +2313,10 @@ body {
     background: rgba(255, 255, 255, 0.05);
 }
 
+.permission-option:active {
+    background: rgba(255, 255, 255, 0.1);
+}
+
 .permission-option .option-cursor {
     color: var(--accent-color);
     font-weight: bold;


### PR DESCRIPTION
## Summary
- Add click/touch handlers to permission approval options for mobile support
- Users can now tap on Allow, Allow & Remember, or Deny to immediately select and confirm
- Add visual feedback (`:active` state) for touch interactions
- Update hint text from "↑↓ to select, Enter to confirm" to "↑↓ or tap to select"

## Problem
The permission approval UI only supported keyboard navigation (arrow keys + Enter). On mobile devices, users had no way to approve or deny tool permissions.

## Solution
Added a new `PermissionSelectAndConfirm(usize)` message that combines selection and confirmation into a single action. Each permission option now has an `onclick` handler that triggers this message.

## Test plan
- [ ] On mobile device, tap on "Allow" option and verify permission is granted
- [ ] On mobile device, tap on "Deny" option and verify permission is denied
- [ ] On mobile device, tap on "Allow & Remember" (when shown) and verify it works
- [ ] Verify keyboard navigation still works on desktop
- [ ] Verify visual feedback appears when tapping options

🤖 Generated with [Claude Code](https://claude.com/claude-code)