### PR TITLE
Add GitHub and bug report links to splash page

### DIFF
--- a/frontend/src/pages/splash.rs
+++ b/frontend/src/pages/splash.rs
@@ -75,6 +75,27 @@ pub fn splash_page() -> Html {
                     <span class="google-icon">{ "G" }</span>
                     { " Sign in with Google" }
                 </button>
+
+                <div class="splash-footer">
+                    <a
+                        href="https://github.com/meawoppl/cc-proxy"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="footer-link"
+                    >
+                        <span class="github-icon">{ "" }</span>
+                        { "GitHub" }
+                    </a>
+                    <a
+                        href="https://github.com/meawoppl/cc-proxy/issues/new"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="footer-link bug-report"
+                    >
+                        <span class="bug-icon">{ "🐛" }</span>
+                        { "Report a Bug" }
+                    </a>
+                </div>
             </div>
         </div>
     }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -167,6 +167,43 @@ body {
     font-weight: bold;
 }
 
+.splash-footer {
+    margin-top: 2rem;
+    display: flex;
+    gap: 1.5rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.footer-link {
+    color: var(--text-secondary);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    transition: color 0.2s, background 0.2s;
+}
+
+.footer-link:hover {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.footer-link.bug-report:hover {
+    color: var(--warning);
+}
+
+.github-icon {
+    font-size: 1.1rem;
+}
+
+.bug-icon {
+    font-size: 1rem;
+}
+
 /* Dashboard */
 .dashboard-container {
     min-height: 100vh;


### PR DESCRIPTION
## Summary
- Add GitHub repository link to the splash page footer
- Add "Report a Bug" button linking to the issues page

## Changes
- Added footer section below the login button with two links
- GitHub link opens the repo in a new tab
- Bug report link opens issues/new for easy bug submission
- Styled with hover effects matching the existing design

## Test plan
- [ ] Visit splash page and verify GitHub link works
- [ ] Verify "Report a Bug" link opens issues/new
- [ ] Check hover effects look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)