### PR TITLE
Fix URL link styling - use correct CSS variable

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1060,9 +1060,9 @@ body {
 
 /* Clickable links in messages */
 .message-link {
-    color: var(--accent-color);
+    color: var(--accent);
     text-decoration: none;
-    border-bottom: 1px dotted var(--accent-color);
+    border-bottom: 1px dotted var(--accent);
     transition: all 0.15s ease;
 }
 
@@ -1082,7 +1082,7 @@ body {
     gap: 0.25rem;
     padding: 0.5rem 0.75rem;
     background: rgba(99, 102, 241, 0.1);
-    border-left: 3px solid var(--accent-color);
+    border-left: 3px solid var(--accent);
     border-radius: 0 4px 4px 0;
     margin: 0.5rem 0;
     font-family: var(--font-mono);
@@ -1100,7 +1100,7 @@ body {
 }
 
 .tool-name {
-    color: var(--accent-color);
+    color: var(--accent);
     font-weight: 600;
     flex-shrink: 0;
 }
@@ -2580,7 +2580,7 @@ body {
 }
 
 .permission-option .option-cursor {
-    color: var(--accent-color);
+    color: var(--accent);
     font-weight: bold;
     width: 1ch;
 }
@@ -2599,7 +2599,7 @@ body {
 }
 
 .permission-option.selected.remember .option-label {
-    color: var(--accent-color);
+    color: var(--accent);
 }
 
 .permission-option.selected.deny .option-label {
@@ -2615,7 +2615,7 @@ body {
 
 .permission-prompt:focus {
     outline: none;
-    border-color: var(--accent-color);
+    border-color: var(--accent);
 }
 
 .session-view-input {


### PR DESCRIPTION
## Summary
Fixed URL links not displaying with purple/accent color styling.

## Root Cause
The CSS was using `var(--accent-color)` but the actual variable defined in `:root` is `--accent`. Since `--accent-color` doesn't exist, the browser fell back to inheriting the parent text color.

## Changes
Replaced all occurrences of `var(--accent-color)` with `var(--accent)`:
- `.message-link` color and border
- `.tool-use` border-left
- `.tool-name` color
- `.permission-option .option-cursor` color
- `.permission-option.selected.remember` color
- `.permission-prompt:focus` border-color

Fixes #36

## Test plan
- [ ] Verify URLs in messages now display with purple accent color
- [ ] Verify tool names still display with accent color
- [ ] Verify permission prompt styling is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)