### PR TITLE
Add release workflow for automatic binary publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,178 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:  # Allow manual trigger
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-linux:
+    name: Build (Linux x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-linux"
+
+      - name: Build proxy
+        run: cargo build -p claude-proxy --release
+
+      - name: Rename binary
+        run: mv target/release/claude-proxy target/release/claude-proxy-linux-x86_64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-proxy-linux-x86_64
+          path: target/release/claude-proxy-linux-x86_64
+
+  build-macos-arm64:
+    name: Build (macOS ARM64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-macos-arm64"
+
+      - name: Build proxy
+        run: cargo build -p claude-proxy --release
+
+      - name: Ad-hoc code sign
+        run: codesign -s - target/release/claude-proxy
+
+      - name: Rename binary
+        run: mv target/release/claude-proxy target/release/claude-proxy-darwin-aarch64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-proxy-darwin-aarch64
+          path: target/release/claude-proxy-darwin-aarch64
+
+  build-macos-intel:
+    name: Build (macOS Intel)
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-macos-intel"
+
+      - name: Build proxy
+        run: cargo build -p claude-proxy --release
+
+      - name: Ad-hoc code sign
+        run: codesign -s - target/release/claude-proxy
+
+      - name: Rename binary
+        run: mv target/release/claude-proxy target/release/claude-proxy-darwin-x86_64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-proxy-darwin-x86_64
+          path: target/release/claude-proxy-darwin-x86_64
+
+  build-windows:
+    name: Build (Windows x86_64)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-windows"
+
+      - name: Build proxy
+        run: cargo build -p claude-proxy --release
+
+      - name: Rename binary
+        run: mv target/release/claude-proxy.exe target/release/claude-proxy-windows-x86_64.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-proxy-windows-x86_64
+          path: target/release/claude-proxy-windows-x86_64.exe
+
+  release:
+    name: Create Release
+    needs: [build-linux, build-macos-arm64, build-macos-intel, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: binaries
+
+      - name: Prepare release files
+        run: |
+          mkdir -p release
+          mv binaries/claude-proxy-linux-x86_64/claude-proxy-linux-x86_64 release/
+          mv binaries/claude-proxy-darwin-aarch64/claude-proxy-darwin-aarch64 release/
+          mv binaries/claude-proxy-darwin-x86_64/claude-proxy-darwin-x86_64 release/
+          mv binaries/claude-proxy-windows-x86_64/claude-proxy-windows-x86_64.exe release/
+          chmod +x release/claude-proxy-linux-x86_64 release/claude-proxy-darwin-*
+          ls -la release/
+
+      - name: Delete existing latest release
+        run: gh release delete latest --yes || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create latest release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: latest
+          name: "Latest Build #${{ github.run_number }}"
+          body: |
+            Automatic build from main branch.
+
+            **Build:** #${{ github.run_number }}
+            **Commit:** ${{ github.sha }}
+            **Date:** ${{ github.event.head_commit.timestamp }}
+
+            ## Downloads
+            | Platform | Binary |
+            |----------|--------|
+            | Linux (x86_64) | `claude-proxy-linux-x86_64` |
+            | macOS (Apple Silicon M1+) | `claude-proxy-darwin-aarch64` |
+            | macOS (Intel) | `claude-proxy-darwin-x86_64` |
+            | Windows (x86_64) | `claude-proxy-windows-x86_64.exe` |
+          files: |
+            release/claude-proxy-linux-x86_64
+            release/claude-proxy-darwin-aarch64
+            release/claude-proxy-darwin-x86_64
+            release/claude-proxy-windows-x86_64.exe
+          prerelease: false
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Creates a release workflow that automatically publishes proxy binaries on every push to main.

## Platforms
| Platform | Binary | Runner |
|----------|--------|--------|
| Linux (x86_64) | `claude-proxy-linux-x86_64` | ubuntu-latest |
| macOS (Apple Silicon M1+) | `claude-proxy-darwin-aarch64` | macos-14 |
| macOS (Intel) | `claude-proxy-darwin-x86_64` | macos-13 |
| Windows (x86_64) | `claude-proxy-windows-x86_64.exe` | windows-latest |

## How it works
1. **Triggers** on every push to `main` (or manual dispatch)
2. **Builds** binaries for all 4 platforms in parallel
3. **Publishes** to a rolling GitHub Release tagged `latest`
4. **URLs are stable:**
   ```
   https://github.com/meawoppl/cc-proxy/releases/download/latest/claude-proxy-linux-x86_64
   https://github.com/meawoppl/cc-proxy/releases/download/latest/claude-proxy-darwin-aarch64
   https://github.com/meawoppl/cc-proxy/releases/download/latest/claude-proxy-darwin-x86_64
   https://github.com/meawoppl/cc-proxy/releases/download/latest/claude-proxy-windows-x86_64.exe
   ```

## Versioning
- Uses `github.run_number` as build number (increments with each CI run)
- No git tags needed - just merge to main
- Release body shows build number, commit SHA, and date

## Next Steps (follow-up PRs)
- Update backend `/api/download/proxy` to redirect to these URLs
- Update install script to use platform detection

Relates to #37

## Test plan
- [ ] Merge to main and verify release workflow runs
- [ ] Check that `latest` release is created with all 4 binaries
- [ ] Verify download URLs work for each platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)