### PR TITLE
Add auto-update from GitHub releases

### DIFF
--- a/proxy/src/ui.rs
+++ b/proxy/src/ui.rs
@@ -212,3 +212,87 @@ pub fn print_update_complete() {
     println!("  Please run the command again to use the updated version.");
     println!();
 }
+
+/// Print checking for updates message
+pub fn print_checking_for_updates() {
+    println!();
+    println!(
+        "  {} Checking for updates from GitHub...",
+        "→".bright_blue()
+    );
+}
+
+/// Print up to date message
+pub fn print_up_to_date() {
+    println!(
+        "  {} {} is up to date.",
+        "✓".bright_green(),
+        "claude-proxy".bright_cyan()
+    );
+    println!();
+}
+
+/// Print update available message
+pub fn print_update_available(version: &str, download_url: &str) {
+    println!();
+    println!(
+        "{}",
+        "╭──────────────────────────────────────╮".bright_yellow()
+    );
+    println!(
+        "{}",
+        "│         Update Available             │".bright_yellow()
+    );
+    println!(
+        "{}",
+        "╰──────────────────────────────────────╯".bright_yellow()
+    );
+    println!();
+    println!("  {} {}", "Version:".dimmed(), version.bright_white());
+    println!();
+    println!("  To update, run:");
+    println!(
+        "    {} {}",
+        "$".dimmed(),
+        "claude-proxy --update".bright_cyan()
+    );
+    println!();
+    println!("  Or download manually from:");
+    println!("    {}", download_url.bright_blue());
+    println!();
+}
+
+/// Print update check failed message
+pub fn print_update_check_failed(error: &str) {
+    println!(
+        "  {} Failed to check for updates: {}",
+        "✗".bright_red(),
+        error
+    );
+    println!();
+}
+
+/// Print updating from GitHub message
+pub fn print_updating_from_github() {
+    println!();
+    println!(
+        "  {} Downloading latest version from GitHub...",
+        "→".bright_blue()
+    );
+}
+
+/// Print update failed message
+pub fn print_update_failed(error: &str) {
+    println!();
+    println!("  {} Update failed: {}", "✗".bright_red(), error);
+    println!();
+}
+
+/// Print pending update applied message (Windows)
+pub fn print_pending_update_applied() {
+    println!();
+    println!(
+        "  {} Pending update applied successfully.",
+        "✓".bright_green()
+    );
+}

--- a/proxy/src/update.rs
+++ b/proxy/src/update.rs
@@ -1,12 +1,18 @@
 //! Auto-update functionality for the claude-proxy binary
 //!
-//! On startup, checks if a newer version is available from the backend
-//! and self-updates if necessary.
+//! On startup, checks if a newer version is available and self-updates if necessary.
+//! Supports two update sources:
+//! 1. Backend server (primary) - via /api/download/proxy endpoint
+//! 2. GitHub releases (fallback) - via GitHub API
 
 use anyhow::{bail, Context, Result};
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::fs;
-use tracing::info;
+use tracing::{info, warn};
+
+/// GitHub repository for releases
+const GITHUB_REPO: &str = "meawoppl/cc-proxy";
 
 /// Result of an update check
 #[derive(Debug)]
@@ -15,6 +21,66 @@ pub enum UpdateResult {
     UpToDate,
     /// Binary was updated, needs relaunch
     Updated,
+    /// Update available but not installed (check-only mode)
+    UpdateAvailable {
+        version: String,
+        download_url: String,
+    },
+}
+
+/// Platform information for selecting the correct binary
+#[derive(Debug, Clone)]
+pub struct Platform {
+    pub os: &'static str,
+    pub arch: &'static str,
+    pub binary_name: &'static str,
+}
+
+impl Platform {
+    /// Detect the current platform
+    pub fn current() -> Self {
+        let (os, arch) = if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
+            ("linux", "x86_64")
+        } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+            ("darwin", "aarch64")
+        } else if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
+            ("darwin", "x86_64")
+        } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+            ("windows", "x86_64")
+        } else {
+            // Fallback - may not work but allows compilation
+            ("unknown", "unknown")
+        };
+
+        let binary_name = match (os, arch) {
+            ("linux", "x86_64") => "claude-proxy-linux-x86_64",
+            ("darwin", "aarch64") => "claude-proxy-darwin-aarch64",
+            ("darwin", "x86_64") => "claude-proxy-darwin-x86_64",
+            ("windows", "x86_64") => "claude-proxy-windows-x86_64.exe",
+            _ => "claude-proxy",
+        };
+
+        Platform {
+            os,
+            arch,
+            binary_name,
+        }
+    }
+}
+
+/// GitHub release asset from the API
+#[derive(Debug, Deserialize)]
+struct GitHubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+/// GitHub release from the API
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    name: String,
+    assets: Vec<GitHubAsset>,
 }
 
 /// Convert backend URL (ws:// or wss://) to HTTP URL for downloads
@@ -32,7 +98,7 @@ fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(hash)
 }
 
-/// Check for updates and self-update if necessary
+/// Check for updates from backend server and self-update if necessary
 ///
 /// This function:
 /// 1. Computes SHA256 of the current binary
@@ -53,11 +119,19 @@ pub fn check_for_update(backend_url: &str) -> Result<UpdateResult> {
 
     // Convert WebSocket URL to HTTP for the download endpoint
     let http_base = ws_to_http_url(backend_url);
-    let download_url = format!("{}/api/download/proxy", http_base);
+    let platform = Platform::current();
+    let download_url = format!(
+        "{}/api/download/proxy?os={}&arch={}",
+        http_base, platform.os, platform.arch
+    );
 
     // HEAD request to get remote hash
     info!("Checking for updates at {}", download_url);
-    let client = reqwest::blocking::Client::new();
+    let client = reqwest::blocking::Client::builder()
+        .user_agent("claude-proxy")
+        .build()
+        .context("Failed to create HTTP client")?;
+
     let resp = client
         .head(&download_url)
         .send()
@@ -105,11 +179,110 @@ pub fn check_for_update(backend_url: &str) -> Result<UpdateResult> {
         );
     }
 
-    info!("Download verified, installing update...");
+    install_binary(&self_path, &new_binary)?;
+    Ok(UpdateResult::Updated)
+}
+
+/// Check for updates from GitHub releases
+///
+/// This is a fallback when no backend is configured or backend is unreachable.
+pub fn check_for_update_github(check_only: bool) -> Result<UpdateResult> {
+    let self_path = std::env::current_exe().context("Failed to get current executable path")?;
+    let self_bytes = fs::read(&self_path).context("Failed to read current binary")?;
+    let self_hash = sha256_hex(&self_bytes);
+
+    info!("Current binary hash: {}", &self_hash[..16]);
+
+    let platform = Platform::current();
+    if platform.os == "unknown" {
+        bail!(
+            "Unsupported platform: {} {}",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        );
+    }
+
+    info!("Checking for updates from GitHub releases...");
+    info!("Platform: {} {}", platform.os, platform.arch);
+
+    let client = reqwest::blocking::Client::builder()
+        .user_agent("claude-proxy")
+        .build()
+        .context("Failed to create HTTP client")?;
+
+    // Get the latest release from GitHub API
+    let api_url = format!(
+        "https://api.github.com/repos/{}/releases/tags/latest",
+        GITHUB_REPO
+    );
+
+    let resp = client
+        .get(&api_url)
+        .send()
+        .context("Failed to fetch GitHub release info")?;
+
+    if !resp.status().is_success() {
+        bail!("GitHub API returned {}", resp.status());
+    }
+
+    let release: GitHubRelease = resp.json().context("Failed to parse GitHub release JSON")?;
+    info!("Latest release: {} ({})", release.name, release.tag_name);
+
+    // Find the asset for our platform
+    let asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == platform.binary_name)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No binary found for platform {} {} in release assets. Available: {:?}",
+                platform.os,
+                platform.arch,
+                release.assets.iter().map(|a| &a.name).collect::<Vec<_>>()
+            )
+        })?;
+
+    info!("Found asset: {}", asset.name);
+
+    // Download to check hash (we don't have a remote hash from GitHub, so we compare content)
+    info!("Downloading update from GitHub...");
+    let resp = client
+        .get(&asset.browser_download_url)
+        .send()
+        .context("Failed to download from GitHub")?;
+
+    if !resp.status().is_success() {
+        bail!("Download failed: GitHub returned {}", resp.status());
+    }
+
+    let new_binary = resp.bytes().context("Failed to read download response")?;
+    let new_hash = sha256_hex(&new_binary);
+
+    info!("Downloaded binary hash: {}", &new_hash[..16]);
+
+    if self_hash == new_hash {
+        info!("Binary is up to date");
+        return Ok(UpdateResult::UpToDate);
+    }
+
+    if check_only {
+        return Ok(UpdateResult::UpdateAvailable {
+            version: release.name,
+            download_url: asset.browser_download_url.clone(),
+        });
+    }
+
+    install_binary(&self_path, &new_binary)?;
+    Ok(UpdateResult::Updated)
+}
+
+/// Install a new binary by atomically replacing the current executable
+fn install_binary(self_path: &std::path::Path, new_binary: &[u8]) -> Result<()> {
+    info!("Installing update...");
 
     // Atomic replacement: write to temp file, then rename
     let temp_path = self_path.with_extension("tmp");
-    fs::write(&temp_path, &new_binary).context("Failed to write temporary file")?;
+    fs::write(&temp_path, new_binary).context("Failed to write temporary file")?;
 
     // Set executable permission on Unix
     #[cfg(unix)]
@@ -120,11 +293,113 @@ pub fn check_for_update(backend_url: &str) -> Result<UpdateResult> {
         fs::set_permissions(&temp_path, perms)?;
     }
 
-    // Atomic rename
-    fs::rename(&temp_path, &self_path).context("Failed to replace binary")?;
+    // On Windows, we can't replace a running executable directly
+    #[cfg(windows)]
+    {
+        // Try to rename the current binary to .old first
+        let old_path = self_path.with_extension("old.exe");
+        let _ = fs::remove_file(&old_path); // Remove any existing .old file
 
-    info!("Update installed successfully");
-    Ok(UpdateResult::Updated)
+        match fs::rename(self_path, &old_path) {
+            Ok(_) => {
+                // Successfully moved current binary, now rename temp to current
+                if let Err(e) = fs::rename(&temp_path, self_path) {
+                    // Try to restore the old binary
+                    let _ = fs::rename(&old_path, self_path);
+                    bail!("Failed to install update: {}", e);
+                }
+                // Clean up old binary
+                let _ = fs::remove_file(&old_path);
+                info!("Update installed successfully");
+                return Ok(());
+            }
+            Err(_) => {
+                // Binary is locked - save as pending update
+                let pending_path = self_path.with_extension("new.exe");
+                fs::rename(&temp_path, &pending_path).context("Failed to save pending update")?;
+                info!(
+                    "Update saved to {}. It will be applied on next startup.",
+                    pending_path.display()
+                );
+                // Return a special result indicating pending update
+                bail!("Update pending - will be applied on next startup");
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        // Atomic rename on Unix
+        fs::rename(&temp_path, self_path).context("Failed to replace binary")?;
+        info!("Update installed successfully");
+    }
+
+    Ok(())
+}
+
+/// Check for and apply pending updates (Windows only)
+///
+/// On Windows, if the binary was locked during an update, we save the new
+/// version as `.new.exe`. This function checks for and applies that update.
+pub fn apply_pending_update() -> Result<bool> {
+    #[cfg(windows)]
+    {
+        let self_path = std::env::current_exe().context("Failed to get current executable path")?;
+        let pending_path = self_path.with_extension("new.exe");
+        if pending_path.exists() {
+            info!("Found pending update at {}", pending_path.display());
+
+            // Try to replace the current binary
+            let old_path = self_path.with_extension("old.exe");
+            let _ = fs::remove_file(&old_path);
+
+            // Try to move current to old
+            match fs::rename(&self_path, &old_path) {
+                Ok(_) => {
+                    // Move pending to current
+                    if let Err(e) = fs::rename(&pending_path, &self_path) {
+                        // Restore old binary
+                        let _ = fs::rename(&old_path, &self_path);
+                        warn!("Failed to apply pending update: {}", e);
+                        return Ok(false);
+                    }
+                    // Clean up
+                    let _ = fs::remove_file(&old_path);
+                    info!("Pending update applied successfully");
+                    return Ok(true);
+                }
+                Err(e) => {
+                    warn!("Cannot apply pending update (binary still locked?): {}", e);
+                    return Ok(false);
+                }
+            }
+        }
+    }
+
+    // No pending update or not Windows
+    Ok(false)
+}
+
+/// Check for updates, trying backend first then falling back to GitHub
+pub fn check_for_update_with_fallback(
+    backend_url: Option<&str>,
+    check_only: bool,
+) -> Result<UpdateResult> {
+    // Try backend first if available
+    if let Some(url) = backend_url {
+        match check_for_update(url) {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                warn!(
+                    "Backend update check failed: {}. Trying GitHub releases...",
+                    e
+                );
+            }
+        }
+    }
+
+    // Fall back to GitHub releases
+    check_for_update_github(check_only)
 }
 
 /// Get the backend URL for update checks from config


### PR DESCRIPTION
## Summary
- Adds GitHub releases as update source (fallback when backend unavailable)
- Adds platform detection for Linux x86_64, macOS ARM64/Intel, Windows x86_64
- Adds `--check-update` to check for updates without installing
- Adds `--update` to force update from GitHub releases
- Handles Windows locked binary by saving pending update for next startup

## Implementation

The update flow now:
1. Checks for pending updates on startup (Windows only)
2. Tries backend first, falls back to GitHub releases
3. Compares SHA256 hashes to detect new versions
4. Atomically replaces the binary (or saves as pending on Windows if locked)

## Test plan
- [ ] `claude-proxy --check-update` shows update status
- [ ] `claude-proxy --update` downloads and installs from GitHub
- [ ] Auto-update works on startup when new version available
- [ ] Fallback to GitHub works when backend is unavailable
- [ ] Windows pending update mechanism works

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)