### PR TITLE
CI: Update macOS Intel build to use macos-14 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,32 +66,34 @@ jobs:
 
   build-macos-intel:
     name: Build (macOS Intel)
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "release-macos-intel"
 
-      - name: Build proxy
-        run: cargo build -p claude-proxy --release
+      - name: Build proxy (cross-compile for x86_64)
+        run: cargo build -p claude-proxy --release --target x86_64-apple-darwin
 
       - name: Ad-hoc code sign
-        run: codesign -s - target/release/claude-proxy
+        run: codesign -s - target/x86_64-apple-darwin/release/claude-proxy
 
       - name: Rename binary
-        run: mv target/release/claude-proxy target/release/claude-proxy-darwin-x86_64
+        run: mv target/x86_64-apple-darwin/release/claude-proxy target/x86_64-apple-darwin/release/claude-proxy-darwin-x86_64
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: claude-proxy-darwin-x86_64
-          path: target/release/claude-proxy-darwin-x86_64
+          path: target/x86_64-apple-darwin/release/claude-proxy-darwin-x86_64
 
   build-windows:
     name: Build (Windows x86_64)


### PR DESCRIPTION
## Summary
- Update macOS Intel build job from `macos-13` to `macos-14` runner
- Use cross-compilation with `x86_64-apple-darwin` target since macos-14 runners are ARM64

## Context
The macos-13 based runner images are being retired by GitHub Actions.

Reference: https://github.com/actions/runner-images/issues/13046

## Test plan
- [ ] CI workflow runs successfully
- [ ] macOS Intel binary is produced correctly
- [ ] Binary works on Intel Macs

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)