### PR TITLE
Fix modal width - install modal now uses full 600px width

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -528,7 +528,7 @@ pub fn dashboard_page() -> Html {
 
                     html! {
                         <div class="modal-overlay" onclick={on_cancel_delete.clone()}>
-                            <div class="modal-content" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                            <div class="modal-content delete-confirm" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
                                 <h2>{ "Delete Session?" }</h2>
                                 <p>{ format!("Are you sure you want to delete \"{}\"?", session_name) }</p>
                                 <p class="modal-warning">{ "This action cannot be undone." }</p>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -277,6 +277,10 @@ body {
 }
 
 .modal-content {
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
     max-width: 600px;
     width: 90%;
     animation: scaleIn 0.2s ease-out;
@@ -2844,25 +2848,9 @@ body {
     to { opacity: 1; }
 }
 
-.modal-content {
-    background: var(--bg-darker);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 1.5rem;
+/* Delete confirmation modals should be narrower */
+.modal-content.delete-confirm {
     max-width: 400px;
-    width: 90%;
-    animation: slideIn 0.15s ease-out;
-}
-
-@keyframes slideIn {
-    from {
-        opacity: 0;
-        transform: translateY(-20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
 }
 
 .modal-content h2 {


### PR DESCRIPTION
## Summary
The install/new session modal was incorrectly constrained to 400px width due to CSS cascade order (a later `.modal-content` definition was overriding the earlier one).

## Changes
- Consolidate duplicate `.modal-content` CSS definitions into one
- Set default modal max-width to 600px for better content display
- Add `.delete-confirm` class for narrower delete confirmation modals (400px)
- Use `scaleIn` animation for smoother modal appearance

## Before
- Install modal: 400px max-width (too narrow)
- Delete modal: 400px max-width

## After
- Install modal: 600px max-width (proper width for setup content)
- Delete modal: 400px max-width (unchanged, using `.delete-confirm` class)

## Test plan
- [ ] Install/new session modal displays at proper 600px width
- [ ] Delete confirmation modal still displays at narrower 400px width
- [ ] Modal animations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)