### PR TITLE
Add keyboard nav mode and fix installer for running binaries

### DIFF
--- a/backend/src/handlers/downloads.rs
+++ b/backend/src/handlers/downloads.rs
@@ -73,10 +73,9 @@ echo ""
 
 # Check if binary already exists
 if [ -x "${{BIN_PATH}}" ]; then
-    echo "claude-proxy is already installed at: ${{BIN_PATH}}"
+    echo "claude-proxy found at: ${{BIN_PATH}}"
+    echo "Updating to latest version..."
     echo ""
-{init_section}
-    exit 0
 fi
 
 # Create config directory
@@ -130,19 +129,23 @@ echo "Binary: ${{BINARY_NAME}}"
 echo "Installing to: ${{BIN_PATH}}"
 echo ""
 
-# Download the binary
+# Download the binary to a temp file first (allows replacing running binary)
+TEMP_BIN="${{BIN_PATH}}.new.$$"
 echo "Downloading claude-proxy from GitHub releases..."
 if command -v curl &> /dev/null; then
-    curl -fsSL "${{DOWNLOAD_URL}}" -o "${{BIN_PATH}}"
+    curl -fsSL "${{DOWNLOAD_URL}}" -o "${{TEMP_BIN}}"
 elif command -v wget &> /dev/null; then
-    wget -q "${{DOWNLOAD_URL}}" -O "${{BIN_PATH}}"
+    wget -q "${{DOWNLOAD_URL}}" -O "${{TEMP_BIN}}"
 else
     echo "Error: curl or wget required"
     exit 1
 fi
 
 # Make executable
-chmod +x "${{BIN_PATH}}"
+chmod +x "${{TEMP_BIN}}"
+
+# Atomic replace (works even if binary is running)
+mv -f "${{TEMP_BIN}}" "${{BIN_PATH}}"
 
 # macOS: Remove quarantine attribute if present
 if [ "${{OS}}" = "Darwin" ]; then

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2457,6 +2457,29 @@ body {
     color: var(--success);
 }
 
+/* Number annotation for nav mode (1-9 keys) */
+.pill-number {
+    display: none;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--accent);
+    background: rgba(122, 162, 247, 0.3);
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-family: monospace;
+}
+
+.session-pill.nav-mode .pill-number {
+    display: inline-block;
+}
+
+/* Nav mode selection highlight */
+.session-pill.nav-mode.focused {
+    border-color: var(--accent);
+    background: rgba(122, 162, 247, 0.25);
+    box-shadow: 0 0 0 3px rgba(122, 162, 247, 0.4);
+}
+
 /* ==========================================================================
    Session View - Main Terminal Area
    ========================================================================== */
@@ -2795,6 +2818,18 @@ body {
     cursor: not-allowed;
 }
 
+/* Nav mode: dim the input area to indicate it's not active */
+.session-views-container.nav-mode .session-view-input {
+    opacity: 0.5;
+    pointer-events: none;
+    border-top: 1px dashed var(--accent);
+}
+
+.session-views-container.nav-mode .session-view-input .message-input {
+    border-color: var(--accent);
+    background: rgba(122, 162, 247, 0.05);
+}
+
 /* ==========================================================================
    Keyboard Hints Footer
    ========================================================================== */
@@ -2823,6 +2858,23 @@ body {
     padding: 0.15rem 0.4rem;
     font-family: monospace;
     font-size: 0.7rem;
+}
+
+/* Nav mode indicator badge */
+.keyboard-hints .mode-indicator {
+    font-weight: 700;
+    font-size: 0.75rem;
+    background: var(--accent);
+    color: var(--bg-dark);
+    padding: 0.2rem 0.6rem;
+    border-radius: 4px;
+    letter-spacing: 0.5px;
+}
+
+/* Nav mode styling for keyboard hints bar */
+.keyboard-hints.nav-mode {
+    background: rgba(122, 162, 247, 0.15);
+    border-top-color: var(--accent);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- Two-mode keyboard navigation system (Edit/Nav modes) for the dashboard
- Sessions now sorted by repo name then hostname for stable ordering
- Install script uses atomic file replacement to work with running binaries

## Test plan
- [ ] Press Escape to enter nav mode, verify NAV badge appears and input dims
- [ ] Use arrow keys or j/k to navigate sessions in nav mode
- [ ] Press 1-9 to directly select sessions
- [ ] Verify Shift+Tab jumps to next waiting session
- [ ] Verify sessions with pending permission requests show as "awaiting"
- [ ] Test installer script updates binary while proxies are running