### PR TITLE
Fix session visibility and registration acknowledgment

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2404,6 +2404,29 @@ body {
     color: white;
 }
 
+/* Disconnected session (DB status) styling */
+.session-pill.status-disconnected {
+    opacity: 0.6;
+    background: rgba(127, 132, 156, 0.1);
+    border-color: var(--text-secondary);
+}
+
+.session-pill.status-disconnected:hover {
+    opacity: 0.8;
+    background: rgba(127, 132, 156, 0.15);
+}
+
+.session-pill.status-disconnected.focused {
+    opacity: 0.85;
+    border-color: var(--text-secondary);
+    box-shadow: 0 0 0 2px rgba(127, 132, 156, 0.3);
+}
+
+.session-pill.status-disconnected .pill-project,
+.session-pill.status-disconnected .pill-hostname {
+    color: var(--text-secondary);
+}
+
 /* Parked session styling */
 .session-pill.parked {
     opacity: 0.5;

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -147,10 +147,10 @@ async fn run_single_connection(
         Err(duration) => return ConnectionResult::Disconnected(duration),
     };
 
-    let (mut ws_write, ws_read) = ws_stream.split();
+    let (mut ws_write, mut ws_read) = ws_stream.split();
 
-    // Register with backend
-    if let Err(duration) = register_session(&mut ws_write, config).await {
+    // Register with backend and wait for acknowledgment
+    if let Err(duration) = register_session(&mut ws_write, &mut ws_read, config).await {
         return ConnectionResult::Disconnected(duration);
     }
 
@@ -191,11 +191,16 @@ async fn connect_to_backend(
     }
 }
 
-/// Register session with the backend
-async fn register_session<S>(ws_write: &mut S, config: &SessionConfig) -> Result<(), Duration>
+/// Register session with the backend and wait for acknowledgment
+async fn register_session<S, R>(
+    ws_write: &mut S,
+    ws_read: &mut R,
+    config: &SessionConfig,
+) -> Result<(), Duration>
 where
     S: SinkExt<Message> + Unpin,
     S::Error: std::fmt::Display,
+    R: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
 {
     ui::print_status("Registering session...");
 
@@ -211,12 +216,61 @@ where
 
     if let Err(e) = ws_write.send(Message::Text(json)).await {
         ui::print_failed();
-        error!("Failed to register session: {}", e);
+        error!("Failed to send registration message: {}", e);
         return Err(Duration::ZERO);
     }
 
-    ui::print_registered();
-    Ok(())
+    // Wait for RegisterAck with timeout
+    let ack_timeout = tokio::time::timeout(Duration::from_secs(10), async {
+        while let Some(msg) = ws_read.next().await {
+            match msg {
+                Ok(Message::Text(text)) => {
+                    if let Ok(ProxyMessage::RegisterAck {
+                        success,
+                        session_id: _,
+                        error,
+                    }) = serde_json::from_str::<ProxyMessage>(&text)
+                    {
+                        return Some((success, error));
+                    }
+                }
+                Ok(Message::Close(_)) => return None,
+                Err(_) => return None,
+                _ => continue,
+            }
+        }
+        None
+    })
+    .await;
+
+    match ack_timeout {
+        Ok(Some((true, _))) => {
+            ui::print_registered();
+            Ok(())
+        }
+        Ok(Some((false, error))) => {
+            let err_msg = error.as_deref().unwrap_or("Unknown error");
+            ui::print_registration_failed(err_msg);
+            if err_msg.contains("Authentication") || err_msg.contains("authenticate") {
+                ui::print_reauth_hint();
+            }
+            error!("Registration failed: {}", err_msg);
+            Err(Duration::ZERO)
+        }
+        Ok(None) => {
+            ui::print_failed();
+            error!("Connection closed during registration");
+            Err(Duration::ZERO)
+        }
+        Err(_) => {
+            // Timeout - assume success for backwards compatibility with older backends
+            ui::print_registered();
+            info!(
+                "No RegisterAck received (timeout), assuming success for backwards compatibility"
+            );
+            Ok(())
+        }
+    }
 }
 
 /// Permission response data

--- a/proxy/src/ui.rs
+++ b/proxy/src/ui.rs
@@ -128,6 +128,25 @@ pub fn print_failed() {
     println!("{}", "failed".bright_red());
 }
 
+/// Print registration failure with error message
+pub fn print_registration_failed(error: &str) {
+    println!("{}", "failed".bright_red());
+    println!(
+        "  {} Registration error: {}",
+        "✗".bright_red(),
+        error.bright_red()
+    );
+}
+
+/// Print hint to re-authenticate
+pub fn print_reauth_hint() {
+    println!(
+        "  {} Run: {} to re-authenticate",
+        "→".bright_blue(),
+        "claude-proxy logout && claude-proxy login".bright_cyan()
+    );
+}
+
 /// Print connection restored message
 pub fn print_connection_restored() {
     println!("  {} Connection restored", "✓".bright_green());

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -75,6 +75,17 @@ pub enum ProxyMessage {
         #[serde(skip_serializing_if = "Option::is_none")]
         reason: Option<String>,
     },
+
+    /// Backend acknowledgment of session registration
+    RegisterAck {
+        /// Whether registration succeeded
+        success: bool,
+        /// The session ID that was registered
+        session_id: Uuid,
+        /// Error message if registration failed
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
This PR addresses two related issues:

### Issue #63: Show disconnected sessions in UI
- Include all sessions in the session rail, not just active ones
- Sort sessions with active first, then by repo name/hostname
- Add `.status-disconnected` CSS class with grayed-out styling
- Disconnected sessions are visually distinct but still accessible for viewing history

### Issue #65: Add RegisterAck protocol message
- Add `RegisterAck` message type to shared protocol
- Backend sends `RegisterAck` after registration with success/error status
- Proxy waits for `RegisterAck` with 10s timeout (for backwards compatibility with older backends)
- Clear error messages for auth failures with re-auth hints
- Prevents silent registration failures where proxy thinks it's connected but session isn't persisted

## Test plan
- [ ] Start backend and frontend
- [ ] Create a new session, verify it shows as active
- [ ] Disconnect the proxy, verify session shows as disconnected (grayed out) in UI
- [ ] Click on disconnected session, verify historical messages are viewable
- [ ] Test proxy with invalid auth token, verify clear error message
- [ ] Test backwards compatibility: proxy should work with backends that don't send RegisterAck

Fixes #63
Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)