### PR TITLE
Add session and credential management page

### DIFF
--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -2,7 +2,7 @@ mod components;
 mod pages;
 pub mod utils;
 
-use pages::{dashboard::DashboardPage, splash::SplashPage};
+use pages::{dashboard::DashboardPage, settings::SettingsPage, splash::SplashPage};
 use yew::prelude::*;
 use yew_router::prelude::*;
 
@@ -12,12 +12,15 @@ pub enum Route {
     Home,
     #[at("/dashboard")]
     Dashboard,
+    #[at("/settings")]
+    Settings,
 }
 
 fn switch(routes: Route) -> Html {
     match routes {
         Route::Home => html! { <SplashPage /> },
         Route::Dashboard => html! { <DashboardPage /> },
+        Route::Settings => html! { <SettingsPage /> },
     }
 }
 

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -1,5 +1,6 @@
 use crate::components::{group_messages, MessageGroupRenderer, ProxyTokenSetup};
 use crate::utils;
+use crate::Route;
 use futures_util::{SinkExt, StreamExt};
 use gloo_net::http::Request;
 use gloo_net::websocket::{futures::WebSocket, Message};
@@ -13,6 +14,7 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{Element, HtmlInputElement, KeyboardEvent};
 use yew::prelude::*;
+use yew_router::prelude::*;
 
 /// Type alias for WebSocket sender to reduce type complexity
 type WsSender = Rc<RefCell<Option<futures_util::stream::SplitSink<WebSocket, Message>>>>;
@@ -496,6 +498,9 @@ pub fn dashboard_page() -> Html {
                     >
                         { if *show_new_session { "Close" } else { "+ New Session" } }
                     </button>
+                    <Link<Route> to={Route::Settings} classes="settings-button">
+                        { "Settings" }
+                    </Link<Route>>
                     <a href="/api/auth/logout" class="logout-button">
                         { "Logout" }
                     </a>

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -1,2 +1,3 @@
 pub mod dashboard;
+pub mod settings;
 pub mod splash;

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -1,0 +1,691 @@
+use crate::utils;
+use gloo_net::http::Request;
+use shared::{
+    CreateProxyTokenRequest, CreateProxyTokenResponse, ProxyTokenInfo, ProxyTokenListResponse,
+    SessionInfo,
+};
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+use crate::Route;
+
+/// Settings page tabs
+#[derive(Clone, Copy, PartialEq)]
+enum SettingsTab {
+    Tokens,
+    Sessions,
+}
+
+/// Calculate days until expiration from ISO date string
+fn days_until_expiration(expires_at: &str) -> Option<i64> {
+    // Parse ISO date and compare with current time
+    // expires_at format: "2026-02-14T19:58:20.769821Z" or similar
+    let now = js_sys::Date::now();
+    let expires = js_sys::Date::parse(expires_at);
+    if expires.is_nan() {
+        return None;
+    }
+    let diff_ms = expires - now;
+    let diff_days = (diff_ms / (1000.0 * 60.0 * 60.0 * 24.0)).floor() as i64;
+    Some(diff_days)
+}
+
+/// Format a timestamp for display
+fn format_timestamp(ts: &str) -> String {
+    // Parse and format nicely
+    let date = js_sys::Date::new(&ts.into());
+    if date.get_time().is_nan() {
+        return ts.to_string();
+    }
+    format!(
+        "{}-{:02}-{:02} {:02}:{:02}",
+        date.get_full_year(),
+        date.get_month() + 1,
+        date.get_date(),
+        date.get_hours(),
+        date.get_minutes()
+    )
+}
+
+/// Token row component
+#[derive(Properties, PartialEq)]
+struct TokenRowProps {
+    token: ProxyTokenInfo,
+    on_revoke: Callback<Uuid>,
+}
+
+#[function_component(TokenRow)]
+fn token_row(props: &TokenRowProps) -> Html {
+    let token = &props.token;
+    let on_revoke = props.on_revoke.clone();
+    let token_id = token.id;
+
+    let days_left = days_until_expiration(&token.expires_at);
+    let is_expired = days_left.map(|d| d < 0).unwrap_or(false);
+    let is_expiring_soon = days_left.map(|d| (0..=7).contains(&d)).unwrap_or(false);
+
+    let status_class = if token.revoked {
+        "token-status revoked"
+    } else if is_expired {
+        "token-status expired"
+    } else if is_expiring_soon {
+        "token-status expiring-soon"
+    } else {
+        "token-status active"
+    };
+
+    let status_text = if token.revoked {
+        "Revoked".to_string()
+    } else if is_expired {
+        "Expired".to_string()
+    } else if let Some(days) = days_left {
+        if days == 0 {
+            "Expires today".to_string()
+        } else if days == 1 {
+            "Expires tomorrow".to_string()
+        } else if days <= 7 {
+            format!("Expires in {} days", days)
+        } else {
+            "Active".to_string()
+        }
+    } else {
+        "Active".to_string()
+    };
+
+    let on_revoke_click = Callback::from(move |_| {
+        on_revoke.emit(token_id);
+    });
+
+    html! {
+        <tr class={if token.revoked || is_expired { "token-row disabled" } else { "token-row" }}>
+            <td class="token-name">{ &token.name }</td>
+            <td class="token-created">{ format_timestamp(&token.created_at) }</td>
+            <td class="token-last-used">
+                { token.last_used_at.as_ref().map(|t| format_timestamp(t)).unwrap_or_else(|| "Never".to_string()) }
+            </td>
+            <td class="token-expires">{ format_timestamp(&token.expires_at) }</td>
+            <td class={status_class}>{ status_text }</td>
+            <td class="token-actions">
+                if !token.revoked && !is_expired {
+                    <button class="revoke-button" onclick={on_revoke_click}>
+                        { "Revoke" }
+                    </button>
+                }
+            </td>
+        </tr>
+    }
+}
+
+/// Session row component
+#[derive(Properties, PartialEq)]
+struct SessionRowProps {
+    session: SessionInfo,
+    on_delete: Callback<Uuid>,
+}
+
+#[function_component(SessionRow)]
+fn session_row(props: &SessionRowProps) -> Html {
+    let session = &props.session;
+    let on_delete = props.on_delete.clone();
+    let session_id = session.id;
+
+    let status_class = match session.status {
+        shared::SessionStatus::Active => "session-status active",
+        shared::SessionStatus::Inactive => "session-status inactive",
+        shared::SessionStatus::Disconnected => "session-status disconnected",
+    };
+
+    let on_delete_click = Callback::from(move |_| {
+        on_delete.emit(session_id);
+    });
+
+    // Extract project name from working directory
+    let project = session
+        .working_directory
+        .as_ref()
+        .and_then(|dir| dir.split('/').next_back())
+        .unwrap_or("Unknown");
+
+    html! {
+        <tr class="session-row">
+            <td class="session-name" title={session.session_name.clone()}>{ project }</td>
+            <td class="session-directory" title={session.working_directory.clone().unwrap_or_default()}>
+                { session.working_directory.as_deref().unwrap_or("—") }
+            </td>
+            <td class="session-branch">
+                { session.git_branch.as_deref().unwrap_or("—") }
+            </td>
+            <td class="session-activity">{ format_timestamp(&session.last_activity) }</td>
+            <td class="session-created">{ format_timestamp(&session.created_at) }</td>
+            <td class={status_class}>{ session.status.as_str() }</td>
+            <td class="session-actions">
+                <button class="delete-button" onclick={on_delete_click}>
+                    { "Delete" }
+                </button>
+            </td>
+        </tr>
+    }
+}
+
+/// New token form state
+#[derive(Clone, Default)]
+struct NewTokenForm {
+    name: String,
+    expires_in_days: u32,
+}
+
+#[function_component(SettingsPage)]
+pub fn settings_page() -> Html {
+    let navigator = use_navigator().unwrap();
+    let active_tab = use_state(|| SettingsTab::Tokens);
+
+    // Token state
+    let tokens = use_state(Vec::<ProxyTokenInfo>::new);
+    let tokens_loading = use_state(|| true);
+    let new_token_form = use_state(NewTokenForm::default);
+    let created_token = use_state(|| None::<CreateProxyTokenResponse>);
+    let show_create_form = use_state(|| false);
+
+    // Session state
+    let sessions = use_state(Vec::<SessionInfo>::new);
+    let sessions_loading = use_state(|| true);
+
+    // Confirmation modal state
+    let confirm_action = use_state(|| None::<(String, Callback<MouseEvent>)>);
+
+    // Fetch tokens
+    let fetch_tokens = {
+        let tokens = tokens.clone();
+        let tokens_loading = tokens_loading.clone();
+
+        Callback::from(move |_| {
+            let tokens = tokens.clone();
+            let tokens_loading = tokens_loading.clone();
+
+            spawn_local(async move {
+                let api_endpoint = utils::api_url("/api/proxy-tokens");
+                match Request::get(&api_endpoint).send().await {
+                    Ok(response) => {
+                        if response.status() == 401 {
+                            if let Some(window) = web_sys::window() {
+                                let _ = window.location().set_href("/api/auth/logout");
+                            }
+                            return;
+                        }
+                        if let Ok(data) = response.json::<ProxyTokenListResponse>().await {
+                            tokens.set(data.tokens);
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Failed to fetch tokens: {:?}", e);
+                    }
+                }
+                tokens_loading.set(false);
+            });
+        })
+    };
+
+    // Fetch sessions
+    let fetch_sessions = {
+        let sessions = sessions.clone();
+        let sessions_loading = sessions_loading.clone();
+
+        Callback::from(move |_| {
+            let sessions = sessions.clone();
+            let sessions_loading = sessions_loading.clone();
+
+            spawn_local(async move {
+                let api_endpoint = utils::api_url("/api/sessions");
+                match Request::get(&api_endpoint).send().await {
+                    Ok(response) => {
+                        if response.status() == 401 {
+                            if let Some(window) = web_sys::window() {
+                                let _ = window.location().set_href("/api/auth/logout");
+                            }
+                            return;
+                        }
+                        if let Ok(data) = response.json::<serde_json::Value>().await {
+                            if let Some(session_list) = data.get("sessions") {
+                                if let Ok(parsed) =
+                                    serde_json::from_value::<Vec<SessionInfo>>(session_list.clone())
+                                {
+                                    sessions.set(parsed);
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Failed to fetch sessions: {:?}", e);
+                    }
+                }
+                sessions_loading.set(false);
+            });
+        })
+    };
+
+    // Initial fetch
+    {
+        let fetch_tokens = fetch_tokens.clone();
+        let fetch_sessions = fetch_sessions.clone();
+        use_effect_with((), move |_| {
+            fetch_tokens.emit(());
+            fetch_sessions.emit(());
+            || ()
+        });
+    }
+
+    // Revoke token handler
+    let on_revoke_token = {
+        let tokens = tokens.clone();
+        let confirm_action = confirm_action.clone();
+
+        Callback::from(move |token_id: Uuid| {
+            let tokens = tokens.clone();
+            let confirm_action_inner = confirm_action.clone();
+
+            let action = Callback::from(move |_: MouseEvent| {
+                let tokens = tokens.clone();
+                let confirm_action_inner = confirm_action_inner.clone();
+
+                spawn_local(async move {
+                    let api_endpoint = utils::api_url(&format!("/api/proxy-tokens/{}", token_id));
+                    match Request::delete(&api_endpoint).send().await {
+                        Ok(response) => {
+                            if response.status() == 204 || response.status() == 200 {
+                                // Update local state to mark as revoked
+                                let mut updated: Vec<ProxyTokenInfo> = (*tokens).to_vec();
+                                if let Some(token) = updated.iter_mut().find(|t| t.id == token_id) {
+                                    token.revoked = true;
+                                }
+                                tokens.set(updated);
+                            }
+                        }
+                        Err(e) => {
+                            log::error!("Failed to revoke token: {:?}", e);
+                        }
+                    }
+                    confirm_action_inner.set(None);
+                });
+            });
+
+            confirm_action.set(Some((
+                "Revoke this token? Connected proxies will be disconnected.".to_string(),
+                action,
+            )));
+        })
+    };
+
+    // Delete session handler
+    let on_delete_session = {
+        let sessions = sessions.clone();
+        let confirm_action = confirm_action.clone();
+
+        Callback::from(move |session_id: Uuid| {
+            let sessions = sessions.clone();
+            let confirm_action_inner = confirm_action.clone();
+
+            let action = Callback::from(move |_: MouseEvent| {
+                let sessions = sessions.clone();
+                let confirm_action_inner = confirm_action_inner.clone();
+
+                spawn_local(async move {
+                    let api_endpoint = utils::api_url(&format!("/api/sessions/{}", session_id));
+                    match Request::delete(&api_endpoint).send().await {
+                        Ok(response) => {
+                            if response.status() == 204 || response.status() == 200 {
+                                // Remove from local state
+                                let updated: Vec<SessionInfo> = (*sessions)
+                                    .iter()
+                                    .filter(|s| s.id != session_id)
+                                    .cloned()
+                                    .collect();
+                                sessions.set(updated);
+                            }
+                        }
+                        Err(e) => {
+                            log::error!("Failed to delete session: {:?}", e);
+                        }
+                    }
+                    confirm_action_inner.set(None);
+                });
+            });
+
+            confirm_action.set(Some((
+                "Delete this session? All message history will be lost.".to_string(),
+                action,
+            )));
+        })
+    };
+
+    // Create token handler
+    let on_create_token = {
+        let new_token_form = new_token_form.clone();
+        let created_token = created_token.clone();
+        let fetch_tokens = fetch_tokens.clone();
+
+        Callback::from(move |e: SubmitEvent| {
+            e.prevent_default();
+            let form_data = (*new_token_form).clone();
+            let created_token = created_token.clone();
+            let fetch_tokens = fetch_tokens.clone();
+
+            if form_data.name.trim().is_empty() {
+                return;
+            }
+
+            spawn_local(async move {
+                let api_endpoint = utils::api_url("/api/proxy-tokens");
+                let request_body = CreateProxyTokenRequest {
+                    name: form_data.name.trim().to_string(),
+                    expires_in_days: if form_data.expires_in_days > 0 {
+                        form_data.expires_in_days
+                    } else {
+                        30
+                    },
+                };
+
+                match Request::post(&api_endpoint)
+                    .json(&request_body)
+                    .unwrap()
+                    .send()
+                    .await
+                {
+                    Ok(response) => {
+                        if let Ok(data) = response.json::<CreateProxyTokenResponse>().await {
+                            created_token.set(Some(data));
+                            // Refresh token list
+                            fetch_tokens.emit(());
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Failed to create token: {:?}", e);
+                    }
+                }
+            });
+        })
+    };
+
+    // Form input handlers
+    let on_name_input = {
+        let new_token_form = new_token_form.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            let mut form = (*new_token_form).clone();
+            form.name = input.value();
+            new_token_form.set(form);
+        })
+    };
+
+    let on_days_input = {
+        let new_token_form = new_token_form.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            let mut form = (*new_token_form).clone();
+            form.expires_in_days = input.value().parse().unwrap_or(30);
+            new_token_form.set(form);
+        })
+    };
+
+    // Tab click handlers
+    let on_tokens_tab = {
+        let active_tab = active_tab.clone();
+        Callback::from(move |_| active_tab.set(SettingsTab::Tokens))
+    };
+
+    let on_sessions_tab = {
+        let active_tab = active_tab.clone();
+        Callback::from(move |_| active_tab.set(SettingsTab::Sessions))
+    };
+
+    // Toggle create form
+    let toggle_create_form = {
+        let show_create_form = show_create_form.clone();
+        let created_token = created_token.clone();
+        let new_token_form = new_token_form.clone();
+        Callback::from(move |_| {
+            if *show_create_form {
+                // Closing - reset form
+                created_token.set(None);
+                new_token_form.set(NewTokenForm::default());
+            }
+            show_create_form.set(!*show_create_form);
+        })
+    };
+
+    // Cancel confirmation
+    let cancel_confirm = {
+        let confirm_action = confirm_action.clone();
+        Callback::from(move |_| {
+            confirm_action.set(None);
+        })
+    };
+
+    // Back to dashboard
+    let go_back = {
+        let navigator = navigator.clone();
+        Callback::from(move |_| {
+            navigator.push(&Route::Dashboard);
+        })
+    };
+
+    // Count expiring tokens (within 7 days)
+    let expiring_count = tokens
+        .iter()
+        .filter(|t| !t.revoked)
+        .filter(|t| {
+            days_until_expiration(&t.expires_at)
+                .map(|d| (0..=7).contains(&d))
+                .unwrap_or(false)
+        })
+        .count();
+
+    html! {
+        <div class="settings-container">
+            <header class="settings-header">
+                <button class="back-button" onclick={go_back}>
+                    { "< Back to Dashboard" }
+                </button>
+                <h1>{ "Settings" }</h1>
+                <a href="/api/auth/logout" class="logout-button">
+                    { "Logout" }
+                </a>
+            </header>
+
+            <nav class="settings-tabs">
+                <button
+                    class={classes!("tab-button", (*active_tab == SettingsTab::Tokens).then_some("active"))}
+                    onclick={on_tokens_tab}
+                >
+                    { "Credentials" }
+                    if expiring_count > 0 {
+                        <span class="expiring-badge">{ expiring_count }</span>
+                    }
+                </button>
+                <button
+                    class={classes!("tab-button", (*active_tab == SettingsTab::Sessions).then_some("active"))}
+                    onclick={on_sessions_tab}
+                >
+                    { "Sessions" }
+                    <span class="count-badge">{ sessions.len() }</span>
+                </button>
+            </nav>
+
+            <main class="settings-content">
+                // Token Management Tab
+                if *active_tab == SettingsTab::Tokens {
+                    <section class="tokens-section">
+                        <div class="section-header">
+                            <h2>{ "Proxy Credentials" }</h2>
+                            <p class="section-description">
+                                { "Manage authentication tokens for your Claude Code proxy connections." }
+                            </p>
+                            <button class="create-button" onclick={toggle_create_form.clone()}>
+                                { if *show_create_form { "Cancel" } else { "+ Create Token" } }
+                            </button>
+                        </div>
+
+                        // Create token form
+                        if *show_create_form {
+                            <div class="create-token-form">
+                                if let Some(token_response) = &*created_token {
+                                    <div class="token-created-success">
+                                        <h3>{ "Token Created Successfully" }</h3>
+                                        <p class="warning">
+                                            { "Copy this token now. It will not be shown again!" }
+                                        </p>
+                                        <div class="token-display">
+                                            <code>{ &token_response.token }</code>
+                                        </div>
+                                        <div class="init-url">
+                                            <label>{ "Or use this initialization URL:" }</label>
+                                            <code>{ &token_response.init_url }</code>
+                                        </div>
+                                        <p class="expires-info">
+                                            { format!("Expires: {}", format_timestamp(&token_response.expires_at)) }
+                                        </p>
+                                        <button onclick={toggle_create_form.clone()}>{ "Done" }</button>
+                                    </div>
+                                } else {
+                                    <form onsubmit={on_create_token}>
+                                        <div class="form-group">
+                                            <label for="token-name">{ "Token Name" }</label>
+                                            <input
+                                                type="text"
+                                                id="token-name"
+                                                placeholder="e.g., My Laptop, Work Machine"
+                                                value={new_token_form.name.clone()}
+                                                oninput={on_name_input}
+                                                required=true
+                                            />
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="token-days">{ "Expires In (days)" }</label>
+                                            <input
+                                                type="number"
+                                                id="token-days"
+                                                min="1"
+                                                max="365"
+                                                value={new_token_form.expires_in_days.to_string()}
+                                                oninput={on_days_input}
+                                            />
+                                        </div>
+                                        <button type="submit" class="submit-button">
+                                            { "Create Token" }
+                                        </button>
+                                    </form>
+                                }
+                            </div>
+                        }
+
+                        // Token list
+                        if *tokens_loading {
+                            <div class="loading">
+                                <div class="spinner"></div>
+                                <p>{ "Loading tokens..." }</p>
+                            </div>
+                        } else if tokens.is_empty() {
+                            <div class="empty-state">
+                                <p>{ "No tokens found. Create one to connect a proxy." }</p>
+                            </div>
+                        } else {
+                            <div class="table-container">
+                                <table class="tokens-table">
+                                    <thead>
+                                        <tr>
+                                            <th>{ "Name" }</th>
+                                            <th>{ "Created" }</th>
+                                            <th>{ "Last Used" }</th>
+                                            <th>{ "Expires" }</th>
+                                            <th>{ "Status" }</th>
+                                            <th>{ "Actions" }</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        { for tokens.iter().map(|token| {
+                                            html! {
+                                                <TokenRow
+                                                    key={token.id.to_string()}
+                                                    token={token.clone()}
+                                                    on_revoke={on_revoke_token.clone()}
+                                                />
+                                            }
+                                        }) }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </section>
+                }
+
+                // Session Management Tab
+                if *active_tab == SettingsTab::Sessions {
+                    <section class="sessions-section">
+                        <div class="section-header">
+                            <h2>{ "Session History" }</h2>
+                            <p class="section-description">
+                                { "View and manage your Claude Code sessions across all machines." }
+                            </p>
+                        </div>
+
+                        if *sessions_loading {
+                            <div class="loading">
+                                <div class="spinner"></div>
+                                <p>{ "Loading sessions..." }</p>
+                            </div>
+                        } else if sessions.is_empty() {
+                            <div class="empty-state">
+                                <p>{ "No sessions found." }</p>
+                            </div>
+                        } else {
+                            <div class="table-container">
+                                <table class="sessions-table">
+                                    <thead>
+                                        <tr>
+                                            <th>{ "Project" }</th>
+                                            <th>{ "Directory" }</th>
+                                            <th>{ "Branch" }</th>
+                                            <th>{ "Last Activity" }</th>
+                                            <th>{ "Created" }</th>
+                                            <th>{ "Status" }</th>
+                                            <th>{ "Actions" }</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        { for sessions.iter().map(|session| {
+                                            html! {
+                                                <SessionRow
+                                                    key={session.id.to_string()}
+                                                    session={session.clone()}
+                                                    on_delete={on_delete_session.clone()}
+                                                />
+                                            }
+                                        }) }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </section>
+                }
+            </main>
+
+            // Confirmation Modal
+            if let Some((message, action)) = &*confirm_action {
+                <div class="modal-overlay" onclick={cancel_confirm.clone()}>
+                    <div class="confirm-modal" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                        <p>{ message }</p>
+                        <div class="confirm-actions">
+                            <button class="cancel-button" onclick={cancel_confirm.clone()}>
+                                { "Cancel" }
+                            </button>
+                            <button class="confirm-button" onclick={action.clone()}>
+                                { "Confirm" }
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+}

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3135,3 +3135,524 @@ body {
     background: #ff5a72;
     border-color: #ff5a72;
 }
+
+/* =============================================================================
+   Settings Page
+   ============================================================================= */
+
+.settings-container {
+    min-height: 100vh;
+    background: var(--bg-dark);
+    display: flex;
+    flex-direction: column;
+}
+
+.settings-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 2rem;
+    background: var(--bg-darker);
+    border-bottom: 1px solid var(--border);
+}
+
+.settings-header h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    color: var(--text-primary);
+}
+
+.back-button {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: all 0.2s;
+}
+
+.back-button:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.settings-button {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: all 0.2s;
+}
+
+.settings-button:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+/* Settings Tabs */
+.settings-tabs {
+    display: flex;
+    gap: 0;
+    padding: 0 2rem;
+    background: var(--bg-darker);
+    border-bottom: 1px solid var(--border);
+}
+
+.tab-button {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    padding: 1rem 1.5rem;
+    font-size: 1rem;
+    cursor: pointer;
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    transition: color 0.2s;
+}
+
+.tab-button:hover {
+    color: var(--text-primary);
+}
+
+.tab-button.active {
+    color: var(--accent);
+}
+
+.tab-button.active::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--accent);
+}
+
+.expiring-badge {
+    background: var(--error);
+    color: white;
+    font-size: 0.75rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+    font-weight: 600;
+}
+
+.count-badge {
+    background: var(--border);
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+}
+
+/* Settings Content */
+.settings-content {
+    flex: 1;
+    padding: 2rem;
+    overflow-y: auto;
+}
+
+.section-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.section-header h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    color: var(--text-primary);
+}
+
+.section-description {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin: 0.25rem 0 0 0;
+    flex-basis: 100%;
+}
+
+.create-button {
+    background: var(--accent);
+    border: none;
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: all 0.2s;
+}
+
+.create-button:hover {
+    background: var(--accent-hover);
+}
+
+/* Tables */
+.table-container {
+    overflow-x: auto;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+}
+
+.tokens-table,
+.sessions-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.tokens-table th,
+.sessions-table th {
+    text-align: left;
+    padding: 0.75rem 1rem;
+    background: var(--bg-darker);
+    color: var(--text-secondary);
+    font-weight: 500;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+}
+
+.tokens-table td,
+.sessions-table td {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-primary);
+}
+
+.tokens-table tr:last-child td,
+.sessions-table tr:last-child td {
+    border-bottom: none;
+}
+
+.token-row.disabled {
+    opacity: 0.5;
+}
+
+.token-name,
+.session-name {
+    font-weight: 500;
+}
+
+.session-directory {
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+}
+
+/* Status indicators */
+.token-status,
+.session-status {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.token-status.active {
+    background: rgba(158, 206, 106, 0.2);
+    color: var(--success);
+}
+
+.token-status.expiring-soon {
+    background: rgba(255, 158, 100, 0.2);
+    color: #ff9e64;
+}
+
+.token-status.expired,
+.token-status.revoked {
+    background: rgba(247, 118, 142, 0.2);
+    color: var(--error);
+}
+
+.session-status.active {
+    background: rgba(158, 206, 106, 0.2);
+    color: var(--success);
+}
+
+.session-status.inactive {
+    background: rgba(255, 158, 100, 0.2);
+    color: #ff9e64;
+}
+
+.session-status.disconnected {
+    background: rgba(127, 132, 156, 0.2);
+    color: var(--text-secondary);
+}
+
+/* Action buttons */
+.revoke-button,
+.delete-button {
+    background: transparent;
+    border: 1px solid var(--error);
+    color: var(--error);
+    padding: 0.25rem 0.75rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    transition: all 0.2s;
+}
+
+.revoke-button:hover,
+.delete-button:hover {
+    background: var(--error);
+    color: white;
+}
+
+/* Create Token Form */
+.create-token-form {
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.create-token-form form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: flex-end;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.form-group label {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.form-group input {
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    min-width: 200px;
+}
+
+.form-group input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.form-group input[type="number"] {
+    min-width: 100px;
+}
+
+.submit-button {
+    background: var(--accent);
+    border: none;
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: all 0.2s;
+}
+
+.submit-button:hover {
+    background: var(--accent-hover);
+}
+
+/* Token Created Success */
+.token-created-success {
+    text-align: center;
+}
+
+.token-created-success h3 {
+    color: var(--success);
+    margin: 0 0 1rem 0;
+}
+
+.token-created-success .warning {
+    color: var(--error);
+    font-weight: 500;
+    margin-bottom: 1rem;
+}
+
+.token-display,
+.init-url {
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+.token-display code,
+.init-url code {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    word-break: break-all;
+    color: var(--accent);
+}
+
+.init-url label {
+    display: block;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-bottom: 0.5rem;
+}
+
+.expires-info {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+}
+
+.token-created-success button {
+    background: var(--accent);
+    border: none;
+    color: white;
+    padding: 0.5rem 2rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+/* Confirmation Modal */
+.confirm-modal {
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    max-width: 400px;
+    text-align: center;
+}
+
+.confirm-modal p {
+    color: var(--text-primary);
+    margin: 0 0 1.5rem 0;
+    font-size: 1rem;
+}
+
+.confirm-actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+}
+
+.cancel-button {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    padding: 0.5rem 1.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.cancel-button:hover {
+    border-color: var(--text-secondary);
+}
+
+.confirm-button {
+    background: var(--error);
+    border: none;
+    color: white;
+    padding: 0.5rem 1.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.confirm-button:hover {
+    background: #ff5a72;
+}
+
+/* Empty State */
+.tokens-section .empty-state,
+.sessions-section .empty-state {
+    text-align: center;
+    padding: 3rem;
+    color: var(--text-secondary);
+}
+
+/* Loading State */
+.tokens-section .loading,
+.sessions-section .loading {
+    text-align: center;
+    padding: 3rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .settings-header {
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .settings-header h1 {
+        order: -1;
+        flex-basis: 100%;
+        text-align: center;
+    }
+
+    .settings-tabs {
+        padding: 0 1rem;
+        overflow-x: auto;
+    }
+
+    .settings-content {
+        padding: 1rem;
+    }
+
+    .section-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .create-button {
+        width: 100%;
+        text-align: center;
+    }
+
+    .create-token-form form {
+        flex-direction: column;
+    }
+
+    .form-group input {
+        width: 100%;
+        min-width: auto;
+    }
+
+    .table-container {
+        font-size: 0.85rem;
+    }
+
+    .tokens-table th,
+    .tokens-table td,
+    .sessions-table th,
+    .sessions-table td {
+        padding: 0.5rem;
+    }
+
+    /* Hide less important columns on mobile */
+    .token-created,
+    .session-created {
+        display: none;
+    }
+}

--- a/shared/src/proxy_tokens.rs
+++ b/shared/src/proxy_tokens.rs
@@ -76,7 +76,7 @@ pub struct CreateProxyTokenResponse {
 }
 
 /// Info about an existing proxy token (without the secret)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProxyTokenInfo {
     pub id: Uuid,
     pub name: String,


### PR DESCRIPTION
## Summary
- Adds a new Settings page (`/settings`) for managing sessions and credentials
- Accessible via "Settings" button in dashboard header
- Implements token creation, viewing, and revocation
- Implements session viewing and deletion
- Shows expiration warnings for tokens approaching expiry

## Features

### Session Management Tab
- Lists all sessions with metadata (project, directory, branch, status)
- Shows last activity and creation timestamps
- Delete sessions with confirmation dialog
- Status indicators (active/inactive/disconnected)

### Credentials Tab  
- Lists all proxy authentication tokens
- Shows name, creation date, last used, expiration
- Create new tokens with custom name and expiration period
- Revoke tokens with confirmation
- Visual indicators for token status (active/expiring soon/expired/revoked)
- Badge showing count of tokens expiring within 7 days

## Screenshots
The page features a tabbed interface with:
- Clean table layouts for both sessions and tokens
- Responsive design for mobile
- Confirmation modals for destructive actions
- Token creation form with immediate display of new token

## Test plan
- [ ] Navigate to Settings from dashboard
- [ ] View sessions list and delete a session
- [ ] View tokens list
- [ ] Create a new token, verify it displays once
- [ ] Revoke a token, verify it shows as revoked
- [ ] Check expiration warnings display correctly
- [ ] Verify mobile responsiveness

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)