### PR TITLE
Hide bare status system messages in frontend

### DIFF
--- a/frontend/src/components/message_renderer.rs
+++ b/frontend/src/components/message_renderer.rs
@@ -466,8 +466,10 @@ fn render_overload_error(msg: &ErrorMessage) -> Html {
 fn render_system_message(msg: &SystemMessage) -> Html {
     let subtype = msg.subtype.as_deref().unwrap_or("system");
 
-    // Hide init messages - they're not informative to users
-    if subtype == "init" {
+    // Hide uninformative system messages
+    // - "init": Session initialization (no useful info)
+    // - "status": Bare status updates with no content
+    if subtype == "init" || subtype == "status" {
         return html! {};
     }
 


### PR DESCRIPTION
## Summary
- Hides system messages with subtype "status" that provide no useful content
- These were appearing as bare "Status" text with no context
- Follows the same pattern as hiding "init" messages

Fixes #72

## Test plan
- [ ] Bare "Status" lines no longer appear in terminal view
- [ ] Other system messages still render correctly