### PR TITLE
Add WebSocket reconnection with status banner

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2413,6 +2413,34 @@ body {
     animation: pulse 2s infinite;
 }
 
+/* Reconnection banner */
+.reconnection-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 0.5rem 1rem;
+    background: rgba(247, 118, 142, 0.15);
+    border-bottom: 1px solid rgba(247, 118, 142, 0.3);
+}
+
+.reconnection-banner .reconnection-spinner {
+    color: var(--error);
+    font-size: 1rem;
+    animation: spin 1s linear infinite;
+}
+
+.reconnection-banner .reconnection-text {
+    color: var(--error);
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
 .focus-flow-header .new-session-button {
     padding: 0.5rem 1rem;
     border-radius: 6px;


### PR DESCRIPTION
## Summary
- Add visual reconnection banner when sessions disconnect from the server
- Implement automatic reconnection with exponential backoff (1s, 2s, 4s, 8s, 16s, 30s max)
- Preserve user input text during disconnection so nothing is lost
- Resume sessions with `resuming: true` flag after reconnection

## Test plan
- [ ] Start backend and frontend with `./scripts/dev.sh start`
- [ ] Open dashboard in browser with a session
- [ ] Stop backend: `./scripts/dev.sh stop`
- [ ] Verify banner appears showing "Reconnecting... (attempt N)"
- [ ] Verify input text remains in chat bar
- [ ] Restart backend
- [ ] Verify banner disappears and connection resumes
- [ ] Verify session continues working normally