### PR TITLE
Build backend in CI with caching for faster container builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
         with:
@@ -34,8 +37,17 @@ jobs:
       - name: Install trunk
         run: cargo install trunk --locked
 
+      - name: Build backend
+        run: cargo build --release -p backend
+
       - name: Build frontend
         run: cd frontend && trunk build
+
+      - name: Prepare build artifacts
+        run: |
+          mkdir -p build-output
+          cp target/release/backend build-output/
+          cp -r frontend/dist build-output/frontend-dist
 
       - name: Log in to Container Registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- Build backend binary in CI runner instead of inside Docker container
- Leverage Rust build caching (`Swatinem/rust-cache`) for faster incremental builds
- Simplify Dockerfile to just copy pre-built artifacts

## Changes
- **container.yml**: Added backend build step before Docker build, copies artifacts to `build-output/`
- **Dockerfile**: Removed multi-stage Rust build, now just copies pre-built binaries

## Benefits
- Faster builds: CI caching means only changed code needs recompilation
- Simpler Dockerfile: No Rust toolchain needed in container
- Smaller build context: Only final artifacts are copied

## Test plan
- [ ] Container workflow passes (builds backend + Docker image)
- [ ] Container image works correctly when deployed