### PR TITLE
Add replay_after to WebSocket Register for deduplication

### DIFF
--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -346,6 +346,7 @@ async fn register_session(
         working_directory: config.working_directory.clone(),
         resuming: config.resuming,
         git_branch: config.git_branch.clone(),
+        replay_after: None, // Proxy doesn't need history replay
     };
 
     if let Err(e) = conn.send(&register_msg).await {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -32,6 +32,10 @@ pub enum ProxyMessage {
         /// Current git branch (if in a git repo)
         #[serde(default)]
         git_branch: Option<String>,
+        /// Only replay messages created after this timestamp (ISO 8601 format)
+        /// If None, replay all history. Used by web clients to avoid duplicate messages.
+        #[serde(default)]
+        replay_after: Option<String>,
     },
 
     /// Output from Claude Code to be displayed


### PR DESCRIPTION
## Summary
- Eliminates duplicate messages when frontend reconnects by adding `replay_after` timestamp field to WebSocket Register message
- Backend filters message history to only replay messages after the specified timestamp
- Frontend tracks last message timestamp and uses it on reconnection

## Test plan
- [ ] Connect to a session, send messages, then disconnect/reconnect - should not see duplicate messages
- [ ] Test initial page load - should fetch REST messages first, then WebSocket only delivers new ones
- [ ] Test with no prior messages - should work normally with replay_after = None

🤖 Generated with [Claude Code](https://claude.com/claude-code)