### PR TITLE
Queue messages for disconnected proxies

### DIFF
--- a/backend/src/handlers/websocket.rs
+++ b/backend/src/handlers/websocket.rs
@@ -11,13 +11,28 @@ use dashmap::DashMap;
 use diesel::prelude::*;
 use futures_util::{SinkExt, StreamExt};
 use shared::ProxyMessage;
+use std::collections::VecDeque;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tower_cookies::Cookies;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 const SESSION_COOKIE_NAME: &str = "cc_session";
+
+/// Maximum number of messages to queue per session when proxy is disconnected
+const MAX_PENDING_MESSAGES_PER_SESSION: usize = 100;
+
+/// Maximum age of pending messages before they're dropped (5 minutes)
+const MAX_PENDING_MESSAGE_AGE: Duration = Duration::from_secs(300);
+
+/// A message queued for a disconnected proxy
+#[derive(Clone)]
+struct PendingMessage {
+    msg: ProxyMessage,
+    queued_at: Instant,
+}
 
 pub type SessionId = String;
 pub type ClientSender = mpsc::UnboundedSender<ProxyMessage>;
@@ -32,6 +47,8 @@ pub struct SessionManager {
     pub user_clients: Arc<DashMap<Uuid, Vec<ClientSender>>>,
     // Map of session_id -> last acknowledged sequence number (for deduplication)
     pub last_ack_seq: Arc<DashMap<Uuid, u64>>,
+    // Map of session_key -> pending messages for disconnected proxies
+    pending_messages: Arc<DashMap<SessionId, VecDeque<PendingMessage>>>,
 }
 
 impl Default for SessionManager {
@@ -41,6 +58,7 @@ impl Default for SessionManager {
             web_clients: Arc::new(DashMap::new()),
             user_clients: Arc::new(DashMap::new()),
             last_ack_seq: Arc::new(DashMap::new()),
+            pending_messages: Arc::new(DashMap::new()),
         }
     }
 }
@@ -52,12 +70,56 @@ impl SessionManager {
 
     pub fn register_session(&self, session_key: SessionId, sender: ClientSender) {
         info!("Registering session: {}", session_key);
+
+        // Replay any pending messages before registering the new sender
+        let pending_count = self.replay_pending_messages(&session_key, &sender);
+        if pending_count > 0 {
+            info!(
+                "Replayed {} pending messages to reconnected proxy for session: {}",
+                pending_count, session_key
+            );
+        }
+
         self.sessions.insert(session_key, sender);
+    }
+
+    /// Replay pending messages to a newly connected proxy
+    /// Returns the number of messages replayed
+    fn replay_pending_messages(&self, session_key: &SessionId, sender: &ClientSender) -> usize {
+        let mut replayed = 0;
+        let now = Instant::now();
+
+        if let Some(mut pending) = self.pending_messages.get_mut(session_key) {
+            // Filter out expired messages and send valid ones
+            while let Some(pending_msg) = pending.pop_front() {
+                if now.duration_since(pending_msg.queued_at) < MAX_PENDING_MESSAGE_AGE {
+                    if sender.send(pending_msg.msg).is_ok() {
+                        replayed += 1;
+                    } else {
+                        // Sender failed, stop replaying
+                        warn!("Failed to replay pending message, sender closed");
+                        break;
+                    }
+                } else {
+                    debug!(
+                        "Dropping expired pending message (age: {:?})",
+                        now.duration_since(pending_msg.queued_at)
+                    );
+                }
+            }
+        }
+
+        // Clean up the pending queue for this session
+        self.pending_messages.remove(session_key);
+
+        replayed
     }
 
     pub fn unregister_session(&self, session_key: &SessionId) {
         info!("Unregistering session: {}", session_key);
         self.sessions.remove(session_key);
+        // Note: We keep pending_messages around so messages can still be queued
+        // and will be delivered when the proxy reconnects
     }
 
     pub fn add_web_client(&self, session_key: SessionId, sender: ClientSender) {
@@ -74,12 +136,59 @@ impl SessionManager {
         }
     }
 
+    /// Send a message to a session's proxy.
+    /// If the proxy is disconnected, the message is queued for delivery when it reconnects.
+    /// Returns true if the message was sent or queued successfully.
     pub fn send_to_session(&self, session_key: &SessionId, msg: ProxyMessage) -> bool {
         if let Some(sender) = self.sessions.get(session_key) {
-            sender.send(msg).is_ok()
-        } else {
-            false
+            if sender.send(msg.clone()).is_ok() {
+                return true;
+            }
         }
+
+        // Proxy not connected or send failed - queue the message
+        self.queue_pending_message(session_key, msg)
+    }
+
+    /// Queue a message for a disconnected proxy
+    fn queue_pending_message(&self, session_key: &SessionId, msg: ProxyMessage) -> bool {
+        let mut queue = self
+            .pending_messages
+            .entry(session_key.clone())
+            .or_default();
+
+        // Enforce size limit - drop oldest messages if queue is full
+        while queue.len() >= MAX_PENDING_MESSAGES_PER_SESSION {
+            if let Some(dropped) = queue.pop_front() {
+                warn!(
+                    "Pending message queue full for session {}, dropping oldest message (age: {:?})",
+                    session_key,
+                    Instant::now().duration_since(dropped.queued_at)
+                );
+            }
+        }
+
+        queue.push_back(PendingMessage {
+            msg,
+            queued_at: Instant::now(),
+        });
+
+        info!(
+            "Queued message for disconnected proxy, session: {}, queue size: {}",
+            session_key,
+            queue.len()
+        );
+
+        true
+    }
+
+    /// Get the number of pending messages for a session (for monitoring/debugging)
+    #[allow(dead_code)]
+    pub fn pending_message_count(&self, session_key: &SessionId) -> usize {
+        self.pending_messages
+            .get(session_key)
+            .map(|q| q.len())
+            .unwrap_or(0)
     }
 
     pub fn add_user_client(&self, user_id: Uuid, sender: ClientSender) {


### PR DESCRIPTION
## Summary
- Add pending message queue to `SessionManager` for messages sent to disconnected proxies
- Replay queued messages when proxy reconnects
- Prevent message loss during proxy reconnection window

## Problem
When the backend restarts or the proxy temporarily disconnects, messages sent by the frontend during the reconnection window were silently dropped. The `send_to_session()` function returned `false` and logged a warning, but the message was lost forever.

## Solution
Add an in-memory queue per session that:
- Queues `ClaudeInput` and `PermissionResponse` messages when the proxy is disconnected
- Replays all pending messages when the proxy re-registers
- Enforces a size limit (100 messages) to prevent memory exhaustion
- Drops messages older than 5 minutes to prevent stale input
- Logs queue activity for debugging

## Test plan
- [ ] Start backend and proxy, open frontend
- [ ] Stop the backend (`./scripts/dev.sh stop`)
- [ ] Send a message from the frontend (it should queue)
- [ ] Restart the backend (`./scripts/dev.sh start`)
- [ ] Verify proxy reconnects and receives the queued message
- [ ] Verify the message appears in Claude's input