### PR TITLE
Fix awaiting state not updating after LoadHistory

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -1314,6 +1314,8 @@ impl Component for SessionView {
                 self.messages = messages;
                 // Store timestamp for reconnection replay_after
                 self.last_message_timestamp = last_timestamp;
+                // Trigger CheckAwaiting to update parent state based on loaded messages
+                ctx.link().send_message(SessionViewMsg::CheckAwaiting);
                 true
             }
             SessionViewMsg::ReceivedOutput(output) => {


### PR DESCRIPTION
## Summary
- Fix bug where sessions weren't marked as "awaiting input" after loading history via REST
- Root cause: `CheckAwaiting` checks `self.messages`, but messages weren't populated yet
- Solution: Trigger `CheckAwaiting` after `LoadHistory` populates `self.messages`

## Test plan
- [ ] Load a session that's waiting for user input - should show awaiting indicator
- [ ] Load a session that's mid-task - should not show awaiting indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)