### PR TITLE
Make paused sessions more greyed out and disable awaiting highlight

### DIFF
--- a/frontend/styles/session-view.css
+++ b/frontend/styles/session-view.css
@@ -311,18 +311,33 @@
     color: var(--text-secondary);
 }
 
-/* Paused session styling */
+/* Paused session styling - more greyed out, no awaiting highlight */
 .session-pill.paused {
-    opacity: 0.5;
+    opacity: 0.35;
     border-style: dashed;
+    filter: grayscale(50%);
 }
 
 .session-pill.paused:hover {
-    opacity: 0.75;
+    opacity: 0.55;
+    filter: grayscale(30%);
 }
 
 .session-pill.paused.focused {
-    opacity: 0.7;
+    opacity: 0.5;
+    filter: grayscale(40%);
+}
+
+/* Paused sessions should NOT show awaiting (red) highlighting */
+.session-pill.paused.awaiting {
+    border-color: var(--border);
+    animation: none;
+    box-shadow: none;
+}
+
+.session-pill.paused.focused.awaiting {
+    border-color: var(--text-secondary);
+    background: rgba(127, 132, 156, 0.15);
 }
 
 .pill-paused-badge {


### PR DESCRIPTION
## Summary
- Reduce opacity from 0.5 to 0.35 for paused sessions to make them more visually subdued
- Add grayscale filter to make paused sessions dimmer
- Override awaiting (red) styling for paused sessions - paused sessions shouldn't show the urgent red border/animation

## Test plan
- [ ] Open dashboard with multiple sessions
- [ ] Pause a session and verify it appears more greyed out than before
- [ ] Have a paused session that is awaiting input and verify it does NOT show the red awaiting highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)