### PR TITLE
Add voice STT debugging logs, keyboard shortcut, and auto-send

### DIFF
--- a/backend/src/handlers/voice.rs
+++ b/backend/src/handlers/voice.rs
@@ -235,6 +235,10 @@ async fn handle_voice_socket(
                                     let client_tx_clone = client_tx.clone();
                                     tokio::spawn(async move {
                                         while let Some(result) = result_rx.recv().await {
+                                            info!(
+                                                "Forwarding to WebSocket: is_final={}, transcript=\"{}\"",
+                                                result.is_final, result.transcript
+                                            );
                                             let msg = ProxyMessage::Transcription {
                                                 session_id,
                                                 transcript: result.transcript,
@@ -242,6 +246,7 @@ async fn handle_voice_socket(
                                                 confidence: result.confidence,
                                             };
                                             if client_tx_clone.send(msg).is_err() {
+                                                info!("Client disconnected, stopping transcription forwarding");
                                                 break;
                                             }
                                         }

--- a/backend/src/speech.rs
+++ b/backend/src/speech.rs
@@ -50,7 +50,7 @@ impl Default for SpeechConfig {
             language_code: "en-US".to_string(),
             encoding: AudioEncoding::Linear16,
             interim_results: true,
-            single_utterance: true, // Auto-stop when speaker finishes
+            single_utterance: true, // Auto-end when speaker stops, sends final result immediately
         }
     }
 }
@@ -195,9 +195,36 @@ async fn run_recognition(
     });
 
     // Process recognition results
+    // Google can send multiple results per response - log ALL of them for debugging
     while let Some(response) = result_receiver.recv().await {
-        for result in response.results {
+        let result_count = response.results.len();
+        info!("Received STT response with {} result(s)", result_count);
+
+        // Log ALL results in the response for debugging
+        for (idx, result) in response.results.iter().enumerate() {
+            let alternatives_count = result.alternatives.len();
+            info!(
+                "  Result[{}]: is_final={}, stability={:.3}, alternatives={}",
+                idx, result.is_final, result.stability, alternatives_count
+            );
+
+            for (alt_idx, alt) in result.alternatives.iter().enumerate() {
+                info!(
+                    "    Alt[{}]: confidence={:.3}, transcript=\"{}\"",
+                    alt_idx, alt.confidence, alt.transcript
+                );
+            }
+        }
+
+        // Use the last result which is typically the most complete/stable
+        // Earlier results in the array may be partial word fragments
+        if let Some(result) = response.results.last() {
             if let Some(alternative) = result.alternatives.first() {
+                info!(
+                    ">>> Sending to frontend: is_final={}, transcript=\"{}\"",
+                    result.is_final, alternative.transcript
+                );
+
                 let transcription = TranscriptionResult {
                     transcript: alternative.transcript.clone(),
                     is_final: result.is_final,

--- a/frontend/src/components/voice_input.rs
+++ b/frontend/src/components/voice_input.rs
@@ -58,6 +58,9 @@ pub struct VoiceInputProps {
     /// Whether the component is disabled
     #[prop_or(false)]
     pub disabled: bool,
+    /// Optional NodeRef to attach to the button for programmatic control
+    #[prop_or_default]
+    pub button_ref: Option<NodeRef>,
 }
 
 /// Voice input state
@@ -244,9 +247,9 @@ impl Component for VoiceInput {
         let title = if !self.browser_supported {
             "Voice input not supported in this browser"
         } else if self.is_recording {
-            "Stop recording"
+            "Stop recording (Ctrl+M)"
         } else {
-            "Start voice input"
+            "Start voice input (Ctrl+M)"
         };
 
         // Calculate volume level bar style when recording
@@ -263,8 +266,12 @@ impl Component for VoiceInput {
             String::new()
         };
 
+        // Use provided ref or create a dummy one (button_ref is optional for keyboard shortcut)
+        let button_ref = ctx.props().button_ref.clone().unwrap_or_default();
+
         html! {
             <button
+                ref={button_ref}
                 class={button_class}
                 onclick={onclick}
                 disabled={disabled}


### PR DESCRIPTION
## Summary
- Add detailed INFO logging for Google Speech-to-Text responses to debug display issues (logs result count, stability, all transcripts)
- Add Ctrl+M keyboard shortcut to toggle voice recording
- Auto-send message to Claude when final transcription is received (with `single_utterance: true` mode)
- Use last result from STT response (most complete) instead of iterating all results

## Test plan
- [ ] Enable voice for a user and test Ctrl+M toggles recording
- [ ] Speak and verify message auto-sends after speech ends
- [ ] Check backend logs for detailed STT response information
- [ ] Verify volume level indicator still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)