### PR TITLE
Show voice shortcut hint when voice is enabled

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -734,6 +734,9 @@ pub fn dashboard_page() -> Html {
                                         <span>{ "Esc = nav mode" }</span>
                                         <span>{ "Shift+Tab = next (skip paused)" }</span>
                                         <span>{ "Ctrl+Shift+P = pause" }</span>
+                                        if *voice_enabled {
+                                            <span>{ "Ctrl+M = voice" }</span>
+                                        }
                                         <span>{ "Enter = send" }</span>
                                     </>
                                 }


### PR DESCRIPTION
## Summary
- Displays "Ctrl+M = voice" in the keyboard hints bar when voice is enabled for the user

## Test plan
- [ ] Set voice_enabled=true for a user in the database
- [ ] Verify the keyboard hints bar shows "Ctrl+M = voice"
- [ ] Verify users without voice enabled do not see the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)