### PR TITLE
Add session sharing UI with member management

### DIFF
--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -3,19 +3,31 @@ use axum::{
     http::StatusCode,
     Json,
 };
+use chrono::NaiveDateTime;
 use diesel::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tower_cookies::Cookies;
 use uuid::Uuid;
 
-use crate::{models::Message, models::Session, AppState};
+use crate::{
+    models::{Message, NewSessionMember, Session, SessionMember},
+    AppState,
+};
 
 const SESSION_COOKIE_NAME: &str = "cc_session";
 
+/// Session with the current user's role included
+#[derive(Debug, Serialize)]
+pub struct SessionWithRole {
+    #[serde(flatten)]
+    pub session: Session,
+    pub my_role: String,
+}
+
 #[derive(Debug, Serialize)]
 pub struct SessionListResponse {
-    pub sessions: Vec<Session>,
+    pub sessions: Vec<SessionWithRole>,
 }
 
 pub async fn list_sessions(
@@ -32,16 +44,26 @@ pub async fn list_sessions(
 
     use crate::schema::{session_members, sessions};
 
-    // Get all sessions the user is a member of (owner, editor, or viewer)
-    let results = sessions::table
+    // Get all sessions the user is a member of, including their role
+    let results: Vec<(Session, String)> = sessions::table
         .inner_join(session_members::table.on(session_members::session_id.eq(sessions::id)))
         .filter(session_members::user_id.eq(current_user_id))
-        .select(Session::as_select())
+        .select((Session::as_select(), session_members::role))
         .order(sessions::last_activity.desc())
-        .load::<Session>(&mut conn)
+        .load(&mut conn)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    Ok(Json(SessionListResponse { sessions: results }))
+    let sessions_with_role = results
+        .into_iter()
+        .map(|(session, role)| SessionWithRole {
+            session,
+            my_role: role,
+        })
+        .collect();
+
+    Ok(Json(SessionListResponse {
+        sessions: sessions_with_role,
+    }))
 }
 
 /// Extract user_id from signed session cookie
@@ -182,4 +204,265 @@ pub async fn delete_session(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+// ============================================================================
+// Session Member Management
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+pub struct SessionMemberInfo {
+    pub user_id: Uuid,
+    pub email: String,
+    pub name: Option<String>,
+    pub role: String,
+    pub created_at: NaiveDateTime,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionMembersResponse {
+    pub members: Vec<SessionMemberInfo>,
+}
+
+/// User info selected from joined query
+#[derive(Debug, Queryable)]
+struct UserBasicInfo {
+    id: Uuid,
+    email: String,
+    name: Option<String>,
+}
+
+/// List all members of a session
+pub async fn list_session_members(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path(session_id): Path<Uuid>,
+) -> Result<Json<SessionMembersResponse>, StatusCode> {
+    let current_user_id = extract_user_id(&app_state, &cookies)?;
+
+    let mut conn = app_state
+        .db_pool
+        .get()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    use crate::schema::{session_members, users};
+
+    // Verify the current user is a member of this session
+    let _membership = session_members::table
+        .filter(session_members::session_id.eq(session_id))
+        .filter(session_members::user_id.eq(current_user_id))
+        .first::<SessionMember>(&mut conn)
+        .optional()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    // Get all members with user info
+    let members: Vec<(SessionMember, UserBasicInfo)> = session_members::table
+        .inner_join(users::table.on(users::id.eq(session_members::user_id)))
+        .filter(session_members::session_id.eq(session_id))
+        .select((
+            SessionMember::as_select(),
+            (users::id, users::email, users::name),
+        ))
+        .load(&mut conn)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let member_infos = members
+        .into_iter()
+        .map(|(member, user)| SessionMemberInfo {
+            user_id: user.id,
+            email: user.email,
+            name: user.name,
+            role: member.role,
+            created_at: member.created_at,
+        })
+        .collect();
+
+    Ok(Json(SessionMembersResponse {
+        members: member_infos,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AddMemberRequest {
+    pub email: String,
+    pub role: String,
+}
+
+/// Add a member to a session (owner only)
+pub async fn add_session_member(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path(session_id): Path<Uuid>,
+    Json(req): Json<AddMemberRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let current_user_id = extract_user_id(&app_state, &cookies)?;
+
+    // Validate role
+    if req.role != "editor" && req.role != "viewer" {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let mut conn = app_state
+        .db_pool
+        .get()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    use crate::schema::{session_members, users};
+
+    // Verify the current user is the owner
+    let _owner_membership = session_members::table
+        .filter(session_members::session_id.eq(session_id))
+        .filter(session_members::user_id.eq(current_user_id))
+        .filter(session_members::role.eq("owner"))
+        .first::<SessionMember>(&mut conn)
+        .optional()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::FORBIDDEN)?;
+
+    // Find the user by email
+    let target_user_id: Uuid = users::table
+        .filter(users::email.eq(&req.email))
+        .select(users::id)
+        .first(&mut conn)
+        .optional()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    // Check if user is already a member
+    let existing = session_members::table
+        .filter(session_members::session_id.eq(session_id))
+        .filter(session_members::user_id.eq(target_user_id))
+        .first::<SessionMember>(&mut conn)
+        .optional()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if existing.is_some() {
+        return Err(StatusCode::CONFLICT);
+    }
+
+    // Add the member
+    let new_member = NewSessionMember {
+        session_id,
+        user_id: target_user_id,
+        role: req.role,
+    };
+
+    diesel::insert_into(session_members::table)
+        .values(&new_member)
+        .execute(&mut conn)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(StatusCode::CREATED)
+}
+
+/// Remove a member from a session
+/// Owner can remove anyone; non-owner can only remove themselves (leave)
+pub async fn remove_session_member(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path((session_id, target_user_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, StatusCode> {
+    let current_user_id = extract_user_id(&app_state, &cookies)?;
+
+    let mut conn = app_state
+        .db_pool
+        .get()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    use crate::schema::session_members;
+
+    // Get the current user's membership
+    let current_membership = session_members::table
+        .filter(session_members::session_id.eq(session_id))
+        .filter(session_members::user_id.eq(current_user_id))
+        .first::<SessionMember>(&mut conn)
+        .optional()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let is_owner = current_membership.role == "owner";
+
+    // Non-owners can only remove themselves
+    if !is_owner && current_user_id != target_user_id {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    // Owners cannot remove themselves (would leave session ownerless)
+    if is_owner && current_user_id == target_user_id {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    // Remove the member
+    let deleted = diesel::delete(
+        session_members::table
+            .filter(session_members::session_id.eq(session_id))
+            .filter(session_members::user_id.eq(target_user_id)),
+    )
+    .execute(&mut conn)
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if deleted == 0 {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateMemberRoleRequest {
+    pub role: String,
+}
+
+/// Update a member's role (owner only)
+pub async fn update_session_member_role(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path((session_id, target_user_id)): Path<(Uuid, Uuid)>,
+    Json(req): Json<UpdateMemberRoleRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let current_user_id = extract_user_id(&app_state, &cookies)?;
+
+    // Validate role
+    if req.role != "editor" && req.role != "viewer" {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let mut conn = app_state
+        .db_pool
+        .get()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    use crate::schema::session_members;
+
+    // Verify the current user is the owner
+    let _owner_membership = session_members::table
+        .filter(session_members::session_id.eq(session_id))
+        .filter(session_members::user_id.eq(current_user_id))
+        .filter(session_members::role.eq("owner"))
+        .first::<SessionMember>(&mut conn)
+        .optional()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::FORBIDDEN)?;
+
+    // Cannot change own role
+    if current_user_id == target_user_id {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    // Update the role
+    let updated = diesel::update(
+        session_members::table
+            .filter(session_members::session_id.eq(session_id))
+            .filter(session_members::user_id.eq(target_user_id)),
+    )
+    .set(session_members::role.eq(&req.role))
+    .execute(&mut conn)
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if updated == 0 {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(StatusCode::OK)
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -247,6 +247,17 @@ async fn main() -> anyhow::Result<()> {
             "/api/sessions/:id",
             axum::routing::delete(handlers::sessions::delete_session),
         )
+        // Session member management routes
+        .route(
+            "/api/sessions/:id/members",
+            get(handlers::sessions::list_session_members)
+                .post(handlers::sessions::add_session_member),
+        )
+        .route(
+            "/api/sessions/:id/members/:user_id",
+            axum::routing::delete(handlers::sessions::remove_session_member)
+                .patch(handlers::sessions::update_session_member_role),
+        )
         .route(
             "/api/sessions/:id/messages",
             get(handlers::messages::list_messages).post(handlers::messages::create_message),

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -168,7 +168,6 @@ pub struct NewDeletedSessionCosts {
 // Session Member Models
 // ============================================================================
 
-#[allow(dead_code)] // Will be used for querying session membership in UI
 #[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]
 #[diesel(table_name = crate::schema::session_members)]
 #[diesel(check_for_backend(diesel::pg::Pg))]

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -24,6 +24,7 @@ web-sys = { workspace = true, features = [
     "Window",
     "Document",
     "HtmlElement",
+    "HtmlSelectElement",
     "Location",
     "Storage",
     "Navigator",

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -2,9 +2,11 @@ mod copy_command;
 mod markdown;
 mod message_renderer;
 mod proxy_token_setup;
+mod share_dialog;
 mod voice_input;
 
 pub use copy_command::CopyCommand;
 pub use message_renderer::{group_messages, MessageGroupRenderer};
 pub use proxy_token_setup::ProxyTokenSetup;
+pub use share_dialog::ShareDialog;
 pub use voice_input::VoiceInput;

--- a/frontend/src/components/share_dialog.rs
+++ b/frontend/src/components/share_dialog.rs
@@ -1,0 +1,380 @@
+use gloo_net::http::Request;
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+use crate::utils;
+
+/// Member info returned from API
+#[derive(Clone, Debug, PartialEq, serde::Deserialize)]
+pub struct MemberInfo {
+    pub user_id: Uuid,
+    pub email: String,
+    pub name: Option<String>,
+    pub role: String,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize)]
+struct MembersResponse {
+    members: Vec<MemberInfo>,
+}
+
+#[derive(Properties, PartialEq)]
+pub struct ShareDialogProps {
+    pub session_id: Uuid,
+    pub on_close: Callback<()>,
+}
+
+pub enum ShareDialogMsg {
+    LoadMembers,
+    MembersLoaded(Vec<MemberInfo>),
+    UpdateEmail(String),
+    UpdateRole(String),
+    AddMember,
+    MemberAdded,
+    RemoveMember(Uuid),
+    MemberRemoved(Uuid),
+    ChangeRole(Uuid, String),
+    RoleChanged(Uuid, String),
+    SetError(String),
+}
+
+pub struct ShareDialog {
+    members: Vec<MemberInfo>,
+    loading: bool,
+    email_input: String,
+    new_role: String,
+    error: Option<String>,
+}
+
+impl Component for ShareDialog {
+    type Message = ShareDialogMsg;
+    type Properties = ShareDialogProps;
+
+    fn create(ctx: &Context<Self>) -> Self {
+        ctx.link().send_message(ShareDialogMsg::LoadMembers);
+        Self {
+            members: Vec::new(),
+            loading: true,
+            email_input: String::new(),
+            new_role: "viewer".to_string(),
+            error: None,
+        }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            ShareDialogMsg::LoadMembers => {
+                self.loading = true;
+                let session_id = ctx.props().session_id;
+                let link = ctx.link().clone();
+                spawn_local(async move {
+                    let url = utils::api_url(&format!("/api/sessions/{}/members", session_id));
+                    match Request::get(&url).send().await {
+                        Ok(response) if response.ok() => {
+                            if let Ok(data) = response.json::<MembersResponse>().await {
+                                link.send_message(ShareDialogMsg::MembersLoaded(data.members));
+                            }
+                        }
+                        Ok(response) => {
+                            log::error!("Failed to load members: {}", response.status());
+                            link.send_message(ShareDialogMsg::SetError(
+                                "Failed to load members".to_string(),
+                            ));
+                        }
+                        Err(e) => {
+                            log::error!("Failed to load members: {:?}", e);
+                            link.send_message(ShareDialogMsg::SetError(
+                                "Failed to load members".to_string(),
+                            ));
+                        }
+                    }
+                });
+                true
+            }
+            ShareDialogMsg::MembersLoaded(members) => {
+                self.members = members;
+                self.loading = false;
+                true
+            }
+            ShareDialogMsg::UpdateEmail(email) => {
+                self.email_input = email;
+                true
+            }
+            ShareDialogMsg::UpdateRole(role) => {
+                self.new_role = role;
+                true
+            }
+            ShareDialogMsg::AddMember => {
+                if self.email_input.trim().is_empty() {
+                    return false;
+                }
+                let session_id = ctx.props().session_id;
+                let email = self.email_input.trim().to_string();
+                let role = self.new_role.clone();
+                let link = ctx.link().clone();
+
+                spawn_local(async move {
+                    let url = utils::api_url(&format!("/api/sessions/{}/members", session_id));
+                    let body = serde_json::json!({ "email": email, "role": role });
+                    match Request::post(&url)
+                        .header("Content-Type", "application/json")
+                        .body(body.to_string())
+                        .unwrap()
+                        .send()
+                        .await
+                    {
+                        Ok(response) if response.status() == 201 => {
+                            link.send_message(ShareDialogMsg::MemberAdded);
+                        }
+                        Ok(response) if response.status() == 404 => {
+                            link.send_message(ShareDialogMsg::SetError(
+                                "User not found".to_string(),
+                            ));
+                        }
+                        Ok(response) if response.status() == 409 => {
+                            link.send_message(ShareDialogMsg::SetError(
+                                "User is already a member".to_string(),
+                            ));
+                        }
+                        Ok(response) => {
+                            log::error!("Failed to add member: {}", response.status());
+                            link.send_message(ShareDialogMsg::SetError(
+                                "Failed to add member".to_string(),
+                            ));
+                        }
+                        Err(e) => {
+                            log::error!("Failed to add member: {:?}", e);
+                            link.send_message(ShareDialogMsg::SetError(
+                                "Failed to add member".to_string(),
+                            ));
+                        }
+                    }
+                });
+                true
+            }
+            ShareDialogMsg::MemberAdded => {
+                self.email_input.clear();
+                self.error = None;
+                ctx.link().send_message(ShareDialogMsg::LoadMembers);
+                true
+            }
+            ShareDialogMsg::RemoveMember(user_id) => {
+                let session_id = ctx.props().session_id;
+                let link = ctx.link().clone();
+                spawn_local(async move {
+                    let url = utils::api_url(&format!(
+                        "/api/sessions/{}/members/{}",
+                        session_id, user_id
+                    ));
+                    match Request::delete(&url).send().await {
+                        Ok(response) if response.status() == 204 => {
+                            link.send_message(ShareDialogMsg::MemberRemoved(user_id));
+                        }
+                        Ok(response) => {
+                            log::error!("Failed to remove member: {}", response.status());
+                            link.send_message(ShareDialogMsg::SetError(
+                                "Failed to remove member".to_string(),
+                            ));
+                        }
+                        Err(e) => {
+                            log::error!("Failed to remove member: {:?}", e);
+                            link.send_message(ShareDialogMsg::SetError(
+                                "Failed to remove member".to_string(),
+                            ));
+                        }
+                    }
+                });
+                true
+            }
+            ShareDialogMsg::MemberRemoved(user_id) => {
+                self.members.retain(|m| m.user_id != user_id);
+                self.error = None;
+                true
+            }
+            ShareDialogMsg::ChangeRole(user_id, new_role) => {
+                let session_id = ctx.props().session_id;
+                let link = ctx.link().clone();
+                let role = new_role.clone();
+                spawn_local(async move {
+                    let url = utils::api_url(&format!(
+                        "/api/sessions/{}/members/{}",
+                        session_id, user_id
+                    ));
+                    let body = serde_json::json!({ "role": role });
+                    match Request::patch(&url)
+                        .header("Content-Type", "application/json")
+                        .body(body.to_string())
+                        .unwrap()
+                        .send()
+                        .await
+                    {
+                        Ok(response) if response.ok() => {
+                            link.send_message(ShareDialogMsg::RoleChanged(user_id, role));
+                        }
+                        Ok(response) => {
+                            log::error!("Failed to change role: {}", response.status());
+                            link.send_message(ShareDialogMsg::SetError(
+                                "Failed to change role".to_string(),
+                            ));
+                        }
+                        Err(e) => {
+                            log::error!("Failed to change role: {:?}", e);
+                            link.send_message(ShareDialogMsg::SetError(
+                                "Failed to change role".to_string(),
+                            ));
+                        }
+                    }
+                });
+                true
+            }
+            ShareDialogMsg::RoleChanged(user_id, new_role) => {
+                if let Some(member) = self.members.iter_mut().find(|m| m.user_id == user_id) {
+                    member.role = new_role;
+                }
+                self.error = None;
+                true
+            }
+            ShareDialogMsg::SetError(error) => {
+                self.error = Some(error);
+                self.loading = false;
+                true
+            }
+        }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let on_close = ctx.props().on_close.clone();
+        let on_overlay_click = {
+            let on_close = on_close.clone();
+            Callback::from(move |_| on_close.emit(()))
+        };
+        let on_dialog_click = Callback::from(|e: MouseEvent| {
+            e.stop_propagation();
+        });
+
+        let on_email_input = ctx.link().callback(|e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            ShareDialogMsg::UpdateEmail(input.value())
+        });
+
+        let on_role_change = ctx.link().callback(|e: Event| {
+            let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
+            ShareDialogMsg::UpdateRole(select.value())
+        });
+
+        let on_add_click = ctx.link().callback(|_| ShareDialogMsg::AddMember);
+
+        let on_keypress = ctx.link().batch_callback(|e: KeyboardEvent| {
+            if e.key() == "Enter" {
+                Some(ShareDialogMsg::AddMember)
+            } else {
+                None
+            }
+        });
+
+        html! {
+            <div class="share-dialog-overlay" onclick={on_overlay_click}>
+                <div class="share-dialog" onclick={on_dialog_click}>
+                    <div class="share-dialog-header">
+                        <h2>{ "Share Session" }</h2>
+                        <button class="share-dialog-close" onclick={move |_| on_close.emit(())}>
+                            { "×" }
+                        </button>
+                    </div>
+
+                    {
+                        if let Some(error) = &self.error {
+                            html! {
+                                <div class="share-dialog-error">
+                                    { error }
+                                </div>
+                            }
+                        } else {
+                            html! {}
+                        }
+                    }
+
+                    <div class="share-dialog-add">
+                        <input
+                            type="email"
+                            placeholder="Email address"
+                            value={self.email_input.clone()}
+                            oninput={on_email_input}
+                            onkeypress={on_keypress}
+                        />
+                        <select value={self.new_role.clone()} onchange={on_role_change}>
+                            <option value="viewer">{ "Viewer" }</option>
+                            <option value="editor">{ "Editor" }</option>
+                        </select>
+                        <button onclick={on_add_click}>{ "Add" }</button>
+                    </div>
+
+                    <div class="share-dialog-members">
+                        {
+                            if self.loading {
+                                html! { <div class="share-dialog-loading">{ "Loading..." }</div> }
+                            } else if self.members.is_empty() {
+                                html! { <div class="share-dialog-empty">{ "No members yet" }</div> }
+                            } else {
+                                html! {
+                                    <ul>
+                                        { for self.members.iter().map(|member| self.view_member(ctx, member)) }
+                                    </ul>
+                                }
+                            }
+                        }
+                    </div>
+                </div>
+            </div>
+        }
+    }
+}
+
+impl ShareDialog {
+    fn view_member(&self, ctx: &Context<Self>, member: &MemberInfo) -> Html {
+        let is_owner = member.role == "owner";
+        let user_id = member.user_id;
+        let display_name = member
+            .name
+            .as_ref()
+            .map(|n| format!("{} ({})", n, member.email))
+            .unwrap_or_else(|| member.email.clone());
+
+        let on_remove = ctx
+            .link()
+            .callback(move |_| ShareDialogMsg::RemoveMember(user_id));
+
+        let on_role_change = {
+            let link = ctx.link().clone();
+            Callback::from(move |e: Event| {
+                let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
+                link.send_message(ShareDialogMsg::ChangeRole(user_id, select.value()));
+            })
+        };
+
+        html! {
+            <li class="share-dialog-member">
+                <span class="member-name">{ display_name }</span>
+                {
+                    if is_owner {
+                        html! { <span class="member-role owner">{ "Owner" }</span> }
+                    } else {
+                        html! {
+                            <>
+                                <select class="member-role-select" value={member.role.clone()} onchange={on_role_change}>
+                                    <option value="viewer" selected={member.role == "viewer"}>{ "Viewer" }</option>
+                                    <option value="editor" selected={member.role == "editor"}>{ "Editor" }</option>
+                                </select>
+                                <button class="member-remove" onclick={on_remove} title="Remove member">
+                                    { "×" }
+                                </button>
+                            </>
+                        }
+                    }
+                }
+            </li>
+        }
+    }
+}

--- a/frontend/styles/session-view.css
+++ b/frontend/styles/session-view.css
@@ -833,3 +833,299 @@
     background: rgba(122, 162, 247, 0.05);
 }
 
+/* ==========================================================================
+   Role Badge (for shared sessions)
+   ========================================================================== */
+
+.pill-role-badge {
+    font-size: 0.65rem;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+}
+
+.pill-role-badge.role-editor {
+    background: rgba(224, 175, 104, 0.3);
+    color: #e0af68;
+}
+
+.pill-role-badge.role-viewer {
+    background: rgba(127, 132, 156, 0.3);
+    color: var(--text-secondary);
+}
+
+/* ==========================================================================
+   Share Button (for session owners)
+   ========================================================================== */
+
+.pill-share {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.9rem;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    transition: background 0.15s, color 0.15s;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.pill-share:hover {
+    background: rgba(122, 162, 247, 0.2);
+    color: var(--accent);
+}
+
+.pill-share:active {
+    background: rgba(122, 162, 247, 0.3);
+}
+
+/* ==========================================================================
+   Leave Button (for non-owners)
+   ========================================================================== */
+
+.pill-leave {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.9rem;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    transition: background 0.15s, color 0.15s;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.pill-leave:hover {
+    background: rgba(224, 175, 104, 0.2);
+    color: #e0af68;
+}
+
+.pill-leave:active {
+    background: rgba(224, 175, 104, 0.3);
+}
+
+/* ==========================================================================
+   Share Dialog
+   ========================================================================== */
+
+.share-dialog-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    padding: 1rem;
+}
+
+.share-dialog {
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    width: 100%;
+    max-width: 450px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.share-dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-darker);
+}
+
+.share-dialog-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.share-dialog-close {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    line-height: 1;
+    transition: background 0.15s, color 0.15s;
+}
+
+.share-dialog-close:hover {
+    background: rgba(247, 118, 142, 0.2);
+    color: var(--error);
+}
+
+.share-dialog-error {
+    background: rgba(247, 118, 142, 0.2);
+    color: var(--error);
+    padding: 0.75rem 1.25rem;
+    font-size: 0.9rem;
+    border-bottom: 1px solid rgba(247, 118, 142, 0.3);
+}
+
+.share-dialog-add {
+    display: flex;
+    gap: 0.5rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.share-dialog-add input {
+    flex: 1;
+    min-width: 0;
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.6rem 0.75rem;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.share-dialog-add input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.share-dialog-add select {
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.6rem 0.75rem;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+
+.share-dialog-add button {
+    background: var(--accent);
+    border: none;
+    border-radius: 6px;
+    padding: 0.6rem 1rem;
+    color: white;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.share-dialog-add button:hover {
+    background: var(--accent-hover);
+}
+
+.share-dialog-members {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem 0;
+}
+
+.share-dialog-members ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.share-dialog-loading,
+.share-dialog-empty {
+    padding: 2rem;
+    text-align: center;
+    color: var(--text-secondary);
+}
+
+.share-dialog-member {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.share-dialog-member:last-child {
+    border-bottom: none;
+}
+
+.share-dialog-member .member-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.share-dialog-member .member-role {
+    font-size: 0.75rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+.share-dialog-member .member-role.owner {
+    background: rgba(158, 206, 106, 0.3);
+    color: var(--success);
+}
+
+.share-dialog-member .member-role-select {
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.3rem 0.5rem;
+    color: var(--text-primary);
+    font-size: 0.8rem;
+    cursor: pointer;
+}
+
+.share-dialog-member .member-remove {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1.2rem;
+    cursor: pointer;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    line-height: 1;
+    transition: background 0.15s, color 0.15s;
+}
+
+.share-dialog-member .member-remove:hover {
+    background: rgba(247, 118, 142, 0.2);
+    color: var(--error);
+}
+
+/* Mobile responsiveness for share dialog */
+@media (max-width: 480px) {
+    .share-dialog {
+        max-width: 100%;
+        max-height: 90vh;
+        border-radius: 8px;
+    }
+
+    .share-dialog-add {
+        flex-direction: column;
+    }
+
+    .share-dialog-add input,
+    .share-dialog-add select,
+    .share-dialog-add button {
+        width: 100%;
+    }
+}
+

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -219,6 +219,8 @@ pub struct SessionInfo {
     pub updated_at: Option<String>,
     #[serde(default)]
     pub git_branch: Option<String>,
+    /// The current user's role in this session (owner, editor, viewer)
+    pub my_role: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Add full session sharing UI: share button, member management dialog, role badges, and leave functionality
- Backend endpoints for member management (list, add, remove, change role)
- Frontend displays user's role in each session and provides appropriate controls

## Test plan
- [ ] Create a session (auto-becomes owner)
- [ ] Click share button - dialog opens
- [ ] Add another user by email
- [ ] Verify new user sees session with role badge (editor/viewer)
- [ ] Verify non-owner sees "Leave" instead of delete
- [ ] Verify owner can change roles and remove members
- [ ] Verify non-owner can leave a shared session
- [ ] Test mobile tap support on share/leave buttons