### PR TITLE
Add bug report link to dashboard footer

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -897,6 +897,18 @@ pub fn dashboard_page() -> Html {
                 }
             }
 
+            // Footer with bug report link
+            <footer class="dashboard-footer">
+                <a
+                    href="https://github.com/meawoppl/cc-proxy/issues/new"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="footer-link bug-report"
+                >
+                    <span class="bug-icon">{ "🐛" }</span>
+                    { "Report a Bug" }
+                </a>
+            </footer>
         </div>
     }
 }

--- a/frontend/styles/dashboard.css
+++ b/frontend/styles/dashboard.css
@@ -366,3 +366,39 @@
     word-break: break-all;
 }
 
+/* Dashboard Footer */
+.dashboard-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+    padding: 0.5rem 1rem;
+    background: linear-gradient(to top, var(--bg-dark) 0%, transparent 100%);
+    pointer-events: none;
+}
+
+.dashboard-footer .footer-link {
+    pointer-events: auto;
+    color: var(--text-secondary);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    transition: color 0.2s, background 0.2s;
+    background: rgba(0, 0, 0, 0.3);
+}
+
+.dashboard-footer .footer-link:hover {
+    color: var(--warning);
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.dashboard-footer .bug-icon {
+    font-size: 1rem;
+}
+


### PR DESCRIPTION
## Summary
- Adds a fixed footer to the dashboard with a bug report link pointing to GitHub issues
- Uses a subtle design that doesn't interfere with main content