### PR TITLE
Fix question option selection for 3+ options

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -1564,13 +1564,20 @@ impl Component for SessionView {
                 true
             }
             SessionViewMsg::PermissionSelectUp => {
-                if self.pending_permission.is_some() {
-                    let max = if self
-                        .pending_permission
-                        .as_ref()
-                        .map(|p| !p.permission_suggestions.is_empty())
-                        .unwrap_or(false)
-                    {
+                if let Some(ref perm) = self.pending_permission {
+                    // Calculate max based on whether this is an AskUserQuestion or regular permission
+                    let max = if perm.tool_name == "AskUserQuestion" {
+                        // For questions, max is based on number of options
+                        if let Some(parsed) = parse_ask_user_question(&perm.input) {
+                            parsed
+                                .questions
+                                .first()
+                                .map(|q| q.options.len().saturating_sub(1))
+                                .unwrap_or(0)
+                        } else {
+                            0
+                        }
+                    } else if !perm.permission_suggestions.is_empty() {
                         2 // Allow, Allow & Remember, Deny
                     } else {
                         1 // Allow, Deny
@@ -1584,13 +1591,20 @@ impl Component for SessionView {
                 true
             }
             SessionViewMsg::PermissionSelectDown => {
-                if self.pending_permission.is_some() {
-                    let max = if self
-                        .pending_permission
-                        .as_ref()
-                        .map(|p| !p.permission_suggestions.is_empty())
-                        .unwrap_or(false)
-                    {
+                if let Some(ref perm) = self.pending_permission {
+                    // Calculate max based on whether this is an AskUserQuestion or regular permission
+                    let max = if perm.tool_name == "AskUserQuestion" {
+                        // For questions, max is based on number of options
+                        if let Some(parsed) = parse_ask_user_question(&perm.input) {
+                            parsed
+                                .questions
+                                .first()
+                                .map(|q| q.options.len().saturating_sub(1))
+                                .unwrap_or(0)
+                        } else {
+                            0
+                        }
+                    } else if !perm.permission_suggestions.is_empty() {
                         2 // Allow, Allow & Remember, Deny
                     } else {
                         1 // Allow, Deny


### PR DESCRIPTION
## Summary
- Fixed keyboard navigation (up/down arrows) for AskUserQuestion dialogs with more than 2 options
- Previously, navigation was hardcoded to max of 2 options (for permission dialogs), which prevented selecting options beyond the first 2 in question dialogs
- Now properly calculates max based on the actual number of question options

## The Bug
When Claude asked a question with 3+ options, users could only navigate to the first 2 options using keyboard arrows. Mouse clicks worked for all options, but arrow keys wrapped at index 2.

## The Fix
Updated `PermissionSelectUp` and `PermissionSelectDown` handlers to detect when the pending permission is an `AskUserQuestion` and use the actual option count instead of the hardcoded permission option count (2 or 3).