### PR TITLE
Display Read tool file path inline like Edit tool

### DIFF
--- a/frontend/src/components/message_renderer.rs
+++ b/frontend/src/components/message_renderer.rs
@@ -927,6 +927,7 @@ fn render_read_tool(input: &Value) -> Html {
             <div class="tool-use-header">
                 <span class="tool-icon">{ "📖" }</span>
                 <span class="tool-name">{ "Read" }</span>
+                <span class="read-file-path">{ file_path }</span>
                 {
                     if let Some(range) = range_info {
                         html! { <span class="tool-meta">{ range }</span> }
@@ -935,7 +936,6 @@ fn render_read_tool(input: &Value) -> Html {
                     }
                 }
             </div>
-            <div class="file-path">{ file_path }</div>
         </div>
     }
 }

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -306,7 +306,8 @@
     flex-wrap: wrap;
 }
 
-.edit-file-path {
+.edit-file-path,
+.read-file-path {
     color: var(--text-primary);
     font-weight: 500;
     word-break: break-all;


### PR DESCRIPTION
## Summary
- Moved Read tool file path from a separate line to inline in the header
- Now matches Edit tool styling for consistency