### PR TITLE
Handle detached HEAD state in git branch detection

### DIFF
--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -511,21 +511,34 @@ async fn run_message_loop(
 
 /// Get the current git branch name, if in a git repository
 fn get_git_branch(cwd: &str) -> Option<String> {
-    std::process::Command::new("git")
+    let output = std::process::Command::new("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(cwd)
         .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let branch = String::from_utf8(output.stdout)
         .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                String::from_utf8(output.stdout)
-                    .ok()
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty() && s != "HEAD")
-            } else {
-                None
-            }
-        })
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
+
+    // If we're in detached HEAD state, get the short commit hash instead
+    if branch == "HEAD" {
+        std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .current_dir(cwd)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| format!("detached:{}", s.trim()))
+    } else {
+        Some(branch)
+    }
 }
 
 /// Check if a tool use is a Bash command containing "git"


### PR DESCRIPTION
## Summary
- When in detached HEAD state, display `detached:<short-hash>` instead of showing nothing
- Updates both `get_git_branch` functions in proxy (main.rs and session.rs)

## Test plan
- [ ] Checkout a specific commit (e.g., `git checkout HEAD~1`)
- [ ] Start a session and verify it shows `detached:abc1234` format
- [ ] Checkout a branch and verify normal branch name displays