### PR TITLE
Move bug report link into keyboard hints bar

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -783,31 +783,41 @@ pub fn dashboard_page() -> Html {
 
                     // Keyboard hints - context-sensitive based on mode
                     <div class={classes!("keyboard-hints", if *nav_mode { Some("nav-mode") } else { None })}>
-                        {
-                            if *nav_mode {
-                                html! {
-                                    <>
-                                        <span class="mode-indicator">{ "NAV" }</span>
-                                        <span>{ "↑↓ or jk = navigate" }</span>
-                                        <span>{ "1-9 = select" }</span>
-                                        <span>{ "w = next waiting" }</span>
-                                        <span>{ "Enter/Esc = edit mode" }</span>
-                                    </>
-                                }
-                            } else {
-                                html! {
-                                    <>
-                                        <span>{ "Esc = nav mode" }</span>
-                                        <span>{ "Shift+Tab = next (skip paused)" }</span>
-                                        <span>{ "Ctrl+Shift+P = pause" }</span>
-                                        if *voice_enabled {
-                                            <span>{ "Ctrl+M = voice" }</span>
-                                        }
-                                        <span>{ "Enter = send" }</span>
-                                    </>
+                        <div class="hints-content">
+                            {
+                                if *nav_mode {
+                                    html! {
+                                        <>
+                                            <span class="mode-indicator">{ "NAV" }</span>
+                                            <span>{ "↑↓ or jk = navigate" }</span>
+                                            <span>{ "1-9 = select" }</span>
+                                            <span>{ "w = next waiting" }</span>
+                                            <span>{ "Enter/Esc = edit mode" }</span>
+                                        </>
+                                    }
+                                } else {
+                                    html! {
+                                        <>
+                                            <span>{ "Esc = nav mode" }</span>
+                                            <span>{ "Shift+Tab = next (skip paused)" }</span>
+                                            <span>{ "Ctrl+Shift+P = pause" }</span>
+                                            if *voice_enabled {
+                                                <span>{ "Ctrl+M = voice" }</span>
+                                            }
+                                            <span>{ "Enter = send" }</span>
+                                        </>
+                                    }
                                 }
                             }
-                        }
+                        </div>
+                        <a
+                            href="https://github.com/meawoppl/cc-proxy/issues/new"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="bug-report-link"
+                        >
+                            { "🐛 Report a Bug" }
+                        </a>
                     </div>
                 </>
             }
@@ -840,19 +850,6 @@ pub fn dashboard_page() -> Html {
                     html! {}
                 }
             }
-
-            // Footer with bug report link
-            <footer class="dashboard-footer">
-                <a
-                    href="https://github.com/meawoppl/cc-proxy/issues/new"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="footer-link bug-report"
-                >
-                    <span class="bug-icon">{ "🐛" }</span>
-                    { "Report a Bug" }
-                </a>
-            </footer>
         </div>
     }
 }

--- a/frontend/styles/dashboard.css
+++ b/frontend/styles/dashboard.css
@@ -375,39 +375,3 @@
     word-break: break-all;
 }
 
-/* Dashboard Footer */
-.dashboard-footer {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    display: flex;
-    justify-content: center;
-    padding: 0.5rem 1rem;
-    background: linear-gradient(to top, var(--bg-dark) 0%, transparent 100%);
-    pointer-events: none;
-}
-
-.dashboard-footer .footer-link {
-    pointer-events: auto;
-    color: var(--text-secondary);
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    border-radius: 6px;
-    font-size: 0.85rem;
-    transition: color 0.2s, background 0.2s;
-    background: rgba(0, 0, 0, 0.3);
-}
-
-.dashboard-footer .footer-link:hover {
-    color: var(--warning);
-    background: rgba(0, 0, 0, 0.5);
-}
-
-.dashboard-footer .bug-icon {
-    font-size: 1rem;
-}
-

--- a/frontend/styles/keyboard.css
+++ b/frontend/styles/keyboard.css
@@ -4,14 +4,21 @@
 
 .keyboard-hints {
     display: flex;
-    justify-content: center;
-    gap: 2rem;
+    justify-content: space-between;
+    align-items: center;
     padding: 0.5rem 1rem;
     background: var(--bg-darker);
     border-top: 1px solid var(--border);
 }
 
-.keyboard-hints span {
+.keyboard-hints .hints-content {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    flex: 1;
+}
+
+.keyboard-hints .hints-content span {
     font-size: 0.75rem;
     color: var(--text-secondary);
     display: flex;
@@ -43,6 +50,22 @@
 .keyboard-hints.nav-mode {
     background: rgba(122, 162, 247, 0.15);
     border-top-color: var(--accent);
+}
+
+/* Bug report link in keyboard hints bar */
+.keyboard-hints .bug-report-link {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    transition: color 0.2s, background 0.2s;
+    white-space: nowrap;
+}
+
+.keyboard-hints .bug-report-link:hover {
+    color: var(--warning);
+    background: rgba(0, 0, 0, 0.3);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- Move the "Report a Bug" link from a fixed footer overlay into the far right of the keyboard hints bar
- This prevents the bug report link from eclipsing the command menu at the bottom of the screen
- Clean up unused dashboard-footer CSS

## Test plan
- [ ] Verify bug report link appears at far right of keyboard hints bar
- [ ] Verify keyboard shortcuts are still centered and visible
- [ ] Verify link hover state works (turns warning color)
- [ ] Verify clicking the link opens GitHub issues page

🤖 Generated with [Claude Code](https://claude.com/claude-code)