### PR TITLE
Fix reconnection banner count for paused sessions

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -651,9 +651,14 @@ pub fn dashboard_page() -> Html {
     let waiting_count = awaiting_sessions.len();
 
     // Count disconnected sessions for the reconnection banner
+    // Only count sessions that are both activated (have started loading) and not paused
     let disconnected_count = active_sessions
         .iter()
-        .filter(|s| !connected_sessions.contains(&s.id))
+        .filter(|s| {
+            activated_sessions.contains(&s.id)
+                && !paused_sessions.contains(&s.id)
+                && !connected_sessions.contains(&s.id)
+        })
         .count();
 
     // Two-mode keyboard handling:


### PR DESCRIPTION
## Summary
- Fix the reconnection banner to not count paused or unactivated sessions as "disconnected"
- Paused sessions intentionally don't have WebSocket connections (lazy loading)
- Only count sessions that have been activated and are not paused when determining if they're disconnected

## Test plan
- Pause a session
- Reload the page
- Verify the reconnection banner doesn't show paused sessions as disconnecting