### PR TITLE
Add user banning with reason and complete data revocation

### DIFF
--- a/backend/migrations/2026-01-18-023257_add_ban_reason/down.sql
+++ b/backend/migrations/2026-01-18-023257_add_ban_reason/down.sql
@@ -1,0 +1,2 @@
+-- Remove ban_reason column from users table
+ALTER TABLE users DROP COLUMN ban_reason;

--- a/backend/migrations/2026-01-18-023257_add_ban_reason/up.sql
+++ b/backend/migrations/2026-01-18-023257_add_ban_reason/up.sql
@@ -1,0 +1,2 @@
+-- Add ban_reason column to users table
+ALTER TABLE users ADD COLUMN ban_reason TEXT;

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -17,6 +17,7 @@ pub struct User {
     pub is_admin: bool,
     pub disabled: bool,
     pub voice_enabled: bool,
+    pub ban_reason: Option<String>,
 }
 
 #[derive(Debug, Insertable)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -120,6 +120,7 @@ diesel::table! {
         is_admin -> Bool,
         disabled -> Bool,
         voice_enabled -> Bool,
+        ban_reason -> Nullable<Text>,
     }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,6 +18,7 @@
     <link data-trunk rel="css" href="styles/keyboard.css" />
     <link data-trunk rel="css" href="styles/settings.css" />
     <link data-trunk rel="css" href="styles/admin.css" />
+    <link data-trunk rel="css" href="styles/banned.css" />
     <link data-trunk rel="copy-file" href="pcm-processor.js" />
 </head>
 <body></body>

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -6,7 +6,8 @@ pub mod utils;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use pages::{
-    admin::AdminPage, dashboard::DashboardPage, settings::SettingsPage, splash::SplashPage,
+    admin::AdminPage, banned::BannedPage, dashboard::DashboardPage, settings::SettingsPage,
+    splash::SplashPage,
 };
 use yew::prelude::*;
 use yew_router::prelude::*;
@@ -21,6 +22,8 @@ pub enum Route {
     Settings,
     #[at("/admin")]
     Admin,
+    #[at("/banned")]
+    Banned,
 }
 
 fn switch(routes: Route) -> Html {
@@ -29,6 +32,7 @@ fn switch(routes: Route) -> Html {
         Route::Dashboard => html! { <DashboardPage /> },
         Route::Settings => html! { <SettingsPage /> },
         Route::Admin => html! { <AdminPage /> },
+        Route::Banned => html! { <BannedPage /> },
     }
 }
 

--- a/frontend/src/pages/banned.rs
+++ b/frontend/src/pages/banned.rs
@@ -1,0 +1,43 @@
+use gloo::utils::window;
+use yew::prelude::*;
+
+#[function_component(BannedPage)]
+pub fn banned_page() -> Html {
+    // Extract reason from URL query params
+    let reason = window()
+        .location()
+        .search()
+        .ok()
+        .and_then(|search| {
+            let params = web_sys::UrlSearchParams::new_with_str(&search).ok()?;
+            params.get("reason")
+        })
+        .map(|r| {
+            // URL decode the reason
+            js_sys::decode_uri_component(&r)
+                .ok()
+                .map(|s| s.as_string().unwrap_or_default())
+                .unwrap_or(r)
+        })
+        .unwrap_or_else(|| "No reason provided".to_string());
+
+    html! {
+        <div class="banned-container">
+            <div class="banned-content">
+                <div class="banned-icon">{ "🚫" }</div>
+                <h1>{ "Account Suspended" }</h1>
+                <p class="banned-message">
+                    { "Your account has been suspended and you are unable to access this service." }
+                </p>
+                <div class="banned-reason">
+                    <h3>{ "Reason:" }</h3>
+                    <p>{ reason }</p>
+                </div>
+                <p class="banned-contact">
+                    { "If you believe this is an error, please contact " }
+                    <a href="mailto:support@txcl.io">{ "support@txcl.io" }</a>
+                </p>
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod banned;
 pub mod dashboard;
 pub mod settings;
 pub mod splash;

--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -440,3 +440,53 @@
         width: 95%;
     }
 }
+
+/* Ban Modal */
+.ban-modal {
+    max-width: 450px;
+}
+
+.ban-modal h3 {
+    color: var(--error);
+    margin: 0 0 0.75rem 0;
+}
+
+.ban-modal p {
+    color: var(--text-secondary);
+    margin: 0 0 1rem 0;
+    font-size: 0.9rem;
+}
+
+.ban-reason-input {
+    margin-bottom: 1rem;
+}
+
+.ban-reason-input label {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.ban-reason-input input {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.ban-reason-input input:focus {
+    outline: none;
+    border-color: var(--error);
+}
+
+.ban-confirm {
+    background: var(--error) !important;
+}
+
+.ban-confirm:hover {
+    background: #ff6b8a !important;
+}

--- a/frontend/styles/banned.css
+++ b/frontend/styles/banned.css
@@ -1,0 +1,66 @@
+/* Banned Page */
+.banned-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    padding: 2rem;
+}
+
+.banned-content {
+    max-width: 500px;
+    text-align: center;
+    background: var(--bg-darker);
+    border: 1px solid var(--error);
+    border-radius: 8px;
+    padding: 2rem;
+}
+
+.banned-icon {
+    font-size: 4rem;
+    margin-bottom: 1rem;
+}
+
+.banned-content h1 {
+    color: var(--error);
+    margin-bottom: 1rem;
+}
+
+.banned-message {
+    color: var(--text-secondary);
+    margin-bottom: 1.5rem;
+}
+
+.banned-reason {
+    background: rgba(255, 107, 138, 0.1);
+    border: 1px solid var(--error);
+    border-radius: 4px;
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.banned-reason h3 {
+    color: var(--error);
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+}
+
+.banned-reason p {
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.banned-contact {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.banned-contact a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.banned-contact a:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- Add `ban_reason` column to users table for storing ban explanation
- Block banned users from OAuth login - redirects to `/banned` page showing the reason
- Block banned users from using proxy tokens (returns 403 Forbidden)
- Admin UI now shows modal prompting for ban reason when disabling a user
- Banning a user now revokes all proxy tokens AND deletes all sessions/messages/data
- Add `/banned` page with styled display of the ban reason

## Test plan
- [ ] Create a test user and log in
- [ ] As admin, ban the user with a reason
- [ ] Verify user's tokens are revoked
- [ ] Verify user's sessions are deleted
- [ ] Try to log in as banned user - should redirect to /banned with reason
- [ ] Unban user and verify they can log in again