### PR TITLE
Fix waiting count to exclude paused sessions

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -648,7 +648,11 @@ pub fn dashboard_page() -> Html {
         })
     };
 
-    let waiting_count = awaiting_sessions.len();
+    // Count only non-paused sessions that are awaiting input
+    let waiting_count = awaiting_sessions
+        .iter()
+        .filter(|id| !paused_sessions.contains(id))
+        .count();
 
     // Count disconnected sessions for the reconnection banner
     // Only count sessions that are both activated (have started loading) and not paused


### PR DESCRIPTION
## Summary
- Filters out paused sessions from the waiting count in the nav bar badge
- Users expect paused sessions to not count as "waiting" since they intentionally paused them

## Test plan
- [ ] Pause a session that is awaiting input
- [ ] Verify the waiting count in the nav bar decreases
- [ ] Unpause the session
- [ ] Verify the waiting count increases again if still awaiting

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)