### PR TITLE
Add customizable app title via APP_TITLE environment variable

### DIFF
--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -1,0 +1,15 @@
+//! App configuration endpoint
+//!
+//! Returns public application configuration to the frontend.
+
+use crate::AppState;
+use axum::{extract::State, Json};
+use shared::AppConfig;
+use std::sync::Arc;
+
+/// GET /api/config - Returns application configuration
+pub async fn get_config(State(app_state): State<Arc<AppState>>) -> Json<AppConfig> {
+    Json(AppConfig {
+        app_title: app_state.app_title.clone(),
+    })
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod auth;
+pub mod config;
 pub mod device_flow;
 pub mod downloads;
 pub mod messages;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -47,6 +47,7 @@ pub struct AppState {
     pub cookie_key: Key,
     pub jwt_secret: String,
     pub speech_credentials_path: Option<String>,
+    pub app_title: String,
 }
 
 #[tokio::main]
@@ -213,6 +214,9 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
+    // App title (customizable via environment variable)
+    let app_title = env::var("APP_TITLE").unwrap_or_else(|_| "Claude Code Sessions".to_string());
+
     // Create app state
     let app_state = Arc::new(AppState {
         dev_mode: args.dev_mode,
@@ -228,6 +232,7 @@ async fn main() -> anyhow::Result<()> {
         cookie_key,
         jwt_secret,
         speech_credentials_path,
+        app_title,
     });
 
     // Setup CORS
@@ -240,6 +245,8 @@ async fn main() -> anyhow::Result<()> {
     let mut app = Router::new()
         // Health check endpoint
         .route("/api/health", get(|| async { "OK" }))
+        // App configuration (public, no auth required)
+        .route("/api/config", get(handlers::config::get_config))
         // Session API routes
         .route("/api/sessions", get(handlers::sessions::list_sessions))
         .route("/api/sessions/:id", get(handlers::sessions::get_session))

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -5,7 +5,7 @@ use futures_util::{SinkExt, StreamExt};
 use gloo::timers::callback::Timeout;
 use gloo_net::http::Request;
 use gloo_net::websocket::{futures::WebSocket, Message};
-use shared::{ProxyMessage, SessionCost, SessionInfo};
+use shared::{AppConfig, ProxyMessage, SessionCost, SessionInfo};
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
@@ -121,6 +121,8 @@ pub fn dashboard_page() -> Html {
     let total_user_spend = use_state(|| 0.0f64);
     let is_admin = use_state(|| false);
     let voice_enabled = use_state(|| false);
+    // App title from backend config (customizable via APP_TITLE env var)
+    let app_title = use_state(|| "Claude Code Sessions".to_string());
     // Track which sessions have been activated (focused at least once)
     // This prevents loading history for paused sessions until they're selected
     let activated_sessions = use_state(HashSet::<Uuid>::new);
@@ -142,6 +144,22 @@ pub fn dashboard_page() -> Html {
                         if let Some(voice) = data.get("voice_enabled").and_then(|v| v.as_bool()) {
                             voice_enabled.set(voice);
                         }
+                    }
+                }
+            });
+            || ()
+        });
+    }
+
+    // Fetch app configuration (title, etc.)
+    {
+        let app_title = app_title.clone();
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                let api_endpoint = utils::api_url("/api/config");
+                if let Ok(response) = Request::get(&api_endpoint).send().await {
+                    if let Ok(config) = response.json::<AppConfig>().await {
+                        app_title.set(config.app_title);
                     }
                 }
             });
@@ -748,7 +766,7 @@ pub fn dashboard_page() -> Html {
         <div class="focus-flow-container" onkeydown={on_keydown} tabindex="0">
             // Header with new session button
             <header class="focus-flow-header">
-                <h1>{ "Claude Code Sessions" }</h1>
+                <h1>{ (*app_title).clone() }</h1>
                 <div class="header-actions">
                     {
                         if *total_user_spend > 0.0 {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -269,3 +269,15 @@ pub enum DevicePollResponse {
     #[serde(rename = "denied")]
     Denied,
 }
+
+// ============================================================================
+// App Configuration (served to frontend)
+// ============================================================================
+
+/// Application configuration returned by /api/config endpoint
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppConfig {
+    /// Custom title for the app (displayed in top bar)
+    /// Defaults to "Claude Code Sessions" if not configured
+    pub app_title: String,
+}


### PR DESCRIPTION
## Summary
- Adds `APP_TITLE` environment variable to customize the top bar title
- Default remains "Claude Code Sessions" if not set
- Creates `/api/config` endpoint to serve app configuration to frontend
- Frontend fetches config on load and displays the custom title

## Use Cases
- White-labeling for different deployments
- Organization-specific branding
- Custom naming for different deployment contexts

## Configuration
```bash
# Set custom title in environment
export APP_TITLE="My Organization Portal"
```

## Test plan
- [ ] Start backend without APP_TITLE - should show "Claude Code Sessions"
- [ ] Start backend with APP_TITLE="Custom Title" - should show "Custom Title"
- [ ] Verify /api/config endpoint returns the configured title

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)