### PR TITLE
Show warning title in dev mode

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -215,7 +215,12 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // App title (customizable via environment variable)
-    let app_title = env::var("APP_TITLE").unwrap_or_else(|_| "Claude Code Sessions".to_string());
+    // In dev mode, override with a warning to make it obvious
+    let app_title = if args.dev_mode {
+        "⚠️ INSECURE DEV MODE ⚠️".to_string()
+    } else {
+        env::var("APP_TITLE").unwrap_or_else(|_| "Claude Code Sessions".to_string())
+    };
 
     // Create app state
     let app_state = Arc::new(AppState {


### PR DESCRIPTION
## Summary
When running with `--dev-mode`, the app title in the top bar is now set to "⚠️ INSECURE DEV MODE ⚠️" to make it immediately obvious that:
- OAuth is bypassed
- The instance is not secure for production use

## Test plan
- [ ] Run backend with `--dev-mode` flag
- [ ] Verify the title shows "⚠️ INSECURE DEV MODE ⚠️"
- [ ] Run backend without `--dev-mode` (or with APP_TITLE set)
- [ ] Verify the title shows the configured value or default

🤖 Generated with [Claude Code](https://claude.com/claude-code)