### PR TITLE
Fix status pill overflow in admin tables

### DIFF
--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -170,10 +170,11 @@
 /* User Status Badges */
 .user-status {
     display: inline-block;
-    padding: 0.25rem 0.75rem;
-    border-radius: 12px;
-    font-size: 0.8rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 10px;
+    font-size: 0.75rem;
     font-weight: 500;
+    white-space: nowrap;
 }
 
 .user-status.admin {
@@ -200,10 +201,11 @@
 /* Session Status Badges */
 .session-status {
     display: inline-block;
-    padding: 0.25rem 0.75rem;
-    border-radius: 12px;
-    font-size: 0.8rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 10px;
+    font-size: 0.75rem;
     font-weight: 500;
+    white-space: nowrap;
 }
 
 .session-status.connected {

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -199,9 +199,9 @@
 .token-status,
 .session-status {
     display: inline-block;
-    padding: 0.25rem 0.75rem;
-    border-radius: 12px;
-    font-size: 0.8rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 10px;
+    font-size: 0.75rem;
     font-weight: 500;
     white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- Reduce padding and font-size on status pills (`.user-status`, `.session-status`, `.token-status`) to prevent column overflow
- Changes: `padding: 0.25rem 0.75rem` -> `0.2rem 0.5rem`, `font-size: 0.8rem` -> `0.75rem`, `border-radius: 12px` -> `10px`
- Add `white-space: nowrap` to prevent wrapping

## Test plan
- [ ] Check admin Users table - status column should not overflow
- [ ] Check admin Sessions table - status column should not overflow
- [ ] Check Settings page - token/session status pills should look consistent