### PR TITLE
Rename Disable to Ban in admin UI and add txcl.io to README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
-# Claude Code Portal
+# Claude Code Portal — Try It: [txcl.io](https://txcl.io)
 
 A web portal that extends [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with session sharing, remote access, and collaborative features. Run Claude Code on powerful machines and access it from anywhere through your browser.
-
-## Try It Out
-
-**Live Demo**: [txcl.io](https://txcl.io)
-
-Sign in with Google to get started - your sessions are isolated and secure. This public instance is open to anyone.
 
 ## Features
 

--- a/frontend/src/pages/admin.rs
+++ b/frontend/src/pages/admin.rs
@@ -239,12 +239,12 @@ fn user_row(props: &UserRowProps) -> Html {
                     { if user.is_admin { "Remove Admin" } else { "Make Admin" } }
                 </button>
                 <button
-                    class={classes!("disable-toggle", if user.disabled { Some("active") } else { None })}
+                    class={classes!("ban-toggle", if user.disabled { Some("active") } else { None })}
                     onclick={on_toggle_disabled}
                     disabled={is_self}
-                    title={if is_self { "Cannot disable your own account" } else if user.disabled { "Enable user" } else { "Disable user" }}
+                    title={if is_self { "Cannot ban your own account" } else if user.disabled { "Unban user" } else { "Ban user" }}
                 >
-                    { if user.disabled { "Enable" } else { "Disable" } }
+                    { if user.disabled { "Unban" } else { "Ban" } }
                 </button>
                 <button
                     class={classes!("voice-toggle", if user.voice_enabled { Some("active") } else { None })}

--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -225,7 +225,7 @@
 
 /* Admin Action Buttons */
 .admin-toggle,
-.disable-toggle,
+.ban-toggle,
 .delete-btn {
     padding: 0.35rem 0.75rem;
     border-radius: 4px;
@@ -238,14 +238,14 @@
 }
 
 .admin-toggle:hover:not(:disabled),
-.disable-toggle:hover:not(:disabled),
+.ban-toggle:hover:not(:disabled),
 .delete-btn:hover:not(:disabled) {
     background: var(--bg-hover);
     color: var(--text-primary);
 }
 
 .admin-toggle:disabled,
-.disable-toggle:disabled {
+.ban-toggle:disabled {
     opacity: 0.5;
     cursor: not-allowed;
 }
@@ -256,7 +256,7 @@
     color: var(--accent);
 }
 
-.disable-toggle.active {
+.ban-toggle.active {
     background: rgba(247, 118, 142, 0.2);
     border-color: var(--error);
     color: var(--error);


### PR DESCRIPTION
## Summary
- Rename "Disable/Enable" button to "Ban/Unban" in admin dashboard for clearer action labeling
- Add txcl.io link to README main title
- Remove redundant "Try It Out" section from README (now in title)

## Test plan
- [ ] Verify admin dashboard shows "Ban/Unban" buttons instead of "Disable/Enable"
- [ ] Verify README title includes txcl.io link
- [ ] Verify ban dialog still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)