### PR TITLE
Remove Ctrl+Shift+P pause shortcut

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -689,9 +689,7 @@ pub fn dashboard_page() -> Html {
     let on_keydown = {
         let on_navigate = on_navigate.clone();
         let on_next_active = on_next_active.clone();
-        let on_toggle_pause = on_toggle_pause.clone();
         let on_select_session = on_select_session.clone();
-        let focused_index = focused_index.clone();
         let nav_mode = nav_mode.clone();
         let active_sessions = active_sessions.clone();
         Callback::from(move |e: KeyboardEvent| {


### PR DESCRIPTION
## Summary
- Removes the Ctrl+Shift+P keyboard shortcut for toggling pause
- This shortcut conflicts with the command palette on all major platforms

The pause functionality is still accessible via the pause button in the session pill UI.

## Test plan
- Verify Ctrl+Shift+P no longer triggers pause
- Verify pause button in session pills still works