### PR TITLE
Update splash page terminal to match actual claude-portal CLI output

### DIFF
--- a/frontend/src/pages/splash.rs
+++ b/frontend/src/pages/splash.rs
@@ -36,17 +36,58 @@ pub fn splash_page() -> Html {
                         <div class="terminal-body">
                             <div class="terminal-line">
                                 <span class="prompt">{ "$ " }</span>
-                                <span class="command">{ "claude-portal --session my-dev-machine" }</span>
+                                <span class="command">{ "claude-portal" }</span>
+                            </div>
+                            <div class="terminal-line empty"></div>
+                            <div class="terminal-line">
+                                <span class="output blue">{ "╭──────────────────────────────────────╮" }</span>
                             </div>
                             <div class="terminal-line">
-                                <span class="output">{ "✓ Connected to backend" }</span>
+                                <span class="output blue">{ "│      Claude Code Portal Starting     │" }</span>
                             </div>
                             <div class="terminal-line">
-                                <span class="output">{ "✓ Session registered" }</span>
+                                <span class="output blue">{ "╰──────────────────────────────────────╯" }</span>
+                            </div>
+                            <div class="terminal-line empty"></div>
+                            <div class="terminal-line">
+                                <span class="output dim">{ "  Session: " }</span>
+                                <span class="output">{ "my-workstation-20260117-041500" }</span>
                             </div>
                             <div class="terminal-line">
-                                <span class="prompt">{ "$ " }</span>
-                                <span class="cursor">{ "▊" }</span>
+                                <span class="output dim">{ "  Backend: " }</span>
+                                <span class="output">{ "wss://txcl.io" }</span>
+                            </div>
+                            <div class="terminal-line empty"></div>
+                            <div class="terminal-line">
+                                <span class="output blue">{ "  → " }</span>
+                                <span class="output">{ "Connecting to backend... " }</span>
+                                <span class="output green">{ "connected" }</span>
+                            </div>
+                            <div class="terminal-line">
+                                <span class="output blue">{ "  → " }</span>
+                                <span class="output">{ "Registering session... " }</span>
+                                <span class="output green">{ "registered" }</span>
+                            </div>
+                            <div class="terminal-line">
+                                <span class="output blue">{ "  → " }</span>
+                                <span class="output">{ "Starting Claude Code... " }</span>
+                                <span class="output green">{ "started" }</span>
+                            </div>
+                            <div class="terminal-line empty"></div>
+                            <div class="terminal-line">
+                                <span class="output green">{ "╭──────────────────────────────────────╮" }</span>
+                            </div>
+                            <div class="terminal-line">
+                                <span class="output green">{ "│         ✓ Proxy Ready                │" }</span>
+                            </div>
+                            <div class="terminal-line">
+                                <span class="output green">{ "╰──────────────────────────────────────╯" }</span>
+                            </div>
+                            <div class="terminal-line empty"></div>
+                            <div class="terminal-line">
+                                <span class="output">{ "  Navigate to " }</span>
+                                <span class="output cyan">{ "txcl.io" }</span>
+                                <span class="output">{ " to use the terminal." }</span>
                             </div>
                         </div>
                     </div>

--- a/frontend/styles/splash.css
+++ b/frontend/styles/splash.css
@@ -76,10 +76,16 @@
     padding: 1rem;
     font-family: 'Courier New', monospace;
     text-align: left;
+    white-space: pre;
 }
 
 .terminal-line {
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.25rem;
+    line-height: 1.4;
+}
+
+.terminal-line.empty {
+    height: 0.5rem;
 }
 
 .prompt {
@@ -92,7 +98,23 @@
 }
 
 .output {
+    color: var(--text-primary);
+}
+
+.output.green {
     color: var(--success);
+}
+
+.output.blue {
+    color: var(--accent);
+}
+
+.output.cyan {
+    color: #7dcfff;
+}
+
+.output.dim {
+    color: var(--text-secondary);
 }
 
 .cursor {


### PR DESCRIPTION
## Summary
- Update splash page terminal preview to show realistic claude-portal startup sequence
- Display box banners, session info, and status messages matching actual CLI output
- Add colored output (green for success, blue for accents, cyan for links)
- Add "Navigate to txcl.io to use the terminal" call to action

## Test plan
- [ ] Verify splash page terminal preview looks realistic
- [ ] Verify colors match actual CLI output style
- [ ] Verify spacing is preserved in box drawing characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)