### PR TITLE
Fix raw messages response field name mismatch

### DIFF
--- a/frontend/src/pages/admin.rs
+++ b/frontend/src/pages/admin.rs
@@ -100,7 +100,7 @@ struct RawMessageLogInfo {
 
 #[derive(Debug, Clone, Deserialize)]
 struct RawMessagesResponse {
-    raw_messages: Vec<RawMessageLogInfo>,
+    logs: Vec<RawMessageLogInfo>,
 }
 
 // ============================================================================
@@ -559,7 +559,7 @@ pub fn admin_page() -> Html {
                         }
                         match response.json::<RawMessagesResponse>().await {
                             Ok(data) => {
-                                raw_messages.set(data.raw_messages);
+                                raw_messages.set(data.logs);
                             }
                             Err(e) => {
                                 error.set(Some(format!("Failed to parse raw messages: {:?}", e)));


### PR DESCRIPTION
## Summary
- Frontend expected `raw_messages` field but backend returns `logs`
- Updated frontend to use correct field name from backend response

## Test plan
- [ ] Verify raw messages tab loads in admin dashboard without parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)