### PR TITLE
Add client version reporting for claude-portal clients

### DIFF
--- a/backend/migrations/2026-01-18-045238_add_client_version_to_sessions/down.sql
+++ b/backend/migrations/2026-01-18-045238_add_client_version_to_sessions/down.sql
@@ -1,0 +1,2 @@
+-- Remove client_version column from sessions table
+ALTER TABLE sessions DROP COLUMN client_version;

--- a/backend/migrations/2026-01-18-045238_add_client_version_to_sessions/up.sql
+++ b/backend/migrations/2026-01-18-045238_add_client_version_to_sessions/up.sql
@@ -1,0 +1,2 @@
+-- Add client_version column to sessions table (nullable for backwards compatibility)
+ALTER TABLE sessions ADD COLUMN client_version VARCHAR(32);

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -48,6 +48,7 @@ pub struct Session {
     pub output_tokens: i64,
     pub cache_creation_tokens: i64,
     pub cache_read_tokens: i64,
+    pub client_version: Option<String>,
 }
 
 #[derive(Debug, Insertable)]
@@ -72,6 +73,7 @@ pub struct NewSessionWithId {
     pub working_directory: Option<String>,
     pub status: String,
     pub git_branch: Option<String>,
+    pub client_version: Option<String>,
 }
 
 #[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -102,6 +102,8 @@ diesel::table! {
         output_tokens -> Int8,
         cache_creation_tokens -> Int8,
         cache_read_tokens -> Int8,
+        #[max_length = 32]
+        client_version -> Nullable<Varchar>,
     }
 }
 

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -1361,6 +1361,7 @@ impl Component for SessionView {
                         resuming: false,
                         git_branch: None,
                         replay_after: last_message_time,
+                        client_version: None, // Web client, not proxy
                     };
 
                     if let Ok(json) = serde_json::to_string(&register_msg) {
@@ -1885,6 +1886,7 @@ impl Component for SessionView {
                                 resuming: true, // Mark as resuming connection
                                 git_branch: None,
                                 replay_after, // Only get messages after last seen
+                                client_version: None, // Web client, not proxy
                             };
 
                             if let Ok(json) = serde_json::to_string(&register_msg) {

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -347,6 +347,7 @@ async fn register_session(
         resuming: config.resuming,
         git_branch: config.git_branch.clone(),
         replay_after: None, // Proxy doesn't need history replay
+        client_version: Some(env!("CARGO_PKG_VERSION").to_string()),
     };
 
     if let Err(e) = conn.send(&register_msg).await {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -36,6 +36,9 @@ pub enum ProxyMessage {
         /// If None, replay all history. Used by web clients to avoid duplicate messages.
         #[serde(default)]
         replay_after: Option<String>,
+        /// Client version (e.g., "1.0.0") - helps track client versions in use
+        #[serde(default)]
+        client_version: Option<String>,
     },
 
     /// Output from Claude Code to be displayed


### PR DESCRIPTION
## Summary
- Add `client_version` field to `ProxyMessage::Register` (optional, backwards compatible with `#[serde(default)]`)
- Proxy sends its version from Cargo.toml on registration
- Backend stores `client_version` in sessions table and updates on reconnection

## Test plan
- [ ] Connect claude-portal client, verify version logged in backend
- [ ] Verify old clients without version field still connect successfully
- [ ] Check database has client_version column populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)