### PR TITLE
Show waiting session count in browser tab and fix app name

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Claude Code Proxy</title>
+    <title>Claude Code Portal</title>
     <link data-trunk rel="rust" data-wasm-opt="z" />
     <!-- CSS files split for maintainability -->
     <link data-trunk rel="css" href="styles/base.css" />

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -640,6 +640,27 @@ pub fn dashboard_page() -> Html {
         .filter(|id| !paused_sessions.contains(id))
         .count();
 
+    // Update browser tab title based on waiting sessions count
+    {
+        let app_title = app_title.clone();
+        use_effect_with(
+            (waiting_count, (*app_title).clone()),
+            move |(count, title)| {
+                if let Some(window) = web_sys::window() {
+                    if let Some(document) = window.document() {
+                        let new_title = if *count > 0 {
+                            format!("({}) {}", count, title)
+                        } else {
+                            title.clone()
+                        };
+                        document.set_title(&new_title);
+                    }
+                }
+                || ()
+            },
+        );
+    }
+
     // Count disconnected sessions for the reconnection banner
     // Only count sessions that are both activated (have started loading) and not paused
     let disconnected_count = active_sessions


### PR DESCRIPTION
## Summary
- Show the number of waiting sessions in the browser tab title (e.g., "(3) Claude Code Portal")
- Rename default title from "Claude Code Proxy" to "Claude Code Portal" to match rebrand

## Details
When sessions are awaiting input, the browser tab title updates to show the count, making it easy to see at a glance if sessions need attention without switching tabs.

## Test plan
- [ ] Open dashboard with multiple sessions
- [ ] Verify tab shows "(N) Claude Code Portal" when N sessions await input
- [ ] Verify tab shows "Claude Code Portal" when no sessions await input
- [ ] Verify paused sessions don't count toward the waiting count

🤖 Generated with [Claude Code](https://claude.com/claude-code)