### PR TITLE
Restore vertical stacking layout for session pills

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -1062,15 +1062,17 @@ fn session_rail(props: &SessionRailProps) -> Html {
                             <span class={connection_class}>
                                 { if is_connected { "●" } else { "○" } }
                             </span>
-                            <span class="pill-hostname" title={session.session_name.clone()}>{ hostname }</span>
-                            <span class="pill-folder" title={session.working_directory.clone()}>{ folder }</span>
-                            {
-                                if let Some(ref branch) = session.git_branch {
-                                    html! { <span class="pill-branch">{ branch }</span> }
-                                } else {
-                                    html! {}
+                            <span class="pill-name" title={session.session_name.clone()}>
+                                <span class="pill-folder">{ folder }</span>
+                                <span class="pill-hostname">{ hostname }</span>
+                                {
+                                    if let Some(ref branch) = session.git_branch {
+                                        html! { <span class="pill-branch">{ branch }</span> }
+                                    } else {
+                                        html! {}
+                                    }
                                 }
-                            }
+                            </span>
                             {
                                 if cost > 0.0 {
                                     html! { <span class="pill-cost">{ format!("${:.2}", cost) }</span> }

--- a/frontend/styles/session-view.css
+++ b/frontend/styles/session-view.css
@@ -192,15 +192,11 @@
     color: var(--error);
 }
 
-.pill-hostname {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-    white-space: nowrap;
+.pill-name {
+    display: flex;
+    flex-direction: column;
+    max-width: 200px;
     overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 120px;
-    padding-right: 0.5rem;
-    border-right: 1px solid var(--border);
 }
 
 .pill-folder {
@@ -210,7 +206,14 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 180px;
+}
+
+.pill-hostname {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .pill-branch {
@@ -289,7 +292,8 @@
 }
 
 .session-pill.status-disconnected .pill-folder,
-.session-pill.status-disconnected .pill-hostname {
+.session-pill.status-disconnected .pill-hostname,
+.session-pill.status-disconnected .pill-name {
     color: var(--text-secondary);
 }
 


### PR DESCRIPTION
## Summary
- Restores the vertical stacking layout for session pills that was accidentally changed in PR #171
- Wraps folder, hostname, and branch back in a `.pill-name` container with `flex-direction: column`

## What happened
PR #171 removed the `.pill-name` wrapper element, causing the three text elements (folder, hostname, branch) to become direct children of `.session-pill`. Since `.session-pill` uses a row flex layout, they all appeared on the same horizontal line instead of stacked vertically.

## Test plan
- [x] Verify session pills show folder on top, hostname below, branch at bottom
- [x] Check that disconnected session styling still works
- [x] Confirm layout matches pre-PR #171 appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)