### PR TITLE
Add Open Graph and Twitter Card meta tags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,20 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Claude Code Portal</title>
+
+    <!-- Open Graph / Link Preview -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Claude Code Portal" />
+    <meta property="og:description" content="A web-based portal for managing Claude Code sessions with real-time collaboration and multi-session support." />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Claude Code Portal" />
+    <meta name="twitter:description" content="A web-based portal for managing Claude Code sessions with real-time collaboration and multi-session support." />
+
+    <!-- General meta -->
+    <meta name="description" content="A web-based portal for managing Claude Code sessions with real-time collaboration and multi-session support." />
+
     <link data-trunk rel="rust" data-wasm-opt="z" />
     <!-- CSS files split for maintainability -->
     <link data-trunk rel="css" href="styles/base.css" />


### PR DESCRIPTION
## Summary
- Adds Open Graph meta tags for better link previews on social media
- Adds Twitter Card meta tags for Twitter/X link previews
- Adds general description meta tag for SEO

## Test plan
- [ ] Share a link to the portal and verify preview shows title and description
- [ ] Test on Discord, Slack, Twitter, and other platforms

Note: No preview image included yet - can be added in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)