### PR TITLE
Streamline README by moving usage and OAuth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,6 @@ A web portal that extends [Claude Code](https://docs.anthropic.com/en/docs/claud
 - **Long-Running Tasks**: Start a task, walk away, check results later from any device
 - **Consistent Environment**: Keep your dev environment on one machine, access it everywhere
 
-## Deployment Modes
-
-Claude Code Portal supports different authentication configurations:
-
-| Mode | Use Case | Configuration |
-|------|----------|---------------|
-| **Single User** | Personal server | Restrict to your Google account |
-| **Organization** | Team/company | Limit to specific email domain |
-| **Public** | Open access (like txcl.io) | Allow any Google account |
-
-See [Google OAuth Configuration](#google-oauth-configuration) for setup details.
-
 ## Quick Start
 
 ```bash
@@ -87,100 +75,15 @@ The **portal** refers to the complete system: backend server, web frontend, and 
 | **CLI** | `claude-portal` binary that wraps Claude Code and connects to backend |
 | **Shared** | Common types and protocol definitions (WASM-compatible) |
 
-## Usage
-
-### Web Interface
-
-1. Open the portal URL in your browser
-2. Sign in with Google
-3. View your active Claude Code sessions
-4. Click any session to interact with Claude
-5. Use the microphone button or `Ctrl+M` for voice input
-
-### Running the CLI
-
-On your development machine:
-
-```bash
-claude-portal \
-  --backend-url wss://your-portal.com \
-  --session-name "my-dev-machine"
-```
-
-On first run, the CLI displays a verification URL and code for OAuth authentication. Credentials are cached in `~/.config/claude-code-portal/config.json`.
-
-### Voice Commands
-
-The web interface supports voice input for hands-free coding:
-
-- Click the microphone icon or press `Ctrl+M` to start recording
-- Speak your command naturally
-- Click again or press `Ctrl+M` to stop and send
-- Works in Chrome, Edge, and other browsers with Web Speech API support
-
-## Google OAuth Configuration
-
-To deploy your own instance, you need Google OAuth credentials:
-
-### 1. Create a Google Cloud Project
-
-1. Go to [Google Cloud Console](https://console.cloud.google.com/)
-2. Create a new project or select an existing one
-3. Enable the **Google+ API** (for user info)
-
-### 2. Configure OAuth Consent Screen
-
-1. Navigate to **APIs & Services > OAuth consent screen**
-2. Choose **External** (or **Internal** for Google Workspace orgs)
-3. Fill in the required fields:
-   - App name: Your portal name
-   - User support email: Your email
-   - Developer contact: Your email
-4. Add scopes: `email`, `profile`, `openid`
-5. Add test users if in testing mode
-
-### 3. Create OAuth Credentials
-
-1. Navigate to **APIs & Services > Credentials**
-2. Click **Create Credentials > OAuth client ID**
-3. Application type: **Web application**
-4. Add authorized redirect URIs:
-   - `https://your-domain.com/auth/google/callback`
-   - `http://localhost:3000/auth/google/callback` (for development)
-5. Save the **Client ID** and **Client Secret**
-
-### 4. Configure Environment Variables
-
-Create a `.env` file or set environment variables:
-
-```bash
-GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
-GOOGLE_CLIENT_SECRET=your-client-secret
-GOOGLE_REDIRECT_URI=https://your-domain.com/auth/google/callback
-
-# Optional: Restrict access to specific email domain
-# ALLOWED_EMAIL_DOMAIN=yourcompany.com
-
-# Optional: Restrict to specific email addresses
-# ALLOWED_EMAILS=user1@gmail.com,user2@gmail.com
-```
-
-### Access Control Options
-
-| Variable | Effect |
-|----------|--------|
-| No restrictions | Any Google account can sign in |
-| `ALLOWED_EMAIL_DOMAIN=company.com` | Only `@company.com` emails allowed |
-| `ALLOWED_EMAILS=a@x.com,b@y.com` | Only listed emails allowed |
-
 ## Documentation
 
 | Document | Description |
 |----------|-------------|
+| [Usage Guide](docs/USAGE.md) | Web interface, CLI options, voice input, session sharing |
 | [Local Development](docs/LOCAL_DEVELOPMENT.md) | Quick setup with `dev.sh`, available commands |
 | [Development Guide](docs/DEVELOPING.md) | Full dev workflow, building, testing, contributing |
+| [Deployment Guide](docs/DEPLOYING.md) | Production deployment, Google OAuth setup, configuration |
 | [Docker Guide](docs/DOCKER.md) | Docker and Kubernetes deployment with 1Password |
-| [Deployment Guide](docs/DEPLOYING.md) | Production deployment and configuration |
 | [Troubleshooting](TROUBLESHOOTING.md) | Common issues and solutions |
 
 ## Platform Support

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -8,9 +8,7 @@ This guide covers deploying claude-code-portal to production.
   - [NeonDB](https://neon.tech) (recommended, serverless)
   - Or any PostgreSQL 12+ instance
 
-- **Google OAuth Credentials**
-  - [Create OAuth Client](https://console.cloud.google.com/apis/credentials)
-  - Set authorized redirect URI: `https://your-domain.com/auth/google/callback`
+- **Google OAuth Credentials** (see [Google OAuth Setup](#google-oauth-setup) below)
 
 ## Environment Variables
 
@@ -52,7 +50,7 @@ docker-compose logs -f backend
 docker-compose down
 ```
 
-See [DOCKER.md](../DOCKER.md) for detailed Docker deployment instructions.
+See [DOCKER.md](DOCKER.md) for detailed Docker deployment instructions.
 
 ## Manual Deployment
 
@@ -170,3 +168,67 @@ Pre-built binaries for all platforms are available from [GitHub Releases](https:
 ## Troubleshooting
 
 See [TROUBLESHOOTING.md](../TROUBLESHOOTING.md) for common issues and solutions.
+
+## Google OAuth Setup
+
+To deploy your own instance, you need Google OAuth credentials.
+
+### 1. Create a Google Cloud Project
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project or select an existing one
+3. Enable the **Google+ API** (for user info)
+
+### 2. Configure OAuth Consent Screen
+
+1. Navigate to **APIs & Services > OAuth consent screen**
+2. Choose **External** (or **Internal** for Google Workspace orgs)
+3. Fill in the required fields:
+   - App name: Your portal name
+   - User support email: Your email
+   - Developer contact: Your email
+4. Add scopes: `email`, `profile`, `openid`
+5. Add test users if in testing mode
+
+### 3. Create OAuth Credentials
+
+1. Navigate to **APIs & Services > Credentials**
+2. Click **Create Credentials > OAuth client ID**
+3. Application type: **Web application**
+4. Add authorized redirect URIs:
+   - `https://your-domain.com/auth/google/callback`
+   - `http://localhost:3000/auth/google/callback` (for development)
+5. Save the **Client ID** and **Client Secret**
+
+### 4. Configure Environment
+
+Add to your `.env` file:
+
+```bash
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
+GOOGLE_REDIRECT_URI=https://your-domain.com/auth/google/callback
+```
+
+### Access Control Options
+
+Control who can access your portal:
+
+| Variable | Effect |
+|----------|--------|
+| *(none)* | Any Google account can sign in |
+| `ALLOWED_EMAIL_DOMAIN=company.com` | Only `@company.com` emails allowed |
+| `ALLOWED_EMAILS=a@x.com,b@y.com` | Only listed emails allowed |
+
+Example configurations:
+
+```bash
+# Single user (personal server)
+ALLOWED_EMAILS=your.email@gmail.com
+
+# Organization (team/company)
+ALLOWED_EMAIL_DOMAIN=yourcompany.com
+
+# Public access (like txcl.io)
+# Don't set either variable
+```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,164 @@
+# Usage Guide
+
+This guide covers how to use Claude Code Portal once it's set up.
+
+## Web Interface
+
+1. Open the portal URL in your browser
+2. Sign in with Google
+3. View your active Claude Code sessions
+4. Click any session to interact with Claude
+5. Use the microphone button or `Ctrl+M` for voice input
+
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+M` | Toggle voice recording |
+| `Enter` | Send message |
+| `Escape` | Cancel current action |
+
+### Session Management
+
+- **Active sessions** show a green indicator
+- **Disconnected sessions** are greyed out but remain accessible for history
+- **Paused sessions** are dimmed and excluded from rotation
+- Click the pause button on any session to toggle pause state
+
+## Running the CLI
+
+On your development machine, run the `claude-portal` binary to connect to the portal:
+
+```bash
+claude-portal \
+  --backend-url wss://your-portal.com \
+  --session-name "my-dev-machine"
+```
+
+### First Run Authentication
+
+On first run, the CLI displays a verification URL and code:
+
+```
+To authenticate, visit: https://your-portal.com/device
+Enter code: ABCD-1234
+```
+
+Open the URL in your browser, sign in with Google, and enter the code. Credentials are cached in `~/.config/claude-code-portal/config.json`.
+
+### CLI Options
+
+```bash
+claude-portal [OPTIONS] -- [CLAUDE_ARGS]
+
+Options:
+  --backend-url <URL>     Backend WebSocket URL [default: ws://localhost:3000]
+  --session-name <NAME>   Session name [default: hostname-timestamp]
+  --auth-token <TOKEN>    Authentication token (skips OAuth flow)
+  --reauth                Force re-authentication
+  --logout                Remove cached credentials and exit
+
+# All arguments after -- are forwarded to the claude CLI
+```
+
+### Examples
+
+```bash
+# Connect to production portal
+claude-portal --backend-url wss://txcl.io
+
+# Use a custom session name
+claude-portal --backend-url wss://txcl.io --session-name "gpu-workstation"
+
+# Force re-authentication
+claude-portal --backend-url wss://txcl.io --reauth
+
+# Clear cached credentials
+claude-portal --logout
+
+# Pass arguments to claude CLI
+claude-portal --backend-url wss://txcl.io -- --model claude-3-opus
+```
+
+## Voice Commands
+
+The web interface supports voice input for hands-free coding:
+
+1. Click the microphone icon or press `Ctrl+M` to start recording
+2. Speak your command naturally
+3. Click again or press `Ctrl+M` to stop and send
+
+### Browser Support
+
+Voice input works in browsers with Web Speech API support:
+- Chrome (recommended)
+- Edge
+- Safari
+- Firefox (limited support)
+
+### Tips for Voice Input
+
+- Speak clearly and at a natural pace
+- The transcript appears in real-time as you speak
+- You can edit the transcribed text before sending
+- Works best in quiet environments
+
+## Session Sharing
+
+Share sessions with team members for collaborative coding:
+
+1. Click the share icon on any session you own
+2. Enter the email address of the person to share with
+3. Choose their role:
+   - **Editor**: Can send messages and interact with Claude
+   - **Viewer**: Can only watch the session
+4. The shared user will see the session in their dashboard
+
+### Managing Shared Sessions
+
+- **Owners** can add/remove members and change roles
+- **Editors** can interact but cannot manage sharing
+- **Viewers** have read-only access
+- Click "Leave" on a shared session to remove yourself
+
+## Tips and Best Practices
+
+### Session Naming
+
+Use descriptive session names to easily identify sessions:
+```bash
+# Good session names
+claude-portal --session-name "gpu-ml-training"
+claude-portal --session-name "frontend-dev"
+claude-portal --session-name "raspberry-pi"
+
+# Default uses hostname + timestamp
+claude-portal  # Results in: my-laptop-20260118-143022
+```
+
+### Multiple Sessions
+
+You can run multiple `claude-portal` instances on the same machine:
+```bash
+# Terminal 1
+claude-portal --session-name "project-a"
+
+# Terminal 2
+claude-portal --session-name "project-b"
+```
+
+### Long-Running Tasks
+
+For long-running tasks:
+1. Start the task in your session
+2. Close your browser - the session continues running
+3. Check back later from any device
+4. All history is preserved
+
+### Working Directory
+
+The portal displays the working directory where `claude-portal` was started. Run it from your project root for clear context:
+```bash
+cd ~/projects/my-app
+claude-portal --backend-url wss://txcl.io
+```


### PR DESCRIPTION
## Summary
- Create `docs/USAGE.md` with comprehensive usage guide
- Move Google OAuth configuration from README to `docs/DEPLOYING.md`
- Streamline README to focus on overview and quick start

## Changes

### New: docs/USAGE.md
Detailed usage guide covering:
- Web interface walkthrough
- Keyboard shortcuts
- CLI options and examples
- Voice input setup and tips
- Session sharing
- Best practices

### Updated: docs/DEPLOYING.md
- Added complete Google OAuth setup instructions (moved from README)
- Added access control configuration examples
- Fixed broken link to DOCKER.md

### Updated: README.md
Removed detailed sections (now in docs), keeping:
- Features and use cases
- Quick start
- Architecture diagram
- Documentation links table
- Platform support, technologies, contributing

## Before/After

**Before**: README was 222 lines with embedded OAuth setup and usage instructions
**After**: README is 126 lines, focused on overview with links to detailed docs

## Test plan
- [x] All documentation links are valid
- [x] USAGE.md covers all moved content
- [x] DEPLOYING.md has complete OAuth instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)