### PR TITLE
Simplify Docker guide and update environment variables

### DIFF
--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -15,23 +15,29 @@ This guide covers deploying claude-code-portal to production.
 Create a `.env` file or set these environment variables:
 
 ```bash
-# Database Connection (required)
+# Required
 DATABASE_URL=postgresql://user:password@host:5432/database?sslmode=require
-
-# Google OAuth (required for production)
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 GOOGLE_REDIRECT_URI=https://your-domain.com/auth/google/callback
-
-# Server Configuration
-HOST=0.0.0.0
-PORT=3000
-
-# Security (required for production)
 SESSION_SECRET=generate-a-random-32-char-secret-here
 
-# Frontend Path (usually auto-detected)
-FRONTEND_DIST=frontend/dist
+# Optional - Server configuration
+# HOST=0.0.0.0
+# PORT=3000
+# BASE_URL=https://your-domain.com
+
+# Optional - Customize app title
+# APP_TITLE=Claude Code Portal
+
+# Optional - Google Cloud Speech-to-Text (for server-side voice transcription)
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+# Optional - Frontend path (auto-detected)
+# FRONTEND_DIST=frontend/dist
+
+# Optional - Proxy binary path for downloads (auto-detected)
+# PROXY_BINARY_PATH=/app/claude-portal
 ```
 
 ## Docker Deployment (Recommended)
@@ -210,25 +216,9 @@ GOOGLE_CLIENT_SECRET=your-client-secret
 GOOGLE_REDIRECT_URI=https://your-domain.com/auth/google/callback
 ```
 
-### Access Control Options
+### Access Control
 
-Control who can access your portal:
+By default, any Google account can sign in. To restrict access:
 
-| Variable | Effect |
-|----------|--------|
-| *(none)* | Any Google account can sign in |
-| `ALLOWED_EMAIL_DOMAIN=company.com` | Only `@company.com` emails allowed |
-| `ALLOWED_EMAILS=a@x.com,b@y.com` | Only listed emails allowed |
-
-Example configurations:
-
-```bash
-# Single user (personal server)
-ALLOWED_EMAILS=your.email@gmail.com
-
-# Organization (team/company)
-ALLOWED_EMAIL_DOMAIN=yourcompany.com
-
-# Public access (like txcl.io)
-# Don't set either variable
-```
+1. Use the admin panel (`/admin`) to disable unwanted users after they sign in
+2. For Google Workspace organizations, configure the OAuth consent screen as "Internal" to restrict to your domain

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,90 +1,80 @@
 # Docker Deployment Guide
 
-This guide covers running CC-Proxy backend in Docker with 1Password secret injection.
+This guide covers running Claude Code Portal in Docker.
 
-## Quick Start (Local Development)
-
-For local development without 1Password:
+## Quick Start
 
 ```bash
-# Start PostgreSQL and backend
+# Build and start
 docker-compose up -d
-
-# Run database migrations
-docker-compose exec backend /app/backend migrate
 
 # View logs
 docker-compose logs -f backend
 
-# Stop everything
+# Stop
 docker-compose down
 ```
 
-## Production Deployment with 1Password
-
-### Option 1: Using 1Password Service Account (Recommended)
-
-1. **Create a 1Password Service Account**
-   - Go to your 1Password account settings
-   - Create a service account with read access to your vault
-   - Copy the service account token
-
-2. **Set up your secrets in 1Password**
-   - Follow the guide in `SETUP_1PASSWORD.md`
-   - Ensure all secrets are stored in 1Password
-
-3. **Build the Docker image**
-   ```bash
-   docker build -f backend/Dockerfile -t claude-code-portal-backend .
-   ```
-
-4. **Run with service account token**
-   ```bash
-   docker run -d \
-     --name claude-code-portal-backend \
-     -p 3000:3000 \
-     -e OP_SERVICE_ACCOUNT_TOKEN="your_service_account_token" \
-     claude-code-portal-backend
-   ```
-
-### Option 2: Using 1Password Connect
-
-1. **Deploy 1Password Connect Server**
-   ```bash
-   # Follow: https://developer.1password.com/docs/connect/get-started/
-   docker run -d \
-     --name op-connect \
-     -p 8080:8080 \
-     -v /path/to/1password-credentials.json:/home/opuser/.op/1password-credentials.json \
-     1password/connect-api:latest
-   ```
-
-2. **Configure backend to use Connect**
-   ```bash
-   docker run -d \
-     --name claude-code-portal-backend \
-     -p 3000:3000 \
-     -e OP_CONNECT_HOST="http://op-connect:8080" \
-     -e OP_CONNECT_TOKEN="your_connect_token" \
-     --link op-connect \
-     claude-code-portal-backend
-   ```
-
-### Option 3: Mount 1Password CLI Config (Local Testing)
+## Building the Image
 
 ```bash
-# Sign in to 1Password CLI locally first
-op signin
+docker build -f backend/Dockerfile -t claude-code-portal-backend .
+```
 
-# Run container with mounted config
+## Running with Environment Variables
+
+Create a `.env` file with your configuration:
+
+```bash
+# .env
+
+# Required
+DATABASE_URL=postgresql://user:password@host:5432/database?sslmode=require
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
+GOOGLE_REDIRECT_URI=https://your-domain.com/auth/google/callback
+SESSION_SECRET=generate-a-random-32-char-secret-here
+
+# Optional - Server configuration
+# HOST=0.0.0.0
+# PORT=3000
+# BASE_URL=https://your-domain.com
+
+# Optional - Customize app title shown in browser
+# APP_TITLE=Claude Code Portal
+
+# Optional - Google Cloud Speech-to-Text (for server-side voice transcription)
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+# Optional - Path to proxy binary for downloads (auto-detected if not set)
+# PROXY_BINARY_PATH=/app/claude-portal
+```
+
+Run the container with the env file:
+
+```bash
 docker run -d \
   --name claude-code-portal-backend \
   -p 3000:3000 \
-  -v ~/.config/op:/root/.config/op:ro \
+  --env-file .env \
   claude-code-portal-backend
 ```
 
-## Docker Compose Production Setup
+Or pass variables directly:
+
+```bash
+docker run -d \
+  --name claude-code-portal-backend \
+  -p 3000:3000 \
+  -e DATABASE_URL="postgresql://..." \
+  -e GOOGLE_CLIENT_ID="..." \
+  -e GOOGLE_CLIENT_SECRET="..." \
+  -e GOOGLE_REDIRECT_URI="https://your-domain.com/auth/google/callback" \
+  -e SESSION_SECRET="$(openssl rand -base64 32)" \
+  claude-code-portal-backend
+```
+
+## Docker Compose
 
 Create a `docker-compose.prod.yml`:
 
@@ -97,13 +87,8 @@ services:
     container_name: claude-code-portal-backend
     ports:
       - "3000:3000"
-    environment:
-      # 1Password Service Account Token
-      OP_SERVICE_ACCOUNT_TOKEN: ${OP_SERVICE_ACCOUNT_TOKEN}
-
-      # Or 1Password Connect
-      # OP_CONNECT_HOST: http://op-connect:8080
-      # OP_CONNECT_TOKEN: ${OP_CONNECT_TOKEN}
+    env_file:
+      - .env
     restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/"]
@@ -111,229 +96,21 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-    networks:
-      - claude-code-portal-network
-
-  # Optional: 1Password Connect
-  op-connect:
-    image: 1password/connect-api:latest
-    container_name: op-connect
-    ports:
-      - "8080:8080"
-    volumes:
-      - ./1password-credentials.json:/home/opuser/.op/1password-credentials.json:ro
-    environment:
-      OP_SESSION: ${OP_CONNECT_TOKEN}
-    networks:
-      - claude-code-portal-network
-
-networks:
-  claude-code-portal-network:
-    driver: bridge
 ```
 
 Run with:
 
 ```bash
-# Set your service account token
-export OP_SERVICE_ACCOUNT_TOKEN="your_token_here"
-
-# Start services
 docker-compose -f docker-compose.prod.yml up -d
-
-# View logs
-docker-compose -f docker-compose.prod.yml logs -f
 ```
 
-## Kubernetes Deployment
+## Production Setup with Traefik
 
-### With 1Password Operator
-
-1. **Install 1Password Operator**
-   ```bash
-   helm repo add 1password https://1password.github.io/connect-helm-charts
-   helm install connect 1password/connect \
-     --set-file connect.credentials=1password-credentials.json
-   ```
-
-2. **Create OnePasswordItem resource**
-   ```yaml
-   # k8s/secrets.yaml
-   apiVersion: onepassword.com/v1
-   kind: OnePasswordItem
-   metadata:
-     name: claude-code-portal-secrets
-   spec:
-     itemPath: "vaults/Development/items/claude-code-portal-secrets"
-   ```
-
-3. **Deploy backend**
-   ```yaml
-   # k8s/deployment.yaml
-   apiVersion: apps/v1
-   kind: Deployment
-   metadata:
-     name: claude-code-portal-backend
-   spec:
-     replicas: 2
-     selector:
-       matchLabels:
-         app: claude-code-portal-backend
-     template:
-       metadata:
-         labels:
-           app: claude-code-portal-backend
-       spec:
-         containers:
-         - name: backend
-           image: claude-code-portal-backend:latest
-           ports:
-           - containerPort: 3000
-           env:
-           - name: DATABASE_URL
-             valueFrom:
-               secretKeyRef:
-                 name: claude-code-portal-secrets
-                 key: database_url
-           - name: GOOGLE_CLIENT_ID
-             valueFrom:
-               secretKeyRef:
-                 name: claude-code-portal-secrets
-                 key: google_client_id
-           # ... etc
-   ```
-
-## Building for Different Architectures
-
-### Multi-platform build
-
-```bash
-# Enable buildx
-docker buildx create --use
-
-# Build for multiple platforms
-docker buildx build \
-  --platform linux/amd64,linux/arm64 \
-  -f backend/Dockerfile \
-  -t your-registry/claude-code-portal-backend:latest \
-  --push \
-  .
-```
-
-## Optimizing Build Times
-
-### Use BuildKit cache
-
-```bash
-# Enable BuildKit
-export DOCKER_BUILDKIT=1
-
-# Build with cache
-docker build \
-  --cache-from claude-code-portal-backend:latest \
-  -f backend/Dockerfile \
-  -t claude-code-portal-backend:latest \
-  .
-```
-
-### Pre-cache dependencies
-
-```bash
-# Build a dependencies-only image first
-docker build \
-  --target builder \
-  -f backend/Dockerfile \
-  -t claude-code-portal-backend:deps \
-  .
-
-# Then build full image (will use cached deps)
-docker build \
-  --cache-from claude-code-portal-backend:deps \
-  -f backend/Dockerfile \
-  -t claude-code-portal-backend:latest \
-  .
-```
-
-## Environment Variables
-
-The Docker container supports these environment variables:
-
-### Required (via 1Password)
-- `DATABASE_URL` - PostgreSQL connection string
-- `GOOGLE_CLIENT_ID` - Google OAuth client ID
-- `GOOGLE_CLIENT_SECRET` - Google OAuth client secret
-- `SESSION_SECRET` - Session encryption key
-
-### Optional
-- `GOOGLE_REDIRECT_URI` - OAuth callback (default: http://localhost:3000/auth/google/callback)
-- `HOST` - Bind host (default: 0.0.0.0)
-- `PORT` - Bind port (default: 3000)
-
-### 1Password Configuration
-- `OP_SERVICE_ACCOUNT_TOKEN` - Service account token for secret access
-- `OP_CONNECT_HOST` - 1Password Connect server URL
-- `OP_CONNECT_TOKEN` - 1Password Connect access token
-
-## Troubleshooting
-
-### Container exits immediately
-
-Check logs:
-```bash
-docker logs claude-code-portal-backend
-```
-
-Common issues:
-- 1Password CLI can't authenticate (missing token)
-- Database connection failed
-- Missing required environment variables
-
-### 1Password authentication failed
-
-Verify your service account token:
-```bash
-docker run --rm \
-  -e OP_SERVICE_ACCOUNT_TOKEN="your_token" \
-  claude-code-portal-backend \
-  op vault list
-```
-
-### Database connection failed
-
-Test database connectivity:
-```bash
-docker run --rm \
-  -e DATABASE_URL="postgresql://..." \
-  claude-code-portal-backend \
-  bash -c 'apt-get update && apt-get install -y postgresql-client && psql $DATABASE_URL -c "SELECT 1"'
-```
-
-### Health check failing
-
-Test the endpoint manually:
-```bash
-docker exec claude-code-portal-backend curl -f http://localhost:3000/
-```
-
-## Production Checklist
-
-- [ ] Use 1Password Service Account or Connect for secret management
-- [ ] Set up proper database backups
-- [ ] Configure TLS/SSL termination (via reverse proxy)
-- [ ] Set up monitoring and logging
-- [ ] Use a production-grade PostgreSQL (not docker-compose db)
-- [ ] Configure proper resource limits
-- [ ] Set up auto-restart policies
-- [ ] Use secrets management for OP_SERVICE_ACCOUNT_TOKEN
-- [ ] Enable Docker Content Trust for image verification
-- [ ] Regular security updates (`docker pull` latest base images)
-
-## Example Production Stack
+Example with automatic TLS via Let's Encrypt:
 
 ```yaml
-# docker-compose.prod.yml - Full production stack
+# docker-compose.prod.yml
 services:
-  # Traefik reverse proxy with TLS
   traefik:
     image: traefik:v2.10
     command:
@@ -351,13 +128,93 @@ services:
       - ./letsencrypt:/letsencrypt
 
   backend:
-    image: claude-code-portal-backend:latest
-    environment:
-      OP_SERVICE_ACCOUNT_TOKEN: ${OP_SERVICE_ACCOUNT_TOKEN}
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    env_file:
+      - .env
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.backend.rule=Host(`api.yoursite.com`)"
+      - "traefik.http.routers.backend.rule=Host(`portal.yoursite.com`)"
       - "traefik.http.routers.backend.entrypoints=websecure"
       - "traefik.http.routers.backend.tls.certresolver=letsencrypt"
     restart: always
 ```
+
+## Multi-Architecture Builds
+
+Build for both AMD64 and ARM64:
+
+```bash
+docker buildx create --use
+
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -f backend/Dockerfile \
+  -t your-registry/claude-code-portal-backend:latest \
+  --push \
+  .
+```
+
+## Environment Variables Reference
+
+### Required
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | PostgreSQL connection string |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
+| `GOOGLE_REDIRECT_URI` | OAuth callback URL (e.g., `https://your-domain.com/auth/google/callback`) |
+| `SESSION_SECRET` | Session encryption key (32+ chars recommended) |
+
+### Optional
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HOST` | `0.0.0.0` | Bind address |
+| `PORT` | `3000` | Bind port |
+| `BASE_URL` | Auto-detected | Public URL for OAuth callbacks |
+| `APP_TITLE` | `Claude Code Sessions` | Title shown in browser tab |
+| `GOOGLE_APPLICATION_CREDENTIALS` | *(none)* | Path to GCP service account JSON for Speech-to-Text |
+| `PROXY_BINARY_PATH` | Auto-detected | Path to `claude-portal` binary for downloads |
+
+## Troubleshooting
+
+### Container exits immediately
+
+Check logs:
+```bash
+docker logs claude-code-portal-backend
+```
+
+Common causes:
+- Missing required environment variables
+- Database connection failed
+- Invalid OAuth credentials
+
+### Database connection failed
+
+Test connectivity:
+```bash
+docker run --rm --env-file .env claude-code-portal-backend \
+  bash -c 'psql $DATABASE_URL -c "SELECT 1"'
+```
+
+### Health check failing
+
+Test the endpoint:
+```bash
+docker exec claude-code-portal-backend curl -f http://localhost:3000/
+```
+
+## Production Checklist
+
+- [ ] Use a production PostgreSQL database (not the dev docker-compose db)
+- [ ] Set up database backups
+- [ ] Configure TLS/SSL (via Traefik, nginx, or cloud load balancer)
+- [ ] Set strong `SESSION_SECRET`
+- [ ] Configure access restrictions (`ALLOWED_EMAIL_DOMAIN` or `ALLOWED_EMAILS`)
+- [ ] Set up monitoring and log aggregation
+- [ ] Configure resource limits
+- [ ] Enable auto-restart (`restart: always`)


### PR DESCRIPTION
## Summary
- Remove all 1Password-specific content from DOCKER.md
- Show simple `.env` file injection instead
- Update environment variables documentation to match actual backend code

## Changes

### docs/DOCKER.md
- Removed 1Password Service Account, Connect, and Operator sections
- Removed Kubernetes 1Password integration
- Simplified to show `--env-file .env` pattern
- Updated env vars reference to match actual usage
- Kept: Quick start, building, Docker Compose, Traefik example, multi-arch builds, troubleshooting

### docs/DEPLOYING.md  
- Updated environment variables section with all actual vars
- Removed undocumented `ALLOWED_EMAIL_DOMAIN` and `ALLOWED_EMAILS` (not implemented)
- Added `APP_TITLE`, `BASE_URL`, `GOOGLE_APPLICATION_CREDENTIALS`, `PROXY_BINARY_PATH`
- Simplified access control section (use admin panel or Google Workspace internal OAuth)

## Environment Variables (actual)

**Required:**
- `DATABASE_URL`
- `GOOGLE_CLIENT_ID`
- `GOOGLE_CLIENT_SECRET`
- `GOOGLE_REDIRECT_URI`
- `SESSION_SECRET`

**Optional:**
- `HOST`, `PORT`, `BASE_URL`
- `APP_TITLE`
- `GOOGLE_APPLICATION_CREDENTIALS` (Speech-to-Text)
- `FRONTEND_DIST`, `PROXY_BINARY_PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)