### PR TITLE
Add collapsible divider between active and inactive sessions

### DIFF
--- a/frontend/styles/session-view.css
+++ b/frontend/styles/session-view.css
@@ -138,6 +138,45 @@
     border-radius: 2px;
 }
 
+/* Divider between active and inactive sessions */
+.session-rail-divider {
+    display: flex;
+    align-items: center;
+    align-self: stretch;
+    gap: 0.25rem;
+    padding: 0 0.25rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.session-rail-divider .divider-line {
+    width: 1px;
+    align-self: stretch;
+    margin: 0.35rem 0;
+    background: var(--border);
+}
+
+.session-rail-divider .divider-toggle {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+    padding: 0.15rem 0.35rem;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.2s;
+}
+
+.session-rail-divider .divider-toggle:hover {
+    border-color: var(--text-secondary);
+    color: var(--text-primary);
+}
+
+.session-rail-divider.collapsed .divider-toggle {
+    background: rgba(0, 0, 0, 0.2);
+}
+
 .session-pill {
     position: relative;
     display: flex;


### PR DESCRIPTION
## Summary
- Adds a visual divider in the session rail separating active sessions (connected and not paused) from inactive sessions (disconnected or paused)
- Includes a toggle button to show/hide inactive sessions
- Collapsed state is persisted to localStorage

## Test plan
- [ ] Verify active sessions appear before the divider
- [ ] Verify inactive/paused sessions appear after the divider
- [ ] Click the toggle to collapse - inactive sessions should hide and show count
- [ ] Click again to expand - inactive sessions should reappear
- [ ] Refresh page - collapsed state should persist
- [ ] Verify nav mode numbering (1-9) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)