### PR TITLE
Add graceful shutdown notifications to clients

### DIFF
--- a/frontend/styles/session-view.css
+++ b/frontend/styles/session-view.css
@@ -80,6 +80,28 @@
     to { transform: rotate(360deg); }
 }
 
+/* Server shutdown banner */
+.server-shutdown-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: rgba(255, 158, 100, 0.15);
+    border-bottom: 1px solid rgba(255, 158, 100, 0.4);
+    animation: pulse 2s infinite;
+}
+
+.server-shutdown-banner .shutdown-icon {
+    font-size: 1.1rem;
+}
+
+.server-shutdown-banner .shutdown-text {
+    color: var(--warning, #ff9e64);
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
 .focus-flow-header .new-session-button {
     padding: 0.5rem 1rem;
     border-radius: 6px;

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -1012,6 +1012,17 @@ async fn handle_ws_text_message(
                 let _ = ws.send(Message::Text(json)).await;
             }
         }
+        ProxyMessage::ServerShutdown {
+            reason,
+            reconnect_delay_ms,
+        } => {
+            warn!(
+                "Server shutting down: {} (reconnecting in {}ms)",
+                reason, reconnect_delay_ms
+            );
+            // Returning false will trigger the reconnect cycle
+            return false;
+        }
         _ => {
             debug!("ws msg: {:?}", proxy_msg);
         }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -176,6 +176,15 @@ pub enum ProxyMessage {
         /// The session that ended
         session_id: Uuid,
     },
+
+    /// Server is shutting down (backend -> all clients)
+    /// Sent to all connected WebSocket clients before graceful shutdown
+    ServerShutdown {
+        /// Human-readable reason for shutdown (e.g., "Server restarting for update")
+        reason: String,
+        /// Suggested delay before reconnecting (milliseconds)
+        reconnect_delay_ms: u64,
+    },
 }
 
 fn default_language_code() -> String {


### PR DESCRIPTION
## Summary
- Adds ServerShutdown message type to the proxy protocol
- Backend broadcasts ServerShutdown to all connected clients on SIGTERM/SIGINT
- Frontend shows a warning banner and relies on existing reconnect logic
- Proxy client logs a warning and triggers reconnect cycle

## Test plan
- [ ] Start backend normally
- [ ] Connect frontend and proxy clients
- [ ] Send SIGTERM to backend (or Ctrl+C)
- [ ] Verify frontend shows shutdown banner
- [ ] Verify proxy logs warning message
- [ ] Verify both clients reconnect after server restarts

Fixes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)