### PR TITLE
Batch message truncation to reduce database load

### DIFF
--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -113,8 +113,8 @@ pub async fn create_message(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    // Auto-truncate after insert to maintain the limit
-    let _ = truncate_session_messages_internal(&mut conn, session_id);
+    // Queue session for truncation (batched for efficiency)
+    app_state.session_manager.queue_truncation(session_id);
 
     Ok(Json(MessageResponse { message }))
 }


### PR DESCRIPTION
## Summary
- Batches message truncation operations to run every 60 seconds instead of after every message insert
- Sessions needing truncation are queued in a DashSet and processed together
- Reduces database query frequency during high-activity sessions

## Changes
- Added `pending_truncations: Arc<DashSet<Uuid>>` to SessionManager
- Added `queue_truncation()` method to add sessions to the pending set
- Added `drain_pending_truncations()` method to collect and clear pending sessions
- Replaced direct `truncate_session_messages_internal()` calls with `queue_truncation()`
- Added background task in main.rs that runs batched truncation every minute

## Benefits
- Fewer DELETE queries per second during active sessions
- More messages deleted per query (batched)
- No functional change to message limit enforcement (still keeps last 100 messages)

## Test plan
- [ ] Start backend and observe "Started message truncation task" log
- [ ] Send multiple messages to a session
- [ ] Verify truncation runs after ~60 seconds (check logs for "Batched truncation complete")
- [ ] Verify message count stays at/below 100 after truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)