### PR TITLE
Clear shutdown banner when WebSocket reconnects

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -246,6 +246,7 @@ pub fn dashboard_page() -> Html {
                     match WebSocket::open(&ws_endpoint) {
                         Ok(ws) => {
                             attempt = 0; // Reset on successful connection
+                            server_shutdown_reason.set(None); // Clear shutdown banner
                             let (_sender, mut receiver) = ws.split();
 
                             while let Some(msg) = receiver.next().await {


### PR DESCRIPTION
Fixes #198

## Summary
- Clear the server shutdown banner when WebSocket successfully reconnects
- Previously the banner persisted even after server came back online

## Test plan
- [ ] Trigger server shutdown, verify banner appears
- [ ] Wait for server to restart, verify banner clears automatically