### PR TITLE
Remove deprecated /api/download/proxy update check

### DIFF
--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -251,8 +251,7 @@ async fn main() -> Result<()> {
 
     // Check for updates before anything else (unless --no-update or --init/--logout)
     if !args.no_update && args.init.is_none() && !args.logout {
-        let backend_url = update::get_update_backend_url();
-        match update::check_for_update_with_fallback(backend_url.as_deref(), false).await {
+        match update::check_for_update_github(false).await {
             Ok(update::UpdateResult::UpToDate) => {
                 // Continue normally
             }


### PR DESCRIPTION
## Summary
- Remove backend update check that always returned 404
- Updates now only use GitHub releases
- Removes unnecessary network request and warning on startup

Fixes #181

## Test plan
- [ ] Run `claude-portal --check-update` to verify updates still check GitHub
- [ ] Start `claude-portal` normally and verify no 404 warning appears
- [ ] Verify auto-update still works from GitHub releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)