### PR TITLE
Implement ALLOWED_EMAIL_DOMAIN and ALLOWED_EMAILS env vars

### DIFF
--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -6,8 +6,8 @@ pub mod utils;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use pages::{
-    admin::AdminPage, banned::BannedPage, dashboard::DashboardPage, settings::SettingsPage,
-    splash::SplashPage,
+    access_denied::AccessDeniedPage, admin::AdminPage, banned::BannedPage,
+    dashboard::DashboardPage, settings::SettingsPage, splash::SplashPage,
 };
 use yew::prelude::*;
 use yew_router::prelude::*;
@@ -24,6 +24,8 @@ pub enum Route {
     Admin,
     #[at("/banned")]
     Banned,
+    #[at("/access-denied")]
+    AccessDenied,
 }
 
 fn switch(routes: Route) -> Html {
@@ -33,6 +35,7 @@ fn switch(routes: Route) -> Html {
         Route::Settings => html! { <SettingsPage /> },
         Route::Admin => html! { <AdminPage /> },
         Route::Banned => html! { <BannedPage /> },
+        Route::AccessDenied => html! { <AccessDeniedPage /> },
     }
 }
 

--- a/frontend/src/pages/access_denied.rs
+++ b/frontend/src/pages/access_denied.rs
@@ -1,0 +1,23 @@
+use yew::prelude::*;
+
+#[function_component(AccessDeniedPage)]
+pub fn access_denied_page() -> Html {
+    html! {
+        <div class="banned-container">
+            <div class="banned-content">
+                <div class="banned-icon">{ "🔒" }</div>
+                <h1>{ "Access Denied" }</h1>
+                <p class="banned-message">
+                    { "Your email address is not authorized to access this service." }
+                </p>
+                <div class="banned-reason">
+                    <h3>{ "What happened?" }</h3>
+                    <p>{ "This portal restricts access to specific email addresses or domains. Your email is not on the allowlist." }</p>
+                </div>
+                <p class="banned-contact">
+                    { "If you believe this is an error, please contact the portal administrator." }
+                </p>
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -1,3 +1,4 @@
+pub mod access_denied;
 pub mod admin;
 pub mod banned;
 pub mod dashboard;


### PR DESCRIPTION
## Summary
- Add `ALLOWED_EMAIL_DOMAIN` env var to restrict access to a specific email domain (e.g., `company.com`)
- Add `ALLOWED_EMAILS` env var to allow specific email addresses (comma-separated)
- If neither is set, all emails are allowed (current behavior)
- If both are set, either condition grants access (union, not intersection)
- Add `/access-denied` page for unauthorized users

Fixes #180

## Test plan
- [ ] Without env vars set: any Google account can sign in
- [ ] With `ALLOWED_EMAIL_DOMAIN=company.com`: only `*@company.com` emails allowed
- [ ] With `ALLOWED_EMAILS=a@x.com,b@y.com`: only those specific emails allowed
- [ ] With both set: either condition allows access
- [ ] Denied users see `/access-denied` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)