### PR TITLE
Fix ToolResult content field to handle array content blocks

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -9,6 +9,12 @@ pub use proxy_tokens::*;
 pub mod api;
 pub use api::{ApiClientConfig, ApiError, CcProxyApi};
 
+// Re-export claude-codes types for frontend message parsing
+pub use claude_codes::io::{
+    ContentBlock, ImageBlock, ImageSource, TextBlock, ThinkingBlock, ToolResultBlock,
+    ToolResultContent, ToolUseBlock,
+};
+
 /// Message types for the WebSocket proxy protocol
 /// These are used to communicate between:
 /// - proxy <-> backend (session connection)


### PR DESCRIPTION
## Summary
- Re-exports `ToolResultContent` type from `claude-codes` via `shared` crate
- Updates `ContentBlock::ToolResult` to use `Option<ToolResultContent>` instead of `Option<String>`
- Updates rendering logic to extract text from both `Text(String)` and `Structured(Vec<Value>)` variants

The claude-codes protocol allows tool_result content to be either a plain string or an array of content blocks. Previously, the frontend only handled strings, causing array content to fail parsing.

## Test plan
- [ ] Verify tool results with string content still render correctly
- [ ] Verify tool results with array content blocks now render correctly
- [ ] Verify truncation logic still works for long results

Fixes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)