### PR TITLE
Add configurable message retention policy

### DIFF
--- a/backend/migrations/2026-01-18-221922_add_messages_created_at_index/down.sql
+++ b/backend/migrations/2026-01-18-221922_add_messages_created_at_index/down.sql
@@ -1,0 +1,2 @@
+-- Remove the index on messages.created_at
+DROP INDEX IF EXISTS idx_messages_created_at;

--- a/backend/migrations/2026-01-18-221922_add_messages_created_at_index/up.sql
+++ b/backend/migrations/2026-01-18-221922_add_messages_created_at_index/up.sql
@@ -1,0 +1,3 @@
+-- Add index on messages.created_at for efficient retention queries
+-- This supports queries that delete messages older than a certain date
+CREATE INDEX idx_messages_created_at ON messages (created_at);

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -10,13 +10,10 @@ use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tower_cookies::Cookies;
-use tracing::{error, info};
+use tracing::error;
 use uuid::Uuid;
 
 const SESSION_COOKIE_NAME: &str = "cc_session";
-
-/// Maximum number of messages to keep per session
-pub const MAX_MESSAGES_PER_SESSION: i64 = 100;
 
 /// Request body for creating a new message
 #[derive(Debug, Deserialize)]
@@ -151,60 +148,4 @@ pub async fn list_messages(
         messages: message_list,
         total,
     }))
-}
-
-/// Internal function to truncate session messages
-/// Keeps only the last MAX_MESSAGES_PER_SESSION messages for a session
-/// Returns the number of deleted messages
-pub fn truncate_session_messages_internal(
-    conn: &mut diesel::pg::PgConnection,
-    session_id: Uuid,
-) -> Result<usize, StatusCode> {
-    // Count total messages for this session
-    let total_count: i64 = messages::table
-        .filter(messages::session_id.eq(session_id))
-        .count()
-        .get_result(conn)
-        .map_err(|e| {
-            error!("Failed to count messages: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    if total_count <= MAX_MESSAGES_PER_SESSION {
-        return Ok(0);
-    }
-
-    let to_delete = total_count - MAX_MESSAGES_PER_SESSION;
-
-    // Get the IDs of the oldest messages to delete
-    // We order by created_at ASC and take the first `to_delete` messages
-    let ids_to_delete: Vec<Uuid> = messages::table
-        .filter(messages::session_id.eq(session_id))
-        .order(messages::created_at.asc())
-        .limit(to_delete)
-        .select(messages::id)
-        .load(conn)
-        .map_err(|e| {
-            error!("Failed to get messages to delete: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    if ids_to_delete.is_empty() {
-        return Ok(0);
-    }
-
-    // Delete the messages
-    let deleted = diesel::delete(messages::table.filter(messages::id.eq_any(&ids_to_delete)))
-        .execute(conn)
-        .map_err(|e| {
-            error!("Failed to delete old messages: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    info!(
-        "Truncated session {}: deleted {} old messages, keeping last {}",
-        session_id, deleted, MAX_MESSAGES_PER_SESSION
-    );
-
-    Ok(deleted)
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -6,6 +6,7 @@ pub mod downloads;
 pub mod helpers;
 pub mod messages;
 pub mod proxy_tokens;
+pub mod retention;
 pub mod sessions;
 pub mod voice;
 pub mod websocket;

--- a/backend/src/handlers/retention.rs
+++ b/backend/src/handlers/retention.rs
@@ -1,0 +1,120 @@
+//! Message retention and cleanup logic
+
+use crate::schema::messages;
+use chrono::Utc;
+use diesel::prelude::*;
+use tracing::{error, info};
+use uuid::Uuid;
+
+/// Configuration for message retention policy
+#[derive(Clone, Copy, Debug)]
+pub struct RetentionConfig {
+    /// Maximum messages to keep per session
+    pub max_messages_per_session: i64,
+    /// Days to retain messages (0 = disabled)
+    pub retention_days: u32,
+}
+
+impl RetentionConfig {
+    pub fn new(max_messages_per_session: i64, retention_days: u32) -> Self {
+        Self {
+            max_messages_per_session,
+            retention_days,
+        }
+    }
+}
+
+/// Truncate messages for a single session to the configured maximum
+/// Returns the number of deleted messages
+pub fn truncate_session_messages(
+    conn: &mut diesel::pg::PgConnection,
+    session_id: Uuid,
+    config: RetentionConfig,
+) -> Result<usize, diesel::result::Error> {
+    let total_count: i64 = messages::table
+        .filter(messages::session_id.eq(session_id))
+        .count()
+        .get_result(conn)?;
+
+    if total_count <= config.max_messages_per_session {
+        return Ok(0);
+    }
+
+    let to_delete = total_count - config.max_messages_per_session;
+
+    // Get the IDs of the oldest messages to delete
+    let ids_to_delete: Vec<Uuid> = messages::table
+        .filter(messages::session_id.eq(session_id))
+        .order(messages::created_at.asc())
+        .limit(to_delete)
+        .select(messages::id)
+        .load(conn)?;
+
+    if ids_to_delete.is_empty() {
+        return Ok(0);
+    }
+
+    let deleted = diesel::delete(messages::table.filter(messages::id.eq_any(&ids_to_delete)))
+        .execute(conn)?;
+
+    info!(
+        "Truncated session {}: deleted {} old messages, keeping last {}",
+        session_id, deleted, config.max_messages_per_session
+    );
+
+    Ok(deleted)
+}
+
+/// Delete all messages older than the configured retention period
+/// Uses a single bulk delete query for efficiency
+/// Returns the number of deleted messages
+pub fn delete_old_messages(
+    conn: &mut diesel::pg::PgConnection,
+    config: RetentionConfig,
+) -> Result<usize, diesel::result::Error> {
+    if config.retention_days == 0 {
+        return Ok(0);
+    }
+
+    let cutoff = Utc::now().naive_utc() - chrono::Duration::days(config.retention_days as i64);
+
+    let deleted =
+        diesel::delete(messages::table.filter(messages::created_at.lt(cutoff))).execute(conn)?;
+
+    if deleted > 0 {
+        info!(
+            "Retention cleanup: deleted {} messages older than {} days",
+            deleted, config.retention_days
+        );
+    }
+
+    Ok(deleted)
+}
+
+/// Run the full retention cleanup process:
+/// 1. Delete messages older than retention_days
+/// 2. Truncate per-session message counts
+pub fn run_retention_cleanup(
+    conn: &mut diesel::pg::PgConnection,
+    pending_session_ids: Vec<Uuid>,
+    config: RetentionConfig,
+) -> (usize, usize) {
+    let mut age_deleted = 0;
+    let mut count_deleted = 0;
+
+    // First, bulk delete old messages
+    match delete_old_messages(conn, config) {
+        Ok(deleted) => age_deleted = deleted,
+        Err(e) => error!("Failed to delete old messages: {:?}", e),
+    }
+
+    // Then truncate per-session counts
+    for session_id in pending_session_ids {
+        match truncate_session_messages(conn, session_id, config) {
+            Ok(deleted) => count_deleted += deleted,
+            Err(e) => error!("Failed to truncate session {}: {:?}", session_id, e),
+        }
+    }
+
+    (age_deleted, count_deleted)
+}


### PR DESCRIPTION
## Summary

Implements automatic message retention/deletion as described in #208:
- Adds `MESSAGE_RETENTION_COUNT` env var to limit messages per session (default: 100)
- Adds `MESSAGE_RETENTION_DAYS` env var to delete old messages (default: 30 days, 0 to disable)
- Creates `RetentionConfig` struct for clean configuration handling
- Adds database index on `messages.created_at` for efficient age-based queries
- Refactors batched truncation to use new retention module

Closes #208

## Test plan
- [x] Backend builds without warnings
- [x] Clippy passes
- [x] All tests pass
- [ ] Start backend with custom env vars and verify logging shows configured values
- [ ] Verify messages older than retention period get deleted
- [ ] Verify per-session message count is enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)