### PR TITLE
Document message retention environment variables

### DIFF
--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -42,6 +42,10 @@ SESSION_SECRET=generate-a-random-32-char-secret-here
 # Optional - Access control (restrict who can sign in)
 # ALLOWED_EMAIL_DOMAIN=yourcompany.com
 # ALLOWED_EMAILS=user1@gmail.com,user2@example.com
+
+# Optional - Message retention (data cleanup)
+# MESSAGE_RETENTION_COUNT=100    # Max messages per session (default: 100)
+# MESSAGE_RETENTION_DAYS=30      # Delete messages older than N days (default: 30, 0=disabled)
 ```
 
 ## Docker Deployment (Recommended)
@@ -163,6 +167,7 @@ Admins can access the admin dashboard at `/admin` which provides:
 - **HTTPS**: Use HTTPS in production (handled by reverse proxy)
 - **Environment Secrets**: Never commit `.env` to version control
 - **Database**: Use SSL/TLS for database connections in production
+- **Data Retention**: Message data is automatically deleted based on `MESSAGE_RETENTION_DAYS` (default 30) and per-session limits (`MESSAGE_RETENTION_COUNT`, default 100). Adjust these values based on your compliance requirements.
 
 ## Platform Support
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -52,6 +52,10 @@ SESSION_SECRET=generate-a-random-32-char-secret-here
 # Optional - Access control (restrict who can sign in)
 # ALLOWED_EMAIL_DOMAIN=yourcompany.com
 # ALLOWED_EMAILS=user1@gmail.com,user2@example.com
+
+# Optional - Message retention (data cleanup)
+# MESSAGE_RETENTION_COUNT=100    # Max messages per session (default: 100)
+# MESSAGE_RETENTION_DAYS=30      # Delete messages older than N days (default: 30, 0=disabled)
 ```
 
 Run the container with the env file:
@@ -184,6 +188,8 @@ docker buildx build \
 | `PROXY_BINARY_PATH` | Auto-detected | Path to `claude-portal` binary for downloads |
 | `ALLOWED_EMAIL_DOMAIN` | *(none)* | Restrict sign-in to emails from this domain |
 | `ALLOWED_EMAILS` | *(none)* | Comma-separated list of allowed email addresses |
+| `MESSAGE_RETENTION_COUNT` | `100` | Maximum messages to keep per session |
+| `MESSAGE_RETENTION_DAYS` | `30` | Delete messages older than N days (0 = disabled) |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Documents the new message retention environment variables added in PR #211:
- `MESSAGE_RETENTION_COUNT` (default: 100)
- `MESSAGE_RETENTION_DAYS` (default: 30)

Updates both DEPLOYING.md and DOCKER.md with:
- Env var examples in the configuration section
- Security considerations noting data retention policy
- Environment variables reference table entries

## Test plan
- [x] Documentation renders correctly in markdown preview