### PR TITLE
Add rich renderer for ExitPlanMode tool

### DIFF
--- a/frontend/src/components/message_renderer.rs
+++ b/frontend/src/components/message_renderer.rs
@@ -707,6 +707,7 @@ fn render_tool_use(name: &str, input: &Value) -> Html {
         "Write" => render_write_tool(input),
         "TodoWrite" => render_todowrite_tool(input),
         "AskUserQuestion" => render_askuserquestion_tool(input),
+        "ExitPlanMode" => render_exitplanmode_tool(input),
         "Bash" => render_bash_tool(input),
         "Read" => render_read_tool(input),
         "Glob" => render_glob_tool(input),
@@ -873,6 +874,51 @@ fn render_askuserquestion_tool(input: &Value) -> Html {
                     }).collect::<Html>()
                 }
             </div>
+        </div>
+    }
+}
+
+/// Render ExitPlanMode with formatted plan and permissions list
+fn render_exitplanmode_tool(input: &Value) -> Html {
+    let allowed_prompts = input
+        .get("allowedPrompts")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    html! {
+        <div class="tool-use exitplanmode-tool">
+            <div class="tool-use-header">
+                <span class="tool-icon">{ "📋" }</span>
+                <span class="tool-name">{ "Plan Complete" }</span>
+            </div>
+            {
+                if !allowed_prompts.is_empty() {
+                    html! {
+                        <div class="permissions-section">
+                            <div class="permissions-header">{ "Requested Permissions:" }</div>
+                            <div class="permissions-list">
+                                {
+                                    allowed_prompts.iter().map(|p| {
+                                        let tool = p.get("tool").and_then(|t| t.as_str()).unwrap_or("Unknown");
+                                        let prompt = p.get("prompt").and_then(|p| p.as_str()).unwrap_or("");
+                                        html! {
+                                            <div class="permission-item">
+                                                <span class="permission-bullet">{ "•" }</span>
+                                                <span class="permission-tool">{ tool }</span>
+                                                <span class="permission-separator">{ ": " }</span>
+                                                <span class="permission-prompt">{ prompt }</span>
+                                            </div>
+                                        }
+                                    }).collect::<Html>()
+                                }
+                            </div>
+                        </div>
+                    }
+                } else {
+                    html! {}
+                }
+            }
         </div>
     }
 }

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -208,6 +208,57 @@
     font-weight: 500;
 }
 
+/* ExitPlanMode Tool */
+.exitplanmode-tool {
+    background: rgba(158, 206, 106, 0.08);
+    border-left-color: var(--success);
+}
+
+.permissions-section {
+    margin-top: 0.5rem;
+    padding: 0.5rem;
+    background: rgba(0, 0, 0, 0.15);
+    border-radius: 4px;
+}
+
+.permissions-header {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+}
+
+.permissions-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.permission-item {
+    display: flex;
+    align-items: baseline;
+    font-size: 0.85rem;
+    font-family: var(--font-mono);
+}
+
+.permission-bullet {
+    color: var(--success);
+    margin-right: 0.5rem;
+}
+
+.permission-tool {
+    color: var(--accent);
+    font-weight: 500;
+}
+
+.permission-separator {
+    color: var(--text-muted);
+}
+
+.permission-prompt {
+    color: var(--text-primary);
+}
+
 /* Bash Tool */
 .bash-tool {
     background: rgba(127, 132, 156, 0.1);


### PR DESCRIPTION
## Summary
- Add dedicated renderer for ExitPlanMode tool_use blocks
- Displays "Plan Complete" header with clipboard icon
- Shows formatted list of requested permissions with tool and prompt

Fixes #213

## Test plan
- [ ] View a session with ExitPlanMode tool_use in the message history
- [ ] Verify permissions are displayed in a formatted list
- [ ] Verify styling matches other tool renderers

🤖 Generated with [Claude Code](https://claude.com/claude-code)