### PR TITLE
Make result message stats use consistent font styling

### DIFF
--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -465,8 +465,6 @@
 
 .result-message .stat-item.tokens {
     color: var(--text-secondary);
-    font-family: 'Courier New', monospace;
-    font-size: 0.75rem;
 }
 
 .result-message .stat-item.turns {


### PR DESCRIPTION
## Summary
- Remove special font-family and font-size from token counts in result messages
- Time and token counts now use the same base styling for visual consistency

## Test plan
- [ ] View a completed session with result message
- [ ] Verify duration and token counts have matching font size and style

🤖 Generated with [Claude Code](https://claude.com/claude-code)