### PR TITLE
Hide keyboard hints on mobile

### DIFF
--- a/frontend/styles/keyboard.css
+++ b/frontend/styles/keyboard.css
@@ -132,3 +132,13 @@
     border-color: #ff5a72;
 }
 
+/* ==========================================================================
+   Mobile - hide keyboard hints (no keyboard on mobile)
+   ========================================================================== */
+
+@media (max-width: 768px) {
+    .keyboard-hints {
+        display: none;
+    }
+}
+


### PR DESCRIPTION
## Summary
Hide the keyboard shortcut hints footer on mobile screens - users don't have keyboards there.

## Test plan
- [ ] View on mobile viewport, verify keyboard hints bar is hidden