### PR TITLE
Fix mobile input hidden by keyboard

### DIFF
--- a/frontend/styles/session-view.css
+++ b/frontend/styles/session-view.css
@@ -5,9 +5,16 @@
 .focus-flow-container {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: 100dvh; /* Dynamic viewport height - adjusts for mobile keyboard, falls back to 100vh */
     background: var(--bg-dark);
     outline: none;
+}
+
+/* Fallback for browsers that don't support dvh */
+@supports not (height: 100dvh) {
+    .focus-flow-container {
+        height: 100vh;
+    }
 }
 
 .focus-flow-header {
@@ -1483,16 +1490,22 @@
         padding: 0.2rem 0.4rem;
     }
 
-    /* Messages area */
+    /* Messages area - ensure scrolling and input stays visible */
     .session-view-messages {
         padding: 0.75rem;
+        flex: 1;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
     }
 
-    /* Input area - full width, stacked */
+    /* Input area - full width, sticky to bottom */
     .session-view-input {
         padding: 0.75rem;
         gap: 0.5rem;
         flex-wrap: wrap;
+        position: sticky;
+        bottom: 0;
+        z-index: 10;
     }
 
     .session-view-input .input-prompt {


### PR DESCRIPTION
## Summary
- Use `100dvh` (dynamic viewport height) which adjusts when mobile keyboard appears
- Make input sticky to bottom with `position: sticky`
- Add `-webkit-overflow-scrolling: touch` for smooth iOS scrolling

## Test plan
- [ ] Open on mobile device, tap input field
- [ ] Verify keyboard appears and input stays visible above it
- [ ] Verify messages still scroll properly