### PR TITLE
Fix Windows build errors in proxy

### DIFF
--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -91,12 +91,12 @@ impl ConfigLock {
                     if let Ok(mut existing) = File::open(&lock_path) {
                         let mut pid_str = String::new();
                         if existing.read_to_string(&mut pid_str).is_ok() {
-                            if let Ok(pid) = pid_str.trim().parse::<u32>() {
+                            if let Ok(_pid) = pid_str.trim().parse::<u32>() {
                                 // Check if process is still running (Unix-specific)
                                 #[cfg(unix)]
                                 {
                                     // kill with signal 0 checks if process exists
-                                    if unsafe { libc::kill(pid as i32, 0) } != 0 {
+                                    if unsafe { libc::kill(_pid as i32, 0) } != 0 {
                                         // Process is dead, remove stale lock
                                         let _ = fs::remove_file(&lock_path);
                                         continue;

--- a/proxy/src/update.rs
+++ b/proxy/src/update.rs
@@ -8,6 +8,8 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::fs;
 use tracing::info;
+#[cfg(windows)]
+use tracing::warn;
 
 /// GitHub repository for releases
 const GITHUB_REPO: &str = "meawoppl/claude-code-portal";
@@ -244,9 +246,8 @@ fn install_binary(self_path: &std::path::Path, new_binary: &[u8]) -> Result<()> 
         // Atomic rename on Unix
         fs::rename(&temp_path, self_path).context("Failed to replace binary")?;
         info!("Update installed successfully");
+        Ok(())
     }
-
-    Ok(())
 }
 
 /// Check for and apply pending updates (Windows only)


### PR DESCRIPTION
## Summary

Fix Windows build errors that were causing the release workflow to fail.

## Changes

### proxy/src/update.rs
- Add conditional `#[cfg(windows)]` import for `tracing::warn` (only used on Windows)
- Move `Ok(())` inside `#[cfg(not(windows))]` block to fix unreachable code warning

### proxy/src/config.rs
- Rename `pid` to `_pid` to silence unused variable warning on Windows (variable only used in `#[cfg(unix)]` block)

## Test plan

- [ ] Windows build should now succeed
- [ ] Linux/macOS builds should continue to work