### PR TITLE
Include user_code in auth URL for one-click login

### DIFF
--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -80,6 +80,10 @@ pub async fn device_flow_login(backend_url: &str) -> Result<(String, String, Str
         .context("Failed to parse device code response")?;
 
     // Step 2: Display instructions to user
+    let full_url = format!(
+        "{}?user_code={}",
+        response.verification_uri, response.user_code
+    );
     println!();
     println!(
         "{}",
@@ -94,15 +98,14 @@ pub async fn device_flow_login(backend_url: &str) -> Result<(String, String, Str
         "╚═══════════════════════════════════════════════════════╝".bright_blue()
     );
     println!();
-    println!("  To authenticate this machine, please visit:");
+    println!("  To authenticate this machine, visit:");
     println!();
-    println!("    {}", response.verification_uri.bright_green().bold());
-    println!();
-    println!("  And enter the code:");
+    println!("    {}", full_url.bright_green().bold());
     println!();
     println!(
-        "    {}",
-        response.user_code.bright_yellow().bold().underline()
+        "  {} Code: {}",
+        "📋".bright_cyan(),
+        response.user_code.bright_yellow().bold()
     );
     println!();
     println!("  {} Waiting for authentication...", "⏳".bright_cyan());


### PR DESCRIPTION
## Summary
- Display full URL with `user_code` parameter in terminal output
- Users can now click or copy the URL directly instead of manually entering the code
- Code is still shown separately for reference

## Test plan
- [ ] Run `claude-portal` without cached credentials
- [ ] Verify the displayed URL includes the `?user_code=XXX-XXX` parameter
- [ ] Click the URL and verify it goes directly to OAuth flow