### PR TITLE
Simplify install flow to use device auth

### DIFF
--- a/frontend/src/components/proxy_token_setup.rs
+++ b/frontend/src/components/proxy_token_setup.rs
@@ -1,20 +1,10 @@
 //! Proxy Token Setup Component
 //!
-//! Displays instructions for setting up the proxy CLI with a pre-authenticated token.
+//! Displays instructions for setting up the proxy CLI with device flow authentication.
 
 use crate::components::CopyCommand;
-use crate::utils;
 use gloo::utils::window;
-use gloo_net::http::Request;
-use shared::{CreateProxyTokenRequest, CreateProxyTokenResponse};
 use yew::prelude::*;
-
-#[derive(Clone, PartialEq)]
-enum TokenState {
-    Loading,
-    HasToken(CreateProxyTokenResponse),
-    Error(String),
-}
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Platform {
@@ -51,7 +41,6 @@ fn detect_platform() -> Platform {
 
 #[function_component(ProxyTokenSetup)]
 pub fn proxy_token_setup() -> Html {
-    let token_state = use_state(|| TokenState::Loading);
     let detected = detect_platform();
     let selected_platform = use_state(|| detected);
 
@@ -60,202 +49,105 @@ pub fn proxy_token_setup() -> Html {
         .and_then(|w| w.location().origin().ok())
         .unwrap_or_else(|| "http://localhost:3000".to_string());
 
-    // Auto-generate token on mount
-    {
-        let token_state = token_state.clone();
-
-        use_effect_with((), move |_| {
-            let token_state = token_state.clone();
-
-            wasm_bindgen_futures::spawn_local(async move {
-                let api_endpoint = utils::api_url("/api/proxy-tokens");
-
-                let request_body = CreateProxyTokenRequest {
-                    name: format!(
-                        "CLI Setup - {}",
-                        js_sys::Date::new_0().to_locale_string("en-US", &js_sys::Object::new())
-                    ),
-                    expires_in_days: 30,
-                };
-
-                match Request::post(&api_endpoint)
-                    .json(&request_body)
-                    .expect("Failed to serialize request")
-                    .send()
-                    .await
-                {
-                    Ok(response) => {
-                        if response.ok() {
-                            if let Ok(data) = response.json::<CreateProxyTokenResponse>().await {
-                                token_state.set(TokenState::HasToken(data));
-                            } else {
-                                token_state
-                                    .set(TokenState::Error("Failed to parse response".to_string()));
-                            }
-                        } else if response.status() == 401 {
-                            // Session invalid - redirect to logout
-                            if let Some(window) = web_sys::window() {
-                                let _ = window.location().set_href("/api/auth/logout");
-                            }
-                        } else {
-                            token_state.set(TokenState::Error(format!(
-                                "Server error: {}",
-                                response.status()
-                            )));
-                        }
-                    }
-                    Err(e) => {
-                        token_state.set(TokenState::Error(format!("Request failed: {:?}", e)));
-                    }
-                }
-            });
-
-            || ()
-        });
-    }
-
     let platforms = [Platform::Linux, Platform::MacOS, Platform::Windows];
 
-    match (*token_state).clone() {
-        TokenState::Loading => {
-            html! {
-                <div class="proxy-setup loading">
-                    <div class="spinner-small"></div>
-                    <span>{ "Generating setup command..." }</span>
-                </div>
-            }
+    // Derive WebSocket URL from current origin (http->ws, https->wss)
+    let ws_backend_url = base_url
+        .replace("https://", "wss://")
+        .replace("http://", "ws://");
+
+    let install_command = match *selected_platform {
+        Platform::Linux | Platform::MacOS => {
+            format!("curl -fsSL \"{}/api/download/install.sh\" | bash", base_url)
         }
-        TokenState::HasToken(token_response) => {
-            // URL-encode the init_url for the query parameter
-            let encoded_init_url = js_sys::encode_uri_component(&token_response.init_url);
+        Platform::Windows => format!(
+            "# Download from GitHub releases, then run:\n.\\claude-portal.exe --backend-url \"{}\"",
+            ws_backend_url
+        ),
+    };
+    let run_command = match *selected_platform {
+        Platform::Linux | Platform::MacOS => "claude-portal".to_string(),
+        Platform::Windows => ".\\claude-portal.exe".to_string(),
+    };
 
-            // Derive WebSocket URL from current origin (http->ws, https->wss)
-            let ws_backend_url = base_url
-                .replace("https://", "wss://")
-                .replace("http://", "ws://");
-            let encoded_backend_url = js_sys::encode_uri_component(&ws_backend_url);
+    html! {
+        <div class="proxy-setup has-token">
+            <h3>{ "Quick Setup" }</h3>
 
-            let install_command = match *selected_platform {
-                Platform::Linux | Platform::MacOS => format!(
-                    "curl -fsSL \"{}/api/download/install.sh?init_url={}&backend_url={}\" | bash",
-                    base_url, encoded_init_url, encoded_backend_url
-                ),
-                Platform::Windows => format!(
-                    "# Download from GitHub releases, then run:\n.\\claude-portal.exe --init \"{}\" --backend-url \"{}\"",
-                    token_response.init_url, ws_backend_url
-                ),
-            };
-            let run_command = match *selected_platform {
-                Platform::Linux | Platform::MacOS => "claude-portal".to_string(),
-                Platform::Windows => ".\\claude-portal.exe".to_string(),
-            };
+            <div class="platform-selector">
+                {for platforms.iter().map(|platform| {
+                    let is_selected = *selected_platform == *platform;
+                    let platform = *platform;
+                    let selected_platform = selected_platform.clone();
 
-            html! {
-                <div class="proxy-setup has-token">
-                    <h3>{ "Quick Setup" }</h3>
+                    let class = classes!(
+                        "platform-option",
+                        is_selected.then_some("selected")
+                    );
 
-                    <div class="platform-selector">
-                        {for platforms.iter().map(|platform| {
-                            let is_selected = *selected_platform == *platform;
-                            let platform = *platform;
-                            let selected_platform = selected_platform.clone();
+                    let onclick = Callback::from(move |_| {
+                        selected_platform.set(platform);
+                    });
 
-                            let class = classes!(
-                                "platform-option",
-                                is_selected.then_some("selected")
-                            );
+                    html! {
+                        <button {class} {onclick}>
+                            {platform.label()}
+                        </button>
+                    }
+                })}
+            </div>
 
-                            let onclick = Callback::from(move |_| {
-                                selected_platform.set(platform);
-                            });
+            <div class="setup-step">
+                <span class="step-number">{ "1" }</span>
+                <div class="step-content">
+                    <p class="step-label">{ "Install:" }</p>
+                    <CopyCommand command={install_command} />
+                </div>
+            </div>
 
-                            html! {
-                                <button {class} {onclick}>
-                                    {platform.label()}
-                                </button>
-                            }
-                        })}
-                    </div>
+            <div class="setup-step">
+                <span class="step-number">{ "2" }</span>
+                <div class="step-content">
+                    <p class="step-label">{ "Start a session:" }</p>
+                    <CopyCommand command={run_command} />
+                    <p class="step-hint">{ "(Opens browser to authenticate on first run)" }</p>
+                </div>
+            </div>
 
-                    <div class="setup-step">
-                        <span class="step-number">{ "1" }</span>
-                        <div class="step-content">
-                            <p class="step-label">{ "Install and initialize:" }</p>
-                            <CopyCommand command={install_command} />
-                        </div>
-                    </div>
-
-                    <div class="setup-step">
-                        <span class="step-number">{ "2" }</span>
-                        <div class="step-content">
-                            <p class="step-label">{ "Start a session:" }</p>
-                            <CopyCommand command={run_command} />
-                        </div>
-                    </div>
-
-                    <div class="setup-notes">
-                        <p class="note expiry">
+            <div class="setup-notes">
+                {if *selected_platform == Platform::Windows {
+                    html! {
+                        <>
+                            <p class="note warning-note">
+                                <span class="note-icon">{ "!" }</span>
+                                { "Windows support is experimental and largely untested. " }
+                                <a href="https://github.com/meawoppl/claude-code-portal/issues" target="_blank">
+                                    { "Please report issues!" }
+                                </a>
+                            </p>
+                            <p class="note windows-note">
+                                <span class="note-icon">{ "!" }</span>
+                                { "Download Windows binary from " }
+                                <a href="https://github.com/meawoppl/claude-code-portal/releases/latest" target="_blank">
+                                    { "GitHub releases" }
+                                </a>
+                            </p>
+                        </>
+                    }
+                } else if *selected_platform == Platform::MacOS {
+                    html! {
+                        <p class="note warning-note">
                             <span class="note-icon">{ "!" }</span>
-                            { format!("Token expires: {}", format_expiry(&token_response.expires_at)) }
+                            { "macOS support is experimental and largely untested. " }
+                            <a href="https://github.com/meawoppl/claude-code-portal/issues" target="_blank">
+                                { "Please report issues!" }
+                            </a>
                         </p>
-                        {if *selected_platform == Platform::Windows {
-                            html! {
-                                <>
-                                    <p class="note warning-note">
-                                        <span class="note-icon">{ "!" }</span>
-                                        { "Windows support is experimental and largely untested. " }
-                                        <a href="https://github.com/meawoppl/claude-code-portal/issues" target="_blank">
-                                            { "Please report issues!" }
-                                        </a>
-                                    </p>
-                                    <p class="note windows-note">
-                                        <span class="note-icon">{ "!" }</span>
-                                        { "Download Windows binary from " }
-                                        <a href="https://github.com/meawoppl/claude-code-portal/releases/latest" target="_blank">
-                                            { "GitHub releases" }
-                                        </a>
-                                    </p>
-                                </>
-                            }
-                        } else if *selected_platform == Platform::MacOS {
-                            html! {
-                                <p class="note warning-note">
-                                    <span class="note-icon">{ "!" }</span>
-                                    { "macOS support is experimental and largely untested. " }
-                                    <a href="https://github.com/meawoppl/claude-code-portal/issues" target="_blank">
-                                        { "Please report issues!" }
-                                    </a>
-                                </p>
-                            }
-                        } else {
-                            html! {}
-                        }}
-                    </div>
-                </div>
-            }
-        }
-        TokenState::Error(error) => {
-            html! {
-                <div class="proxy-setup error">
-                    <h3>{ "Error" }</h3>
-                    <p class="error-message">{ error }</p>
-                    <p class="setup-description">{ "Close and try again." }</p>
-                </div>
-            }
-        }
+                    }
+                } else {
+                    html! {}
+                }}
+            </div>
+        </div>
     }
-}
-
-fn format_expiry(timestamp: &str) -> String {
-    use js_sys::Date;
-
-    let parsed = Date::parse(timestamp);
-    if parsed.is_nan() {
-        return timestamp.to_string();
-    }
-
-    let date = Date::new(&wasm_bindgen::JsValue::from_f64(parsed));
-    date.to_locale_date_string("en-US", &js_sys::Object::new())
-        .as_string()
-        .unwrap_or_else(|| timestamp.to_string())
 }

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -313,6 +313,13 @@
     margin-bottom: 0.5rem;
 }
 
+.step-hint {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin-top: 0.5rem;
+    font-style: italic;
+}
+
 .setup-step .copy-command {
     margin: 0;
 }


### PR DESCRIPTION
## Summary
- Remove token-based init from install script
- Install script now just downloads binary and writes `config.json` with backend_url
- Frontend setup component no longer generates tokens - just shows simple curl command
- Authentication happens via device flow on first run of `claude-portal`

This simplifies onboarding:
1. Run: `curl -fsSL "https://txcl.io/api/download/install.sh" | bash`
2. Run: `claude-portal`
3. Opens browser to authenticate (instantly if already logged in)

## Test plan
- [ ] Visit dashboard, click "+ New Session"
- [ ] Verify simpler curl command is shown (no token params)
- [ ] Run the curl command on a fresh machine
- [ ] Run `claude-portal` - verify device auth flow starts
- [ ] Complete auth in browser - verify CLI receives credentials