### PR TITLE
Device flow creates proper JWT tokens

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -171,6 +171,7 @@ pub async fn callback(
         // Complete device flow
         if let Some(ref store) = app_state.device_flow_store {
             if let Ok(()) = crate::handlers::device_flow::complete_device_flow(
+                &app_state,
                 store,
                 &device_user_code,
                 user.id,


### PR DESCRIPTION
## Summary
- Fix device flow authentication by creating proper JWT tokens instead of simple prefixed tokens
- Store token hash in database so `verify_and_get_user` can validate them
- Tokens now expire in 30 days and include user email in claims

## Test plan
- [ ] Run `claude-portal` and complete device flow authentication
- [ ] Verify session registers successfully after authentication
- [ ] Verify token appears in user's token list in web UI