### PR TITLE
Add approval step to device flow (fixes #231)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -348,6 +348,14 @@ async fn main() -> anyhow::Result<()> {
             "/api/auth/device",
             get(handlers::device_flow::device_verify_page),
         )
+        .route(
+            "/api/auth/device/approve",
+            post(handlers::device_flow::device_approve),
+        )
+        .route(
+            "/api/auth/device/deny",
+            post(handlers::device_flow::device_deny),
+        )
         // WebSocket routes
         .route(
             "/ws/session",

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -416,7 +416,7 @@ async fn resolve_auth_token(
 
     // Need to authenticate
     info!("Authenticating via device flow");
-    let (token, user_id, user_email) = auth::device_flow_login(backend_url).await?;
+    let (token, user_id, user_email) = auth::device_flow_login(backend_url, Some(cwd)).await?;
 
     config.set_session_auth(
         cwd.to_string(),


### PR DESCRIPTION
## Summary
- Device flow now requires explicit user approval before completing authorization
- Proxy CLI sends hostname and working directory with device code request
- New approval page displays device info for user review before authorization
- Added approve/deny endpoints for user action

## Changes
- **Backend**: Added `hostname` and `working_directory` fields to `DeviceFlowState`
- **Backend**: `device_code` endpoint accepts JSON body with device metadata
- **Backend**: New `/api/auth/device/approve` and `/api/auth/device/deny` POST endpoints
- **Backend**: OAuth callback redirects to approval page instead of auto-completing
- **Backend**: `render_approval_page()` generates styled HTML approval UI
- **Proxy CLI**: Sends hostname (via `hostname::get()`) and working directory with code request
- **Tests**: Updated for new `DeviceFlowState` fields

## UX Flow
1. User runs `claude-portal` in terminal
2. Terminal shows auth URL with user code
3. User visits URL in browser
4. If not logged in → OAuth → redirect back
5. **NEW**: Approval page shows hostname + directory being authorized
6. User clicks "Approve" or "Deny"
7. CLI receives token (or denial) via polling

## Test plan
- [ ] `cargo test -p backend` passes (24 tests)
- [ ] Run `claude-portal`, verify approval page shows hostname/directory
- [ ] Click "Approve" - verify CLI receives token
- [ ] Click "Deny" - verify CLI shows "denied" error
- [ ] Verify existing logged-in users see approval page (not auto-complete)

Fixes #231