### PR TITLE
Fix install script config structure

### DIFF
--- a/backend/src/handlers/downloads.rs
+++ b/backend/src/handlers/downloads.rs
@@ -138,7 +138,9 @@ fi
 echo "Configuring backend URL: ${{BACKEND_URL}}"
 cat > "${{CONFIG_FILE}}" << EOF
 {{
-  "backend_url": "${{BACKEND_URL}}"
+  "preferences": {{
+    "default_backend_url": "${{BACKEND_URL}}"
+  }}
 }}
 EOF
 echo ""


### PR DESCRIPTION
## Summary
- Install script was writing `{"backend_url": "..."}` 
- Proxy expects `{"preferences": {"default_backend_url": "..."}}`
- Fresh installs would fail with "No backend URL configured"

## Test plan
- [ ] Delete ~/.config/claude-code-portal/
- [ ] Run install script from Quick Setup
- [ ] Verify config.json has correct structure
- [ ] Run claude-portal - should connect without --backend-url flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)