### PR TITLE
Update claude-codes to 2.1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,9 +591,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.15"
+version = "2.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ec1f92ded514afab3154292c94bd007f19190298bee8ca1f7fdfc715303783"
+checksum = "477b4ce752da2da315da9a8424457ca50a7306c80c7fded7af12257b73ed8e99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1059,7 +1059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2075,7 +2075,7 @@ dependencies = [
  "hyper 1.8.1",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2521,7 +2521,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3318,7 +3318,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3865,7 +3865,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Claude Code integration
-claude-codes = "2.1.4"
+claude-codes = "2.1.16"
 
 # Frontend (Yew)
 yew = { version = "0.21", features = ["csr"] }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,4 +16,4 @@ uuid = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["serde", "wasmbind"] }
 
 # Claude Code types (WASM-compatible, no tokio)
-claude-codes = { version = "2.1.3", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.16", default-features = false, features = ["types"] }


### PR DESCRIPTION
## Summary
- Update `claude-codes` dependency from 2.1.4 to 2.1.16 in workspace
- Update `claude-codes` from 2.1.3 to 2.1.16 in shared crate (WASM-compatible types-only)

## Changes in claude-codes 2.1.15-2.1.16
- Fixed PermissionSuggestion struct to match real protocol
- Added support for addRules permission format
- Various bug fixes and improvements

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace` passes  
- [x] `cargo test --workspace` passes
- [x] `cargo build --target wasm32-unknown-unknown -p shared` passes (WASM compatibility)