### PR TITLE
Fix reauth hint to use --reauth flag

### DIFF
--- a/proxy/src/ui.rs
+++ b/proxy/src/ui.rs
@@ -143,7 +143,7 @@ pub fn print_reauth_hint() {
     println!(
         "  {} Run: {} to re-authenticate",
         "→".bright_blue(),
-        "claude-portal logout && claude-portal login".bright_cyan()
+        "claude-portal --reauth".bright_cyan()
     );
 }
 


### PR DESCRIPTION
## Summary
Fix the suggested command in the reauth hint message.

## Changes
- Changed `claude-portal logout && claude-portal login` to `claude-portal --reauth`

The previous command didn't exist - `logout` and `login` are not subcommands. The correct flag is `--reauth`.