### PR TITLE
Add multiline input with Shift+Enter

### DIFF
--- a/frontend/styles/session-view.css
+++ b/frontend/styles/session-view.css
@@ -942,7 +942,7 @@
 
 .session-view-input {
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     gap: 0.75rem;
     padding: 1rem 1.5rem;
     background: var(--bg-darker);
@@ -964,8 +964,15 @@
     padding: 0.75rem 1rem;
     color: var(--text-primary);
     font-size: 0.95rem;
+    font-family: inherit;
     outline: none;
     transition: border-color 0.2s;
+    resize: none;
+    min-height: 1.4em;
+    max-height: 10em;
+    overflow-y: auto;
+    line-height: 1.4;
+    field-sizing: content;
 }
 
 .session-view-input .message-input:focus {
@@ -1507,8 +1514,8 @@
     .session-view-input {
         padding: 0.75rem;
         gap: 0.5rem;
-        flex-wrap: wrap;
         flex-shrink: 0; /* Prevent input from shrinking */
+        align-items: flex-end;
     }
 
     .session-view-input .input-prompt {


### PR DESCRIPTION
## Summary
- Changed input to textarea for multiline support
- Enter sends message, Shift+Enter inserts newline
- Auto-resize textarea using CSS `field-sizing: content` (with max-height)
- Updated placeholder to hint at Shift+Enter functionality

## Use Cases
- Writing longer prompts with code examples
- Pasting multi-line content
- Formatting complex instructions

Fixes #239, #223