### PR TITLE
Include deleted session costs in top bar spend

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,8 +1,13 @@
 use anyhow::Result;
+use bigdecimal::ToPrimitive;
 use diesel::pg::PgConnection;
+use diesel::prelude::*;
 use diesel::r2d2::{self, ConnectionManager, Pool};
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use std::env;
+use uuid::Uuid;
+
+use crate::schema;
 
 pub type DbPool = Pool<ConnectionManager<PgConnection>>;
 
@@ -33,4 +38,90 @@ pub fn run_migrations(pool: &DbPool) -> Result<Vec<String>> {
         .collect();
 
     Ok(applied)
+}
+
+/// Aggregated usage data for a user (includes both active and deleted sessions)
+#[derive(Debug, Default, Clone)]
+pub struct UserUsage {
+    pub cost_usd: f64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+}
+
+/// Fetch aggregated usage for a specific user (active sessions + deleted session costs)
+pub fn get_user_usage(
+    conn: &mut diesel::PgConnection,
+    user_id: Uuid,
+) -> std::result::Result<UserUsage, diesel::result::Error> {
+    // Get cost and tokens from active sessions
+    let active_cost: f64 = schema::sessions::table
+        .filter(schema::sessions::user_id.eq(user_id))
+        .select(diesel::dsl::sum(schema::sessions::total_cost_usd))
+        .first::<Option<f64>>(conn)?
+        .unwrap_or(0.0);
+
+    let active_input: i64 = schema::sessions::table
+        .filter(schema::sessions::user_id.eq(user_id))
+        .select(diesel::dsl::sum(schema::sessions::input_tokens))
+        .first::<Option<bigdecimal::BigDecimal>>(conn)
+        .ok()
+        .flatten()
+        .and_then(|d| d.to_i64())
+        .unwrap_or(0);
+
+    let active_output: i64 = schema::sessions::table
+        .filter(schema::sessions::user_id.eq(user_id))
+        .select(diesel::dsl::sum(schema::sessions::output_tokens))
+        .first::<Option<bigdecimal::BigDecimal>>(conn)
+        .ok()
+        .flatten()
+        .and_then(|d| d.to_i64())
+        .unwrap_or(0);
+
+    let active_cache_creation: i64 = schema::sessions::table
+        .filter(schema::sessions::user_id.eq(user_id))
+        .select(diesel::dsl::sum(schema::sessions::cache_creation_tokens))
+        .first::<Option<bigdecimal::BigDecimal>>(conn)
+        .ok()
+        .flatten()
+        .and_then(|d| d.to_i64())
+        .unwrap_or(0);
+
+    let active_cache_read: i64 = schema::sessions::table
+        .filter(schema::sessions::user_id.eq(user_id))
+        .select(diesel::dsl::sum(schema::sessions::cache_read_tokens))
+        .first::<Option<bigdecimal::BigDecimal>>(conn)
+        .ok()
+        .flatten()
+        .and_then(|d| d.to_i64())
+        .unwrap_or(0);
+
+    // Get usage from deleted sessions for this user (single row per user)
+    let (deleted_cost, deleted_input, deleted_output, deleted_cache_creation, deleted_cache_read): (
+        f64,
+        i64,
+        i64,
+        i64,
+        i64,
+    ) = schema::deleted_session_costs::table
+        .filter(schema::deleted_session_costs::user_id.eq(user_id))
+        .select((
+            schema::deleted_session_costs::cost_usd,
+            schema::deleted_session_costs::input_tokens,
+            schema::deleted_session_costs::output_tokens,
+            schema::deleted_session_costs::cache_creation_tokens,
+            schema::deleted_session_costs::cache_read_tokens,
+        ))
+        .first(conn)
+        .unwrap_or((0.0, 0, 0, 0, 0));
+
+    Ok(UserUsage {
+        cost_usd: active_cost + deleted_cost,
+        input_tokens: active_input + deleted_input,
+        output_tokens: active_output + deleted_output,
+        cache_creation_tokens: active_cache_creation + deleted_cache_creation,
+        cache_read_tokens: active_cache_read + deleted_cache_read,
+    })
 }

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -16,101 +16,12 @@ use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::{
+    db::get_user_usage,
     models::{NewRawMessageLog, RawMessageLog, User},
     schema, AppState,
 };
 
 const SESSION_COOKIE_NAME: &str = "cc_session";
-
-// ============================================================================
-// Usage Helper - Aggregates cost and token data per user
-// ============================================================================
-
-/// Aggregated usage data for a user (includes both active and deleted sessions)
-#[derive(Debug, Default, Clone)]
-pub struct UserUsage {
-    pub cost_usd: f64,
-    pub input_tokens: i64,
-    pub output_tokens: i64,
-    pub cache_creation_tokens: i64,
-    pub cache_read_tokens: i64,
-}
-
-/// Fetch aggregated usage for a specific user (active sessions + deleted session costs)
-pub fn get_user_usage(
-    conn: &mut diesel::PgConnection,
-    user_id: Uuid,
-) -> Result<UserUsage, diesel::result::Error> {
-    // Get cost and tokens from active sessions
-    let active_cost: f64 = schema::sessions::table
-        .filter(schema::sessions::user_id.eq(user_id))
-        .select(diesel::dsl::sum(schema::sessions::total_cost_usd))
-        .first::<Option<f64>>(conn)?
-        .unwrap_or(0.0);
-
-    let active_input: i64 = schema::sessions::table
-        .filter(schema::sessions::user_id.eq(user_id))
-        .select(diesel::dsl::sum(schema::sessions::input_tokens))
-        .first::<Option<bigdecimal::BigDecimal>>(conn)
-        .ok()
-        .flatten()
-        .and_then(|d| d.to_i64())
-        .unwrap_or(0);
-
-    let active_output: i64 = schema::sessions::table
-        .filter(schema::sessions::user_id.eq(user_id))
-        .select(diesel::dsl::sum(schema::sessions::output_tokens))
-        .first::<Option<bigdecimal::BigDecimal>>(conn)
-        .ok()
-        .flatten()
-        .and_then(|d| d.to_i64())
-        .unwrap_or(0);
-
-    let active_cache_creation: i64 = schema::sessions::table
-        .filter(schema::sessions::user_id.eq(user_id))
-        .select(diesel::dsl::sum(schema::sessions::cache_creation_tokens))
-        .first::<Option<bigdecimal::BigDecimal>>(conn)
-        .ok()
-        .flatten()
-        .and_then(|d| d.to_i64())
-        .unwrap_or(0);
-
-    let active_cache_read: i64 = schema::sessions::table
-        .filter(schema::sessions::user_id.eq(user_id))
-        .select(diesel::dsl::sum(schema::sessions::cache_read_tokens))
-        .first::<Option<bigdecimal::BigDecimal>>(conn)
-        .ok()
-        .flatten()
-        .and_then(|d| d.to_i64())
-        .unwrap_or(0);
-
-    // Get usage from deleted sessions for this user (single row per user)
-    let (deleted_cost, deleted_input, deleted_output, deleted_cache_creation, deleted_cache_read): (
-        f64,
-        i64,
-        i64,
-        i64,
-        i64,
-    ) = schema::deleted_session_costs::table
-        .filter(schema::deleted_session_costs::user_id.eq(user_id))
-        .select((
-            schema::deleted_session_costs::cost_usd,
-            schema::deleted_session_costs::input_tokens,
-            schema::deleted_session_costs::output_tokens,
-            schema::deleted_session_costs::cache_creation_tokens,
-            schema::deleted_session_costs::cache_read_tokens,
-        ))
-        .first(conn)
-        .unwrap_or((0.0, 0, 0, 0, 0));
-
-    Ok(UserUsage {
-        cost_usd: active_cost + deleted_cost,
-        input_tokens: active_input + deleted_input,
-        output_tokens: active_output + deleted_output,
-        cache_creation_tokens: active_cache_creation + deleted_cache_creation,
-        cache_read_tokens: active_cache_read + deleted_cache_read,
-    })
-}
 
 // ============================================================================
 // Admin Guard - extracts and validates admin user from cookies


### PR DESCRIPTION
## Summary
The dashboard top bar spend was only counting active sessions, while the admin dashboard included both active and deleted session costs. Now both use the same calculation.

- Uses `get_user_usage()` from admin module to compute total spend
- Matches the value shown in admin dashboard for each user