### PR TITLE
Pass extra CLI args through to Claude binary

### DIFF
--- a/claude-session-lib/src/snapshot.rs
+++ b/claude-session-lib/src/snapshot.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use crate::buffer::BufferedOutput;
 
 /// Configuration for creating a session
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SessionConfig {
     /// Unique session identifier
     pub session_id: Uuid,
@@ -20,6 +20,9 @@ pub struct SessionConfig {
     pub resume: bool,
     /// Optional path to claude binary (defaults to "claude" in PATH)
     pub claude_path: Option<PathBuf>,
+    /// Extra arguments to pass to the claude CLI
+    #[serde(default)]
+    pub extra_args: Vec<String>,
 }
 
 /// A pending permission request that hasn't been responded to
@@ -96,6 +99,7 @@ mod tests {
             session_name: "test-session".to_string(),
             resume: false,
             claude_path: None,
+            extra_args: vec![],
         }
     }
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -326,6 +326,7 @@ async fn main() -> Result<()> {
         working_directory: cwd,
         resume: resuming,
         git_branch,
+        claude_args: args.claude_args.clone(),
     };
 
     // Start Claude and run session
@@ -505,6 +506,7 @@ async fn create_claude_session(config: &ProxySessionConfig) -> Result<ClaudeSess
         session_name: config.session_name.clone(),
         resume: config.resume,
         claude_path: None,
+        extra_args: config.claude_args.clone(),
     };
 
     if config.resume {

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -73,6 +73,8 @@ pub struct ProxySessionConfig {
     pub working_directory: String,
     pub resume: bool,
     pub git_branch: Option<String>,
+    /// Extra arguments to pass through to the claude CLI
+    pub claude_args: Vec<String>,
 }
 
 /// Exponential backoff helper


### PR DESCRIPTION
## Summary
- Add `extra_args` field to `SessionConfig` in claude-session-lib
- Pass CLI args (after `--`) through to the Claude binary
- Log full Claude command on spawn for debugging

## Test plan
- [x] Build passes
- [x] Tests pass
- [ ] Manual: `claude-portal -- --model sonnet` passes `--model sonnet` to Claude