### PR TITLE
Compact tool headers: inline command/pattern display

### DIFF
--- a/frontend/src/components/message_renderer.rs
+++ b/frontend/src/components/message_renderer.rs
@@ -931,11 +931,16 @@ fn render_bash_tool(input: &Value) -> Html {
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
+    // Format timeout with appropriate units (ms for <1s, seconds, minutes)
+    let timeout_str = timeout.map(format_duration);
+
     html! {
         <div class="tool-use bash-tool">
             <div class="tool-use-header">
                 <span class="tool-icon">{ "$" }</span>
                 <span class="tool-name">{ "Bash" }</span>
+                <code class="bash-command-inline">{ command }</code>
+                <span class="tool-header-spacer"></span>
                 {
                     if background {
                         html! { <span class="tool-badge background">{ "background" }</span> }
@@ -944,8 +949,8 @@ fn render_bash_tool(input: &Value) -> Html {
                     }
                 }
                 {
-                    if let Some(t) = timeout {
-                        html! { <span class="tool-meta">{ format!("timeout: {}ms", t) }</span> }
+                    if let Some(t) = timeout_str {
+                        html! { <span class="tool-meta timeout">{ t }</span> }
                     } else {
                         html! {}
                     }
@@ -958,7 +963,6 @@ fn render_bash_tool(input: &Value) -> Html {
                     html! {}
                 }
             }
-            <pre class="bash-command">{ format!("$ {}", command) }</pre>
         </div>
     }
 }
@@ -1007,8 +1011,8 @@ fn render_glob_tool(input: &Value) -> Html {
             <div class="tool-use-header">
                 <span class="tool-icon">{ "🔍" }</span>
                 <span class="tool-name">{ "Glob" }</span>
+                <code class="glob-pattern-inline">{ pattern }</code>
             </div>
-            <div class="glob-pattern">{ pattern }</div>
             {
                 if let Some(p) = path {
                     html! { <div class="glob-path">{ format!("in {}", p) }</div> }
@@ -1033,6 +1037,7 @@ fn render_grep_tool(input: &Value) -> Html {
             <div class="tool-use-header">
                 <span class="tool-icon">{ "🔎" }</span>
                 <span class="tool-name">{ "Grep" }</span>
+                <code class="grep-pattern-inline">{ format!("/{}/", pattern) }</code>
                 {
                     if case_insensitive {
                         html! { <span class="tool-badge">{ "-i" }</span> }
@@ -1041,7 +1046,6 @@ fn render_grep_tool(input: &Value) -> Html {
                     }
                 }
             </div>
-            <div class="grep-pattern">{ format!("/{}/", pattern) }</div>
             <div class="grep-options">
                 {
                     if let Some(g) = glob {

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -270,11 +270,39 @@
     font-weight: bold;
 }
 
+.bash-tool .tool-use-header {
+    flex-wrap: nowrap;
+}
+
+.bash-command-inline {
+    flex: 1;
+    min-width: 0;
+    padding: 0.15rem 0.4rem;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 3px;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tool-header-spacer {
+    flex: 1;
+}
+
+.tool-meta.timeout {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+}
+
 .bash-description {
     color: var(--text-secondary);
     font-size: 0.8rem;
     font-style: italic;
     padding: 0.25rem 0;
+    margin-top: 0.25rem;
 }
 
 .bash-command {
@@ -306,6 +334,14 @@
     border-left-color: var(--accent);
 }
 
+.glob-pattern-inline {
+    padding: 0.15rem 0.4rem;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 3px;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+}
+
 .glob-pattern {
     color: var(--text-primary);
     font-size: 0.9rem;
@@ -315,12 +351,21 @@
 .glob-path {
     color: var(--text-muted);
     font-size: 0.8rem;
+    margin-top: 0.25rem;
 }
 
 /* Grep Tool */
 .grep-tool {
     background: rgba(122, 162, 247, 0.08);
     border-left-color: var(--accent);
+}
+
+.grep-pattern-inline {
+    padding: 0.15rem 0.4rem;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 3px;
+    color: var(--text-primary);
+    font-size: 0.85rem;
 }
 
 .grep-pattern {
@@ -333,6 +378,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+    margin-top: 0.25rem;
 }
 
 .grep-option {


### PR DESCRIPTION
## Summary
- Bash: command displayed inline with tool name, timeout shown in decimal seconds (e.g., "120.0s")
- Glob: pattern shown inline with tool name
- Grep: pattern shown inline with tool name  
- Description text moved below header for Bash tool

## Before
```
$ Bash
  timeout: 120000ms
List files
$ ls -la
```

## After  
```
$ Bash  ls -la                          120.0s
  List files
```

## Test plan
- [x] Build passes
- [x] Clippy clean
- [ ] Manual: verify tool rendering in dashboard