### PR TITLE
Bump claude-codes to 2.1.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,9 +591,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.16"
+version = "2.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "477b4ce752da2da315da9a8424457ca50a7306c80c7fded7af12257b73ed8e99"
+checksum = "491ed22602c439d64882bccc5dcb929b605659d7183b0464242382ba86a4d33a"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Claude Code integration
-claude-codes = "2.1.16"
+claude-codes = "2.1.17"
 
 # Frontend (Yew)
 yew = { version = "0.21", features = ["csr"] }

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -6,7 +6,7 @@ description = "Library for managing Claude Code sessions"
 license = "MIT"
 
 [dependencies]
-claude-codes = "2.1"
+claude-codes = "2.1.17"
 tokio = { version = "1", features = ["sync", "time", "process"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,4 +16,4 @@ uuid = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["serde", "wasmbind"] }
 
 # Claude Code types (WASM-compatible, no tokio)
-claude-codes = { version = "2.1.16", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.17", default-features = false, features = ["types"] }


### PR DESCRIPTION
## Summary
Updates `claude-codes` from 2.1.16 to 2.1.17.

### New in 2.1.17
- **`ClaudeOutput::Error` variant** - Captures API errors (overload 529, rate limits 429, server errors 500)
- **`Permission` struct** - New typed API for "remember this decision" functionality
- **`decision_reason` and `tool_use_id` fields** - Now exposed on `ToolPermissionRequest`

### Changes in this PR
- Handle `ClaudeOutput::Error` in the proxy with appropriate logging
  - Uses helpers: `is_overloaded()`, `is_rate_limited()`, `is_server_error()`
- Use typed `Permission` API instead of manual JSON conversion
  - `Permission::from_suggestion()` converts PermissionSuggestion to Permission
  - `PermissionResult::allow_with_typed_permissions()` for clean type-safe permission handling

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] Clippy clean