### PR TITLE
Fix bash tool display: natural width, timeout prefix

### DIFF
--- a/frontend/src/components/message_renderer.rs
+++ b/frontend/src/components/message_renderer.rs
@@ -950,7 +950,7 @@ fn render_bash_tool(input: &Value) -> Html {
                 }
                 {
                     if let Some(t) = timeout_str {
-                        html! { <span class="tool-meta timeout">{ t }</span> }
+                        html! { <span class="tool-meta timeout">{ format!("timeout={}", t) }</span> }
                     } else {
                         html! {}
                     }

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -275,8 +275,9 @@
 }
 
 .bash-command-inline {
-    flex: 1;
+    flex: 0 1 auto;
     min-width: 0;
+    max-width: 70%;
     padding: 0.15rem 0.4rem;
     background: rgba(0, 0, 0, 0.25);
     border-radius: 3px;
@@ -288,7 +289,7 @@
 }
 
 .tool-header-spacer {
-    flex: 1;
+    flex: 1 1 auto;
 }
 
 .tool-meta.timeout {


### PR DESCRIPTION
## Summary
- Command highlight now fits its content naturally (max 70% of header width)
- Timeout displays with `timeout=` prefix to distinguish from execution duration

## Before
```
$ Bash  ls -la________________________________  2.0s
```

## After
```
$ Bash  ls -la           timeout=2.0s
```

## Test plan
- [x] Build passes
- [ ] Manual: verify bash tool looks correct in dashboard