### PR TITLE
Enhance PermissionResponse with typed permissions support

### DIFF
--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -69,5 +69,5 @@ pub use session::{PermissionResponse, Session, SessionEvent};
 pub use snapshot::{PendingPermission, SessionConfig, SessionSnapshot};
 
 // Re-export claude_codes types that appear in our public API
-pub use claude_codes::io::{ControlResponse, PermissionResult, PermissionSuggestion};
-pub use claude_codes::ClaudeOutput;
+pub use claude_codes::io::PermissionSuggestion;
+pub use claude_codes::{ClaudeOutput, Permission};


### PR DESCRIPTION
## Summary
Removes the `send_raw_control_response` workaround by enhancing `PermissionResponse` to support all permission scenarios.

### Changes
- **PermissionResponse now supports "remember this decision"**
  - `permissions: Vec<Permission>` field for granting future permissions
  - `reason: Option<String>` field for denial reasons
  
- **New constructors**:
  - `allow_and_remember(permissions)` - Allow and grant permissions
  - `allow_with_input_and_remember(input, permissions)` - Allow with modified input + permissions
  - `deny_with_reason(reason)` - Deny with custom reason

- **respond_permission handles all cases**:
  - Simple allow/deny
  - Allow with permissions (remember this decision)
  - Deny with custom reason

- **Removed `send_raw_control_response`** - No longer needed since `respond_permission` handles everything

- **Re-export `Permission`** from claude_codes for convenience

## Before
```rust
// Had to use low-level send_raw_control_response
let ctrl_response = ControlResponse::from_result(
    &request_id,
    PermissionResult::allow_with_typed_permissions(input, permissions)
);
claude_session.send_raw_control_response(&request_id, ctrl_response).await?;
```

## After
```rust
// Clean high-level API
let response = PermissionResponse::allow_with_input_and_remember(input, permissions);
claude_session.respond_permission(&request_id, response).await?;
```

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] Clippy clean