### PR TITLE
Fix API error rendering and add --replay-user-messages flag

### DIFF
--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -418,7 +418,8 @@ impl Session {
             .arg("--input-format")
             .arg("stream-json")
             .arg("--permission-prompt-tool")
-            .arg("stdio");
+            .arg("stdio")
+            .arg("--replay-user-messages");
 
         if config.resume {
             cmd.arg("--resume").arg(config.session_id.to_string());
@@ -445,6 +446,7 @@ impl Session {
                     "stream-json",
                     "--permission-prompt-tool",
                     "stdio",
+                    "--replay-user-messages",
                 ]
                 .iter()
                 .map(|s| s.to_string()),

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -220,3 +220,83 @@
     color: var(--text-primary);
 }
 
+/* ==========================================================================
+   Anthropic API Error Message
+   ========================================================================== */
+
+.anthropic-error-message {
+    background: rgba(247, 118, 142, 0.08);
+    border: 1px solid rgba(247, 118, 142, 0.3);
+}
+
+.anthropic-error-message .message-header {
+    background: rgba(247, 118, 142, 0.15);
+    border-bottom-color: rgba(247, 118, 142, 0.3);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.message-type-badge.anthropic-error {
+    background: rgba(247, 118, 142, 0.25);
+    color: var(--error);
+}
+
+.anthropic-error-message .http-status {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    padding: 0.15rem 0.5rem;
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+}
+
+.anthropic-error-content {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.anthropic-error-content .error-icon {
+    font-size: 2rem;
+    line-height: 1;
+    color: var(--error);
+    flex-shrink: 0;
+}
+
+.anthropic-error-content .error-details {
+    flex: 1;
+}
+
+.anthropic-error-content .error-type-display {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--error);
+    margin-bottom: 0.25rem;
+}
+
+.anthropic-error-content .error-message-text {
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.anthropic-error-message .error-request-id {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid rgba(247, 118, 142, 0.2);
+    font-size: 0.8rem;
+}
+
+.anthropic-error-message .request-id-label {
+    color: var(--text-secondary);
+}
+
+.anthropic-error-message .request-id-value {
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    background: rgba(0, 0, 0, 0.2);
+    padding: 0.15rem 0.4rem;
+    border-radius: 3px;
+}


### PR DESCRIPTION
## Summary
- Fixes #252 - Anthropic API errors now render with nice formatting instead of raw JSON
- Adds `--replay-user-messages` flag to Claude spawn so user messages are echoed back and displayed in the web UI

## Changes

### Anthropic Error Rendering
- Added `try_render_api_error()` function to detect and parse Anthropic API errors from result messages
- New styled `anthropic-error-message` component with:
  - Error icon and type display (e.g., "Internal Server Error", "Rate Limited")
  - Human-readable error message
  - Request ID for debugging
  - HTTP status code when available

### User Message Display
- Added `--replay-user-messages` flag to Claude CLI spawn in `claude-session-lib`
- This causes Claude to echo back user input messages, which are then stored and displayed in the web UI

## Test plan
- [ ] Trigger an API error (e.g., rate limit, server error) and verify it renders nicely
- [ ] Send a message and verify user messages appear in the conversation view