### PR TITLE
Faster reconnect after graceful server shutdown

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -495,7 +495,7 @@ async fn shutdown_signal(app_state: Arc<AppState>) {
         .session_manager
         .broadcast_to_all(shared::ProxyMessage::ServerShutdown {
             reason: "Server is restarting".to_string(),
-            reconnect_delay_ms: 5000,
+            reconnect_delay_ms: 1000,
         });
 
     // Give clients a moment to receive the message


### PR DESCRIPTION
## Summary
- Reduced server-side recommended reconnect delay from 5s to 1s
- Added `ServerShutdown` variant to `ConnectionResult` to distinguish graceful shutdowns
- Reset backoff immediately on graceful shutdown instead of using accumulated backoff
- Proxy now uses server's suggested delay for graceful shutdowns

Fixes #270

## Changes

**Backend (`main.rs`):**
- Changed `reconnect_delay_ms` from 5000 to 1000

**Proxy (`session.rs`):**
- Added `GracefulShutdown` struct and `WsMessageResult` enum
- Added `ServerShutdown(Duration)` variant to `ConnectionResult`
- Updated `handle_ws_text_message` to return `WsMessageResult::GracefulShutdown` with delay
- Added channel to propagate graceful shutdown from WS reader to main loop
- Connection loop resets backoff and uses server's delay for graceful shutdowns
- Added `Backoff::reset()` method for unconditional reset

## Test plan
- [ ] CI passes
- [ ] Deploy to staging and verify faster reconnect (~1-2s vs 30+s) after container restart