### PR TITLE
Refactor proxy WebSocket channels to use event enum

### DIFF
--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -445,13 +445,8 @@ async fn run_proxy_session(mut config: ProxySessionConfig) -> Result<()> {
 
         ui::print_started();
 
-        // Create input channel (shared across reconnections)
-        let (input_tx, mut input_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-
         // Run the connection loop
-        let result =
-            session::run_connection_loop(&config, &mut claude_session, input_tx, &mut input_rx)
-                .await;
+        let result = session::run_connection_loop(&config, &mut claude_session).await;
 
         let _ = claude_session.stop().await;
 


### PR DESCRIPTION
## Summary
- Replaced multiple separate channels with unified `WsEvent` enum
- Reduced `spawn_ws_reader` parameters from 7 to 4
- Simplified `ConnectionState` by removing individual receivers
- Removed unused `input_tx`/`input_rx` channel pair

Fixes #271

## Changes

**New `WsEvent` enum:**
```rust
pub enum WsEvent {
    Input(String),
    WiggumActivation(String),
    PermissionResponse(PermissionResponseData),
    OutputAck(u64),
    ServerShutdown { reconnect_delay_ms: u64 },
}
```

**Before:**
- `spawn_ws_reader` took 7 parameters (input_tx, perm_tx, ack_tx, ws_write, disconnect_tx, wiggum_tx)
- Multiple `select!` branches for each event type
- Separate channel creation for each event type

**After:**
- `spawn_ws_reader` takes 4 parameters (event_tx, ws_write, disconnect_tx)
- Single `select!` branch for all WsEvents with pattern matching
- Single unified channel for all events

## Benefits
- Cleaner function signatures
- Easier to add new event types
- Single point of event routing
- Better testability

## Test plan
- [x] All tests pass
- [x] Clippy clean
- [ ] Manual testing with proxy connecting to backend