### PR TITLE
Constrain pill branch width, faster rail scroll

### DIFF
--- a/frontend/styles/session-view.css
+++ b/frontend/styles/session-view.css
@@ -149,7 +149,6 @@
     background: var(--bg-darker);
     border-bottom: 1px solid var(--border);
     overflow-x: auto;
-    scroll-behavior: smooth;
     scrollbar-width: thin;
     scrollbar-color: var(--border) transparent;
 }
@@ -291,6 +290,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    max-width: 150px;
 }
 
 .session-pill.status-disconnected .pill-branch {


### PR DESCRIPTION
## Summary
- Adds `max-width: 150px` to `.pill-branch` so long branch names truncate with ellipsis instead of making the pill extra wide
- Removes `scroll-behavior: smooth` from the session rail for snappier scrolling