### PR TITLE
Pill branch start-ellipsis, tooltip, faster scroll

### DIFF
--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -51,7 +51,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             if let Some(rail) = rail_ref.cast::<HtmlElement>() {
                 e.prevent_default();
                 let delta = e.delta_y();
-                rail.set_scroll_left(rail.scroll_left() + delta as i32);
+                rail.set_scroll_left(rail.scroll_left() + (delta * 3.0) as i32);
             }
         })
     };
@@ -142,7 +142,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     <span class="pill-hostname">{ hostname }</span>
                     {
                         if let Some(ref branch) = session.git_branch {
-                            html! { <span class="pill-branch">{ branch }</span> }
+                            html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
                         } else {
                             html! {}
                         }

--- a/frontend/styles/session-view.css
+++ b/frontend/styles/session-view.css
@@ -149,6 +149,7 @@
     background: var(--bg-darker);
     border-bottom: 1px solid var(--border);
     overflow-x: auto;
+    scroll-behavior: smooth;
     scrollbar-width: thin;
     scrollbar-color: var(--border) transparent;
 }
@@ -291,6 +292,8 @@
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 150px;
+    direction: rtl;
+    text-align: left;
 }
 
 .session-pill.status-disconnected .pill-branch {


### PR DESCRIPTION
## Summary
- Branch names in session pills now truncate with ellipsis at the start (showing the end of the branch name which is usually more informative)
- Hovering over a truncated branch name shows the full name in a tooltip
- Mouse wheel scrolling on the session rail is 3x faster for quicker navigation

## Test plan
- [ ] Verify long branch names show ellipsis at the start (e.g. `...feature-name` instead of `meawoppl/long-...`)
- [ ] Hover over a truncated branch name to confirm full name tooltip appears
- [ ] Scroll the session rail with mouse wheel and confirm it moves faster