### PR TITLE
Extract shared protocol constants

### DIFF
--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -21,7 +21,7 @@ use crate::{
     schema, AppState,
 };
 
-const SESSION_COOKIE_NAME: &str = "cc_session";
+use shared::protocol::SESSION_COOKIE_NAME;
 
 // ============================================================================
 // Admin Guard - extracts and validates admin user from cookies

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -17,7 +17,7 @@ use crate::{
     AppState,
 };
 
-const SESSION_COOKIE_NAME: &str = "cc_session";
+use shared::protocol::SESSION_COOKIE_NAME;
 
 /// Regular web login - redirects to Google OAuth
 pub async fn login(State(app_state): State<Arc<AppState>>) -> impl IntoResponse {

--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -21,10 +21,7 @@ use crate::{
     AppState,
 };
 
-const SESSION_COOKIE_NAME: &str = "cc_session";
-
-/// Time in seconds before a device authorization code expires
-const DEVICE_CODE_EXPIRES_SECS: u64 = 300;
+use shared::protocol::{DEVICE_CODE_EXPIRES_SECS, SESSION_COOKIE_NAME};
 
 /// Error response for device flow endpoints
 #[derive(Debug, Serialize)]

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -13,7 +13,7 @@ use tower_cookies::Cookies;
 use tracing::error;
 use uuid::Uuid;
 
-const SESSION_COOKIE_NAME: &str = "cc_session";
+use shared::protocol::SESSION_COOKIE_NAME;
 
 /// Request body for creating a new message
 #[derive(Debug, Deserialize)]

--- a/backend/src/handlers/proxy_tokens.rs
+++ b/backend/src/handlers/proxy_tokens.rs
@@ -286,7 +286,7 @@ async fn get_user_id_from_session(
     // Get signed session cookie
     let session_cookie = cookies
         .signed(&app_state.cookie_key)
-        .get("cc_session")
+        .get(shared::protocol::SESSION_COOKIE_NAME)
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
     // Parse user_id from cookie value

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -15,7 +15,7 @@ use crate::{
     AppState,
 };
 
-const SESSION_COOKIE_NAME: &str = "cc_session";
+use shared::protocol::SESSION_COOKIE_NAME;
 
 /// Session with the current user's role included
 #[derive(Debug, Serialize)]

--- a/backend/src/handlers/voice.rs
+++ b/backend/src/handlers/voice.rs
@@ -23,7 +23,7 @@ use tower_cookies::Cookies;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-const SESSION_COOKIE_NAME: &str = "cc_session";
+use shared::protocol::SESSION_COOKIE_NAME;
 
 /// Extract user_id from signed session cookie
 fn extract_user_id_from_cookies(app_state: &AppState, cookies: &Cookies) -> Option<Uuid> {

--- a/backend/src/handlers/websocket/auth.rs
+++ b/backend/src/handlers/websocket/auth.rs
@@ -4,7 +4,7 @@ use tower_cookies::Cookies;
 use tracing::{error, warn};
 use uuid::Uuid;
 
-const SESSION_COOKIE_NAME: &str = "cc_session";
+use shared::protocol::SESSION_COOKIE_NAME;
 
 /// Extract user_id from signed session cookie for web client authentication
 pub fn extract_user_id_from_cookies(app_state: &AppState, cookies: &Cookies) -> Option<Uuid> {

--- a/backend/src/handlers/websocket/mod.rs
+++ b/backend/src/handlers/websocket/mod.rs
@@ -21,12 +21,10 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::AppState;
+use shared::protocol::{MAX_PENDING_MESSAGES_PER_SESSION, MAX_PENDING_MESSAGE_AGE_SECS};
 
-/// Maximum number of messages to queue per session when proxy is disconnected
-const MAX_PENDING_MESSAGES_PER_SESSION: usize = 100;
-
-/// Maximum age of pending messages before they're dropped (5 minutes)
-const MAX_PENDING_MESSAGE_AGE: Duration = Duration::from_secs(300);
+/// Maximum age of pending messages before they're dropped
+const MAX_PENDING_MESSAGE_AGE: Duration = Duration::from_secs(MAX_PENDING_MESSAGE_AGE_SECS);
 
 /// A message queued for a disconnected proxy
 #[derive(Clone)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,6 +5,9 @@ use uuid::Uuid;
 pub mod proxy_tokens;
 pub use proxy_tokens::*;
 
+// Protocol constants shared between backend and proxy
+pub mod protocol;
+
 // API client types and trait
 pub mod api;
 pub use api::{ApiClientConfig, ApiError, CcProxyApi};

--- a/shared/src/protocol.rs
+++ b/shared/src/protocol.rs
@@ -1,0 +1,12 @@
+/// Session cookie name used for web client authentication.
+/// Shared between all backend handlers that read or write the session cookie.
+pub const SESSION_COOKIE_NAME: &str = "cc_session";
+
+/// Maximum number of messages to queue per session when the proxy is disconnected.
+pub const MAX_PENDING_MESSAGES_PER_SESSION: usize = 100;
+
+/// Maximum age (in seconds) of pending messages before they are dropped.
+pub const MAX_PENDING_MESSAGE_AGE_SECS: u64 = 300;
+
+/// Device authorization code lifetime in seconds (5 minutes).
+pub const DEVICE_CODE_EXPIRES_SECS: u64 = 300;


### PR DESCRIPTION
## Summary
- Creates `shared/src/protocol.rs` with constants previously duplicated across backend handlers
- Consolidates `SESSION_COOKIE_NAME` (was defined 7 times in 7 different files)
- Consolidates `DEVICE_CODE_EXPIRES_SECS` and `MAX_PENDING_MESSAGES_PER_SESSION` constants
- Updates all 10 backend handler files to import from shared

Closes #293

## Test plan
- [ ] `cargo build --workspace` passes
- [ ] `cargo clippy --workspace` passes
- [ ] `cargo test --workspace` passes
- [ ] Verify no remaining `const SESSION_COOKIE_NAME` in backend sources