### PR TITLE
Fix duplicate sessions on SessionNotFound retry

### DIFF
--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -48,6 +48,7 @@ pub async fn list_sessions(
     let results: Vec<(Session, String)> = sessions::table
         .inner_join(session_members::table.on(session_members::session_id.eq(sessions::id)))
         .filter(session_members::user_id.eq(current_user_id))
+        .filter(sessions::status.ne("replaced"))
         .select((Session::as_select(), session_members::role))
         .order(sessions::last_activity.desc())
         .load(&mut conn)

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -103,6 +103,7 @@ fn handle_proxy_message(
             git_branch,
             replay_after: _,
             client_version,
+            replaces_session_id,
         } => {
             let key = claude_session_id.to_string();
             *session_key = Some(key.clone());
@@ -118,6 +119,7 @@ fn handle_proxy_message(
                 git_branch: &git_branch,
                 client_version: &client_version,
                 session_key: &key,
+                replaces_session_id,
             };
             let result = register_or_update_session(app_state, &params);
 

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -44,6 +44,7 @@ pub fn connect_websocket(
                     git_branch: None,
                     replay_after,
                     client_version: None,
+                    replaces_session_id: None,
                 };
 
                 if let Ok(json) = serde_json::to_string(&register_msg) {

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -75,6 +75,8 @@ pub struct ProxySessionConfig {
     pub git_branch: Option<String>,
     /// Extra arguments to pass through to the claude CLI
     pub claude_args: Vec<String>,
+    /// If this session replaces a previous one (after SessionNotFound), the old session ID
+    pub replaces_session_id: Option<Uuid>,
 }
 
 /// Exponential backoff helper
@@ -390,6 +392,7 @@ async fn register_session(
         git_branch: config.git_branch.clone(),
         replay_after: None, // Proxy doesn't need history replay
         client_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        replaces_session_id: config.replaces_session_id,
     };
 
     if let Err(e) = conn.send(&register_msg).await {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -48,6 +48,10 @@ pub enum ProxyMessage {
         /// Client version (e.g., "1.0.0") - helps track client versions in use
         #[serde(default)]
         client_version: Option<String>,
+        /// If this session replaces a previous one (e.g. after SessionNotFound),
+        /// the old session ID so the backend can mark it as replaced.
+        #[serde(default)]
+        replaces_session_id: Option<Uuid>,
     },
 
     /// Output from Claude Code to be displayed
@@ -504,12 +508,14 @@ mod tests {
                 git_branch,
                 replay_after,
                 client_version,
+                replaces_session_id,
                 ..
             } => {
                 assert!(!resuming);
                 assert!(git_branch.is_none());
                 assert!(replay_after.is_none());
                 assert!(client_version.is_none());
+                assert!(replaces_session_id.is_none());
             }
             _ => panic!("Wrong variant"),
         }


### PR DESCRIPTION
## Summary
- When the proxy resumes a session but Claude reports `SessionNotFound` (local session expired), it creates a new session with a fresh UUID. Previously both old and new sessions appeared in the frontend.
- Added `replaces_session_id` field to `ProxyMessage::Register` so the proxy can tell the backend which session is being superseded
- Backend marks the old session as "replaced" and filters it from `list_sessions`

## Test plan
- [x] `cargo test --workspace` — all 78 tests pass
- [x] `cargo clippy --workspace` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: start proxy, kill it, restart in same directory — should see only one session