### PR TITLE
Batch history replay into single message

### DIFF
--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -513,6 +513,21 @@ impl SessionView {
                 ctx.link().send_message(SessionViewMsg::CheckAwaiting);
                 false
             }
+            WsEvent::HistoryBatch(messages) => {
+                self.messages.extend(messages);
+                if self.messages.len() > MAX_MESSAGES_PER_SESSION {
+                    let excess = self.messages.len() - MAX_MESSAGES_PER_SESSION;
+                    self.messages.drain(0..excess);
+                }
+                self.last_message_timestamp = Some(
+                    js_sys::Date::new_0()
+                        .to_iso_string()
+                        .as_string()
+                        .unwrap_or_default(),
+                );
+                ctx.link().send_message(SessionViewMsg::CheckAwaiting);
+                true
+            }
             WsEvent::Permission(perm) => {
                 ctx.link()
                     .send_message(SessionViewMsg::PermissionRequest(perm));

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -17,6 +17,7 @@ pub enum WsEvent {
     Connected(WsSender),
     Error(String),
     Output(String),
+    HistoryBatch(Vec<String>),
     Permission(PendingPermission),
     BranchChanged(Option<String>),
 }
@@ -86,6 +87,10 @@ fn handle_proxy_message(msg: ProxyMessage, on_event: &Callback<WsEvent>) {
     match msg {
         ProxyMessage::ClaudeOutput { content } => {
             on_event.emit(WsEvent::Output(content.to_string()));
+        }
+        ProxyMessage::HistoryBatch { messages } => {
+            let strings: Vec<String> = messages.into_iter().map(|v| v.to_string()).collect();
+            on_event.emit(WsEvent::HistoryBatch(strings));
         }
         ProxyMessage::PermissionRequest {
             request_id,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -132,6 +132,10 @@ pub enum ProxyMessage {
         session_costs: Vec<SessionCost>,
     },
 
+    /// Batch of historical messages sent during replay (backend -> web client).
+    /// Sent as a single message to avoid per-message rendering overhead.
+    HistoryBatch { messages: Vec<serde_json::Value> },
+
     /// Sequenced output from Claude Code (proxy -> backend)
     /// Messages are held in proxy buffer until acknowledged
     SequencedOutput {


### PR DESCRIPTION
## Summary
- History replay previously sent each message as an individual `ClaudeOutput` over WebSocket, causing per-message re-renders and scroll jank on reconnect
- Added `HistoryBatch` protocol message that sends all replay messages in a single WebSocket frame
- Frontend handles the batch in one render pass, eliminating the scrolling noise

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace` — clean
- [ ] Manual: open a session with history, refresh page — messages should appear instantly without scrolling animation