### PR TITLE
Stable-width pills, remove cost from rail

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -34,7 +34,6 @@ pub fn dashboard_page() -> Html {
     // Use the client websocket hook for spend updates
     let ws_hook = use_client_websocket();
     let total_user_spend = ws_hook.total_spend;
-    let session_costs = ws_hook.session_costs.clone();
     let server_shutdown_reason = ws_hook.shutdown_reason.clone();
 
     // UI state
@@ -489,7 +488,6 @@ pub fn dashboard_page() -> Html {
                         awaiting_sessions={(*awaiting_sessions).clone()}
                         paused_sessions={(*paused_sessions).clone()}
                         inactive_hidden={*inactive_hidden}
-                        session_costs={session_costs.clone()}
                         connected_sessions={(*connected_sessions).clone()}
                         nav_mode={keyboard_nav.nav_mode}
                         on_select={on_select_session.clone()}

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -2,7 +2,7 @@
 
 use crate::utils;
 use shared::SessionInfo;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use uuid::Uuid;
 use web_sys::{Element, HtmlElement, WheelEvent};
 use yew::prelude::*;
@@ -15,7 +15,6 @@ pub struct SessionRailProps {
     pub awaiting_sessions: HashSet<Uuid>,
     pub paused_sessions: HashSet<Uuid>,
     pub inactive_hidden: bool,
-    pub session_costs: HashMap<Uuid, f64>,
     pub connected_sessions: HashSet<Uuid>,
     pub nav_mode: bool,
     pub on_select: Callback<usize>,
@@ -67,7 +66,6 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         let is_awaiting = props.awaiting_sessions.contains(&session.id);
         let is_paused = props.paused_sessions.contains(&session.id);
         let is_connected = props.connected_sessions.contains(&session.id);
-        let cost = props.session_costs.get(&session.id).copied().unwrap_or(0.0);
 
         let on_click = {
             let on_select = props.on_select.clone();
@@ -148,13 +146,6 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                         }
                     }
                 </span>
-                {
-                    if cost > 0.0 {
-                        html! { <span class="pill-cost">{ format!("${:.2}", cost) }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
                 {
                     if is_paused {
                         html! { <span class="pill-paused-badge">{ "ᴾ" }</span> }

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -123,7 +123,7 @@
 .pill-name {
     display: flex;
     flex-direction: column;
-    max-width: 200px;
+    width: 150px;
     overflow: hidden;
 }
 
@@ -171,15 +171,6 @@
 
 .pill-status.disconnected {
     color: var(--text-secondary);
-}
-
-.pill-cost {
-    font-size: 0.7rem;
-    font-family: monospace;
-    color: var(--success);
-    padding: 0.1rem 0.3rem;
-    background: rgba(158, 206, 106, 0.15);
-    border-radius: 3px;
 }
 
 .pill-delete {


### PR DESCRIPTION
## Summary
- Remove per-session cost display (`$X.XX`) from session pills — this was the main cause of variable pill widths
- Set `.pill-name` to fixed 150px width so all pills are the same size
- Clean up unused `session_costs` field and `HashMap`/`SessionCost` imports from the client websocket hook

## Test plan
- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy --workspace` — clean, no warnings
- [x] `cargo fmt --check` — clean