### PR TITLE
Fix wiggum mode not activating

### DIFF
--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -54,6 +54,7 @@ pub fn replay_pending_inputs_from_db(
             session_id,
             seq: input.seq_num,
             content,
+            send_mode: None,
         };
 
         if sender.send(msg).is_ok() {

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -299,6 +299,7 @@ fn handle_web_input(
                 session_id,
                 seq,
                 content,
+                send_mode,
             },
         ) {
             warn!(

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -163,6 +163,9 @@ pub enum ProxyMessage {
         seq: i64,
         /// The actual input content
         content: serde_json::Value,
+        /// Send mode (normal or wiggum loop)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        send_mode: Option<SendMode>,
     },
 
     /// Acknowledge receipt of input messages (proxy -> backend)
@@ -399,6 +402,7 @@ mod tests {
             session_id,
             seq: 5,
             content: serde_json::json!({"type": "human", "message": "test"}),
+            send_mode: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ProxyMessage = serde_json::from_str(&json).unwrap();
@@ -408,10 +412,12 @@ mod tests {
                 session_id: sid,
                 seq,
                 content,
+                send_mode,
             } => {
                 assert_eq!(sid, session_id);
                 assert_eq!(seq, 5);
                 assert_eq!(content["type"], "human");
+                assert!(send_mode.is_none());
             }
             _ => panic!("Wrong variant"),
         }


### PR DESCRIPTION
## Summary
- **Bug 1**: Backend converted `ClaudeInput` to `SequencedInput` for reliable delivery, but `SequencedInput` lacked a `send_mode` field — the wiggum flag was silently dropped, so the proxy never entered wiggum mode
- **Bug 2**: Race condition where `tokio::select!` could process the prompt before setting `wiggum_state`, causing the loop logic to be skipped

## Fix
- Added `send_mode: Option<SendMode>` to `SequencedInput` in shared protocol
- Backend now passes `send_mode` through when converting `ClaudeInput` → `SequencedInput`
- Moved prompt sending into the `wiggum_rx` select handler so state and prompt are set atomically

## Test plan
- [ ] Send a wiggum mode message from the frontend
- [ ] Verify proxy logs show "Wiggum mode activated"
- [ ] Verify Claude responds and wiggum loop re-sends prompt
- [ ] Verify loop terminates when Claude responds with "DONE"
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace` clean