### PR TITLE
Add persistent launcher service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,3 +210,52 @@ jobs:
           name: proxy-darwin-aarch64
           path: target/release/claude-portal
 
+  build-launcher-linux:
+    name: Build Launcher (Linux x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.92.0
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "launcher-linux"
+
+      - name: Build launcher
+        run: cargo build -p claude-portal-launcher --release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: launcher-linux-x86_64
+          path: target/release/claude-portal-launcher
+
+  build-launcher-macos-arm64:
+    name: Build Launcher (macOS ARM64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.92.0
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "launcher-macos-arm64"
+
+      - name: Build launcher
+        run: cargo build -p claude-portal-launcher --release
+
+      - name: Ad-hoc code sign
+        run: codesign -s - target/release/claude-portal-launcher
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: launcher-darwin-aarch64
+          path: target/release/claude-portal-launcher
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "claude-portal-launcher"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "futures-util",
+ "hostname",
+ "serde",
+ "serde_json",
+ "shared",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "claude-session-lib"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-session-lib"]
+members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-session-lib", "launcher"]
 resolver = "2"
 
 [workspace.package]

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -1,0 +1,161 @@
+use axum::{extract::State, http::StatusCode, Json};
+use serde::Deserialize;
+use shared::{LauncherInfo, ProxyMessage};
+use std::sync::Arc;
+use tower_cookies::Cookies;
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::AppState;
+
+/// GET /api/launchers - List connected launchers for the current user
+pub async fn list_launchers(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+) -> Result<Json<Vec<LauncherInfo>>, StatusCode> {
+    let user_id = get_user_id(&app_state, &cookies)?;
+    let launchers = app_state.session_manager.get_launchers_for_user(&user_id);
+    Ok(Json(launchers))
+}
+
+#[derive(Deserialize)]
+pub struct LaunchRequest {
+    pub working_directory: String,
+    #[serde(default)]
+    pub session_name: Option<String>,
+    #[serde(default)]
+    pub launcher_id: Option<Uuid>,
+    #[serde(default)]
+    pub claude_args: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct LaunchResponse {
+    pub request_id: Uuid,
+}
+
+/// POST /api/launch - Request launching a new session
+pub async fn launch_session(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Json(req): Json<LaunchRequest>,
+) -> Result<Json<LaunchResponse>, StatusCode> {
+    let user_id = get_user_id(&app_state, &cookies)?;
+
+    // Find the right launcher
+    let launcher_id = if let Some(id) = req.launcher_id {
+        id
+    } else {
+        // Auto-select: pick the first connected launcher for this user
+        let launchers = app_state.session_manager.get_launchers_for_user(&user_id);
+        launchers.first().map(|l| l.launcher_id).ok_or_else(|| {
+            error!("No connected launchers for user {}", user_id);
+            StatusCode::NOT_FOUND
+        })?
+    };
+
+    // Create a fresh short-lived proxy token for the child process
+    let auth_token = mint_launch_token(&app_state, user_id)?;
+
+    let request_id = Uuid::new_v4();
+    let launch_msg = ProxyMessage::LaunchSession {
+        request_id,
+        user_id,
+        auth_token,
+        working_directory: req.working_directory.clone(),
+        session_name: req.session_name,
+        claude_args: req.claude_args,
+    };
+
+    if !app_state
+        .session_manager
+        .send_to_launcher(&launcher_id, launch_msg)
+    {
+        error!("Failed to send launch request to launcher {}", launcher_id);
+        return Err(StatusCode::BAD_GATEWAY);
+    }
+
+    info!(
+        "Launch request sent: request_id={}, launcher={}, dir={}",
+        request_id, launcher_id, req.working_directory
+    );
+
+    Ok(Json(LaunchResponse { request_id }))
+}
+
+fn mint_launch_token(app_state: &AppState, user_id: Uuid) -> Result<String, StatusCode> {
+    let mut conn = app_state
+        .db_pool
+        .get()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    use crate::schema::users;
+    use diesel::prelude::*;
+
+    let user: crate::models::User = users::table.find(user_id).first(&mut conn).map_err(|e| {
+        error!("Failed to find user: {}", e);
+        StatusCode::NOT_FOUND
+    })?;
+
+    let token_id = Uuid::new_v4();
+    let token = crate::jwt::create_proxy_token(
+        app_state.jwt_secret.as_bytes(),
+        token_id,
+        user_id,
+        &user.email,
+        1, // 1 day expiration for launched sessions
+    )
+    .map_err(|e| {
+        error!("Failed to create launch token: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Store token hash in DB
+    let token_hash = crate::jwt::hash_token(&token);
+    let new_token = crate::models::NewProxyAuthToken {
+        user_id,
+        name: "launcher-spawned".to_string(),
+        token_hash,
+        expires_at: (chrono::Utc::now() + chrono::Duration::days(1)).naive_utc(),
+    };
+
+    use crate::schema::proxy_auth_tokens;
+    diesel::insert_into(proxy_auth_tokens::table)
+        .values(&new_token)
+        .execute(&mut conn)
+        .map_err(|e| {
+            error!("Failed to store launch token: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(token)
+}
+
+fn get_user_id(app_state: &AppState, cookies: &Cookies) -> Result<Uuid, StatusCode> {
+    if app_state.dev_mode {
+        use crate::schema::users;
+        use diesel::prelude::*;
+
+        let mut conn = app_state
+            .db_pool
+            .get()
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        let user: crate::models::User = users::table
+            .filter(users::email.eq("testing@testing.local"))
+            .first(&mut conn)
+            .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+        return Ok(user.id);
+    }
+
+    let session_cookie = cookies
+        .signed(&app_state.cookie_key)
+        .get(shared::protocol::SESSION_COOKIE_NAME)
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    session_cookie
+        .value()
+        .parse()
+        .map_err(|_| StatusCode::UNAUTHORIZED)
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod device_flow;
 pub mod downloads;
 pub mod helpers;
+pub mod launchers;
 pub mod messages;
 pub mod proxy_tokens;
 pub mod retention;

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -1,0 +1,213 @@
+use axum::extract::ws::{Message, WebSocket};
+use futures_util::{SinkExt, StreamExt};
+use shared::ProxyMessage;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use super::LauncherConnection;
+use crate::AppState;
+
+pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>) {
+    let (mut ws_write, mut ws_read) = socket.split();
+
+    // Wait for LauncherRegister message
+    let (launcher_id, launcher_name, hostname, user_id) = loop {
+        match ws_read.next().await {
+            Some(Ok(Message::Text(text))) => {
+                if let Ok(ProxyMessage::LauncherRegister {
+                    launcher_id,
+                    launcher_name,
+                    auth_token,
+                    hostname,
+                    ..
+                }) = serde_json::from_str(&text)
+                {
+                    // Authenticate
+                    let user_id = if let Some(ref token) = auth_token {
+                        match app_state.db_pool.get() {
+                            Ok(mut conn) => {
+                                match crate::handlers::proxy_tokens::verify_and_get_user(
+                                    &app_state, &mut conn, token,
+                                ) {
+                                    Ok((uid, email)) => {
+                                        info!("Launcher authenticated as {} ({})", email, uid);
+                                        uid
+                                    }
+                                    Err(_) => {
+                                        if app_state.dev_mode {
+                                            get_dev_user_id(&app_state)
+                                        } else {
+                                            send_register_ack(
+                                                &mut ws_write,
+                                                launcher_id,
+                                                false,
+                                                Some("Authentication failed"),
+                                            )
+                                            .await;
+                                            return;
+                                        }
+                                    }
+                                }
+                            }
+                            Err(_) => {
+                                send_register_ack(
+                                    &mut ws_write,
+                                    launcher_id,
+                                    false,
+                                    Some("Database error"),
+                                )
+                                .await;
+                                return;
+                            }
+                        }
+                    } else if app_state.dev_mode {
+                        get_dev_user_id(&app_state)
+                    } else {
+                        send_register_ack(
+                            &mut ws_write,
+                            launcher_id,
+                            false,
+                            Some("No auth token provided"),
+                        )
+                        .await;
+                        return;
+                    };
+
+                    break (launcher_id, launcher_name, hostname, user_id);
+                }
+            }
+            Some(Ok(Message::Close(_))) | None => return,
+            _ => continue,
+        }
+    };
+
+    // Send RegisterAck
+    send_register_ack(&mut ws_write, launcher_id, true, None).await;
+
+    // Create channel for sending messages to this launcher
+    let (tx, mut rx) = mpsc::unbounded_channel::<ProxyMessage>();
+
+    app_state.session_manager.register_launcher(
+        launcher_id,
+        LauncherConnection {
+            sender: tx,
+            launcher_name: launcher_name.clone(),
+            hostname,
+            user_id,
+            running_sessions: Vec::new(),
+        },
+    );
+
+    info!(
+        "Launcher '{}' registered for user {}",
+        launcher_name, user_id
+    );
+
+    // Main message loop
+    loop {
+        tokio::select! {
+            // Messages from the launcher
+            msg = ws_read.next() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        handle_launcher_message(
+                            &text,
+                            launcher_id,
+                            user_id,
+                            &app_state,
+                        );
+                    }
+                    Some(Ok(Message::Close(_))) | None => {
+                        info!("Launcher '{}' disconnected", launcher_name);
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        error!("Launcher WebSocket error: {}", e);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+
+            // Messages to forward to the launcher
+            Some(msg) = rx.recv() => {
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    if ws_write.send(Message::Text(json)).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    app_state.session_manager.unregister_launcher(&launcher_id);
+}
+
+fn handle_launcher_message(text: &str, launcher_id: Uuid, user_id: Uuid, app_state: &AppState) {
+    let msg: ProxyMessage = match serde_json::from_str(text) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    match msg {
+        ProxyMessage::LaunchSessionResult {
+            request_id,
+            success,
+            session_id,
+            pid,
+            ref error,
+        } => {
+            if success {
+                info!(
+                    "Launch succeeded: request={}, session={:?}, pid={:?}",
+                    request_id, session_id, pid
+                );
+            } else {
+                warn!("Launch failed: request={}, error={:?}", request_id, error);
+            }
+            // Broadcast result to the user's web clients
+            app_state.session_manager.broadcast_to_user(&user_id, msg);
+        }
+        ProxyMessage::LauncherHeartbeat {
+            running_sessions, ..
+        } => {
+            // Update the launcher's running sessions
+            if let Some(mut launcher) = app_state.session_manager.launchers.get_mut(&launcher_id) {
+                launcher.running_sessions = running_sessions;
+            }
+        }
+        _ => {}
+    }
+}
+
+type WsSink = futures_util::stream::SplitSink<WebSocket, Message>;
+
+async fn send_register_ack(
+    ws_write: &mut WsSink,
+    launcher_id: Uuid,
+    success: bool,
+    error: Option<&str>,
+) {
+    let ack = ProxyMessage::LauncherRegisterAck {
+        success,
+        launcher_id,
+        error: error.map(|s| s.to_string()),
+    };
+    if let Ok(json) = serde_json::to_string(&ack) {
+        let _ = ws_write.send(Message::Text(json)).await;
+    }
+}
+
+fn get_dev_user_id(app_state: &AppState) -> Uuid {
+    use crate::schema::users;
+    use diesel::prelude::*;
+
+    let mut conn = app_state.db_pool.get().expect("DB connection for dev mode");
+    let user: crate::models::User = users::table
+        .filter(users::email.eq("testing@testing.local"))
+        .first(&mut conn)
+        .expect("Test user must exist in dev mode");
+    user.id
+}

--- a/backend/src/jwt.rs
+++ b/backend/src/jwt.rs
@@ -39,6 +39,7 @@ pub fn create_proxy_token(
         email: email.to_string(),
         iat: now.timestamp(),
         exp: exp.timestamp(),
+        token_type: "proxy".to_string(),
     };
 
     let token = encode(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -365,6 +365,13 @@ async fn main() -> anyhow::Result<()> {
             "/ws/voice/:session_id",
             get(handlers::voice::handle_voice_websocket),
         )
+        .route(
+            "/ws/launcher",
+            get(handlers::websocket::handle_launcher_websocket),
+        )
+        // Launcher API routes
+        .route("/api/launchers", get(handlers::launchers::list_launchers))
+        .route("/api/launch", post(handlers::launchers::launch_session))
         // Download routes for proxy binary and install script
         .route(
             "/api/download/install.sh",

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -1,0 +1,175 @@
+use gloo_net::http::Request;
+use shared::LauncherInfo;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct LaunchDialogProps {
+    pub on_close: Callback<()>,
+}
+
+#[function_component(LaunchDialog)]
+pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
+    let launchers = use_state(Vec::<LauncherInfo>::new);
+    let working_dir = use_state(String::new);
+    let session_name = use_state(String::new);
+    let launching = use_state(|| false);
+    let error_msg = use_state(|| None::<String>);
+    let success_msg = use_state(|| None::<String>);
+
+    // Fetch launchers on mount
+    {
+        let launchers = launchers.clone();
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                if let Ok(resp) = Request::get("/api/launchers").send().await {
+                    if let Ok(data) = resp.json::<Vec<LauncherInfo>>().await {
+                        launchers.set(data);
+                    }
+                }
+            });
+            || ()
+        });
+    }
+
+    let on_dir_input = {
+        let working_dir = working_dir.clone();
+        Callback::from(move |e: InputEvent| {
+            if let Some(input) = e.target_dyn_into::<HtmlInputElement>() {
+                working_dir.set(input.value());
+            }
+        })
+    };
+
+    let on_name_input = {
+        let session_name = session_name.clone();
+        Callback::from(move |e: InputEvent| {
+            if let Some(input) = e.target_dyn_into::<HtmlInputElement>() {
+                session_name.set(input.value());
+            }
+        })
+    };
+
+    let on_launch = {
+        let working_dir = working_dir.clone();
+        let session_name = session_name.clone();
+        let launching = launching.clone();
+        let error_msg = error_msg.clone();
+        let success_msg = success_msg.clone();
+        Callback::from(move |_| {
+            let dir = (*working_dir).clone();
+            if dir.is_empty() {
+                error_msg.set(Some("Working directory is required".to_string()));
+                return;
+            }
+
+            let name = if session_name.is_empty() {
+                None
+            } else {
+                Some((*session_name).clone())
+            };
+
+            let launching = launching.clone();
+            let error_msg = error_msg.clone();
+            let success_msg = success_msg.clone();
+
+            launching.set(true);
+            error_msg.set(None);
+            success_msg.set(None);
+
+            spawn_local(async move {
+                let body = serde_json::json!({
+                    "working_directory": dir,
+                    "session_name": name,
+                    "claude_args": [],
+                });
+
+                match Request::post("/api/launch")
+                    .json(&body)
+                    .unwrap()
+                    .send()
+                    .await
+                {
+                    Ok(resp) if resp.ok() => {
+                        success_msg.set(Some("Session launching...".to_string()));
+                    }
+                    Ok(resp) => {
+                        let status = resp.status();
+                        let text = resp.text().await.unwrap_or_default();
+                        if status == 404 {
+                            error_msg.set(Some("No connected launchers".to_string()));
+                        } else {
+                            error_msg.set(Some(format!("Error {}: {}", status, text)));
+                        }
+                    }
+                    Err(e) => {
+                        error_msg.set(Some(format!("Request failed: {}", e)));
+                    }
+                }
+                launching.set(false);
+            });
+        })
+    };
+
+    let on_backdrop = {
+        let on_close = props.on_close.clone();
+        Callback::from(move |_| on_close.emit(()))
+    };
+
+    html! {
+        <div class="launch-dialog-backdrop" onclick={on_backdrop}>
+            <div class="launch-dialog" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                <h3>{ "Launch Session" }</h3>
+
+                if launchers.is_empty() {
+                    <p class="launch-no-launchers">
+                        { "No launchers connected. Run " }
+                        <code>{ "claude-portal-launcher" }</code>
+                        { " on your machine." }
+                    </p>
+                } else {
+                    <p class="launch-info">
+                        { format!("{} launcher(s) connected", launchers.len()) }
+                    </p>
+
+                    <div class="launch-field">
+                        <label>{ "Working Directory" }</label>
+                        <input
+                            type="text"
+                            placeholder="/home/user/project"
+                            value={(*working_dir).clone()}
+                            oninput={on_dir_input}
+                        />
+                    </div>
+
+                    <div class="launch-field">
+                        <label>{ "Session Name (optional)" }</label>
+                        <input
+                            type="text"
+                            placeholder="my-feature"
+                            value={(*session_name).clone()}
+                            oninput={on_name_input}
+                        />
+                    </div>
+
+                    if let Some(ref err) = *error_msg {
+                        <p class="launch-error">{ err }</p>
+                    }
+
+                    if let Some(ref msg) = *success_msg {
+                        <p class="launch-success">{ msg }</p>
+                    }
+
+                    <button
+                        class="launch-button"
+                        onclick={on_launch}
+                        disabled={*launching}
+                    >
+                        { if *launching { "Launching..." } else { "Launch" } }
+                    </button>
+                }
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -1,5 +1,6 @@
 mod copy_command;
 mod diff;
+mod launch_dialog;
 mod markdown;
 pub mod message_renderer;
 mod proxy_token_setup;
@@ -8,6 +9,7 @@ mod tool_renderers;
 mod voice_input;
 
 pub use copy_command::CopyCommand;
+pub use launch_dialog::LaunchDialog;
 pub use message_renderer::{group_messages, MessageGroupRenderer};
 pub use proxy_token_setup::ProxyTokenSetup;
 pub use share_dialog::ShareDialog;

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -5,7 +5,7 @@ use super::session_view::SessionView;
 use super::types::{
     load_inactive_hidden, load_paused_sessions, save_inactive_hidden, save_paused_sessions,
 };
-use crate::components::ProxyTokenSetup;
+use crate::components::{LaunchDialog, ProxyTokenSetup};
 use crate::hooks::{use_client_websocket, use_keyboard_nav, use_sessions, KeyboardNavConfig};
 use crate::utils;
 use crate::Route;
@@ -42,6 +42,7 @@ pub fn dashboard_page() -> Html {
 
     // UI state
     let show_new_session = use_state(|| false);
+    let show_launch_dialog = use_state(|| false);
     let focused_index = use_state(|| 0usize);
     let awaiting_sessions = use_state(HashSet::<Uuid>::new);
     let paused_sessions = use_state(load_paused_sessions);
@@ -316,6 +317,20 @@ pub fn dashboard_page() -> Html {
         })
     };
 
+    let toggle_launch_dialog = {
+        let show_launch_dialog = show_launch_dialog.clone();
+        Callback::from(move |_: MouseEvent| {
+            show_launch_dialog.set(!*show_launch_dialog);
+        })
+    };
+
+    let on_launch_close = {
+        let show_launch_dialog = show_launch_dialog.clone();
+        Callback::from(move |_| {
+            show_launch_dialog.set(false);
+        })
+    };
+
     // Session state callbacks
     let on_awaiting_change = {
         let awaiting_sessions = awaiting_sessions.clone();
@@ -488,6 +503,13 @@ pub fn dashboard_page() -> Html {
                     >
                         { if *show_new_session { "Close" } else { "+ New Session" } }
                     </button>
+                    <button
+                        class="header-button launch-button"
+                        onclick={toggle_launch_dialog.clone()}
+                        title="Launch a new session via launcher"
+                    >
+                        { "Launch" }
+                    </button>
                     {
                         if *is_admin {
                             html! {
@@ -515,6 +537,11 @@ pub fn dashboard_page() -> Html {
                         <ProxyTokenSetup />
                     </div>
                 </div>
+            }
+
+            // Launch session dialog
+            if *show_launch_dialog {
+                <LaunchDialog on_close={on_launch_close.clone()} />
             }
 
             if loading {

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -324,3 +324,128 @@
     margin: 0;
 }
 
+/* ==========================================================================
+   Launch Dialog Component
+   ========================================================================== */
+
+.launch-dialog-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    animation: fadeIn 0.2s ease-out;
+}
+
+.launch-dialog {
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 2rem;
+    max-width: 480px;
+    width: 90%;
+    animation: scaleIn 0.2s ease-out;
+}
+
+.launch-dialog h3 {
+    margin: 0 0 1rem;
+    font-size: 1.3rem;
+    color: var(--text-primary);
+}
+
+.launch-no-launchers {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.launch-no-launchers code {
+    background: var(--bg-dark);
+    padding: 0.15rem 0.4rem;
+    border-radius: 3px;
+    font-family: 'Courier New', Consolas, monospace;
+    font-size: 0.85rem;
+    color: var(--accent);
+}
+
+.launch-info {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin: 0 0 1.25rem;
+}
+
+.launch-field {
+    margin-bottom: 1rem;
+}
+
+.launch-field label {
+    display: block;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-bottom: 0.4rem;
+}
+
+.launch-field input {
+    width: 100%;
+    padding: 0.6rem 0.75rem;
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-family: 'Courier New', Consolas, monospace;
+    box-sizing: border-box;
+}
+
+.launch-field input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.launch-field input::placeholder {
+    color: var(--text-muted);
+}
+
+.launch-error {
+    color: var(--error);
+    font-size: 0.9rem;
+    margin: 0.75rem 0;
+}
+
+.launch-success {
+    color: var(--success);
+    font-size: 0.9rem;
+    margin: 0.75rem 0;
+}
+
+.launch-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+    margin-top: 0.5rem;
+}
+
+.launch-button:hover:not(:disabled) {
+    background: var(--accent-hover);
+}
+
+.launch-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "claude-portal-launcher"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "claude-portal-launcher"
+path = "src/main.rs"
+
+[dependencies]
+# Shared types
+shared = { path = "../shared" }
+
+# Async runtime
+tokio = { workspace = true, features = ["full"] }
+
+# WebSocket client
+tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+futures-util = "0.3"
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# CLI argument parsing
+clap = { version = "4.5", features = ["derive", "env"] }
+
+# Logging
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+# UUID
+uuid = { workspace = true }
+
+# Hostname
+hostname = "0.4"
+
+# Time
+chrono = { workspace = true, features = ["std", "clock"] }
+
+# URL parsing
+url = "2.5"

--- a/launcher/service/claude-portal-launcher.service
+++ b/launcher/service/claude-portal-launcher.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Claude Portal Launcher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.cargo/bin/claude-portal-launcher --foreground
+Restart=on-failure
+RestartSec=5
+Environment=LAUNCHER_AUTH_TOKEN=
+Environment=LAUNCHER_BACKEND_URL=
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=%h/.config/claude-code-portal
+
+[Install]
+WantedBy=default.target

--- a/launcher/service/com.claude-portal.launcher.plist
+++ b/launcher/service/com.claude-portal.launcher.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-portal.launcher</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/claude-portal-launcher</string>
+        <string>--foreground</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/claude-portal-launcher.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/claude-portal-launcher.stderr.log</string>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+</dict>
+</plist>

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -1,0 +1,201 @@
+use crate::process_manager::ProcessManager;
+use futures_util::{SinkExt, StreamExt};
+use shared::ProxyMessage;
+use std::time::{Duration, Instant};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+const SUPERVISION_INTERVAL: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+pub async fn run_launcher_loop(
+    backend_url: &str,
+    launcher_id: Uuid,
+    launcher_name: &str,
+    auth_token: Option<&str>,
+    mut process_manager: ProcessManager,
+) -> anyhow::Result<()> {
+    let mut backoff = Duration::from_secs(1);
+
+    loop {
+        let ws_url = format!("{}/ws/launcher", backend_url);
+        info!("Connecting to backend: {}", ws_url);
+
+        match connect_async(&ws_url).await {
+            Ok((ws_stream, _)) => {
+                info!("Connected to backend");
+                backoff = Duration::from_secs(1);
+
+                let (mut write, mut read) = ws_stream.split();
+
+                // Send registration
+                let register = ProxyMessage::LauncherRegister {
+                    launcher_id,
+                    launcher_name: launcher_name.to_string(),
+                    auth_token: auth_token.map(|s| s.to_string()),
+                    hostname: hostname::get()
+                        .map(|h| h.to_string_lossy().to_string())
+                        .unwrap_or_default(),
+                    version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                };
+                let json = serde_json::to_string(&register)?;
+                write.send(Message::Text(json)).await?;
+
+                // Wait for RegisterAck
+                let ack_ok = loop {
+                    match read.next().await {
+                        Some(Ok(Message::Text(text))) => {
+                            if let Ok(ProxyMessage::LauncherRegisterAck {
+                                success, error, ..
+                            }) = serde_json::from_str(&text)
+                            {
+                                if success {
+                                    info!("Registration successful");
+                                    break true;
+                                } else {
+                                    error!("Registration failed: {}", error.unwrap_or_default());
+                                    break false;
+                                }
+                            }
+                        }
+                        Some(Ok(Message::Close(_))) | None => break false,
+                        _ => continue,
+                    }
+                };
+
+                if !ack_ok {
+                    warn!("Registration failed, will retry");
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                    continue;
+                }
+
+                // Main loop
+                let mut heartbeat_timer = tokio::time::interval(HEARTBEAT_INTERVAL);
+                let mut supervision_timer = tokio::time::interval(SUPERVISION_INTERVAL);
+                let start = Instant::now();
+
+                loop {
+                    tokio::select! {
+                        msg = read.next() => {
+                            match msg {
+                                Some(Ok(Message::Text(text))) => {
+                                    handle_message(
+                                        &text,
+                                        &mut write,
+                                        &mut process_manager,
+                                    ).await;
+                                }
+                                Some(Ok(Message::Close(_))) | None => {
+                                    info!("WebSocket closed by server");
+                                    break;
+                                }
+                                Some(Err(e)) => {
+                                    error!("WebSocket error: {}", e);
+                                    break;
+                                }
+                                _ => {}
+                            }
+                        }
+
+                        _ = heartbeat_timer.tick() => {
+                            let hb = ProxyMessage::LauncherHeartbeat {
+                                launcher_id,
+                                running_sessions: process_manager.running_session_ids(),
+                                uptime_secs: start.elapsed().as_secs(),
+                            };
+                            if let Ok(json) = serde_json::to_string(&hb) {
+                                if write.send(Message::Text(json)).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+
+                        _ = supervision_timer.tick() => {
+                            let exited = process_manager.reap_exited();
+                            for (session_id, code) in exited {
+                                info!("Session {} exited with code {:?}", session_id, code);
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to connect: {}", e);
+            }
+        }
+
+        info!("Reconnecting in {:?}...", backoff);
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(MAX_BACKOFF);
+    }
+}
+
+type WsWrite = futures_util::stream::SplitSink<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    Message,
+>;
+
+async fn handle_message(text: &str, write: &mut WsWrite, process_manager: &mut ProcessManager) {
+    let msg: ProxyMessage = match serde_json::from_str(text) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    match msg {
+        ProxyMessage::LaunchSession {
+            request_id,
+            auth_token,
+            working_directory,
+            session_name,
+            claude_args,
+            ..
+        } => {
+            info!(
+                "Launch request: dir={}, name={:?}",
+                working_directory, session_name
+            );
+
+            let result = process_manager.spawn(
+                &auth_token,
+                &working_directory,
+                session_name.as_deref(),
+                &claude_args,
+            );
+
+            let response = match result {
+                Ok(spawn_result) => ProxyMessage::LaunchSessionResult {
+                    request_id,
+                    success: true,
+                    session_id: Some(spawn_result.session_id),
+                    pid: Some(spawn_result.pid),
+                    error: None,
+                },
+                Err(e) => {
+                    error!("Failed to spawn: {}", e);
+                    ProxyMessage::LaunchSessionResult {
+                        request_id,
+                        success: false,
+                        session_id: None,
+                        pid: None,
+                        error: Some(e.to_string()),
+                    }
+                }
+            };
+
+            if let Ok(json) = serde_json::to_string(&response) {
+                let _ = write.send(Message::Text(json)).await;
+            }
+        }
+        ProxyMessage::StopSession { session_id } => {
+            info!("Stop request for session {}", session_id);
+            process_manager.stop(&session_id).await;
+        }
+        ProxyMessage::ServerShutdown { reason, .. } => {
+            info!("Server shutting down: {}", reason);
+        }
+        _ => {}
+    }
+}

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1,0 +1,80 @@
+mod connection;
+mod process_manager;
+
+use clap::Parser;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use uuid::Uuid;
+
+#[derive(Parser, Debug)]
+#[command(name = "claude-portal-launcher")]
+#[command(about = "Persistent daemon that launches claude-portal instances on demand")]
+struct Args {
+    /// Backend WebSocket URL (e.g., ws://localhost:3000)
+    #[arg(long)]
+    backend_url: String,
+
+    /// JWT auth token for the launcher
+    #[arg(long, env = "LAUNCHER_AUTH_TOKEN")]
+    auth_token: Option<String>,
+
+    /// Human-readable name for this launcher (default: hostname)
+    #[arg(long)]
+    name: Option<String>,
+
+    /// Path to the claude-portal binary
+    #[arg(long, default_value = "claude-portal")]
+    proxy_path: String,
+
+    /// Maximum concurrent proxy processes
+    #[arg(long, default_value = "5")]
+    max_processes: usize,
+
+    /// Development mode (no auth required)
+    #[arg(long)]
+    dev: bool,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let launcher_name = args.name.unwrap_or_else(|| {
+        hostname::get()
+            .map(|h| h.to_string_lossy().to_string())
+            .unwrap_or_else(|_| "unknown".to_string())
+    });
+
+    let launcher_id = Uuid::new_v4();
+
+    tracing::info!(
+        "Starting launcher '{}' (id: {})",
+        launcher_name,
+        launcher_id
+    );
+    tracing::info!("Backend URL: {}", args.backend_url);
+    tracing::info!("Proxy binary: {}", args.proxy_path);
+    tracing::info!("Max processes: {}", args.max_processes);
+
+    let process_manager = process_manager::ProcessManager::new(
+        args.proxy_path.into(),
+        args.backend_url.clone(),
+        args.max_processes,
+        args.dev,
+    );
+
+    connection::run_launcher_loop(
+        &args.backend_url,
+        launcher_id,
+        &launcher_name,
+        args.auth_token.as_deref(),
+        process_manager,
+    )
+    .await
+}

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tokio::process::Child;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+pub struct ManagedProcess {
+    pub pid: u32,
+    pub child: Child,
+}
+
+pub struct ProcessManager {
+    processes: HashMap<Uuid, ManagedProcess>,
+    proxy_path: PathBuf,
+    backend_url: String,
+    max_processes: usize,
+    dev_mode: bool,
+}
+
+pub struct SpawnResult {
+    pub session_id: Uuid,
+    pub pid: u32,
+}
+
+impl ProcessManager {
+    pub fn new(
+        proxy_path: PathBuf,
+        backend_url: String,
+        max_processes: usize,
+        dev_mode: bool,
+    ) -> Self {
+        Self {
+            processes: HashMap::new(),
+            proxy_path,
+            backend_url,
+            max_processes,
+            dev_mode,
+        }
+    }
+
+    pub fn running_session_ids(&self) -> Vec<Uuid> {
+        self.processes.keys().copied().collect()
+    }
+
+    pub fn spawn(
+        &mut self,
+        auth_token: &str,
+        working_directory: &str,
+        session_name: Option<&str>,
+        claude_args: &[String],
+    ) -> anyhow::Result<SpawnResult> {
+        if self.processes.len() >= self.max_processes {
+            anyhow::bail!(
+                "At process limit ({}/{})",
+                self.processes.len(),
+                self.max_processes
+            );
+        }
+
+        // Validate working directory exists
+        let wd = std::path::Path::new(working_directory);
+        if !wd.is_dir() {
+            anyhow::bail!("Working directory does not exist: {}", working_directory);
+        }
+
+        let session_id = Uuid::new_v4();
+        let default_name = format!("launched-{}", chrono::Local::now().format("%H%M%S"));
+        let name = session_name.unwrap_or(&default_name);
+
+        let mut cmd = tokio::process::Command::new(&self.proxy_path);
+        cmd.arg("--backend-url").arg(&self.backend_url);
+        cmd.arg("--session-name").arg(name);
+        cmd.arg("--new-session");
+
+        if self.dev_mode {
+            cmd.arg("--dev");
+        }
+
+        // Pass auth token via env var to avoid /proc exposure
+        cmd.env("PORTAL_AUTH_TOKEN", auth_token);
+        cmd.arg("--auth-token").arg(auth_token);
+
+        // Pass through extra claude args after --
+        if !claude_args.is_empty() {
+            cmd.arg("--");
+            for arg in claude_args {
+                cmd.arg(arg);
+            }
+        }
+
+        cmd.current_dir(working_directory);
+        cmd.stdin(std::process::Stdio::null());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let child = cmd.spawn()?;
+        let pid = child.id().unwrap_or(0);
+
+        info!(
+            "Spawned proxy process: pid={}, session_name={}, dir={}",
+            pid, name, working_directory
+        );
+
+        let result = SpawnResult { session_id, pid };
+
+        self.processes
+            .insert(session_id, ManagedProcess { pid, child });
+
+        Ok(result)
+    }
+
+    pub async fn stop(&mut self, session_id: &Uuid) -> bool {
+        if let Some(mut proc) = self.processes.remove(session_id) {
+            info!(
+                "Stopping process for session {}, pid={}",
+                session_id, proc.pid
+            );
+            if let Err(e) = proc.child.kill().await {
+                warn!("Failed to kill process {}: {}", proc.pid, e);
+            }
+            true
+        } else {
+            warn!("No process found for session {}", session_id);
+            false
+        }
+    }
+
+    /// Check for exited child processes and remove them.
+    /// Returns list of (session_id, exit_code) for processes that exited.
+    pub fn reap_exited(&mut self) -> Vec<(Uuid, Option<i32>)> {
+        let mut exited = Vec::new();
+
+        for (session_id, proc) in self.processes.iter_mut() {
+            match proc.child.try_wait() {
+                Ok(Some(status)) => {
+                    exited.push((*session_id, status.code()));
+                }
+                Ok(None) => { /* still running */ }
+                Err(e) => {
+                    error!("Error checking process {}: {}", proc.pid, e);
+                    exited.push((*session_id, None));
+                }
+            }
+        }
+
+        for (session_id, code) in &exited {
+            if let Some(proc) = self.processes.remove(session_id) {
+                info!(
+                    "Process exited: session={}, pid={}, code={:?}",
+                    session_id, proc.pid, code
+                );
+            }
+        }
+
+        exited
+    }
+}

--- a/shared/src/proxy_tokens.rs
+++ b/shared/src/proxy_tokens.rs
@@ -20,6 +20,13 @@ pub struct ProxyTokenClaims {
     pub iat: i64,
     /// Expires at (Unix timestamp)
     pub exp: i64,
+    /// Token type: "proxy" or "launcher"
+    #[serde(default = "default_token_type")]
+    pub token_type: String,
+}
+
+fn default_token_type() -> String {
+    "proxy".to_string()
 }
 
 /// Configuration encoded in the init URL


### PR DESCRIPTION
## Summary
- New `claude-portal-launcher` binary that runs on the host OS as a daemon, connects to the backend via WebSocket, and spawns `claude-portal` child processes on demand
- Backend integration: new `/ws/launcher` WebSocket endpoint, `GET /api/launchers` and `POST /api/launch` REST endpoints, SessionManager extended with launcher registry
- Frontend: "Launch" button on dashboard with launch dialog (working directory, session name inputs)
- Protocol: 6 new `ProxyMessage` variants for launcher registration, session launch/result, stop, and heartbeat
- Auth: `token_type` field on `ProxyTokenClaims` to distinguish proxy vs launcher tokens
- Service files: systemd unit and launchd plist for daemon management
- CI: Launcher build jobs for Linux x86_64 and macOS ARM64

## Architecture
```
User clicks "Launch" in browser
  → Frontend POST /api/launch → Backend
  → Backend forwards LaunchSession to launcher via WS
  → Launcher spawns claude-portal child process
  → claude-portal connects back (existing flow)
  → Session appears live in dashboard
```

## New files
- `launcher/` — New workspace crate with CLI, process manager, WebSocket connection
- `backend/src/handlers/launchers.rs` — REST API for launch operations
- `backend/src/handlers/websocket/launcher_socket.rs` — Launcher WebSocket handler
- `frontend/src/components/launch_dialog.rs` — Launch dialog UI component

## Test plan
- [ ] `cargo test --workspace` passes (78 tests, all green)
- [ ] `cargo clippy --workspace` clean
- [ ] `cargo fmt --check` clean
- [ ] Frontend WASM build succeeds
- [ ] CI builds launcher for Linux and macOS