### PR TITLE
Add image lightbox with download button

### DIFF
--- a/frontend/src/components/message_renderer.rs
+++ b/frontend/src/components/message_renderer.rs
@@ -736,9 +736,66 @@ fn render_image_source(source: &ImageSource) -> Html {
     }
     let src = format!("data:{};base64,{}", source.media_type, source.data);
     html! {
-        <div class="tool-result-image">
-            <img src={src} alt="Tool result image" />
-        </div>
+        <ImageViewer src={src} media_type={source.media_type.clone()} />
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct ImageViewerProps {
+    pub src: String,
+    pub media_type: String,
+}
+
+#[function_component(ImageViewer)]
+fn image_viewer(props: &ImageViewerProps) -> Html {
+    let expanded = use_state(|| false);
+
+    let on_thumb_click = {
+        let expanded = expanded.clone();
+        Callback::from(move |_: MouseEvent| expanded.set(true))
+    };
+
+    let on_close = {
+        let expanded = expanded.clone();
+        Callback::from(move |_: MouseEvent| expanded.set(false))
+    };
+
+    let ext = match props.media_type.as_str() {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/svg+xml" => "svg",
+        _ => "bin",
+    };
+
+    let download_name = format!("image.{ext}");
+
+    html! {
+        <>
+            <div class="tool-result-image" onclick={on_thumb_click}>
+                <img src={props.src.clone()} alt="Tool result image" />
+            </div>
+            if *expanded {
+                <div class="image-lightbox" onclick={on_close.clone()}>
+                    <div class="image-lightbox-content" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                        <img src={props.src.clone()} alt="Full size image" />
+                        <div class="image-lightbox-controls">
+                            <a
+                                class="image-lightbox-download"
+                                href={props.src.clone()}
+                                download={download_name}
+                            >
+                                { "Download" }
+                            </a>
+                            <button class="image-lightbox-close" onclick={on_close}>
+                                { "\u{00d7}" }
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            }
+        </>
     }
 }
 

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -298,6 +298,7 @@
     overflow: hidden;
     border-radius: 4px;
     border: 1px solid var(--border);
+    cursor: pointer;
 }
 
 .tool-result-image img {
@@ -305,6 +306,70 @@
     max-height: 600px;
     object-fit: contain;
     display: block;
+}
+
+/* Image lightbox overlay */
+.image-lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+}
+
+.image-lightbox-content {
+    position: relative;
+    max-width: 95vw;
+    max-height: 95vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.image-lightbox-content img {
+    max-width: 95vw;
+    max-height: 85vh;
+    object-fit: contain;
+    border-radius: 4px;
+}
+
+.image-lightbox-controls {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    margin-top: 1rem;
+}
+
+.image-lightbox-download {
+    padding: 0.5rem 1rem;
+    background: var(--accent);
+    color: var(--bg-dark);
+    border-radius: 4px;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.image-lightbox-download:hover {
+    background: var(--accent-hover);
+}
+
+.image-lightbox-close {
+    padding: 0.5rem 0.75rem;
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--text-primary);
+    border: none;
+    border-radius: 4px;
+    font-size: 1.25rem;
+    cursor: pointer;
+    line-height: 1;
+}
+
+.image-lightbox-close:hover {
+    background: rgba(255, 255, 255, 0.25);
 }
 
 .tool-result-message {


### PR DESCRIPTION
## Summary
- Clicking any rendered image opens a fullscreen lightbox overlay
- Lightbox shows full-resolution image with Download button and close (x)
- Clicking the backdrop closes the lightbox
- Download link uses the data URI with appropriate file extension

## Test plan
- [ ] Click an inline image — lightbox opens
- [ ] Click backdrop — lightbox closes
- [ ] Click Download — browser downloads the image file
- [ ] Close button works
- [ ] Click on the image itself in lightbox doesn't close it