### PR TITLE
Restrict launch button to admin users

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -503,19 +503,21 @@ pub fn dashboard_page() -> Html {
                     >
                         { if *show_new_session { "Close" } else { "+ New Session" } }
                     </button>
-                    <button
-                        class="header-button launch-button"
-                        onclick={toggle_launch_dialog.clone()}
-                        title="Launch a new session via launcher"
-                    >
-                        { "Launch" }
-                    </button>
                     {
                         if *is_admin {
                             html! {
-                                <button class="header-button" onclick={go_to_admin.clone()}>
-                                    { "Admin" }
-                                </button>
+                                <>
+                                    <button
+                                        class="header-button"
+                                        onclick={toggle_launch_dialog.clone()}
+                                        title="Launch a new session via launcher"
+                                    >
+                                        { "Launch" }
+                                    </button>
+                                    <button class="header-button" onclick={go_to_admin.clone()}>
+                                        { "Admin" }
+                                    </button>
+                                </>
                             }
                         } else {
                             html! {}


### PR DESCRIPTION
## Summary
- Launch button now only visible to admins (same guard as Admin button)
- Removed `launch-button` class from header button so it matches the other header button styles

## Test plan
- [ ] Non-admin users don't see the Launch button
- [ ] Admin users see Launch and Admin buttons together
- [ ] Launch button matches Admin/Settings/Logout button styling