### PR TITLE
Add SVG portal rendering from proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,7 @@ name = "claude-portal"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "claude-codes",

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -283,8 +283,8 @@ fn max_image_base64_bytes() -> usize {
         * 1024
 }
 
-/// Scan a "user" message's tool result blocks for images and return
-/// a `PortalMessage` for each one found.
+/// Scan a "user" message's tool result blocks for base64 image blocks
+/// in Structured results and return a `PortalMessage` for each one found.
 fn extract_image_portal_messages(content: &serde_json::Value) -> Vec<shared::PortalMessage> {
     let mut portal_messages = Vec::new();
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -66,6 +66,7 @@ chrono = { workspace = true, features = ["std", "clock"] }
 sha2 = "0.10"
 hex = "0.4"
 claude-session-lib = { version = "0.1.0", path = "../claude-session-lib" }
+base64 = "0.22"
 
 # Unix system calls (for lock file process checking)
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
## Summary
- Proxy detects when Claude's Read tool targets `.svg` files by tracking `tool_use_id` → `file_path` from assistant messages
- When the corresponding tool result arrives, reads the SVG from disk, base64-encodes it, and sends as a portal image message
- Respects `PORTAL_MAX_IMAGE_MB` env var for size limits (default 2 MB)
- Fixes broken backend call site for `extract_image_portal_messages` (was passing removed `tool_use_files` arg)
- Removes unused `base64` dependency from backend

## Test plan
- [ ] Have Claude read an SVG file and verify the image renders in the portal
- [ ] Test with an oversized SVG to verify the size limit message appears
- [ ] Verify existing image rendering (PNG/JPEG in tool results) still works