### PR TITLE
Capture Escape key in image lightbox

### DIFF
--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -42,6 +42,7 @@ web-sys = { workspace = true, features = [
     "MediaStreamAudioSourceNode",
     "MessageEvent",
     "MessagePort",
+    "KeyboardEvent",
 ] }
 
 # Utility libraries for WASM


### PR DESCRIPTION
## Summary
- Adds a document-level keydown listener (capture phase) when the image lightbox is open
- Escape key closes the lightbox and stops propagation so it doesn't trigger keyboard nav mode
- Listener auto-removes when lightbox closes (RAII via gloo EventListener)

## Test plan
- [ ] Open an image lightbox, press Escape — lightbox should close
- [ ] Verify Escape still activates nav mode when no lightbox is open