### PR TITLE
Add session-tagged JSON logging to proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,6 +4490,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4499,12 +4509,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "2.0"
 
 # Logging
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
 claude-codes = "2.1.17"

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -87,6 +87,7 @@ impl ProcessManager {
         cmd.arg("--backend-url").arg(&self.backend_url);
         cmd.arg("--session-name").arg(name);
         cmd.arg("--new-session");
+        cmd.arg("--session-id-tag").arg(session_id.to_string());
 
         if self.dev_mode {
             cmd.arg("--dev");


### PR DESCRIPTION
## Summary
- Adds `--session-id-tag <UUID>` hidden CLI flag to the proxy, set by the launcher when spawning
- When the flag is present, switches tracing output to JSON format so the launcher's line readers can parse structured fields (level, message, session_id)
- Launcher now passes `--session-id-tag` with the generated session UUID at spawn time
- Enables `json` feature on `tracing-subscriber` workspace dependency

Closes #323

## Test plan
- [ ] `cargo build --workspace` passes
- [ ] `cargo clippy --workspace` clean
- [ ] `cargo build --target wasm32-unknown-unknown -p shared` succeeds
- [ ] Run proxy with `--session-id-tag <uuid>` — verify JSON log output
- [ ] Run proxy without the flag — verify human-readable log output unchanged