### PR TITLE
Fix PNG portal extraction for untagged content

### DIFF
--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -351,12 +351,11 @@ fn extract_image_portal_messages(
 
         let tool_use_id = block.get("tool_use_id").and_then(|t| t.as_str());
 
-        // Handle Structured tool result content
-        let structured_blocks = block
-            .get("content")
-            .filter(|c| c.get("type").and_then(|t| t.as_str()) == Some("Structured"))
-            .and_then(|c| c.get("value"))
-            .and_then(|v| v.as_array());
+        // Handle structured tool result content.
+        // claude-codes uses #[serde(untagged)] on ToolResultContent, so
+        // Structured(Vec<Value>) serializes as a bare JSON array, not
+        // {"type": "Structured", "value": [...]}.
+        let structured_blocks = block.get("content").and_then(|c| c.as_array());
 
         let Some(structured_blocks) = structured_blocks else {
             continue;


### PR DESCRIPTION
## Summary
- `extract_image_portal_messages` was looking for `{"type": "Structured", "value": [...]}` in tool result content
- But `claude-codes` uses `#[serde(untagged)]` on `ToolResultContent`, so `Structured(Vec<Value>)` serializes as a bare JSON array `[...]`
- The filter never matched, so PNG images from Read tool results were never extracted as portal messages
- Fix: check if `content` is an array directly

## Test plan
- [ ] Read a PNG file through a proxied session — should now appear as a portal image with header
- [ ] Read an SVG file — should still work (handled by proxy, not this code path)