### PR TITLE
Replace inline image rendering with [image] tag

### DIFF
--- a/frontend/src/components/message_renderer.rs
+++ b/frontend/src/components/message_renderer.rs
@@ -874,21 +874,7 @@ fn render_structured_block(block: &Value) -> Html {
     let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
     match block_type {
         "image" => {
-            let source_val = block.get("source");
-            let media_type = source_val
-                .and_then(|s| s.get("media_type"))
-                .and_then(|m| m.as_str())
-                .unwrap_or("image/png");
-            let data = source_val
-                .and_then(|s| s.get("data"))
-                .and_then(|d| d.as_str())
-                .unwrap_or("");
-            let source = ImageSource {
-                source_type: "base64".to_string(),
-                media_type: media_type.to_string(),
-                data: data.to_string(),
-            };
-            render_image_source(&source)
+            html! { <span class="tool-result-image-tag">{ "[image]" }</span> }
         }
         "text" => {
             let text = block.get("text").and_then(|t| t.as_str()).unwrap_or("");

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -292,6 +292,12 @@
     overflow-y: auto;
 }
 
+.tool-result-image-tag {
+    color: var(--text-secondary);
+    font-style: italic;
+    font-size: 0.85em;
+}
+
 .tool-result-image {
     margin: 0.5rem 0;
     max-width: 100%;


### PR DESCRIPTION
## Summary
- Portal messages now handle image display, so structured tool result image blocks show `[image]` instead of rendering full base64 inline
- The text description from the LLM remains visible in the tool result
- Adds small CSS class for the tag styling

## Test plan
- [ ] Image read tool results show `[image]` text instead of inline image
- [ ] Text description from LLM still renders below the tag
- [ ] Portal message still shows the full image