### PR TITLE
Add stop session button for launcher-spawned sessions

### DIFF
--- a/backend/src/handlers/websocket/mod.rs
+++ b/backend/src/handlers/websocket/mod.rs
@@ -254,6 +254,21 @@ impl SessionManager {
             false
         }
     }
+
+    /// Find the launcher running a given session and send StopSession to it.
+    /// Returns true if the message was sent successfully.
+    pub fn stop_session_on_launcher(&self, session_id: Uuid) -> bool {
+        for entry in self.launchers.iter() {
+            if entry.value().running_sessions.contains(&session_id) {
+                return entry
+                    .value()
+                    .sender
+                    .send(ProxyMessage::StopSession { session_id })
+                    .is_ok();
+            }
+        }
+        false
+    }
 }
 
 pub async fn handle_session_websocket(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -310,6 +310,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/sessions/:id",
             axum::routing::delete(handlers::sessions::delete_session),
         )
+        .route(
+            "/api/sessions/:id/stop",
+            post(handlers::sessions::stop_session),
+        )
         // Session member management routes
         .route(
             "/api/sessions/:id/members",

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -365,6 +365,25 @@ pub fn dashboard_page() -> Html {
         })
     };
 
+    let on_stop = {
+        Callback::from(move |session_id: Uuid| {
+            spawn_local(async move {
+                let url = utils::api_url(&format!("/api/sessions/{}/stop", session_id));
+                match Request::post(&url).send().await {
+                    Ok(resp) if resp.status() == 202 => {
+                        log::info!("Stop request sent for session {}", session_id);
+                    }
+                    Ok(resp) => {
+                        log::error!("Failed to stop session: status {}", resp.status());
+                    }
+                    Err(e) => {
+                        log::error!("Failed to stop session: {:?}", e);
+                    }
+                }
+            });
+        })
+    };
+
     let on_toggle_pause = {
         let paused_sessions = paused_sessions.clone();
         Callback::from(move |session_id: Uuid| {
@@ -586,6 +605,7 @@ pub fn dashboard_page() -> Html {
                         on_leave={on_leave.clone()}
                         on_toggle_pause={on_toggle_pause.clone()}
                         on_toggle_inactive_hidden={on_toggle_inactive_hidden.clone()}
+                        on_stop={on_stop.clone()}
                     />
 
                     // Session views

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -21,6 +21,7 @@ pub struct SessionRailProps {
     pub on_leave: Callback<Uuid>,
     pub on_toggle_pause: Callback<Uuid>,
     pub on_toggle_inactive_hidden: Callback<MouseEvent>,
+    pub on_stop: Callback<Uuid>,
 }
 
 /// SessionRail - Horizontal carousel of session pills
@@ -87,6 +88,15 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             Callback::from(move |e: MouseEvent| {
                 e.stop_propagation();
                 on_leave.emit(session_id);
+            })
+        };
+
+        let on_stop = {
+            let on_stop = props.on_stop.clone();
+            let session_id = session.id;
+            Callback::from(move |e: MouseEvent| {
+                e.stop_propagation();
+                on_stop.emit(session_id);
             })
         };
 
@@ -158,6 +168,17 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     if session.my_role != "owner" {
                         let role_class = format!("pill-role-badge role-{}", session.my_role);
                         html! { <span class={role_class}>{ &session.my_role }</span> }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
+                    if is_connected && session.status == shared::SessionStatus::Active {
+                        html! {
+                            <button class="pill-stop" onclick={on_stop} title="Stop session">
+                                { "■" }
+                            </button>
+                        }
                     } else {
                         html! {}
                     }

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -76,6 +76,7 @@
         font-size: 0.5rem;
     }
 
+    .pill-stop,
     .pill-pause,
     .pill-leave,
     .pill-delete {

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -254,6 +254,27 @@
     font-weight: 600;
 }
 
+.pill-stop {
+    width: 24px;
+    height: 24px;
+    border: 1px solid var(--border);
+    background: rgba(247, 118, 142, 0.1);
+    color: var(--text-secondary);
+    font-size: 10px;
+    cursor: pointer;
+    border-radius: 4px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.pill-stop:hover {
+    background: rgba(247, 118, 142, 0.3);
+    border-color: var(--error);
+    color: var(--error);
+}
+
 .pill-pause {
     width: 24px;
     height: 24px;


### PR DESCRIPTION
## Summary
- Add `POST /api/sessions/:id/stop` REST endpoint that finds the launcher running a session and sends `StopSession`
- Add `stop_session_on_launcher()` method to `SessionManager` that searches launchers by running session ID
- Add stop button (■) in session rail for active, connected sessions
- Button calls the REST endpoint, launcher kills the process, sends `SessionExited`

## Test plan
- [ ] Stop button appears on active, connected sessions in the rail
- [ ] Stop button does not appear on disconnected sessions
- [ ] Clicking stop sends POST to `/api/sessions/:id/stop`
- [ ] Launcher receives `StopSession` and kills the process
- [ ] Returns 404 if no launcher has that session