### PR TITLE
Add launcher selection UI to LaunchDialog

### DIFF
--- a/docs/LAUNCHER_ROADMAP.md
+++ b/docs/LAUNCHER_ROADMAP.md
@@ -17,11 +17,10 @@
 - **Service file cleanup**: Removed non-existent `--foreground` flag
   from systemd and launchd service files.
 
+- **Launcher selection UI**: LaunchDialog shows launcher cards with
+  name, hostname, and running session count; user picks target launcher.
+
 ## Remaining Work
-
-### Cleanup
-
-- Launcher selection UI in `LaunchDialog` (show name, hostname, load).
 
 ### Install / Config
 

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -449,3 +449,52 @@
     cursor: not-allowed;
 }
 
+.launcher-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.launcher-card {
+    padding: 0.6rem 0.75rem;
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.launcher-card:hover {
+    border-color: var(--text-muted);
+}
+
+.launcher-card.selected {
+    border-color: var(--accent);
+    background: rgba(125, 174, 255, 0.05);
+}
+
+.launcher-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.launcher-card-name {
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-weight: 500;
+}
+
+.launcher-card-sessions {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+}
+
+.launcher-card-hostname {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-family: 'Courier New', Consolas, monospace;
+}
+


### PR DESCRIPTION
## Summary
- LaunchDialog now shows clickable launcher cards instead of just a count
- Each card displays launcher name, hostname, and running session count
- First launcher is auto-selected; user can click to pick a different one
- Selected `launcher_id` is sent to `POST /api/launch` (backend already supports it)

## Test plan
- Open LaunchDialog with 1+ launchers connected
- Verify launcher cards render with name/hostname/sessions
- Click different launchers to change selection
- Launch a session and verify it targets the selected launcher