### PR TITLE
Add launcher config file and install script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "dirs",
  "futures-util",
  "hostname",
  "serde",
@@ -700,6 +701,7 @@ dependencies = [
  "shared",
  "tokio",
  "tokio-tungstenite",
+ "toml 1.0.1+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1063,7 +1065,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -1074,8 +1085,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2531,7 +2554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bda1634d70d5bd53553cf15dca9842a396e8c799982a3ad22998dc44d961f24"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.9.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3233,6 +3256,17 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4257,6 +4291,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.0.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe30f93627849fa362d4a602212d41bb237dc2bd0f8ba0b2ce785012e124220"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,6 +4316,15 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
@@ -4284,9 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
 dependencies = [
  "winnow 0.7.14",
 ]

--- a/docs/LAUNCHER_ROADMAP.md
+++ b/docs/LAUNCHER_ROADMAP.md
@@ -20,10 +20,7 @@
 - **Launcher selection UI**: LaunchDialog shows launcher cards with
   name, hostname, and running session count; user picks target launcher.
 
-## Remaining Work
-
-### Install / Config
-
-- Install script for systemd/launchd service setup.
-- Launcher config file (`~/.config/claude-portal/launcher.toml`) so
-  users don't need CLI args for everything.
+- **Config file**: Launcher reads `~/.config/claude-portal/launcher.toml`;
+  CLI args override config values.
+- **Install script**: `launcher/install.sh` detects OS, builds if needed,
+  creates config template, installs systemd/launchd service.

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -44,3 +44,5 @@ chrono = { workspace = true, features = ["std", "clock"] }
 
 # URL parsing
 url = "2.5"
+toml = "1.0.1"
+dirs = "6.0.0"

--- a/launcher/install.sh
+++ b/launcher/install.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BINARY_NAME="claude-portal-launcher"
+CONFIG_DIR="${HOME}/.config/claude-portal"
+CONFIG_FILE="${CONFIG_DIR}/launcher.toml"
+
+echo "=== Claude Portal Launcher Installer ==="
+echo
+
+# Detect OS
+OS="$(uname -s)"
+case "${OS}" in
+    Linux*)  PLATFORM="linux";;
+    Darwin*) PLATFORM="macos";;
+    *)       echo "Unsupported OS: ${OS}"; exit 1;;
+esac
+
+echo "Platform: ${PLATFORM}"
+
+# Check if binary is available
+BINARY_PATH="$(command -v "${BINARY_NAME}" 2>/dev/null || true)"
+if [ -z "${BINARY_PATH}" ]; then
+    # Check if it was built locally
+    REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+    if [ -f "${REPO_ROOT}/target/release/${BINARY_NAME}" ]; then
+        BINARY_PATH="${REPO_ROOT}/target/release/${BINARY_NAME}"
+        echo "Found release binary: ${BINARY_PATH}"
+    elif [ -f "${HOME}/.cargo/bin/${BINARY_NAME}" ]; then
+        BINARY_PATH="${HOME}/.cargo/bin/${BINARY_NAME}"
+        echo "Found cargo binary: ${BINARY_PATH}"
+    else
+        echo "Binary not found. Building from source..."
+        cargo install --path "$(dirname "$0")"
+        BINARY_PATH="${HOME}/.cargo/bin/${BINARY_NAME}"
+    fi
+else
+    echo "Found binary: ${BINARY_PATH}"
+fi
+
+# Create config directory
+mkdir -p "${CONFIG_DIR}"
+
+# Create config file if it doesn't exist
+if [ ! -f "${CONFIG_FILE}" ]; then
+    echo "Creating config file: ${CONFIG_FILE}"
+    cat > "${CONFIG_FILE}" << 'TOML'
+# Claude Portal Launcher Configuration
+# CLI arguments and environment variables override these values.
+
+# Backend WebSocket URL (required)
+# backend_url = "wss://portal.example.com"
+
+# Auth token (or set LAUNCHER_AUTH_TOKEN env var)
+# auth_token = "your-jwt-token"
+
+# Human-readable name (default: hostname)
+# name = "my-workstation"
+
+# Path to the claude-portal proxy binary
+# proxy_path = "claude-portal"
+
+# Maximum concurrent proxy processes
+# max_processes = 5
+TOML
+    echo "  Edit ${CONFIG_FILE} to configure your launcher."
+else
+    echo "Config file already exists: ${CONFIG_FILE}"
+fi
+
+echo
+
+# Install service
+if [ "${PLATFORM}" = "linux" ]; then
+    SERVICE_DIR="${HOME}/.config/systemd/user"
+    SERVICE_FILE="${SERVICE_DIR}/claude-portal-launcher.service"
+    TEMPLATE="$(dirname "$0")/service/claude-portal-launcher.service"
+
+    mkdir -p "${SERVICE_DIR}"
+
+    if [ -f "${TEMPLATE}" ]; then
+        # Replace %h with $HOME for the ExecStart path
+        sed "s|%h|${HOME}|g" "${TEMPLATE}" > "${SERVICE_FILE}"
+        echo "Installed systemd service: ${SERVICE_FILE}"
+        echo
+        echo "To start the launcher:"
+        echo "  systemctl --user daemon-reload"
+        echo "  systemctl --user enable claude-portal-launcher"
+        echo "  systemctl --user start claude-portal-launcher"
+        echo
+        echo "To check status:"
+        echo "  systemctl --user status claude-portal-launcher"
+        echo "  journalctl --user -u claude-portal-launcher -f"
+    else
+        echo "Warning: service template not found at ${TEMPLATE}"
+    fi
+
+elif [ "${PLATFORM}" = "macos" ]; then
+    PLIST_DIR="${HOME}/Library/LaunchAgents"
+    PLIST_FILE="${PLIST_DIR}/com.claude-portal.launcher.plist"
+    TEMPLATE="$(dirname "$0")/service/com.claude-portal.launcher.plist"
+
+    mkdir -p "${PLIST_DIR}"
+
+    if [ -f "${TEMPLATE}" ]; then
+        # Replace the binary path with the actual path
+        sed "s|/usr/local/bin/${BINARY_NAME}|${BINARY_PATH}|g" "${TEMPLATE}" > "${PLIST_FILE}"
+        echo "Installed launchd agent: ${PLIST_FILE}"
+        echo
+        echo "To start the launcher:"
+        echo "  launchctl load ${PLIST_FILE}"
+        echo
+        echo "To check status:"
+        echo "  launchctl list | grep claude-portal"
+        echo "  tail -f /tmp/claude-portal-launcher.stdout.log"
+        echo
+        echo "To stop:"
+        echo "  launchctl unload ${PLIST_FILE}"
+    else
+        echo "Warning: plist template not found at ${TEMPLATE}"
+    fi
+fi
+
+echo
+echo "Done! Edit ${CONFIG_FILE} before starting the service."

--- a/launcher/src/config.rs
+++ b/launcher/src/config.rs
@@ -1,0 +1,35 @@
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize, Default)]
+pub struct LauncherConfig {
+    pub backend_url: Option<String>,
+    pub auth_token: Option<String>,
+    pub name: Option<String>,
+    pub proxy_path: Option<String>,
+    pub max_processes: Option<usize>,
+}
+
+fn config_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("~/.config"))
+        .join("claude-portal")
+        .join("launcher.toml")
+}
+
+pub fn load_config() -> LauncherConfig {
+    let path = config_path();
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => match toml::from_str(&contents) {
+            Ok(config) => {
+                tracing::info!("Loaded config from {}", path.display());
+                config
+            }
+            Err(e) => {
+                tracing::warn!("Failed to parse {}: {}", path.display(), e);
+                LauncherConfig::default()
+            }
+        },
+        Err(_) => LauncherConfig::default(),
+    }
+}

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod connection;
 mod process_manager;
 
@@ -11,7 +12,7 @@ use uuid::Uuid;
 struct Args {
     /// Backend WebSocket URL (e.g., ws://localhost:3000)
     #[arg(long)]
-    backend_url: String,
+    backend_url: Option<String>,
 
     /// JWT auth token for the launcher
     #[arg(long, env = "LAUNCHER_AUTH_TOKEN")]
@@ -22,12 +23,12 @@ struct Args {
     name: Option<String>,
 
     /// Path to the claude-portal binary
-    #[arg(long, default_value = "claude-portal")]
-    proxy_path: String,
+    #[arg(long)]
+    proxy_path: Option<String>,
 
     /// Maximum concurrent proxy processes
-    #[arg(long, default_value = "5")]
-    max_processes: usize,
+    #[arg(long)]
+    max_processes: Option<usize>,
 
     /// Development mode (no auth required)
     #[arg(long)]
@@ -45,7 +46,22 @@ async fn main() -> anyhow::Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let launcher_name = args.name.unwrap_or_else(|| {
+    let config = config::load_config();
+
+    // CLI args override config file values
+    let backend_url = args
+        .backend_url
+        .or(config.backend_url)
+        .ok_or_else(|| anyhow::anyhow!("--backend-url is required (or set in config file)"))?;
+
+    let auth_token = args.auth_token.or(config.auth_token);
+    let proxy_path = args
+        .proxy_path
+        .or(config.proxy_path)
+        .unwrap_or_else(|| "claude-portal".to_string());
+    let max_processes = args.max_processes.or(config.max_processes).unwrap_or(5);
+
+    let launcher_name = args.name.or(config.name).unwrap_or_else(|| {
         hostname::get()
             .map(|h| h.to_string_lossy().to_string())
             .unwrap_or_else(|_| "unknown".to_string())
@@ -58,22 +74,22 @@ async fn main() -> anyhow::Result<()> {
         launcher_name,
         launcher_id
     );
-    tracing::info!("Backend URL: {}", args.backend_url);
-    tracing::info!("Proxy binary: {}", args.proxy_path);
-    tracing::info!("Max processes: {}", args.max_processes);
+    tracing::info!("Backend URL: {}", backend_url);
+    tracing::info!("Proxy binary: {}", proxy_path);
+    tracing::info!("Max processes: {}", max_processes);
 
     let (process_manager, log_rx) = process_manager::ProcessManager::new(
-        args.proxy_path.into(),
-        args.backend_url.clone(),
-        args.max_processes,
+        proxy_path.into(),
+        backend_url.clone(),
+        max_processes,
         args.dev,
     );
 
     connection::run_launcher_loop(
-        &args.backend_url,
+        &backend_url,
         launcher_id,
         &launcher_name,
-        args.auth_token.as_deref(),
+        auth_token.as_deref(),
         process_manager,
         log_rx,
     )


### PR DESCRIPTION
## Summary
- Launcher reads `~/.config/claude-portal/launcher.toml` for persistent config
- CLI args and env vars override config file values
- `backend_url` can now come from config (no longer a required CLI arg)
- `launcher/install.sh` detects Linux/macOS, builds if needed, creates config template, installs systemd/launchd service
- Completes all items on the launcher roadmap

## Config example
```toml
backend_url = "wss://portal.example.com"
name = "my-workstation"
proxy_path = "claude-portal"
max_processes = 5
```

## Test plan
- Run `launcher/install.sh` on Linux/macOS
- Verify config file created at `~/.config/claude-portal/launcher.toml`
- Verify service file installed
- Run launcher with config file only (no CLI args except --dev)
- Run launcher with CLI args overriding config values