### PR TITLE
Bump workspace version to 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.0.0"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.0.0"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal-launcher"
-version = "1.0.0"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.0.0"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.0.0"
+version = "1.1.2"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.0.0"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.2"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## Summary
- Bump workspace version from 1.0.0 to 1.1.2

## Test plan
- [ ] `cargo build --workspace` passes