### PR TITLE
Add directory browser to launch dialog

### DIFF
--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -196,6 +196,11 @@ fn handle_launcher_message(text: &str, launcher_id: Uuid, user_id: Uuid, app_sta
             info!("Proxy exited: session={}, code={:?}", session_id, exit_code);
             app_state.session_manager.broadcast_to_user(&user_id, msg);
         }
+        ProxyMessage::ListDirectoriesResult { request_id, .. } => {
+            app_state
+                .session_manager
+                .complete_dir_request(request_id, msg);
+        }
         _ => {}
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -387,6 +387,10 @@ async fn main() -> anyhow::Result<()> {
         )
         // Launcher API routes
         .route("/api/launchers", get(handlers::launchers::list_launchers))
+        .route(
+            "/api/launchers/:launcher_id/directories",
+            get(handlers::launchers::list_directories),
+        )
         .route("/api/launch", post(handlers::launchers::launch_session))
         // Download routes for proxy binary and install script
         .route(

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -1,5 +1,7 @@
+use gloo::timers::callback::Timeout;
 use gloo_net::http::Request;
-use shared::LauncherInfo;
+use shared::{DirectoryEntry, LauncherInfo};
+use std::rc::Rc;
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::HtmlInputElement;
@@ -14,22 +16,40 @@ pub struct LaunchDialogProps {
 pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     let launchers = use_state(Vec::<LauncherInfo>::new);
     let selected_launcher = use_state(|| None::<Uuid>);
-    let working_dir = use_state(String::new);
+    let current_path = use_state(|| "/".to_string());
+    let dir_entries = use_state(Vec::<DirectoryEntry>::new);
+    let dir_loading = use_state(|| false);
+    let dir_error = use_state(|| None::<String>);
     let session_name = use_state(String::new);
     let launching = use_state(|| false);
     let error_msg = use_state(|| None::<String>);
     let success_msg = use_state(|| None::<String>);
+    let debounce_handle = use_mut_ref(|| None::<Timeout>);
 
     // Fetch launchers on mount
     {
         let launchers = launchers.clone();
         let selected_launcher = selected_launcher.clone();
+        let current_path = current_path.clone();
+        let dir_entries = dir_entries.clone();
+        let dir_loading = dir_loading.clone();
+        let dir_error = dir_error.clone();
         use_effect_with((), move |_| {
             spawn_local(async move {
                 if let Ok(resp) = Request::get("/api/launchers").send().await {
                     if let Ok(data) = resp.json::<Vec<LauncherInfo>>().await {
                         if let Some(first) = data.first() {
-                            selected_launcher.set(Some(first.launcher_id));
+                            let lid = first.launcher_id;
+                            selected_launcher.set(Some(lid));
+                            // Fetch initial directory listing
+                            fetch_directories(
+                                lid,
+                                "/".to_string(),
+                                current_path,
+                                dir_entries,
+                                dir_loading,
+                                dir_error,
+                            );
                         }
                         launchers.set(data);
                     }
@@ -39,11 +59,37 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         });
     }
 
-    let on_dir_input = {
-        let working_dir = working_dir.clone();
+    let on_path_input = {
+        let selected_launcher = selected_launcher.clone();
+        let current_path = current_path.clone();
+        let dir_entries = dir_entries.clone();
+        let dir_loading = dir_loading.clone();
+        let dir_error = dir_error.clone();
+        let debounce_handle = debounce_handle.clone();
         Callback::from(move |e: InputEvent| {
             if let Some(input) = e.target_dyn_into::<HtmlInputElement>() {
-                working_dir.set(input.value());
+                let path = input.value();
+                current_path.set(path.clone());
+
+                // Debounce: cancel previous timer, start new one
+                let launcher_id = *selected_launcher;
+                if let Some(lid) = launcher_id {
+                    let current_path = current_path.clone();
+                    let dir_entries = dir_entries.clone();
+                    let dir_loading = dir_loading.clone();
+                    let dir_error = dir_error.clone();
+                    let handle = Timeout::new(300, move || {
+                        fetch_directories(
+                            lid,
+                            path,
+                            current_path,
+                            dir_entries,
+                            dir_loading,
+                            dir_error,
+                        );
+                    });
+                    *debounce_handle.borrow_mut() = Some(handle);
+                }
             }
         })
     };
@@ -57,15 +103,61 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         })
     };
 
+    let navigate_to = {
+        let selected_launcher = selected_launcher.clone();
+        let current_path = current_path.clone();
+        let dir_entries = dir_entries.clone();
+        let dir_loading = dir_loading.clone();
+        let dir_error = dir_error.clone();
+        Rc::new(move |path: String| {
+            current_path.set(path.clone());
+            if let Some(lid) = *selected_launcher {
+                fetch_directories(
+                    lid,
+                    path,
+                    current_path.clone(),
+                    dir_entries.clone(),
+                    dir_loading.clone(),
+                    dir_error.clone(),
+                );
+            }
+        })
+    };
+
+    let on_launcher_change = {
+        let selected_launcher = selected_launcher.clone();
+        let current_path = current_path.clone();
+        let dir_entries = dir_entries.clone();
+        let dir_loading = dir_loading.clone();
+        let dir_error = dir_error.clone();
+        Callback::from(move |e: Event| {
+            if let Some(select) = e.target_dyn_into::<web_sys::HtmlSelectElement>() {
+                if let Ok(id) = select.value().parse::<Uuid>() {
+                    selected_launcher.set(Some(id));
+                    let path = "/".to_string();
+                    current_path.set(path.clone());
+                    fetch_directories(
+                        id,
+                        path,
+                        current_path.clone(),
+                        dir_entries.clone(),
+                        dir_loading.clone(),
+                        dir_error.clone(),
+                    );
+                }
+            }
+        })
+    };
+
     let on_launch = {
-        let working_dir = working_dir.clone();
+        let current_path = current_path.clone();
         let session_name = session_name.clone();
         let selected_launcher = selected_launcher.clone();
         let launching = launching.clone();
         let error_msg = error_msg.clone();
         let success_msg = success_msg.clone();
         Callback::from(move |_| {
-            let dir = (*working_dir).clone();
+            let dir = (*current_path).clone();
             if dir.is_empty() {
                 error_msg.set(Some("Working directory is required".to_string()));
                 return;
@@ -126,6 +218,83 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         Callback::from(move |_| on_close.emit(()))
     };
 
+    // Build breadcrumb segments from current path
+    let path_str = (*current_path).clone();
+    let breadcrumbs: Vec<(String, String)> = {
+        let mut segs = vec![("/".to_string(), "/".to_string())];
+        let trimmed = path_str.trim_start_matches('/');
+        if !trimmed.is_empty() {
+            let mut built = String::from("/");
+            for part in trimmed.split('/') {
+                if part.is_empty() {
+                    continue;
+                }
+                built.push_str(part);
+                built.push('/');
+                segs.push((built.clone(), part.to_string()));
+            }
+        }
+        segs
+    };
+
+    // Find selected launcher info for subtitle
+    let selected_info: Option<LauncherInfo> = (*selected_launcher)
+        .and_then(|lid| launchers.iter().find(|l| l.launcher_id == lid).cloned());
+
+    // Pre-compute directory listing HTML
+    let dir_listing_html = if *dir_loading {
+        html! { <div class="dir-loading">{ "Loading..." }</div> }
+    } else if let Some(ref err) = *dir_error {
+        html! { <div class="dir-error-msg">{ err }</div> }
+    } else if dir_entries.is_empty() {
+        html! { <div class="dir-empty">{ "Empty directory" }</div> }
+    } else {
+        let parent = parent_path(&current_path);
+        let nav_up = navigate_to.clone();
+        let on_up = Callback::from(move |_: MouseEvent| {
+            nav_up(parent.clone());
+        });
+        let entries_html = dir_entries
+            .iter()
+            .map(|entry| {
+                if entry.is_dir {
+                    let nav = navigate_to.clone();
+                    let mut child = (*current_path).clone();
+                    if !child.ends_with('/') {
+                        child.push('/');
+                    }
+                    child.push_str(&entry.name);
+                    child.push('/');
+                    let onclick = Callback::from(move |_: MouseEvent| {
+                        nav(child.clone());
+                    });
+                    html! {
+                        <div class="dir-entry dir-entry-folder" onclick={onclick}>
+                            <span class="dir-entry-icon">{ "\u{1F4C1}" }</span>
+                            <span class="dir-entry-name">{ &entry.name }</span>
+                        </div>
+                    }
+                } else {
+                    html! {
+                        <div class="dir-entry dir-entry-file">
+                            <span class="dir-entry-icon">{ "\u{1F4C4}" }</span>
+                            <span class="dir-entry-name">{ &entry.name }</span>
+                        </div>
+                    }
+                }
+            })
+            .collect::<Html>();
+        html! {
+            <>
+                <div class="dir-entry dir-entry-folder" onclick={on_up}>
+                    <span class="dir-entry-icon">{ "\u{1F4C1}" }</span>
+                    <span class="dir-entry-name">{ ".." }</span>
+                </div>
+                { entries_html }
+            </>
+        }
+    };
+
     html! {
         <div class="launch-dialog-backdrop" onclick={on_backdrop}>
             <div class="launch-dialog" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
@@ -138,47 +307,66 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                         { " on your machine." }
                     </p>
                 } else {
+                    // Launcher selector
                     <div class="launch-field">
                         <label>{ "Launcher" }</label>
-                        <div class="launcher-list">
-                            { launchers.iter().map(|launcher| {
-                                let is_selected = *selected_launcher == Some(launcher.launcher_id);
-                                let card_class = classes!(
-                                    "launcher-card",
-                                    if is_selected { Some("selected") } else { None },
-                                );
-                                let launcher_id = launcher.launcher_id;
-                                let on_select = {
-                                    let selected_launcher = selected_launcher.clone();
-                                    Callback::from(move |_: MouseEvent| {
-                                        selected_launcher.set(Some(launcher_id));
-                                    })
-                                };
+                        <select class="launcher-select" onchange={on_launcher_change}>
+                            { launchers.iter().map(|l| {
+                                let selected = *selected_launcher == Some(l.launcher_id);
                                 html! {
-                                    <div class={card_class} onclick={on_select}>
-                                        <div class="launcher-card-header">
-                                            <span class="launcher-card-name">{ &launcher.launcher_name }</span>
-                                            <span class="launcher-card-sessions">
-                                                { format!("{} running", launcher.running_sessions) }
-                                            </span>
-                                        </div>
-                                        <span class="launcher-card-hostname">{ &launcher.hostname }</span>
-                                    </div>
+                                    <option value={l.launcher_id.to_string()} {selected}>
+                                        { format!("{} — {}", l.launcher_name, l.hostname) }
+                                    </option>
+                                }
+                            }).collect::<Html>() }
+                        </select>
+                        if let Some(ref info) = selected_info {
+                            <span class="launcher-subtitle">
+                                { format!("{} running", info.running_sessions) }
+                            </span>
+                        }
+                    </div>
+
+                    // Directory browser
+                    <div class="launch-field">
+                        <label>{ "Directory" }</label>
+                        <input
+                            type="text"
+                            class="dir-path-input"
+                            value={(*current_path).clone()}
+                            oninput={on_path_input}
+                        />
+                        <div class="dir-breadcrumb">
+                            { breadcrumbs.iter().enumerate().map(|(i, (full_path, label))| {
+                                let nav = navigate_to.clone();
+                                let p = full_path.clone();
+                                let is_last = i == breadcrumbs.len() - 1;
+                                let onclick = Callback::from(move |e: MouseEvent| {
+                                    e.prevent_default();
+                                    nav(p.clone());
+                                });
+                                html! {
+                                    <>
+                                        if i > 0 {
+                                            <span class="dir-breadcrumb-sep">{ "/" }</span>
+                                        }
+                                        <a
+                                            class={classes!("dir-breadcrumb-seg", is_last.then_some("active"))}
+                                            href="#"
+                                            {onclick}
+                                        >
+                                            { label }
+                                        </a>
+                                    </>
                                 }
                             }).collect::<Html>() }
                         </div>
+                        <div class="dir-browser">
+                            { dir_listing_html }
+                        </div>
                     </div>
 
-                    <div class="launch-field">
-                        <label>{ "Working Directory" }</label>
-                        <input
-                            type="text"
-                            placeholder="/home/user/project"
-                            value={(*working_dir).clone()}
-                            oninput={on_dir_input}
-                        />
-                    </div>
-
+                    // Session name
                     <div class="launch-field">
                         <label>{ "Session Name (optional)" }</label>
                         <input
@@ -197,15 +385,77 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                         <p class="launch-success">{ msg }</p>
                     }
 
-                    <button
-                        class="launch-button"
-                        onclick={on_launch}
-                        disabled={*launching}
-                    >
-                        { if *launching { "Launching..." } else { "Launch" } }
-                    </button>
+                    <div class="launch-actions">
+                        <button
+                            class="launch-button-cancel"
+                            onclick={
+                                let on_close = props.on_close.clone();
+                                Callback::from(move |_| on_close.emit(()))
+                            }
+                        >
+                            { "Cancel" }
+                        </button>
+                        <button
+                            class="launch-button"
+                            onclick={on_launch}
+                            disabled={*launching}
+                        >
+                            { if *launching { "Launching..." } else { "Launch" } }
+                        </button>
+                    </div>
                 }
             </div>
         </div>
     }
+}
+
+fn parent_path(path: &str) -> String {
+    let trimmed = path.trim_end_matches('/');
+    match trimmed.rfind('/') {
+        Some(0) | None => "/".to_string(),
+        Some(idx) => format!("{}/", &trimmed[..idx]),
+    }
+}
+
+fn fetch_directories(
+    launcher_id: Uuid,
+    path: String,
+    current_path: UseStateHandle<String>,
+    dir_entries: UseStateHandle<Vec<DirectoryEntry>>,
+    dir_loading: UseStateHandle<bool>,
+    dir_error: UseStateHandle<Option<String>>,
+) {
+    dir_loading.set(true);
+    dir_error.set(None);
+    spawn_local(async move {
+        let url = format!(
+            "/api/launchers/{}/directories?path={}",
+            launcher_id,
+            js_sys::encode_uri_component(&path)
+        );
+        match Request::get(&url).send().await {
+            Ok(resp) if resp.ok() => {
+                if let Ok(entries) = resp.json::<Vec<DirectoryEntry>>().await {
+                    dir_entries.set(entries);
+                    current_path.set(path);
+                } else {
+                    dir_error.set(Some("Failed to parse response".to_string()));
+                }
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                if status == 400 {
+                    dir_error.set(Some("Path not found or not readable".to_string()));
+                } else if status == 504 {
+                    dir_error.set(Some("Launcher not responding".to_string()));
+                } else {
+                    dir_error.set(Some(format!("Error {}", status)));
+                }
+            }
+            Err(e) => {
+                dir_error.set(Some(format!("Request failed: {}", e)));
+            }
+        }
+        dir_loading.set(false);
+    });
 }

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -349,7 +349,7 @@
     border: 1px solid var(--border);
     border-radius: 8px;
     padding: 2rem;
-    max-width: 480px;
+    max-width: 540px;
     width: 90%;
     animation: scaleIn 0.2s ease-out;
 }
@@ -437,7 +437,6 @@
     font-size: 1rem;
     font-weight: 500;
     cursor: pointer;
-    margin-top: 0.5rem;
 }
 
 .launch-button:hover:not(:disabled) {
@@ -449,52 +448,144 @@
     cursor: not-allowed;
 }
 
-.launcher-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.launcher-card {
+.launcher-select {
+    width: 100%;
     padding: 0.6rem 0.75rem;
     background: var(--bg-dark);
     border: 1px solid var(--border);
     border-radius: 6px;
-    cursor: pointer;
-    display: flex;
-    flex-direction: column;
-    gap: 0.2rem;
-}
-
-.launcher-card:hover {
-    border-color: var(--text-muted);
-}
-
-.launcher-card.selected {
-    border-color: var(--accent);
-    background: rgba(125, 174, 255, 0.05);
-}
-
-.launcher-card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.launcher-card-name {
     color: var(--text-primary);
     font-size: 0.95rem;
+    box-sizing: border-box;
+    cursor: pointer;
+}
+
+.launcher-select:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.launcher-subtitle {
+    display: block;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin-top: 0.3rem;
+}
+
+.dir-path-input {
+    margin-bottom: 0.4rem;
+}
+
+.dir-breadcrumb {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.15rem;
+    padding: 0.3rem 0;
+    font-size: 0.8rem;
+    font-family: 'Courier New', Consolas, monospace;
+}
+
+.dir-breadcrumb-sep {
+    color: var(--text-muted);
+}
+
+.dir-breadcrumb-seg {
+    color: var(--accent);
+    text-decoration: none;
+    padding: 0.1rem 0.2rem;
+    border-radius: 3px;
+}
+
+.dir-breadcrumb-seg:hover {
+    background: rgba(125, 174, 255, 0.1);
+}
+
+.dir-breadcrumb-seg.active {
+    color: var(--text-primary);
     font-weight: 500;
 }
 
-.launcher-card-sessions {
-    color: var(--text-muted);
-    font-size: 0.8rem;
+.dir-browser {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-dark);
+    max-height: 240px;
+    overflow-y: auto;
 }
 
-.launcher-card-hostname {
-    color: var(--text-secondary);
-    font-size: 0.8rem;
+.dir-entry {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.75rem;
+    cursor: default;
+    font-size: 0.9rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.dir-entry:last-child {
+    border-bottom: none;
+}
+
+.dir-entry-folder {
+    cursor: pointer;
+}
+
+.dir-entry-folder:hover {
+    background: rgba(125, 174, 255, 0.06);
+}
+
+.dir-entry-icon {
+    font-size: 0.85rem;
+    flex-shrink: 0;
+}
+
+.dir-entry-name {
+    color: var(--text-primary);
     font-family: 'Courier New', Consolas, monospace;
+    font-size: 0.85rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dir-entry-file .dir-entry-name {
+    color: var(--text-secondary);
+}
+
+.dir-loading,
+.dir-error-msg,
+.dir-empty {
+    padding: 1.5rem;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.dir-error-msg {
+    color: var(--error);
+}
+
+.launch-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.launch-button-cancel {
+    padding: 0.75rem 1.5rem;
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+.launch-button-cancel:hover {
+    border-color: var(--text-muted);
+    color: var(--text-primary);
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -299,6 +299,17 @@ pub enum ProxyMessage {
         session_id: Uuid,
         exit_code: Option<i32>,
     },
+
+    /// Request directory listing from a launcher (backend -> launcher)
+    ListDirectories { request_id: Uuid, path: String },
+
+    /// Directory listing response (launcher -> backend)
+    ListDirectoriesResult {
+        request_id: Uuid,
+        #[serde(default)]
+        entries: Vec<DirectoryEntry>,
+        error: Option<String>,
+    },
 }
 
 fn default_language_code() -> String {
@@ -340,6 +351,13 @@ pub enum SendMode {
     /// Wiggum mode - iterative autonomous loop until completion
     /// Proxy will re-send the prompt after each result until Claude responds with "DONE"
     Wiggum,
+}
+
+/// A directory entry returned by the launcher's filesystem listing
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DirectoryEntry {
+    pub name: String,
+    pub is_dir: bool,
 }
 
 /// Info about a connected launcher daemon


### PR DESCRIPTION
## Summary
- Replaces the bare text-input launch modal with an interactive directory browser
- Frontend fetches directory listings from the launcher's filesystem via a new REST endpoint
- Launcher selector changed from card list to a compact dropdown
- Breadcrumb navigation and debounced path input for snappy directory browsing

## Architecture
New sync REST endpoint (`GET /api/launchers/:id/directories?path=`) uses oneshot channel + 5s timeout to proxy the request through the backend WebSocket to the launcher, which reads its local filesystem and responds.

## Test plan
- [ ] Start backend + launcher, open dashboard, click Launch
- [ ] Directory browser shows launcher's filesystem
- [ ] Navigate into directories by clicking entries
- [ ] Use breadcrumbs to go up
- [ ] Type a path manually — debounced fetch updates listing
- [ ] Switch launchers — directory resets to /
- [ ] Select directory and launch session