### PR TITLE
Polish launch dialog directory browser

### DIFF
--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -53,8 +53,10 @@ pub fn extract_hostname(session_name: &str) -> &str {
 
 /// Extract folder name from path (last path component)
 pub fn extract_folder(path: &str) -> &str {
-    path.rsplit('/')
+    let trimmed = path.trim_end_matches('/');
+    trimmed
+        .rsplit('/')
         .next()
         .filter(|s| !s.is_empty())
-        .unwrap_or(path)
+        .unwrap_or(trimmed)
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -309,6 +309,8 @@ pub enum ProxyMessage {
         #[serde(default)]
         entries: Vec<DirectoryEntry>,
         error: Option<String>,
+        #[serde(default)]
+        resolved_path: Option<String>,
     },
 }
 


### PR DESCRIPTION
## Summary
- Default directory path to user's home directory (`~`) instead of `/`
- Case-insensitive prefix filtering when typing a partial path fragment (e.g. `/home/user/re` filters to entries starting with "re")
- Fix session pill showing full working directory path instead of just the last folder name
- Launcher returns `resolved_path` so frontend knows the actual path after `~` expansion

## Test plan
- [ ] Open launch dialog — starts in home directory
- [ ] Type partial path like `/home/user/re` — list filters to matching entries
- [ ] Launch a session — pill shows folder name, not full path