### PR TITLE
Switch pill menu to click-to-open dropdown

### DIFF
--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -92,11 +92,10 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             Callback::from(move |_| on_select.emit(index))
         };
 
-        let on_context_menu = {
+        let on_toggle_menu = {
             let context_menu_session = context_menu_session.clone();
             let session_id = session.id;
             Callback::from(move |e: MouseEvent| {
-                e.prevent_default();
                 e.stop_propagation();
                 context_menu_session.set(Some(session_id));
             })
@@ -221,7 +220,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         };
 
         html! {
-            <div class={pill_class} onclick={on_click} oncontextmenu={on_context_menu} key={session.id.to_string()}>
+            <div class={pill_class} onclick={on_click} key={session.id.to_string()}>
                 {
                     if let Some(num) = &number_annotation {
                         html! { <span class="pill-number">{ num }</span> }
@@ -258,6 +257,9 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                         html! {}
                     }
                 }
+                <button type="button" class="pill-menu-toggle" onclick={on_toggle_menu}>
+                    { "▼" }
+                </button>
                 { context_menu_html }
             </div>
         }

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -233,7 +233,30 @@
     font-weight: 600;
 }
 
-/* Context menu (right-click on pill) */
+/* Pill menu toggle (▼ button) */
+.pill-menu-toggle {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.6rem;
+    cursor: pointer;
+    padding: 0.2rem 0.3rem;
+    border-radius: 4px;
+    transition: color 0.15s, background 0.15s;
+    flex-shrink: 0;
+    opacity: 0;
+}
+
+.session-pill:hover .pill-menu-toggle {
+    opacity: 1;
+}
+
+.pill-menu-toggle:hover {
+    color: var(--text-primary);
+    background: rgba(122, 162, 247, 0.2);
+}
+
+/* Pill dropdown menu */
 .pill-context-menu {
     position: absolute;
     top: 100%;


### PR DESCRIPTION
## Summary
- Replace right-click context menu with a click-to-open `▼` toggle button on session pills
- Toggle button appears on pill hover, matching the send button dropdown pattern
- Click outside to dismiss menu

## Test plan
- [ ] Hover a session pill → `▼` button appears
- [ ] Click `▼` → dropdown menu opens below the pill
- [ ] Click Stop/Pause/Leave → action fires, menu closes
- [ ] Click outside → menu closes