### PR TITLE
Fix pill dropdown clipping and always show toggle

### DIFF
--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -23,6 +23,8 @@ wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true, features = [
     "Window",
     "Document",
+    "Element",
+    "DomRect",
     "HtmlElement",
     "HtmlSelectElement",
     "Location",

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -9,7 +9,6 @@
     background: var(--bg-darker);
     border-bottom: 1px solid var(--border);
     overflow-x: auto;
-    overflow-y: visible;
     scroll-behavior: smooth;
     scrollbar-width: thin;
     scrollbar-color: var(--border) transparent;
@@ -244,11 +243,6 @@
     border-radius: 4px;
     transition: color 0.15s, background 0.15s;
     flex-shrink: 0;
-    opacity: 0;
-}
-
-.session-pill:hover .pill-menu-toggle {
-    opacity: 1;
 }
 
 .pill-menu-toggle:hover {
@@ -256,12 +250,9 @@
     background: rgba(122, 162, 247, 0.2);
 }
 
-/* Pill dropdown menu */
+/* Pill dropdown menu - uses fixed positioning to escape overflow clipping */
 .pill-context-menu {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    margin-top: 4px;
+    position: fixed;
     background: var(--bg-darker);
     border: 1px solid var(--border);
     border-radius: 6px;


### PR DESCRIPTION
## Summary
- Fix dropdown menu being clipped by the session rail's `overflow-x: auto` (which forces `overflow-y: auto` too)
- Use `position: fixed` with computed coordinates from `getBoundingClientRect()` so the menu escapes overflow
- Make the `▼` toggle button always visible (not just on hover)
- Remove unused `overflow-y: visible` which had no effect

## Test plan
- [ ] Click `▼` on any session pill → dropdown appears below the button, not clipped
- [ ] Dropdown floats over the chat area below
- [ ] Click outside → menu closes
- [ ] Actions (Stop/Pause/Leave) still work correctly