### PR TITLE
Pill dropdown uses send button pattern

### DIFF
--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -250,25 +250,23 @@
     background: rgba(122, 162, 247, 0.2);
 }
 
-/* Invisible overlay to catch clicks outside the dropdown */
-.pill-dropdown-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 99;
-}
-
-/* Pill dropdown menu - rendered outside the rail with fixed positioning */
+/* Pill dropdown menu - fixed positioning to escape rail overflow clipping.
+   Always in DOM, toggled by .open class (same pattern as send button dropdown). */
 .pill-dropdown {
     position: fixed;
     background: var(--bg-darker);
     border: 1px solid var(--border);
     border-radius: 6px;
     min-width: 160px;
-    display: flex;
+    display: none;
     flex-direction: column;
     overflow: hidden;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     z-index: 100;
+}
+
+.pill-dropdown.open {
+    display: flex;
 }
 
 .pill-menu-option {


### PR DESCRIPTION
## Summary
- Replaces overlay-based click-outside-to-close with container div onclick (matching the send button dropdown pattern)
- Dropdown always in DOM, toggled by `.open` CSS class instead of conditional rendering
- Container div wraps rail + dropdown; clicking container closes menu, `stop_propagation` on toggle button and dropdown prevents bubbling
- Removes `.pill-dropdown-overlay` CSS

## Test plan
- [ ] Click ▼ on a session pill — dropdown appears below the button
- [ ] Click outside dropdown — it closes
- [ ] Click a menu option (stop/pause/leave) — action fires, menu closes
- [ ] Click ▼ again on same pill — menu toggles closed
- [ ] Click ▼ on different pill — old menu closes, new one opens