### PR TITLE
Reorder dropdown, require double-click to stop

### DIFF
--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -296,6 +296,11 @@
     background: rgba(247, 118, 142, 0.15);
 }
 
+.pill-menu-option.stop.confirming {
+    background: rgba(247, 118, 142, 0.2);
+    font-weight: 600;
+}
+
 .pill-menu-option.pause.active {
     color: var(--success);
 }


### PR DESCRIPTION
## Summary
- Moved Pause/Unpause above Stop in the pill dropdown menu
- Stop Session now requires two clicks: first click shows "Click again to confirm", second click actually stops
- Confirm state resets when menu closes (click outside, toggle, or switching pills)

## Test plan
- [ ] Open pill dropdown — Pause appears first, then Stop, then Leave
- [ ] Click Stop once — text changes to "Click again to confirm" with highlighted background
- [ ] Click Stop again — session actually stops, menu closes
- [ ] Click Stop once then click outside — menu closes, reopening shows "Stop Session" again
- [ ] Click Stop once then open different pill's menu — confirm state resets