### PR TITLE
Add hostname column, launcher_id, close launch dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "claude-codes",
  "directories",
  "futures-util",
+ "hostname",
  "serde",
  "serde_json",
  "shared",

--- a/backend/migrations/2026-02-16-171025_add_hostname_and_launcher_id/down.sql
+++ b/backend/migrations/2026-02-16-171025_add_hostname_and_launcher_id/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sessions DROP COLUMN hostname;
+ALTER TABLE sessions DROP COLUMN launcher_id;

--- a/backend/migrations/2026-02-16-171025_add_hostname_and_launcher_id/up.sql
+++ b/backend/migrations/2026-02-16-171025_add_hostname_and_launcher_id/up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE sessions ADD COLUMN hostname VARCHAR(255) NOT NULL DEFAULT 'unknown';
+ALTER TABLE sessions ADD COLUMN launcher_id UUID;
+
+-- Backfill hostname from session_name (format: "hostname-YYYYMMDD-HHMMSS")
+-- Strip the trailing -YYYYMMDD-HHMMSS pattern to extract the hostname
+UPDATE sessions
+SET hostname = regexp_replace(session_name, '-\d{8}-\d{6}$', '')
+WHERE session_name ~ '-\d{8}-\d{6}$';

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -523,6 +523,7 @@ pub struct AdminSessionInfo {
     pub created_at: String,
     pub last_activity: String,
     pub is_connected: bool,
+    pub hostname: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -573,6 +574,7 @@ pub async fn list_sessions(
                 created_at: session.created_at.to_string(),
                 last_activity: session.last_activity.to_string(),
                 is_connected,
+                hostname: session.hostname,
             }
         })
         .collect();

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -104,6 +104,8 @@ fn handle_proxy_message(
             replay_after: _,
             client_version,
             replaces_session_id,
+            hostname,
+            launcher_id,
         } => {
             let key = claude_session_id.to_string();
             *session_key = Some(key.clone());
@@ -120,6 +122,8 @@ fn handle_proxy_message(
                 client_version: &client_version,
                 session_key: &key,
                 replaces_session_id,
+                hostname: hostname.as_deref().unwrap_or("unknown"),
+                launcher_id,
             };
             let result = register_or_update_session(app_state, &params);
 

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -22,6 +22,8 @@ pub struct RegistrationParams<'a> {
     pub client_version: &'a Option<String>,
     pub session_key: &'a str,
     pub replaces_session_id: Option<Uuid>,
+    pub hostname: &'a str,
+    pub launcher_id: Option<Uuid>,
 }
 
 /// Register or update a session in the database.
@@ -77,6 +79,7 @@ pub fn register_or_update_session(
                 sessions::working_directory.eq(params.working_directory),
                 sessions::git_branch.eq(params.git_branch),
                 sessions::client_version.eq(params.client_version),
+                sessions::hostname.eq(params.hostname),
             ))
             .execute(&mut conn)
         {
@@ -138,6 +141,8 @@ fn create_new_session(
         status: "active".to_string(),
         git_branch: params.git_branch.clone(),
         client_version: params.client_version.clone(),
+        hostname: params.hostname.to_string(),
+        launcher_id: params.launcher_id,
     };
 
     match diesel::insert_into(sessions::table)

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -50,6 +50,8 @@ pub struct Session {
     pub cache_read_tokens: i64,
     pub client_version: Option<String>,
     pub input_seq: i64,
+    pub hostname: String,
+    pub launcher_id: Option<Uuid>,
 }
 
 #[derive(Debug, Insertable)]
@@ -75,6 +77,8 @@ pub struct NewSessionWithId {
     pub status: String,
     pub git_branch: Option<String>,
     pub client_version: Option<String>,
+    pub hostname: String,
+    pub launcher_id: Option<Uuid>,
 }
 
 #[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -117,6 +117,9 @@ diesel::table! {
         #[max_length = 32]
         client_version -> Nullable<Varchar>,
         input_seq -> Int8,
+        #[max_length = 255]
+        hostname -> Varchar,
+        launcher_id -> Nullable<Uuid>,
     }
 }
 

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -20,3 +20,4 @@ tracing = "0.1"
 anyhow = { workspace = true }
 base64 = "0.22"
 directories = "5.0"
+hostname = "0.4.2"

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -30,7 +30,6 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     let session_name = use_state(String::new);
     let launching = use_state(|| false);
     let error_msg = use_state(|| None::<String>);
-    let success_msg = use_state(|| None::<String>);
     let debounce_handle = use_mut_ref(|| None::<Timeout>);
 
     // Fetch launchers on mount
@@ -162,7 +161,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let selected_launcher = selected_launcher.clone();
         let launching = launching.clone();
         let error_msg = error_msg.clone();
-        let success_msg = success_msg.clone();
+        let on_close = props.on_close.clone();
         Callback::from(move |_| {
             let dir = (*current_path).clone();
             if dir.is_empty() {
@@ -179,11 +178,10 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
             let launcher_id = *selected_launcher;
             let launching = launching.clone();
             let error_msg = error_msg.clone();
-            let success_msg = success_msg.clone();
+            let on_close = on_close.clone();
 
             launching.set(true);
             error_msg.set(None);
-            success_msg.set(None);
 
             spawn_local(async move {
                 let body = serde_json::json!({
@@ -200,7 +198,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     .await
                 {
                     Ok(resp) if resp.ok() => {
-                        success_msg.set(Some("Session launching...".to_string()));
+                        on_close.emit(());
                     }
                     Ok(resp) => {
                         let status = resp.status();
@@ -386,10 +384,6 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
                     if let Some(ref err) = *error_msg {
                         <p class="launch-error">{ err }</p>
-                    }
-
-                    if let Some(ref msg) = *success_msg {
-                        <p class="launch-success">{ msg }</p>
                     }
 
                     <div class="launch-actions">

--- a/frontend/src/pages/admin.rs
+++ b/frontend/src/pages/admin.rs
@@ -69,6 +69,8 @@ struct AdminSessionInfo {
     total_cost_usd: f64,
     last_activity: String,
     is_connected: bool,
+    #[serde(default)]
+    hostname: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -280,7 +282,7 @@ fn session_row(props: &SessionRowProps) -> Html {
         &session.status
     };
 
-    let hostname = utils::extract_hostname(&session.session_name);
+    let hostname = &session.hostname;
     let project_name = utils::extract_folder(&session.working_directory);
 
     html! {

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -147,8 +147,8 @@ pub fn dashboard_page() -> Html {
             let folder_b = utils::extract_folder(&b.working_directory);
             match folder_a.to_lowercase().cmp(&folder_b.to_lowercase()) {
                 std::cmp::Ordering::Equal => {
-                    let hostname_a = utils::extract_hostname(&a.session_name);
-                    let hostname_b = utils::extract_hostname(&b.session_name);
+                    let hostname_a = &a.hostname;
+                    let hostname_b = &b.hostname;
                     hostname_a.to_lowercase().cmp(&hostname_b.to_lowercase())
                 }
                 other => other,

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -230,7 +230,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             },
         );
 
-        let hostname = utils::extract_hostname(&session.session_name);
+        let hostname = &session.hostname;
         let folder = utils::extract_folder(&session.working_directory);
 
         let connection_class = if is_connected {

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -46,6 +46,8 @@ pub fn connect_websocket(
                     replay_after,
                     client_version: None,
                     replaces_session_id: None,
+                    hostname: None,
+                    launcher_id: None,
                 };
 
                 if let Ok(json) = serde_json::to_string(&register_msg) {

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -149,7 +149,7 @@ fn session_row(props: &SessionRowProps) -> Html {
     });
 
     let project = utils::extract_folder(&session.working_directory);
-    let hostname = utils::extract_hostname(&session.session_name);
+    let hostname = &session.hostname;
 
     // Only owners can share
     let is_owner = session.my_role == "owner";

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -37,20 +37,6 @@ pub fn ws_url(path: &str) -> String {
     format!("{}{}", get_ws_url(), path)
 }
 
-/// Extract hostname from session_name (format: "hostname-YYYYMMDD-HHMMSS")
-pub fn extract_hostname(session_name: &str) -> &str {
-    let mut dash_count = 0;
-    for (i, c) in session_name.bytes().enumerate().rev() {
-        if c == b'-' {
-            dash_count += 1;
-            if dash_count == 2 {
-                return &session_name[..i];
-            }
-        }
-    }
-    session_name
-}
-
 /// Extract folder name from path (last path component)
 pub fn extract_folder(path: &str) -> &str {
     let trimmed = path.trim_end_matches('/');

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -18,6 +18,7 @@ pub async fn run_launcher_loop(
     mut process_manager: ProcessManager,
     mut exit_rx: mpsc::UnboundedReceiver<SessionExited>,
 ) -> anyhow::Result<()> {
+    process_manager.set_launcher_id(launcher_id);
     let mut backoff = Duration::from_secs(1);
 
     loop {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -352,6 +352,7 @@ async fn main() -> Result<()> {
         git_branch,
         claude_args: args.claude_args.clone(),
         replaces_session_id: None,
+        launcher_id: None,
     };
 
     // Start Claude and run session

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -52,6 +52,12 @@ pub enum ProxyMessage {
         /// the old session ID so the backend can mark it as replaced.
         #[serde(default)]
         replaces_session_id: Option<Uuid>,
+        /// Hostname of the machine running the session
+        #[serde(default)]
+        hostname: Option<String>,
+        /// Launcher ID if this session was started by a launcher
+        #[serde(default)]
+        launcher_id: Option<Uuid>,
     },
 
     /// Output from Claude Code to be displayed
@@ -389,6 +395,12 @@ pub struct SessionInfo {
     pub git_branch: Option<String>,
     /// The current user's role in this session (owner, editor, viewer)
     pub my_role: String,
+    /// Hostname of the machine running the session
+    #[serde(default)]
+    pub hostname: String,
+    /// Launcher ID if this session was started by a launcher
+    #[serde(default)]
+    pub launcher_id: Option<Uuid>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Adds `hostname` (NOT NULL, default 'unknown') and `launcher_id` (nullable UUID) columns to sessions table
- Migration backfills hostname from existing `session_name` format (`hostname-YYYYMMDD-HHMMSS`)
- Proxy and launcher send hostname via Register message; launcher passes its launcher_id to spawned sessions
- Frontend reads `session.hostname` directly instead of parsing from session_name
- Launch dialog closes immediately on success instead of showing a message

## Test plan
- [ ] Run `diesel migration run` — new columns added, existing sessions backfilled
- [ ] Launch session via dialog — dialog closes, session appears with correct hostname
- [ ] Verify launcher-spawned sessions have `launcher_id` set in DB
- [ ] Verify proxy-spawned sessions have hostname set, `launcher_id` NULL
- [ ] Check admin page shows hostname correctly
- [ ] Check settings page shows hostname correctly