### PR TITLE
Gracefully handle stale permission responses

### DIFF
--- a/claude-session-lib/src/proxy_session.rs
+++ b/claude-session-lib/src/proxy_session.rs
@@ -1381,8 +1381,7 @@ async fn run_main_loop(
                 };
 
                 if let Err(e) = claude_session.respond_permission(&perm_response.request_id, lib_response).await {
-                    error!("Failed to send permission response to Claude: {}", e);
-                    return ConnectionResult::ClaudeExited;
+                    warn!("Permission response failed (stale request?): {}", e);
                 }
             }
 


### PR DESCRIPTION
## Summary
- When a permission response arrives for a request_id that no longer has a pending request, log a warning instead of killing the session
- This can happen when a permission request times out or the context moves on before the user responds

Fixes #352

## Test plan
- [ ] Approve a plan mode permission after context has moved on — session should continue
- [ ] Normal permission flow still works as expected