### PR TITLE
Remove duplicate hostname from launcher dropdown

### DIFF
--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -320,7 +320,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                                 let selected = *selected_launcher == Some(l.launcher_id);
                                 html! {
                                     <option value={l.launcher_id.to_string()} {selected}>
-                                        { format!("{} — {}", l.launcher_name, l.hostname) }
+                                        { &l.launcher_name }
                                     </option>
                                 }
                             }).collect::<Html>() }


### PR DESCRIPTION
## Summary
- Launcher dropdown was showing `hostname — hostname` since both `launcher_name` and `hostname` default to the machine hostname
- Now just shows the launcher name

## Test plan
- [ ] Open launch dialog — launcher dropdown shows name once, not duplicated