### PR TITLE
Create config directory before acquiring lock file

### DIFF
--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -65,6 +65,12 @@ impl ConfigLock {
     /// Uses a PID-style lockfile with retry logic
     pub fn acquire(config_path: &Path) -> Result<Self> {
         let lock_path = config_path.with_extension("lock");
+
+        // Ensure parent directory exists before creating lock file
+        if let Some(parent) = lock_path.parent() {
+            fs::create_dir_all(parent).context("Failed to create config directory")?;
+        }
+
         let max_attempts = 50; // 5 seconds total with 100ms sleep
         let mut attempts = 0;
 


### PR DESCRIPTION
## Summary
- On fresh installs (e.g. macOS), the config directory doesn't exist yet
- `ConfigLock::acquire` tried to create the lock file before the parent directory existed, causing "No such file or directory" error
- Now creates the parent directory before attempting to create the lock file

Fixes #357

## Test plan
- [ ] Fresh install on macOS — `claude-portal` starts without error
- [ ] Existing installs unaffected