### PR TITLE
Default proxy backend URL like launcher

### DIFF
--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -315,13 +315,18 @@ async fn main() -> Result<()> {
     // Resolve session (new or resume)
     let (session_id, session_name, resuming) = resolve_session(&args, &cwd)?;
 
-    // Resolve backend URL: CLI arg > per-directory config > global default
-    let backend_url = args.backend_url.clone()
+    // Resolve backend URL: CLI arg > per-directory config > global default > compile-time default
+    let default_url = if cfg!(debug_assertions) {
+        "ws://localhost:3000"
+    } else {
+        "wss://txcl.io"
+    };
+    let backend_url = args
+        .backend_url
+        .clone()
         .or_else(|| config.get_backend_url(&cwd).map(|s| s.to_string()))
         .or_else(|| config.preferences.default_backend_url.clone())
-        .ok_or_else(|| anyhow::anyhow!(
-            "No backend URL configured. Run with --init <URL> first, or specify --backend-url explicitly."
-        ))?;
+        .unwrap_or_else(|| default_url.to_string());
 
     // Print startup info
     ui::print_startup_banner();


### PR DESCRIPTION
## Summary
- Proxy binary now defaults to `wss://txcl.io` in release builds and `ws://localhost:3000` in debug builds
- Same pattern the launcher already uses (from PR #350)
- No longer errors out if no backend URL is configured — falls through to the compile-time default

## Test plan
- [ ] Debug build connects to `ws://localhost:3000` by default
- [ ] Release build connects to `wss://txcl.io` by default
- [ ] CLI `--backend-url` still overrides
- [ ] Per-directory and global config still take priority over default