### PR TITLE
Extract shared default_backend_url function

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -45,15 +45,10 @@ async fn main() -> anyhow::Result<()> {
     let config = config::load_config();
 
     // CLI args override config file, which overrides the compile-time default
-    let default_url = if cfg!(debug_assertions) {
-        "ws://localhost:3000"
-    } else {
-        "wss://txcl.io"
-    };
     let backend_url = args
         .backend_url
         .or(config.backend_url)
-        .unwrap_or_else(|| default_url.to_string());
+        .unwrap_or_else(|| shared::default_backend_url().to_string());
 
     let auth_token = match args.auth_token.or(config.auth_token) {
         Some(token) => Some(token),

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -316,17 +316,12 @@ async fn main() -> Result<()> {
     let (session_id, session_name, resuming) = resolve_session(&args, &cwd)?;
 
     // Resolve backend URL: CLI arg > per-directory config > global default > compile-time default
-    let default_url = if cfg!(debug_assertions) {
-        "ws://localhost:3000"
-    } else {
-        "wss://txcl.io"
-    };
     let backend_url = args
         .backend_url
         .clone()
         .or_else(|| config.get_backend_url(&cwd).map(|s| s.to_string()))
         .or_else(|| config.preferences.default_backend_url.clone())
-        .unwrap_or_else(|| default_url.to_string());
+        .unwrap_or_else(|| shared::default_backend_url().to_string());
 
     // Print startup info
     ui::print_startup_banner();

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -12,6 +12,16 @@ pub mod protocol;
 pub mod api;
 pub use api::{ApiClientConfig, ApiError, CcProxyApi};
 
+/// Default backend URL based on build profile.
+/// Release builds point to `wss://txcl.io`, debug builds to `ws://localhost:3000`.
+pub fn default_backend_url() -> &'static str {
+    if cfg!(debug_assertions) {
+        "ws://localhost:3000"
+    } else {
+        "wss://txcl.io"
+    }
+}
+
 // Re-export claude-codes types for frontend message parsing
 pub use claude_codes::io::{
     ContentBlock, ImageBlock, ImageSource, PermissionSuggestion, TextBlock, ThinkingBlock,


### PR DESCRIPTION
## Summary
- Moved the duplicate `cfg!(debug_assertions)` backend URL logic from both proxy and launcher into `shared::default_backend_url()`
- Single source of truth: `wss://txcl.io` in release, `ws://localhost:3000` in debug

## Test plan
- [ ] Both proxy and launcher resolve to the same default URL
- [ ] CLI overrides still work for both binaries