### PR TITLE
Click-outside closes dropdown, copy session ID

### DIFF
--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -317,6 +317,14 @@
     background: rgba(224, 175, 104, 0.15);
 }
 
+.pill-menu-option.copy-id .option-hint {
+    font-family: monospace;
+}
+
+.pill-menu-option.copy-id.copied {
+    color: var(--success);
+}
+
 .pill-menu-option .option-hint {
     font-size: 0.7rem;
     font-weight: 400;


### PR DESCRIPTION
## Summary
- Clicking anywhere outside the session pill dropdown now closes it (previously required clicking the pill again)
- Added "Session ID" menu item that copies the full UUID to clipboard with visual "Copied!" feedback

## Test plan
- [ ] Open dropdown by clicking a pill, click anywhere outside → dropdown closes
- [ ] Open dropdown, click "Session ID" → copies UUID to clipboard, shows "Copied!" briefly
- [ ] Existing dropdown actions (pause, stop, leave) still work