### PR TITLE
Share option in pill dropdown, log claude version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "uuid",
+ "which 8.0.0",
 ]
 
 [[package]]
@@ -1161,6 +1162,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if 1.0.4",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -3115,7 +3122,7 @@ dependencies = [
  "regex",
  "syn 1.0.109",
  "tempfile",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -4917,6 +4924,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.1.3",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5288,6 +5306,12 @@ dependencies = [
  "cfg-if 1.0.4",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -21,3 +21,4 @@ anyhow = { workspace = true }
 base64 = "0.22"
 directories = "5.0"
 hostname = "0.4.2"
+which = "8.0.0"


### PR DESCRIPTION
## Summary
- Add "Share Session" button to session pill dropdown menu (only visible to session owners) that opens the existing ShareDialog modal for managing access
- Log resolved claude binary path (`which claude`) and `claude --version` output before spawning, to help diagnose version mismatch issues

## Test plan
- [ ] Open pill dropdown on an owned session — "Share Session" option appears
- [ ] Open pill dropdown on a shared session — "Share Session" does not appear
- [ ] Click "Share Session" — ShareDialog modal opens, dropdown closes
- [ ] Start a proxy session — logs show `Claude binary: /path/to/claude` and `Claude version: x.y.z`