### PR TITLE
Add CLI args and skip-permissions to launch dialog

### DIFF
--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -413,6 +413,21 @@
     color: var(--text-muted);
 }
 
+.launch-checkbox label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    font-family: 'Courier New', Consolas, monospace;
+    font-size: 0.9rem;
+}
+
+.launch-checkbox input[type="checkbox"] {
+    width: auto;
+    accent-color: var(--accent);
+    cursor: pointer;
+}
+
 .launch-error {
     color: var(--error);
     font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- Add "Extra CLI Arguments" text input to the launch dialog for passing arbitrary flags to the claude CLI (e.g. `--model sonnet`)
- Add "--dangerously-skip-permissions" checkbox that appends the flag when checked
- `claude_args` was already plumbed through backend/launcher/proxy — this just exposes it in the UI

## Test plan
- [ ] Open launch dialog — new fields appear below session name
- [ ] Type args like `--model sonnet` — they're passed through to the spawned proxy
- [ ] Check the skip-permissions box — `--dangerously-skip-permissions` is included in args
- [ ] Launch without either field filled — works as before (empty args)