### PR TITLE
Remove session name, use shared LaunchRequest type

### DIFF
--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -4,6 +4,7 @@ use axum::{
     Json,
 };
 use serde::Deserialize;
+use shared::api::LaunchRequest;
 use shared::{DirectoryEntry, LauncherInfo, ProxyMessage};
 use std::sync::Arc;
 use tower_cookies::Cookies;
@@ -20,17 +21,6 @@ pub async fn list_launchers(
     let user_id = get_user_id(&app_state, &cookies)?;
     let launchers = app_state.session_manager.get_launchers_for_user(&user_id);
     Ok(Json(launchers))
-}
-
-#[derive(Deserialize)]
-pub struct LaunchRequest {
-    pub working_directory: String,
-    #[serde(default)]
-    pub session_name: Option<String>,
-    #[serde(default)]
-    pub launcher_id: Option<Uuid>,
-    #[serde(default)]
-    pub claude_args: Vec<String>,
 }
 
 #[derive(serde::Serialize)]
@@ -67,7 +57,7 @@ pub async fn launch_session(
         user_id,
         auth_token,
         working_directory: req.working_directory.clone(),
-        session_name: req.session_name,
+        session_name: None,
         claude_args: req.claude_args,
     };
 

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -71,6 +71,16 @@ pub struct DeviceCodeResponse {
     pub interval: u64,
 }
 
+/// Request to launch a session via a launcher
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaunchRequest {
+    pub working_directory: String,
+    #[serde(default)]
+    pub launcher_id: Option<uuid::Uuid>,
+    #[serde(default)]
+    pub claude_args: Vec<String>,
+}
+
 /// API endpoint definitions
 pub mod endpoints {
     pub const HEALTH: &str = "/";


### PR DESCRIPTION
## Summary
- Remove the "Session Name" field from the launch dialog (auto-generated from hostname+timestamp)
- Move `LaunchRequest` struct to `shared/src/api.rs` so both frontend and backend use the same type
- Replace `serde_json::json!` in frontend with typed `LaunchRequest` struct

## Test plan
- [ ] Launch dialog no longer shows session name input
- [ ] Launching still works — session name auto-generated by launcher
- [ ] Backend correctly deserializes the request