### PR TITLE
Comprehensive mobile responsive CSS

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Claude Code Portal</title>
 
     <!-- Open Graph / Link Preview -->

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -2,13 +2,26 @@
    Mobile Responsiveness
    ========================================================================== */
 
+/* --- Safe area insets for notched devices (iPhone X+, etc.) -------------- */
+@supports (padding: env(safe-area-inset-bottom)) {
+    .focus-flow-header {
+        padding-left: max(0.75rem, env(safe-area-inset-left));
+        padding-right: max(0.75rem, env(safe-area-inset-right));
+    }
+
+    .session-view-input {
+        padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+    }
+}
+
+/* --- Tablet + phone (max-width: 768px) ---------------------------------- */
 @media (max-width: 768px) {
     /* Ensure dashboard fills exactly the viewport on mobile */
     .focus-flow-container {
         overflow: hidden;
     }
 
-    /* Header - make more compact */
+    /* ---- Header ---- */
     .focus-flow-header {
         padding: 0.5rem 0.75rem;
         flex-wrap: wrap;
@@ -39,7 +52,7 @@
         font-size: 0.8rem;
     }
 
-    /* Session rail - horizontal scroll with smaller pills */
+    /* ---- Session rail ---- */
     .session-rail {
         padding: 0.5rem;
         gap: 0.4rem;
@@ -94,7 +107,11 @@
         font-size: 0.6rem;
     }
 
-    /* Session view header - stack on mobile */
+    .pill-menu-toggle {
+        padding: 0.35rem 0.45rem;
+    }
+
+    /* ---- Session view header ---- */
     .session-view-header {
         padding: 0.5rem 0.75rem;
         flex-wrap: wrap;
@@ -128,7 +145,7 @@
         padding: 0.2rem 0.4rem;
     }
 
-    /* Messages area - ensure scrolling and input stays visible */
+    /* ---- Messages area ---- */
     .session-view-messages {
         padding: 0.75rem;
         flex: 1;
@@ -136,11 +153,11 @@
         -webkit-overflow-scrolling: touch;
     }
 
-    /* Input area - full width at bottom */
+    /* ---- Input area ---- */
     .session-view-input {
         padding: 0.75rem;
         gap: 0.5rem;
-        flex-shrink: 0; /* Prevent input from shrinking */
+        flex-shrink: 0;
         align-items: flex-end;
     }
 
@@ -170,7 +187,183 @@
         height: 18px;
     }
 
-    /* Permission prompts */
+    /* ---- Dashboard page ---- */
+    .dashboard-container {
+        padding: 1rem;
+    }
+
+    .dashboard-header {
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+    }
+
+    .header-button {
+        padding: 0.4rem 0.75rem;
+        font-size: 0.8rem;
+    }
+
+    .sessions-list {
+        gap: 0.75rem;
+    }
+
+    .session-portal {
+        border-radius: 6px;
+    }
+
+    /* Hover transform doesn't work well on touch */
+    .session-portal:hover {
+        transform: none;
+    }
+
+    .empty-state {
+        padding: 2rem 1rem;
+    }
+
+    .onboarding-container {
+        padding: 1rem;
+    }
+
+    .onboarding-content h2 {
+        font-size: 1.2rem;
+    }
+
+    .onboarding-step {
+        padding: 0.75rem;
+        gap: 0.75rem;
+    }
+
+    .code-block {
+        padding: 0.75rem;
+        font-size: 0.85rem;
+        overflow-x: auto;
+    }
+
+    /* Modals go near-fullscreen on mobile */
+    .modal-content {
+        width: 95%;
+        max-width: none;
+        padding: 1rem;
+        max-height: 90dvh;
+        overflow-y: auto;
+    }
+
+    /* ---- Messages ---- */
+    .claude-message {
+        margin-bottom: 0.75rem;
+    }
+
+    .claude-message .message-header {
+        padding: 0.4rem 0.75rem;
+        gap: 0.5rem;
+    }
+
+    .claude-message .message-body {
+        padding: 0.75rem;
+    }
+
+    .message-type-badge {
+        font-size: 0.65rem;
+        padding: 0.2rem 0.5rem;
+    }
+
+    /* Init info stacks better on mobile */
+    .init-row {
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+
+    .init-label {
+        min-width: unset;
+        font-size: 0.75rem;
+    }
+
+    .init-value {
+        font-size: 0.8rem;
+        word-break: break-all;
+    }
+
+    .init-details {
+        gap: 0.5rem;
+    }
+
+    .detail-group {
+        padding: 0.25rem 0.4rem;
+    }
+
+    /* Usage badge wraps on small screens */
+    .assistant-message .usage-badge {
+        margin-left: 0;
+    }
+
+    /* ---- Markdown ---- */
+    .md-code-block .md-code {
+        font-size: 0.8rem;
+        padding: 0.5rem 0.75rem;
+    }
+
+    .md-table-header,
+    .md-table-cell {
+        padding: 0.35rem 0.5rem;
+        font-size: 0.8rem;
+    }
+
+    .md-h1 { font-size: 1.25rem; }
+    .md-h2 { font-size: 1.1rem; }
+    .md-h3 { font-size: 1rem; }
+
+    /* ---- Tools ---- */
+    .tool-use {
+        padding: 0.4rem 0.6rem;
+        font-size: 0.8rem;
+    }
+
+    .tool-use-header {
+        flex-wrap: wrap;
+        gap: 0.35rem;
+    }
+
+    .bash-command-inline {
+        max-width: 100%;
+    }
+
+    .bash-command {
+        font-size: 0.8rem;
+        padding: 0.4rem;
+    }
+
+    .tool-args {
+        font-size: 0.75rem;
+    }
+
+    .tool-result {
+        padding: 0.4rem 0.6rem;
+        font-size: 0.8rem;
+    }
+
+    .tool-result-content {
+        font-size: 0.75rem;
+        max-height: 150px;
+    }
+
+    .diff-view {
+        font-size: 0.75rem;
+        max-height: 300px;
+    }
+
+    .write-content {
+        font-size: 0.75rem;
+        max-height: 200px;
+    }
+
+    /* Result stats bar wraps */
+    .result-message .result-stats-bar {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        font-size: 0.75rem;
+    }
+
+    /* ---- Permission prompts ---- */
     .permission-prompt {
         margin: 0.5rem 0.75rem;
         padding: 0.75rem;
@@ -193,6 +386,10 @@
         font-size: 0.85rem;
     }
 
+    .permission-option {
+        padding: 0.35rem 0.5rem;
+    }
+
     /* AskUserQuestion - more compact */
     .ask-user-question .question-text {
         font-size: 0.9rem;
@@ -210,7 +407,7 @@
         font-size: 0.75rem;
     }
 
-    /* Reconnection banner */
+    /* ---- Reconnection banner ---- */
     .reconnection-banner {
         padding: 0.4rem 0.75rem;
     }
@@ -219,7 +416,7 @@
         font-size: 0.8rem;
     }
 
-    /* Server shutdown banner */
+    /* ---- Server shutdown banner ---- */
     .server-shutdown-banner {
         padding: 0.5rem 0.75rem;
     }
@@ -227,9 +424,94 @@
     .server-shutdown-banner .shutdown-text {
         font-size: 0.8rem;
     }
+
+    /* ---- Share dialog ---- */
+    .share-dialog {
+        max-width: 100%;
+        max-height: 85dvh;
+        border-radius: 8px;
+    }
+
+    .share-dialog-overlay {
+        padding: 0.5rem;
+        align-items: flex-end;
+    }
+
+    .share-dialog-add {
+        flex-direction: column;
+        gap: 0.4rem;
+    }
+
+    .share-dialog-add input,
+    .share-dialog-add select,
+    .share-dialog-add button {
+        width: 100%;
+    }
+
+    .share-dialog-add input,
+    .share-dialog-add select {
+        font-size: 16px; /* Prevent iOS zoom */
+    }
+
+    .share-dialog-member {
+        padding: 0.6rem 0.75rem;
+        gap: 0.5rem;
+    }
+
+    /* ---- Launch dialog ---- */
+    .launch-dialog {
+        max-width: 100%;
+        width: 95%;
+        padding: 1.25rem;
+        max-height: 85dvh;
+        overflow-y: auto;
+    }
+
+    .launch-dialog h3 {
+        font-size: 1.1rem;
+    }
+
+    .launch-field input {
+        font-size: 16px; /* Prevent iOS zoom */
+    }
+
+    .dir-browser {
+        max-height: 180px;
+    }
+
+    .launch-actions {
+        flex-direction: column-reverse;
+    }
+
+    .launch-actions button {
+        width: 100%;
+    }
+
+    /* ---- Image lightbox ---- */
+    .image-lightbox {
+        padding: 0.5rem;
+    }
+
+    .image-lightbox-content img {
+        max-height: 75vh;
+    }
+
+    .image-lightbox-controls {
+        gap: 0.5rem;
+    }
+
+    /* ---- Anthropic error messages ---- */
+    .anthropic-error-content {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .anthropic-error-content .error-icon {
+        font-size: 1.5rem;
+    }
 }
 
-/* Extra small screens */
+/* --- Phone-only (max-width: 480px) -------------------------------------- */
 @media (max-width: 480px) {
     .focus-flow-header h1 {
         font-size: 0.85rem;
@@ -267,23 +549,130 @@
     .session-view-input .input-prompt {
         display: none;
     }
+
+    /* Dashboard even tighter */
+    .dashboard-container {
+        padding: 0.75rem;
+    }
+
+    .dashboard-header {
+        margin-bottom: 0.75rem;
+    }
+
+    .header-actions {
+        flex-wrap: wrap;
+    }
+
+    .section-title {
+        font-size: 1rem;
+    }
+
+    /* Messages even more compact */
+    .session-view-messages {
+        padding: 0.5rem;
+    }
+
+    .claude-message .message-body {
+        padding: 0.5rem;
+    }
+
+    /* Tool renders ultra-compact */
+    .tool-use,
+    .tool-result {
+        padding: 0.3rem 0.5rem;
+    }
+
+    .bash-command-inline,
+    .glob-pattern-inline,
+    .grep-pattern-inline {
+        font-size: 0.8rem;
+    }
+
+    /* Dialogs go fullscreen */
+    .launch-dialog-backdrop,
+    .share-dialog-overlay {
+        padding: 0;
+        align-items: stretch;
+    }
+
+    .launch-dialog,
+    .share-dialog {
+        border-radius: 0;
+        max-height: 100dvh;
+        width: 100%;
+    }
+
+    .modal-content {
+        border-radius: 0;
+        width: 100%;
+        max-height: 100dvh;
+    }
+
+    /* Overload/compaction messages */
+    .overload-content,
+    .compaction-content {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .overload-icon,
+    .compaction-icon {
+        font-size: 1.2rem;
+    }
 }
 
-/* Share dialog mobile */
-@media (max-width: 480px) {
-    .share-dialog {
-        max-width: 100%;
-        max-height: 90vh;
-        border-radius: 8px;
+/* --- Keyboard-open behavior --------------------------------------------- *
+ * When the virtual keyboard opens on mobile, the browser resizes the visual
+ * viewport. We use 100dvh (dynamic viewport height) in session-layout.css
+ * which automatically accounts for this. These rules ensure the input area
+ * stays anchored to the bottom edge above the keyboard.
+ *
+ * Key behaviors:
+ *  - .focus-flow-container uses height:100dvh -> shrinks when keyboard opens
+ *  - .session-view-messages uses flex:1 -> absorbs the shrink
+ *  - .session-view-input uses flex-shrink:0 -> stays full size
+ *  - The send-mode-dropdown uses bottom:100% so it floats above input
+ *  - iOS 16px font-size on inputs prevents auto-zoom
+ */
+
+/* Touch-friendly: enlarge interactive targets for coarse pointers */
+@media (pointer: coarse) {
+    .pill-menu-toggle {
+        min-width: 36px;
+        min-height: 36px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
     }
 
-    .share-dialog-add {
-        flex-direction: column;
+    .pill-menu-option {
+        min-height: 44px;
+        padding: 0.7rem 0.8rem;
+        justify-content: center;
     }
 
-    .share-dialog-add input,
-    .share-dialog-add select,
-    .share-dialog-add button {
-        width: 100%;
+    .permission-option {
+        min-height: 44px;
+        padding: 0.5rem 0.6rem;
+    }
+
+    .ask-user-question .question-option {
+        min-height: 44px;
+    }
+
+    .ask-user-question .submit-all-answers {
+        min-height: 44px;
+    }
+
+    .header-button {
+        min-height: 40px;
+    }
+
+    .send-mode-toggle {
+        min-width: 40px;
+    }
+
+    .dir-entry {
+        min-height: 40px;
     }
 }


### PR DESCRIPTION
## Summary
- Fill all mobile CSS gaps: dashboard, messages, markdown, tools, dialogs, error displays
- Add `env(safe-area-inset-*)` for notched devices (iPhone X+)
- Add `viewport-fit=cover` meta tag to enable safe area insets
- Add `@media (pointer: coarse)` for 44px touch targets on all interactive elements
- Use `dvh` units for dialog max-heights so they shrink when virtual keyboard opens
- Dialogs go fullscreen at 480px, near-fullscreen at 768px
- 16px font-size on all mobile inputs to prevent iOS auto-zoom

## Test plan
- [ ] Open on iPhone/Android — verify no horizontal overflow
- [ ] Tap input field — keyboard opens, input stays visible above it
- [ ] Open pill dropdown — touch targets are large enough
- [ ] Open share/launch dialogs on phone — should be fullscreen
- [ ] Verify notched device (iPhone X+) doesn't clip behind home indicator
- [ ] Permission prompts and AskUserQuestion options have adequate tap area