### PR TITLE
Fix text overflow on iPad rotation

### DIFF
--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -17,6 +17,7 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-width: 0;
 }
 
 .session-view-wrapper.hidden {
@@ -32,6 +33,7 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-width: 0; /* Prevent flex child from overflowing parent on rotation */
 }
 
 @keyframes slideIn {
@@ -128,5 +130,7 @@
 .session-view-messages {
     flex: 1;
     overflow-y: auto;
+    overflow-x: hidden;
     padding: 1rem 1.5rem;
+    min-width: 0; /* Allow flex child to shrink below content size */
 }


### PR DESCRIPTION
## Summary
- Add `min-width: 0` to session-view-wrapper, session-view, and session-view-messages flex children
- Add `overflow-x: hidden` to messages scroll area

Flex children default to `min-width: auto`, preventing them from shrinking below their content width. On iPad rotation (landscape -> portrait), content laid out for the wider viewport can't shrink, causing horizontal overflow. `min-width: 0` allows the flex chain to actually constrain width on resize.

## Test plan
- [ ] Open session on large iPad in landscape, rotate to portrait — no horizontal overflow
- [ ] Long code blocks and bash commands stay contained within viewport