### PR TITLE
Remove safe-area bottom padding from input

### DIFF
--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -8,10 +8,6 @@
         padding-left: max(0.75rem, env(safe-area-inset-left));
         padding-right: max(0.75rem, env(safe-area-inset-right));
     }
-
-    .session-view-input {
-        padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
-    }
 }
 
 /* --- Tablet + phone (max-width: 768px) ---------------------------------- */


### PR DESCRIPTION
## Summary
- Removes `padding-bottom: max(0.75rem, env(safe-area-inset-bottom))` from `.session-view-input`
- The `100dvh` container already shrinks when the keyboard opens, making safe-area bottom padding redundant
- This was causing ~34px of extra space between the keyboard and text input on iOS

## Test plan
- [ ] Open on iPhone, tap input to open keyboard — no excessive gap between keyboard and text box
- [ ] Rotate device — input still accessible
- [ ] Home indicator area still looks correct when keyboard is closed