### PR TITLE
Add PR URL detection and link on branch pills

### DIFF
--- a/backend/migrations/2026-02-18-222738_add_pr_url/down.sql
+++ b/backend/migrations/2026-02-18-222738_add_pr_url/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN pr_url;

--- a/backend/migrations/2026-02-18-222738_add_pr_url/up.sql
+++ b/backend/migrations/2026-02-18-222738_add_pr_url/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN pr_url VARCHAR(512);

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -52,6 +52,7 @@ pub struct Session {
     pub input_seq: i64,
     pub hostname: String,
     pub launcher_id: Option<Uuid>,
+    pub pr_url: Option<String>,
 }
 
 #[derive(Debug, Insertable)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -120,6 +120,8 @@ diesel::table! {
         #[max_length = 255]
         hostname -> Varchar,
         launcher_id -> Nullable<Uuid>,
+        #[max_length = 512]
+        pr_url -> Nullable<Varchar>,
     }
 }
 

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -419,13 +419,16 @@ pub fn dashboard_page() -> Html {
     let on_branch_change = {
         let set_sessions = sessions_hook.set_sessions.clone();
         let sessions = sessions.clone();
-        Callback::from(move |(session_id, branch): (Uuid, Option<String>)| {
-            let mut updated = sessions.clone();
-            if let Some(session) = updated.iter_mut().find(|s| s.id == session_id) {
-                session.git_branch = branch;
-            }
-            set_sessions.emit(updated);
-        })
+        Callback::from(
+            move |(session_id, branch, pr_url): (Uuid, Option<String>, Option<String>)| {
+                let mut updated = sessions.clone();
+                if let Some(session) = updated.iter_mut().find(|s| s.id == session_id) {
+                    session.git_branch = branch;
+                    session.pr_url = pr_url;
+                }
+                set_sessions.emit(updated);
+            },
+        )
     };
 
     // Computed values

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -357,7 +357,17 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     <span class="pill-hostname">{ hostname }</span>
                     {
                         if let Some(ref branch) = session.git_branch {
-                            html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
+                            if let Some(ref url) = session.pr_url {
+                                html! {
+                                    <a class="pill-branch pill-branch-link" href={url.clone()}
+                                       target="_blank" title={format!("{} (PR)", branch)}
+                                       onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                                        { branch }
+                                    </a>
+                                }
+                            } else {
+                                html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
+                            }
                         } else {
                             html! {}
                         }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -33,7 +33,7 @@ pub struct SessionViewProps {
     pub on_cost_change: Callback<(Uuid, f64)>,
     pub on_connected_change: Callback<(Uuid, bool)>,
     pub on_message_sent: Callback<Uuid>,
-    pub on_branch_change: Callback<(Uuid, Option<String>)>,
+    pub on_branch_change: Callback<(Uuid, Option<String>, Option<String>)>,
     #[prop_or(false)]
     pub voice_enabled: bool,
 }
@@ -55,7 +55,7 @@ pub enum SessionViewMsg {
     DenyPermission,
     PermissionSelectUp,
     PermissionSelectDown,
-    BranchChanged(Option<String>),
+    BranchChanged(Option<String>, Option<String>),
     PermissionConfirm,
     PermissionSelectAndConfirm(usize),
     HistoryUp,
@@ -315,9 +315,11 @@ impl Component for SessionView {
                     .emit((session_id, is_awaiting));
                 false
             }
-            SessionViewMsg::BranchChanged(branch) => {
+            SessionViewMsg::BranchChanged(branch, pr_url) => {
                 let session_id = ctx.props().session.id;
-                ctx.props().on_branch_change.emit((session_id, branch));
+                ctx.props()
+                    .on_branch_change
+                    .emit((session_id, branch, pr_url));
                 false
             }
             SessionViewMsg::HistoryUp => {
@@ -524,9 +526,9 @@ impl SessionView {
                     .send_message(SessionViewMsg::PermissionRequest(perm));
                 false
             }
-            WsEvent::BranchChanged(branch) => {
+            WsEvent::BranchChanged(branch, pr_url) => {
                 ctx.link()
-                    .send_message(SessionViewMsg::BranchChanged(branch));
+                    .send_message(SessionViewMsg::BranchChanged(branch, pr_url));
                 false
             }
         }

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -20,7 +20,7 @@ pub enum WsEvent {
     Output(String),
     HistoryBatch(Vec<String>),
     Permission(PendingPermission),
-    BranchChanged(Option<String>),
+    BranchChanged(Option<String>, Option<String>),
 }
 
 /// Connect to WebSocket and start receiving messages.
@@ -116,8 +116,9 @@ fn handle_proxy_message(msg: ProxyMessage, on_event: &Callback<WsEvent>) {
         ProxyMessage::SessionUpdate {
             session_id: _,
             git_branch,
+            pr_url,
         } => {
-            on_event.emit(WsEvent::BranchChanged(git_branch));
+            on_event.emit(WsEvent::BranchChanged(git_branch, pr_url));
         }
         _ => {}
     }

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -156,6 +156,15 @@
     text-align: left;
 }
 
+.pill-branch-link {
+    text-decoration: underline;
+    color: var(--accent);
+}
+
+.pill-branch-link:hover {
+    color: var(--accent-hover);
+}
+
 .session-pill.status-disconnected .pill-branch {
     color: var(--text-secondary);
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -138,6 +138,9 @@ pub enum ProxyMessage {
         /// Updated git branch (if changed)
         #[serde(skip_serializing_if = "Option::is_none")]
         git_branch: Option<String>,
+        /// GitHub PR URL for the current branch (if any)
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pr_url: Option<String>,
     },
 
     /// User spend update (sent to web clients periodically)
@@ -411,6 +414,9 @@ pub struct SessionInfo {
     /// Launcher ID if this session was started by a launcher
     #[serde(default)]
     pub launcher_id: Option<Uuid>,
+    /// GitHub PR URL for the current branch
+    #[serde(default)]
+    pub pr_url: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Proxy looks up GitHub PR URLs via `gh pr view` when branch changes or on initial connection
- Branch name on session pill becomes a clickable underlined hyperlink when a PR exists
- Both `git` and `gh` CLI commands trigger PR URL re-checks
- New `pr_url` column in sessions table, propagated through shared types, backend, and frontend

## Test plan
- [ ] Start proxy on a branch with a PR → pill shows underlined branch linking to PR
- [ ] Click PR link → opens in new tab, doesn't select the session pill
- [ ] Branch with no PR → plain text as before
- [ ] Claude runs `git checkout other-branch` → pill updates branch and PR link
- [ ] Claude runs `gh pr create` → PR URL updates on the pill