### PR TITLE
Add OG preview cards for link sharing

### DIFF
--- a/frontend/assets/og-preview.svg
+++ b/frontend/assets/og-preview.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="0" y="0" width="1200" height="4" fill="#7aa2f7"/>
+  <text x="600" y="260" font-family="system-ui, -apple-system, sans-serif" font-size="64" font-weight="700" fill="#c0caf5" text-anchor="middle">Claude Code Portal</text>
+  <text x="600" y="340" font-family="system-ui, -apple-system, sans-serif" font-size="28" fill="#a9b1d6" text-anchor="middle">Rich, interactive Claude Code sessions.</text>
+  <text x="600" y="385" font-family="system-ui, -apple-system, sans-serif" font-size="28" fill="#a9b1d6" text-anchor="middle">Visually pleasant and easy to multitask between many sessions.</text>
+  <text x="600" y="470" font-family="monospace" font-size="22" fill="#7aa2f7" text-anchor="middle">txcl.io</text>
+  <rect x="0" y="626" width="1200" height="4" fill="#7aa2f7"/>
+</svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,15 +8,18 @@
     <!-- Open Graph / Link Preview -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Claude Code Portal" />
-    <meta property="og:description" content="A web-based portal for managing Claude Code sessions with real-time collaboration and multi-session support." />
+    <meta property="og:description" content="Rich, interactive Claude Code sessions. Visually pleasant and easy to multitask between many sessions." />
+    <meta property="og:image" content="https://txcl.io/og-preview.svg" />
+    <meta property="og:url" content="https://txcl.io" />
 
     <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Claude Code Portal" />
-    <meta name="twitter:description" content="A web-based portal for managing Claude Code sessions with real-time collaboration and multi-session support." />
+    <meta name="twitter:description" content="Rich, interactive Claude Code sessions. Visually pleasant and easy to multitask between many sessions." />
+    <meta name="twitter:image" content="https://txcl.io/og-preview.svg" />
 
     <!-- General meta -->
-    <meta name="description" content="A web-based portal for managing Claude Code sessions with real-time collaboration and multi-session support." />
+    <meta name="description" content="Rich, interactive Claude Code sessions. Visually pleasant and easy to multitask between many sessions." />
 
     <link data-trunk rel="rust" data-wasm-opt="z" />
     <!-- CSS files split for maintainability -->
@@ -41,6 +44,7 @@
     <link data-trunk rel="css" href="styles/banned.css" />
     <link data-trunk rel="copy-file" href="pcm-processor.js" />
     <link data-trunk rel="copy-file" href="assets/wiggum.png" />
+    <link data-trunk rel="copy-file" href="assets/og-preview.svg" />
 </head>
 <body></body>
 </html>


### PR DESCRIPTION
## Summary
- Add SVG preview image (1200x630) matching app's dark theme
- Update OG and Twitter Card meta tags with new description
- Add `og:image`, `og:url`, and `twitter:image` tags
- Use `summary_large_image` for bigger Twitter previews

## Test plan
- [ ] Build succeeds, `og-preview.svg` present in `dist/`
- [ ] Test with https://www.opengraph.xyz/ after deploy
- [ ] Share link in Discord/Slack to verify preview card renders