### PR TITLE
Update claude-codes to 2.1.20, display rate limit events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,9 +639,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.19"
+version = "2.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911736d5dc04f7b543790174f7c773e530bc8ff690f70111d28f582c3c81a760"
+checksum = "bfb80490e37786349826a4c3a3bd4eeddd0d11f60667e151b98beb1f07c09cbf"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1108,7 +1108,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1182,7 +1182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2198,7 +2198,7 @@ dependencies = [
  "hyper 1.8.1",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2650,7 +2650,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3509,7 +3509,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4065,7 +4065,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4974,7 +4974,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = "2.1.19"
+claude-codes = "2.1.20"
 
 # Frontend (Yew)
 yew = { version = "0.21", features = ["csr"] }

--- a/claude-session-lib/src/proxy_session.rs
+++ b/claude-session-lib/src/proxy_session.rs
@@ -1143,6 +1143,13 @@ fn log_claude_output(output: &ClaudeOutput) {
                 error!("← [error] API error: {}", err.error.message);
             }
         }
+        ClaudeOutput::RateLimitEvent(evt) => {
+            let info = &evt.rate_limit_info;
+            debug!(
+                "← [rate_limit_event] status={} type={} resets_at={} overage={}",
+                info.status, info.rate_limit_type, info.resets_at, info.is_using_overage
+            );
+        }
     }
 }
 

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -601,6 +601,17 @@
     color: var(--text-muted);
 }
 
+/* Rate Limit Event Message */
+.rate-limit-message {
+    border-left: 3px solid #e0af68;
+    background: rgba(224, 175, 104, 0.05);
+}
+
+.message-type-badge.rate-limit {
+    background: rgba(224, 175, 104, 0.2);
+    color: #e0af68;
+}
+
 /* Compaction/Summary Message */
 .compaction-message {
     border-left: 3px solid #7aa2f7;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,4 +16,4 @@ uuid = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["serde", "wasmbind"] }
 
 # Claude Code types (WASM-compatible, no tokio)
-claude-codes = { version = "2.1.17", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.20", default-features = false, features = ["types"] }


### PR DESCRIPTION
## Summary
- Update `claude-codes` crate from 2.1.19 to 2.1.20 (workspace + shared)
- Handle new `RateLimitEvent` variant in proxy logging
- Add frontend rendering for rate limit events with timer icon, status, type, and reset countdown
- Add CSS styles for rate limit message display

## Test plan
- [ ] Backend clippy passes
- [ ] Frontend builds successfully
- [ ] Rate limit events render with styled UI instead of raw JSON
- [ ] Reset countdown shows correct time remaining