### PR TITLE
Add comma formatting to dollar amounts

### DIFF
--- a/frontend/src/pages/admin.rs
+++ b/frontend/src/pages/admin.rs
@@ -218,7 +218,7 @@ fn user_row(props: &UserRowProps) -> Html {
             <td>{ user.name.as_deref().unwrap_or("-") }</td>
             <td class={status_class}>{ status_text }</td>
             <td class="numeric">{ user.session_count }</td>
-            <td class="numeric">{ format!("${:.2}", user.total_spend_usd) }</td>
+            <td class="numeric">{ utils::format_dollars(user.total_spend_usd) }</td>
             <td class="timestamp">{ format_timestamp(&user.created_at) }</td>
             <td class="actions">
                 <button
@@ -293,7 +293,7 @@ fn session_row(props: &SessionRowProps) -> Html {
             <td class="session-project">{ project_name }</td>
             <td class="session-branch">{ session.git_branch.as_deref().unwrap_or("-") }</td>
             <td class={status_class}>{ status_text }</td>
-            <td class="numeric">{ format!("${:.2}", session.total_cost_usd) }</td>
+            <td class="numeric">{ utils::format_dollars(session.total_cost_usd) }</td>
             <td class="timestamp">{ format_timestamp(&session.last_activity) }</td>
             <td class="actions">
                 <button class="delete-btn" onclick={on_delete} title="Delete session">
@@ -1033,7 +1033,7 @@ pub fn admin_page() -> Html {
                                                             />
                                                             <StatCard
                                                                 label="Total API Spend"
-                                                                value={format!("${:.2}", s.total_spend_usd)}
+                                                                value={utils::format_dollars(s.total_spend_usd)}
                                                                 class="spend-card"
                                                             />
                                                             <StatCard

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -500,7 +500,7 @@ pub fn dashboard_page() -> Html {
                             );
                             html! {
                                 <span class={spend_class} title="Total spend across all sessions">
-                                    { format!("${:.2}", total_user_spend) }
+                                    { utils::format_dollars(total_user_spend) }
                                 </span>
                             }
                         } else {

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -37,6 +37,20 @@ pub fn ws_url(path: &str) -> String {
     format!("{}{}", get_ws_url(), path)
 }
 
+/// Format a dollar amount with commas (e.g., 1234.56 -> "$1,234.56")
+pub fn format_dollars(amount: f64) -> String {
+    let formatted = format!("{:.2}", amount);
+    let (integer, decimal) = formatted.split_once('.').unwrap();
+    let with_commas: String = integer
+        .as_bytes()
+        .rchunks(3)
+        .rev()
+        .map(|chunk| std::str::from_utf8(chunk).unwrap())
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("${}.{}", with_commas, decimal)
+}
+
 /// Extract folder name from path (last path component)
 pub fn extract_folder(path: &str) -> &str {
     let trimmed = path.trim_end_matches('/');


### PR DESCRIPTION
## Summary
- Dollar amounts now display with comma grouping (e.g., `$1,234.56` instead of `$1234.56`)
- Added `format_dollars()` utility function
- Applied to header spend badge, admin user table, admin session table, and admin stats card