### PR TITLE
Skip spend animation on initial page load

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -39,6 +39,7 @@ pub fn dashboard_page() -> Html {
     // Track spend tier for timed animations
     let prev_spend_tier = use_state(|| 0u8);
     let spend_animating = use_state(|| false);
+    let spend_initialized = use_state(|| false);
 
     // UI state
     let show_new_session = use_state(|| false);
@@ -59,6 +60,7 @@ pub fn dashboard_page() -> Html {
     {
         let spend_animating = spend_animating.clone();
         let prev_spend_tier = prev_spend_tier.clone();
+        let spend_initialized = spend_initialized.clone();
         let current_tier = if total_user_spend >= 10000.0 {
             5u8
         } else if total_user_spend >= 1000.0 {
@@ -74,7 +76,11 @@ pub fn dashboard_page() -> Html {
         };
         use_effect_with(current_tier, move |tier| {
             let tier = *tier;
-            if tier > *prev_spend_tier {
+            if !*spend_initialized {
+                // First tier value from page load — record it, don't animate
+                spend_initialized.set(true);
+                prev_spend_tier.set(tier);
+            } else if tier > *prev_spend_tier {
                 spend_animating.set(true);
                 let duration_ms = match tier {
                     1 => 500,


### PR DESCRIPTION
## Summary
- Spend badge no longer fires tier animations when the page first loads
- Only animates when spend increases to a new tier during an active session
- Tracks initialization state so the first tier value is silently recorded

## Test plan
- [ ] Reload page with existing spend — badge appears at correct tier color without animation
- [ ] During active session, cross a tier threshold — animation fires as expected