### PR TITLE
Add Open PR option to session pill dropdown

### DIFF
--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -220,6 +220,25 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             html! {}
         };
 
+        let pr_option = if let Some(ref url) = session.pr_url {
+            let pr_number = url.rsplit('/').next().unwrap_or("").to_string();
+            let label = if pr_number.is_empty() {
+                "Open PR".to_string()
+            } else {
+                format!("Open PR #{}", pr_number)
+            };
+            let href = url.clone();
+            html! {
+                <a class="pill-menu-option pr-link" href={href} target="_blank"
+                   onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                    { label }
+                    <span class="option-hint">{ "GitHub" }</span>
+                </a>
+            }
+        } else {
+            html! {}
+        };
+
         let share_option = if session.my_role == "owner" {
             let share_session_id = share_session_id.clone();
             let session_id = session.id;
@@ -249,6 +268,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     <span class="option-hint">{ short_id }</span>
                 </button>
                 { share_option }
+                { pr_option }
                 <button
                     type="button"
                     class={classes!("pill-menu-option", "pause", is_paused.then_some("active"))}

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -334,6 +334,15 @@
     color: var(--success);
 }
 
+a.pill-menu-option.pr-link {
+    text-decoration: none;
+    color: #7aa2f7;
+}
+
+a.pill-menu-option.pr-link:hover {
+    background: rgba(122, 162, 247, 0.15);
+}
+
 .pill-menu-option .option-hint {
     font-size: 0.7rem;
     font-weight: 400;


### PR DESCRIPTION
## Summary
- When a session has a PR URL, the pill dropdown menu shows an "Open PR #NNN" option
- Extracts PR number from the GitHub URL for the label
- Opens in a new tab, styled consistently with other dropdown options

## Test plan
- [ ] Session on a branch with a PR shows "Open PR #NNN" in the dropdown
- [ ] Clicking opens the GitHub PR in a new tab
- [ ] Sessions without a PR don't show the option