### PR TITLE
Add active heartbeat for dead connection detection

### DIFF
--- a/claude-session-lib/src/heartbeat.rs
+++ b/claude-session-lib/src/heartbeat.rs
@@ -1,0 +1,44 @@
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+pub const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Tracks heartbeat round-trip timing for dead connection detection.
+///
+/// The proxy sends a Heartbeat every `HEARTBEAT_INTERVAL`. The backend echoes
+/// it back. If no echo is received within `HEARTBEAT_TIMEOUT`, the connection
+/// is considered dead and the proxy forces a reconnect.
+#[derive(Clone)]
+pub struct HeartbeatTracker {
+    last_received: Arc<Mutex<Instant>>,
+}
+
+impl Default for HeartbeatTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HeartbeatTracker {
+    pub fn new() -> Self {
+        Self {
+            last_received: Arc::new(Mutex::new(Instant::now())),
+        }
+    }
+
+    /// Called when a heartbeat echo is received from the backend.
+    pub fn received(&self) {
+        *self.last_received.lock().unwrap() = Instant::now();
+    }
+
+    /// Returns true if no heartbeat echo has been received within the timeout.
+    pub fn is_expired(&self) -> bool {
+        self.last_received.lock().unwrap().elapsed() > HEARTBEAT_TIMEOUT
+    }
+
+    /// Seconds since last heartbeat echo, for logging.
+    pub fn elapsed_secs(&self) -> u64 {
+        self.last_received.lock().unwrap().elapsed().as_secs()
+    }
+}

--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -59,6 +59,7 @@
 
 pub mod buffer;
 pub mod error;
+pub mod heartbeat;
 pub mod output_buffer;
 pub mod proxy_session;
 pub mod session;


### PR DESCRIPTION
## Summary
- Proxy now sends `Heartbeat` every 30s and expects an echo back from the backend
- If no echo within 45s, the connection is considered dead and the proxy forces a reconnect
- Fixes sessions going invisible after internet loss (half-open TCP connections would persist for minutes with no detection)
- New `HeartbeatTracker` module in claude-session-lib for clean separation

## Test plan
- [ ] Proxy connects, heartbeat debug logs appear every ~30s
- [ ] Kill backend → proxy detects within 45s and reconnects
- [ ] Simulate internet loss → proxy detects dead connection and reconnects
- [ ] Normal operation unaffected (heartbeat echo keeps tracker alive)