### PR TITLE
Migrate WebSocket plumbing to ws-bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "ws-bridge",
 ]
 
 [[package]]
@@ -696,18 +697,17 @@ dependencies = [
  "clap",
  "claude-session-lib",
  "dirs",
- "futures-util",
  "hostname",
  "portal-auth",
  "serde",
  "serde_json",
  "shared",
  "tokio",
- "tokio-tungstenite",
  "toml 1.0.1+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "ws-bridge",
 ]
 
 [[package]]
@@ -719,17 +719,16 @@ dependencies = [
  "chrono",
  "claude-codes",
  "directories",
- "futures-util",
  "hostname",
  "serde",
  "serde_json",
  "shared",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
  "tracing",
  "uuid",
  "which 8.0.0",
+ "ws-bridge",
 ]
 
 [[package]]
@@ -1274,6 +1273,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-logger",
  "web-sys",
+ "ws-bridge",
  "yew",
  "yew-router",
 ]
@@ -3845,6 +3845,7 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+ "ws-bridge",
 ]
 
 [[package]]
@@ -5325,6 +5326,23 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "ws-bridge"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c734714c0599a9c58636018ec7fa85d0dd57d702d72cd331bd5eb31fcbd85d27"
+dependencies = [
+ "axum 0.7.9",
+ "futures-util",
+ "gloo-net 0.6.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "yew"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,6 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 
 # UUID
 uuid = { version = "1.11", features = ["v4", "serde", "js"] }
+
+# WebSocket bridge
+ws-bridge = "0.1.0"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -79,3 +79,4 @@ google-cognitive-apis = { version = "0.2.2", features = ["speech-to-text"] }
 md5 = "0.8.0"
 rust-embed = { version = "8.11.0", features = ["axum", "mime-guess"] }
 mime_guess = "2.0.5"
+ws-bridge = { workspace = true, features = ["server"] }

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use serde::Deserialize;
 use shared::api::LaunchRequest;
-use shared::{DirectoryEntry, LauncherInfo, ProxyMessage};
+use shared::{DirectoryEntry, LauncherInfo, LauncherToServer, ServerToLauncher};
 use std::sync::Arc;
 use tower_cookies::Cookies;
 use tracing::{error, info, warn};
@@ -52,7 +52,7 @@ pub async fn launch_session(
     let auth_token = mint_launch_token(&app_state, user_id)?;
 
     let request_id = Uuid::new_v4();
-    let launch_msg = ProxyMessage::LaunchSession {
+    let launch_msg = ServerToLauncher::LaunchSession {
         request_id,
         user_id,
         auth_token,
@@ -113,7 +113,7 @@ pub async fn list_directories(
 
     let sent = app_state.session_manager.send_to_launcher(
         &launcher_id,
-        ProxyMessage::ListDirectories {
+        ServerToLauncher::ListDirectories {
             request_id,
             path: query.path.clone(),
         },
@@ -129,7 +129,7 @@ pub async fn list_directories(
     }
 
     match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
-        Ok(Ok(ProxyMessage::ListDirectoriesResult {
+        Ok(Ok(LauncherToServer::ListDirectoriesResult {
             entries,
             error,
             resolved_path,

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -9,8 +9,6 @@ license = "MIT"
 shared = { path = "../shared" }
 claude-codes = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
-futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
@@ -22,3 +20,4 @@ base64 = "0.22"
 directories = "5.0"
 hostname = "0.4.2"
 which = "8.0.0"
+ws-bridge = { workspace = true, features = ["native-client"] }

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -70,3 +70,4 @@ futures-channel = "0.3"
 uuid = { workspace = true, features = ["v4", "serde", "js"] }
 js-sys = "0.3.83"
 pulldown-cmark = { version = "0.13.0", default-features = false }
+ws-bridge = { workspace = true, features = ["yew-client"] }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -5,7 +5,7 @@ use crate::utils;
 use gloo::timers::callback::Timeout;
 use gloo_net::http::Request;
 use shared::api::{ErrorMessage, PermissionAnswers};
-use shared::{ProxyMessage, SendMode, SessionInfo};
+use shared::{ClientToServer, SendMode, SessionInfo};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -547,7 +547,7 @@ impl SessionView {
         ctx.props().on_message_sent.emit(session_id);
 
         if let Some(ref sender) = self.ws_sender {
-            let msg = ProxyMessage::ClaudeInput {
+            let msg = ClientToServer::ClaudeInput {
                 content: serde_json::Value::String(input),
                 send_mode: if send_mode == SendMode::Normal {
                     None
@@ -654,7 +654,7 @@ impl SessionView {
     fn handle_approve_permission(&mut self, ctx: &Context<Self>, remember: bool) -> bool {
         if let Some(perm) = self.pending_permission.take() {
             if let Some(ref sender) = self.ws_sender {
-                let msg = ProxyMessage::PermissionResponse {
+                let msg = ClientToServer::PermissionResponse {
                     request_id: perm.request_id,
                     allow: true,
                     input: Some(perm.input),
@@ -678,7 +678,7 @@ impl SessionView {
     fn handle_deny_permission(&mut self, ctx: &Context<Self>) -> bool {
         if let Some(perm) = self.pending_permission.take() {
             if let Some(ref sender) = self.ws_sender {
-                let msg = ProxyMessage::PermissionResponse {
+                let msg = ClientToServer::PermissionResponse {
                     request_id: perm.request_id,
                     allow: false,
                     input: None,
@@ -753,7 +753,7 @@ impl SessionView {
                     serde_json::to_value(PermissionAnswers::empty()).unwrap_or_default()
                 };
 
-                let msg = ProxyMessage::PermissionResponse {
+                let msg = ClientToServer::PermissionResponse {
                     request_id: perm.request_id,
                     allow: true,
                     input: Some(answers_json),

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -20,16 +20,7 @@ pub const INACTIVE_HIDDEN_STORAGE_KEY: &str = "claude-portal-inactive-hidden";
 pub const MAX_MESSAGES_PER_SESSION: usize = 100;
 
 /// Type alias for WebSocket sender to reduce type complexity
-pub type WsSender = Rc<
-    RefCell<
-        Option<
-            futures_util::stream::SplitSink<
-                gloo_net::websocket::futures::WebSocket,
-                gloo_net::websocket::Message,
-            >,
-        >,
-    >,
->;
+pub type WsSender = Rc<RefCell<Option<ws_bridge::yew_client::Sender<shared::ClientEndpoint>>>>;
 
 /// Message data from the API
 #[derive(Clone, PartialEq, Deserialize)]

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -15,10 +15,6 @@ shared = { path = "../shared" }
 # Async runtime
 tokio = { workspace = true, features = ["full"] }
 
-# WebSocket client
-tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
-futures-util = "0.3"
-
 # Serialization
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -45,3 +41,4 @@ toml = "1.0.1"
 dirs = "6.0.0"
 portal-auth = { version = "0.1.0", path = "../portal-auth" }
 claude-session-lib = { version = "0.1.0", path = "../claude-session-lib" }
+ws-bridge = { workspace = true, features = ["native-client"] }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -17,3 +17,6 @@ chrono = { workspace = true, default-features = false, features = ["serde", "was
 
 # Claude Code types (WASM-compatible, no tokio)
 claude-codes = { version = "2.1.20", default-features = false, features = ["types"] }
+
+# Typed WebSocket endpoints (core traits only — WASM-safe, no features needed)
+ws-bridge = { workspace = true }

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -1,0 +1,532 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+pub use ws_bridge::WsEndpoint;
+
+use crate::{DirectoryEntry, PermissionSuggestion, SendMode, SessionCost, SessionStatus};
+
+// =============================================================================
+// Session endpoint: proxy <-> backend (/ws/session)
+// =============================================================================
+
+pub struct SessionEndpoint;
+
+impl WsEndpoint for SessionEndpoint {
+    const PATH: &'static str = "/ws/session";
+    type ServerMsg = ServerToProxy;
+    type ClientMsg = ProxyToServer;
+}
+
+/// Messages the proxy sends to the backend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ProxyToServer {
+    /// Register a new session or connect to an existing one
+    Register {
+        session_id: Uuid,
+        session_name: String,
+        auth_token: Option<String>,
+        working_directory: String,
+        #[serde(default)]
+        resuming: bool,
+        #[serde(default)]
+        git_branch: Option<String>,
+        #[serde(default)]
+        replay_after: Option<String>,
+        #[serde(default)]
+        client_version: Option<String>,
+        #[serde(default)]
+        replaces_session_id: Option<Uuid>,
+        #[serde(default)]
+        hostname: Option<String>,
+        #[serde(default)]
+        launcher_id: Option<Uuid>,
+    },
+
+    /// Raw output from Claude Code (unsequenced fallback)
+    ClaudeOutput { content: serde_json::Value },
+
+    /// Sequenced output from Claude Code
+    SequencedOutput {
+        seq: u64,
+        content: serde_json::Value,
+    },
+
+    /// Keepalive heartbeat
+    Heartbeat,
+
+    /// Permission request from Claude (tool wants to execute)
+    PermissionRequest {
+        request_id: String,
+        tool_name: String,
+        input: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        permission_suggestions: Vec<PermissionSuggestion>,
+    },
+
+    /// Update session metadata (e.g., git branch changed)
+    SessionUpdate {
+        session_id: Uuid,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        git_branch: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pr_url: Option<String>,
+    },
+
+    /// Acknowledge receipt of input messages
+    InputAck { session_id: Uuid, ack_seq: i64 },
+
+    /// Session status update
+    SessionStatus { status: SessionStatus },
+}
+
+/// Messages the backend sends to the proxy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ServerToProxy {
+    /// Acknowledge session registration
+    RegisterAck {
+        success: bool,
+        session_id: Uuid,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+
+    /// Keepalive heartbeat
+    Heartbeat,
+
+    /// User input (unsequenced fallback)
+    ClaudeInput {
+        content: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        send_mode: Option<SendMode>,
+    },
+
+    /// Sequenced user input
+    SequencedInput {
+        session_id: Uuid,
+        seq: i64,
+        content: serde_json::Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        send_mode: Option<SendMode>,
+    },
+
+    /// User's permission decision
+    PermissionResponse {
+        request_id: String,
+        allow: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        input: Option<serde_json::Value>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        permissions: Vec<PermissionSuggestion>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+
+    /// Acknowledge receipt of output messages
+    OutputAck { session_id: Uuid, ack_seq: u64 },
+
+    /// Server is shutting down
+    ServerShutdown {
+        reason: String,
+        reconnect_delay_ms: u64,
+    },
+}
+
+// =============================================================================
+// Client endpoint: frontend <-> backend (/ws/client)
+// =============================================================================
+
+pub struct ClientEndpoint;
+
+impl WsEndpoint for ClientEndpoint {
+    const PATH: &'static str = "/ws/client";
+    type ServerMsg = ServerToClient;
+    type ClientMsg = ClientToServer;
+}
+
+/// Messages the frontend sends to the backend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ClientToServer {
+    /// Register to receive updates for a session
+    Register {
+        session_id: Uuid,
+        session_name: String,
+        auth_token: Option<String>,
+        working_directory: String,
+        #[serde(default)]
+        resuming: bool,
+        #[serde(default)]
+        git_branch: Option<String>,
+        #[serde(default)]
+        replay_after: Option<String>,
+        #[serde(default)]
+        client_version: Option<String>,
+        #[serde(default)]
+        replaces_session_id: Option<Uuid>,
+        #[serde(default)]
+        hostname: Option<String>,
+        #[serde(default)]
+        launcher_id: Option<Uuid>,
+    },
+
+    /// User sends input to Claude
+    ClaudeInput {
+        content: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        send_mode: Option<SendMode>,
+    },
+
+    /// User's permission decision
+    PermissionResponse {
+        request_id: String,
+        allow: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        input: Option<serde_json::Value>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        permissions: Vec<PermissionSuggestion>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+}
+
+/// Messages the backend sends to the frontend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ServerToClient {
+    /// Output from Claude Code
+    ClaudeOutput { content: serde_json::Value },
+
+    /// Batch of historical messages for replay
+    HistoryBatch { messages: Vec<serde_json::Value> },
+
+    /// Permission request from Claude (tool wants to execute)
+    PermissionRequest {
+        request_id: String,
+        tool_name: String,
+        input: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        permission_suggestions: Vec<PermissionSuggestion>,
+    },
+
+    /// Error message
+    Error { message: String },
+
+    /// Session metadata changed
+    SessionUpdate {
+        session_id: Uuid,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        git_branch: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pr_url: Option<String>,
+    },
+
+    /// User spend data update
+    UserSpendUpdate {
+        total_spend_usd: f64,
+        session_costs: Vec<SessionCost>,
+    },
+
+    /// Server is shutting down
+    ServerShutdown {
+        reason: String,
+        reconnect_delay_ms: u64,
+    },
+
+    /// Session status changed
+    SessionStatus { status: SessionStatus },
+
+    /// Launch session result (forwarded from launcher)
+    LaunchSessionResult {
+        request_id: Uuid,
+        success: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        session_id: Option<Uuid>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pid: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+
+    /// A proxy process exited (forwarded from launcher)
+    SessionExited {
+        session_id: Uuid,
+        exit_code: Option<i32>,
+    },
+}
+
+// =============================================================================
+// Launcher endpoint: launcher <-> backend (/ws/launcher)
+// =============================================================================
+
+pub struct LauncherEndpoint;
+
+impl WsEndpoint for LauncherEndpoint {
+    const PATH: &'static str = "/ws/launcher";
+    type ServerMsg = ServerToLauncher;
+    type ClientMsg = LauncherToServer;
+}
+
+/// Messages the launcher sends to the backend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum LauncherToServer {
+    /// Register a launcher daemon
+    LauncherRegister {
+        launcher_id: Uuid,
+        launcher_name: String,
+        auth_token: Option<String>,
+        hostname: String,
+        #[serde(default)]
+        version: Option<String>,
+    },
+
+    /// Result of a launch request
+    LaunchSessionResult {
+        request_id: Uuid,
+        success: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        session_id: Option<Uuid>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pid: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+
+    /// Launcher heartbeat with running process summary
+    LauncherHeartbeat {
+        launcher_id: Uuid,
+        running_sessions: Vec<Uuid>,
+        uptime_secs: u64,
+    },
+
+    /// Log output from a proxy process
+    ProxyLog {
+        session_id: Uuid,
+        level: String,
+        message: String,
+        timestamp: String,
+    },
+
+    /// A proxy process exited
+    SessionExited {
+        session_id: Uuid,
+        exit_code: Option<i32>,
+    },
+
+    /// Directory listing response
+    ListDirectoriesResult {
+        request_id: Uuid,
+        #[serde(default)]
+        entries: Vec<DirectoryEntry>,
+        error: Option<String>,
+        #[serde(default)]
+        resolved_path: Option<String>,
+    },
+}
+
+/// Messages the backend sends to the launcher.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ServerToLauncher {
+    /// Acknowledge launcher registration
+    LauncherRegisterAck {
+        success: bool,
+        launcher_id: Uuid,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+
+    /// Request to launch a new proxy instance
+    LaunchSession {
+        request_id: Uuid,
+        user_id: Uuid,
+        auth_token: String,
+        working_directory: String,
+        #[serde(default)]
+        session_name: Option<String>,
+        #[serde(default)]
+        claude_args: Vec<String>,
+    },
+
+    /// Request to stop a running session
+    StopSession { session_id: Uuid },
+
+    /// Request directory listing
+    ListDirectories { request_id: Uuid, path: String },
+
+    /// Server is shutting down
+    ServerShutdown {
+        reason: String,
+        reconnect_delay_ms: u64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_endpoint_path() {
+        assert_eq!(SessionEndpoint::PATH, "/ws/session");
+    }
+
+    #[test]
+    fn client_endpoint_path() {
+        assert_eq!(ClientEndpoint::PATH, "/ws/client");
+    }
+
+    #[test]
+    fn launcher_endpoint_path() {
+        assert_eq!(LauncherEndpoint::PATH, "/ws/launcher");
+    }
+
+    #[test]
+    fn proxy_to_server_register_roundtrip() {
+        let msg = ProxyToServer::Register {
+            session_id: Uuid::nil(),
+            session_name: "test".into(),
+            auth_token: None,
+            working_directory: "/tmp".into(),
+            resuming: false,
+            git_branch: None,
+            replay_after: None,
+            client_version: None,
+            replaces_session_id: None,
+            hostname: None,
+            launcher_id: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"Register""#));
+        let parsed: ProxyToServer = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ProxyToServer::Register { session_name, .. } => {
+                assert_eq!(session_name, "test");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn server_to_proxy_sequenced_input_roundtrip() {
+        let msg = ServerToProxy::SequencedInput {
+            session_id: Uuid::nil(),
+            seq: 5,
+            content: serde_json::json!({"text": "hello"}),
+            send_mode: Some(SendMode::Wiggum),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"SequencedInput""#));
+        let parsed: ServerToProxy = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ServerToProxy::SequencedInput { seq, send_mode, .. } => {
+                assert_eq!(seq, 5);
+                assert_eq!(send_mode, Some(SendMode::Wiggum));
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn client_to_server_claude_input_roundtrip() {
+        let msg = ClientToServer::ClaudeInput {
+            content: serde_json::json!({"text": "hi"}),
+            send_mode: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"ClaudeInput""#));
+        let parsed: ClientToServer = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ClientToServer::ClaudeInput { send_mode, .. } => {
+                assert!(send_mode.is_none());
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn server_to_client_output_roundtrip() {
+        let msg = ServerToClient::ClaudeOutput {
+            content: serde_json::json!({"type": "assistant", "text": "hello"}),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: ServerToClient = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ServerToClient::ClaudeOutput { content } => {
+                assert_eq!(content["text"], "hello");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn launcher_to_server_register_roundtrip() {
+        let msg = LauncherToServer::LauncherRegister {
+            launcher_id: Uuid::nil(),
+            launcher_name: "test-launcher".into(),
+            auth_token: Some("tok".into()),
+            hostname: "host1".into(),
+            version: Some("1.0".into()),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"LauncherRegister""#));
+        let parsed: LauncherToServer = serde_json::from_str(&json).unwrap();
+        match parsed {
+            LauncherToServer::LauncherRegister { launcher_name, .. } => {
+                assert_eq!(launcher_name, "test-launcher");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn server_to_launcher_launch_roundtrip() {
+        let msg = ServerToLauncher::LaunchSession {
+            request_id: Uuid::nil(),
+            user_id: Uuid::nil(),
+            auth_token: "token".into(),
+            working_directory: "/home".into(),
+            session_name: Some("my-session".into()),
+            claude_args: vec!["--verbose".into()],
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"LaunchSession""#));
+        let parsed: ServerToLauncher = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ServerToLauncher::LaunchSession {
+                working_directory,
+                claude_args,
+                ..
+            } => {
+                assert_eq!(working_directory, "/home");
+                assert_eq!(claude_args, vec!["--verbose"]);
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    /// Verify wire-format compatibility of per-endpoint types.
+    #[test]
+    fn wire_compat_register() {
+        // Register JSON format
+        let json = r#"{
+            "type": "Register",
+            "session_id": "550e8400-e29b-41d4-a716-446655440000",
+            "session_name": "test",
+            "auth_token": null,
+            "working_directory": "/tmp"
+        }"#;
+        // Must parse as both ProxyToServer and ClientToServer
+        let _: ProxyToServer = serde_json::from_str(json).unwrap();
+        let _: ClientToServer = serde_json::from_str(json).unwrap();
+    }
+
+    #[test]
+    fn wire_compat_server_shutdown() {
+        let json = r#"{"type":"ServerShutdown","reason":"update","reconnect_delay_ms":5000}"#;
+        // Must parse in all three server->X enums
+        let _: ServerToProxy = serde_json::from_str(json).unwrap();
+        let _: ServerToClient = serde_json::from_str(json).unwrap();
+        let _: ServerToLauncher = serde_json::from_str(json).unwrap();
+    }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,6 +5,10 @@ use uuid::Uuid;
 pub mod proxy_tokens;
 pub use proxy_tokens::*;
 
+// Typed WebSocket endpoint definitions
+pub mod endpoints;
+pub use endpoints::*;
+
 // Protocol constants shared between backend and proxy
 pub mod protocol;
 
@@ -28,309 +32,35 @@ pub use claude_codes::io::{
     ToolResultBlock, ToolResultContent, ToolUseBlock,
 };
 
-/// Message types for the WebSocket proxy protocol
-/// These are used to communicate between:
-/// - proxy <-> backend (session connection)
-/// - frontend <-> backend (web client connection)
+/// Voice WebSocket message types (frontend <-> backend via /ws/voice/:id).
+/// These are NOT part of the typed ws-bridge endpoints because voice mixes
+/// binary audio frames with JSON text messages.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
-pub enum ProxyMessage {
-    /// Register a new session or connect to an existing one
-    Register {
-        /// The Claude Code session ID (UUID) - used as primary key
-        session_id: Uuid,
-        /// Human-readable session name for display
-        session_name: String,
-        /// JWT auth token for user authentication
-        auth_token: Option<String>,
-        /// Working directory where the session was started
-        working_directory: String,
-        /// Whether this is resuming an existing session
-        #[serde(default)]
-        resuming: bool,
-        /// Current git branch (if in a git repo)
-        #[serde(default)]
-        git_branch: Option<String>,
-        /// Only replay messages created after this timestamp (ISO 8601 format)
-        /// If None, replay all history. Used by web clients to avoid duplicate messages.
-        #[serde(default)]
-        replay_after: Option<String>,
-        /// Client version (e.g., "1.0.0") - helps track client versions in use
-        #[serde(default)]
-        client_version: Option<String>,
-        /// If this session replaces a previous one (e.g. after SessionNotFound),
-        /// the old session ID so the backend can mark it as replaced.
-        #[serde(default)]
-        replaces_session_id: Option<Uuid>,
-        /// Hostname of the machine running the session
-        #[serde(default)]
-        hostname: Option<String>,
-        /// Launcher ID if this session was started by a launcher
-        #[serde(default)]
-        launcher_id: Option<Uuid>,
-    },
-
-    /// Output from Claude Code to be displayed
-    ClaudeOutput { content: serde_json::Value },
-
-    /// Input to Claude Code from user
-    ClaudeInput {
-        content: serde_json::Value,
-        /// Optional send mode (normal, wiggum)
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        send_mode: Option<SendMode>,
-    },
-
-    /// Heartbeat to keep connection alive
-    Heartbeat,
-
-    /// Error message
-    Error { message: String },
-
-    /// Session status update
-    SessionStatus { status: SessionStatus },
-
-    /// Permission request from Claude (tool wants to execute)
-    PermissionRequest {
-        /// Unique ID for this permission request (to correlate responses)
-        request_id: String,
-        /// Name of the tool requesting permission
-        tool_name: String,
-        /// Tool input parameters
-        input: serde_json::Value,
-        /// Suggested permissions to grant (for "allow & remember" feature)
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        permission_suggestions: Vec<PermissionSuggestion>,
-    },
-
-    /// Permission response from user
-    PermissionResponse {
-        /// The request_id this responds to
-        request_id: String,
-        /// Whether to allow the tool
-        allow: bool,
-        /// The original tool input (required when allow=true)
-        #[serde(skip_serializing_if = "Option::is_none")]
-        input: Option<serde_json::Value>,
-        /// Permissions to grant for future similar operations
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        permissions: Vec<PermissionSuggestion>,
-        /// Optional reason for denial
-        #[serde(skip_serializing_if = "Option::is_none")]
-        reason: Option<String>,
-    },
-
-    /// Backend acknowledgment of session registration
-    RegisterAck {
-        /// Whether registration succeeded
-        success: bool,
-        /// The session ID that was registered
-        session_id: Uuid,
-        /// Error message if registration failed
-        #[serde(skip_serializing_if = "Option::is_none")]
-        error: Option<String>,
-    },
-
-    /// Update session metadata (e.g., git branch changed)
-    SessionUpdate {
-        /// The session ID to update
-        session_id: Uuid,
-        /// Updated git branch (if changed)
-        #[serde(skip_serializing_if = "Option::is_none")]
-        git_branch: Option<String>,
-        /// GitHub PR URL for the current branch (if any)
-        #[serde(skip_serializing_if = "Option::is_none", default)]
-        pr_url: Option<String>,
-    },
-
-    /// User spend update (sent to web clients periodically)
-    UserSpendUpdate {
-        /// Total spend across all sessions for this user
-        total_spend_usd: f64,
-        /// Per-session spend breakdown
-        session_costs: Vec<SessionCost>,
-    },
-
-    /// Batch of historical messages sent during replay (backend -> web client).
-    /// Sent as a single message to avoid per-message rendering overhead.
-    HistoryBatch { messages: Vec<serde_json::Value> },
-
-    /// Sequenced output from Claude Code (proxy -> backend)
-    /// Messages are held in proxy buffer until acknowledged
-    SequencedOutput {
-        /// Monotonic sequence number for this output
-        seq: u64,
-        /// The actual output content
-        content: serde_json::Value,
-    },
-
-    /// Acknowledge receipt of output messages (backend -> proxy)
-    /// All messages with seq <= ack_seq are confirmed stored
-    OutputAck {
-        /// The session this acknowledgment is for
-        session_id: Uuid,
-        /// All messages with sequence <= this are confirmed received
-        ack_seq: u64,
-    },
-
-    /// Sequenced input from frontend (frontend -> backend -> proxy)
-    /// Backend stores these until proxy acknowledges receipt
-    SequencedInput {
-        /// The session this input is for
-        session_id: Uuid,
-        /// Monotonic sequence number for this input
-        seq: i64,
-        /// The actual input content
-        content: serde_json::Value,
-        /// Send mode (normal or wiggum loop)
-        #[serde(skip_serializing_if = "Option::is_none")]
-        send_mode: Option<SendMode>,
-    },
-
-    /// Acknowledge receipt of input messages (proxy -> backend)
-    /// Backend removes pending inputs with seq <= ack_seq
-    InputAck {
-        /// The session this acknowledgment is for
-        session_id: Uuid,
-        /// All inputs with sequence <= this are confirmed received
-        ack_seq: i64,
-    },
-
-    // =========================================================================
-    // Voice Input Messages (frontend <-> backend)
-    // =========================================================================
+pub enum VoiceMessage {
     /// Start voice recording session (frontend -> backend)
     StartVoice {
-        /// The session to associate voice input with
         session_id: Uuid,
-        /// Language code for speech recognition (default: "en-US")
         #[serde(default = "default_language_code")]
         language_code: String,
     },
 
     /// Stop voice recording (frontend -> backend)
-    StopVoice {
-        /// The session to stop voice input for
-        session_id: Uuid,
-    },
+    StopVoice { session_id: Uuid },
 
     /// Transcription result from speech-to-text (backend -> frontend)
     Transcription {
-        /// The session this transcription is for
         session_id: Uuid,
-        /// The transcribed text
         transcript: String,
-        /// Whether this is a final result (vs interim/partial)
         is_final: bool,
-        /// Confidence score (0.0 to 1.0)
         confidence: f32,
     },
 
     /// Voice error (backend -> frontend)
-    VoiceError {
-        /// The session this error is for
-        session_id: Uuid,
-        /// Error message
-        message: String,
-    },
+    VoiceError { session_id: Uuid, message: String },
 
     /// Voice session ended (backend -> frontend)
-    /// Sent when speech recognition detects end of speech (single_utterance mode)
-    VoiceEnded {
-        /// The session that ended
-        session_id: Uuid,
-    },
-
-    /// Server is shutting down (backend -> all clients)
-    /// Sent to all connected WebSocket clients before graceful shutdown
-    ServerShutdown {
-        /// Human-readable reason for shutdown (e.g., "Server restarting for update")
-        reason: String,
-        /// Suggested delay before reconnecting (milliseconds)
-        reconnect_delay_ms: u64,
-    },
-
-    // =========================================================================
-    // Launcher Messages (launcher <-> backend)
-    // =========================================================================
-    /// Register a launcher daemon with the backend
-    LauncherRegister {
-        launcher_id: Uuid,
-        launcher_name: String,
-        auth_token: Option<String>,
-        hostname: String,
-        #[serde(default)]
-        version: Option<String>,
-    },
-
-    /// Backend acknowledges launcher registration
-    LauncherRegisterAck {
-        success: bool,
-        launcher_id: Uuid,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        error: Option<String>,
-    },
-
-    /// Request to launch a new proxy instance (backend -> launcher)
-    LaunchSession {
-        request_id: Uuid,
-        user_id: Uuid,
-        auth_token: String,
-        working_directory: String,
-        #[serde(default)]
-        session_name: Option<String>,
-        #[serde(default)]
-        claude_args: Vec<String>,
-    },
-
-    /// Response from launcher about a launch request (launcher -> backend)
-    LaunchSessionResult {
-        request_id: Uuid,
-        success: bool,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        session_id: Option<Uuid>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pid: Option<u32>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        error: Option<String>,
-    },
-
-    /// Request to stop a running session (backend -> launcher)
-    StopSession { session_id: Uuid },
-
-    /// Launcher heartbeat with summary of running processes
-    LauncherHeartbeat {
-        launcher_id: Uuid,
-        running_sessions: Vec<Uuid>,
-        uptime_secs: u64,
-    },
-
-    /// Log output from a proxy process (launcher -> backend)
-    ProxyLog {
-        session_id: Uuid,
-        level: String,
-        message: String,
-        timestamp: String,
-    },
-
-    /// A proxy process exited (launcher -> backend)
-    SessionExited {
-        session_id: Uuid,
-        exit_code: Option<i32>,
-    },
-
-    /// Request directory listing from a launcher (backend -> launcher)
-    ListDirectories { request_id: Uuid, path: String },
-
-    /// Directory listing response (launcher -> backend)
-    ListDirectoriesResult {
-        request_id: Uuid,
-        #[serde(default)]
-        entries: Vec<DirectoryEntry>,
-        error: Option<String>,
-        #[serde(default)]
-        resolved_path: Option<String>,
-    },
+    VoiceEnded { session_id: Uuid },
 }
 
 fn default_language_code() -> String {
@@ -591,182 +321,6 @@ pub struct AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn sequenced_output_roundtrip() {
-        let msg = ProxyMessage::SequencedOutput {
-            seq: 42,
-            content: serde_json::json!({"type": "assistant", "text": "hello"}),
-        };
-        let json = serde_json::to_string(&msg).unwrap();
-        let parsed: ProxyMessage = serde_json::from_str(&json).unwrap();
-
-        match parsed {
-            ProxyMessage::SequencedOutput { seq, content } => {
-                assert_eq!(seq, 42);
-                assert_eq!(content["type"], "assistant");
-            }
-            _ => panic!("Wrong variant"),
-        }
-    }
-
-    #[test]
-    fn output_ack_roundtrip() {
-        let session_id = Uuid::new_v4();
-        let msg = ProxyMessage::OutputAck {
-            session_id,
-            ack_seq: 99,
-        };
-        let json = serde_json::to_string(&msg).unwrap();
-        let parsed: ProxyMessage = serde_json::from_str(&json).unwrap();
-
-        match parsed {
-            ProxyMessage::OutputAck {
-                session_id: sid,
-                ack_seq,
-            } => {
-                assert_eq!(sid, session_id);
-                assert_eq!(ack_seq, 99);
-            }
-            _ => panic!("Wrong variant"),
-        }
-    }
-
-    #[test]
-    fn sequenced_input_roundtrip() {
-        let session_id = Uuid::new_v4();
-        let msg = ProxyMessage::SequencedInput {
-            session_id,
-            seq: 5,
-            content: serde_json::json!({"type": "human", "message": "test"}),
-            send_mode: None,
-        };
-        let json = serde_json::to_string(&msg).unwrap();
-        let parsed: ProxyMessage = serde_json::from_str(&json).unwrap();
-
-        match parsed {
-            ProxyMessage::SequencedInput {
-                session_id: sid,
-                seq,
-                content,
-                send_mode,
-            } => {
-                assert_eq!(sid, session_id);
-                assert_eq!(seq, 5);
-                assert_eq!(content["type"], "human");
-                assert!(send_mode.is_none());
-            }
-            _ => panic!("Wrong variant"),
-        }
-    }
-
-    #[test]
-    fn input_ack_roundtrip() {
-        let session_id = Uuid::new_v4();
-        let msg = ProxyMessage::InputAck {
-            session_id,
-            ack_seq: 10,
-        };
-        let json = serde_json::to_string(&msg).unwrap();
-        let parsed: ProxyMessage = serde_json::from_str(&json).unwrap();
-
-        match parsed {
-            ProxyMessage::InputAck {
-                session_id: sid,
-                ack_seq,
-            } => {
-                assert_eq!(sid, session_id);
-                assert_eq!(ack_seq, 10);
-            }
-            _ => panic!("Wrong variant"),
-        }
-    }
-
-    #[test]
-    fn permission_request_roundtrip() {
-        let msg = ProxyMessage::PermissionRequest {
-            request_id: "req-123".to_string(),
-            tool_name: "Bash".to_string(),
-            input: serde_json::json!({"command": "ls"}),
-            permission_suggestions: vec![],
-        };
-        let json = serde_json::to_string(&msg).unwrap();
-        let parsed: ProxyMessage = serde_json::from_str(&json).unwrap();
-
-        match parsed {
-            ProxyMessage::PermissionRequest {
-                request_id,
-                tool_name,
-                ..
-            } => {
-                assert_eq!(request_id, "req-123");
-                assert_eq!(tool_name, "Bash");
-            }
-            _ => panic!("Wrong variant"),
-        }
-    }
-
-    #[test]
-    fn claude_input_with_send_mode() {
-        let msg = ProxyMessage::ClaudeInput {
-            content: serde_json::json!({"text": "hello"}),
-            send_mode: Some(SendMode::Wiggum),
-        };
-        let json = serde_json::to_string(&msg).unwrap();
-        let parsed: ProxyMessage = serde_json::from_str(&json).unwrap();
-
-        match parsed {
-            ProxyMessage::ClaudeInput { send_mode, .. } => {
-                assert_eq!(send_mode, Some(SendMode::Wiggum));
-            }
-            _ => panic!("Wrong variant"),
-        }
-    }
-
-    #[test]
-    fn claude_input_default_send_mode() {
-        // When send_mode is absent, it should default to None
-        let json = r#"{"type":"ClaudeInput","content":{"text":"hi"}}"#;
-        let parsed: ProxyMessage = serde_json::from_str(json).unwrap();
-
-        match parsed {
-            ProxyMessage::ClaudeInput { send_mode, .. } => {
-                assert_eq!(send_mode, None);
-            }
-            _ => panic!("Wrong variant"),
-        }
-    }
-
-    #[test]
-    fn register_with_defaults() {
-        // Fields with #[serde(default)] should work when absent
-        let json = r#"{
-            "type": "Register",
-            "session_id": "550e8400-e29b-41d4-a716-446655440000",
-            "session_name": "test",
-            "auth_token": null,
-            "working_directory": "/tmp"
-        }"#;
-        let parsed: ProxyMessage = serde_json::from_str(json).unwrap();
-
-        match parsed {
-            ProxyMessage::Register {
-                resuming,
-                git_branch,
-                replay_after,
-                client_version,
-                replaces_session_id,
-                ..
-            } => {
-                assert!(!resuming);
-                assert!(git_branch.is_none());
-                assert!(replay_after.is_none());
-                assert!(client_version.is_none());
-                assert!(replaces_session_id.is_none());
-            }
-            _ => panic!("Wrong variant"),
-        }
-    }
 
     #[test]
     fn session_status_serialization() {


### PR DESCRIPTION
## Summary
- Replace manual serde + split + mpsc boilerplate across all 3 WebSocket endpoints with ws-bridge typed connections
- Split monolithic `ProxyMessage` enum into per-endpoint typed enums (`ProxyToServer`/`ServerToProxy`, `ClientToServer`/`ServerToClient`, `LauncherToServer`/`ServerToLauncher`)
- Remove `tokio-tungstenite` and `futures-util` from proxy and launcher crates

## Changes
- **Backend**: `ws_bridge::server::into_connection` for proxy, web client, and launcher handlers
- **Proxy** (`claude-session-lib`): `ws_bridge::native_client::connect::<SessionEndpoint>` — all sends/recvs are typed, no manual serde
- **Launcher**: `ws_bridge::native_client::connect::<LauncherEndpoint>` — same pattern
- **Frontend**: `ws_bridge::yew_client::connect_to::<ClientEndpoint>` for both dashboard hook and session view
- **Voice endpoint excluded** — it mixes binary audio + JSON text which ws-bridge doesn't support

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` — all 81 tests pass
- [x] `cargo clippy --workspace` — clean
- [x] `cargo build --target wasm32-unknown-unknown -p shared` — WASM compat
- [x] `cargo fmt --check` — formatted
- [ ] Manual test: connect proxy, verify messages flow through typed channels
- [ ] Manual test: connect frontend, verify session view + spend updates work
- [ ] Manual test: connect launcher, verify session launch/stop works

Closes #400