### PR TITLE
Fix PR URL detection and remove pill link

### DIFF
--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -377,17 +377,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     <span class="pill-hostname">{ hostname }</span>
                     {
                         if let Some(ref branch) = session.git_branch {
-                            if let Some(ref url) = session.pr_url {
-                                html! {
-                                    <a class="pill-branch pill-branch-link" href={url.clone()}
-                                       target="_blank" title={format!("{} (PR)", branch)}
-                                       onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                                        { branch }
-                                    </a>
-                                }
-                            } else {
-                                html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
-                            }
+                            html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
                         } else {
                             html! {}
                         }

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -156,14 +156,6 @@
     text-align: left;
 }
 
-.pill-branch-link {
-    text-decoration: underline;
-    color: var(--accent);
-}
-
-.pill-branch-link:hover {
-    color: var(--accent-hover);
-}
 
 .session-pill.status-disconnected .pill-branch {
     color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- Fix two bugs preventing PR URL detection after `gh pr create`
- Remove clickable PR link from session pill (accidental clicks)

## Bug fixes
1. **Timing**: `pending_git_check` was set and consumed in the same loop iteration — `gh pr view` ran before `gh pr create` finished. Now the check is deferred to the next message.
2. **PR-only changes**: `check_and_send_branch_update` only sent updates when the branch changed. Creating a PR doesn't change the branch, so the new PR URL was never detected. Now also checks for PR URL changes.

## UI change
- Branch text on session pill is now always plain text (no clickable link)
- "Open PR" option remains in the pill dropdown menu

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt`
- [ ] Run `gh pr create` in a session, verify PR URL appears in dashboard