### PR TITLE
Defer AudioContext creation to user gesture

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -204,6 +204,7 @@ pub fn dashboard_page() -> Html {
         let activated_sessions = activated_sessions.clone();
         let active_sessions = active_sessions.clone();
         Callback::from(move |index: usize| {
+            crate::audio::ensure_audio_context();
             crate::audio::play_sound(crate::audio::SoundEvent::SessionSwap);
             focused_index.set(index);
             if let Some(session) = active_sessions.get(index) {

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -535,6 +535,7 @@ impl SessionView {
     }
 
     fn handle_send_input_with_mode(&mut self, ctx: &Context<Self>, send_mode: SendMode) -> bool {
+        crate::audio::ensure_audio_context();
         let input = self.input_value.trim().to_string();
         if input.is_empty() {
             return false;


### PR DESCRIPTION
## Summary
- Fix browser warning: "An AudioContext was prevented from starting automatically"
- AudioContext is now only created on user gestures (clicks, form submit)

## Changes
- Split `get_or_create_context()` into `ensure_audio_context()` (creates on gesture) and `get_context()` (returns existing or None)
- Call `ensure_audio_context()` from session select click and input submit
- `play_preview()` (settings page) also creates context since it's click-triggered
- WebSocket-triggered sounds (`Activity`, `Error`, `AwaitingInput`) silently no-op until first user interaction

## Test plan
- [x] `cargo build --target wasm32-unknown-unknown -p frontend`
- [ ] Load dashboard, verify no AudioContext console warning
- [ ] Click a session, verify sounds work after first click