### PR TITLE
Remove macOS experimental warning

### DIFF
--- a/frontend/src/components/proxy_token_setup.rs
+++ b/frontend/src/components/proxy_token_setup.rs
@@ -124,16 +124,6 @@ pub fn proxy_token_setup() -> Html {
                             </p>
                         </>
                     }
-                } else if *selected_platform == Platform::MacOS {
-                    html! {
-                        <p class="note warning-note">
-                            <span class="note-icon">{ "!" }</span>
-                            { "macOS support is experimental and largely untested. " }
-                            <a href="https://github.com/meawoppl/claude-code-portal/issues" target="_blank">
-                                { "Please report issues!" }
-                            </a>
-                        </p>
-                    }
                 } else {
                     html! {}
                 }}


### PR DESCRIPTION
## Summary
- Remove the "macOS support is experimental" warning from the proxy setup instructions
- macOS has been stable for a while now

Fixes #406