### PR TITLE
Add Codex agent support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "claude-codes",
+ "codex-codes",
  "directories",
  "hostname",
  "serde",
@@ -744,6 +745,17 @@ dependencies = [
  "shared",
  "tabled",
  "tokio",
+]
+
+[[package]]
+name = "codex-codes"
+version = "0.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e9f1faf1e4ca89510a48e58e519c32a953af4e2a4c5a628eb7c1e94a071c1f"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3854,6 +3866,7 @@ version = "1.1.2"
 dependencies = [
  "chrono",
  "claude-codes",
+ "codex-codes",
  "serde",
  "serde_json",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # Claude Code integration
 claude-codes = "2.1.46"
 
+# Codex CLI integration
+codex-codes = "0.100.0"
+
 # Frontend (Yew)
 yew = { version = "0.21", features = ["csr"] }
 yew-router = "0.18"

--- a/backend/migrations/2026-02-21-204646_add_agent_type_to_sessions/down.sql
+++ b/backend/migrations/2026-02-21-204646_add_agent_type_to_sessions/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN agent_type;

--- a/backend/migrations/2026-02-21-204646_add_agent_type_to_sessions/up.sql
+++ b/backend/migrations/2026-02-21-204646_add_agent_type_to_sessions/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN agent_type VARCHAR(16) NOT NULL DEFAULT 'claude';

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -59,6 +59,7 @@ pub async fn launch_session(
         working_directory: req.working_directory.clone(),
         session_name: None,
         claude_args: req.claude_args,
+        agent_type: req.agent_type,
     };
 
     if !app_state

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -97,6 +97,7 @@ fn handle_proxy_message(
             replaces_session_id,
             hostname,
             launcher_id,
+            agent_type,
         } => {
             let key = claude_session_id.to_string();
             *session_key = Some(key.clone());
@@ -115,6 +116,7 @@ fn handle_proxy_message(
                 replaces_session_id,
                 hostname: hostname.as_deref().unwrap_or("unknown"),
                 launcher_id,
+                agent_type,
             };
             let result = register_or_update_session(app_state, &params);
 

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -1,6 +1,7 @@
 use crate::models::{NewSessionMember, NewSessionWithId};
 use crate::AppState;
 use diesel::prelude::*;
+use shared::AgentType;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -24,6 +25,7 @@ pub struct RegistrationParams<'a> {
     pub replaces_session_id: Option<Uuid>,
     pub hostname: &'a str,
     pub launcher_id: Option<Uuid>,
+    pub agent_type: AgentType,
 }
 
 /// Register or update a session in the database.
@@ -143,6 +145,7 @@ fn create_new_session(
         client_version: params.client_version.clone(),
         hostname: params.hostname.to_string(),
         launcher_id: params.launcher_id,
+        agent_type: params.agent_type.as_str().to_string(),
     };
 
     match diesel::insert_into(sessions::table)
@@ -163,8 +166,8 @@ fn create_new_session(
             }
 
             info!(
-                "Session persisted to DB: {} ({}) branch: {:?}",
-                params.session_name, params.claude_session_id, params.git_branch
+                "Session persisted to DB: {} ({}) branch: {:?} agent: {}",
+                params.session_name, params.claude_session_id, params.git_branch, params.agent_type
             );
             RegistrationResult {
                 success: true,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -54,6 +54,7 @@ pub struct Session {
     pub hostname: String,
     pub launcher_id: Option<Uuid>,
     pub pr_url: Option<String>,
+    pub agent_type: String,
 }
 
 #[derive(Debug, Insertable)]
@@ -81,6 +82,7 @@ pub struct NewSessionWithId {
     pub client_version: Option<String>,
     pub hostname: String,
     pub launcher_id: Option<Uuid>,
+    pub agent_type: String,
 }
 
 #[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -122,6 +122,8 @@ diesel::table! {
         launcher_id -> Nullable<Uuid>,
         #[max_length = 512]
         pr_url -> Nullable<Varchar>,
+        #[max_length = 16]
+        agent_type -> Varchar,
     }
 }
 

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [dependencies]
 shared = { path = "../shared" }
 claude-codes = { workspace = true }
+codex-codes = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/claude-session-lib/src/snapshot.rs
+++ b/claude-session-lib/src/snapshot.rs
@@ -23,6 +23,9 @@ pub struct SessionConfig {
     /// Extra arguments to pass to the claude CLI
     #[serde(default)]
     pub extra_args: Vec<String>,
+    /// Which agent CLI to use
+    #[serde(default)]
+    pub agent_type: shared::AgentType,
 }
 
 /// A pending permission request that hasn't been responded to
@@ -100,6 +103,7 @@ mod tests {
             resume: false,
             claude_path: None,
             extra_args: vec![],
+            agent_type: Default::default(),
         }
     }
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -1,0 +1,469 @@
+use super::markdown::render_markdown;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use yew::prelude::*;
+
+// Local deserialization types mirroring codex-codes, using Option wrappers
+// for lenient parsing (same strategy as message_renderer.rs for Claude).
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CodexEvent {
+    #[serde(rename = "thread.started")]
+    ThreadStarted {
+        thread_id: Option<String>,
+    },
+    #[serde(rename = "turn.started")]
+    TurnStarted {},
+    #[serde(rename = "turn.completed")]
+    TurnCompleted {
+        usage: Option<CodexUsage>,
+    },
+    #[serde(rename = "turn.failed")]
+    TurnFailed {
+        error: Option<CodexError>,
+    },
+    #[serde(rename = "item.started")]
+    ItemStarted {
+        item: Option<CodexItem>,
+    },
+    #[serde(rename = "item.updated")]
+    ItemUpdated {
+        item: Option<CodexItem>,
+    },
+    #[serde(rename = "item.completed")]
+    ItemCompleted {
+        item: Option<CodexItem>,
+    },
+    Error {
+        message: Option<String>,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CodexUsage {
+    pub input_tokens: Option<u64>,
+    pub cached_input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CodexError {
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CodexItem {
+    AgentMessage {
+        id: Option<String>,
+        text: Option<String>,
+    },
+    Reasoning {
+        id: Option<String>,
+        text: Option<String>,
+    },
+    CommandExecution {
+        id: Option<String>,
+        command: Option<String>,
+        aggregated_output: Option<String>,
+        exit_code: Option<i32>,
+        status: Option<String>,
+    },
+    FileChange {
+        id: Option<String>,
+        changes: Option<Vec<FileChange>>,
+        status: Option<String>,
+    },
+    McpToolCall {
+        id: Option<String>,
+        server: Option<String>,
+        tool: Option<String>,
+        arguments: Option<Value>,
+        status: Option<String>,
+    },
+    WebSearch {
+        id: Option<String>,
+        query: Option<String>,
+    },
+    TodoList {
+        id: Option<String>,
+        items: Option<Vec<TodoEntry>>,
+    },
+    Error {
+        id: Option<String>,
+        message: Option<String>,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChange {
+    pub path: Option<String>,
+    pub kind: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TodoEntry {
+    pub text: Option<String>,
+    pub completed: Option<bool>,
+}
+
+// --- Components ---
+
+#[derive(Properties, PartialEq)]
+pub struct CodexMessageRendererProps {
+    pub json: String,
+}
+
+#[function_component(CodexMessageRenderer)]
+pub fn codex_message_renderer(props: &CodexMessageRendererProps) -> Html {
+    let parsed: Result<CodexEvent, _> = serde_json::from_str(&props.json);
+
+    match parsed {
+        Ok(CodexEvent::ThreadStarted { .. }) => html! {},
+        Ok(CodexEvent::TurnStarted {}) => html! {},
+        Ok(CodexEvent::TurnCompleted { usage }) => render_turn_completed(usage.as_ref()),
+        Ok(CodexEvent::TurnFailed { error }) => render_turn_failed(error.as_ref()),
+        Ok(CodexEvent::ItemStarted { item }) | Ok(CodexEvent::ItemUpdated { item }) => {
+            render_item(item.as_ref(), false)
+        }
+        Ok(CodexEvent::ItemCompleted { item }) => render_item(item.as_ref(), true),
+        Ok(CodexEvent::Error { message }) => render_thread_error(message.as_deref()),
+        Ok(CodexEvent::Unknown) | Err(_) => render_raw_codex(&props.json),
+    }
+}
+
+fn render_item(item: Option<&CodexItem>, completed: bool) -> Html {
+    let Some(item) = item else {
+        return html! {};
+    };
+    match item {
+        CodexItem::AgentMessage { text, .. } => render_agent_message(text.as_deref()),
+        CodexItem::Reasoning { text, .. } => render_reasoning(text.as_deref()),
+        CodexItem::CommandExecution {
+            command,
+            aggregated_output,
+            exit_code,
+            status,
+            ..
+        } => render_command_execution(
+            command.as_deref(),
+            aggregated_output.as_deref(),
+            *exit_code,
+            status.as_deref(),
+            completed,
+        ),
+        CodexItem::FileChange {
+            changes, status, ..
+        } => render_file_change(changes.as_deref(), status.as_deref()),
+        CodexItem::McpToolCall {
+            server,
+            tool,
+            status,
+            ..
+        } => render_mcp_tool_call(server.as_deref(), tool.as_deref(), status.as_deref()),
+        CodexItem::WebSearch { query, .. } => render_web_search(query.as_deref()),
+        CodexItem::TodoList { items, .. } => render_todo_list(items.as_deref()),
+        CodexItem::Error { message, .. } => render_item_error(message.as_deref()),
+        CodexItem::Unknown => html! {},
+    }
+}
+
+fn render_agent_message(text: Option<&str>) -> Html {
+    let text = text.unwrap_or("");
+    if text.is_empty() {
+        return html! {};
+    }
+    html! {
+        <div class="claude-message assistant-message">
+            <div class="message-header">
+                <span class="message-type-badge assistant">{ "Codex" }</span>
+            </div>
+            <div class="message-body">
+                <div class="assistant-text">{ render_markdown(text) }</div>
+            </div>
+        </div>
+    }
+}
+
+fn render_reasoning(text: Option<&str>) -> Html {
+    let text = text.unwrap_or("");
+    if text.is_empty() {
+        return html! {};
+    }
+    html! {
+        <div class="claude-message assistant-message">
+            <div class="message-body">
+                <div class="thinking-block">
+                    <span class="thinking-label">{ "reasoning" }</span>
+                    <div class="thinking-content">{ text }</div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+fn render_command_execution(
+    command: Option<&str>,
+    output: Option<&str>,
+    exit_code: Option<i32>,
+    status: Option<&str>,
+    completed: bool,
+) -> Html {
+    let cmd = command.unwrap_or("(unknown command)");
+    let out = output.unwrap_or("");
+
+    let status_text = if completed {
+        match exit_code {
+            Some(0) => "completed".to_string(),
+            Some(code) => format!("exit {}", code),
+            None => status.unwrap_or("completed").to_string(),
+        }
+    } else {
+        "running...".to_string()
+    };
+
+    let is_error = exit_code.is_some_and(|c| c != 0);
+
+    html! {
+        <div class="claude-message assistant-message">
+            <div class="message-body">
+                <div class="tool-use-section">
+                    <div class="tool-use-header">
+                        <span class="tool-icon">{ "$" }</span>
+                        <span class="tool-name">{ "Bash" }</span>
+                        <span class="tool-meta">{ &status_text }</span>
+                    </div>
+                    <pre class="tool-input-content">{ cmd }</pre>
+                    {
+                        if !out.is_empty() {
+                            let class = if is_error { "tool-result error" } else { "tool-result" };
+                            html! {
+                                <div class={class}>
+                                    <pre class="tool-result-content">{ out }</pre>
+                                </div>
+                            }
+                        } else {
+                            html! {}
+                        }
+                    }
+                </div>
+            </div>
+        </div>
+    }
+}
+
+fn render_file_change(changes: Option<&[FileChange]>, status: Option<&str>) -> Html {
+    let changes = changes.unwrap_or(&[]);
+    if changes.is_empty() {
+        return html! {};
+    }
+
+    let status_label = status.unwrap_or("completed");
+
+    html! {
+        <div class="claude-message assistant-message">
+            <div class="message-body">
+                <div class="tool-use-section">
+                    <div class="tool-use-header">
+                        <span class="tool-icon">{ "\u{1f4dd}" }</span>
+                        <span class="tool-name">{ "File Changes" }</span>
+                        <span class="tool-meta">{ status_label }</span>
+                    </div>
+                    <div class="file-changes-list">
+                        { for changes.iter().map(|c| {
+                            let path = c.path.as_deref().unwrap_or("(unknown)");
+                            let kind = c.kind.as_deref().unwrap_or("update");
+                            let kind_class = format!("file-change-kind {}", kind);
+                            html! {
+                                <div class="file-change-entry">
+                                    <span class={kind_class}>{ kind }</span>
+                                    <span class="file-change-path">{ path }</span>
+                                </div>
+                            }
+                        })}
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+fn render_mcp_tool_call(server: Option<&str>, tool: Option<&str>, status: Option<&str>) -> Html {
+    let server = server.unwrap_or("(unknown)");
+    let tool = tool.unwrap_or("(unknown)");
+    let status = status.unwrap_or("in_progress");
+
+    html! {
+        <div class="claude-message assistant-message">
+            <div class="message-body">
+                <div class="tool-use-section">
+                    <div class="tool-use-header">
+                        <span class="tool-icon">{ "\u{1f50c}" }</span>
+                        <span class="tool-name">{ format!("{} / {}", server, tool) }</span>
+                        <span class="tool-meta">{ status }</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+fn render_web_search(query: Option<&str>) -> Html {
+    let query = query.unwrap_or("(no query)");
+    html! {
+        <div class="claude-message assistant-message">
+            <div class="message-body">
+                <div class="tool-use-section">
+                    <div class="tool-use-header">
+                        <span class="tool-icon">{ "\u{1f50d}" }</span>
+                        <span class="tool-name">{ "Web Search" }</span>
+                    </div>
+                    <pre class="tool-input-content">{ query }</pre>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+fn render_todo_list(items: Option<&[TodoEntry]>) -> Html {
+    let items = items.unwrap_or(&[]);
+    if items.is_empty() {
+        return html! {};
+    }
+    html! {
+        <div class="claude-message assistant-message">
+            <div class="message-body">
+                <div class="tool-use-section">
+                    <div class="tool-use-header">
+                        <span class="tool-icon">{ "\u{2611}" }</span>
+                        <span class="tool-name">{ "Todo List" }</span>
+                    </div>
+                    <div class="codex-todo-list">
+                        { for items.iter().map(|item| {
+                            let text = item.text.as_deref().unwrap_or("");
+                            let done = item.completed.unwrap_or(false);
+                            let marker = if done { "\u{2611}" } else { "\u{2610}" };
+                            let class = if done { "codex-todo done" } else { "codex-todo" };
+                            html! {
+                                <div class={class}>
+                                    <span class="codex-todo-marker">{ marker }</span>
+                                    <span class="codex-todo-text">{ text }</span>
+                                </div>
+                            }
+                        })}
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+fn render_turn_completed(usage: Option<&CodexUsage>) -> Html {
+    let input = usage.and_then(|u| u.input_tokens).unwrap_or(0);
+    let output = usage.and_then(|u| u.output_tokens).unwrap_or(0);
+    let cached = usage.and_then(|u| u.cached_input_tokens).unwrap_or(0);
+
+    let tooltip = format!("Input: {} | Output: {} | Cached: {}", input, output, cached);
+
+    html! {
+        <div class="claude-message result-message success">
+            <div class="result-stats-bar">
+                <span class="result-status success">{ "\u{2713}" }</span>
+                {
+                    if input > 0 || output > 0 {
+                        html! {
+                            <>
+                                <span class="stat-item tokens" title={tooltip}>
+                                    { format!("{}\u{2193} {}\u{2191}", input, output) }
+                                </span>
+                            </>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
+            </div>
+        </div>
+    }
+}
+
+fn render_turn_failed(error: Option<&CodexError>) -> Html {
+    let message = error
+        .and_then(|e| e.message.as_deref())
+        .unwrap_or("Turn failed");
+
+    html! {
+        <div class="claude-message error-message-display">
+            <div class="message-header">
+                <span class="message-type-badge result error">{ "Turn Failed" }</span>
+            </div>
+            <div class="message-body">
+                <div class="error-text">{ message }</div>
+            </div>
+        </div>
+    }
+}
+
+fn render_thread_error(message: Option<&str>) -> Html {
+    let message = message.unwrap_or("Unknown error");
+    html! {
+        <div class="claude-message error-message-display">
+            <div class="message-header">
+                <span class="message-type-badge result error">{ "Error" }</span>
+            </div>
+            <div class="message-body">
+                <div class="error-text">{ message }</div>
+            </div>
+        </div>
+    }
+}
+
+fn render_item_error(message: Option<&str>) -> Html {
+    let message = message.unwrap_or("Unknown error");
+    html! {
+        <div class="claude-message error-message-display">
+            <div class="message-header">
+                <span class="message-type-badge result error">{ "Error" }</span>
+            </div>
+            <div class="message-body">
+                <div class="error-text">{ message }</div>
+            </div>
+        </div>
+    }
+}
+
+fn render_raw_codex(json: &str) -> Html {
+    let display = serde_json::from_str::<Value>(json)
+        .ok()
+        .and_then(|v| serde_json::to_string_pretty(&v).ok())
+        .unwrap_or_else(|| json.to_string());
+
+    html! {
+        <div class="claude-message raw-message">
+            <div class="message-header">
+                <span class="message-type-badge raw">{ "Codex Raw" }</span>
+            </div>
+            <div class="message-body">
+                <pre class="raw-json">{ display }</pre>
+            </div>
+        </div>
+    }
+}
+
+/// Check if a Codex message indicates "awaiting" (turn complete or turn failed)
+pub fn is_codex_terminal_event(json: &str) -> Option<bool> {
+    let val: Value = serde_json::from_str(json).ok()?;
+    let event_type = val.get("type")?.as_str()?;
+    match event_type {
+        "turn.completed" | "turn.failed" => Some(true),
+        "item.started" | "item.updated" | "item.completed" | "turn.started" | "thread.started" => {
+            Some(false)
+        }
+        _ => None,
+    }
+}

--- a/frontend/src/components/message_renderer.rs
+++ b/frontend/src/components/message_renderer.rs
@@ -260,10 +260,18 @@ pub struct MessageRendererProps {
     pub json: String,
     #[prop_or_default]
     pub session_id: Option<Uuid>,
+    #[prop_or_default]
+    pub agent_type: shared::AgentType,
 }
 
 #[function_component(MessageRenderer)]
 pub fn message_renderer(props: &MessageRendererProps) -> Html {
+    if props.agent_type == shared::AgentType::Codex {
+        return html! {
+            <super::codex_renderer::CodexMessageRenderer json={props.json.clone()} />
+        };
+    }
+
     let parsed: Result<ClaudeMessage, _> = serde_json::from_str(&props.json);
 
     match parsed {
@@ -285,13 +293,15 @@ pub struct MessageGroupRendererProps {
     pub group: MessageGroup,
     #[prop_or_default]
     pub session_id: Option<Uuid>,
+    #[prop_or_default]
+    pub agent_type: shared::AgentType,
 }
 
 #[function_component(MessageGroupRenderer)]
 pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
     match &props.group {
         MessageGroup::Single(json) => {
-            html! { <MessageRenderer json={json.clone()} session_id={props.session_id} /> }
+            html! { <MessageRenderer json={json.clone()} session_id={props.session_id} agent_type={props.agent_type} /> }
         }
         MessageGroup::AssistantGroup(messages) => render_assistant_group(messages),
     }

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod codex_renderer;
 mod copy_command;
 mod diff;
 mod launch_dialog;

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -384,6 +384,13 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     }
                 </span>
                 {
+                    if session.agent_type == shared::AgentType::Codex {
+                        html! { <span class="pill-agent-badge codex">{ "Codex" }</span> }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
                     if is_paused {
                         html! { <span class="pill-paused-badge">{ "ᴾ" }</span> }
                     } else {

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -47,6 +47,7 @@ pub fn connect_websocket(
                     replaces_session_id: None,
                     hostname: None,
                     launcher_id: None,
+                    agent_type: Default::default(),
                 };
 
                 if sender.send(register_msg).await.is_err() {

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -309,3 +309,71 @@
     padding: 0.15rem 0.4rem;
     border-radius: 3px;
 }
+
+/* ==========================================================================
+   Codex-specific Renderers
+   ========================================================================== */
+
+.file-changes-list {
+    padding: 0.5rem 0;
+}
+
+.file-change-entry {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.2rem 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+}
+
+.file-change-kind {
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    text-transform: uppercase;
+    min-width: 4em;
+    text-align: center;
+}
+
+.file-change-kind.add {
+    color: #9ece6a;
+    background: rgba(158, 206, 106, 0.15);
+}
+
+.file-change-kind.delete {
+    color: #f7768e;
+    background: rgba(247, 118, 142, 0.15);
+}
+
+.file-change-kind.update {
+    color: #7aa2f7;
+    background: rgba(122, 162, 247, 0.15);
+}
+
+.file-change-path {
+    color: var(--text-primary);
+}
+
+.codex-todo-list {
+    padding: 0.5rem 0;
+}
+
+.codex-todo {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.2rem 0.5rem;
+    font-size: 0.85rem;
+}
+
+.codex-todo.done .codex-todo-text {
+    text-decoration: line-through;
+    color: var(--text-secondary);
+}
+
+.codex-todo-marker {
+    font-size: 1rem;
+    flex-shrink: 0;
+}

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -233,6 +233,19 @@
     font-weight: 600;
 }
 
+.pill-agent-badge {
+    font-size: 0.6rem;
+    font-weight: 600;
+    padding: 0 0.3rem;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+
+.pill-agent-badge.codex {
+    color: #0a4;
+    background: rgba(0, 170, 68, 0.15);
+}
+
 /* Pill menu toggle (▼ button) */
 .pill-menu-toggle {
     background: transparent;

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -227,11 +227,12 @@ async fn handle_message(
             working_directory,
             session_name,
             claude_args,
+            agent_type,
             ..
         } => {
             info!(
-                "Launch request: dir={}, name={:?}",
-                working_directory, session_name
+                "Launch request: dir={}, name={:?}, agent={}",
+                working_directory, session_name, agent_type
             );
 
             let result = process_manager
@@ -240,6 +241,7 @@ async fn handle_message(
                     &working_directory,
                     session_name.as_deref(),
                     &claude_args,
+                    agent_type,
                 )
                 .await;
 

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -62,6 +62,7 @@ impl ProcessManager {
         working_directory: &str,
         session_name: Option<&str>,
         claude_args: &[String],
+        agent_type: shared::AgentType,
     ) -> anyhow::Result<SpawnResult> {
         if self.tasks.len() >= self.max_sessions {
             anyhow::bail!(
@@ -100,6 +101,7 @@ impl ProcessManager {
             claude_args: claude_args.to_vec(),
             replaces_session_id: None,
             launcher_id: self.launcher_id,
+            agent_type,
         };
 
         let exit_tx = self.exit_tx.clone();
@@ -150,6 +152,7 @@ async fn run_session_task(mut config: ProxySessionConfig) -> Option<i32> {
             resume: config.resume,
             claude_path: None,
             extra_args: config.claude_args.clone(),
+            agent_type: config.agent_type,
         };
 
         let mut claude_session = match ClaudeSession::new(claude_config).await {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -129,6 +129,10 @@ struct Args {
     #[arg(long, value_name = "UUID", hide = true)]
     session_id_tag: Option<Uuid>,
 
+    /// Agent CLI to use: "claude" (default) or "codex".
+    #[arg(long, value_name = "AGENT", default_value = "claude")]
+    agent: String,
+
     /// Enable debug-level logging for troubleshooting.
     #[arg(long, short = 'v')]
     verbose: bool,
@@ -346,6 +350,10 @@ async fn main() -> Result<()> {
         info!("Detected git branch: {}", branch);
     }
 
+    // Parse agent type
+    let agent_type: shared::AgentType =
+        args.agent.parse().map_err(|e: String| anyhow::anyhow!(e))?;
+
     // Build session config
     let session_config = ProxySessionConfig {
         backend_url,
@@ -358,6 +366,7 @@ async fn main() -> Result<()> {
         claude_args: args.claude_args.clone(),
         replaces_session_id: None,
         launcher_id: None,
+        agent_type,
     };
 
     // Start Claude and run session
@@ -540,6 +549,7 @@ async fn create_claude_session(config: &ProxySessionConfig) -> Result<ClaudeSess
         resume: config.resume,
         claude_path: None,
         extra_args: config.claude_args.clone(),
+        agent_type: config.agent_type,
     };
 
     if config.resume {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -18,5 +18,8 @@ chrono = { workspace = true, default-features = false, features = ["serde", "was
 # Claude Code types (WASM-compatible, no tokio)
 claude-codes = { version = "2.1.20", default-features = false, features = ["types"] }
 
+# Codex CLI types (WASM-compatible, types only)
+codex-codes = { workspace = true }
+
 # Typed WebSocket endpoints (core traits only — WASM-safe, no features needed)
 ws-bridge = { workspace = true }

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -79,6 +79,8 @@ pub struct LaunchRequest {
     pub launcher_id: Option<uuid::Uuid>,
     #[serde(default)]
     pub claude_args: Vec<String>,
+    #[serde(default)]
+    pub agent_type: crate::AgentType,
 }
 
 /// Request body for device code creation

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 pub use ws_bridge::WsEndpoint;
 
-use crate::{DirectoryEntry, PermissionSuggestion, SendMode, SessionCost, SessionStatus};
+use crate::{
+    AgentType, DirectoryEntry, PermissionSuggestion, SendMode, SessionCost, SessionStatus,
+};
 
 // =============================================================================
 // Session endpoint: proxy <-> backend (/ws/session)
@@ -40,6 +42,8 @@ pub enum ProxyToServer {
         hostname: Option<String>,
         #[serde(default)]
         launcher_id: Option<Uuid>,
+        #[serde(default)]
+        agent_type: AgentType,
     },
 
     /// Raw output from Claude Code (unsequenced fallback)
@@ -168,6 +172,8 @@ pub enum ClientToServer {
         hostname: Option<String>,
         #[serde(default)]
         launcher_id: Option<Uuid>,
+        #[serde(default)]
+        agent_type: AgentType,
     },
 
     /// User sends input to Claude
@@ -347,6 +353,8 @@ pub enum ServerToLauncher {
         session_name: Option<String>,
         #[serde(default)]
         claude_args: Vec<String>,
+        #[serde(default)]
+        agent_type: AgentType,
     },
 
     /// Request to stop a running session
@@ -395,6 +403,7 @@ mod tests {
             replaces_session_id: None,
             hostname: None,
             launcher_id: None,
+            agent_type: AgentType::Claude,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"Register""#));
@@ -488,6 +497,7 @@ mod tests {
             working_directory: "/home".into(),
             session_name: Some("my-session".into()),
             claude_args: vec!["--verbose".into()],
+            agent_type: AgentType::Claude,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"LaunchSession""#));

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -32,6 +32,41 @@ pub use claude_codes::io::{
     ToolResultBlock, ToolResultContent, ToolUseBlock,
 };
 
+/// Which agent CLI backs a session
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentType {
+    #[default]
+    Claude,
+    Codex,
+}
+
+impl AgentType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            AgentType::Claude => "claude",
+            AgentType::Codex => "codex",
+        }
+    }
+}
+
+impl std::fmt::Display for AgentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for AgentType {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "claude" => Ok(AgentType::Claude),
+            "codex" => Ok(AgentType::Codex),
+            other => Err(format!("unknown agent type: {}", other)),
+        }
+    }
+}
+
 /// Voice WebSocket message types (frontend <-> backend via /ws/voice/:id).
 /// These are NOT part of the typed ws-bridge endpoints because voice mixes
 /// binary audio frames with JSON text messages.
@@ -155,6 +190,9 @@ pub struct SessionInfo {
     /// GitHub PR URL for the current branch
     #[serde(default)]
     pub pr_url: Option<String>,
+    /// Which agent CLI backs this session (claude or codex)
+    #[serde(default)]
+    pub agent_type: AgentType,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Add `AgentType` enum (`Claude` | `Codex`) across shared/backend/frontend/proxy/launcher
- Codex proxy driver: spawns `codex --json --full-auto` per user message, reads JSONL via `RawOutput` event path that bypasses Claude-specific processing
- Frontend Codex renderer with support for all Codex event types (agent messages, command execution, file changes, reasoning, todo lists, etc.)
- Agent type selector in launch dialog, badge in session rail
- DB migration for `agent_type` column on sessions table

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace` (0 warnings)
- [x] `cargo test --workspace` (81 tests pass)
- [x] `cargo build --target wasm32-unknown-unknown -p shared` (WASM compat)
- [x] `cargo fmt --check`