### PR TITLE
Rename branding to Agent Portal

### DIFF
--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -425,7 +425,7 @@ fn render_approval_page(
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Approve Device - Claude Code Portal</title>
+    <title>Approve Device - Agent Portal</title>
     <style>
         :root {{
             --bg-dark: #1a1b26;
@@ -640,7 +640,7 @@ const DEVICE_CODE_FORM_HTML: &str = r#"<!DOCTYPE html>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Device Authentication - Claude Code Portal</title>
+    <title>Device Authentication - Agent Portal</title>
     <style>
         :root {
             --bg-dark: #1a1b26;

--- a/backend/src/handlers/downloads.rs
+++ b/backend/src/handlers/downloads.rs
@@ -34,7 +34,7 @@ pub async fn install_script(
 
     let script = format!(
         r##"#!/bin/bash
-# Claude Code Portal Installer
+# Agent Portal Installer
 # Downloads and installs the claude-portal binary, then configures backend URL
 
 set -e
@@ -46,7 +46,7 @@ CONFIG_FILE="${{CONFIG_DIR}}/config.json"
 GITHUB_RELEASE_URL="https://github.com/meawoppl/claude-code-portal/releases/download/latest"
 BACKEND_URL="{backend_url}"
 
-echo "Claude Code Portal Installer"
+echo "Agent Portal Installer"
 echo "============================"
 echo ""
 
@@ -153,7 +153,7 @@ add_to_path() {{
     if [ -f "${{rc_file}}" ]; then
         if ! grep -q "claude-code-portal" "${{rc_file}}" 2>/dev/null; then
             echo "" >> "${{rc_file}}"
-            echo "# Claude Code Portal binary path" >> "${{rc_file}}"
+            echo "# Agent Portal binary path" >> "${{rc_file}}"
             echo "${{path_line}}" >> "${{rc_file}}"
             echo "Updated: ${{rc_file}}"
             return 0

--- a/frontend/assets/og-preview.svg
+++ b/frontend/assets/og-preview.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
   <rect width="1200" height="630" fill="#1a1b26"/>
   <rect x="0" y="0" width="1200" height="4" fill="#7aa2f7"/>
-  <text x="600" y="260" font-family="system-ui, -apple-system, sans-serif" font-size="64" font-weight="700" fill="#c0caf5" text-anchor="middle">Claude Code Portal</text>
-  <text x="600" y="340" font-family="system-ui, -apple-system, sans-serif" font-size="28" fill="#a9b1d6" text-anchor="middle">Rich, interactive Claude Code sessions.</text>
+  <text x="600" y="260" font-family="system-ui, -apple-system, sans-serif" font-size="64" font-weight="700" fill="#c0caf5" text-anchor="middle">Agent Portal</text>
+  <text x="600" y="340" font-family="system-ui, -apple-system, sans-serif" font-size="28" fill="#a9b1d6" text-anchor="middle">Rich, interactive agent sessions.</text>
   <text x="600" y="385" font-family="system-ui, -apple-system, sans-serif" font-size="28" fill="#a9b1d6" text-anchor="middle">Visually pleasant and easy to multitask between many sessions.</text>
   <text x="600" y="470" font-family="monospace" font-size="22" fill="#7aa2f7" text-anchor="middle">txcl.io</text>
   <rect x="0" y="626" width="1200" height="4" fill="#7aa2f7"/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,23 +3,23 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <title>Claude Code Portal</title>
+    <title>Agent Portal</title>
 
     <!-- Open Graph / Link Preview -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Claude Code Portal" />
-    <meta property="og:description" content="Rich, interactive Claude Code sessions. Visually pleasant and easy to multitask between many sessions." />
+    <meta property="og:title" content="Agent Portal" />
+    <meta property="og:description" content="Rich, interactive agent sessions. Visually pleasant and easy to multitask between many sessions." />
     <meta property="og:image" content="https://txcl.io/og-preview.svg" />
     <meta property="og:url" content="https://txcl.io" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Claude Code Portal" />
-    <meta name="twitter:description" content="Rich, interactive Claude Code sessions. Visually pleasant and easy to multitask between many sessions." />
+    <meta name="twitter:title" content="Agent Portal" />
+    <meta name="twitter:description" content="Rich, interactive agent sessions. Visually pleasant and easy to multitask between many sessions." />
     <meta name="twitter:image" content="https://txcl.io/og-preview.svg" />
 
     <!-- General meta -->
-    <meta name="description" content="Rich, interactive Claude Code sessions. Visually pleasant and easy to multitask between many sessions." />
+    <meta name="description" content="Rich, interactive agent sessions. Visually pleasant and easy to multitask between many sessions." />
 
     <link data-trunk rel="rust" data-wasm-opt="z" />
     <!-- CSS files split for maintainability -->

--- a/frontend/src/pages/splash.rs
+++ b/frontend/src/pages/splash.rs
@@ -17,9 +17,9 @@ pub fn splash_page() -> Html {
         <div class="splash-container">
             <div class="splash-content">
                 <div class="splash-header">
-                    <h1>{ "Claude Code Portal" }</h1>
+                    <h1>{ "Agent Portal" }</h1>
                     <p class="tagline">
-                        { "Access your remote Claude Code sessions from anywhere" }
+                        { "Access your remote agent sessions from anywhere" }
                     </p>
                 </div>
 
@@ -43,7 +43,7 @@ pub fn splash_page() -> Html {
                                 <span class="output blue">{ "╭──────────────────────────────────────╮" }</span>
                             </div>
                             <div class="terminal-line">
-                                <span class="output blue">{ "│      Claude Code Portal Starting     │" }</span>
+                                <span class="output blue">{ "│        Agent Portal Starting         │" }</span>
                             </div>
                             <div class="terminal-line">
                                 <span class="output blue">{ "╰──────────────────────────────────────╯" }</span>
@@ -100,11 +100,11 @@ pub fn splash_page() -> Html {
                     </div>
                     <div class="feature">
                         <h3>{ "🔄 Multiple Sessions" }</h3>
-                        <p>{ "Manage and switch between multiple Claude Code sessions" }</p>
+                        <p>{ "Manage and switch between multiple agent sessions" }</p>
                     </div>
                     <div class="feature">
                         <h3>{ "🚀 Fire & Forget" }</h3>
-                        <p>{ "Start Claude tasks and walk away. Check results later from any device" }</p>
+                        <p>{ "Start agent tasks and walk away. Check results later from any device" }</p>
                     </div>
                     <div class="feature">
                         <h3>{ "🔒 Secure" }</h3>

--- a/proxy/src/ui.rs
+++ b/proxy/src/ui.rs
@@ -12,7 +12,7 @@ pub fn print_startup_banner() {
     );
     println!(
         "{}",
-        "│      Claude Code Portal Starting     │".bright_blue()
+        "│        Agent Portal Starting         │".bright_blue()
     );
     println!(
         "{}",


### PR DESCRIPTION
## Summary
- Rename all user-facing "Claude Code Portal" branding to "Agent Portal"
- Update page titles, meta tags, splash page, startup banner, device auth pages, and installer script
- Binary name (`claude-portal`) and config paths unchanged for backward compatibility

## Test plan
- [ ] Verify splash page shows "Agent Portal"
- [ ] Verify browser tab title says "Agent Portal"
- [ ] Verify proxy startup banner says "Agent Portal Starting"
- [ ] Verify device auth pages title correctly
- [ ] All tests pass, clippy clean