### PR TITLE
Rename claude-portal-launcher to agent-launcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,13 +225,13 @@ jobs:
           shared-key: "launcher-linux"
 
       - name: Build launcher
-        run: cargo build -p claude-portal-launcher --release
+        run: cargo build -p agent-launcher --release
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: launcher-linux-x86_64
-          path: target/release/claude-portal-launcher
+          path: target/release/agent-launcher
 
   build-launcher-macos-arm64:
     name: Build Launcher (macOS ARM64)
@@ -248,16 +248,16 @@ jobs:
           shared-key: "launcher-macos-arm64"
 
       - name: Build launcher
-        run: cargo build -p claude-portal-launcher --release
+        run: cargo build -p agent-launcher --release
 
       - name: Ad-hoc code sign
-        run: codesign -s - target/release/claude-portal-launcher
+        run: codesign -s - target/release/agent-launcher
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: launcher-darwin-aarch64
-          path: target/release/claude-portal-launcher
+          path: target/release/agent-launcher
 
   build-proxy-windows:
     name: Build Proxy (Windows x86_64)
@@ -297,11 +297,11 @@ jobs:
           shared-key: "launcher-windows"
 
       - name: Build launcher
-        run: cargo build -p claude-portal-launcher --release
+        run: cargo build -p agent-launcher --release
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: launcher-windows-x86_64
-          path: target/release/claude-portal-launcher.exe
+          path: target/release/agent-launcher.exe
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
         run: cargo build -p claude-portal --release
 
       - name: Build launcher
-        run: cargo build -p claude-portal-launcher --release
+        run: cargo build -p agent-launcher --release
 
       - name: Rename binaries
         run: |
           mv target/release/claude-portal target/release/claude-portal-linux-x86_64
-          mv target/release/claude-portal-launcher target/release/claude-portal-launcher-linux-x86_64
+          mv target/release/agent-launcher target/release/agent-launcher-linux-x86_64
 
       - name: Upload proxy artifact
         uses: actions/upload-artifact@v4
@@ -43,8 +43,8 @@ jobs:
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v4
         with:
-          name: claude-portal-launcher-linux-x86_64
-          path: target/release/claude-portal-launcher-linux-x86_64
+          name: agent-launcher-linux-x86_64
+          path: target/release/agent-launcher-linux-x86_64
 
   build-macos-arm64:
     name: Build (macOS ARM64)
@@ -64,17 +64,17 @@ jobs:
         run: cargo build -p claude-portal --release
 
       - name: Build launcher
-        run: cargo build -p claude-portal-launcher --release
+        run: cargo build -p agent-launcher --release
 
       - name: Ad-hoc code sign
         run: |
           codesign -s - target/release/claude-portal
-          codesign -s - target/release/claude-portal-launcher
+          codesign -s - target/release/agent-launcher
 
       - name: Rename binaries
         run: |
           mv target/release/claude-portal target/release/claude-portal-darwin-aarch64
-          mv target/release/claude-portal-launcher target/release/claude-portal-launcher-darwin-aarch64
+          mv target/release/agent-launcher target/release/agent-launcher-darwin-aarch64
 
       - name: Upload proxy artifact
         uses: actions/upload-artifact@v4
@@ -85,8 +85,8 @@ jobs:
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v4
         with:
-          name: claude-portal-launcher-darwin-aarch64
-          path: target/release/claude-portal-launcher-darwin-aarch64
+          name: agent-launcher-darwin-aarch64
+          path: target/release/agent-launcher-darwin-aarch64
 
   build-macos-intel:
     name: Build (macOS Intel)
@@ -108,17 +108,17 @@ jobs:
         run: cargo build -p claude-portal --release --target x86_64-apple-darwin
 
       - name: Build launcher (cross-compile for x86_64)
-        run: cargo build -p claude-portal-launcher --release --target x86_64-apple-darwin
+        run: cargo build -p agent-launcher --release --target x86_64-apple-darwin
 
       - name: Ad-hoc code sign
         run: |
           codesign -s - target/x86_64-apple-darwin/release/claude-portal
-          codesign -s - target/x86_64-apple-darwin/release/claude-portal-launcher
+          codesign -s - target/x86_64-apple-darwin/release/agent-launcher
 
       - name: Rename binaries
         run: |
           mv target/x86_64-apple-darwin/release/claude-portal target/x86_64-apple-darwin/release/claude-portal-darwin-x86_64
-          mv target/x86_64-apple-darwin/release/claude-portal-launcher target/x86_64-apple-darwin/release/claude-portal-launcher-darwin-x86_64
+          mv target/x86_64-apple-darwin/release/agent-launcher target/x86_64-apple-darwin/release/agent-launcher-darwin-x86_64
 
       - name: Upload proxy artifact
         uses: actions/upload-artifact@v4
@@ -129,8 +129,8 @@ jobs:
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v4
         with:
-          name: claude-portal-launcher-darwin-x86_64
-          path: target/x86_64-apple-darwin/release/claude-portal-launcher-darwin-x86_64
+          name: agent-launcher-darwin-x86_64
+          path: target/x86_64-apple-darwin/release/agent-launcher-darwin-x86_64
 
   build-windows:
     name: Build (Windows x86_64)
@@ -150,12 +150,12 @@ jobs:
         run: cargo build -p claude-portal --release
 
       - name: Build launcher
-        run: cargo build -p claude-portal-launcher --release
+        run: cargo build -p agent-launcher --release
 
       - name: Rename binaries
         run: |
           mv target/release/claude-portal.exe target/release/claude-portal-windows-x86_64.exe
-          mv target/release/claude-portal-launcher.exe target/release/claude-portal-launcher-windows-x86_64.exe
+          mv target/release/agent-launcher.exe target/release/agent-launcher-windows-x86_64.exe
 
       - name: Upload proxy artifact
         uses: actions/upload-artifact@v4
@@ -166,8 +166,8 @@ jobs:
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v4
         with:
-          name: claude-portal-launcher-windows-x86_64
-          path: target/release/claude-portal-launcher-windows-x86_64.exe
+          name: agent-launcher-windows-x86_64
+          path: target/release/agent-launcher-windows-x86_64.exe
 
   release:
     name: Create Release
@@ -190,12 +190,12 @@ jobs:
           mv binaries/claude-portal-darwin-aarch64/claude-portal-darwin-aarch64 release/
           mv binaries/claude-portal-darwin-x86_64/claude-portal-darwin-x86_64 release/
           mv binaries/claude-portal-windows-x86_64/claude-portal-windows-x86_64.exe release/
-          mv binaries/claude-portal-launcher-linux-x86_64/claude-portal-launcher-linux-x86_64 release/
-          mv binaries/claude-portal-launcher-darwin-aarch64/claude-portal-launcher-darwin-aarch64 release/
-          mv binaries/claude-portal-launcher-darwin-x86_64/claude-portal-launcher-darwin-x86_64 release/
-          mv binaries/claude-portal-launcher-windows-x86_64/claude-portal-launcher-windows-x86_64.exe release/
+          mv binaries/agent-launcher-linux-x86_64/agent-launcher-linux-x86_64 release/
+          mv binaries/agent-launcher-darwin-aarch64/agent-launcher-darwin-aarch64 release/
+          mv binaries/agent-launcher-darwin-x86_64/agent-launcher-darwin-x86_64 release/
+          mv binaries/agent-launcher-windows-x86_64/agent-launcher-windows-x86_64.exe release/
           chmod +x release/claude-portal-linux-x86_64 release/claude-portal-darwin-*
-          chmod +x release/claude-portal-launcher-linux-x86_64 release/claude-portal-launcher-darwin-*
+          chmod +x release/agent-launcher-linux-x86_64 release/agent-launcher-darwin-*
           ls -la release/
 
       - name: Delete existing latest release
@@ -225,22 +225,22 @@ jobs:
             | macOS (Intel) | `claude-portal-darwin-x86_64` |
             | Windows (x86_64) | `claude-portal-windows-x86_64.exe` |
 
-            ### Launcher (`claude-portal-launcher`)
+            ### Launcher (`agent-launcher`)
             | Platform | Binary |
             |----------|--------|
-            | Linux (x86_64) | `claude-portal-launcher-linux-x86_64` |
-            | macOS (Apple Silicon M1+) | `claude-portal-launcher-darwin-aarch64` |
-            | macOS (Intel) | `claude-portal-launcher-darwin-x86_64` |
-            | Windows (x86_64) | `claude-portal-launcher-windows-x86_64.exe` |
+            | Linux (x86_64) | `agent-launcher-linux-x86_64` |
+            | macOS (Apple Silicon M1+) | `agent-launcher-darwin-aarch64` |
+            | macOS (Intel) | `agent-launcher-darwin-x86_64` |
+            | Windows (x86_64) | `agent-launcher-windows-x86_64.exe` |
           files: |
             release/claude-portal-linux-x86_64
             release/claude-portal-darwin-aarch64
             release/claude-portal-darwin-x86_64
             release/claude-portal-windows-x86_64.exe
-            release/claude-portal-launcher-linux-x86_64
-            release/claude-portal-launcher-darwin-aarch64
-            release/claude-portal-launcher-darwin-x86_64
-            release/claude-portal-launcher-windows-x86_64.exe
+            release/agent-launcher-linux-x86_64
+            release/agent-launcher-darwin-aarch64
+            release/agent-launcher-darwin-x86_64
+            release/agent-launcher-windows-x86_64.exe
           prerelease: false
           make_latest: true
         env:

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -339,7 +339,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                 if launchers.is_empty() {
                     <p class="launch-no-launchers">
                         { "No launchers connected. Run " }
-                        <code>{ "claude-portal-launcher" }</code>
+                        <code>{ "agent-launcher" }</code>
                         { " on your machine." }
                     </p>
                 } else {

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "claude-portal-launcher"
+name = "agent-launcher"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 
 [[bin]]
-name = "claude-portal-launcher"
+name = "agent-launcher"
 path = "src/main.rs"
 
 [dependencies]

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use uuid::Uuid;
 
 #[derive(Parser, Debug)]
-#[command(name = "claude-portal-launcher")]
+#[command(name = "agent-launcher")]
 #[command(about = "Persistent daemon that launches claude-portal sessions as in-process tasks")]
 struct Args {
     /// Backend WebSocket URL (default: wss://txcl.io in release, ws://localhost:3000 in debug)
@@ -67,7 +67,7 @@ enum ServiceAction {
     Status,
 }
 
-const BINARY_PREFIX: &str = "claude-portal-launcher";
+const BINARY_PREFIX: &str = "agent-launcher";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/launcher/src/service.rs
+++ b/launcher/src/service.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 // --- Linux (systemd) ---
 
 #[cfg(target_os = "linux")]
-const SERVICE_NAME: &str = "claude-portal-launcher";
+const SERVICE_NAME: &str = "agent-launcher";
 
 #[cfg(target_os = "linux")]
 fn service_file_path() -> Result<std::path::PathBuf> {
@@ -18,7 +18,7 @@ fn service_file_path() -> Result<std::path::PathBuf> {
 fn generate_unit(binary_path: &str) -> String {
     format!(
         r#"[Unit]
-Description=Claude Portal Launcher
+Description=Agent Launcher
 After=network-online.target
 Wants=network-online.target
 
@@ -121,7 +121,7 @@ pub fn status() -> Result<()> {
 
     if !service_path.exists() {
         println!("Service is not installed.");
-        println!("  Run 'claude-portal-launcher service install' to set it up.");
+        println!("  Run 'agent-launcher service install' to set it up.");
         return Ok(());
     }
 
@@ -142,7 +142,7 @@ pub fn status() -> Result<()> {
 // --- macOS (launchd) ---
 
 #[cfg(target_os = "macos")]
-const PLIST_LABEL: &str = "com.claude-portal.launcher";
+const PLIST_LABEL: &str = "com.agent-portal.launcher";
 
 #[cfg(target_os = "macos")]
 fn plist_path() -> Result<std::path::PathBuf> {
@@ -175,9 +175,9 @@ fn generate_plist(binary_path: &str) -> String {
         <false/>
     </dict>
     <key>StandardOutPath</key>
-    <string>/tmp/claude-portal-launcher.stdout.log</string>
+    <string>/tmp/agent-launcher.stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/claude-portal-launcher.stderr.log</string>
+    <string>/tmp/agent-launcher.stderr.log</string>
     <key>ThrottleInterval</key>
     <integer>5</integer>
 </dict>
@@ -226,7 +226,7 @@ pub fn install() -> Result<()> {
     println!("Loaded {}", PLIST_LABEL);
     println!();
     println!("Launcher is installed and running.");
-    println!("  Logs: tail -f /tmp/claude-portal-launcher.stdout.log");
+    println!("  Logs: tail -f /tmp/agent-launcher.stdout.log");
 
     Ok(())
 }
@@ -263,7 +263,7 @@ pub fn status() -> Result<()> {
 
     if !plist.exists() {
         println!("Service is not installed.");
-        println!("  Run 'claude-portal-launcher service install' to set it up.");
+        println!("  Run 'agent-launcher service install' to set it up.");
         return Ok(());
     }
 
@@ -284,7 +284,7 @@ pub fn status() -> Result<()> {
         }
         println!();
         println!("Service is installed and running.");
-        println!("  Logs: tail -f /tmp/claude-portal-launcher.stdout.log");
+        println!("  Logs: tail -f /tmp/agent-launcher.stdout.log");
     }
 
     Ok(())

--- a/portal-update/src/lib.rs
+++ b/portal-update/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! On startup, checks if a newer version is available from GitHub releases
 //! and self-updates if necessary. Parameterized by binary name so both
-//! `claude-portal` and `claude-portal-launcher` can use it.
+//! `claude-portal` and `agent-launcher` can use it.
 
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
@@ -41,7 +41,7 @@ impl Platform {
     /// Detect the current platform for a given binary prefix.
     ///
     /// The `binary_prefix` is the base name of the binary (e.g. "claude-portal"
-    /// or "claude-portal-launcher"). The platform suffix is appended automatically.
+    /// or "agent-launcher"). The platform suffix is appended automatically.
     pub fn current(binary_prefix: &str) -> Self {
         let (os, arch) = if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
             ("linux", "x86_64")
@@ -98,7 +98,7 @@ fn sha256_hex(bytes: &[u8]) -> String {
 
 /// Check for updates from GitHub releases.
 ///
-/// `binary_prefix` is the base name (e.g. "claude-portal" or "claude-portal-launcher").
+/// `binary_prefix` is the base name (e.g. "claude-portal" or "agent-launcher").
 /// If `check_only` is true, reports availability without installing.
 pub async fn check_for_update(binary_prefix: &str, check_only: bool) -> Result<UpdateResult> {
     let self_path = std::env::current_exe().context("Failed to get current executable path")?;


### PR DESCRIPTION
## Summary
- Rename the launcher binary from `claude-portal-launcher` to `agent-launcher`
- Update crate name, CLI command name, service names, log paths, and CI/release workflows
- Update frontend UI text referencing the launcher binary
- Update portal-update doc comments

## Test plan
- [ ] `cargo build --workspace` succeeds
- [ ] All tests pass
- [ ] CI builds the launcher under the new binary name
- [ ] Release workflow produces `agent-launcher-*` artifacts