### PR TITLE
Increase proxy reconnect and heartbeat timeouts

### DIFF
--- a/claude-session-lib/src/heartbeat.rs
+++ b/claude-session-lib/src/heartbeat.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
-pub const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(5);
+pub const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Tracks heartbeat round-trip timing for dead connection detection.
 ///

--- a/claude-session-lib/src/proxy_session.rs
+++ b/claude-session-lib/src/proxy_session.rs
@@ -59,7 +59,7 @@ impl Backoff {
         Self {
             current: 1,
             initial: 1,
-            max: 2,
+            max: 30,
             multiplier: 2,
             stable_threshold: 30,
         }


### PR DESCRIPTION
## Summary
- Proxy reconnect max backoff: 2s → 30s (matches launcher backoff ceiling)
- Proxy heartbeat timeout: 5s → 15s (gives proxies more time before declaring connection dead)

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` passing
- [x] `cargo clippy --workspace` clean