### PR TITLE
Auto-delete tokens expired more than 7 days

### DIFF
--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -967,6 +967,9 @@ pub fn settings_page() -> Html {
                                     </tbody>
                                 </table>
                             </div>
+                            <p class="section-note">
+                                { "Credentials expired for more than 7 days are automatically deleted." }
+                            </p>
                         }
                     </section>
                 }


### PR DESCRIPTION
## Summary
- Deletes proxy auth tokens that have been expired for more than 7 days
- Runs as part of the existing hourly session age cleanup task
- Adds a note in the credentials settings UI: "Credentials expired for more than 7 days are automatically deleted."

## Test plan
- [ ] `cargo clippy --workspace` clean
- [ ] Verify note appears below the token table in settings