### PR TITLE
Add shim mode for VS Code extension bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A web portal that extends [Claude Code](https://docs.anthropic.com/en/docs/claud
 - **Persistent History**: All conversations stored and accessible across devices
 - **Flexible Authentication**: Configure for single-user, organization-only, or public access
 - **Real-time Sync**: Multiple viewers see updates instantly via WebSocket
+- **VS Code Integration**: Use Claude Code in VS Code while sessions appear on the portal dashboard
 
 ## Use Cases
 
@@ -84,6 +85,7 @@ The **portal** refers to the complete system: backend server, web frontend, and 
 | [Development Guide](docs/DEVELOPING.md) | Full dev workflow, building, testing, contributing |
 | [Deployment Guide](docs/DEPLOYING.md) | Production deployment, Google OAuth setup, configuration |
 | [Docker Guide](docs/DOCKER.md) | Docker and Kubernetes deployment with 1Password |
+| [VS Code Setup](docs/VSCODE_SETUP.md) | Use Claude Code in VS Code with portal integration |
 | [Troubleshooting](TROUBLESHOOTING.md) | Common issues and solutions |
 
 ## Platform Support

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -275,11 +275,7 @@ async fn main() -> anyhow::Result<()> {
         db_pool: pool.clone(),
         session_manager: session_manager.clone(),
         oauth_basic_client,
-        device_flow_store: if args.dev_mode {
-            None
-        } else {
-            Some(device_flow_store.clone())
-        },
+        device_flow_store: Some(device_flow_store.clone()),
         public_url: public_url.clone(),
         cookie_key,
         jwt_secret,

--- a/docs/PORTAL_SETUP.md
+++ b/docs/PORTAL_SETUP.md
@@ -1,0 +1,56 @@
+# Portal Setup — Local Development
+
+## Overview
+
+Two changes are needed to route VS Code Claude Code sessions through the portal:
+
+1. A shim script that wraps the `claude` binary
+2. A VS Code setting that points to the shim
+
+## Changes Made
+
+### 1. Shim Script
+
+**File**: `~/.claude/claude-portal-shim.sh`
+
+```bash
+#!/bin/bash
+exec claude-portal --shim --backend-url ws://localhost:3000 -- "$@"
+```
+
+This intercepts every VS Code Claude session and routes it through the portal proxy in `--shim` mode. Claude still works normally — the shim transparently tees output to the portal backend.
+
+### 2. VS Code Setting
+
+**File**: VS Code `settings.json` (global)
+
+```json
+"claudeCode.claudeProcessWrapper": "/path/to/.claude/claude-portal-shim.sh"
+```
+
+This tells the Claude Code extension to use the shim as a process wrapper when launching Claude. **Note**: the old setting name `claude-code.claudeBinaryPath` does not work — the correct setting is `claudeCode.claudeProcessWrapper`.
+
+## Starting the Portal
+
+```bash
+./scripts/up.sh
+```
+
+This starts Docker Desktop (if needed), PostgreSQL, runs migrations, builds the frontend, and starts the backend. The portal is then available at http://localhost:3000/.
+
+## How It Works
+
+```
+VS Code Extension
+    → launches claude-portal-shim.sh (instead of claude)
+    → claude-portal --shim spawns the real claude binary
+    → stdin/stdout pass through transparently to VS Code
+    → output is also forwarded to portal backend via WebSocket
+```
+
+If the portal backend is down, Claude still works normally in VS Code — the shim degrades gracefully.
+
+## Undoing These Changes
+
+1. Delete `~/.claude/claude-portal-shim.sh`
+2. Remove the `claudeCode.claudeProcessWrapper` line from VS Code settings

--- a/docs/VSCODE_SETUP.md
+++ b/docs/VSCODE_SETUP.md
@@ -1,0 +1,132 @@
+# VS Code Extension Setup
+
+Route Claude Code extension sessions through the portal so they appear on the dashboard.
+
+## Prerequisites
+
+- `claude-portal` binary installed (from [GitHub Releases](https://github.com/meawoppl/claude-code-portal/releases/latest) or built from source)
+- Portal backend running (locally or remotely)
+
+## Setup
+
+### 1. Authenticate (one-time per machine)
+
+Run from a terminal — the device flow requires interactive approval:
+
+```bash
+claude-portal --backend-url wss://your-portal-server.example.com
+```
+
+For local development:
+```bash
+claude-portal --backend-url ws://localhost:3000
+```
+
+This will:
+1. Display a verification URL
+2. Prompt you to visit the URL in your browser
+3. Show an approval page (auto-approved in dev mode)
+4. Store the auth token locally
+
+Once authenticated, all future sessions (terminal and VS Code) reuse the stored token.
+
+**Important**: The auth token is stored per-working-directory. The shim uses a cross-directory fallback, so authenticating from *any* directory is sufficient for VS Code sessions to work.
+
+**Config location on macOS**: `~/Library/Application Support/com.anthropic.claude-code-portal/config.json` (not `~/.config/`). The proxy uses the `directories` crate which follows OS-standard paths.
+
+### 2. Create the shim script
+
+```bash
+cat > ~/.claude/claude-portal-shim.sh << 'EOF'
+#!/bin/bash
+exec claude-portal --shim --backend-url wss://your-portal-server.example.com -- "$@"
+EOF
+chmod +x ~/.claude/claude-portal-shim.sh
+```
+
+For local development, use `ws://localhost:3000` instead.
+
+### 3. Configure VS Code
+
+Add to your VS Code `settings.json` (Cmd+Shift+P > "Open User Settings (JSON)"):
+
+```json
+"claudeCode.claudeProcessWrapper": "/Users/<you>/.claude/claude-portal-shim.sh"
+```
+
+### 4. Restart VS Code
+
+Cmd+Q and reopen. Claude sessions will now appear on the portal dashboard.
+
+## How It Works
+
+```
+VS Code Extension
+    -> launches claude-portal-shim.sh (instead of claude directly)
+    -> claude-portal --shim spawns the real claude binary
+    -> stdin/stdout pass through transparently to VS Code
+    -> output is also forwarded to portal backend via WebSocket
+```
+
+- Claude works exactly as before from VS Code's perspective
+- The shim is transparent — same stdin/stdout JSON protocol
+- All tracing/diagnostic output goes to stderr (never contaminates JSON on stdout)
+- If the portal backend is down, Claude still works (graceful degradation)
+
+### Authentication in shim mode
+
+The shim **never** triggers interactive device flow authentication. This is by design — the device flow requires a browser and would block Claude from starting.
+
+Instead, the shim resolves auth in this order:
+1. Cached token for the current working directory
+2. **Cross-directory fallback**: most recently used token from any directory
+3. No token (session may still register in dev mode)
+
+If no cached token is found, the shim logs a warning to stderr and continues without portal auth. To fix, run the interactive auth from a terminal (Step 1 above).
+
+## Troubleshooting
+
+### "CLI output was not valid JSON"
+
+The portal binary is printing non-JSON to stdout. Ensure you have the latest binary with tracing directed to stderr:
+
+```bash
+# Rebuild from source
+cd /path/to/claude-code-portal
+cargo build --release -p claude-portal
+cp target/release/claude-portal ~/.claude/claude-portal
+```
+
+### "Claude Code process exited with code 1"
+
+The shim crashed before launching claude. Common causes:
+
+| Cause | Fix |
+|-------|-----|
+| Auth failed | Run `claude-portal --backend-url wss://your-server` in a terminal to authenticate interactively |
+| Backend unreachable | Check that the portal server is running |
+
+### Session not showing on dashboard
+
+The shim launched claude but couldn't register with the portal. Check:
+
+1. **Auth token exists**: Check the config file for `auth_token` entries:
+   - macOS: `cat ~/Library/Application\ Support/com.anthropic.claude-code-portal/config.json`
+   - Linux: `cat ~/.config/claude-code-portal/config.json`
+2. **Backend is reachable**: `curl https://your-portal-server/` should return HTML
+3. **WebSocket connects**: Check stderr output (visible in VS Code output panel > Claude Code)
+
+If no auth token, run the interactive auth from a terminal (Step 1 above).
+
+## Removing the Integration
+
+1. Remove the shim setting from VS Code:
+   ```
+   Delete "claudeCode.claudeProcessWrapper" from settings.json
+   ```
+2. Optionally delete the shim script:
+   ```bash
+   rm ~/.claude/claude-portal-shim.sh
+   ```
+
+Claude will launch directly without the portal.

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -222,6 +222,15 @@ impl ProxyConfig {
         self.sessions.get(working_dir)
     }
 
+    /// Find any valid cached auth token, regardless of working directory.
+    /// Returns the most recently used token. Used by shim mode as a fallback
+    /// when no token exists for the current working directory.
+    pub fn get_any_session_auth(&self) -> Option<&SessionAuth> {
+        self.sessions
+            .values()
+            .max_by(|a, b| a.last_used.cmp(&b.last_used))
+    }
+
     pub fn set_session_auth(&mut self, working_dir: String, auth: SessionAuth) {
         self.sessions.insert(working_dir, auth);
     }

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -1,1 +1,356 @@
+// Re-export library types used by main.rs and shim.rs
 pub use claude_session_lib::proxy_session::*;
+
+// ---------------------------------------------------------------------------
+// Raw tokio-tungstenite helpers for shim mode.
+//
+// The shim manages its own WebSocket connection independently of the library's
+// ws_bridge-based connection loop. These types and functions provide low-level
+// WS primitives that the shim needs.
+// ---------------------------------------------------------------------------
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt, StreamExt};
+use shared::{ProxyToServer, SendMode, ServerToProxy};
+use tokio::sync::mpsc;
+use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
+use tracing::{debug, error, info, warn};
+
+/// Raw tokio-tungstenite WebSocket stream type.
+pub type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// Shared write half for concurrent WebSocket sends (raw).
+pub type SharedWsWrite = Arc<tokio::sync::Mutex<SplitSink<WsStream, Message>>>;
+
+/// WebSocket connection wrapper (raw tokio-tungstenite).
+pub struct WebSocketConnection {
+    write: SplitSink<WsStream, Message>,
+    read: SplitStream<WsStream>,
+}
+
+impl WebSocketConnection {
+    pub fn new(stream: WsStream) -> Self {
+        let (write, read) = stream.split();
+        Self { write, read }
+    }
+
+    /// Send a serializable message as JSON text.
+    pub async fn send<T: serde::Serialize>(&mut self, msg: &T) -> Result<(), String> {
+        let json = serde_json::to_string(msg).map_err(|e| e.to_string())?;
+        self.write
+            .send(Message::Text(json))
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    /// Receive the next raw WebSocket message.
+    pub async fn recv(&mut self) -> Option<Result<Message, tokio_tungstenite::tungstenite::Error>> {
+        self.read.next().await
+    }
+
+    /// Split into write and read halves for concurrent use.
+    pub fn split(self) -> (SplitSink<WsStream, Message>, SplitStream<WsStream>) {
+        (self.write, self.read)
+    }
+}
+
+/// Connect to the backend WebSocket (raw, no TUI output).
+pub async fn connect_ws(backend_url: &str) -> Result<WebSocketConnection, Duration> {
+    let ws_url = format!("{}/ws/session", backend_url);
+
+    match connect_async(&ws_url).await {
+        Ok((stream, _)) => {
+            info!("Connected to backend");
+            Ok(WebSocketConnection::new(stream))
+        }
+        Err(e) => {
+            error!("Failed to connect to backend: {}", e);
+            Err(Duration::ZERO)
+        }
+    }
+}
+
+/// Register session with the backend and wait for acknowledgment (raw WS).
+///
+/// Returns `Ok(())` on success, `Err((Duration, Option<String>))` on failure.
+pub async fn register_with_backend(
+    conn: &mut WebSocketConnection,
+    config: &ProxySessionConfig,
+) -> Result<(), (Duration, Option<String>)> {
+    let hostname = hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let register_msg = ProxyToServer::Register {
+        session_id: config.session_id,
+        session_name: config.session_name.clone(),
+        auth_token: config.auth_token.clone(),
+        working_directory: config.working_directory.clone(),
+        resuming: config.resume,
+        git_branch: config.git_branch.clone(),
+        replay_after: None,
+        client_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        replaces_session_id: config.replaces_session_id,
+        hostname: Some(hostname),
+        launcher_id: config.launcher_id,
+        agent_type: config.agent_type,
+    };
+
+    if let Err(e) = conn.send(&register_msg).await {
+        error!("Failed to send registration message: {}", e);
+        return Err((Duration::ZERO, Some(e)));
+    }
+
+    // Wait for RegisterAck with timeout
+    let ack_timeout = tokio::time::timeout(Duration::from_secs(10), async {
+        while let Some(msg) = conn.recv().await {
+            match msg {
+                Ok(Message::Text(text)) => {
+                    if let Ok(ServerToProxy::RegisterAck {
+                        success,
+                        session_id: _,
+                        error,
+                    }) = serde_json::from_str::<ServerToProxy>(&text)
+                    {
+                        return Some((success, error));
+                    }
+                }
+                Ok(Message::Close(_)) => return None,
+                Err(_) => return None,
+                _ => continue,
+            }
+        }
+        None
+    })
+    .await;
+
+    match ack_timeout {
+        Ok(Some((true, _))) => {
+            info!("Session registered successfully");
+            Ok(())
+        }
+        Ok(Some((false, error))) => {
+            let err_msg = error.clone().unwrap_or_else(|| "Unknown error".to_string());
+            error!("Registration failed: {}", err_msg);
+            Err((Duration::ZERO, error))
+        }
+        Ok(None) => {
+            error!("Connection closed during registration");
+            Err((Duration::ZERO, None))
+        }
+        Err(_) => {
+            info!(
+                "No RegisterAck received (timeout), assuming success for backwards compatibility"
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Get the current git branch name, if in a git repository.
+pub fn get_git_branch(cwd: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let branch = String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
+
+    if branch == "HEAD" {
+        std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .current_dir(cwd)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| format!("detached:{}", s.trim()))
+    } else {
+        Some(branch)
+    }
+}
+
+/// Result from handling a raw WebSocket text message.
+pub enum WsMessageResult {
+    Continue,
+    Disconnect,
+    GracefulShutdown(u64),
+}
+
+/// Spawn a WebSocket reader task (raw tokio-tungstenite).
+///
+/// Reads raw WS text messages, parses them as `ServerToProxy`, and dispatches
+/// to typed channels for the shim's select loop.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_ws_reader(
+    mut ws_read: SplitStream<WsStream>,
+    input_tx: mpsc::UnboundedSender<String>,
+    perm_tx: mpsc::UnboundedSender<PermissionResponseData>,
+    ack_tx: mpsc::UnboundedSender<u64>,
+    ws_write: SharedWsWrite,
+    disconnect_tx: tokio::sync::oneshot::Sender<()>,
+    wiggum_tx: mpsc::UnboundedSender<String>,
+    graceful_shutdown_tx: mpsc::UnboundedSender<GracefulShutdown>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(msg) = ws_read.next().await {
+            match msg {
+                Ok(Message::Text(text)) => {
+                    match handle_ws_text_message(
+                        &text, &input_tx, &perm_tx, &ack_tx, &ws_write, &wiggum_tx,
+                    )
+                    .await
+                    {
+                        WsMessageResult::Continue => {}
+                        WsMessageResult::Disconnect => break,
+                        WsMessageResult::GracefulShutdown(delay_ms) => {
+                            let _ = graceful_shutdown_tx.send(GracefulShutdown {
+                                reconnect_delay_ms: delay_ms,
+                            });
+                            break;
+                        }
+                    }
+                }
+                Ok(Message::Close(_)) => {
+                    info!("WebSocket closed by server");
+                    break;
+                }
+                Err(e) => {
+                    error!("WebSocket error: {}", e);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        debug!("WebSocket reader ended");
+        let _ = disconnect_tx.send(());
+    })
+}
+
+/// Handle a raw text message from the WebSocket.
+async fn handle_ws_text_message(
+    text: &str,
+    input_tx: &mpsc::UnboundedSender<String>,
+    perm_tx: &mpsc::UnboundedSender<PermissionResponseData>,
+    ack_tx: &mpsc::UnboundedSender<u64>,
+    ws_write: &SharedWsWrite,
+    wiggum_tx: &mpsc::UnboundedSender<String>,
+) -> WsMessageResult {
+    let server_msg = match serde_json::from_str::<ServerToProxy>(text) {
+        Ok(msg) => msg,
+        Err(_) => return WsMessageResult::Continue,
+    };
+
+    match server_msg {
+        ServerToProxy::ClaudeInput { content, send_mode } => {
+            let user_text = match &content {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+
+            if send_mode == Some(SendMode::Wiggum) {
+                if wiggum_tx.send(user_text).is_err() {
+                    error!("Failed to send wiggum activation");
+                    return WsMessageResult::Disconnect;
+                }
+            } else if input_tx.send(user_text).is_err() {
+                error!("Failed to send input to channel");
+                return WsMessageResult::Disconnect;
+            }
+        }
+        ServerToProxy::SequencedInput {
+            session_id,
+            seq,
+            content,
+            send_mode,
+        } => {
+            let user_text = match &content {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+
+            if send_mode == Some(SendMode::Wiggum) {
+                if wiggum_tx.send(user_text).is_err() {
+                    error!("Failed to send wiggum activation");
+                    return WsMessageResult::Disconnect;
+                }
+            } else if input_tx.send(user_text).is_err() {
+                error!("Failed to send input to channel");
+                return WsMessageResult::Disconnect;
+            }
+
+            // Send InputAck back to backend
+            let ack = ProxyToServer::InputAck {
+                session_id,
+                ack_seq: seq,
+            };
+            let mut ws = ws_write.lock().await;
+            if let Ok(json) = serde_json::to_string(&ack) {
+                if let Err(e) = ws.send(Message::Text(json)).await {
+                    error!("Failed to send InputAck: {}", e);
+                }
+            }
+        }
+        ServerToProxy::PermissionResponse {
+            request_id,
+            allow,
+            input,
+            permissions,
+            reason,
+        } => {
+            if perm_tx
+                .send(PermissionResponseData {
+                    request_id,
+                    allow,
+                    input,
+                    permissions,
+                    reason,
+                })
+                .is_err()
+            {
+                error!("Failed to send permission response to channel");
+                return WsMessageResult::Disconnect;
+            }
+        }
+        ServerToProxy::OutputAck {
+            session_id: _,
+            ack_seq,
+        } => {
+            if ack_tx.send(ack_seq).is_err() {
+                error!("Failed to send output ack to channel");
+                return WsMessageResult::Disconnect;
+            }
+        }
+        ServerToProxy::Heartbeat => {
+            let mut ws = ws_write.lock().await;
+            if let Ok(json) = serde_json::to_string(&ProxyToServer::Heartbeat) {
+                let _ = ws.send(Message::Text(json)).await;
+            }
+        }
+        ServerToProxy::ServerShutdown {
+            reason,
+            reconnect_delay_ms,
+        } => {
+            warn!(
+                "Server shutting down: {} (reconnecting in {}ms)",
+                reason, reconnect_delay_ms
+            );
+            return WsMessageResult::GracefulShutdown(reconnect_delay_ms);
+        }
+        _ => {}
+    }
+
+    WsMessageResult::Continue
+}

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -1,0 +1,710 @@
+//! Shim mode: transparent proxy between a parent process (e.g., VS Code) and Claude.
+//!
+//! In shim mode, the proxy acts as a stdin/stdout bridge. All claude output is
+//! forwarded to stdout (for the parent process) while also being sent to the
+//! portal backend via WebSocket. Input from both stdin and the portal web UI
+//! reaches claude's stdin. This enables VS Code extension sessions to appear
+//! in the portal dashboard.
+//!
+//! All diagnostic output goes to stderr only — stdout is reserved for claude I/O.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::session::{
+    connect_ws, get_git_branch, register_with_backend, Backoff, GracefulShutdown,
+    PermissionResponseData, ProxySessionConfig, SharedWsWrite,
+};
+use anyhow::Result;
+use claude_codes::io::{
+    ControlRequestPayload, ControlResponse, ControlResponseMessage, PermissionResult,
+};
+use claude_codes::{ClaudeInput, ClaudeOutput};
+use claude_session_lib::output_buffer::PendingOutputBuffer;
+use futures_util::SinkExt;
+use shared::ProxyToServer;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::{mpsc, Mutex};
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{debug, error, info, warn};
+
+/// Permission tracking for deduplication between VS Code and portal responses.
+#[derive(Debug)]
+enum PermissionState {
+    /// Waiting for a response from either source.
+    Pending,
+    /// Already answered — ignore duplicate responses.
+    Answered,
+}
+
+/// Run the shim: spawn claude, bridge stdin/stdout, connect to portal.
+///
+/// This function calls `std::process::exit` with claude's exit code when claude exits,
+/// so it effectively never returns normally.
+pub async fn run_shim(config: ProxySessionConfig) -> Result<()> {
+    info!("Starting shim mode");
+
+    // Spawn claude binary with the same flags as claude-session-lib
+    let mut child = spawn_claude(&config)?;
+
+    let claude_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("Failed to capture claude stdin"))?;
+    let claude_stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("Failed to capture claude stdout"))?;
+    let claude_stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("Failed to capture claude stderr"))?;
+
+    // Shared handle to claude's stdin (both VS Code input and portal input write here)
+    let claude_stdin = Arc::new(Mutex::new(claude_stdin));
+
+    // Permission dedup state
+    let permissions: Arc<Mutex<HashMap<String, PermissionState>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+
+    // Pipe claude's stderr to our stderr
+    let stderr_task = tokio::spawn(async move {
+        let mut reader = BufReader::new(claude_stderr).lines();
+        while let Ok(Some(line)) = reader.next_line().await {
+            eprintln!("{}", line);
+        }
+    });
+
+    // Output buffer for reliable delivery to portal
+    let output_buffer = Arc::new(Mutex::new(
+        PendingOutputBuffer::new(config.session_id)
+            .unwrap_or_else(|_| PendingOutputBuffer::new(config.session_id).unwrap()),
+    ));
+
+    // Channel for portal-sent message texts (for user echo dedup in VS Code).
+    // The sender is used in the WS connection loop; the receiver lives in the
+    // stdout reader task where it's drained synchronously via try_recv() — no
+    // async Mutex in the hot path.
+    let (portal_text_tx, portal_text_rx) = mpsc::unbounded_channel::<String>();
+
+    // On resume, don't filter user echoes until first stdin input arrives.
+    // During resume replay, Claude re-emits all past user messages and VS Code needs them.
+    let filtering_active = Arc::new(AtomicBool::new(!config.resume));
+
+    // Run the connection loop (reconnects automatically)
+    run_shim_loop(
+        &config,
+        claude_stdout,
+        claude_stdin,
+        permissions,
+        output_buffer,
+        portal_text_tx,
+        portal_text_rx,
+        filtering_active,
+    )
+    .await;
+
+    // Wait for claude to finish and exit with its exit code
+    let code = match child.wait().await {
+        Ok(status) => status.code().unwrap_or(1),
+        Err(e) => {
+            error!("Failed to wait for claude: {}", e);
+            1
+        }
+    };
+
+    stderr_task.abort();
+    info!("Claude exited with code {}", code);
+    std::process::exit(code);
+}
+
+/// Spawn the claude binary with piped stdin/stdout/stderr.
+fn spawn_claude(config: &ProxySessionConfig) -> Result<tokio::process::Child> {
+    let mut cmd = Command::new("claude");
+    cmd.arg("--print")
+        .arg("--verbose")
+        .arg("--output-format")
+        .arg("stream-json")
+        .arg("--input-format")
+        .arg("stream-json")
+        .arg("--permission-prompt-tool")
+        .arg("stdio")
+        .arg("--replay-user-messages");
+
+    if config.resume {
+        cmd.arg("--resume").arg(config.session_id.to_string());
+    } else {
+        cmd.arg("--session-id").arg(config.session_id.to_string());
+    }
+
+    for arg in &config.claude_args {
+        cmd.arg(arg);
+    }
+
+    cmd.current_dir(&config.working_directory);
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    info!(
+        "Spawning claude in shim mode (session={}, resume={})",
+        config.session_id, config.resume
+    );
+
+    cmd.spawn()
+        .map_err(|e| anyhow::anyhow!("Failed to spawn claude: {}", e))
+}
+
+/// Main shim loop with WebSocket reconnection.
+///
+/// Reads claude's stdout and forwards to both our stdout and the portal backend.
+/// Reads our stdin and portal WebSocket input, forwards both to claude's stdin.
+#[allow(clippy::too_many_arguments)]
+async fn run_shim_loop(
+    config: &ProxySessionConfig,
+    claude_stdout: tokio::process::ChildStdout,
+    claude_stdin: Arc<Mutex<tokio::process::ChildStdin>>,
+    permissions: Arc<Mutex<HashMap<String, PermissionState>>>,
+    output_buffer: Arc<Mutex<PendingOutputBuffer>>,
+    portal_text_tx: mpsc::UnboundedSender<String>,
+    portal_text_rx: mpsc::UnboundedReceiver<String>,
+    filtering_active: Arc<AtomicBool>,
+) {
+    let mut backoff = Backoff::new();
+    let mut first_connection = true;
+    let mut claude_stdout_reader = BufReader::new(claude_stdout).lines();
+
+    // Channel for sequenced outputs to send to portal (seq assigned at buffer push time)
+    let (output_line_tx, mut output_line_rx) =
+        mpsc::unbounded_channel::<(u64, serde_json::Value)>();
+
+    // Channel for permission requests extracted from claude stdout
+    let (perm_request_tx, mut perm_request_rx) = mpsc::unbounded_channel::<ProxyToServer>();
+
+    // Our stdout handle (for forwarding to VS Code)
+    let our_stdout = Arc::new(Mutex::new(tokio::io::stdout()));
+
+    // Our stdin (from VS Code)
+    let own_stdin = tokio::io::stdin();
+    let mut own_stdin_reader = BufReader::new(own_stdin).lines();
+
+    // Read claude stdout and forward to our stdout + output channel
+    // This runs independently of the WebSocket connection
+    let output_buffer_for_reader = output_buffer.clone();
+    let our_stdout_for_reader = our_stdout.clone();
+    let permissions_for_reader = permissions.clone();
+    let filtering_for_reader = filtering_active.clone();
+
+    // Claude stdout reader task: reads lines, forwards to stdout and queues for portal.
+    //
+    // User echo dedup: when --replay-user-messages is active, Claude echoes every user
+    // message back on stdout. VS Code already displays what the user typed, so these
+    // echoes create duplicates. We filter them out UNLESS the message came from the
+    // portal (which VS Code doesn't know about and needs to see).
+    //
+    // Portal-sent texts arrive via channel (try_recv, non-blocking) to avoid any
+    // async Mutex in this hot path.
+    let stdout_reader_task = tokio::spawn(async move {
+        let mut portal_text_rx = portal_text_rx;
+        let mut portal_texts: Vec<String> = Vec::new();
+
+        while let Ok(Some(line)) = claude_stdout_reader.next_line().await {
+            // Drain any new portal-sent texts (non-blocking, no Mutex)
+            while let Ok(text) = portal_text_rx.try_recv() {
+                portal_texts.push(text);
+            }
+
+            let parsed = serde_json::from_str::<serde_json::Value>(&line).ok();
+
+            // Decide if this line should go to VS Code stdout.
+            // All non-user messages always go through. For user echoes, check
+            // if it came from the portal (tracked text match) or from VS Code (filter it).
+            let forward_to_vscode = match &parsed {
+                Some(value) if value.get("type").and_then(|t| t.as_str()) == Some("user") => {
+                    if !filtering_for_reader.load(Ordering::Relaxed) {
+                        // Resume replay phase — forward all user echoes
+                        true
+                    } else {
+                        // Check if this echo is from a portal-sent message
+                        match extract_user_text(value) {
+                            Some(ref text) => {
+                                if let Some(pos) = portal_texts.iter().position(|t| t == text) {
+                                    portal_texts.remove(pos);
+                                    true // Portal message — VS Code needs to see it
+                                } else {
+                                    false // Local echo — VS Code already has it
+                                }
+                            }
+                            None => true, // Can't extract text — forward to be safe
+                        }
+                    }
+                }
+                _ => true, // Non-user or non-JSON: always forward
+            };
+
+            // Forward to VS Code stdout (when appropriate)
+            if forward_to_vscode {
+                let mut stdout = our_stdout_for_reader.lock().await;
+                if let Err(e) = stdout.write_all(line.as_bytes()).await {
+                    error!("Failed to write to stdout: {}", e);
+                    break;
+                }
+                if let Err(e) = stdout.write_all(b"\n").await {
+                    error!("Failed to write newline to stdout: {}", e);
+                    break;
+                }
+                let _ = stdout.flush().await;
+            }
+
+            // Parse for portal forwarding (independent of VS Code decision)
+            if let Some(value) = parsed {
+                let msg_type = value.get("type").and_then(|t| t.as_str());
+
+                // Skip protocol noise that the portal doesn't need
+                if matches!(msg_type, Some("stream_event") | Some("control_response")) {
+                    continue;
+                }
+
+                // Send control_request (can_use_tool) as a typed PermissionRequest
+                // so the portal shows an interactive approval dialog
+                if msg_type == Some("control_request") {
+                    if let Ok(ClaudeOutput::ControlRequest(req)) =
+                        serde_json::from_value::<ClaudeOutput>(value.clone())
+                    {
+                        let mut perms = permissions_for_reader.lock().await;
+                        perms.insert(req.request_id.clone(), PermissionState::Pending);
+                        debug!("Tracking permission request: {}", req.request_id);
+
+                        if let ControlRequestPayload::CanUseTool(tool_req) = req.request {
+                            let _ = perm_request_tx.send(ProxyToServer::PermissionRequest {
+                                request_id: req.request_id,
+                                tool_name: tool_req.tool_name,
+                                input: tool_req.input,
+                                permission_suggestions: tool_req.permission_suggestions,
+                            });
+                            continue;
+                        }
+                    }
+                    // Non-can_use_tool control requests (hooks, mcp, init) — skip
+                    continue;
+                }
+
+                // Buffer regular output for portal delivery (seq assigned here)
+                let seq = {
+                    let mut buf = output_buffer_for_reader.lock().await;
+                    buf.push(value.clone())
+                };
+                let _ = output_line_tx.send((seq, value));
+            }
+        }
+        info!("Claude stdout ended");
+    });
+
+    // Stdin reader task: reads VS Code input, forwards to claude + tracks permissions
+    let claude_stdin_for_reader = claude_stdin.clone();
+    let permissions_for_stdin = permissions.clone();
+    let filtering_for_stdin = filtering_active.clone();
+    let (stdin_line_tx, mut stdin_line_rx) = mpsc::unbounded_channel::<String>();
+
+    let stdin_reader_task = tokio::spawn(async move {
+        while let Ok(Some(line)) = own_stdin_reader.next_line().await {
+            // Activate user echo filtering after first stdin input.
+            // On resume, this marks the end of the replay phase.
+            filtering_for_stdin.store(true, Ordering::Relaxed);
+            // Check if this is a permission response from VS Code (for dedup tracking)
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) {
+                if value.get("type").and_then(|t| t.as_str()) == Some("control_response") {
+                    if let Some(request_id) = value.get("request_id").and_then(|r| r.as_str()) {
+                        let mut perms = permissions_for_stdin.lock().await;
+                        if let Some(state) = perms.get_mut(request_id) {
+                            if matches!(state, PermissionState::Pending) {
+                                *state = PermissionState::Answered;
+                                debug!("Permission {} answered by VS Code (stdin)", request_id);
+                            } else {
+                                // Already answered by portal — still forward to claude
+                                // (claude handles duplicate gracefully)
+                                debug!(
+                                    "Permission {} already answered, forwarding anyway",
+                                    request_id
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Always forward stdin to claude (transparency)
+            let mut stdin = claude_stdin_for_reader.lock().await;
+            if let Err(e) = stdin.write_all(line.as_bytes()).await {
+                error!("Failed to write to claude stdin: {}", e);
+                break;
+            }
+            if let Err(e) = stdin.write_all(b"\n").await {
+                error!("Failed to write newline to claude stdin: {}", e);
+                break;
+            }
+            let _ = stdin.flush().await;
+
+            // Also notify the WS loop (for input forwarding to portal if needed)
+            let _ = stdin_line_tx.send(line);
+        }
+        info!("Own stdin ended (parent process disconnected)");
+    });
+
+    // WebSocket connection loop with reconnection
+    loop {
+        // Connect to portal backend
+        let conn = match connect_ws(&config.backend_url).await {
+            Ok(conn) => {
+                if !first_connection {
+                    info!("Reconnected to portal backend");
+                }
+                backoff.reset();
+                conn
+            }
+            Err(_) => {
+                if first_connection {
+                    info!("Portal backend unreachable, continuing without portal");
+                } else {
+                    warn!(
+                        "Failed to reconnect, retrying in {}s",
+                        backoff.current_secs()
+                    );
+                }
+                tokio::time::sleep(backoff.sleep_duration()).await;
+                backoff.advance();
+                first_connection = false;
+                continue;
+            }
+        };
+
+        // Register session
+        let mut conn = conn;
+        let config_with_branch = ProxySessionConfig {
+            git_branch: get_git_branch(&config.working_directory),
+            ..config.clone()
+        };
+
+        if let Err((_, err)) = register_with_backend(&mut conn, &config_with_branch).await {
+            warn!(
+                "Registration failed: {}, retrying in {}s",
+                err.as_deref().unwrap_or("unknown"),
+                backoff.current_secs()
+            );
+            tokio::time::sleep(backoff.sleep_duration()).await;
+            backoff.advance();
+            first_connection = false;
+            continue;
+        }
+
+        first_connection = false;
+
+        // Replay pending messages
+        {
+            let buf = output_buffer.lock().await;
+            let pending = buf.pending_count();
+            if pending > 0 {
+                info!("Replaying {} pending messages", pending);
+                for p in buf.get_pending() {
+                    let msg = ProxyToServer::SequencedOutput {
+                        seq: p.seq,
+                        content: p.content.clone(),
+                    };
+                    if let Err(e) = conn.send(&msg).await {
+                        error!("Failed to replay: {}", e);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Run message loop for this connection
+        let connection_start = Instant::now();
+        let result = run_shim_connection(
+            config,
+            conn,
+            &mut output_line_rx,
+            &mut perm_request_rx,
+            &mut stdin_line_rx,
+            claude_stdin.clone(),
+            permissions.clone(),
+            output_buffer.clone(),
+            portal_text_tx.clone(),
+        )
+        .await;
+
+        // Persist buffer on disconnect
+        if let Err(e) = output_buffer.lock().await.persist() {
+            warn!("Failed to persist buffer: {}", e);
+        }
+
+        match result {
+            ShimConnectionResult::ClaudeExited => {
+                info!("Claude exited, shutting down shim");
+                stdout_reader_task.abort();
+                stdin_reader_task.abort();
+                return;
+            }
+            ShimConnectionResult::Disconnected => {
+                backoff.reset_if_stable(connection_start.elapsed());
+                let pending = output_buffer.lock().await.pending_count();
+                warn!(
+                    "Portal disconnected, {} pending messages, reconnecting in {}s",
+                    pending,
+                    backoff.current_secs()
+                );
+                tokio::time::sleep(backoff.sleep_duration()).await;
+                backoff.advance();
+            }
+            ShimConnectionResult::ServerShutdown(delay) => {
+                backoff.reset();
+                info!(
+                    "Server shutting down, reconnecting in {}ms",
+                    delay.as_millis()
+                );
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
+
+enum ShimConnectionResult {
+    ClaudeExited,
+    Disconnected,
+    ServerShutdown(Duration),
+}
+
+/// Run the message loop for a single WebSocket connection.
+#[allow(clippy::too_many_arguments)]
+async fn run_shim_connection(
+    config: &ProxySessionConfig,
+    conn: crate::session::WebSocketConnection,
+    output_line_rx: &mut mpsc::UnboundedReceiver<(u64, serde_json::Value)>,
+    perm_request_rx: &mut mpsc::UnboundedReceiver<ProxyToServer>,
+    stdin_line_rx: &mut mpsc::UnboundedReceiver<String>,
+    claude_stdin: Arc<Mutex<tokio::process::ChildStdin>>,
+    permissions: Arc<Mutex<HashMap<String, PermissionState>>>,
+    output_buffer: Arc<Mutex<PendingOutputBuffer>>,
+    portal_text_tx: mpsc::UnboundedSender<String>,
+) -> ShimConnectionResult {
+    let (ws_write, ws_read) = conn.split();
+    let ws_write: SharedWsWrite = Arc::new(Mutex::new(ws_write));
+
+    // Channels for WS reader dispatching
+    let (input_tx, mut input_rx) = mpsc::unbounded_channel::<String>();
+    let (perm_tx, mut perm_rx) = mpsc::unbounded_channel::<PermissionResponseData>();
+    let (ack_tx, mut ack_rx) = mpsc::unbounded_channel::<u64>();
+    let (wiggum_tx, mut wiggum_rx) = mpsc::unbounded_channel::<String>();
+    let (graceful_shutdown_tx, mut graceful_shutdown_rx) =
+        mpsc::unbounded_channel::<GracefulShutdown>();
+    let (disconnect_tx, mut disconnect_rx) = tokio::sync::oneshot::channel::<()>();
+
+    // Reuse the existing WS reader (parses portal messages into typed channels)
+    let reader_task = crate::session::spawn_ws_reader(
+        ws_read,
+        input_tx,
+        perm_tx,
+        ack_tx,
+        ws_write.clone(),
+        disconnect_tx,
+        wiggum_tx,
+        graceful_shutdown_tx,
+    );
+
+    // Main select loop
+    let result = loop {
+        tokio::select! {
+            // Portal disconnected
+            _ = &mut disconnect_rx => {
+                info!("Portal WebSocket disconnected");
+                break ShimConnectionResult::Disconnected;
+            }
+
+            // Server graceful shutdown
+            Some(shutdown) = graceful_shutdown_rx.recv() => {
+                break ShimConnectionResult::ServerShutdown(
+                    Duration::from_millis(shutdown.reconnect_delay_ms)
+                );
+            }
+
+            // Claude output ready to send to portal (seq was assigned at buffer push time)
+            Some((seq, content)) = output_line_rx.recv() => {
+                let msg = ProxyToServer::SequencedOutput { seq, content };
+                let mut ws = ws_write.lock().await;
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    if let Err(e) = ws.send(Message::Text(json)).await {
+                        error!("Failed to send output to portal: {}", e);
+                        break ShimConnectionResult::Disconnected;
+                    }
+                }
+            }
+
+            // Permission request from claude → send as typed PermissionRequest
+            Some(perm_msg) = perm_request_rx.recv() => {
+                let mut ws = ws_write.lock().await;
+                if let Ok(json) = serde_json::to_string(&perm_msg) {
+                    if let Err(e) = ws.send(Message::Text(json)).await {
+                        error!("Failed to send permission request to portal: {}", e);
+                        break ShimConnectionResult::Disconnected;
+                    }
+                }
+            }
+
+            // Text input from portal web UI
+            Some(text) = input_rx.recv() => {
+                debug!("Portal input: {}", &text[..text.len().min(80)]);
+                // Track for user echo dedup — stdout reader will match and forward to VS Code
+                let _ = portal_text_tx.send(text.clone());
+                let mut stdin = claude_stdin.lock().await;
+                // Build a proper ClaudeInput::User message (same format the normal proxy uses)
+                let input = ClaudeInput::user_message(&text, config.session_id);
+                if let Ok(json_line) = serde_json::to_string(&input) {
+                    if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
+                        error!("Failed to write portal input to claude: {}", e);
+                        break ShimConnectionResult::ClaudeExited;
+                    }
+                    let _ = stdin.write_all(b"\n").await;
+                    let _ = stdin.flush().await;
+                }
+            }
+
+            // Wiggum mode from portal
+            Some(prompt) = wiggum_rx.recv() => {
+                debug!("Portal wiggum input: {}", &prompt[..prompt.len().min(60)]);
+                let wiggum_prompt = format!(
+                    "{}\n\nTake action on the directions above until fully complete. If complete, respond only with DONE.",
+                    prompt
+                );
+                // Track the full wiggum text for user echo dedup
+                let _ = portal_text_tx.send(wiggum_prompt.clone());
+                let mut stdin = claude_stdin.lock().await;
+                let input = ClaudeInput::user_message(&wiggum_prompt, config.session_id);
+                if let Ok(json_line) = serde_json::to_string(&input) {
+                    if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
+                        error!("Failed to write wiggum input to claude: {}", e);
+                        break ShimConnectionResult::ClaudeExited;
+                    }
+                    let _ = stdin.write_all(b"\n").await;
+                    let _ = stdin.flush().await;
+                }
+            }
+
+            // Permission response from portal
+            Some(perm_response) = perm_rx.recv() => {
+                let request_id = &perm_response.request_id;
+
+                // Check dedup state
+                let should_forward = {
+                    let mut perms = permissions.lock().await;
+                    match perms.get(request_id) {
+                        Some(PermissionState::Pending) => {
+                            *perms.get_mut(request_id).unwrap() = PermissionState::Answered;
+                            debug!("Permission {} answered by portal", request_id);
+                            true
+                        }
+                        Some(PermissionState::Answered) => {
+                            debug!("Permission {} already answered, ignoring portal response", request_id);
+                            false
+                        }
+                        None => {
+                            // Unknown permission — forward anyway
+                            warn!("Unknown permission {}, forwarding", request_id);
+                            true
+                        }
+                    }
+                };
+
+                if should_forward {
+                    // Build ControlResponse and wrap with type tag for claude's stdin
+                    let ctrl_response: ControlResponseMessage = build_control_response(&perm_response).into();
+                    if let Ok(json_line) = serde_json::to_string(&ctrl_response) {
+                        let mut stdin = claude_stdin.lock().await;
+                        if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
+                            error!("Failed to write permission response to claude: {}", e);
+                            break ShimConnectionResult::ClaudeExited;
+                        }
+                        let _ = stdin.write_all(b"\n").await;
+                        let _ = stdin.flush().await;
+                    }
+                    // Do NOT write to our stdout — VS Code didn't request this
+                }
+            }
+
+            // Output acknowledgments from portal
+            Some(ack_seq) = ack_rx.recv() => {
+                let mut buf = output_buffer.lock().await;
+                buf.acknowledge(ack_seq);
+                if let Err(e) = buf.persist() {
+                    warn!("Failed to persist buffer after ack: {}", e);
+                }
+            }
+
+            // Detect if stdin_line_rx closes (parent process disconnected)
+            // This is informational only — stdin forwarding is handled by the reader task
+            _ = stdin_line_rx.recv() => {
+                // Just drain — actual forwarding happens in the stdin reader task
+            }
+        }
+    };
+
+    reader_task.abort();
+    result
+}
+
+/// Extract the text content from a user message echo JSON.
+///
+/// Expected format: `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"..."}]}}`
+/// Returns None if the structure doesn't match (safe fallback: caller forwards to VS Code).
+fn extract_user_text(value: &serde_json::Value) -> Option<String> {
+    let content = value.get("message")?.get("content")?.as_array()?;
+    let mut texts = Vec::new();
+    for block in content {
+        if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+            if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                texts.push(text);
+            }
+        }
+    }
+    if texts.is_empty() {
+        None
+    } else {
+        Some(texts.join(""))
+    }
+}
+
+/// Build a ControlResponse from a portal PermissionResponse.
+/// Mirrors the logic in session.rs run_main_loop's permission handling.
+fn build_control_response(perm: &PermissionResponseData) -> ControlResponse {
+    use claude_codes::io::Permission;
+
+    let input_value = perm
+        .input
+        .clone()
+        .unwrap_or(serde_json::Value::Object(Default::default()));
+
+    if perm.allow {
+        let permissions: Vec<Permission> = perm
+            .permissions
+            .iter()
+            .map(Permission::from_suggestion)
+            .collect();
+
+        if permissions.is_empty() {
+            ControlResponse::from_result(&perm.request_id, PermissionResult::allow(input_value))
+        } else {
+            ControlResponse::from_result(
+                &perm.request_id,
+                PermissionResult::allow_with_typed_permissions(input_value, permissions),
+            )
+        }
+    } else {
+        let reason = perm
+            .reason
+            .clone()
+            .unwrap_or_else(|| "User denied".to_string());
+        ControlResponse::from_result(&perm.request_id, PermissionResult::deny(reason))
+    }
+}

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# One-command portal startup: ensures Docker is running, then starts dev environment
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check if Docker daemon is running
+if ! docker info >/dev/null 2>&1; then
+    echo "Starting Docker Desktop..."
+    open -a Docker
+
+    echo -n "Waiting for Docker"
+    for i in {1..60}; do
+        if docker info >/dev/null 2>&1; then
+            echo " ready!"
+            break
+        fi
+        echo -n "."
+        sleep 2
+    done
+
+    if ! docker info >/dev/null 2>&1; then
+        echo ""
+        echo "Error: Docker failed to start after 2 minutes"
+        exit 1
+    fi
+fi
+
+exec "$SCRIPT_DIR/dev.sh" start


### PR DESCRIPTION
## Summary
- Adds `--shim` flag to claude-portal for transparent stdin/stdout bridging between VS Code and the claude CLI
- All claude output forwards to both stdout (VS Code) and portal backend via WebSocket
- Input from both stdin (VS Code) and portal web UI reaches claude
- Permission request deduplication between VS Code and portal responses
- User echo dedup to prevent duplicate messages in VS Code

Closes #426

## Implementation
- New `proxy/src/shim.rs` module (~710 lines) with the full shim loop
- Shim mode skips TUI banners, update checks, and interactive auth
- Auth falls back to cached tokens from any directory
- WebSocket reconnection with backoff (portal is optional in shim mode)
- Raw tokio-tungstenite WS helpers added to `session.rs` alongside the library re-export

## Test plan
- [ ] Build: `cargo build --workspace && cargo clippy --workspace`
- [ ] Run in shim mode: `claude-portal --shim` (requires claude CLI)
- [ ] Verify normal proxy mode still works without `--shim`
- [ ] VS Code extension can spawn `claude-portal --shim` as subprocess