### PR TITLE
Reduce noisy log output for file uploads and image display

### DIFF
--- a/claude-session-lib/src/proxy_session.rs
+++ b/claude-session-lib/src/proxy_session.rs
@@ -1305,7 +1305,10 @@ async fn handle_ws_message(
     heartbeat: &crate::heartbeat::HeartbeatTracker,
     file_upload_tx: &mpsc::UnboundedSender<FileUploadEvent>,
 ) -> WsMessageResult {
-    if !matches!(proxy_msg, ServerToProxy::Heartbeat) {
+    if !matches!(
+        proxy_msg,
+        ServerToProxy::Heartbeat | ServerToProxy::FileUploadChunk { .. }
+    ) {
         debug!("ws recv: {:?}", proxy_msg);
     }
 

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -73,7 +73,7 @@
 }
 
 .send-button-container .send-button {
-    border-radius: 0;
+    border-radius: 6px 0 0 6px;
     padding: 0.75rem 1rem;
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -300,7 +300,7 @@ impl PortalMessage {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum PortalContent {
     Text {
@@ -314,6 +314,26 @@ pub enum PortalContent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         file_size: Option<u64>,
     },
+}
+
+impl std::fmt::Debug for PortalContent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Text { text } => f.debug_struct("Text").field("text", text).finish(),
+            Self::Image {
+                media_type,
+                data,
+                file_path,
+                file_size,
+            } => f
+                .debug_struct("Image")
+                .field("media_type", media_type)
+                .field("data", &format_args!("<{} bytes base64>", data.len()))
+                .field("file_path", file_path)
+                .field("file_size", file_size)
+                .finish(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Skip debug logging for `FileUploadChunk` WebSocket messages (same treatment as `Heartbeat`)
- Custom `Debug` impl for `PortalContent` to show `<N bytes base64>` instead of dumping raw image data
- Restore left-side border-radius on the send button inside the send-button-container

## Test plan
- [ ] Upload a file and verify no per-chunk `ws recv: FileUploadChunk` log spam
- [ ] Trigger an image display and verify logs show byte count instead of raw base64
- [ ] Verify send button has rounded left corners again

🤖 Generated with [Claude Code](https://claude.com/claude-code)