### PR TITLE
Bump version to 1.2.0 and require version bumps in PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,7 +530,7 @@ The workspace version lives in `Cargo.toml` under `[workspace.package]`. When sh
 - **Patch bump** (e.g. 1.1.2 → 1.1.3): bug fixes, dependency updates, minor tweaks
 - **Minor bump** (e.g. 1.1.3 → 1.2.0): new features, new crates, protocol changes
 
-Always increment at least the patch version when shipping a meaningful change.
+**Every PR must include at least a patch version bump.** Bump the version in the same commit/PR as the code change — do not ship a PR without incrementing the version.
 
 ### No `serde_json::json!`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.1.2"
+version = "1.2.0"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## Summary
- Minor version bump 1.1.2 → 1.2.0
- Update CLAUDE.md to mandate at least a patch version bump in every PR

## Test plan
- [ ] Verify `Cargo.toml` workspace version is `1.2.0`
- [ ] Verify CLAUDE.md versioning instructions are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)