### PR TITLE
Show Compaction Beginning/Completed messages in UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## Summary
- Render "Compaction Beginning" message when `status: "compacting"` system message arrives (was previously silently hidden)
- Render "Compaction Completed" with summary/stats for `compact_boundary` messages (was previously showing a raw badge)
- Renamed "Context Compacted" badge to "Compaction Completed" for consistency

## Test plan
- [ ] Trigger context compaction in a session and verify "Compaction Beginning" appears
- [ ] Verify "Compaction Completed" appears with summary text after compaction finishes
- [ ] Verify other system status messages (init, etc.) are still hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)