### PR TITLE
Skip confirmation when deleting raw messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## Summary
- Remove confirmation dialog when deleting raw message log entries
- Raw messages are low-value diagnostic entries, so the extra click just adds friction

## Test plan
- [ ] Click delete on a raw message in admin panel — should delete immediately without a confirmation popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)