### PR TITLE
Add paste and drag-and-drop file upload support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -54,6 +54,11 @@ web-sys = { workspace = true, features = [
     "MessageEvent",
     "MessagePort",
     "KeyboardEvent",
+    "ClipboardEvent",
+    "DataTransfer",
+    "DataTransferItem",
+    "DataTransferItemList",
+    "DragEvent",
 ] }
 
 # Utility libraries for WASM

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -343,6 +343,36 @@
     color: var(--bg-dark);
 }
 
+/* Drop hint — shown as subtle static label, prominent on drag-hover */
+.session-view-input .drop-hint {
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    opacity: 0.4;
+    pointer-events: none;
+    white-space: nowrap;
+    transition: opacity 0.15s, color 0.15s;
+}
+
+.session-view-input.drag-hover .drop-hint {
+    opacity: 1;
+    color: var(--accent);
+}
+
+/* Drag-hover: highlight the input area */
+.session-view-input.drag-hover {
+    border-top-color: var(--accent);
+    background: rgba(122, 162, 247, 0.06);
+}
+
+.session-view-input.drag-hover .message-input {
+    border-color: var(--accent);
+    border-style: dashed;
+}
+
 /* Nav mode: dim the input area to indicate it's not active */
 .session-views-container.nav-mode .session-view-input {
     opacity: 0.5;


### PR DESCRIPTION
## Summary
- **Paste**: Copy an image/file to clipboard and paste directly into the input bar — it will be uploaded and sent as an attachment
- **Drag & drop**: Drag any file onto the input area to upload it
- **Drop hint**: A subtle label "Drop files here to upload" appears above the input bar at all times, and highlights in accent color when a drag is active
- **Drag hover**: Input area gets a dashed blue border when a file is being dragged over it
- All three paths feed into the existing chunked upload + WebSocket protocol unchanged

## Test plan
- [ ] Copy an image and paste into the session input — should upload and send
- [ ] Drag a file onto the input area — should highlight, then upload on drop
- [ ] Drag out without dropping — highlight should clear
- [ ] "Drop files here to upload" hint visible (subtle) at rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)