### PR TITLE
Fix drag-hover highlight not clearing after file drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -441,8 +441,9 @@ impl Component for SessionView {
                 self.handle_send_input_with_mode(ctx, SendMode::Wiggum)
             }
             SessionViewMsg::FilesSelected(files) => {
-                // Close dropdown and start uploading all files, then send combined message
+                // Close dropdown, clear drag state, and start uploading all files
                 self.send_mode_dropdown_open = false;
+                self.drag_hover = false;
                 self.upload_progress = Some(0.0);
                 let link = ctx.link().clone();
                 let sender = self.ws_sender.clone();


### PR DESCRIPTION
## Summary
After dropping a file onto the input area, the dashed blue border and highlighted drop hint stayed visible. Fixed by resetting `drag_hover = false` in the `FilesSelected` message handler.

## Test plan
- [ ] Drag a file onto the input bar and drop it — highlight should clear immediately when the upload starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)