### PR TITLE
Add sparkline activity indicator to session pills

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -11,7 +11,7 @@ use crate::utils;
 use crate::Route;
 use gloo_net::http::Request;
 use shared::{AppConfig, SessionInfo};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::MouseEvent;
@@ -54,6 +54,7 @@ pub fn dashboard_page() -> Html {
     let voice_enabled = use_state(|| false);
     let app_title = use_state(|| "Claude Code Sessions".to_string());
     let activated_sessions = use_state(HashSet::<Uuid>::new);
+    let activity_timestamps = use_state(HashMap::<Uuid, Vec<f64>>::new);
     let initial_focus_set = use_state(|| false);
 
     // Detect spend tier changes and trigger timed animation
@@ -425,6 +426,19 @@ pub fn dashboard_page() -> Html {
         })
     };
 
+    let on_activity = {
+        let activity_timestamps = activity_timestamps.clone();
+        Callback::from(move |session_id: Uuid| {
+            let now = js_sys::Date::now();
+            let cutoff = now - 300_000.0; // 5 minutes
+            let mut map = (*activity_timestamps).clone();
+            let timestamps = map.entry(session_id).or_default();
+            timestamps.retain(|&t| t > cutoff);
+            timestamps.push(now);
+            activity_timestamps.set(map);
+        })
+    };
+
     let on_branch_change = {
         let set_sessions = sessions_hook.set_sessions.clone();
         let sessions = sessions.clone();
@@ -613,6 +627,7 @@ pub fn dashboard_page() -> Html {
                         inactive_hidden={*inactive_hidden}
                         connected_sessions={(*connected_sessions).clone()}
                         nav_mode={keyboard_nav.nav_mode}
+                        activity_timestamps={(*activity_timestamps).clone()}
                         on_select={on_select_session.clone()}
                         on_leave={on_leave.clone()}
                         on_toggle_pause={on_toggle_pause.clone()}
@@ -640,6 +655,7 @@ pub fn dashboard_page() -> Html {
                                                 on_connected_change={on_connected_change.clone()}
                                                 on_message_sent={on_message_sent.clone()}
                                                 on_branch_change={on_branch_change.clone()}
+                                                on_activity={on_activity.clone()}
                                                 voice_enabled={*voice_enabled}
                                             />
                                         </div>

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -7,7 +7,7 @@ use crate::components::ShareDialog;
 use crate::utils;
 use gloo::events::EventListener;
 use shared::SessionInfo;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 use wasm_bindgen::JsCast;
 use web_sys::{Element, HtmlElement, WheelEvent};
@@ -23,6 +23,8 @@ pub struct SessionRailProps {
     pub inactive_hidden: bool,
     pub connected_sessions: HashSet<Uuid>,
     pub nav_mode: bool,
+    #[prop_or_default]
+    pub activity_timestamps: HashMap<Uuid, Vec<f64>>,
     pub on_select: Callback<usize>,
     pub on_leave: Callback<Uuid>,
     pub on_toggle_pause: Callback<Uuid>,
@@ -360,6 +362,36 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             None
         };
 
+        // Build sparkline ticks for this session
+        let sparkline = {
+            let now = js_sys::Date::now();
+            let window_ms = 300_000.0; // 5 minutes
+            let cutoff = now - window_ms;
+            let ticks: Vec<f64> = props
+                .activity_timestamps
+                .get(&session.id)
+                .map(|ts| {
+                    ts.iter()
+                        .filter(|&&t| t > cutoff)
+                        .map(|&t| (t - cutoff) / window_ms * 100.0)
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            if ticks.is_empty() {
+                html! {}
+            } else {
+                html! {
+                    <div class="pill-sparkline">
+                        { ticks.iter().map(|pct| {
+                            let style = format!("left: {:.1}%", pct);
+                            html! { <span class="sparkline-tick" {style} /> }
+                        }).collect::<Html>() }
+                    </div>
+                }
+            }
+        };
+
         html! {
             <div class={pill_class} onclick={on_click} key={session.id.to_string()}>
                 {
@@ -408,6 +440,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 <button type="button" class="pill-menu-toggle" onclick={on_toggle_menu}>
                     { "▼" }
                 </button>
+                { sparkline }
             </div>
         }
     };

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -34,6 +34,8 @@ pub struct SessionViewProps {
     pub on_connected_change: Callback<(Uuid, bool)>,
     pub on_message_sent: Callback<Uuid>,
     pub on_branch_change: Callback<(Uuid, Option<String>, Option<String>)>,
+    #[prop_or_default]
+    pub on_activity: Callback<Uuid>,
     #[prop_or(false)]
     pub voice_enabled: bool,
 }
@@ -834,6 +836,7 @@ impl SessionView {
             }
         }
         crate::audio::play_sound(crate::audio::SoundEvent::Activity);
+        ctx.props().on_activity.emit(ctx.props().session.id);
         self.messages.push(output);
         if self.messages.len() > MAX_MESSAGES_PER_SESSION {
             let excess = self.messages.len() - MAX_MESSAGES_PER_SESSION;

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -161,6 +161,36 @@
     color: var(--text-secondary);
 }
 
+/* Sparkline - activity ticks at bottom of pill */
+.pill-sparkline {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    pointer-events: none;
+    overflow: hidden;
+    border-radius: 0 0 20px 20px;
+}
+
+.sparkline-tick {
+    position: absolute;
+    bottom: 0;
+    width: 2px;
+    height: 100%;
+    background: var(--accent);
+    opacity: 0.6;
+    border-radius: 1px;
+}
+
+.session-pill.awaiting .sparkline-tick {
+    background: var(--error);
+}
+
+.session-pill.paused .sparkline-tick {
+    opacity: 0.2;
+}
+
 .pill-status {
     font-size: 0.6rem;
     line-height: 1;


### PR DESCRIPTION
## Summary
- Adds a 3px-tall sparkline bar at the bottom of each session pill showing recent message activity
- Each incoming WebSocket message produces a tick mark, positioned proportionally across a 5-minute window
- Ticks use accent color (blue) by default, switch to red for awaiting sessions, and dim for paused sessions
- Old timestamps are pruned on each update to keep the data lightweight

## Test plan
- [ ] Start a session and send messages — verify ticks appear at bottom of pill
- [ ] Watch ticks accumulate as messages flow, newest on the right
- [ ] Verify awaiting sessions show red ticks
- [ ] Verify paused sessions show dimmed ticks
- [ ] Verify pills with no recent activity show no sparkline