### PR TITLE
Fix sparkline ticks clipping past pill corners

### DIFF
--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -79,6 +79,7 @@
     white-space: nowrap;
     transition: all 0.2s;
     flex-shrink: 0;
+    overflow: hidden;
 }
 
 .session-pill:hover {
@@ -169,8 +170,6 @@
     right: 0;
     height: 3px;
     pointer-events: none;
-    overflow: hidden;
-    border-radius: 0 0 20px 20px;
 }
 
 .sparkline-tick {
@@ -181,10 +180,6 @@
     background: var(--accent);
     opacity: 0.6;
     border-radius: 1px;
-}
-
-.session-pill.awaiting .sparkline-tick {
-    background: var(--error);
 }
 
 .session-pill.paused .sparkline-tick {


### PR DESCRIPTION
## Summary
- Add `overflow: hidden` to `.session-pill` so the sparkline bar clips to the pill's border-radius
- Remove redundant `border-radius` and `overflow` from `.pill-sparkline` since the parent handles it
- Remove awaiting color override on ticks (ticks should stay neutral regardless of pill state)

## Test plan
- [ ] Verify sparkline ticks no longer extend past the rounded corners of session pills
- [ ] Verify pill content (text, badges) still renders correctly with overflow hidden