### PR TITLE
Fix shutdown race showing unexpected disconnect

### DIFF
--- a/claude-session-lib/src/proxy_session.rs
+++ b/claude-session-lib/src/proxy_session.rs
@@ -1508,6 +1508,11 @@ async fn run_main_loop(
             }
 
             _ = &mut state.disconnect_rx => {
+                // Check if a graceful shutdown was queued before the disconnect
+                if let Ok(shutdown) = state.graceful_shutdown_rx.try_recv() {
+                    info!("Server graceful shutdown, will reconnect in {}ms", shutdown.reconnect_delay_ms);
+                    return ConnectionResult::ServerShutdown(Duration::from_millis(shutdown.reconnect_delay_ms));
+                }
                 info!("WebSocket disconnected");
                 return ConnectionResult::Disconnected(state.connection_start.elapsed());
             }

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -519,6 +519,12 @@ async fn run_shim_connection(
         tokio::select! {
             // Portal disconnected
             _ = &mut disconnect_rx => {
+                // Check if a graceful shutdown was queued before the disconnect
+                if let Ok(shutdown) = graceful_shutdown_rx.try_recv() {
+                    break ShimConnectionResult::ServerShutdown(
+                        Duration::from_millis(shutdown.reconnect_delay_ms)
+                    );
+                }
                 info!("Portal WebSocket disconnected");
                 break ShimConnectionResult::Disconnected;
             }


### PR DESCRIPTION
## Summary
- Fix `tokio::select!` race between `disconnect_rx` and `graceful_shutdown_rx` in proxy reconnect loop
- When backend sends `ServerShutdown` then closes the connection, both channels fire simultaneously
- `select!` picks randomly, so ~50% of the time the proxy reported "unexpected disconnect" instead of "server restart"
- Fix: in the `disconnect_rx` branch, `try_recv()` on the shutdown channel first to check if a graceful shutdown was queued
- Applied to both normal mode (`proxy_session.rs`) and shim mode (`shim.rs`)

## Test plan
- [ ] Restart backend while proxy is connected — should log "server restart" not "unexpected disconnect"
- [ ] Verify normal unexpected disconnects (e.g. network drop) still report correctly