### PR TITLE
Color sparkline ticks by message type

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -54,7 +54,7 @@ pub fn dashboard_page() -> Html {
     let voice_enabled = use_state(|| false);
     let app_title = use_state(|| "Claude Code Sessions".to_string());
     let activated_sessions = use_state(HashSet::<Uuid>::new);
-    let activity_timestamps = use_state(HashMap::<Uuid, Vec<f64>>::new);
+    let activity_timestamps = use_state(HashMap::<Uuid, Vec<(f64, String)>>::new);
     let initial_focus_set = use_state(|| false);
 
     // Detect spend tier changes and trigger timed animation
@@ -428,13 +428,13 @@ pub fn dashboard_page() -> Html {
 
     let on_activity = {
         let activity_timestamps = activity_timestamps.clone();
-        Callback::from(move |session_id: Uuid| {
+        Callback::from(move |(session_id, msg_type): (Uuid, String)| {
             let now = js_sys::Date::now();
             let cutoff = now - 300_000.0; // 5 minutes
             let mut map = (*activity_timestamps).clone();
             let timestamps = map.entry(session_id).or_default();
-            timestamps.retain(|&t| t > cutoff);
-            timestamps.push(now);
+            timestamps.retain(|(t, _)| *t > cutoff);
+            timestamps.push((now, msg_type));
             activity_timestamps.set(map);
         })
     };

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -24,7 +24,7 @@ pub struct SessionRailProps {
     pub connected_sessions: HashSet<Uuid>,
     pub nav_mode: bool,
     #[prop_or_default]
-    pub activity_timestamps: HashMap<Uuid, Vec<f64>>,
+    pub activity_timestamps: HashMap<Uuid, Vec<(f64, String)>>,
     pub on_select: Callback<usize>,
     pub on_leave: Callback<Uuid>,
     pub on_toggle_pause: Callback<Uuid>,
@@ -367,13 +367,24 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             let now = js_sys::Date::now();
             let window_ms = 300_000.0; // 5 minutes
             let cutoff = now - window_ms;
-            let ticks: Vec<f64> = props
+            let ticks: Vec<(f64, &str)> = props
                 .activity_timestamps
                 .get(&session.id)
                 .map(|ts| {
                     ts.iter()
-                        .filter(|&&t| t > cutoff)
-                        .map(|&t| (t - cutoff) / window_ms * 100.0)
+                        .filter(|(t, _)| *t > cutoff)
+                        .map(|(t, msg_type)| {
+                            let pct = (t - cutoff) / window_ms * 100.0;
+                            let css_type = match msg_type.as_str() {
+                                "assistant" => "assistant",
+                                "user" => "user",
+                                "result" => "result",
+                                "portal" => "portal",
+                                "error" => "error",
+                                _ => "other",
+                            };
+                            (pct, css_type)
+                        })
                         .collect()
                 })
                 .unwrap_or_default();
@@ -383,9 +394,10 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             } else {
                 html! {
                     <div class="pill-sparkline">
-                        { ticks.iter().map(|pct| {
+                        { ticks.iter().map(|(pct, css_type)| {
                             let style = format!("left: {:.1}%", pct);
-                            html! { <span class="sparkline-tick" {style} /> }
+                            let class = format!("sparkline-tick tick-{}", css_type);
+                            html! { <span {class} {style} /> }
                         }).collect::<Html>() }
                     </div>
                 }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -35,7 +35,7 @@ pub struct SessionViewProps {
     pub on_message_sent: Callback<Uuid>,
     pub on_branch_change: Callback<(Uuid, Option<String>, Option<String>)>,
     #[prop_or_default]
-    pub on_activity: Callback<Uuid>,
+    pub on_activity: Callback<(Uuid, String)>,
     #[prop_or(false)]
     pub voice_enabled: bool,
 }
@@ -816,8 +816,12 @@ impl SessionView {
     }
 
     fn handle_received_output(&mut self, ctx: &Context<Self>, output: String) -> bool {
+        let mut msg_type = "unknown".to_string();
         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&output) {
-            if parsed.get("type").and_then(|t| t.as_str()) == Some("result") {
+            if let Some(t) = parsed.get("type").and_then(|t| t.as_str()) {
+                msg_type = t.to_string();
+            }
+            if msg_type == "result" {
                 if let Some(cost) = parsed.get("total_cost_usd").and_then(|c| c.as_f64()) {
                     if cost != self.total_cost {
                         self.total_cost = cost;
@@ -836,7 +840,9 @@ impl SessionView {
             }
         }
         crate::audio::play_sound(crate::audio::SoundEvent::Activity);
-        ctx.props().on_activity.emit(ctx.props().session.id);
+        ctx.props()
+            .on_activity
+            .emit((ctx.props().session.id, msg_type));
         self.messages.push(output);
         if self.messages.len() > MAX_MESSAGES_PER_SESSION {
             let excess = self.messages.len() - MAX_MESSAGES_PER_SESSION;

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -177,10 +177,16 @@
     bottom: 0;
     width: 2px;
     height: 100%;
-    background: var(--accent);
-    opacity: 0.6;
+    opacity: 0.7;
     border-radius: 1px;
 }
+
+.sparkline-tick.tick-assistant { background: var(--accent); }
+.sparkline-tick.tick-user { background: var(--success); }
+.sparkline-tick.tick-result { background: #e0af68; }
+.sparkline-tick.tick-portal { background: #bb9af7; }
+.sparkline-tick.tick-error { background: var(--error); }
+.sparkline-tick.tick-other { background: var(--text-secondary); }
 
 .session-pill.paused .sparkline-tick {
     opacity: 0.2;


### PR DESCRIPTION
## Summary
- Sparkline ticks are now colored by message type instead of a uniform accent color
- Blue (accent) = assistant, Green (success) = user, Amber = result/tool, Purple = portal, Red = error
- The `on_activity` callback now carries the message type string alongside the session ID

## Test plan
- [ ] Send a message and verify green (user) + blue (assistant) ticks appear
- [ ] Verify result messages show amber ticks
- [ ] Verify portal messages show purple ticks
- [ ] Verify error messages show red ticks