### PR TITLE
Auto-focus newly launched session when it connects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -18,6 +18,7 @@ struct DirectoryListingResponse {
 #[derive(Properties, PartialEq)]
 pub struct LaunchDialogProps {
     pub on_close: Callback<()>,
+    pub on_launched: Callback<()>,
 }
 
 #[function_component(LaunchDialog)]
@@ -190,6 +191,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let launching = launching.clone();
         let error_msg = error_msg.clone();
         let on_close = props.on_close.clone();
+        let on_launched = props.on_launched.clone();
         Callback::from(move |_| {
             let dir = (*current_path).clone();
             if dir.is_empty() {
@@ -210,6 +212,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
             let launching = launching.clone();
             let error_msg = error_msg.clone();
             let on_close = on_close.clone();
+            let on_launched = on_launched.clone();
 
             launching.set(true);
             error_msg.set(None);
@@ -229,6 +232,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     .await
                 {
                     Ok(resp) if resp.ok() => {
+                        on_launched.emit(());
                         on_close.emit(());
                     }
                     Ok(resp) => {

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -55,6 +55,7 @@ pub fn dashboard_page() -> Html {
     let app_title = use_state(|| "Claude Code Sessions".to_string());
     let activated_sessions = use_state(HashSet::<Uuid>::new);
     let initial_focus_set = use_state(|| false);
+    let sessions_at_launch = use_state(|| None::<HashSet<Uuid>>);
 
     // Detect spend tier changes and trigger timed animation
     {
@@ -198,6 +199,31 @@ pub fn dashboard_page() -> Html {
         );
     }
 
+    // Auto-focus newly launched session when it appears in the session list
+    {
+        let sessions_at_launch = sessions_at_launch.clone();
+        let active_sessions = active_sessions.clone();
+        let focused_index = focused_index.clone();
+        let activated_sessions = activated_sessions.clone();
+
+        use_effect_with(active_sessions.clone(), move |sessions| {
+            if let Some(ref snapshot) = *sessions_at_launch {
+                if let Some((idx, session)) = sessions
+                    .iter()
+                    .enumerate()
+                    .find(|(_, s)| !snapshot.contains(&s.id))
+                {
+                    focused_index.set(idx);
+                    let mut activated = (*activated_sessions).clone();
+                    activated.insert(session.id);
+                    activated_sessions.set(activated);
+                    sessions_at_launch.set(None);
+                }
+            }
+            || ()
+        });
+    }
+
     // Session selection callback
     let on_select_session = {
         let focused_index = focused_index.clone();
@@ -336,6 +362,15 @@ pub fn dashboard_page() -> Html {
         let show_launch_dialog = show_launch_dialog.clone();
         Callback::from(move |_| {
             show_launch_dialog.set(false);
+        })
+    };
+
+    let on_launch_success = {
+        let sessions_at_launch = sessions_at_launch.clone();
+        let active_sessions = active_sessions.clone();
+        Callback::from(move |_| {
+            let snapshot: HashSet<Uuid> = active_sessions.iter().map(|s| s.id).collect();
+            sessions_at_launch.set(Some(snapshot));
         })
     };
 
@@ -574,7 +609,7 @@ pub fn dashboard_page() -> Html {
 
             // Launch session dialog
             if *show_launch_dialog {
-                <LaunchDialog on_close={on_launch_close.clone()} />
+                <LaunchDialog on_close={on_launch_close.clone()} on_launched={on_launch_success.clone()} />
             }
 
             if loading {


### PR DESCRIPTION
## Summary
- Adds `on_launched: Callback<()>` prop to `LaunchDialog`, emitted on successful launch (distinct from cancel/close)
- Dashboard snapshots the current session ID set when a launch succeeds
- A `use_effect_with` on `active_sessions` watches for any session not in the snapshot and auto-focuses + activates it when it appears

## Test plan
- [ ] Launch a session via the Launch dialog
- [ ] Verify the new session is auto-focused when it connects (without manual click)
- [ ] Verify canceling the dialog does NOT trigger auto-focus behavior
- [ ] Verify normal session selection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)