### PR TITLE
Show compaction events as ranges in session sparkline

### DIFF
--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -367,12 +367,19 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             let now = js_sys::Date::now();
             let window_ms = 300_000.0; // 5 minutes
             let cutoff = now - window_ms;
-            let ticks: Vec<(f64, &str)> = props
-                .activity_timestamps
-                .get(&session.id)
+            let timestamps = props.activity_timestamps.get(&session.id);
+
+            // Point ticks (non-compaction)
+            let ticks: Vec<(f64, &str)> = timestamps
                 .map(|ts| {
                     ts.iter()
-                        .filter(|(t, _)| *t > cutoff)
+                        .filter(|(t, msg_type)| {
+                            *t > cutoff
+                                && !matches!(
+                                    msg_type.as_str(),
+                                    "compaction_start" | "compaction_end"
+                                )
+                        })
                         .map(|(t, msg_type)| {
                             let pct = (t - cutoff) / window_ms * 100.0;
                             let css_type = match msg_type.as_str() {
@@ -389,11 +396,41 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 })
                 .unwrap_or_default();
 
-            if ticks.is_empty() {
+            // Compaction ranges: pair up start/end events
+            let compaction_ranges: Vec<(f64, f64)> = {
+                let mut ranges = Vec::new();
+                if let Some(ts) = timestamps {
+                    let mut pending_start: Option<f64> = None;
+                    for (t, msg_type) in ts.iter().filter(|(t, _)| *t > cutoff) {
+                        match msg_type.as_str() {
+                            "compaction_start" => {
+                                pending_start = Some((t - cutoff) / window_ms * 100.0);
+                            }
+                            "compaction_end" => {
+                                let end_pct = (t - cutoff) / window_ms * 100.0;
+                                ranges.push((pending_start.take().unwrap_or(0.0), end_pct));
+                            }
+                            _ => {}
+                        }
+                    }
+                    // In-progress compaction extends to current time
+                    if let Some(start_pct) = pending_start {
+                        ranges.push((start_pct, 100.0));
+                    }
+                }
+                ranges
+            };
+
+            if ticks.is_empty() && compaction_ranges.is_empty() {
                 html! {}
             } else {
                 html! {
                     <div class="pill-sparkline">
+                        { compaction_ranges.iter().map(|(start_pct, end_pct)| {
+                            let width = (end_pct - start_pct).max(1.0);
+                            let style = format!("left: {:.1}%; width: {:.1}%", start_pct, width);
+                            html! { <span class="sparkline-range tick-compaction" {style} /> }
+                        }).collect::<Html>() }
                         { ticks.iter().map(|(pct, css_type)| {
                             let style = format!("left: {:.1}%", pct);
                             let class = format!("sparkline-tick tick-{}", css_type);

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -821,6 +821,18 @@ impl SessionView {
             if let Some(t) = parsed.get("type").and_then(|t| t.as_str()) {
                 msg_type = t.to_string();
             }
+            if msg_type == "system" {
+                let status = parsed.get("status").and_then(|s| s.as_str()).unwrap_or("");
+                let subtype = parsed.get("subtype").and_then(|s| s.as_str()).unwrap_or("");
+                if status == "compacting" {
+                    msg_type = "compaction_start".to_string();
+                } else if matches!(
+                    subtype,
+                    "compaction" | "compact_boundary" | "context_compaction" | "summary"
+                ) {
+                    msg_type = "compaction_end".to_string();
+                }
+            }
             if msg_type == "result" {
                 if let Some(cost) = parsed.get("total_cost_usd").and_then(|c| c.as_f64()) {
                     if cost != self.total_cost {

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -188,7 +188,18 @@
 .sparkline-tick.tick-error { background: var(--error); }
 .sparkline-tick.tick-other { background: var(--text-secondary); }
 
-.session-pill.paused .sparkline-tick {
+.sparkline-range {
+    position: absolute;
+    bottom: 0;
+    height: 100%;
+    opacity: 0.5;
+    border-radius: 1px;
+}
+
+.sparkline-range.tick-compaction { background: #73daca; }
+
+.session-pill.paused .sparkline-tick,
+.session-pill.paused .sparkline-range {
     opacity: 0.2;
 }
 


### PR DESCRIPTION
## Summary
- Detects compaction start (`status: compacting`) and end (`subtype: compaction/compact_boundary/context_compaction/summary`) in received output and emits distinct `compaction_start` / `compaction_end` activity types
- Sparkline pairs these into ranges rendered as a teal band; in-progress compactions extend to the right edge
- Falls back gracefully — an orphaned `compaction_start` with no matching end extends to 100%

## Test plan
- [ ] Trigger a context compaction and verify a teal band appears in the session pill sparkline
- [ ] Verify the band spans from when compaction started to when it completed
- [ ] Verify normal point ticks (assistant, user, result) still render correctly alongside ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)