### PR TITLE
Update codex-codes to 0.101.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.100.1"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a38c5a51ef4458ef8bc442d1868fd82b172ba349865b418067b2e7eb4a68f83"
+checksum = "7e8814f37f6da6430c201decb978367077b4f222495465a529793ec7e2ea5256"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = "2.1.46"
 
 # Codex CLI integration
-codex-codes = { version = "0.100.1", default-features = false, features = ["types"] }
+codex-codes = { version = "0.101.0", default-features = false, features = ["types"] }
 
 # Frontend (Yew)
 yew = { version = "0.21", features = ["csr"] }

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -675,7 +675,7 @@ impl Session {
 
         // Start a thread (conversation session)
         let thread_id = match client.thread_start(&ThreadStartParams::default()).await {
-            Ok(resp) => resp.thread_id,
+            Ok(resp) => resp.thread_id().to_string(),
             Err(e) => {
                 let _ = event_tx.send(IoEvent::Error(SessionError::CommunicationError(format!(
                     "Failed to start Codex thread: {}",


### PR DESCRIPTION
## Summary
- Bump `codex-codes` from 0.100.1 to 0.101.0
- Fix `thread_id` field access → `.thread_id()` method call (breaking API change)
- Automatic `initialize` handshake now happens transparently in `AsyncClient::start_with()`

Closes #446

## Test plan
- [ ] `cargo build --workspace` compiles cleanly
- [ ] Launch a Codex session and verify it starts successfully with the new initialize handshake