### PR TITLE
Make sparkline ticks taller and more visible

### DIFF
--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -168,16 +168,16 @@
     bottom: 0;
     left: 0;
     right: 0;
-    height: 3px;
+    height: 5px;
     pointer-events: none;
 }
 
 .sparkline-tick {
     position: absolute;
     bottom: 0;
-    width: 2px;
+    width: 3px;
     height: 100%;
-    opacity: 0.7;
+    opacity: 1;
     border-radius: 1px;
 }
 


### PR DESCRIPTION
## Summary
- Increase sparkline height from 3px to 5px
- Increase tick width from 2px to 3px
- Set tick opacity to 1 (was 0.7)

## Test plan
- [ ] Verify ticks are clearly visible on session pills