### PR TITLE
Slim down input bar and hide drop hint

### DIFF
--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -6,7 +6,7 @@
     display: flex;
     align-items: flex-end;
     gap: 0.75rem;
-    padding: 1rem 1.5rem;
+    padding: 0.5rem 1rem;
     background: var(--bg-darker);
     border-top: 1px solid var(--border);
     position: relative;
@@ -23,7 +23,7 @@
     background: rgba(0, 0, 0, 0.3);
     border: 1px solid var(--border);
     border-radius: 6px;
-    padding: 0.75rem 1rem;
+    padding: 0.5rem 0.75rem;
     color: var(--text-primary);
     font-size: 0.95rem;
     font-family: inherit;
@@ -47,7 +47,7 @@
 }
 
 .session-view-input .send-button {
-    padding: 0.75rem 1.5rem;
+    padding: 0.5rem 1.25rem;
     background: var(--accent);
     border: none;
     border-radius: 6px;
@@ -386,7 +386,7 @@
     transform: translateX(-50%);
     font-size: 0.72rem;
     color: var(--text-muted);
-    opacity: 0.4;
+    opacity: 0;
     pointer-events: none;
     white-space: nowrap;
     transition: opacity 0.15s, color 0.15s;


### PR DESCRIPTION
## Summary
- Reduce input area padding (1rem → 0.5rem vertical, 1.5rem → 1rem horizontal)
- Reduce textarea padding (0.75rem → 0.5rem)
- Reduce send button padding
- Hide "Drop files here to upload" text by default (only shows on drag-hover)

## Test plan
- [ ] Input bar takes less vertical space
- [ ] Drag files over input still shows the drop hint
- [ ] Input still functions normally