### PR TITLE
Auto-resize textarea for multiline input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.2.5"
+version = "1.2.6"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -259,6 +259,11 @@ impl Component for SessionView {
         match msg {
             SessionViewMsg::WsEvent(event) => self.handle_ws_event(ctx, event),
             SessionViewMsg::UpdateInput(value) => {
+                if value.is_empty() {
+                    if let Some(el) = self.input_ref.cast::<Element>() {
+                        el.remove_attribute("style").ok();
+                    }
+                }
                 self.input_value = value;
                 true
             }
@@ -648,6 +653,10 @@ impl Component for SessionView {
 
         let handle_input = link.callback(|e: InputEvent| {
             let input: HtmlTextAreaElement = e.target_unchecked_into();
+            let el: &Element = input.as_ref();
+            el.set_attribute("style", "height: auto").ok();
+            el.set_attribute("style", &format!("height: {}px", input.scroll_height()))
+                .ok();
             SessionViewMsg::UpdateInput(input.value())
         });
 

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -34,7 +34,6 @@
     max-height: 10em;
     overflow-y: auto;
     line-height: 1.4;
-    field-sizing: content;
 }
 
 .session-view-input .message-input:focus {


### PR DESCRIPTION
## Summary
- Textarea now auto-expands as you type multiline input, stays tight at one line for short messages
- Replaces `field-sizing: content` CSS (limited browser support) with JS-based auto-resize
- Resets height when input is cleared (after sending)
- Capped at `max-height: 10em` with scroll overflow

## Test plan
- [ ] Type a single line — textarea stays compact
- [ ] Type/paste multiple lines — textarea grows smoothly
- [ ] Send a message — textarea shrinks back to one line
- [ ] Shift+Enter adds newlines, textarea grows accordingly