### PR TITLE
Show send-mode dropdown on mobile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.2.6"
+version = "1.2.7"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -173,13 +173,7 @@
         font-size: 0.9rem;
     }
 
-    /* Hide send-mode dropdown on mobile */
-    .send-mode-toggle {
-        display: none;
-    }
-
     .send-button-container .send-button {
-        border-radius: 6px;
         padding: 0.6rem 1rem;
     }
 


### PR DESCRIPTION
## Summary
- Removed the CSS rule that hid the send-mode toggle (triangle dropdown) on mobile viewports
- The wiggum / attachment dropdown is now accessible on mobile devices

## Test plan
- [ ] On mobile (or narrow viewport < 768px), the send button should show the triangle dropdown toggle
- [ ] Tapping the triangle opens the dropdown menu (Send / Wiggum / Attach)