### PR TITLE
Expected sessions and pill link improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.2.8"
+version = "1.3.0"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -158,7 +158,7 @@ pub async fn list_directories(
     }
 }
 
-fn mint_launch_token(app_state: &AppState, user_id: Uuid) -> Result<String, StatusCode> {
+pub(crate) fn mint_launch_token(app_state: &AppState, user_id: Uuid) -> Result<String, StatusCode> {
     let mut conn = app_state
         .db_pool
         .get()

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -2,7 +2,7 @@ use axum::extract::ws::WebSocket;
 use shared::{LauncherEndpoint, LauncherToServer, ServerToClient, ServerToLauncher};
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use super::LauncherConnection;
@@ -218,6 +218,46 @@ fn handle_launcher_message(
             app_state
                 .session_manager
                 .complete_dir_request(request_id, msg);
+        }
+        LauncherToServer::RequestLaunch {
+            request_id,
+            working_directory,
+            session_name,
+            claude_args,
+            agent_type,
+        } => {
+            info!(
+                "Launcher requested launch: dir={}, name={:?}",
+                working_directory, session_name
+            );
+            match crate::handlers::launchers::mint_launch_token(app_state, user_id) {
+                Ok(auth_token) => {
+                    let launch_msg = ServerToLauncher::LaunchSession {
+                        request_id,
+                        user_id,
+                        auth_token,
+                        working_directory,
+                        session_name,
+                        claude_args,
+                        agent_type,
+                    };
+                    if !app_state
+                        .session_manager
+                        .send_to_launcher(&launcher_id, launch_msg)
+                    {
+                        error!(
+                            "Failed to send LaunchSession back to launcher {}",
+                            launcher_id
+                        );
+                    }
+                }
+                Err(status) => {
+                    error!(
+                        "Failed to mint token for launcher RequestLaunch: {:?}",
+                        status
+                    );
+                }
+            }
         }
         LauncherToServer::LauncherRegister { .. } => {}
     }

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -458,9 +458,21 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     <span class="pill-hostname">{ hostname }</span>
                     {
                         if let Some(ref branch) = session.git_branch {
-                            html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
+                            if let Some(ref url) = session.pr_url {
+                                html! {
+                                    <a class="pill-branch pill-link" href={url.clone()} target="_blank"
+                                       title={format!("PR: {}", url)}
+                                       onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                                        { branch }
+                                    </a>
+                                }
+                            } else {
+                                // Derive repo URL from pr_url if we've ever had one,
+                                // otherwise just show plain text branch name
+                                html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
+                            }
                         } else {
-                            html! {}
+                            html! { <span class="pill-branch pill-no-vcs">{ "No VCS" }</span> }
                         }
                     }
                 </span>

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -158,6 +158,21 @@
 }
 
 
+a.pill-branch.pill-link {
+    text-decoration: none;
+    color: var(--accent);
+}
+
+a.pill-branch.pill-link:hover {
+    text-decoration: underline;
+}
+
+.pill-branch.pill-no-vcs {
+    color: var(--text-muted);
+    font-style: normal;
+    font-size: 0.65rem;
+}
+
 .session-pill.status-disconnected .pill-branch {
     color: var(--text-secondary);
 }

--- a/launcher/src/config.rs
+++ b/launcher/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use shared::AgentType;
 use std::path::PathBuf;
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -7,6 +8,19 @@ pub struct LauncherConfig {
     pub auth_token: Option<String>,
     pub name: Option<String>,
     pub max_processes: Option<usize>,
+    #[serde(default)]
+    pub sessions: Vec<ExpectedSession>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExpectedSession {
+    pub working_directory: String,
+    #[serde(default)]
+    pub session_name: Option<String>,
+    #[serde(default)]
+    pub agent_type: AgentType,
+    #[serde(default)]
+    pub claude_args: Vec<String>,
 }
 
 fn config_path() -> PathBuf {
@@ -68,6 +82,7 @@ max_processes = 10
         assert_eq!(config.auth_token.unwrap(), "tok_abc123");
         assert_eq!(config.name.unwrap(), "my-launcher");
         assert_eq!(config.max_processes.unwrap(), 10);
+        assert!(config.sessions.is_empty());
     }
 
     #[test]
@@ -77,6 +92,7 @@ max_processes = 10
         assert!(config.auth_token.is_none());
         assert!(config.name.is_none());
         assert!(config.max_processes.is_none());
+        assert!(config.sessions.is_empty());
     }
 
     #[test]
@@ -102,6 +118,12 @@ auth_token = "secret"
             auth_token: Some("tok_test".to_string()),
             name: Some("test-launcher".to_string()),
             max_processes: Some(3),
+            sessions: vec![ExpectedSession {
+                working_directory: "/home/user/project".to_string(),
+                session_name: Some("my-session".to_string()),
+                agent_type: AgentType::Claude,
+                claude_args: vec!["--verbose".to_string()],
+            }],
         };
         let serialized = toml::to_string_pretty(&config).unwrap();
         let deserialized: LauncherConfig = toml::from_str(&serialized).unwrap();
@@ -109,5 +131,42 @@ auth_token = "secret"
         assert_eq!(deserialized.auth_token, config.auth_token);
         assert_eq!(deserialized.name, config.name);
         assert_eq!(deserialized.max_processes, config.max_processes);
+        assert_eq!(deserialized.sessions.len(), 1);
+        assert_eq!(
+            deserialized.sessions[0].working_directory,
+            "/home/user/project"
+        );
+    }
+
+    #[test]
+    fn parse_config_with_sessions() {
+        let toml = r#"
+backend_url = "wss://example.com"
+auth_token = "tok_abc"
+
+[[sessions]]
+working_directory = "/home/user/project-a"
+session_name = "project-a"
+
+[[sessions]]
+working_directory = "/home/user/project-b"
+agent_type = "codex"
+claude_args = ["--model", "opus"]
+"#;
+        let config: LauncherConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.sessions.len(), 2);
+
+        assert_eq!(config.sessions[0].working_directory, "/home/user/project-a");
+        assert_eq!(
+            config.sessions[0].session_name.as_deref(),
+            Some("project-a")
+        );
+        assert_eq!(config.sessions[0].agent_type, AgentType::Claude);
+        assert!(config.sessions[0].claude_args.is_empty());
+
+        assert_eq!(config.sessions[1].working_directory, "/home/user/project-b");
+        assert!(config.sessions[1].session_name.is_none());
+        assert_eq!(config.sessions[1].agent_type, AgentType::Codex);
+        assert_eq!(config.sessions[1].claude_args, vec!["--model", "opus"]);
     }
 }

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -1,5 +1,7 @@
+use crate::config::ExpectedSession;
 use crate::process_manager::{ProcessManager, SessionExited};
 use shared::{LauncherEndpoint, LauncherToServer, ServerToLauncher};
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
@@ -7,6 +9,8 @@ use uuid::Uuid;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_BACKOFF: Duration = Duration::from_secs(30);
+const RESTART_DELAY: Duration = Duration::from_secs(5);
+const MAX_RESTART_ATTEMPTS: u32 = 3;
 
 pub async fn run_launcher_loop(
     backend_url: &str,
@@ -15,6 +19,7 @@ pub async fn run_launcher_loop(
     auth_token: Option<&str>,
     mut process_manager: ProcessManager,
     mut exit_rx: mpsc::UnboundedReceiver<SessionExited>,
+    expected_sessions: Vec<ExpectedSession>,
 ) -> anyhow::Result<()> {
     process_manager.set_launcher_id(launcher_id);
     let mut backoff = Duration::from_secs(1);
@@ -76,6 +81,35 @@ pub async fn run_launcher_loop(
                     continue;
                 }
 
+                // Reconcile expected sessions: launch any that aren't running
+                let mut restart_counts: HashMap<String, u32> = HashMap::new();
+                if !expected_sessions.is_empty() {
+                    let running_dirs = process_manager.running_directories();
+                    for expected in &expected_sessions {
+                        if running_dirs.contains(&expected.working_directory) {
+                            info!(
+                                "Expected session already running: {}",
+                                expected.working_directory
+                            );
+                            continue;
+                        }
+                        info!("Launching expected session: {}", expected.working_directory);
+                        let request = LauncherToServer::RequestLaunch {
+                            request_id: Uuid::new_v4(),
+                            working_directory: expected.working_directory.clone(),
+                            session_name: expected.session_name.clone(),
+                            claude_args: expected.claude_args.clone(),
+                            agent_type: expected.agent_type,
+                        };
+                        if ws_sender.send(request).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+
+                // Channel for delayed restart requests
+                let (restart_tx, mut restart_rx) = mpsc::unbounded_channel::<ExpectedSession>();
+
                 // Main loop
                 let mut heartbeat_timer = tokio::time::interval(HEARTBEAT_INTERVAL);
                 let start = Instant::now();
@@ -114,6 +148,7 @@ pub async fn run_launcher_loop(
                         }
 
                         Some(exited) = exit_rx.recv() => {
+                            let exited_dir = process_manager.session_working_directory(&exited.session_id);
                             info!(
                                 "Session {} exited with code {:?}",
                                 exited.session_id, exited.exit_code
@@ -124,6 +159,45 @@ pub async fn run_launcher_loop(
                                 exit_code: exited.exit_code,
                             };
                             if ws_sender.send(msg).await.is_err() {
+                                break;
+                            }
+
+                            // Schedule restart if this was an expected session
+                            if let Some(dir) = exited_dir {
+                                if let Some(expected) = expected_sessions.iter().find(|s| s.working_directory == dir) {
+                                    let count = restart_counts.entry(dir.clone()).or_insert(0);
+                                    *count += 1;
+                                    if *count <= MAX_RESTART_ATTEMPTS {
+                                        info!(
+                                            "Expected session exited, scheduling restart ({}/{}): {}",
+                                            count, MAX_RESTART_ATTEMPTS, dir
+                                        );
+                                        let tx = restart_tx.clone();
+                                        let session = expected.clone();
+                                        tokio::spawn(async move {
+                                            tokio::time::sleep(RESTART_DELAY).await;
+                                            let _ = tx.send(session);
+                                        });
+                                    } else {
+                                        warn!(
+                                            "Expected session exceeded max restarts ({}): {}",
+                                            MAX_RESTART_ATTEMPTS, dir
+                                        );
+                                    }
+                                }
+                            }
+                        }
+
+                        Some(session) = restart_rx.recv() => {
+                            info!("Restarting expected session: {}", session.working_directory);
+                            let request = LauncherToServer::RequestLaunch {
+                                request_id: Uuid::new_v4(),
+                                working_directory: session.working_directory,
+                                session_name: session.session_name,
+                                claude_args: session.claude_args,
+                                agent_type: session.agent_type,
+                            };
+                            if ws_sender.send(request).await.is_err() {
                                 break;
                             }
                         }

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -188,6 +188,13 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Backend URL: {}", backend_url);
     tracing::info!("Max sessions: {}", max_sessions);
 
+    if !config.sessions.is_empty() {
+        tracing::info!("Expected sessions configured: {}", config.sessions.len());
+        for s in &config.sessions {
+            tracing::info!("  - {} ({})", s.working_directory, s.agent_type);
+        }
+    }
+
     let (process_manager, exit_rx) =
         process_manager::ProcessManager::new(backend_url.clone(), max_sessions);
 
@@ -198,6 +205,7 @@ async fn main() -> anyhow::Result<()> {
         auth_token.as_deref(),
         process_manager,
         exit_rx,
+        config.sessions,
     )
     .await
 }

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -18,6 +18,7 @@ pub struct SessionExited {
 struct ManagedTask {
     handle: tokio::task::JoinHandle<()>,
     cancel: CancellationToken,
+    working_directory: String,
 }
 
 pub struct ProcessManager {
@@ -56,6 +57,21 @@ impl ProcessManager {
 
     pub fn running_session_ids(&self) -> Vec<Uuid> {
         self.tasks.keys().copied().collect()
+    }
+
+    /// Returns the set of working directories that currently have running sessions.
+    pub fn running_directories(&self) -> Vec<String> {
+        self.tasks
+            .values()
+            .map(|t| t.working_directory.clone())
+            .collect()
+    }
+
+    /// Returns the working directory for a given session, if it exists.
+    pub fn session_working_directory(&self, session_id: &Uuid) -> Option<String> {
+        self.tasks
+            .get(session_id)
+            .map(|t| t.working_directory.clone())
     }
 
     pub async fn spawn(
@@ -123,8 +139,14 @@ impl ProcessManager {
             session_id, name, working_directory
         );
 
-        self.tasks
-            .insert(session_id, ManagedTask { handle, cancel });
+        self.tasks.insert(
+            session_id,
+            ManagedTask {
+                handle,
+                cancel,
+                working_directory: working_directory.to_string(),
+            },
+        );
 
         Ok(SpawnResult { session_id })
     }

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -366,6 +366,18 @@ pub enum LauncherToServer {
         #[serde(default)]
         resolved_path: Option<String>,
     },
+
+    /// Request the backend to mint a token and launch a session
+    RequestLaunch {
+        request_id: Uuid,
+        working_directory: String,
+        #[serde(default)]
+        session_name: Option<String>,
+        #[serde(default)]
+        claude_args: Vec<String>,
+        #[serde(default)]
+        agent_type: AgentType,
+    },
 }
 
 /// Messages the backend sends to the launcher.
@@ -566,6 +578,33 @@ mod tests {
         // Must parse as both ProxyToServer and ClientToServer
         let _: ProxyToServer = serde_json::from_str(json).unwrap();
         let _: ClientToServer = serde_json::from_str(json).unwrap();
+    }
+
+    #[test]
+    fn launcher_request_launch_roundtrip() {
+        let msg = LauncherToServer::RequestLaunch {
+            request_id: Uuid::nil(),
+            working_directory: "/home/user/project".into(),
+            session_name: Some("my-project".into()),
+            claude_args: vec!["--verbose".into()],
+            agent_type: AgentType::Claude,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"RequestLaunch""#));
+        let parsed: LauncherToServer = serde_json::from_str(&json).unwrap();
+        match parsed {
+            LauncherToServer::RequestLaunch {
+                working_directory,
+                session_name,
+                claude_args,
+                ..
+            } => {
+                assert_eq!(working_directory, "/home/user/project");
+                assert_eq!(session_name.as_deref(), Some("my-project"));
+                assert_eq!(claude_args, vec!["--verbose"]);
+            }
+            _ => panic!("Wrong variant"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `[[sessions]]` config to `launcher.toml` for declaring sessions that should always be running
- Launcher auto-launches missing expected sessions on connect and restarts them on exit (5s delay, max 3 retries)
- New `RequestLaunch` protocol message lets launchers request token minting + launch via WebSocket
- Pill branch name links to PR when active, shows "No VCS" when no git repo

## Config Example
```toml
[[sessions]]
working_directory = "/home/user/project-a"
session_name = "project-a"

[[sessions]]
working_directory = "/home/user/project-b"
agent_type = "codex"
claude_args = ["--model", "opus"]
```

## Test plan
- [ ] Add `[[sessions]]` to launcher.toml, start launcher, verify sessions auto-launch
- [ ] Kill a launched session, verify it restarts after 5s
- [ ] Verify restart cap (3 attempts) prevents crash loops
- [ ] Verify pill shows "No VCS" for sessions without git
- [ ] Verify pill branch links to PR when pr_url is set
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace` clean