### PR TITLE
Fix version pin and remove dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/output_buffer.rs
+++ b/claude-session-lib/src/output_buffer.rs
@@ -193,15 +193,8 @@ impl PendingOutputBuffer {
     }
 
     /// Get the last acknowledged sequence number
-    #[allow(dead_code)]
     pub fn last_ack_seq(&self) -> u64 {
         self.state.last_ack_seq
-    }
-
-    /// Get the next sequence number that will be assigned
-    #[allow(dead_code)]
-    pub fn next_seq(&self) -> u64 {
-        self.state.next_seq
     }
 
     /// Persist the buffer state to disk
@@ -226,21 +219,6 @@ impl PendingOutputBuffer {
             self.state.pending.len()
         );
 
-        Ok(())
-    }
-
-    /// Clear the buffer and remove the persistence file
-    #[allow(dead_code)]
-    pub fn clear(&mut self) -> Result<()> {
-        self.state.pending.clear();
-        self.state.last_ack_seq = self.state.next_seq.saturating_sub(1);
-        self.dirty = false;
-
-        if self.persist_path.exists() {
-            fs::remove_file(&self.persist_path).context("Failed to remove buffer file")?;
-        }
-
-        debug!("Cleared buffer for session {}", self.session_id);
         Ok(())
     }
 }

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -125,13 +125,8 @@ impl PermissionResponse {
 /// Internal session state
 enum SessionState {
     Running,
-    WaitingForPermission {
-        #[allow(dead_code)]
-        request_id: String,
-    },
-    Exited {
-        code: i32,
-    },
+    WaitingForPermission,
+    Exited { code: i32 },
 }
 
 /// Commands sent to the agent I/O task
@@ -372,7 +367,7 @@ impl Session {
     pub fn snapshot(&self) -> SessionSnapshot {
         let was_running = matches!(
             self.state,
-            SessionState::Running | SessionState::WaitingForPermission { .. }
+            SessionState::Running | SessionState::WaitingForPermission
         );
         SessionSnapshot::new(
             self.id,
@@ -441,9 +436,7 @@ impl Session {
                                 input: tool_req.input.clone(),
                                 requested_at: Utc::now(),
                             });
-                            self.state = SessionState::WaitingForPermission {
-                                request_id: request_id.clone(),
-                            };
+                            self.state = SessionState::WaitingForPermission;
 
                             // Emit PermissionRequest (not Output) for permission requests
                             return Some(SessionEvent::PermissionRequest {
@@ -479,9 +472,7 @@ impl Session {
                         input: input.clone(),
                         requested_at: Utc::now(),
                     });
-                    self.state = SessionState::WaitingForPermission {
-                        request_id: request_id.clone(),
-                    };
+                    self.state = SessionState::WaitingForPermission;
                     return Some(SessionEvent::PermissionRequest {
                         request_id,
                         tool_name,
@@ -613,7 +604,7 @@ impl Session {
     pub fn is_running(&self) -> bool {
         matches!(
             self.state,
-            SessionState::Running | SessionState::WaitingForPermission { .. }
+            SessionState::Running | SessionState::WaitingForPermission
         )
     }
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,7 +16,7 @@ uuid = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["serde", "wasmbind"] }
 
 # Claude Code types (WASM-compatible, no tokio)
-claude-codes = { version = "2.1.20", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.46", default-features = false, features = ["types"] }
 
 # Codex CLI types (WASM-compatible, types only)
 codex-codes = { workspace = true }


### PR DESCRIPTION
## Summary
- Update `claude-codes` version from `2.1.20` to `2.1.46` in `shared/Cargo.toml`
- Remove unused `next_seq()` and `clear()` methods from `PendingOutputBuffer`
- Remove `#[allow(dead_code)]` from `last_ack_seq()` (it's used in tests)
- Remove unused `request_id` field from `SessionState::WaitingForPermission`

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --check` clean

Fixes #460