### PR TITLE
Consolidate duplicate format_timestamp utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/admin.rs
+++ b/frontend/src/pages/admin.rs
@@ -109,22 +109,6 @@ fn format_tokens(count: i64) -> String {
     }
 }
 
-/// Format a timestamp for display
-fn format_timestamp(ts: &str) -> String {
-    let date = js_sys::Date::new(&ts.into());
-    if date.get_time().is_nan() {
-        return ts.to_string();
-    }
-    format!(
-        "{}-{:02}-{:02} {:02}:{:02}",
-        date.get_full_year(),
-        date.get_month() + 1,
-        date.get_date(),
-        date.get_hours(),
-        date.get_minutes()
-    )
-}
-
 // ============================================================================
 // Stats Card Component
 // ============================================================================
@@ -219,7 +203,7 @@ fn user_row(props: &UserRowProps) -> Html {
             <td class={status_class}>{ status_text }</td>
             <td class="numeric">{ user.session_count }</td>
             <td class="numeric">{ utils::format_dollars(user.total_spend_usd) }</td>
-            <td class="timestamp">{ format_timestamp(&user.created_at) }</td>
+            <td class="timestamp">{ utils::format_timestamp(&user.created_at) }</td>
             <td class="actions">
                 <button
                     class={classes!("admin-toggle", if user.is_admin { Some("active") } else { None })}
@@ -294,7 +278,7 @@ fn session_row(props: &SessionRowProps) -> Html {
             <td class="session-branch">{ session.git_branch.as_deref().unwrap_or("-") }</td>
             <td class={status_class}>{ status_text }</td>
             <td class="numeric">{ utils::format_dollars(session.total_cost_usd) }</td>
-            <td class="timestamp">{ format_timestamp(&session.last_activity) }</td>
+            <td class="timestamp">{ utils::format_timestamp(&session.last_activity) }</td>
             <td class="actions">
                 <button class="delete-btn" onclick={on_delete} title="Delete session">
                     { "Delete" }
@@ -346,7 +330,7 @@ fn raw_message_row(props: &RawMessageRowProps) -> Html {
 
     html! {
         <tr>
-            <td class="timestamp">{ format_timestamp(&msg.created_at) }</td>
+            <td class="timestamp">{ utils::format_timestamp(&msg.created_at) }</td>
             <td class="raw-msg-type">{ msg_type }</td>
             <td class="raw-msg-source">{ &msg.message_source }</td>
             <td class="raw-msg-reason">{ msg.render_reason.as_deref().unwrap_or("-") }</td>
@@ -1228,7 +1212,7 @@ pub fn admin_page() -> Html {
                                 <div class="raw-message-modal-meta">
                                     <span><strong>{ "Source: " }</strong>{ &msg.message_source }</span>
                                     <span><strong>{ "Reason: " }</strong>{ msg.render_reason.as_deref().unwrap_or("-") }</span>
-                                    <span><strong>{ "Time: " }</strong>{ format_timestamp(&msg.created_at) }</span>
+                                    <span><strong>{ "Time: " }</strong>{ utils::format_timestamp(&msg.created_at) }</span>
                                 </div>
                                 <pre class="raw-message-modal-content">{ display_content }</pre>
                             </div>

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -34,23 +34,6 @@ fn days_until_expiration(expires_at: &str) -> Option<i64> {
     Some(diff_days)
 }
 
-/// Format a timestamp for display
-fn format_timestamp(ts: &str) -> String {
-    // Parse and format nicely
-    let date = js_sys::Date::new(&ts.into());
-    if date.get_time().is_nan() {
-        return ts.to_string();
-    }
-    format!(
-        "{}-{:02}-{:02} {:02}:{:02}",
-        date.get_full_year(),
-        date.get_month() + 1,
-        date.get_date(),
-        date.get_hours(),
-        date.get_minutes()
-    )
-}
-
 /// Token row component
 #[derive(Properties, PartialEq)]
 struct TokenRowProps {
@@ -103,11 +86,11 @@ fn token_row(props: &TokenRowProps) -> Html {
     html! {
         <tr class={if token.revoked || is_expired { "token-row disabled" } else { "token-row" }}>
             <td class="token-name">{ &token.name }</td>
-            <td class="token-created">{ format_timestamp(&token.created_at) }</td>
+            <td class="token-created">{ utils::format_timestamp(&token.created_at) }</td>
             <td class="token-last-used">
-                { token.last_used_at.as_ref().map(|t| format_timestamp(t)).unwrap_or_else(|| "Never".to_string()) }
+                { token.last_used_at.as_ref().map(|t| utils::format_timestamp(t)).unwrap_or_else(|| "Never".to_string()) }
             </td>
-            <td class="token-expires">{ format_timestamp(&token.expires_at) }</td>
+            <td class="token-expires">{ utils::format_timestamp(&token.expires_at) }</td>
             <td class={status_class}>{ status_text }</td>
             <td class="token-actions">
                 if !token.revoked && !is_expired {
@@ -170,8 +153,8 @@ fn session_row(props: &SessionRowProps) -> Html {
             <td class="session-branch">
                 { session.git_branch.as_deref().unwrap_or("—") }
             </td>
-            <td class="session-activity">{ format_timestamp(&session.last_activity) }</td>
-            <td class="session-created">{ format_timestamp(&session.created_at) }</td>
+            <td class="session-activity">{ utils::format_timestamp(&session.last_activity) }</td>
+            <td class="session-created">{ utils::format_timestamp(&session.created_at) }</td>
             <td class={status_class}>{ session.status.as_str() }</td>
             <td class="session-actions">
                 if is_owner {
@@ -895,7 +878,7 @@ pub fn settings_page() -> Html {
                                             <code>{ &token_response.init_url }</code>
                                         </div>
                                         <p class="expires-info">
-                                            { format!("Expires: {}", format_timestamp(&token_response.expires_at)) }
+                                            { format!("Expires: {}", utils::format_timestamp(&token_response.expires_at)) }
                                         </p>
                                         <button onclick={toggle_create_form.clone()}>{ "Done" }</button>
                                     </div>

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -51,6 +51,22 @@ pub fn format_dollars(amount: f64) -> String {
     format!("${}.{}", with_commas, decimal)
 }
 
+/// Format a timestamp string for display (e.g., "2026-01-15 14:30")
+pub fn format_timestamp(ts: &str) -> String {
+    let date = js_sys::Date::new(&ts.into());
+    if date.get_time().is_nan() {
+        return ts.to_string();
+    }
+    format!(
+        "{}-{:02}-{:02} {:02}:{:02}",
+        date.get_full_year(),
+        date.get_month() + 1,
+        date.get_date(),
+        date.get_hours(),
+        date.get_minutes()
+    )
+}
+
 /// Extract folder name from path (last path component)
 pub fn extract_folder(path: &str) -> &str {
     let trimmed = path.trim_end_matches('/');


### PR DESCRIPTION
## Summary
- Move `format_timestamp()` from `admin.rs` and `settings.rs` into `frontend/src/utils.rs`
- Both files now use `utils::format_timestamp()` instead of local copies

## Test plan
- [x] `cargo clippy --workspace` clean
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --check` clean

Fixes #459