### PR TITLE
Unify duplicated protocol types in endpoints.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/permissions.rs
+++ b/backend/src/handlers/websocket/permissions.rs
@@ -126,13 +126,13 @@ pub fn handle_permission_response(
 
     if !session_manager.send_to_session(
         session_key,
-        ServerToProxy::PermissionResponse {
+        ServerToProxy::PermissionResponse(shared::PermissionResponseFields {
             request_id,
             allow,
             input,
             permissions,
             reason,
-        },
+        }),
     ) {
         warn!(
             "Failed to send PermissionResponse to session '{}', session not connected",

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -85,7 +85,7 @@ fn handle_proxy_message(
     db_session_id: &mut Option<Uuid>,
 ) {
     match proxy_msg {
-        ProxyToServer::Register {
+        ProxyToServer::Register(shared::RegisterFields {
             session_id: claude_session_id,
             session_name,
             auth_token,
@@ -98,7 +98,7 @@ fn handle_proxy_message(
             hostname,
             launcher_id,
             agent_type,
-        } => {
+        }) => {
             let key = claude_session_id.to_string();
             *session_key = Some(key.clone());
 

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -84,12 +84,12 @@ fn handle_web_client_message(
     pending_uploads: &mut HashMap<String, PendingUpload>,
 ) -> bool {
     match client_msg {
-        ClientToServer::Register {
+        ClientToServer::Register(shared::RegisterFields {
             session_id,
             session_name,
             replay_after,
             ..
-        } => handle_web_register(
+        }) => handle_web_register(
             app_state,
             session_manager,
             db_pool,
@@ -112,13 +112,13 @@ fn handle_web_client_message(
             );
             false
         }
-        ClientToServer::FileUploadStart {
+        ClientToServer::FileUploadStart(shared::FileUploadStartFields {
             upload_id,
             filename,
             content_type,
             total_chunks,
             total_size,
-        } => {
+        }) => {
             handle_file_upload_start(
                 session_manager,
                 session_key,
@@ -131,11 +131,11 @@ fn handle_web_client_message(
             );
             false
         }
-        ClientToServer::FileUploadChunk {
+        ClientToServer::FileUploadChunk(shared::FileUploadChunkFields {
             upload_id,
             chunk_index,
             data,
-        } => {
+        }) => {
             handle_file_upload_chunk(
                 session_manager,
                 session_key,
@@ -146,13 +146,13 @@ fn handle_web_client_message(
             );
             false
         }
-        ClientToServer::PermissionResponse {
+        ClientToServer::PermissionResponse(shared::PermissionResponseFields {
             request_id,
             allow,
             input,
             permissions,
             reason,
-        } => {
+        }) => {
             if let (Some(ref key), Some(session_id)) = (session_key, *verified_session_id) {
                 handle_permission_response(
                     session_manager,
@@ -391,13 +391,13 @@ fn handle_file_upload_start(
 
     // Forward start message to proxy
     if let Some(ref key) = session_key {
-        let msg = ServerToProxy::FileUploadStart {
+        let msg = ServerToProxy::FileUploadStart(shared::FileUploadStartFields {
             upload_id,
             filename: safe_filename,
             content_type,
             total_chunks,
             total_size,
-        };
+        });
         if !session_manager.send_to_session(key, msg) {
             warn!("Session not connected for file upload start");
         }
@@ -429,11 +429,11 @@ fn handle_file_upload_chunk(
 
     // Forward chunk directly to proxy
     if let Some(ref key) = session_key {
-        let msg = ServerToProxy::FileUploadChunk {
+        let msg = ServerToProxy::FileUploadChunk(shared::FileUploadChunkFields {
             upload_id: upload_id.clone(),
             chunk_index,
             data,
-        };
+        });
         if !session_manager.send_to_session(key, msg) {
             warn!("Session not connected for file upload chunk");
         }

--- a/claude-session-lib/src/proxy_session.rs
+++ b/claude-session-lib/src/proxy_session.rs
@@ -414,7 +414,7 @@ async fn register_session(
         .and_then(|h| h.into_string().ok())
         .unwrap_or_else(|| "unknown".to_string());
 
-    let register_msg = ProxyToServer::Register {
+    let register_msg = ProxyToServer::Register(shared::RegisterFields {
         session_id: config.session_id,
         session_name: config.session_name.clone(),
         auth_token: config.auth_token.clone(),
@@ -427,7 +427,7 @@ async fn register_session(
         hostname: Some(hostname),
         launcher_id: config.launcher_id,
         agent_type: config.agent_type,
-    };
+    });
 
     if conn.send(register_msg).await.is_err() {
         error!("Failed to send registration message");
@@ -1311,7 +1311,7 @@ async fn handle_ws_message(
 ) -> WsMessageResult {
     if !matches!(
         proxy_msg,
-        ServerToProxy::Heartbeat | ServerToProxy::FileUploadChunk { .. }
+        ServerToProxy::Heartbeat | ServerToProxy::FileUploadChunk(..)
     ) {
         debug!("ws recv: {:?}", proxy_msg);
     }
@@ -1378,13 +1378,13 @@ async fn handle_ws_message(
                 error!("Failed to send InputAck: {}", e);
             }
         }
-        ServerToProxy::PermissionResponse {
+        ServerToProxy::PermissionResponse(shared::PermissionResponseFields {
             request_id,
             allow,
             input,
             permissions,
             reason,
-        } => {
+        }) => {
             debug!(
                 "→ [perm_response] {} allow={} permissions={} reason={:?}",
                 request_id,
@@ -1430,13 +1430,13 @@ async fn handle_ws_message(
             );
             return WsMessageResult::GracefulShutdown(reconnect_delay_ms);
         }
-        ServerToProxy::FileUploadStart {
+        ServerToProxy::FileUploadStart(shared::FileUploadStartFields {
             upload_id,
             filename,
             content_type: _,
             total_chunks,
             total_size,
-        } => {
+        }) => {
             info!(
                 "[upload {}] Starting: {} ({} bytes, {} chunks)",
                 &upload_id[..8.min(upload_id.len())],
@@ -1457,11 +1457,11 @@ async fn handle_ws_message(
                 return WsMessageResult::Disconnect;
             }
         }
-        ServerToProxy::FileUploadChunk {
+        ServerToProxy::FileUploadChunk(shared::FileUploadChunkFields {
             upload_id,
             chunk_index,
             data,
-        } => {
+        }) => {
             if file_upload_tx
                 .send(FileUploadEvent::Chunk {
                     upload_id,

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -535,13 +535,13 @@ impl Component for SessionView {
 
                         send_message(
                             ws,
-                            ClientToServer::FileUploadStart {
+                            ClientToServer::FileUploadStart(shared::FileUploadStartFields {
                                 upload_id: upload_id.clone(),
                                 filename: file_name.clone(),
                                 content_type: ct,
                                 total_chunks,
                                 total_size: file_size,
-                            },
+                            }),
                         );
 
                         for i in 0..total_chunks {
@@ -555,11 +555,11 @@ impl Component for SessionView {
 
                             send_message(
                                 ws,
-                                ClientToServer::FileUploadChunk {
+                                ClientToServer::FileUploadChunk(shared::FileUploadChunkFields {
                                     upload_id: upload_id.clone(),
                                     chunk_index: i,
                                     data: encoded,
-                                },
+                                }),
                             );
                         }
 
@@ -971,7 +971,7 @@ impl SessionView {
     fn handle_approve_permission(&mut self, ctx: &Context<Self>, remember: bool) -> bool {
         if let Some(perm) = self.pending_permission.take() {
             if let Some(ref sender) = self.ws_sender {
-                let msg = ClientToServer::PermissionResponse {
+                let msg = ClientToServer::PermissionResponse(shared::PermissionResponseFields {
                     request_id: perm.request_id,
                     allow: true,
                     input: Some(perm.input),
@@ -981,7 +981,7 @@ impl SessionView {
                         vec![]
                     },
                     reason: None,
-                };
+                });
                 send_message(sender, msg);
             }
             ctx.link().send_message(SessionViewMsg::CheckAwaiting);
@@ -995,13 +995,13 @@ impl SessionView {
     fn handle_deny_permission(&mut self, ctx: &Context<Self>) -> bool {
         if let Some(perm) = self.pending_permission.take() {
             if let Some(ref sender) = self.ws_sender {
-                let msg = ClientToServer::PermissionResponse {
+                let msg = ClientToServer::PermissionResponse(shared::PermissionResponseFields {
                     request_id: perm.request_id,
                     allow: false,
                     input: None,
                     permissions: vec![],
                     reason: Some("User denied".to_string()),
-                };
+                });
                 send_message(sender, msg);
             }
             ctx.link().send_message(SessionViewMsg::CheckAwaiting);
@@ -1070,13 +1070,13 @@ impl SessionView {
                     serde_json::to_value(PermissionAnswers::empty()).unwrap_or_default()
                 };
 
-                let msg = ClientToServer::PermissionResponse {
+                let msg = ClientToServer::PermissionResponse(shared::PermissionResponseFields {
                     request_id: perm.request_id,
                     allow: true,
                     input: Some(answers_json),
                     permissions: vec![],
                     reason: None,
-                };
+                });
                 send_message(sender, msg);
             }
             self.multi_select_options.clear();

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -35,7 +35,7 @@ pub fn connect_websocket(
             Ok(conn) => {
                 let (mut sender, mut receiver) = conn.split();
 
-                let register_msg = ClientToServer::Register {
+                let register_msg = ClientToServer::Register(shared::RegisterFields {
                     session_id,
                     session_name: session_id.to_string(),
                     auth_token: None,
@@ -48,7 +48,7 @@ pub fn connect_websocket(
                     hostname: None,
                     launcher_id: None,
                     agent_type: Default::default(),
-                };
+                });
 
                 if sender.send(register_msg).await.is_err() {
                     on_event.emit(WsEvent::Error("Failed to send registration".to_string()));

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -85,7 +85,7 @@ pub async fn register_with_backend(
         .and_then(|h| h.into_string().ok())
         .unwrap_or_else(|| "unknown".to_string());
 
-    let register_msg = ProxyToServer::Register {
+    let register_msg = ProxyToServer::Register(shared::RegisterFields {
         session_id: config.session_id,
         session_name: config.session_name.clone(),
         auth_token: config.auth_token.clone(),
@@ -98,7 +98,7 @@ pub async fn register_with_backend(
         hostname: Some(hostname),
         launcher_id: config.launcher_id,
         agent_type: config.agent_type,
-    };
+    });
 
     if let Err(e) = conn.send(&register_msg).await {
         error!("Failed to send registration message: {}", e);
@@ -303,13 +303,13 @@ async fn handle_ws_text_message(
                 }
             }
         }
-        ServerToProxy::PermissionResponse {
+        ServerToProxy::PermissionResponse(shared::PermissionResponseFields {
             request_id,
             allow,
             input,
             permissions,
             reason,
-        } => {
+        }) => {
             if perm_tx
                 .send(PermissionResponseData {
                     request_id,

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -7,6 +7,67 @@ use crate::{
 };
 
 // =============================================================================
+// Shared field structs — used by both proxy and client endpoints
+// =============================================================================
+
+/// Fields for session registration (shared by proxy and web client).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterFields {
+    pub session_id: Uuid,
+    pub session_name: String,
+    pub auth_token: Option<String>,
+    pub working_directory: String,
+    #[serde(default)]
+    pub resuming: bool,
+    #[serde(default)]
+    pub git_branch: Option<String>,
+    #[serde(default)]
+    pub replay_after: Option<String>,
+    #[serde(default)]
+    pub client_version: Option<String>,
+    #[serde(default)]
+    pub replaces_session_id: Option<Uuid>,
+    #[serde(default)]
+    pub hostname: Option<String>,
+    #[serde(default)]
+    pub launcher_id: Option<Uuid>,
+    #[serde(default)]
+    pub agent_type: AgentType,
+}
+
+/// Fields for a permission response (shared by server-to-proxy and client-to-server).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionResponseFields {
+    pub request_id: String,
+    pub allow: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub permissions: Vec<PermissionSuggestion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Fields for starting a file upload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileUploadStartFields {
+    pub upload_id: String,
+    pub filename: String,
+    pub content_type: String,
+    pub total_chunks: u32,
+    #[serde(default)]
+    pub total_size: u64,
+}
+
+/// Fields for a single file upload chunk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileUploadChunkFields {
+    pub upload_id: String,
+    pub chunk_index: u32,
+    pub data: String,
+}
+
+// =============================================================================
 // Session endpoint: proxy <-> backend (/ws/session)
 // =============================================================================
 
@@ -23,28 +84,7 @@ impl WsEndpoint for SessionEndpoint {
 #[serde(tag = "type")]
 pub enum ProxyToServer {
     /// Register a new session or connect to an existing one
-    Register {
-        session_id: Uuid,
-        session_name: String,
-        auth_token: Option<String>,
-        working_directory: String,
-        #[serde(default)]
-        resuming: bool,
-        #[serde(default)]
-        git_branch: Option<String>,
-        #[serde(default)]
-        replay_after: Option<String>,
-        #[serde(default)]
-        client_version: Option<String>,
-        #[serde(default)]
-        replaces_session_id: Option<Uuid>,
-        #[serde(default)]
-        hostname: Option<String>,
-        #[serde(default)]
-        launcher_id: Option<Uuid>,
-        #[serde(default)]
-        agent_type: AgentType,
-    },
+    Register(RegisterFields),
 
     /// Raw output from Claude Code (unsequenced fallback)
     ClaudeOutput { content: serde_json::Value },
@@ -115,37 +155,16 @@ pub enum ServerToProxy {
     },
 
     /// User's permission decision
-    PermissionResponse {
-        request_id: String,
-        allow: bool,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        input: Option<serde_json::Value>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        permissions: Vec<PermissionSuggestion>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        reason: Option<String>,
-    },
+    PermissionResponse(PermissionResponseFields),
 
     /// Acknowledge receipt of output messages
     OutputAck { session_id: Uuid, ack_seq: u64 },
 
     /// Start a chunked file upload to the proxy's working directory
-    FileUploadStart {
-        upload_id: String,
-        filename: String,
-        content_type: String,
-        total_chunks: u32,
-        /// Total decoded file size in bytes (for progress tracking)
-        total_size: u64,
-    },
+    FileUploadStart(FileUploadStartFields),
 
     /// A single chunk of a file upload (base64-encoded, ~1KB decoded)
-    FileUploadChunk {
-        upload_id: String,
-        chunk_index: u32,
-        /// Base64-encoded chunk data
-        data: String,
-    },
+    FileUploadChunk(FileUploadChunkFields),
 
     /// Server is shutting down
     ServerShutdown {
@@ -171,28 +190,7 @@ impl WsEndpoint for ClientEndpoint {
 #[serde(tag = "type")]
 pub enum ClientToServer {
     /// Register to receive updates for a session
-    Register {
-        session_id: Uuid,
-        session_name: String,
-        auth_token: Option<String>,
-        working_directory: String,
-        #[serde(default)]
-        resuming: bool,
-        #[serde(default)]
-        git_branch: Option<String>,
-        #[serde(default)]
-        replay_after: Option<String>,
-        #[serde(default)]
-        client_version: Option<String>,
-        #[serde(default)]
-        replaces_session_id: Option<Uuid>,
-        #[serde(default)]
-        hostname: Option<String>,
-        #[serde(default)]
-        launcher_id: Option<Uuid>,
-        #[serde(default)]
-        agent_type: AgentType,
-    },
+    Register(RegisterFields),
 
     /// User sends input to Claude
     ClaudeInput {
@@ -202,35 +200,13 @@ pub enum ClientToServer {
     },
 
     /// User's permission decision
-    PermissionResponse {
-        request_id: String,
-        allow: bool,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        input: Option<serde_json::Value>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        permissions: Vec<PermissionSuggestion>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        reason: Option<String>,
-    },
+    PermissionResponse(PermissionResponseFields),
 
     /// Start a chunked file upload
-    FileUploadStart {
-        upload_id: String,
-        filename: String,
-        content_type: String,
-        total_chunks: u32,
-        /// Total decoded file size in bytes (for progress tracking)
-        #[serde(default)]
-        total_size: u64,
-    },
+    FileUploadStart(FileUploadStartFields),
 
     /// A single chunk of a file upload
-    FileUploadChunk {
-        upload_id: String,
-        chunk_index: u32,
-        /// Base64-encoded chunk data (~1KB decoded per chunk)
-        data: String,
-    },
+    FileUploadChunk(FileUploadChunkFields),
 }
 
 /// Messages the backend sends to the frontend.
@@ -440,7 +416,7 @@ mod tests {
 
     #[test]
     fn proxy_to_server_register_roundtrip() {
-        let msg = ProxyToServer::Register {
+        let msg = ProxyToServer::Register(RegisterFields {
             session_id: Uuid::nil(),
             session_name: "test".into(),
             auth_token: None,
@@ -453,13 +429,13 @@ mod tests {
             hostname: None,
             launcher_id: None,
             agent_type: AgentType::Claude,
-        };
+        });
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"Register""#));
         let parsed: ProxyToServer = serde_json::from_str(&json).unwrap();
         match parsed {
-            ProxyToServer::Register { session_name, .. } => {
-                assert_eq!(session_name, "test");
+            ProxyToServer::Register(reg) => {
+                assert_eq!(reg.session_name, "test");
             }
             _ => panic!("Wrong variant"),
         }


### PR DESCRIPTION
## Summary
- Extract `RegisterFields`, `PermissionResponseFields`, `FileUploadStartFields`, `FileUploadChunkFields` into shared structs
- Replace duplicated inline struct variants with newtype variants wrapping shared structs
- Wire format is unchanged (verified by existing `wire_compat_register` and `wire_compat_server_shutdown` tests)

## Test plan
- [x] All existing wire-compat tests pass (serde roundtrip unchanged)
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --check` clean

Fixes #457