### PR TITLE
Unify shim WS channels into single event enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.3"
+version = "1.3.4"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -182,45 +182,39 @@ pub fn get_git_branch(cwd: &str) -> Option<String> {
     }
 }
 
-/// Result from handling a raw WebSocket text message.
-pub enum WsMessageResult {
-    Continue,
+/// Events produced by the WebSocket reader for the shim's select loop.
+pub enum WsEvent {
+    /// Text input from the portal web UI
+    Input(String),
+    /// Wiggum mode activation with the original prompt
+    WiggumActivation(String),
+    /// Permission response from the portal
+    PermissionResponse(PermissionResponseData),
+    /// Output acknowledgment from the backend
+    OutputAck(u64),
+    /// WebSocket disconnected (connection closed or error)
     Disconnect,
+    /// Server requested graceful shutdown with reconnect delay
     GracefulShutdown(u64),
 }
 
 /// Spawn a WebSocket reader task (raw tokio-tungstenite).
 ///
 /// Reads raw WS text messages, parses them as `ServerToProxy`, and dispatches
-/// to typed channels for the shim's select loop.
-#[allow(clippy::too_many_arguments)]
+/// events through a single channel for the shim's select loop.
+/// The `ws_write` handle is used internally for Heartbeat and InputAck responses.
 pub fn spawn_ws_reader(
     mut ws_read: SplitStream<WsStream>,
-    input_tx: mpsc::UnboundedSender<String>,
-    perm_tx: mpsc::UnboundedSender<PermissionResponseData>,
-    ack_tx: mpsc::UnboundedSender<u64>,
     ws_write: SharedWsWrite,
-    disconnect_tx: tokio::sync::oneshot::Sender<()>,
-    wiggum_tx: mpsc::UnboundedSender<String>,
-    graceful_shutdown_tx: mpsc::UnboundedSender<GracefulShutdown>,
+    event_tx: mpsc::UnboundedSender<WsEvent>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         while let Some(msg) = ws_read.next().await {
             match msg {
                 Ok(Message::Text(text)) => {
-                    match handle_ws_text_message(
-                        &text, &input_tx, &perm_tx, &ack_tx, &ws_write, &wiggum_tx,
-                    )
-                    .await
-                    {
-                        WsMessageResult::Continue => {}
-                        WsMessageResult::Disconnect => break,
-                        WsMessageResult::GracefulShutdown(delay_ms) => {
-                            let _ = graceful_shutdown_tx.send(GracefulShutdown {
-                                reconnect_delay_ms: delay_ms,
-                            });
-                            break;
-                        }
+                    match handle_ws_text_message(&text, &event_tx, &ws_write).await {
+                        true => {}      // continue
+                        false => break, // disconnect or shutdown already sent
                     }
                 }
                 Ok(Message::Close(_)) => {
@@ -235,22 +229,20 @@ pub fn spawn_ws_reader(
             }
         }
         debug!("WebSocket reader ended");
-        let _ = disconnect_tx.send(());
+        let _ = event_tx.send(WsEvent::Disconnect);
     })
 }
 
 /// Handle a raw text message from the WebSocket.
+/// Returns `true` to continue reading, `false` to stop.
 async fn handle_ws_text_message(
     text: &str,
-    input_tx: &mpsc::UnboundedSender<String>,
-    perm_tx: &mpsc::UnboundedSender<PermissionResponseData>,
-    ack_tx: &mpsc::UnboundedSender<u64>,
+    event_tx: &mpsc::UnboundedSender<WsEvent>,
     ws_write: &SharedWsWrite,
-    wiggum_tx: &mpsc::UnboundedSender<String>,
-) -> WsMessageResult {
+) -> bool {
     let server_msg = match serde_json::from_str::<ServerToProxy>(text) {
         Ok(msg) => msg,
-        Err(_) => return WsMessageResult::Continue,
+        Err(_) => return true,
     };
 
     match server_msg {
@@ -260,15 +252,12 @@ async fn handle_ws_text_message(
                 other => other.to_string(),
             };
 
-            if send_mode == Some(SendMode::Wiggum) {
-                if wiggum_tx.send(user_text).is_err() {
-                    error!("Failed to send wiggum activation");
-                    return WsMessageResult::Disconnect;
-                }
-            } else if input_tx.send(user_text).is_err() {
-                error!("Failed to send input to channel");
-                return WsMessageResult::Disconnect;
-            }
+            let event = if send_mode == Some(SendMode::Wiggum) {
+                WsEvent::WiggumActivation(user_text)
+            } else {
+                WsEvent::Input(user_text)
+            };
+            event_tx.send(event).is_ok()
         }
         ServerToProxy::SequencedInput {
             session_id,
@@ -281,14 +270,13 @@ async fn handle_ws_text_message(
                 other => other.to_string(),
             };
 
-            if send_mode == Some(SendMode::Wiggum) {
-                if wiggum_tx.send(user_text).is_err() {
-                    error!("Failed to send wiggum activation");
-                    return WsMessageResult::Disconnect;
-                }
-            } else if input_tx.send(user_text).is_err() {
-                error!("Failed to send input to channel");
-                return WsMessageResult::Disconnect;
+            let event = if send_mode == Some(SendMode::Wiggum) {
+                WsEvent::WiggumActivation(user_text)
+            } else {
+                WsEvent::Input(user_text)
+            };
+            if event_tx.send(event).is_err() {
+                return false;
             }
 
             // Send InputAck back to backend
@@ -302,6 +290,7 @@ async fn handle_ws_text_message(
                     error!("Failed to send InputAck: {}", e);
                 }
             }
+            true
         }
         ServerToProxy::PermissionResponse(shared::PermissionResponseFields {
             request_id,
@@ -309,35 +298,25 @@ async fn handle_ws_text_message(
             input,
             permissions,
             reason,
-        }) => {
-            if perm_tx
-                .send(PermissionResponseData {
-                    request_id,
-                    allow,
-                    input,
-                    permissions,
-                    reason,
-                })
-                .is_err()
-            {
-                error!("Failed to send permission response to channel");
-                return WsMessageResult::Disconnect;
-            }
-        }
+        }) => event_tx
+            .send(WsEvent::PermissionResponse(PermissionResponseData {
+                request_id,
+                allow,
+                input,
+                permissions,
+                reason,
+            }))
+            .is_ok(),
         ServerToProxy::OutputAck {
             session_id: _,
             ack_seq,
-        } => {
-            if ack_tx.send(ack_seq).is_err() {
-                error!("Failed to send output ack to channel");
-                return WsMessageResult::Disconnect;
-            }
-        }
+        } => event_tx.send(WsEvent::OutputAck(ack_seq)).is_ok(),
         ServerToProxy::Heartbeat => {
             let mut ws = ws_write.lock().await;
             if let Ok(json) = serde_json::to_string(&ProxyToServer::Heartbeat) {
                 let _ = ws.send(Message::Text(json)).await;
             }
+            true
         }
         ServerToProxy::ServerShutdown {
             reason,
@@ -347,10 +326,9 @@ async fn handle_ws_text_message(
                 "Server shutting down: {} (reconnecting in {}ms)",
                 reason, reconnect_delay_ms
             );
-            return WsMessageResult::GracefulShutdown(reconnect_delay_ms);
+            let _ = event_tx.send(WsEvent::GracefulShutdown(reconnect_delay_ms));
+            false // stop reading
         }
-        _ => {}
+        _ => true,
     }
-
-    WsMessageResult::Continue
 }

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::session::{
-    connect_ws, get_git_branch, register_with_backend, Backoff, GracefulShutdown,
-    PermissionResponseData, ProxySessionConfig, SharedWsWrite,
+    connect_ws, get_git_branch, register_with_backend, Backoff, PermissionResponseData,
+    ProxySessionConfig, SharedWsWrite, WsEvent,
 };
 use anyhow::Result;
 use claude_codes::io::{
@@ -493,47 +493,100 @@ async fn run_shim_connection(
     let (ws_write, ws_read) = conn.split();
     let ws_write: SharedWsWrite = Arc::new(Mutex::new(ws_write));
 
-    // Channels for WS reader dispatching
-    let (input_tx, mut input_rx) = mpsc::unbounded_channel::<String>();
-    let (perm_tx, mut perm_rx) = mpsc::unbounded_channel::<PermissionResponseData>();
-    let (ack_tx, mut ack_rx) = mpsc::unbounded_channel::<u64>();
-    let (wiggum_tx, mut wiggum_rx) = mpsc::unbounded_channel::<String>();
-    let (graceful_shutdown_tx, mut graceful_shutdown_rx) =
-        mpsc::unbounded_channel::<GracefulShutdown>();
-    let (disconnect_tx, mut disconnect_rx) = tokio::sync::oneshot::channel::<()>();
+    // Single event channel for all WebSocket reader events
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<WsEvent>();
 
-    // Reuse the existing WS reader (parses portal messages into typed channels)
-    let reader_task = crate::session::spawn_ws_reader(
-        ws_read,
-        input_tx,
-        perm_tx,
-        ack_tx,
-        ws_write.clone(),
-        disconnect_tx,
-        wiggum_tx,
-        graceful_shutdown_tx,
-    );
+    let reader_task = crate::session::spawn_ws_reader(ws_read, ws_write.clone(), event_tx);
 
     // Main select loop
     let result = loop {
         tokio::select! {
-            // Portal disconnected
-            _ = &mut disconnect_rx => {
-                // Check if a graceful shutdown was queued before the disconnect
-                if let Ok(shutdown) = graceful_shutdown_rx.try_recv() {
-                    break ShimConnectionResult::ServerShutdown(
-                        Duration::from_millis(shutdown.reconnect_delay_ms)
-                    );
-                }
-                info!("Portal WebSocket disconnected");
-                break ShimConnectionResult::Disconnected;
-            }
+            // WebSocket events from portal (unified channel)
+            event = event_rx.recv() => {
+                match event {
+                    Some(WsEvent::Input(text)) => {
+                        debug!("Portal input: {}", &text[..text.len().min(80)]);
+                        let _ = portal_text_tx.send(text.clone());
+                        let mut stdin = claude_stdin.lock().await;
+                        let input = ClaudeInput::user_message(&text, config.session_id);
+                        if let Ok(json_line) = serde_json::to_string(&input) {
+                            if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
+                                error!("Failed to write portal input to claude: {}", e);
+                                break ShimConnectionResult::ClaudeExited;
+                            }
+                            let _ = stdin.write_all(b"\n").await;
+                            let _ = stdin.flush().await;
+                        }
+                    }
+                    Some(WsEvent::WiggumActivation(prompt)) => {
+                        debug!("Portal wiggum input: {}", &prompt[..prompt.len().min(60)]);
+                        let wiggum_prompt = format!(
+                            "{}\n\nTake action on the directions above until fully complete. If complete, respond only with DONE.",
+                            prompt
+                        );
+                        let _ = portal_text_tx.send(wiggum_prompt.clone());
+                        let mut stdin = claude_stdin.lock().await;
+                        let input = ClaudeInput::user_message(&wiggum_prompt, config.session_id);
+                        if let Ok(json_line) = serde_json::to_string(&input) {
+                            if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
+                                error!("Failed to write wiggum input to claude: {}", e);
+                                break ShimConnectionResult::ClaudeExited;
+                            }
+                            let _ = stdin.write_all(b"\n").await;
+                            let _ = stdin.flush().await;
+                        }
+                    }
+                    Some(WsEvent::PermissionResponse(perm_response)) => {
+                        let request_id = &perm_response.request_id;
+                        let should_forward = {
+                            let mut perms = permissions.lock().await;
+                            match perms.get(request_id) {
+                                Some(PermissionState::Pending) => {
+                                    *perms.get_mut(request_id).unwrap() = PermissionState::Answered;
+                                    debug!("Permission {} answered by portal", request_id);
+                                    true
+                                }
+                                Some(PermissionState::Answered) => {
+                                    debug!("Permission {} already answered, ignoring portal response", request_id);
+                                    false
+                                }
+                                None => {
+                                    warn!("Unknown permission {}, forwarding", request_id);
+                                    true
+                                }
+                            }
+                        };
 
-            // Server graceful shutdown
-            Some(shutdown) = graceful_shutdown_rx.recv() => {
-                break ShimConnectionResult::ServerShutdown(
-                    Duration::from_millis(shutdown.reconnect_delay_ms)
-                );
+                        if should_forward {
+                            let ctrl_response: ControlResponseMessage = build_control_response(&perm_response).into();
+                            if let Ok(json_line) = serde_json::to_string(&ctrl_response) {
+                                let mut stdin = claude_stdin.lock().await;
+                                if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
+                                    error!("Failed to write permission response to claude: {}", e);
+                                    break ShimConnectionResult::ClaudeExited;
+                                }
+                                let _ = stdin.write_all(b"\n").await;
+                                let _ = stdin.flush().await;
+                            }
+                        }
+                    }
+                    Some(WsEvent::OutputAck(ack_seq)) => {
+                        let mut buf = output_buffer.lock().await;
+                        buf.acknowledge(ack_seq);
+                        if let Err(e) = buf.persist() {
+                            warn!("Failed to persist buffer after ack: {}", e);
+                        }
+                    }
+                    Some(WsEvent::GracefulShutdown(delay_ms)) => {
+                        break ShimConnectionResult::ServerShutdown(
+                            Duration::from_millis(delay_ms)
+                        );
+                    }
+                    Some(WsEvent::Disconnect) | None => {
+                        info!("Portal WebSocket disconnected");
+                        break ShimConnectionResult::Disconnected;
+                    }
+                }
             }
 
             // Claude output ready to send to portal (seq was assigned at buffer push time)
@@ -559,100 +612,8 @@ async fn run_shim_connection(
                 }
             }
 
-            // Text input from portal web UI
-            Some(text) = input_rx.recv() => {
-                debug!("Portal input: {}", &text[..text.len().min(80)]);
-                // Track for user echo dedup — stdout reader will match and forward to VS Code
-                let _ = portal_text_tx.send(text.clone());
-                let mut stdin = claude_stdin.lock().await;
-                // Build a proper ClaudeInput::User message (same format the normal proxy uses)
-                let input = ClaudeInput::user_message(&text, config.session_id);
-                if let Ok(json_line) = serde_json::to_string(&input) {
-                    if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
-                        error!("Failed to write portal input to claude: {}", e);
-                        break ShimConnectionResult::ClaudeExited;
-                    }
-                    let _ = stdin.write_all(b"\n").await;
-                    let _ = stdin.flush().await;
-                }
-            }
-
-            // Wiggum mode from portal
-            Some(prompt) = wiggum_rx.recv() => {
-                debug!("Portal wiggum input: {}", &prompt[..prompt.len().min(60)]);
-                let wiggum_prompt = format!(
-                    "{}\n\nTake action on the directions above until fully complete. If complete, respond only with DONE.",
-                    prompt
-                );
-                // Track the full wiggum text for user echo dedup
-                let _ = portal_text_tx.send(wiggum_prompt.clone());
-                let mut stdin = claude_stdin.lock().await;
-                let input = ClaudeInput::user_message(&wiggum_prompt, config.session_id);
-                if let Ok(json_line) = serde_json::to_string(&input) {
-                    if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
-                        error!("Failed to write wiggum input to claude: {}", e);
-                        break ShimConnectionResult::ClaudeExited;
-                    }
-                    let _ = stdin.write_all(b"\n").await;
-                    let _ = stdin.flush().await;
-                }
-            }
-
-            // Permission response from portal
-            Some(perm_response) = perm_rx.recv() => {
-                let request_id = &perm_response.request_id;
-
-                // Check dedup state
-                let should_forward = {
-                    let mut perms = permissions.lock().await;
-                    match perms.get(request_id) {
-                        Some(PermissionState::Pending) => {
-                            *perms.get_mut(request_id).unwrap() = PermissionState::Answered;
-                            debug!("Permission {} answered by portal", request_id);
-                            true
-                        }
-                        Some(PermissionState::Answered) => {
-                            debug!("Permission {} already answered, ignoring portal response", request_id);
-                            false
-                        }
-                        None => {
-                            // Unknown permission — forward anyway
-                            warn!("Unknown permission {}, forwarding", request_id);
-                            true
-                        }
-                    }
-                };
-
-                if should_forward {
-                    // Build ControlResponse and wrap with type tag for claude's stdin
-                    let ctrl_response: ControlResponseMessage = build_control_response(&perm_response).into();
-                    if let Ok(json_line) = serde_json::to_string(&ctrl_response) {
-                        let mut stdin = claude_stdin.lock().await;
-                        if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
-                            error!("Failed to write permission response to claude: {}", e);
-                            break ShimConnectionResult::ClaudeExited;
-                        }
-                        let _ = stdin.write_all(b"\n").await;
-                        let _ = stdin.flush().await;
-                    }
-                    // Do NOT write to our stdout — VS Code didn't request this
-                }
-            }
-
-            // Output acknowledgments from portal
-            Some(ack_seq) = ack_rx.recv() => {
-                let mut buf = output_buffer.lock().await;
-                buf.acknowledge(ack_seq);
-                if let Err(e) = buf.persist() {
-                    warn!("Failed to persist buffer after ack: {}", e);
-                }
-            }
-
-            // Detect if stdin_line_rx closes (parent process disconnected)
-            // This is informational only — stdin forwarding is handled by the reader task
-            _ = stdin_line_rx.recv() => {
-                // Just drain — actual forwarding happens in the stdin reader task
-            }
+            // Drain stdin lines (actual forwarding happens in the stdin reader task)
+            _ = stdin_line_rx.recv() => {}
         }
     };
 


### PR DESCRIPTION
## Summary
- Replace 6 separate `mpsc` channels + 1 `oneshot` in `spawn_ws_reader` with a single `WsEvent` enum channel
- Function signature goes from 8 params → 3 params (`ws_read`, `ws_write`, `event_tx`)
- Caller (`run_shim_connection`) uses a single pattern match instead of 6 separate `select!` arms for WS events
- Eliminates the disconnect/graceful-shutdown race condition (events are now ordered in the same channel)

## Test plan
- [x] `cargo test --workspace` — all 119 tests pass
- [x] `cargo clippy --workspace` — no warnings
- [x] Behavior is unchanged: Input, WiggumActivation, PermissionResponse, OutputAck, Disconnect, GracefulShutdown all handled identically

Fixes #271