### PR TITLE
Remove PR link wrapping from session pill branches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -458,19 +458,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     <span class="pill-hostname">{ hostname }</span>
                     {
                         if let Some(ref branch) = session.git_branch {
-                            if let Some(ref url) = session.pr_url {
-                                html! {
-                                    <a class="pill-branch pill-link" href={url.clone()} target="_blank"
-                                       title={format!("PR: {}", url)}
-                                       onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                                        { branch }
-                                    </a>
-                                }
-                            } else {
-                                // Derive repo URL from pr_url if we've ever had one,
-                                // otherwise just show plain text branch name
-                                html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
-                            }
+                            html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
                         } else {
                             html! { <span class="pill-branch pill-no-vcs">{ "No VCS" }</span> }
                         }

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -158,14 +158,6 @@
 }
 
 
-a.pill-branch.pill-link {
-    text-decoration: none;
-    color: var(--accent);
-}
-
-a.pill-branch.pill-link:hover {
-    text-decoration: underline;
-}
 
 .pill-branch.pill-no-vcs {
     color: var(--text-muted);
@@ -211,7 +203,7 @@ a.pill-branch.pill-link:hover {
     border-radius: 1px;
 }
 
-.sparkline-range.tick-compaction { background: #73daca; }
+.sparkline-range.tick-compaction { background: #e8a46c; }
 
 .session-pill.paused .sparkline-tick,
 .session-pill.paused .sparkline-range {


### PR DESCRIPTION
## Summary
- Branch names in session rail pills are now always plain text, never clickable links
- Removed the `<a>` tag wrapping for branches with associated PR URLs
- Cleaned up the `a.pill-branch.pill-link` CSS rules that are no longer needed
- Patch version bump to 1.3.5

## Test plan
- [ ] Verify session pills with PR URLs show branch name as plain text
- [ ] Verify session pills without PR URLs still display correctly
- [ ] Verify "No VCS" still renders for sessions without git branches
- [ ] PR link is still accessible via the dropdown menu "Open PR" option