### PR TITLE
Add task/subagent message rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.3.2"
+version = "1.3.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.2"
+version = "1.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -664,9 +664,9 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.46"
+version = "2.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c5fdfedbbacec81b1a3f74f15c4e305dda5c0e0940600a2e3c09ad46080a5b"
+checksum = "950732b27b3ef815d77d5f22a62e0a247e422d6d171f931ef106141f3614f4e1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.2"
+version = "1.3.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.2"
+version = "1.3.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.2"
+version = "1.3.6"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.2"
+version = "1.3.6"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.5"
+version = "1.3.6"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -40,7 +40,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = "2.1.46"
+claude-codes = "2.1.47"
 
 # Codex CLI integration
 codex-codes = { version = "0.101.0", default-features = false, features = ["types"] }

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -371,6 +371,20 @@ fn log_claude_output(output: &ClaudeOutput) {
                     debug!("  tools: {} available", init.tools.len());
                 }
             }
+            if let Some(task) = sys.as_task_started() {
+                debug!(
+                    "  task_started: id={} type={:?} desc={}",
+                    task.task_id,
+                    task.task_type,
+                    truncate(&task.description, 60)
+                );
+            }
+            if let Some(task) = sys.as_task_notification() {
+                debug!(
+                    "  task_notification: id={} status={:?}",
+                    task.task_id, task.status
+                );
+            }
         }
         ClaudeOutput::Assistant(asst) => {
             let msg = &asst.message;

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -366,6 +366,18 @@ pub fn render_system_message(msg: &SystemMessage) -> Html {
         return render_compaction_completed(msg);
     }
 
+    if subtype == "task_started" {
+        return render_task_started(msg);
+    }
+
+    if subtype == "task_progress" {
+        return html! {};
+    }
+
+    if subtype == "task_notification" {
+        return render_task_notification(msg);
+    }
+
     if subtype == "init" || subtype == "status" {
         return html! {};
     }
@@ -466,6 +478,92 @@ fn render_compaction_completed(msg: &SystemMessage) -> Html {
                     </div>
                 </div>
             </div>
+        </div>
+    }
+}
+
+fn render_task_started(msg: &SystemMessage) -> Html {
+    let extra = msg.extra.as_ref();
+    let task_type = extra
+        .and_then(|v| v.get("task_type").and_then(|t| t.as_str()))
+        .unwrap_or("unknown");
+    let description = extra
+        .and_then(|v| v.get("description").and_then(|d| d.as_str()))
+        .unwrap_or("Background task");
+    let task_id = extra
+        .and_then(|v| v.get("task_id").and_then(|t| t.as_str()))
+        .unwrap_or("");
+
+    let type_label = match task_type {
+        "local_agent" => "Sub-agent",
+        "local_bash" => "Background Bash",
+        _ => "Task",
+    };
+
+    html! {
+        <div class="claude-message task-message compact" title={format!("Task ID: {}", task_id)}>
+            <div class="message-header">
+                <span class="message-type-badge task">{ "Task Started" }</span>
+                <span class="task-type-badge">{ type_label }</span>
+                <span class="task-description-inline">{ description }</span>
+            </div>
+        </div>
+    }
+}
+
+fn render_task_notification(msg: &SystemMessage) -> Html {
+    let extra = msg.extra.as_ref();
+    let status = extra
+        .and_then(|v| v.get("status").and_then(|s| s.as_str()))
+        .unwrap_or("completed");
+    let summary_text = msg
+        .summary
+        .as_deref()
+        .or_else(|| extra.and_then(|v| v.get("summary").and_then(|s| s.as_str())));
+    let task_id = extra
+        .and_then(|v| v.get("task_id").and_then(|t| t.as_str()))
+        .unwrap_or("");
+
+    let usage = extra.and_then(|v| v.get("usage"));
+    let duration = usage.and_then(|u| u.get("duration_ms").and_then(|n| n.as_u64()));
+    let tool_uses = usage.and_then(|u| u.get("tool_uses").and_then(|n| n.as_u64()));
+    let total_tokens = usage.and_then(|u| u.get("total_tokens").and_then(|n| n.as_u64()));
+
+    let is_failed = status == "failed";
+    let status_class = if is_failed { "failed" } else { "completed" };
+
+    html! {
+        <div class={classes!("claude-message", "task-message", status_class)}
+             title={format!("Task ID: {}", task_id)}>
+            <div class="message-header">
+                <span class={classes!("message-type-badge", "task", status_class)}>
+                    { if is_failed { "Task Failed" } else { "Task Completed" } }
+                </span>
+                {
+                    if let Some(ms) = duration {
+                        html! { <span class="task-stat">{ format_duration(ms) }</span> }
+                    } else { html! {} }
+                }
+                {
+                    if let Some(tools) = tool_uses {
+                        html! { <span class="task-stat" title="Tool calls">{ format!("{} tools", tools) }</span> }
+                    } else { html! {} }
+                }
+                {
+                    if let Some(tokens) = total_tokens {
+                        html! { <span class="task-stat" title="Total tokens">{ format!("{}k tokens", tokens / 1000) }</span> }
+                    } else { html! {} }
+                }
+            </div>
+            {
+                if let Some(summary) = summary_text {
+                    html! {
+                        <div class="message-body">
+                            <div class="task-summary">{ render_markdown(summary) }</div>
+                        </div>
+                    }
+                } else { html! {} }
+            }
         </div>
     }
 }

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -377,7 +377,10 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                             *t > cutoff
                                 && !matches!(
                                     msg_type.as_str(),
-                                    "compaction_start" | "compaction_end"
+                                    "compaction_start"
+                                        | "compaction_end"
+                                        | "task_start"
+                                        | "task_end"
                                 )
                         })
                         .map(|(t, msg_type)| {
@@ -421,7 +424,31 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 ranges
             };
 
-            if ticks.is_empty() && compaction_ranges.is_empty() {
+            // Task ranges: pair up task_start/task_end events
+            let task_ranges: Vec<(f64, f64)> = {
+                let mut ranges = Vec::new();
+                if let Some(ts) = timestamps {
+                    let mut pending_start: Option<f64> = None;
+                    for (t, msg_type) in ts.iter().filter(|(t, _)| *t > cutoff) {
+                        match msg_type.as_str() {
+                            "task_start" => {
+                                pending_start = Some((t - cutoff) / window_ms * 100.0);
+                            }
+                            "task_end" => {
+                                let end_pct = (t - cutoff) / window_ms * 100.0;
+                                ranges.push((pending_start.take().unwrap_or(0.0), end_pct));
+                            }
+                            _ => {}
+                        }
+                    }
+                    if let Some(start_pct) = pending_start {
+                        ranges.push((start_pct, 100.0));
+                    }
+                }
+                ranges
+            };
+
+            if ticks.is_empty() && compaction_ranges.is_empty() && task_ranges.is_empty() {
                 html! {}
             } else {
                 html! {
@@ -430,6 +457,11 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                             let width = (end_pct - start_pct).max(1.0);
                             let style = format!("left: {:.1}%; width: {:.1}%", start_pct, width);
                             html! { <span class="sparkline-range tick-compaction" {style} /> }
+                        }).collect::<Html>() }
+                        { task_ranges.iter().map(|(start_pct, end_pct)| {
+                            let width = (end_pct - start_pct).max(1.0);
+                            let style = format!("left: {:.1}%; width: {:.1}%", start_pct, width);
+                            html! { <span class="sparkline-range tick-task" {style} /> }
                         }).collect::<Html>() }
                         { ticks.iter().map(|(pct, css_type)| {
                             let style = format!("left: {:.1}%", pct);

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -295,6 +295,10 @@ impl Component for SessionView {
                                     | "summary"
                             ) {
                                 msg_type = "compaction_end".to_string();
+                            } else if subtype == "task_started" {
+                                msg_type = "task_start".to_string();
+                            } else if subtype == "task_notification" {
+                                msg_type = "task_end".to_string();
                             }
                         }
                     }
@@ -874,6 +878,10 @@ impl SessionView {
                     "compaction" | "compact_boundary" | "context_compaction" | "summary"
                 ) {
                     msg_type = "compaction_end".to_string();
+                } else if subtype == "task_started" {
+                    msg_type = "task_start".to_string();
+                } else if subtype == "task_notification" {
+                    msg_type = "task_end".to_string();
                 }
             }
             if msg_type == "result" {

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -204,6 +204,7 @@
 }
 
 .sparkline-range.tick-compaction { background: #e8a46c; }
+.sparkline-range.tick-task { background: #bb9af7; }
 
 .session-pill.paused .sparkline-tick,
 .session-pill.paused .sparkline-range {

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -710,6 +710,61 @@
     overflow-y: auto;
 }
 
+/* Task/Subagent Message */
+.task-message {
+    border-left: 3px solid #bb9af7;
+    background: rgba(187, 154, 247, 0.08);
+}
+
+.task-message.failed {
+    border-left-color: var(--error);
+    background: rgba(247, 118, 142, 0.08);
+}
+
+.message-type-badge.task {
+    background: rgba(187, 154, 247, 0.2);
+    color: #bb9af7;
+}
+
+.message-type-badge.task.failed {
+    background: rgba(247, 118, 142, 0.2);
+    color: var(--error);
+}
+
+.task-type-badge {
+    font-size: 0.65rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    background: rgba(187, 154, 247, 0.15);
+    color: #bb9af7;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.task-description-inline {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.task-stat {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin-left: 0.5rem;
+}
+
+.task-summary {
+    color: var(--text);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
 /* Raw Message */
 .raw-message .raw-json {
     font-family: 'Courier New', monospace;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,7 +16,7 @@ uuid = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["serde", "wasmbind"] }
 
 # Claude Code types (WASM-compatible, no tokio)
-claude-codes = { version = "2.1.46", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.47", default-features = false, features = ["types"] }
 
 # Codex CLI types (WASM-compatible, types only)
 codex-codes = { workspace = true }


### PR DESCRIPTION
## Summary
- Update `claude-codes` to v2.1.47 for typed task system message structs
- Render `task_started` as compact purple cards with task type badge (Sub-agent / Background Bash) and description
- Render `task_notification` as completion cards with status (completed/failed), usage stats, and markdown summary
- Hide `task_progress` messages (too frequent, bookend pair is sufficient)
- Add purple task ranges to session sparkline (parallel to orange compaction ranges)
- Add typed task logging in proxy output forwarder

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] `cargo build --target wasm32-unknown-unknown -p shared` (WASM compat)
- [x] CSS lint passes
- [ ] Visual: task_started shows purple compact card with type badge
- [ ] Visual: task_notification shows purple/red card with summary + stats
- [ ] Visual: sparkline shows purple ranges during task execution

Fixes #468