### PR TITLE
Tasks sidebar toggle and running count polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.9
+
+- Tasks sidebar: header bar toggles open/close (removed separate X button)
+- Tasks sidebar: show running task count in title bar
+
 ## 1.3.8
 
 - Add widget protocol specification (`docs/WIDGET_PROTOCOL.md`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.8"
+version = "1.3.9"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -1524,12 +1524,13 @@ impl SessionView {
             SessionViewMsg::ToggleTasksPanel
         });
 
+        let running_count = self
+            .active_tasks
+            .values()
+            .filter(|t| t.status == TaskStatus::Running)
+            .count();
+
         if !self.tasks_panel_open {
-            let running_count = self
-                .active_tasks
-                .values()
-                .filter(|t| t.status == TaskStatus::Running)
-                .count();
             let label = if running_count > 0 {
                 format!("{}", running_count)
             } else {
@@ -1546,11 +1547,16 @@ impl SessionView {
         let mut tasks: Vec<_> = self.active_tasks.iter().collect();
         tasks.sort_by(|a, b| a.1.started_at.partial_cmp(&b.1.started_at).unwrap());
 
+        let title = if running_count > 0 {
+            format!("Tasks ({})", running_count)
+        } else {
+            "Tasks".to_string()
+        };
+
         html! {
             <div class="tasks-sidebar">
-                <div class="tasks-sidebar-header">
-                    <span class="tasks-sidebar-title">{ "Tasks" }</span>
-                    <button class="tasks-sidebar-close" onclick={on_toggle}>{ "\u{2715}" }</button>
+                <div class="tasks-sidebar-header" onclick={on_toggle}>
+                    <span class="tasks-sidebar-title">{ title }</span>
                 </div>
                 <div class="tasks-sidebar-list">
                     { for tasks.iter().map(|(_, task)| self.render_task_pill(task)) }

--- a/frontend/styles/tasks-sidebar.css
+++ b/frontend/styles/tasks-sidebar.css
@@ -77,6 +77,12 @@
     justify-content: space-between;
     padding: 0.6rem 0.8rem;
     border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.tasks-sidebar-header:hover {
+    background: rgba(255, 255, 255, 0.05);
 }
 
 .tasks-sidebar-title {
@@ -85,22 +91,6 @@
     color: #bb9af7;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-}
-
-.tasks-sidebar-close {
-    background: none;
-    border: none;
-    color: var(--text-secondary);
-    cursor: pointer;
-    font-size: 0.85rem;
-    padding: 2px 6px;
-    border-radius: 4px;
-    transition: background 0.15s;
-}
-
-.tasks-sidebar-close:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: var(--text-primary);
 }
 
 .tasks-sidebar-list {


### PR DESCRIPTION
## Summary
- Sidebar header bar now acts as the toggle control (click to close), removing the separate X button
- Running task count shown in sidebar title bar: "Tasks (2)" when tasks are active

## Test plan
- [ ] Open a session with running sub-agents
- [ ] Verify the tab hint opens the sidebar on click
- [ ] Verify clicking the sidebar header closes it
- [ ] Verify the title shows "Tasks (N)" with running count
- [ ] Verify plain "Tasks" when no tasks are running