### PR TITLE
Render result text in result messages

### DIFF
--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -868,6 +868,21 @@ pub fn render_result_message(msg: &ResultMessage) -> Html {
 
     html! {
         <div class={classes!("claude-message", "result-message", status_class)}>
+            {
+                if let Some(result_text) = msg.result.as_deref() {
+                    if !result_text.is_empty() {
+                        html! {
+                            <div class="message-body">
+                                <div class="result-text">{ render_markdown(result_text) }</div>
+                            </div>
+                        }
+                    } else {
+                        html! {}
+                    }
+                } else {
+                    html! {}
+                }
+            }
             <div class="result-stats-bar">
                 <span class={classes!("result-status", status_class)}>
                     { if is_error { "✗" } else { "✓" } }


### PR DESCRIPTION
## Summary
- Display the optional `.result` text field in result messages above the stats bar
- Renders as markdown, only shown when present and non-empty

## Test plan
- [ ] Observe a successful result message with `.result` content — text should appear above the stats bar
- [ ] Result messages without `.result` should render unchanged (stats bar only)