### PR TITLE
Grey sparkline ranges for tasks and compaction

### DIFF
--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -203,8 +203,8 @@
     border-radius: 1px;
 }
 
-.sparkline-range.tick-compaction { background: #e8a46c; }
-.sparkline-range.tick-task { background: #bb9af7; }
+.sparkline-range.tick-compaction { background: var(--text-secondary); }
+.sparkline-range.tick-task { background: var(--text-secondary); }
 
 .session-pill.paused .sparkline-tick,
 .session-pill.paused .sparkline-range {


### PR DESCRIPTION
## Summary
- Change task and compaction sparkline ranges from purple/orange to neutral grey (`var(--text-secondary)`)

## Test plan
- [ ] Session pills with task or compaction ranges show grey stretches instead of colored ones