### PR TITLE
Increase default image max size to 10 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.12
+
+- Increase default image max size from 2 MB to 10 MB
+
 ## 1.3.11
 
 - Update claude-codes to 2.1.49 (String-to-enum migration for subtype, stop_reason, status)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.11"
+version = "1.3.12"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -242,9 +242,9 @@ async fn check_and_send_branch_update(
     }
 }
 
-/// Default 2 MB limit on image file size for portal messages.
+/// Default 10 MB limit on image file size for portal messages.
 /// Override with PORTAL_MAX_IMAGE_MB environment variable.
-const DEFAULT_MAX_IMAGE_MB: usize = 2;
+const DEFAULT_MAX_IMAGE_MB: usize = 10;
 
 fn max_image_bytes() -> usize {
     std::env::var("PORTAL_MAX_IMAGE_MB")

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -692,9 +692,9 @@ const ALLOWED_IMAGE_MEDIA_TYPES: &[&str] = &[
     "image/svg+xml",
 ];
 
-/// 2 MB limit on base64 data we'll render as an inline image.
-/// Base64 encodes at ~1.33x, so 2MB base64 ≈ 1.5MB raw image.
-const MAX_IMAGE_BASE64_BYTES: usize = 2 * 1024 * 1024;
+/// 10 MB limit on base64 data we'll render as an inline image.
+/// Base64 encodes at ~1.33x, so 10MB base64 ≈ 7.5MB raw image.
+const MAX_IMAGE_BASE64_BYTES: usize = 10 * 1024 * 1024;
 
 fn render_image_source(source: &ImageSource, filename: Option<String>) -> Html {
     if !ALLOWED_IMAGE_MEDIA_TYPES.contains(&source.media_type.as_str()) {
@@ -708,7 +708,7 @@ fn render_image_source(source: &ImageSource, filename: Option<String>) -> Html {
         let size_mb = source.data.len() as f64 / (1024.0 * 1024.0);
         return html! {
             <pre class="tool-result-content">
-                { format!("[image too large: {:.1} MB, limit is 2 MB]", size_mb) }
+                { format!("[image too large: {:.1} MB, limit is 10 MB]", size_mb) }
             </pre>
         };
     }


### PR DESCRIPTION
## Summary
- Increase default image size limit from 2 MB to 10 MB in both proxy and frontend
- Proxy: `DEFAULT_MAX_IMAGE_MB` in output_forwarder (still overridable via `PORTAL_MAX_IMAGE_MB` env var)
- Frontend: `MAX_IMAGE_BASE64_BYTES` in renderers

## Test plan
- [x] Builds clean