### PR TITLE
User name attribution for shared sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.13
+
+- Add user name attribution to messages in shared sessions
+
 ## 1.3.12
 
 - Increase default image max size from 2 MB to 10 MB

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.3.11"
+version = "1.3.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.11"
+version = "1.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.11"
+version = "1.3.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.11"
+version = "1.3.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.11"
+version = "1.3.13"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.11"
+version = "1.3.13"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.12"
+version = "1.3.13"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -84,7 +84,7 @@ pub fn handle_claude_output(
     db_session_id: Option<Uuid>,
     db_pool: &DbPool,
     tx: &ProxySender,
-    content: serde_json::Value,
+    mut content: serde_json::Value,
     seq: Option<u64>,
 ) {
     // Deduplicate sequenced messages before broadcasting
@@ -105,6 +105,29 @@ pub fn handle_claude_output(
                 ack_seq: seq_num,
             });
             return;
+        }
+    }
+
+    // Inject sender attribution into user-type messages
+    let role_str = content
+        .get("type")
+        .and_then(|t| t.as_str())
+        .unwrap_or("assistant");
+    if role_str == "user" {
+        if let Some(session_id) = db_session_id {
+            if let Some((_, (sender_id, sender_name))) =
+                session_manager.last_input_sender.remove(&session_id)
+            {
+                if let Some(obj) = content.as_object_mut() {
+                    obj.insert(
+                        "_sender".to_string(),
+                        serde_json::json!({
+                            "user_id": sender_id.to_string(),
+                            "name": sender_name,
+                        }),
+                    );
+                }
+            }
         }
     }
 

--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -43,6 +43,8 @@ pub struct SessionManager {
     pub pending_truncations: Arc<DashSet<Uuid>>,
     pub launchers: Arc<DashMap<Uuid, LauncherConnection>>,
     pub pending_dir_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
+    /// Tracks who sent the last input for each session (session_id → (user_id, display_name))
+    pub last_input_sender: Arc<DashMap<Uuid, (Uuid, String)>>,
 }
 
 impl Default for SessionManager {
@@ -56,6 +58,7 @@ impl Default for SessionManager {
             pending_truncations: Arc::new(DashSet::new()),
             launchers: Arc::new(DashMap::new()),
             pending_dir_requests: Arc::new(DashMap::new()),
+            last_input_sender: Arc::new(DashMap::new()),
         }
     }
 }

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -109,6 +109,7 @@ fn handle_web_client_message(
                 *verified_session_id,
                 content,
                 send_mode,
+                user_id,
             );
             false
         }
@@ -290,6 +291,7 @@ fn handle_web_input(
     verified_session_id: Option<Uuid>,
     content: serde_json::Value,
     send_mode: Option<SendMode>,
+    user_id: Uuid,
 ) {
     let Some(ref key) = session_key else {
         warn!("Web client tried to send ClaudeInput but no session_key set (not registered?)");
@@ -301,6 +303,28 @@ fn handle_web_input(
     };
 
     info!("Web client sending ClaudeInput to session: {}", key);
+
+    // Track who sent this input so we can attribute the echoed user message
+    if let Ok(mut conn) = db_pool.get() {
+        use crate::schema::users;
+        let display_name: String = users::table
+            .find(user_id)
+            .select(users::name)
+            .first::<Option<String>>(&mut conn)
+            .ok()
+            .flatten()
+            .or_else(|| {
+                users::table
+                    .find(user_id)
+                    .select(users::email)
+                    .first::<String>(&mut conn)
+                    .ok()
+            })
+            .unwrap_or_else(|| "Unknown".to_string());
+        session_manager
+            .last_input_sender
+            .insert(session_id, (user_id, display_name));
+    }
 
     let seq = match db_pool.get() {
         Ok(mut conn) => {

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -76,6 +76,8 @@ pub struct MessageRendererProps {
     pub session_id: Option<Uuid>,
     #[prop_or_default]
     pub agent_type: shared::AgentType,
+    #[prop_or_default]
+    pub current_user_id: Option<String>,
 }
 
 #[function_component(MessageRenderer)]
@@ -92,7 +94,9 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
         Ok(ClaudeMessage::System(msg)) => renderers::render_system_message(&msg),
         Ok(ClaudeMessage::Assistant(msg)) => renderers::render_assistant_message(&msg),
         Ok(ClaudeMessage::Result(msg)) => renderers::render_result_message(&msg),
-        Ok(ClaudeMessage::User(msg)) => renderers::render_user_message(&msg),
+        Ok(ClaudeMessage::User(msg)) => {
+            renderers::render_user_message(&msg, props.current_user_id.as_deref())
+        }
         Ok(ClaudeMessage::Error(msg)) => renderers::render_error_message(&msg),
         Ok(ClaudeMessage::Portal(msg)) => renderers::render_portal_message(&msg),
         Ok(ClaudeMessage::RateLimitEvent(msg)) => renderers::render_rate_limit_event(&msg),
@@ -109,13 +113,15 @@ pub struct MessageGroupRendererProps {
     pub session_id: Option<Uuid>,
     #[prop_or_default]
     pub agent_type: shared::AgentType,
+    #[prop_or_default]
+    pub current_user_id: Option<String>,
 }
 
 #[function_component(MessageGroupRenderer)]
 pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
     match &props.group {
         MessageGroup::Single(json) => {
-            html! { <MessageRenderer json={json.clone()} session_id={props.session_id} agent_type={props.agent_type} /> }
+            html! { <MessageRenderer json={json.clone()} session_id={props.session_id} agent_type={props.agent_type} current_user_id={props.current_user_id.clone()} /> }
         }
         MessageGroup::AssistantGroup(messages) => renderers::render_assistant_group(messages),
     }

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -94,12 +94,17 @@ pub fn render_assistant_group(messages: &[String]) -> Html {
     }
 }
 
-pub fn render_user_message(msg: &UserMessage) -> Html {
+pub fn render_user_message(msg: &UserMessage, current_user_id: Option<&str>) -> Html {
+    let label = match &msg.sender {
+        Some(sender) if current_user_id != Some(sender.user_id.as_str()) => sender.name.clone(),
+        _ => "You".to_string(),
+    };
+
     if let Some(text) = &msg.content {
         html! {
             <div class="claude-message user-message">
                 <div class="message-header">
-                    <span class="message-type-badge user">{ "You" }</span>
+                    <span class="message-type-badge user">{ &label }</span>
                 </div>
                 <div class="message-body">
                     <div class="user-text">{ render_markdown(text) }</div>
@@ -134,7 +139,7 @@ pub fn render_user_message(msg: &UserMessage) -> Html {
             html! {
                 <div class="claude-message user-message">
                     <div class="message-header">
-                        <span class="message-type-badge user">{ "You" }</span>
+                        <span class="message-type-badge user">{ &label }</span>
                     </div>
                     <div class="message-body">
                         <div class="user-text">{ render_markdown(&text_content) }</div>

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -31,10 +31,18 @@ pub struct PortalMessage {
     pub content: Vec<shared::PortalContent>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageSender {
+    pub user_id: String,
+    pub name: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UserMessage {
     pub content: Option<String>,
     pub message: Option<UserMessageContent>,
+    #[serde(default, rename = "_sender")]
+    pub sender: Option<MessageSender>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -52,6 +52,7 @@ pub fn dashboard_page() -> Html {
     let pending_leave = use_state(|| None::<Uuid>);
     let is_admin = use_state(|| false);
     let voice_enabled = use_state(|| false);
+    let current_user_id = use_state(|| None::<String>);
     let app_title = use_state(|| "Claude Code Sessions".to_string());
     let activated_sessions = use_state(HashSet::<Uuid>::new);
     let activity_timestamps = use_state(HashMap::<Uuid, Vec<(f64, String)>>::new);
@@ -104,10 +105,11 @@ pub fn dashboard_page() -> Html {
         });
     }
 
-    // Fetch current user info (to check admin status and voice_enabled)
+    // Fetch current user info (to check admin status, voice_enabled, and user_id)
     {
         let is_admin = is_admin.clone();
         let voice_enabled = voice_enabled.clone();
+        let current_user_id = current_user_id.clone();
         use_effect_with((), move |_| {
             spawn_local(async move {
                 let api_endpoint = utils::api_url("/api/auth/me");
@@ -118,6 +120,9 @@ pub fn dashboard_page() -> Html {
                         }
                         if let Some(voice) = data.get("voice_enabled").and_then(|v| v.as_bool()) {
                             voice_enabled.set(voice);
+                        }
+                        if let Some(id) = data.get("id").and_then(|v| v.as_str()) {
+                            current_user_id.set(Some(id.to_string()));
                         }
                     }
                 }
@@ -693,6 +698,7 @@ pub fn dashboard_page() -> Html {
                                                 on_branch_change={on_branch_change.clone()}
                                                 on_activity={on_activity.clone()}
                                                 voice_enabled={*voice_enabled}
+                                                current_user_id={(*current_user_id).clone()}
                                             />
                                         </div>
                                     }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -59,6 +59,8 @@ pub struct SessionViewProps {
     pub on_activity: Callback<(Uuid, String, f64)>,
     #[prop_or(false)]
     pub voice_enabled: bool,
+    #[prop_or_default]
+    pub current_user_id: Option<String>,
 }
 
 /// Messages for the SessionView component
@@ -854,7 +856,7 @@ impl Component for SessionView {
                     <div class="session-view-messages" ref={self.messages_ref.clone()}>
                         {
                             group_messages(&self.messages).into_iter().map(|group| {
-                                html! { <MessageGroupRenderer group={group} session_id={Some(ctx.props().session.id)} agent_type={ctx.props().session.agent_type} /> }
+                                html! { <MessageGroupRenderer group={group} session_id={Some(ctx.props().session.id)} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} /> }
                             }).collect::<Html>()
                         }
                     </div>


### PR DESCRIPTION
## Summary
- When multiple users share a session, user messages now show the sender's name instead of "You"
- Backend injects `_sender` (user_id + display name) into user-type messages before broadcasting and storing
- Attribution persists in message history — no DB schema changes needed
- Single-user sessions still show "You" (backwards compatible)

## How it works
1. When a web client sends `ClaudeInput`, backend looks up sender name and stores it in `SessionManager.last_input_sender`
2. When the proxy echoes back a `"type": "user"` message, backend injects `_sender: {user_id, name}` into the JSON
3. Frontend parses `_sender` and shows the name (or "You" if it matches the current user)

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] WASM build succeeds
- [ ] Manual: shared session shows other user's name
- [ ] Manual: own messages show "You"
- [ ] Manual: history replay preserves attribution