### PR TITLE
Refactor sender attribution to use DB column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.14
+
+- Refactor sender attribution: store actual sender user_id in DB, reconstruct display info at query time
+
 ## 1.3.13
 
 - Add user name attribution to messages in shared sessions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-launcher"
-version = "1.3.13"
+version = "1.3.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.13"
+version = "1.3.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.13"
+version = "1.3.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.13"
+version = "1.3.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.13"
+version = "1.3.14"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.13"
+version = "1.3.14"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.13"
+version = "1.3.14"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -8,6 +8,7 @@ use axum::{
 };
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tower_cookies::Cookies;
 use tracing::error;
@@ -28,10 +29,19 @@ pub struct MessageResponse {
     pub message: Message,
 }
 
+/// A message with optional sender name (for user-role messages in shared sessions)
+#[derive(Debug, Serialize)]
+pub struct MessageWithSender {
+    #[serde(flatten)]
+    pub message: Message,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender_name: Option<String>,
+}
+
 /// Response for listing messages
 #[derive(Debug, Serialize)]
 pub struct MessagesListResponse {
-    pub messages: Vec<Message>,
+    pub messages: Vec<MessageWithSender>,
     pub total: i64,
 }
 
@@ -142,10 +152,46 @@ pub async fn list_messages(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
+    // Look up sender names for user-role messages
+    use crate::schema::users;
+    let user_ids: Vec<Uuid> = message_list
+        .iter()
+        .filter(|m| m.role == "user")
+        .map(|m| m.user_id)
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    let user_names: HashMap<Uuid, String> = if !user_ids.is_empty() {
+        users::table
+            .filter(users::id.eq_any(&user_ids))
+            .select((users::id, users::name, users::email))
+            .load::<(Uuid, Option<String>, String)>(&mut conn)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(id, name, email)| (id, name.unwrap_or(email)))
+            .collect()
+    } else {
+        HashMap::new()
+    };
+
     let total = message_list.len() as i64;
+    let enriched: Vec<MessageWithSender> = message_list
+        .into_iter()
+        .map(|msg| {
+            let sender_name = if msg.role == "user" {
+                user_names.get(&msg.user_id).cloned()
+            } else {
+                None
+            };
+            MessageWithSender {
+                message: msg,
+                sender_name,
+            }
+        })
+        .collect();
 
     Ok(Json(MessagesListResponse {
-        messages: message_list,
+        messages: enriched,
         total,
     }))
 }

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -84,7 +84,7 @@ pub fn handle_claude_output(
     db_session_id: Option<Uuid>,
     db_pool: &DbPool,
     tx: &ProxySender,
-    mut content: serde_json::Value,
+    content: serde_json::Value,
     seq: Option<u64>,
 ) {
     // Deduplicate sequenced messages before broadcasting
@@ -108,35 +108,30 @@ pub fn handle_claude_output(
         }
     }
 
-    // Inject sender attribution into user-type messages
+    // Extract sender attribution for user-type messages (from last_input_sender, not injected into JSON)
     let role_str = content
         .get("type")
         .and_then(|t| t.as_str())
         .unwrap_or("assistant");
-    if role_str == "user" {
-        if let Some(session_id) = db_session_id {
-            if let Some((_, (sender_id, sender_name))) =
-                session_manager.last_input_sender.remove(&session_id)
-            {
-                if let Some(obj) = content.as_object_mut() {
-                    obj.insert(
-                        "_sender".to_string(),
-                        serde_json::json!({
-                            "user_id": sender_id.to_string(),
-                            "name": sender_name,
-                        }),
-                    );
-                }
-            }
-        }
-    }
+    let sender_info = if role_str == "user" {
+        db_session_id.and_then(|sid| {
+            session_manager
+                .last_input_sender
+                .remove(&sid)
+                .map(|(_, v)| v)
+        })
+    } else {
+        None
+    };
 
-    // Broadcast output to all web clients (after dedup check)
+    // Broadcast output to all web clients with sender metadata alongside content
     if let Some(ref key) = session_key {
         session_manager.broadcast_to_web_clients(
             key,
             ServerToClient::ClaudeOutput {
                 content: content.clone(),
+                sender_user_id: sender_info.as_ref().map(|(id, _)| id.to_string()),
+                sender_name: sender_info.as_ref().map(|(_, name)| name.clone()),
             },
         );
     }
@@ -156,11 +151,17 @@ pub fn handle_claude_output(
                     .unwrap_or("assistant"),
             );
 
+            // Use actual sender's user_id for user messages, fall back to session owner
+            let actual_user_id = sender_info
+                .as_ref()
+                .map(|(id, _)| *id)
+                .unwrap_or(session.user_id);
+
             let new_message = crate::models::NewMessage {
                 session_id,
                 role: role.to_string(),
                 content: content.to_string(),
-                user_id: session.user_id,
+                user_id: actual_user_id,
             };
 
             if let Err(e) = diesel::insert_into(messages::table)

--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -327,6 +327,8 @@ mod tests {
     fn make_client_msg() -> ServerToClient {
         ServerToClient::ClaudeOutput {
             content: serde_json::json!({"text": "hello"}),
+            sender_user_id: None,
+            sender_name: None,
         }
     }
 

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -268,16 +268,54 @@ fn replay_history(
         return;
     }
 
+    // Look up sender names for user-role messages
+    use crate::schema::users;
+    let user_ids: Vec<Uuid> = history
+        .iter()
+        .filter(|m| m.role == "user")
+        .map(|m| m.user_id)
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    let user_names: std::collections::HashMap<Uuid, String> = if !user_ids.is_empty() {
+        users::table
+            .filter(users::id.eq_any(&user_ids))
+            .select((users::id, users::name, users::email))
+            .load::<(Uuid, Option<String>, String)>(&mut conn)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(id, name, email)| (id, name.unwrap_or(email)))
+            .collect()
+    } else {
+        std::collections::HashMap::new()
+    };
+
     let messages: Vec<serde_json::Value> = history
         .into_iter()
         .map(|msg| {
-            serde_json::from_str::<serde_json::Value>(&msg.content).unwrap_or_else(|_| {
-                let fallback = RawMessageFallback {
-                    message_type: msg.role,
-                    content: msg.content,
-                };
-                serde_json::to_value(&fallback).unwrap_or_default()
-            })
+            let mut val =
+                serde_json::from_str::<serde_json::Value>(&msg.content).unwrap_or_else(|_| {
+                    let fallback = RawMessageFallback {
+                        message_type: msg.role.clone(),
+                        content: msg.content.clone(),
+                    };
+                    serde_json::to_value(&fallback).unwrap_or_default()
+                });
+            // Reconstruct _sender for user messages from DB user_id
+            if msg.role == "user" {
+                if let Some(name) = user_names.get(&msg.user_id) {
+                    if let Some(obj) = val.as_object_mut() {
+                        obj.insert(
+                            "_sender".to_string(),
+                            serde_json::json!({
+                                "user_id": msg.user_id.to_string(),
+                                "name": name,
+                            }),
+                        );
+                    }
+                }
+            }
+            val
         })
         .collect();
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -390,7 +390,29 @@ impl Component for SessionView {
                 if !self.active_tasks.is_empty() {
                     self.ensure_task_tick(ctx);
                 }
-                self.messages = messages.into_iter().map(|m| m.content).collect();
+                self.messages = messages
+                    .into_iter()
+                    .map(|m| {
+                        // Inject _sender into user messages from API metadata
+                        if m.role == "user" && (m.user_id.is_some() || m.sender_name.is_some()) {
+                            if let Ok(mut val) =
+                                serde_json::from_str::<serde_json::Value>(&m.content)
+                            {
+                                if let Some(obj) = val.as_object_mut() {
+                                    obj.insert(
+                                        "_sender".to_string(),
+                                        serde_json::json!({
+                                            "user_id": m.user_id.unwrap_or_default(),
+                                            "name": m.sender_name.unwrap_or_default(),
+                                        }),
+                                    );
+                                }
+                                return val.to_string();
+                            }
+                        }
+                        m.content
+                    })
+                    .collect();
                 self.last_message_timestamp = last_timestamp;
                 ctx.link().send_message(SessionViewMsg::CheckAwaiting);
                 true

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -82,8 +82,29 @@ pub fn connect_websocket(
 /// Handle incoming server message and emit appropriate events
 fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
     match msg {
-        ServerToClient::ClaudeOutput { content } => {
-            on_event.emit(WsEvent::Output(content.to_string()));
+        ServerToClient::ClaudeOutput {
+            content,
+            sender_user_id,
+            sender_name,
+        } => {
+            // Inject _sender into content for the renderer if sender info is present
+            let output = if sender_user_id.is_some() || sender_name.is_some() {
+                if let Some(mut obj) = content.as_object().cloned() {
+                    obj.insert(
+                        "_sender".to_string(),
+                        serde_json::json!({
+                            "user_id": sender_user_id.unwrap_or_default(),
+                            "name": sender_name.unwrap_or_default(),
+                        }),
+                    );
+                    serde_json::Value::Object(obj).to_string()
+                } else {
+                    content.to_string()
+                }
+            } else {
+                content.to_string()
+            };
+            on_event.emit(WsEvent::Output(output));
         }
         ServerToClient::HistoryBatch { messages } => {
             let strings: Vec<String> = messages.into_iter().map(|v| v.to_string()).collect();

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -25,11 +25,16 @@ pub type WsSender = Rc<RefCell<Option<ws_bridge::yew_client::Sender<shared::Clie
 /// Message data from the API
 #[derive(Clone, PartialEq, Deserialize)]
 pub struct MessageData {
-    #[allow(dead_code)]
     pub role: String,
     pub content: String,
     /// ISO 8601 timestamp when message was created
     pub created_at: String,
+    /// User ID of who sent this message (for user-role messages)
+    #[serde(default)]
+    pub user_id: Option<String>,
+    /// Display name of the sender (looked up from users table)
+    #[serde(default)]
+    pub sender_name: Option<String>,
 }
 
 /// Response from messages API endpoint

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -214,7 +214,13 @@ pub enum ClientToServer {
 #[serde(tag = "type")]
 pub enum ServerToClient {
     /// Output from Claude Code
-    ClaudeOutput { content: serde_json::Value },
+    ClaudeOutput {
+        content: serde_json::Value,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        sender_user_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        sender_name: Option<String>,
+    },
 
     /// Batch of historical messages for replay
     HistoryBatch { messages: Vec<serde_json::Value> },
@@ -482,11 +488,13 @@ mod tests {
     fn server_to_client_output_roundtrip() {
         let msg = ServerToClient::ClaudeOutput {
             content: serde_json::json!({"type": "assistant", "text": "hello"}),
+            sender_user_id: None,
+            sender_name: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerToClient = serde_json::from_str(&json).unwrap();
         match parsed {
-            ServerToClient::ClaudeOutput { content } => {
+            ServerToClient::ClaudeOutput { content, .. } => {
                 assert_eq!(content["text"], "hello");
             }
             _ => panic!("Wrong variant"),


### PR DESCRIPTION
## Summary
- Stop injecting `_sender` into message JSON before DB storage — content column stays clean
- Store actual sender's `user_id` in `messages.user_id` column instead of always using session owner
- Reconstruct sender info at display time: WS broadcast carries sender fields alongside content, history replay joins with users table
- REST API enriches response with `sender_name` from users table join

## Test plan
- [x] `cargo test --workspace` — all 119 tests pass
- [x] `cargo clippy --workspace` — clean
- [x] `cargo build --target wasm32-unknown-unknown -p shared` — WASM compat verified
- [ ] Manual: shared session shows other user's name on their messages
- [ ] Manual: own messages still show "You"
- [ ] Manual: history replay preserves attribution after reconnect