### PR TITLE
Fix stale subagent entries and sidebar slide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.15
+
+- Fix stale subagent entries persisting across page reloads by clearing task state on history reload
+- Tasks sidebar panel now slides in/out with the drawer instead of instantly appearing/disappearing
+
 ## 1.3.14
 
 - Refactor sender attribution: store actual sender user_id in DB, reconstruct display info at query time

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.14"
+version = "1.3.15"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -318,6 +318,7 @@ impl Component for SessionView {
                     messages.drain(0..excess);
                 }
                 let session_id = ctx.props().session.id;
+                self.active_tasks.clear();
                 for msg in &messages {
                     let mut msg_type = "unknown".to_string();
                     if let Ok(claude_msg) =
@@ -362,16 +363,45 @@ impl Component for SessionView {
                                     },
                                 );
                             } else if let Some(progress) = sys.as_task_progress() {
-                                if let Some(entry) = self.active_tasks.get_mut(&progress.task_id) {
-                                    entry.current_activity = Some(progress.description.clone());
-                                    entry.last_tool_name = Some(progress.last_tool_name.clone());
-                                    entry.duration_ms = Some(progress.usage.duration_ms);
-                                    entry.tool_uses = Some(progress.usage.tool_uses);
-                                    entry.total_tokens = Some(progress.usage.total_tokens);
-                                }
+                                let ts = js_sys::Date::parse(&msg.created_at);
+                                let started_at = if ts.is_finite() { ts } else { 0.0 };
+                                let entry = self
+                                    .active_tasks
+                                    .entry(progress.task_id.clone())
+                                    .or_insert_with(|| TaskEntry {
+                                        task_type: "local_agent".to_string(),
+                                        description: progress.description.clone(),
+                                        started_at,
+                                        status: TaskStatus::Running,
+                                        duration_ms: None,
+                                        tool_uses: None,
+                                        total_tokens: None,
+                                        completed_at: None,
+                                        current_activity: None,
+                                        last_tool_name: None,
+                                    });
+                                entry.current_activity = Some(progress.description.clone());
+                                entry.last_tool_name = Some(progress.last_tool_name.clone());
+                                entry.duration_ms = Some(progress.usage.duration_ms);
+                                entry.tool_uses = Some(progress.usage.tool_uses);
+                                entry.total_tokens = Some(progress.usage.total_tokens);
                             } else if let Some(notif) = sys.as_task_notification() {
                                 msg_type = "task_end".to_string();
-                                self.active_tasks.remove(&notif.task_id);
+                                if let Some(entry) = self.active_tasks.get_mut(&notif.task_id) {
+                                    entry.status = match notif.status {
+                                        shared::CCTaskStatus::Failed => TaskStatus::Failed,
+                                        _ => TaskStatus::Completed,
+                                    };
+                                    let ts = js_sys::Date::parse(&msg.created_at);
+                                    entry.completed_at =
+                                        Some(if ts.is_finite() { ts } else { 0.0 });
+                                    if let Some(usage) = &notif.usage {
+                                        entry.duration_ms = Some(usage.duration_ms);
+                                        entry.tool_uses = Some(usage.tool_uses);
+                                        entry.total_tokens = Some(usage.total_tokens);
+                                    }
+                                }
+                                // If we never saw task_started (truncated), just ignore the notification
                             }
                         }
                     } else if let Ok(parsed) =
@@ -1049,29 +1079,59 @@ impl SessionView {
                             self.schedule_clear_pulse(ctx, 600);
                         }
                     } else if let Some(progress) = sys.as_task_progress() {
-                        if let Some(entry) = self.active_tasks.get_mut(&progress.task_id) {
-                            entry.current_activity = Some(progress.description.clone());
-                            entry.last_tool_name = Some(progress.last_tool_name.clone());
-                            entry.duration_ms = Some(progress.usage.duration_ms);
-                            entry.tool_uses = Some(progress.usage.tool_uses);
-                            entry.total_tokens = Some(progress.usage.total_tokens);
+                        if !self.active_tasks.contains_key(&progress.task_id) {
+                            self.active_tasks.insert(
+                                progress.task_id.clone(),
+                                TaskEntry {
+                                    task_type: "local_agent".to_string(),
+                                    description: progress.description.clone(),
+                                    started_at: js_sys::Date::now(),
+                                    status: TaskStatus::Running,
+                                    duration_ms: None,
+                                    tool_uses: None,
+                                    total_tokens: None,
+                                    completed_at: None,
+                                    current_activity: None,
+                                    last_tool_name: None,
+                                },
+                            );
+                            self.ensure_task_tick(ctx);
                         }
+                        let entry = self.active_tasks.get_mut(&progress.task_id).unwrap();
+                        entry.current_activity = Some(progress.description.clone());
+                        entry.last_tool_name = Some(progress.last_tool_name.clone());
+                        entry.duration_ms = Some(progress.usage.duration_ms);
+                        entry.tool_uses = Some(progress.usage.tool_uses);
+                        entry.total_tokens = Some(progress.usage.total_tokens);
                         // Dim pulse on progress
                         self.tab_anim = Some("progress");
                         self.schedule_clear_pulse(ctx, 400);
                     } else if let Some(notif) = sys.as_task_notification() {
                         msg_type = "task_end".to_string();
-                        if let Some(entry) = self.active_tasks.get_mut(&notif.task_id) {
-                            entry.status = match notif.status {
-                                shared::CCTaskStatus::Failed => TaskStatus::Failed,
-                                _ => TaskStatus::Completed,
-                            };
-                            entry.completed_at = Some(js_sys::Date::now());
-                            if let Some(usage) = &notif.usage {
-                                entry.duration_ms = Some(usage.duration_ms);
-                                entry.tool_uses = Some(usage.tool_uses);
-                                entry.total_tokens = Some(usage.total_tokens);
-                            }
+                        let entry = self
+                            .active_tasks
+                            .entry(notif.task_id.clone())
+                            .or_insert_with(|| TaskEntry {
+                                task_type: "local_agent".to_string(),
+                                description: notif.summary.clone(),
+                                started_at: js_sys::Date::now(),
+                                status: TaskStatus::Running,
+                                duration_ms: None,
+                                tool_uses: None,
+                                total_tokens: None,
+                                completed_at: None,
+                                current_activity: None,
+                                last_tool_name: None,
+                            });
+                        entry.status = match notif.status {
+                            shared::CCTaskStatus::Failed => TaskStatus::Failed,
+                            _ => TaskStatus::Completed,
+                        };
+                        entry.completed_at = Some(js_sys::Date::now());
+                        if let Some(usage) = &notif.usage {
+                            entry.duration_ms = Some(usage.duration_ms);
+                            entry.tool_uses = Some(usage.tool_uses);
+                            entry.total_tokens = Some(usage.total_tokens);
                         }
                         // If no running tasks remain, start departure
                         let still_running = self
@@ -1580,13 +1640,11 @@ impl SessionView {
                     <span class="tasks-tab-count">{ format!("{}", running_count) }</span>
                     <span class="tasks-tab-label">{ "Tasks" }</span>
                 </div>
-                if open {
-                    <div class="tasks-sidebar-panel">
-                        <div class="tasks-sidebar-list">
-                            { for tasks.iter().map(|(_, task)| self.render_task_pill(task)) }
-                        </div>
+                <div class="tasks-sidebar-panel">
+                    <div class="tasks-sidebar-list">
+                        { for tasks.iter().map(|(_, task)| self.render_task_pill(task)) }
                     </div>
-                }
+                </div>
             </div>
         }
     }

--- a/frontend/styles/tasks-sidebar.css
+++ b/frontend/styles/tasks-sidebar.css
@@ -11,8 +11,9 @@
     z-index: 20;
     display: flex;
     pointer-events: none;
-    transition: width 0.2s ease-out;
+    transition: width 0.25s ease-in-out;
     width: 0;
+    overflow: hidden;
     animation: tabSlideIn 0.35s ease-out;
 }
 
@@ -126,7 +127,8 @@
 /* --- Panel (visible when open) --- */
 .tasks-sidebar-panel {
     pointer-events: auto;
-    flex: 1;
+    width: 280px;
+    min-width: 280px;
     display: flex;
     flex-direction: column;
     background: var(--bg-darker);


### PR DESCRIPTION
## Summary
- Clear `active_tasks` on history reload so stale subagent entries from truncated message windows don't persist
- Handle `task_progress` and `task_notification` for unknown task IDs by creating stub entries (gracefully handles truncated history)
- Tasks sidebar panel now slides in/out with the drawer width transition instead of instantly appearing/disappearing

## Test plan
- [ ] Verify subagent entries clear on page reload
- [ ] Verify tasks sidebar slides smoothly when toggling open/closed
- [ ] Verify live task_progress/task_notification still work correctly