### PR TITLE
Backend-authoritative max image size for proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.16
+
+- Backend sends max image size to proxies via RegisterAck; proxy uses it instead of local env var
+- Remove frontend image size check (backend/proxy is authoritative)
+
 ## 1.3.15
 
 - Fix stale subagent entries persisting across page reloads by clearing task state on history reload

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.15"
+version = "1.3.16"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -126,6 +126,7 @@ fn handle_proxy_message(
                 success: result.success,
                 session_id: claude_session_id,
                 error: result.error,
+                max_image_mb: Some(app_state.max_image_mb),
             });
 
             info!(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -53,6 +53,8 @@ pub struct AppState {
     pub message_retention_days: u32,
     /// Days to keep sessions before auto-deletion (default: 14, 0 = disabled)
     pub session_max_age_days: u32,
+    /// Maximum image size in MB that proxies should inline (default: 10)
+    pub max_image_mb: u32,
 }
 
 #[tokio::main]
@@ -259,6 +261,11 @@ async fn main() -> anyhow::Result<()> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(14);
 
+    let max_image_mb: u32 = env::var("PORTAL_MAX_IMAGE_MB")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+
     tracing::info!(
         "Message retention: max {} messages/session, {} days",
         message_retention_count,
@@ -268,6 +275,7 @@ async fn main() -> anyhow::Result<()> {
         "Session max age: {} days (0 = disabled)",
         session_max_age_days
     );
+    tracing::info!("Max image size: {} MB", max_image_mb);
 
     // Create app state
     let app_state = Arc::new(AppState {
@@ -286,6 +294,7 @@ async fn main() -> anyhow::Result<()> {
         message_retention_count,
         message_retention_days,
         session_max_age_days,
+        max_image_mb,
     });
 
     // Setup CORS

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -339,9 +339,10 @@ async fn run_single_connection(session: &mut SessionState<'_>) -> ConnectionResu
     };
 
     // Register with backend and wait for acknowledgment
-    if let Err(duration) = register_session(&mut conn, &config_with_branch).await {
-        return ConnectionResult::Disconnected(duration);
-    }
+    let max_image_mb = match register_session(&mut conn, &config_with_branch).await {
+        Ok(mb) => mb,
+        Err(duration) => return ConnectionResult::Disconnected(duration),
+    };
 
     // Look up PR URL for the current branch and send as SessionUpdate
     if let Some(ref branch) = config_with_branch.git_branch {
@@ -429,7 +430,7 @@ async fn run_single_connection(session: &mut SessionState<'_>) -> ConnectionResu
     }
 
     // Run the message loop - split connection for concurrent read/write
-    run_message_loop(session, &config_with_branch, conn).await
+    run_message_loop(session, &config_with_branch, conn, max_image_mb).await
 }
 
 /// Connect to the backend WebSocket
@@ -455,11 +456,12 @@ async fn connect_to_backend(
     }
 }
 
-/// Register session with the backend and wait for acknowledgment
+/// Register session with the backend and wait for acknowledgment.
+/// On success, returns the backend-provided max_image_mb (if any).
 async fn register_session(
     conn: &mut NativeConnection,
     config: &ProxySessionConfig,
-) -> Result<(), Duration> {
+) -> Result<Option<u32>, Duration> {
     info!("Registering session...");
 
     let hostname = hostname::get()
@@ -495,8 +497,9 @@ async fn register_session(
                     success,
                     session_id: _,
                     error,
+                    max_image_mb,
                 }) => {
-                    return Some((success, error));
+                    return Some((success, error, max_image_mb));
                 }
                 Ok(_) => continue,
                 Err(_) => return None,
@@ -507,11 +510,11 @@ async fn register_session(
     .await;
 
     match ack_timeout {
-        Ok(Some((true, _))) => {
-            info!("Session registered");
-            Ok(())
+        Ok(Some((true, _, max_image_mb))) => {
+            info!("Session registered (max_image_mb: {:?})", max_image_mb);
+            Ok(max_image_mb)
         }
-        Ok(Some((false, error))) => {
+        Ok(Some((false, error, _))) => {
             let err_msg = error.as_deref().unwrap_or("Unknown error");
             error!("Registration failed: {}", err_msg);
             Err(Duration::ZERO)
@@ -525,7 +528,7 @@ async fn register_session(
             info!(
                 "No RegisterAck received (timeout), assuming success for backwards compatibility"
             );
-            Ok(())
+            Ok(None)
         }
     }
 }
@@ -535,6 +538,7 @@ async fn run_message_loop(
     session: &mut SessionState<'_>,
     config: &ProxySessionConfig,
     conn: NativeConnection,
+    max_image_mb: Option<u32>,
 ) -> ConnectionResult {
     let connection_start = Instant::now();
     let session_id = config.session_id;
@@ -583,6 +587,7 @@ async fn run_message_loop(
         current_branch,
         current_pr_url,
         session.output_buffer.clone(),
+        max_image_mb,
     );
 
     // Spawn WebSocket reader task

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -20,6 +20,7 @@ use super::{format_duration, truncate, SharedWsWrite};
 /// Spawn the output forwarder task
 ///
 /// Forwards Claude outputs to WebSocket with sequence numbers for reliable delivery.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_output_forwarder(
     mut output_rx: mpsc::UnboundedReceiver<ClaudeOutput>,
     ws_write: SharedWsWrite,
@@ -28,7 +29,9 @@ pub fn spawn_output_forwarder(
     current_branch: Arc<Mutex<Option<String>>>,
     current_pr_url: Arc<Mutex<Option<String>>>,
     output_buffer: Arc<Mutex<PendingOutputBuffer>>,
+    max_image_mb: Option<u32>,
 ) -> tokio::task::JoinHandle<()> {
+    let max_bytes = max_image_mb.unwrap_or(DEFAULT_MAX_IMAGE_MB) as usize * 1024 * 1024;
     tokio::spawn(async move {
         let mut message_count: u64 = 0;
         let mut pending_git_check = false;
@@ -65,7 +68,8 @@ pub fn spawn_output_forwarder(
             track_image_reads(&output, &mut image_read_map);
 
             // Check for image tool results in user messages and send portal messages
-            let portal_messages = extract_image_portal_messages(&output, &mut image_read_map);
+            let portal_messages =
+                extract_image_portal_messages(&output, &mut image_read_map, max_bytes);
 
             // Serialize and buffer with sequence number
             let content = serde_json::to_value(&output)
@@ -242,18 +246,8 @@ async fn check_and_send_branch_update(
     }
 }
 
-/// Default 10 MB limit on image file size for portal messages.
-/// Override with PORTAL_MAX_IMAGE_MB environment variable.
-const DEFAULT_MAX_IMAGE_MB: usize = 10;
-
-fn max_image_bytes() -> usize {
-    std::env::var("PORTAL_MAX_IMAGE_MB")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_MAX_IMAGE_MB)
-        * 1024
-        * 1024
-}
+/// Default max image size in MB (used when backend doesn't provide a value)
+const DEFAULT_MAX_IMAGE_MB: u32 = 10;
 
 /// Return the MIME type for a supported image extension, or None.
 fn image_mime_type(path: &str) -> Option<&'static str> {
@@ -301,6 +295,7 @@ fn track_image_reads(output: &ClaudeOutput, image_read_map: &mut HashMap<String,
 fn extract_image_portal_messages(
     output: &ClaudeOutput,
     image_read_map: &mut HashMap<String, String>,
+    max_image_bytes: usize,
 ) -> Vec<shared::PortalMessage> {
     let blocks = match output {
         ClaudeOutput::User(user) => &user.message.content,
@@ -320,10 +315,9 @@ fn extract_image_portal_messages(
 
                 match std::fs::read(&file_path) {
                     Ok(data) => {
-                        let max_bytes = max_image_bytes();
-                        if data.len() > max_bytes {
+                        if data.len() > max_image_bytes {
                             let size_mb = data.len() as f64 / (1024.0 * 1024.0);
-                            let limit_mb = max_bytes as f64 / (1024.0 * 1024.0);
+                            let limit_mb = max_image_bytes as f64 / (1024.0 * 1024.0);
                             portal_messages.push(shared::PortalMessage::text(format!(
                                 "Image too large to display: **{:.1} MB** (limit is {:.0} MB)",
                                 size_mb, limit_mb

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -697,23 +697,11 @@ const ALLOWED_IMAGE_MEDIA_TYPES: &[&str] = &[
     "image/svg+xml",
 ];
 
-/// 10 MB limit on base64 data we'll render as an inline image.
-/// Base64 encodes at ~1.33x, so 10MB base64 ≈ 7.5MB raw image.
-const MAX_IMAGE_BASE64_BYTES: usize = 10 * 1024 * 1024;
-
 fn render_image_source(source: &ImageSource, filename: Option<String>) -> Html {
     if !ALLOWED_IMAGE_MEDIA_TYPES.contains(&source.media_type.as_str()) {
         return html! {
             <pre class="tool-result-content">
                 { format!("[unsupported image type: {}]", source.media_type) }
-            </pre>
-        };
-    }
-    if source.data.len() > MAX_IMAGE_BASE64_BYTES {
-        let size_mb = source.data.len() as f64 / (1024.0 * 1024.0);
-        return html! {
-            <pre class="tool-result-content">
-                { format!("[image too large: {:.1} MB, limit is 10 MB]", size_mb) }
             </pre>
         };
     }

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -114,6 +114,7 @@ pub async fn register_with_backend(
                         success,
                         session_id: _,
                         error,
+                        ..
                     }) = serde_json::from_str::<ServerToProxy>(&text)
                     {
                         return Some((success, error));

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -133,6 +133,8 @@ pub enum ServerToProxy {
         session_id: Uuid,
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_image_mb: Option<u32>,
     },
 
     /// Keepalive heartbeat


### PR DESCRIPTION
## Summary
- Backend reads `PORTAL_MAX_IMAGE_MB` env var and sends it to proxies in `RegisterAck`
- Proxy uses the backend-provided value instead of reading its own env var
- Removed frontend `MAX_IMAGE_BASE64_BYTES` check — the proxy is now the sole gatekeeper for image size

## Test plan
- [ ] Set `PORTAL_MAX_IMAGE_MB=5` on backend, verify proxy respects 5 MB limit
- [ ] Verify old proxies (without new field) still work (field is `#[serde(default)]`)
- [ ] Verify frontend renders images without size checking