### PR TITLE
Add toggle to show/hide cost display in session header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.16"
+version = "1.3.17"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -3,7 +3,8 @@
 use super::session_rail::SessionRail;
 use super::session_view::SessionView;
 use super::types::{
-    load_inactive_hidden, load_paused_sessions, save_inactive_hidden, save_paused_sessions,
+    load_inactive_hidden, load_paused_sessions, load_show_cost, save_inactive_hidden,
+    save_paused_sessions, save_show_cost,
 };
 use crate::components::{LaunchDialog, ProxyTokenSetup};
 use crate::hooks::{use_client_websocket, use_keyboard_nav, use_sessions, KeyboardNavConfig};
@@ -48,6 +49,7 @@ pub fn dashboard_page() -> Html {
     let awaiting_sessions = use_state(HashSet::<Uuid>::new);
     let paused_sessions = use_state(load_paused_sessions);
     let inactive_hidden = use_state(load_inactive_hidden);
+    let show_cost = use_state(load_show_cost);
     let connected_sessions = use_state(HashSet::<Uuid>::new);
     let pending_leave = use_state(|| None::<Uuid>);
     let is_admin = use_state(|| false);
@@ -457,6 +459,15 @@ pub fn dashboard_page() -> Html {
         })
     };
 
+    let on_toggle_show_cost = {
+        let show_cost = show_cost.clone();
+        Callback::from(move |_: MouseEvent| {
+            let new_val = !*show_cost;
+            save_show_cost(new_val);
+            show_cost.set(new_val);
+        })
+    };
+
     let on_message_sent = {
         let awaiting_sessions = awaiting_sessions.clone();
         Callback::from(move |current_session_id: Uuid| {
@@ -563,9 +574,20 @@ pub fn dashboard_page() -> Html {
                                 if *spend_animating { Some("spend-animating") } else { None },
                             );
                             html! {
-                                <span class={spend_class} title="Total spend across all sessions">
-                                    { utils::format_dollars(total_user_spend) }
-                                </span>
+                                <>
+                                    if *show_cost {
+                                        <span class={spend_class} title="Total spend across all sessions">
+                                            { utils::format_dollars(total_user_spend) }
+                                        </span>
+                                    }
+                                    <button
+                                        class="cost-toggle-btn"
+                                        onclick={on_toggle_show_cost.clone()}
+                                        title={if *show_cost { "Hide cost" } else { "Show cost" }}
+                                    >
+                                        { if *show_cost { "$" } else { "$?" } }
+                                    </button>
+                                </>
                             }
                         } else {
                             html! {}

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -16,6 +16,9 @@ pub const PAUSED_SESSIONS_STORAGE_KEY: &str = "claude-portal-paused-sessions";
 /// Storage key for inactive hidden state in localStorage
 pub const INACTIVE_HIDDEN_STORAGE_KEY: &str = "claude-portal-inactive-hidden";
 
+/// Storage key for cost display visibility in localStorage
+pub const SHOW_COST_STORAGE_KEY: &str = "claude-portal-show-cost";
+
 /// Maximum number of messages to keep in frontend memory (matches backend limit)
 pub const MAX_MESSAGES_PER_SESSION: usize = 100;
 
@@ -99,6 +102,22 @@ pub fn save_inactive_hidden(hidden: bool) {
             INACTIVE_HIDDEN_STORAGE_KEY,
             if hidden { "true" } else { "false" },
         );
+    }
+}
+
+/// Load cost display preference from localStorage (default: shown)
+pub fn load_show_cost() -> bool {
+    web_sys::window()
+        .and_then(|w| w.local_storage().ok().flatten())
+        .and_then(|storage| storage.get_item(SHOW_COST_STORAGE_KEY).ok().flatten())
+        .map(|v| v != "false")
+        .unwrap_or(true)
+}
+
+/// Save cost display preference to localStorage
+pub fn save_show_cost(show: bool) {
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.set_item(SHOW_COST_STORAGE_KEY, if show { "true" } else { "false" });
     }
 }
 

--- a/frontend/styles/session-layout.css
+++ b/frontend/styles/session-layout.css
@@ -222,3 +222,23 @@
     border-color: var(--text-secondary);
     color: var(--bg-dark);
 }
+
+.cost-toggle-btn {
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-family: monospace;
+    font-weight: 600;
+    padding: 0.2rem 0.4rem;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    line-height: 1;
+}
+
+.cost-toggle-btn:hover {
+    color: var(--text-secondary);
+    border-color: var(--border);
+    background: rgba(255, 255, 255, 0.05);
+}


### PR DESCRIPTION
## Summary
- Adds a small `$` / `$?` button next to the spend badge in the dashboard header
- Clicking it hides or shows the cost badge; preference persists in localStorage
- Resolves #483

## Test plan
- [ ] Verify `$` button appears in header next to spend badge
- [ ] Click to hide cost — badge disappears, button shows `$?`
- [ ] Reload page — hidden state is remembered
- [ ] Click again — badge reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)