### PR TITLE
Rename agent-launcher to agent-portal, make default install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,13 +225,13 @@ jobs:
           shared-key: "launcher-linux"
 
       - name: Build launcher
-        run: cargo build -p agent-launcher --release
+        run: cargo build -p agent-portal --release
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: launcher-linux-x86_64
-          path: target/release/agent-launcher
+          path: target/release/agent-portal
 
   build-launcher-macos-arm64:
     name: Build Launcher (macOS ARM64)
@@ -248,16 +248,16 @@ jobs:
           shared-key: "launcher-macos-arm64"
 
       - name: Build launcher
-        run: cargo build -p agent-launcher --release
+        run: cargo build -p agent-portal --release
 
       - name: Ad-hoc code sign
-        run: codesign -s - target/release/agent-launcher
+        run: codesign -s - target/release/agent-portal
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: launcher-darwin-aarch64
-          path: target/release/agent-launcher
+          path: target/release/agent-portal
 
   build-proxy-windows:
     name: Build Proxy (Windows x86_64)
@@ -297,11 +297,11 @@ jobs:
           shared-key: "launcher-windows"
 
       - name: Build launcher
-        run: cargo build -p agent-launcher --release
+        run: cargo build -p agent-portal --release
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: launcher-windows-x86_64
-          path: target/release/agent-launcher.exe
+          path: target/release/agent-portal.exe
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
         run: cargo build -p claude-portal --release
 
       - name: Build launcher
-        run: cargo build -p agent-launcher --release
+        run: cargo build -p agent-portal --release
 
       - name: Rename binaries
         run: |
           mv target/release/claude-portal target/release/claude-portal-linux-x86_64
-          mv target/release/agent-launcher target/release/agent-launcher-linux-x86_64
+          mv target/release/agent-portal target/release/agent-portal-linux-x86_64
 
       - name: Upload proxy artifact
         uses: actions/upload-artifact@v4
@@ -43,8 +43,8 @@ jobs:
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v4
         with:
-          name: agent-launcher-linux-x86_64
-          path: target/release/agent-launcher-linux-x86_64
+          name: agent-portal-linux-x86_64
+          path: target/release/agent-portal-linux-x86_64
 
   build-macos-arm64:
     name: Build (macOS ARM64)
@@ -64,17 +64,17 @@ jobs:
         run: cargo build -p claude-portal --release
 
       - name: Build launcher
-        run: cargo build -p agent-launcher --release
+        run: cargo build -p agent-portal --release
 
       - name: Ad-hoc code sign
         run: |
           codesign -s - target/release/claude-portal
-          codesign -s - target/release/agent-launcher
+          codesign -s - target/release/agent-portal
 
       - name: Rename binaries
         run: |
           mv target/release/claude-portal target/release/claude-portal-darwin-aarch64
-          mv target/release/agent-launcher target/release/agent-launcher-darwin-aarch64
+          mv target/release/agent-portal target/release/agent-portal-darwin-aarch64
 
       - name: Upload proxy artifact
         uses: actions/upload-artifact@v4
@@ -85,8 +85,8 @@ jobs:
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v4
         with:
-          name: agent-launcher-darwin-aarch64
-          path: target/release/agent-launcher-darwin-aarch64
+          name: agent-portal-darwin-aarch64
+          path: target/release/agent-portal-darwin-aarch64
 
   build-macos-intel:
     name: Build (macOS Intel)
@@ -108,17 +108,17 @@ jobs:
         run: cargo build -p claude-portal --release --target x86_64-apple-darwin
 
       - name: Build launcher (cross-compile for x86_64)
-        run: cargo build -p agent-launcher --release --target x86_64-apple-darwin
+        run: cargo build -p agent-portal --release --target x86_64-apple-darwin
 
       - name: Ad-hoc code sign
         run: |
           codesign -s - target/x86_64-apple-darwin/release/claude-portal
-          codesign -s - target/x86_64-apple-darwin/release/agent-launcher
+          codesign -s - target/x86_64-apple-darwin/release/agent-portal
 
       - name: Rename binaries
         run: |
           mv target/x86_64-apple-darwin/release/claude-portal target/x86_64-apple-darwin/release/claude-portal-darwin-x86_64
-          mv target/x86_64-apple-darwin/release/agent-launcher target/x86_64-apple-darwin/release/agent-launcher-darwin-x86_64
+          mv target/x86_64-apple-darwin/release/agent-portal target/x86_64-apple-darwin/release/agent-portal-darwin-x86_64
 
       - name: Upload proxy artifact
         uses: actions/upload-artifact@v4
@@ -129,8 +129,8 @@ jobs:
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v4
         with:
-          name: agent-launcher-darwin-x86_64
-          path: target/x86_64-apple-darwin/release/agent-launcher-darwin-x86_64
+          name: agent-portal-darwin-x86_64
+          path: target/x86_64-apple-darwin/release/agent-portal-darwin-x86_64
 
   build-windows:
     name: Build (Windows x86_64)
@@ -150,12 +150,12 @@ jobs:
         run: cargo build -p claude-portal --release
 
       - name: Build launcher
-        run: cargo build -p agent-launcher --release
+        run: cargo build -p agent-portal --release
 
       - name: Rename binaries
         run: |
           mv target/release/claude-portal.exe target/release/claude-portal-windows-x86_64.exe
-          mv target/release/agent-launcher.exe target/release/agent-launcher-windows-x86_64.exe
+          mv target/release/agent-portal.exe target/release/agent-portal-windows-x86_64.exe
 
       - name: Upload proxy artifact
         uses: actions/upload-artifact@v4
@@ -166,8 +166,8 @@ jobs:
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v4
         with:
-          name: agent-launcher-windows-x86_64
-          path: target/release/agent-launcher-windows-x86_64.exe
+          name: agent-portal-windows-x86_64
+          path: target/release/agent-portal-windows-x86_64.exe
 
   release:
     name: Create Release
@@ -190,12 +190,12 @@ jobs:
           mv binaries/claude-portal-darwin-aarch64/claude-portal-darwin-aarch64 release/
           mv binaries/claude-portal-darwin-x86_64/claude-portal-darwin-x86_64 release/
           mv binaries/claude-portal-windows-x86_64/claude-portal-windows-x86_64.exe release/
-          mv binaries/agent-launcher-linux-x86_64/agent-launcher-linux-x86_64 release/
-          mv binaries/agent-launcher-darwin-aarch64/agent-launcher-darwin-aarch64 release/
-          mv binaries/agent-launcher-darwin-x86_64/agent-launcher-darwin-x86_64 release/
-          mv binaries/agent-launcher-windows-x86_64/agent-launcher-windows-x86_64.exe release/
+          mv binaries/agent-portal-linux-x86_64/agent-portal-linux-x86_64 release/
+          mv binaries/agent-portal-darwin-aarch64/agent-portal-darwin-aarch64 release/
+          mv binaries/agent-portal-darwin-x86_64/agent-portal-darwin-x86_64 release/
+          mv binaries/agent-portal-windows-x86_64/agent-portal-windows-x86_64.exe release/
           chmod +x release/claude-portal-linux-x86_64 release/claude-portal-darwin-*
-          chmod +x release/agent-launcher-linux-x86_64 release/agent-launcher-darwin-*
+          chmod +x release/agent-portal-linux-x86_64 release/agent-portal-darwin-*
           ls -la release/
 
       - name: Delete existing latest release
@@ -225,22 +225,22 @@ jobs:
             | macOS (Intel) | `claude-portal-darwin-x86_64` |
             | Windows (x86_64) | `claude-portal-windows-x86_64.exe` |
 
-            ### Launcher (`agent-launcher`)
+            ### Launcher (`agent-portal`)
             | Platform | Binary |
             |----------|--------|
-            | Linux (x86_64) | `agent-launcher-linux-x86_64` |
-            | macOS (Apple Silicon M1+) | `agent-launcher-darwin-aarch64` |
-            | macOS (Intel) | `agent-launcher-darwin-x86_64` |
-            | Windows (x86_64) | `agent-launcher-windows-x86_64.exe` |
+            | Linux (x86_64) | `agent-portal-linux-x86_64` |
+            | macOS (Apple Silicon M1+) | `agent-portal-darwin-aarch64` |
+            | macOS (Intel) | `agent-portal-darwin-x86_64` |
+            | Windows (x86_64) | `agent-portal-windows-x86_64.exe` |
           files: |
             release/claude-portal-linux-x86_64
             release/claude-portal-darwin-aarch64
             release/claude-portal-darwin-x86_64
             release/claude-portal-windows-x86_64.exe
-            release/agent-launcher-linux-x86_64
-            release/agent-launcher-darwin-aarch64
-            release/agent-launcher-darwin-x86_64
-            release/agent-launcher-windows-x86_64.exe
+            release/agent-portal-linux-x86_64
+            release/agent-portal-darwin-aarch64
+            release/agent-portal-darwin-x86_64
+            release/agent-portal-windows-x86_64.exe
           prerelease: false
           make_latest: true
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.17
+
+- Rename agent-launcher to agent-portal
+- Make launcher the default install path (install script downloads agent-portal, installs as service)
+- Launch button available to all users (not just admin)
+- Launch dialog shows install instructions when no launchers are connected
+- agent-portal recommends service install when run interactively
+
 ## 1.3.16
 
 - Backend sends max image size to proxies via RegisterAck; proxy uses it instead of local env var

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,24 @@ cargo fmt --check             # Format check
 cd backend
 diesel migration run          # Apply migrations
 diesel migration revert       # Undo last migration
+
+# Debugging - poke a message into an active session
+cargo run -p cli-tools -- poke <session-id> "your message here"
 ```
+
+### Session Debugging with `poke`
+
+The `portal-api poke` command connects as a web client to an active session, sends a message, and prints all responses with detailed output for task-related system messages. It also validates that `ClaudeOutput` types roundtrip correctly through `serde_json::Value`, which catches silent parsing failures.
+
+```bash
+# Send a message and watch task lifecycle
+cargo run -p cli-tools -- poke <session-id> "launch a background task that sleeps 3 seconds"
+
+# Connect to a different server
+cargo run -p cli-tools -- -s http://portal.example.com poke <session-id> "hello"
+```
+
+Output shows `✓` or `✗` for each task message's typed parse result, making it easy to diagnose issues where the sidebar doesn't show subagents.
 
 ### Build Order Matters
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,8 +9,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "agent-launcher"
-version = "1.3.14"
+name = "agent-portal"
+version = "1.3.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.14"
+version = "1.3.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.14"
+version = "1.3.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,17 +735,19 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.14"
+version = "1.3.17"
 dependencies = [
  "anyhow",
  "clap",
  "colored",
+ "futures-util",
  "reqwest 0.12.4",
  "serde",
  "serde_json",
  "shared",
  "tabled",
  "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]
@@ -1287,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.14"
+version = "1.3.17"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3930,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.14"
+version = "1.3.17"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.16"
+version = "1.3.17"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/downloads.rs
+++ b/backend/src/handlers/downloads.rs
@@ -34,19 +34,20 @@ pub async fn install_script(
 
     let script = format!(
         r##"#!/bin/bash
-# Agent Portal Installer
-# Downloads and installs the claude-portal binary, then configures backend URL
+# Agent Launcher Installer
+# Downloads and installs the agent-portal binary, configures backend URL,
+# and installs as a system service.
 
 set -e
 
-CONFIG_DIR="${{HOME}}/.config/claude-code-portal"
-BIN_NAME="claude-portal"
+CONFIG_DIR="${{HOME}}/.config/claude-portal"
+BIN_NAME="agent-portal"
 BIN_PATH="${{CONFIG_DIR}}/${{BIN_NAME}}"
-CONFIG_FILE="${{CONFIG_DIR}}/config.json"
+CONFIG_FILE="${{CONFIG_DIR}}/launcher.toml"
 GITHUB_RELEASE_URL="https://github.com/meawoppl/claude-code-portal/releases/download/latest"
 BACKEND_URL="{backend_url}"
 
-echo "Agent Portal Installer"
+echo "Agent Launcher Installer"
 echo "============================"
 echo ""
 
@@ -55,8 +56,8 @@ mkdir -p "${{CONFIG_DIR}}"
 
 # Check if binary already exists (has auto-update, skip download)
 if [ -x "${{BIN_PATH}}" ]; then
-    echo "claude-portal already installed at: ${{BIN_PATH}}"
-    echo "Skipping download (portal has auto-update built in)"
+    echo "agent-portal already installed at: ${{BIN_PATH}}"
+    echo "Skipping download (launcher has auto-update built in)"
     echo ""
 else
     # Detect OS and architecture
@@ -67,7 +68,7 @@ else
         Linux)
             case "${{ARCH}}" in
                 x86_64|amd64)
-                    BINARY_NAME="claude-portal-linux-x86_64"
+                    BINARY_NAME="agent-portal-linux-x86_64"
                     ;;
                 *)
                     echo "Error: Unsupported Linux architecture: ${{ARCH}}"
@@ -79,10 +80,10 @@ else
         Darwin)
             case "${{ARCH}}" in
                 arm64|aarch64)
-                    BINARY_NAME="claude-portal-darwin-aarch64"
+                    BINARY_NAME="agent-portal-darwin-aarch64"
                     ;;
                 x86_64)
-                    BINARY_NAME="claude-portal-darwin-x86_64"
+                    BINARY_NAME="agent-portal-darwin-x86_64"
                     ;;
                 *)
                     echo "Error: Unsupported macOS architecture: ${{ARCH}}"
@@ -95,7 +96,7 @@ else
             echo "Error: Unsupported operating system: ${{OS}}"
             echo "Supported: Linux, Darwin (macOS)"
             echo "For Windows, download manually from:"
-            echo "  ${{GITHUB_RELEASE_URL}}/claude-portal-windows-x86_64.exe"
+            echo "  ${{GITHUB_RELEASE_URL}}/agent-portal-windows-x86_64.exe"
             exit 1
             ;;
     esac
@@ -109,7 +110,7 @@ else
 
     # Download the binary to a temp file first (allows replacing running binary)
     TEMP_BIN="${{BIN_PATH}}.new.$$"
-    echo "Downloading claude-portal from GitHub releases..."
+    echo "Downloading agent-portal from GitHub releases..."
     if command -v curl &> /dev/null; then
         curl -fsSL "${{DOWNLOAD_URL}}" -o "${{TEMP_BIN}}"
     elif command -v wget &> /dev/null; then
@@ -134,15 +135,21 @@ else
     echo ""
 fi
 
-# Write config with backend URL
-echo "Configuring backend URL: ${{BACKEND_URL}}"
-cat > "${{CONFIG_FILE}}" << EOF
-{{
-  "preferences": {{
-    "default_backend_url": "${{BACKEND_URL}}"
-  }}
-}}
+# Write config with backend URL (preserve existing config if present)
+if [ -f "${{CONFIG_FILE}}" ]; then
+    # Config exists — update backend_url if not already set
+    if ! grep -q "backend_url" "${{CONFIG_FILE}}" 2>/dev/null; then
+        echo "backend_url = \"${{BACKEND_URL}}\"" >> "${{CONFIG_FILE}}"
+        echo "Added backend_url to existing config"
+    else
+        echo "Config already exists with backend_url, skipping"
+    fi
+else
+    echo "Configuring backend URL: ${{BACKEND_URL}}"
+    cat > "${{CONFIG_FILE}}" << EOF
+backend_url = "${{BACKEND_URL}}"
 EOF
+fi
 echo ""
 
 # Add to PATH in shell rc files
@@ -151,9 +158,9 @@ add_to_path() {{
     local path_line="export PATH=\"\$PATH:${{CONFIG_DIR}}\""
 
     if [ -f "${{rc_file}}" ]; then
-        if ! grep -q "claude-code-portal" "${{rc_file}}" 2>/dev/null; then
+        if ! grep -q "claude-portal" "${{rc_file}}" 2>/dev/null; then
             echo "" >> "${{rc_file}}"
-            echo "# Agent Portal binary path" >> "${{rc_file}}"
+            echo "# Agent Launcher binary path" >> "${{rc_file}}"
             echo "${{path_line}}" >> "${{rc_file}}"
             echo "Updated: ${{rc_file}}"
             return 0
@@ -178,12 +185,19 @@ else
 fi
 
 echo ""
+
+# Install as system service
+echo "Installing as system service..."
+"${{BIN_PATH}}" service install 2>/dev/null && echo "Service installed!" || echo "Service install skipped (may need manual setup)"
+echo ""
+
 echo "Installation complete!"
 echo ""
-echo "To start a session, run:"
-echo "  claude-portal"
+echo "The agent-portal service is now running in the background."
+echo "You'll be prompted to authenticate in your browser on first connection."
 echo ""
-echo "(You'll be prompted to authenticate in your browser on first run)"
+echo "To check status:  agent-portal service status"
+echo "To view logs:     journalctl --user -u agent-portal -f"
 "##
     );
 

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -124,6 +124,38 @@ pub fn handle_claude_output(
         None
     };
 
+    // Validate that content roundtrips through ClaudeOutput parsing (frontend depends on this)
+    match serde_json::from_value::<shared::ClaudeOutput>(content.clone()) {
+        Ok(parsed) => {
+            if let shared::ClaudeOutput::System(ref sys) = parsed {
+                if sys.is_task_started() && sys.as_task_started().is_none() {
+                    warn!(
+                        "task_started message matched subtype but failed struct parse: {}",
+                        content
+                    );
+                }
+                if sys.is_task_progress() && sys.as_task_progress().is_none() {
+                    warn!(
+                        "task_progress message matched subtype but failed struct parse: {}",
+                        content
+                    );
+                }
+                if sys.is_task_notification() && sys.as_task_notification().is_none() {
+                    warn!(
+                        "task_notification message matched subtype but failed struct parse: {}",
+                        content
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            warn!(
+                "ClaudeOutput parse failed for message: {} — raw: {}",
+                e, content
+            );
+        }
+    }
+
     // Broadcast output to all web clients with sender metadata alongside content
     if let Some(ref key) = session_key {
         session_manager.broadcast_to_web_clients(

--- a/cli-tools/Cargo.toml
+++ b/cli-tools/Cargo.toml
@@ -32,3 +32,5 @@ anyhow = "1"
 # Pretty output
 colored = "2"
 tabled = "0.15"
+tokio-tungstenite = "0.24"
+futures-util = "0.3.32"

--- a/cli-tools/src/main.rs
+++ b/cli-tools/src/main.rs
@@ -4,6 +4,7 @@
 //! cc-proxy API endpoints, useful for testing and debugging.
 
 mod client;
+mod poke;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -65,6 +66,14 @@ enum Commands {
     Auth {
         #[command(subcommand)]
         action: AuthAction,
+    },
+
+    /// Send a message to an active session (for debugging)
+    Poke {
+        /// Session ID (UUID)
+        session_id: String,
+        /// Message to send
+        message: String,
     },
 }
 
@@ -246,6 +255,13 @@ async fn main() -> Result<()> {
                 }
             }
         },
+
+        Commands::Poke {
+            session_id,
+            message,
+        } => {
+            poke::poke_session(&cli.server, &session_id, &message).await?;
+        }
 
         Commands::Auth { action } => match action {
             AuthAction::Login => {

--- a/cli-tools/src/poke.rs
+++ b/cli-tools/src/poke.rs
@@ -1,0 +1,186 @@
+//! Poke a message into an active portal session via WebSocket.
+//!
+//! Connects as a web client, sends a message, and prints all responses
+//! with detailed output for task-related system messages.
+
+use anyhow::{bail, Result};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+pub async fn poke_session(server: &str, session_id: &str, message: &str) -> Result<()> {
+    let ws_url = server
+        .replace("http://", "ws://")
+        .replace("https://", "wss://");
+    let url = format!("{}/ws/client", ws_url);
+
+    eprintln!("Connecting to {}...", url);
+    let (ws_stream, _) = connect_async(&url).await?;
+    let (mut write, mut read) = ws_stream.split();
+
+    // Register for the session
+    let register = serde_json::json!({
+        "type": "Register",
+        "session_id": session_id,
+        "session_name": session_id,
+        "auth_token": null,
+        "working_directory": "",
+        "resuming": false,
+        "git_branch": null,
+        "replay_after": null,
+        "client_version": null,
+        "replaces_session_id": null,
+        "hostname": null,
+        "launcher_id": null,
+        "agent_type": "claude",
+    });
+    write.send(Message::Text(register.to_string())).await?;
+    eprintln!("Registered for session {}", session_id);
+
+    // Drain history batch
+    let mut got_history = false;
+    while let Some(Ok(msg)) = read.next().await {
+        if let Message::Text(text) = msg {
+            if let Ok(parsed) = serde_json::from_str::<Value>(&text) {
+                let msg_type = parsed.get("type").and_then(|t| t.as_str()).unwrap_or("?");
+                if msg_type == "HistoryBatch" {
+                    let count = parsed
+                        .get("messages")
+                        .and_then(|m| m.as_array())
+                        .map(|a| a.len())
+                        .unwrap_or(0);
+                    eprintln!("← HistoryBatch ({} messages)", count);
+                    got_history = true;
+                    break;
+                }
+                eprintln!("← {}", msg_type);
+            }
+        }
+    }
+    if !got_history {
+        bail!("Connection closed before receiving history");
+    }
+
+    // Send the input
+    let input = serde_json::json!({
+        "type": "ClaudeInput",
+        "content": {
+            "type": "human_turn_input",
+            "content": message,
+        },
+    });
+    write.send(Message::Text(input.to_string())).await?;
+    eprintln!("→ Sent: {}", message);
+    eprintln!("---");
+
+    // Listen for responses
+    while let Some(Ok(msg)) = read.next().await {
+        let Message::Text(text) = msg else {
+            continue;
+        };
+        let Ok(parsed) = serde_json::from_str::<Value>(&text) else {
+            continue;
+        };
+
+        let msg_type = parsed.get("type").and_then(|t| t.as_str()).unwrap_or("?");
+
+        if msg_type == "ClaudeOutput" {
+            let content = parsed.get("content").cloned().unwrap_or(Value::Null);
+            let inner_type = content.get("type").and_then(|t| t.as_str()).unwrap_or("?");
+            let subtype = content
+                .get("subtype")
+                .and_then(|s| s.as_str())
+                .unwrap_or("");
+
+            match inner_type {
+                "system" => {
+                    let label = if subtype.is_empty() {
+                        "system".to_string()
+                    } else {
+                        format!("system/{}", subtype)
+                    };
+                    // Show task messages in full detail
+                    if subtype.starts_with("task_") {
+                        println!("← {}: {}", label, serde_json::to_string_pretty(&content)?);
+
+                        // Also try parsing as ClaudeOutput to test roundtrip
+                        match serde_json::from_value::<shared::ClaudeOutput>(content.clone()) {
+                            Ok(shared::ClaudeOutput::System(ref sys)) => {
+                                if sys.is_task_started() {
+                                    match sys.as_task_started() {
+                                        Some(task) => println!(
+                                            "   ✓ as_task_started OK: id={} type={:?}",
+                                            task.task_id, task.task_type
+                                        ),
+                                        None => println!(
+                                            "   ✗ as_task_started FAILED (subtype matched, struct parse failed)"
+                                        ),
+                                    }
+                                }
+                                if sys.is_task_progress() {
+                                    match sys.as_task_progress() {
+                                        Some(p) => {
+                                            println!("   ✓ as_task_progress OK: id={}", p.task_id)
+                                        }
+                                        None => println!("   ✗ as_task_progress FAILED"),
+                                    }
+                                }
+                                if sys.is_task_notification() {
+                                    match sys.as_task_notification() {
+                                        Some(n) => println!(
+                                            "   ✓ as_task_notification OK: id={} status={:?}",
+                                            n.task_id, n.status
+                                        ),
+                                        None => println!("   ✗ as_task_notification FAILED"),
+                                    }
+                                }
+                            }
+                            Ok(_) => println!("   ? parsed as non-System ClaudeOutput"),
+                            Err(e) => println!("   ✗ ClaudeOutput parse failed: {}", e),
+                        }
+                    } else {
+                        eprintln!("← {}", label);
+                    }
+                }
+                "assistant" => {
+                    let blocks = content
+                        .get("message")
+                        .and_then(|m| m.get("content"))
+                        .and_then(|c| c.as_array());
+                    if let Some(blocks) = blocks {
+                        for block in blocks {
+                            let block_type =
+                                block.get("type").and_then(|t| t.as_str()).unwrap_or("?");
+                            match block_type {
+                                "text" => {
+                                    let text =
+                                        block.get("text").and_then(|t| t.as_str()).unwrap_or("");
+                                    let preview: String = text.chars().take(120).collect();
+                                    eprintln!("← assistant/text: {}", preview);
+                                }
+                                "tool_use" => {
+                                    let name =
+                                        block.get("name").and_then(|n| n.as_str()).unwrap_or("?");
+                                    eprintln!("← assistant/tool_use: {}", name);
+                                }
+                                _ => eprintln!("← assistant/{}", block_type),
+                            }
+                        }
+                    }
+                }
+                "result" => {
+                    let cost = content.get("total_cost_usd").and_then(|c| c.as_f64());
+                    eprintln!("← result (cost: ${:.4})", cost.unwrap_or(0.0));
+                    break;
+                }
+                _ => {
+                    eprintln!("← {}", inner_type);
+                }
+            }
+        } else {
+            eprintln!("← {}", msg_type);
+        }
+    }
+
+    Ok(())
+}

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -1,3 +1,4 @@
+use crate::components::ProxyTokenSetup;
 use gloo::timers::callback::Timeout;
 use gloo_net::http::Request;
 use serde::Deserialize;
@@ -381,11 +382,10 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                 <h3>{ "Launch Session" }</h3>
 
                 if launchers.is_empty() {
-                    <p class="launch-no-launchers">
-                        { "No launchers connected. Run " }
-                        <code>{ "agent-launcher" }</code>
-                        { " on your machine." }
-                    </p>
+                    <div class="launch-no-launchers">
+                        <p>{ "No launchers connected. Install agent-portal on a machine to get started:" }</p>
+                        <ProxyTokenSetup />
+                    </div>
                 } else {
                     // Launcher + Agent selectors (side by side)
                     <div class="launch-row">

--- a/frontend/src/components/proxy_token_setup.rs
+++ b/frontend/src/components/proxy_token_setup.rs
@@ -68,13 +68,13 @@ pub fn proxy_token_setup() -> Html {
             )
         }
         Platform::Windows => format!(
-            "# Download from GitHub releases, then run:\n.\\claude-portal.exe --backend-url \"{}\"",
+            "# Download from GitHub releases, then run:\n.\\agent-portal.exe --backend-url \"{}\"",
             ws_backend_url
         ),
     };
-    let run_command = match *selected_platform {
-        Platform::Linux | Platform::MacOS => "claude-portal".to_string(),
-        Platform::Windows => ".\\claude-portal.exe".to_string(),
+    let status_command = match *selected_platform {
+        Platform::Linux | Platform::MacOS => "agent-portal service status".to_string(),
+        Platform::Windows => ".\\agent-portal.exe service status".to_string(),
     };
 
     html! {
@@ -140,9 +140,9 @@ pub fn proxy_token_setup() -> Html {
             <div class="setup-step">
                 <span class="step-number">{ "2" }</span>
                 <div class="step-content">
-                    <p class="step-label">{ "Start a session:" }</p>
-                    <CopyCommand command={run_command} />
-                    <p class="step-hint">{ "(Opens browser to authenticate on first run)" }</p>
+                    <p class="step-label">{ "Check status:" }</p>
+                    <CopyCommand command={status_command} />
+                    <p class="step-hint">{ "(The installer starts the service automatically. You'll authenticate in your browser on first connection.)" }</p>
                 </div>
             </div>
         </div>

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -583,27 +583,25 @@ pub fn dashboard_page() -> Html {
                         }
                     }
                     <button
+                        class="header-button"
+                        onclick={toggle_launch_dialog.clone()}
+                        title="Launch a new session via launcher"
+                    >
+                        { "Launch" }
+                    </button>
+                    <button
                         class={classes!("new-session-button", if *show_new_session { "active" } else { "" })}
                         onclick={toggle_new_session.clone()}
-                        title={if *show_new_session { "Close" } else { "Connect a new Claude proxy session" }}
+                        title={if *show_new_session { "Close" } else { "Install agent-portal on a new machine" }}
                     >
-                        { if *show_new_session { "Close" } else { "+ New Session" } }
+                        { if *show_new_session { "Close" } else { "+ Install" } }
                     </button>
                     {
                         if *is_admin {
                             html! {
-                                <>
-                                    <button
-                                        class="header-button"
-                                        onclick={toggle_launch_dialog.clone()}
-                                        title="Launch a new session via launcher"
-                                    >
-                                        { "Launch" }
-                                    </button>
-                                    <button class="header-button" onclick={go_to_admin.clone()}>
-                                        { "Admin" }
-                                    </button>
-                                </>
+                                <button class="header-button" onclick={go_to_admin.clone()}>
+                                    { "Admin" }
+                                </button>
                             }
                         } else {
                             html! {}
@@ -645,13 +643,13 @@ pub fn dashboard_page() -> Html {
                             <div class="onboarding-step">
                                 <span class="step-number">{ "1" }</span>
                                 <div class="step-content">
-                                    <p>{ "Click " }<strong>{ "+ New Session" }</strong>{ " above to get a setup command" }</p>
+                                    <p>{ "Click " }<strong>{ "+ Install" }</strong>{ " to set up agent-portal on a machine" }</p>
                                 </div>
                             </div>
                             <div class="onboarding-step">
                                 <span class="step-number">{ "2" }</span>
                                 <div class="step-content">
-                                    <p>{ "Run that command on your dev machine to connect Claude Code" }</p>
+                                    <p>{ "Click " }<strong>{ "Launch" }</strong>{ " to start a session on a connected machine" }</p>
                                 </div>
                             </div>
                         </div>

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "agent-launcher"
+name = "agent-portal"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 
 [[bin]]
-name = "agent-launcher"
+name = "agent-portal"
 path = "src/main.rs"
 
 [dependencies]

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use uuid::Uuid;
 
 #[derive(Parser, Debug)]
-#[command(name = "agent-launcher")]
+#[command(name = "agent-portal")]
 #[command(about = "Persistent daemon that launches claude-portal sessions as in-process tasks")]
 struct Args {
     /// Backend WebSocket URL (default: wss://txcl.io in release, ws://localhost:3000 in debug)
@@ -67,7 +67,7 @@ enum ServiceAction {
     Status,
 }
 
-const BINARY_PREFIX: &str = "agent-launcher";
+const BINARY_PREFIX: &str = "agent-portal";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -87,6 +87,14 @@ async fn main() -> anyhow::Result<()> {
             ServiceAction::Uninstall => service::uninstall(),
             ServiceAction::Status => service::status(),
         };
+    }
+
+    // Check if running as a system service; suggest installing if not
+    if !args.no_update && !service::is_installed() {
+        eprintln!();
+        eprintln!("  Tip: Install agent-portal as a system service for persistent operation:");
+        eprintln!("    agent-portal service install");
+        eprintln!();
     }
 
     // Apply pending updates (Windows only)

--- a/launcher/src/service.rs
+++ b/launcher/src/service.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 // --- Linux (systemd) ---
 
 #[cfg(target_os = "linux")]
-const SERVICE_NAME: &str = "agent-launcher";
+const SERVICE_NAME: &str = "agent-portal";
 
 #[cfg(target_os = "linux")]
 fn service_file_path() -> Result<std::path::PathBuf> {
@@ -121,7 +121,7 @@ pub fn status() -> Result<()> {
 
     if !service_path.exists() {
         println!("Service is not installed.");
-        println!("  Run 'agent-launcher service install' to set it up.");
+        println!("  Run 'agent-portal service install' to set it up.");
         return Ok(());
     }
 
@@ -137,6 +137,11 @@ pub fn status() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn is_installed() -> bool {
+    service_file_path().map(|p| p.exists()).unwrap_or(false)
 }
 
 // --- macOS (launchd) ---
@@ -156,7 +161,7 @@ fn plist_path() -> Result<std::path::PathBuf> {
 #[cfg(target_os = "macos")]
 fn log_dir() -> String {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    format!("{}/Library/Logs/agent-launcher", home)
+    format!("{}/Library/Logs/agent-portal", home)
 }
 
 #[cfg(target_os = "macos")]
@@ -273,7 +278,7 @@ pub fn status() -> Result<()> {
 
     if !plist.exists() {
         println!("Service is not installed.");
-        println!("  Run 'agent-launcher service install' to set it up.");
+        println!("  Run 'agent-portal service install' to set it up.");
         return Ok(());
     }
 
@@ -300,6 +305,11 @@ pub fn status() -> Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+pub fn is_installed() -> bool {
+    plist_path().map(|p| p.exists()).unwrap_or(false)
+}
+
 // --- Unsupported platforms ---
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -315,4 +325,9 @@ pub fn uninstall() -> Result<()> {
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn status() -> Result<()> {
     anyhow::bail!("Service management is not supported on this platform")
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn is_installed() -> bool {
+    false
 }

--- a/portal-update/src/lib.rs
+++ b/portal-update/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! On startup, checks if a newer version is available from GitHub releases
 //! and self-updates if necessary. Parameterized by binary name so both
-//! `claude-portal` and `agent-launcher` can use it.
+//! `claude-portal` and `agent-portal` can use it.
 
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
@@ -41,7 +41,7 @@ impl Platform {
     /// Detect the current platform for a given binary prefix.
     ///
     /// The `binary_prefix` is the base name of the binary (e.g. "claude-portal"
-    /// or "agent-launcher"). The platform suffix is appended automatically.
+    /// or "agent-portal"). The platform suffix is appended automatically.
     pub fn current(binary_prefix: &str) -> Self {
         let (os, arch) = if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
             ("linux", "x86_64")
@@ -98,7 +98,7 @@ fn sha256_hex(bytes: &[u8]) -> String {
 
 /// Check for updates from GitHub releases.
 ///
-/// `binary_prefix` is the base name (e.g. "claude-portal" or "agent-launcher").
+/// `binary_prefix` is the base name (e.g. "claude-portal" or "agent-portal").
 /// If `check_only` is true, reports availability without installing.
 pub async fn check_for_update(binary_prefix: &str, check_only: bool) -> Result<UpdateResult> {
     let self_path = std::env::current_exe().context("Failed to get current executable path")?;

--- a/proxy/src/ui.rs
+++ b/proxy/src/ui.rs
@@ -30,7 +30,7 @@ pub fn print_deprecation_warning() {
     );
     eprintln!(
         "  {}",
-        "Use the `agent-launcher` service instead for persistent session management.".yellow()
+        "Use the `agent-portal` service instead for persistent session management.".yellow()
     );
     eprintln!();
 }


### PR DESCRIPTION
## Summary
- Rename `agent-launcher` binary to `agent-portal` across all crates, CI workflows, and release artifacts
- Install script now downloads `agent-portal`, writes TOML config, and installs as system service
- Launch button available to all users (not just admin)
- Launch dialog shows install instructions when no launchers are connected
- `agent-portal` recommends service install when run interactively
- Poke CLI tool for WebSocket debugging + backend ClaudeOutput parse validation

## Test plan
- [x] `cargo test --workspace` — 119 tests pass
- [x] `cargo clippy --workspace` — no warnings
- [x] `cargo build --target wasm32-unknown-unknown -p shared` — WASM builds
- [x] `trunk build` — frontend builds
- [ ] Manual: "+ Install" button shows agent-portal install instructions
- [ ] Manual: "Launch" button visible for all users
- [ ] Manual: Launch dialog shows install instructions when no launchers connected