### PR TITLE
Differentiate task and portal message colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.18
+
+- Differentiate task and portal message colors (tasks=purple, portal=teal)
+- Sparkline tick colors now match their message type colors
+
 ## 1.3.17
 
 - Rename agent-launcher to agent-portal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.17"
+version = "1.3.18"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -62,12 +62,12 @@
 }
 
 .message-type-badge.portal {
-    background: rgba(187, 154, 247, 0.2);
-    color: var(--link-color);
+    background: rgba(125, 207, 255, 0.2);
+    color: #7dcfff;
 }
 
 .portal-message {
-    border-left: 3px solid var(--link-color);
+    border-left: 3px solid #7dcfff;
 }
 
 .message-type-badge.raw {

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -191,7 +191,7 @@
 .sparkline-tick.tick-assistant { background: var(--accent); }
 .sparkline-tick.tick-user { background: var(--success); }
 .sparkline-tick.tick-result { background: #e0af68; }
-.sparkline-tick.tick-portal { background: #bb9af7; }
+.sparkline-tick.tick-portal { background: #7dcfff; }
 .sparkline-tick.tick-error { background: var(--error); }
 .sparkline-tick.tick-other { background: var(--text-secondary); }
 
@@ -204,7 +204,7 @@
 }
 
 .sparkline-range.tick-compaction { background: var(--text-secondary); }
-.sparkline-range.tick-task { background: var(--text-secondary); }
+.sparkline-range.tick-task { background: #bb9af7; }
 
 .session-pill.paused .sparkline-tick,
 .session-pill.paused .sparkline-range {


### PR DESCRIPTION
## Summary
- Portal messages now use teal (#7dcfff) instead of purple
- Task messages keep purple (#bb9af7)
- Sparkline tick-task ranges now purple (matching task sidebar)
- Sparkline tick-portal points now teal (matching portal messages)

## Test plan
- [ ] Portal messages show teal badge and left border
- [ ] Task sidebar stays purple
- [ ] Sparkline ticks: portal=teal, task=purple, other types unchanged