### PR TITLE
Add login, install, update subcommands to agent-portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.19
+
+- Add `agent-portal login` subcommand for explicit authentication
+- Add `agent-portal install` subcommand to install as system service
+- Add `agent-portal update` subcommand to update binary and restart service
+- Install script no longer auto-installs system service
+- Updated frontend setup instructions with 3-step flow (install, login, service)
+
 ## 1.3.18
 
 - Differentiate task and portal message colors (tasks=purple, portal=teal)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.18"
+version = "1.3.19"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/downloads.rs
+++ b/backend/src/handlers/downloads.rs
@@ -34,9 +34,8 @@ pub async fn install_script(
 
     let script = format!(
         r##"#!/bin/bash
-# Agent Launcher Installer
-# Downloads and installs the agent-portal binary, configures backend URL,
-# and installs as a system service.
+# Agent Portal Installer
+# Downloads and installs the agent-portal binary and configures backend URL.
 
 set -e
 
@@ -47,7 +46,7 @@ CONFIG_FILE="${{CONFIG_DIR}}/launcher.toml"
 GITHUB_RELEASE_URL="https://github.com/meawoppl/claude-code-portal/releases/download/latest"
 BACKEND_URL="{backend_url}"
 
-echo "Agent Launcher Installer"
+echo "Agent Portal Installer"
 echo "============================"
 echo ""
 
@@ -186,18 +185,13 @@ fi
 
 echo ""
 
-# Install as system service
-echo "Installing as system service..."
-"${{BIN_PATH}}" service install 2>/dev/null && echo "Service installed!" || echo "Service install skipped (may need manual setup)"
-echo ""
-
 echo "Installation complete!"
 echo ""
-echo "The agent-portal service is now running in the background."
-echo "You'll be prompted to authenticate in your browser on first connection."
+echo "Next steps:"
+echo "  1. Log in:             agent-portal login"
+echo "  2. Install as service: agent-portal install"
 echo ""
-echo "To check status:  agent-portal service status"
-echo "To view logs:     journalctl --user -u agent-portal -f"
+echo "Or run directly:         agent-portal"
 "##
     );
 

--- a/frontend/src/components/proxy_token_setup.rs
+++ b/frontend/src/components/proxy_token_setup.rs
@@ -72,9 +72,13 @@ pub fn proxy_token_setup() -> Html {
             ws_backend_url
         ),
     };
-    let status_command = match *selected_platform {
-        Platform::Linux | Platform::MacOS => "agent-portal service status".to_string(),
-        Platform::Windows => ".\\agent-portal.exe service status".to_string(),
+    let login_command = match *selected_platform {
+        Platform::Linux | Platform::MacOS => "agent-portal login".to_string(),
+        Platform::Windows => ".\\agent-portal.exe login".to_string(),
+    };
+    let service_command = match *selected_platform {
+        Platform::Linux | Platform::MacOS => "agent-portal install".to_string(),
+        Platform::Windows => ".\\agent-portal.exe install".to_string(),
     };
 
     html! {
@@ -140,9 +144,17 @@ pub fn proxy_token_setup() -> Html {
             <div class="setup-step">
                 <span class="step-number">{ "2" }</span>
                 <div class="step-content">
-                    <p class="step-label">{ "Check status:" }</p>
-                    <CopyCommand command={status_command} />
-                    <p class="step-hint">{ "(The installer starts the service automatically. You'll authenticate in your browser on first connection.)" }</p>
+                    <p class="step-label">{ "Log in:" }</p>
+                    <CopyCommand command={login_command} />
+                </div>
+            </div>
+
+            <div class="setup-step">
+                <span class="step-number">{ "3" }</span>
+                <div class="step-content">
+                    <p class="step-label">{ "Run as a background service:" }</p>
+                    <CopyCommand command={service_command} />
+                    <p class="step-hint">{ "(Or run directly with: agent-portal)" }</p>
                 </div>
             </div>
         </div>

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -36,21 +36,19 @@ struct Args {
     #[arg(long)]
     no_update: bool,
 
-    /// Check for updates without installing
-    #[arg(long)]
-    check_update: bool,
-
-    /// Force update from GitHub releases
-    #[arg(long)]
-    update: bool,
-
     #[command(subcommand)]
     command: Option<Command>,
 }
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Manage the launcher as a system service
+    /// Authenticate with the backend server via browser
+    Login,
+    /// Install agent-portal as a persistent system service
+    Install,
+    /// Update agent-portal to the latest version (restarts service if running)
+    Update,
+    /// Manage the launcher system service
     Service {
         #[command(subcommand)]
         action: ServiceAction,
@@ -80,64 +78,34 @@ async fn main() -> anyhow::Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    // Handle service subcommands before anything else
-    if let Some(Command::Service { action }) = args.command {
-        return match action {
-            ServiceAction::Install => service::install(),
-            ServiceAction::Uninstall => service::uninstall(),
-            ServiceAction::Status => service::status(),
-        };
+    // Handle subcommands before the daemon startup path
+    match args.command {
+        Some(Command::Login) => return cmd_login(&args).await,
+        Some(Command::Install) => return service::install(),
+        Some(Command::Update) => return cmd_update().await,
+        Some(Command::Service { action }) => {
+            return match action {
+                ServiceAction::Install => service::install(),
+                ServiceAction::Uninstall => service::uninstall(),
+                ServiceAction::Status => service::status(),
+            };
+        }
+        None => {}
     }
+
+    // --- Daemon startup path ---
 
     // Check if running as a system service; suggest installing if not
     if !args.no_update && !service::is_installed() {
         eprintln!();
         eprintln!("  Tip: Install agent-portal as a system service for persistent operation:");
-        eprintln!("    agent-portal service install");
+        eprintln!("    agent-portal install");
         eprintln!();
     }
 
     // Apply pending updates (Windows only)
     if let Ok(true) = portal_update::apply_pending_update() {
         info!("Pending update applied successfully");
-    }
-
-    // Handle explicit update commands
-    if args.check_update {
-        match portal_update::check_for_update(BINARY_PREFIX, true).await {
-            Ok(portal_update::UpdateResult::UpToDate) => {
-                info!("Launcher is up to date");
-            }
-            Ok(portal_update::UpdateResult::UpdateAvailable {
-                version,
-                download_url,
-            }) => {
-                info!("Update available: {} ({})", version, download_url);
-            }
-            Ok(portal_update::UpdateResult::Updated) => {}
-            Err(e) => {
-                warn!("Update check failed: {}", e);
-            }
-        }
-        return Ok(());
-    }
-
-    if args.update {
-        match portal_update::check_for_update(BINARY_PREFIX, false).await {
-            Ok(portal_update::UpdateResult::UpToDate) => {
-                info!("Launcher is up to date");
-            }
-            Ok(portal_update::UpdateResult::Updated) => {
-                info!("Launcher updated successfully, please restart");
-                std::process::exit(0);
-            }
-            Ok(portal_update::UpdateResult::UpdateAvailable { .. }) => {}
-            Err(e) => {
-                warn!("Update failed: {}", e);
-                return Err(e);
-            }
-        }
-        return Ok(());
     }
 
     // Auto-update on startup (unless --no-update)
@@ -216,4 +184,51 @@ async fn main() -> anyhow::Result<()> {
         config.sessions,
     )
     .await
+}
+
+/// `agent-portal login` — authenticate via device flow and save the token
+async fn cmd_login(args: &Args) -> anyhow::Result<()> {
+    let config = config::load_config();
+    let backend_url = args
+        .backend_url
+        .clone()
+        .or(config.backend_url)
+        .unwrap_or_else(|| shared::default_backend_url().to_string());
+
+    println!("Authenticating with {}...", backend_url);
+    let result = portal_auth::device_flow_login(&backend_url, None).await?;
+    config::save_auth_token(&result.access_token)?;
+    println!();
+    println!("Logged in as {}", result.user_email);
+    Ok(())
+}
+
+/// `agent-portal update` — update binary and restart service if running
+async fn cmd_update() -> anyhow::Result<()> {
+    // Apply any pending updates first (Windows)
+    if let Ok(true) = portal_update::apply_pending_update() {
+        info!("Pending update applied successfully");
+    }
+
+    match portal_update::check_for_update(BINARY_PREFIX, false).await {
+        Ok(portal_update::UpdateResult::UpToDate) => {
+            println!("agent-portal is already up to date.");
+        }
+        Ok(portal_update::UpdateResult::Updated) => {
+            println!("agent-portal updated successfully.");
+            // Restart the service if it's installed and running
+            if service::is_installed() {
+                println!("Restarting system service...");
+                service::restart()?;
+                println!("Service restarted.");
+            }
+        }
+        Ok(portal_update::UpdateResult::UpdateAvailable { version, .. }) => {
+            println!("Update available: {}", version);
+        }
+        Err(e) => {
+            anyhow::bail!("Update failed: {}", e);
+        }
+    }
+    Ok(())
 }

--- a/launcher/src/service.rs
+++ b/launcher/src/service.rs
@@ -140,6 +140,13 @@ pub fn status() -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
+pub fn restart() -> Result<()> {
+    systemctl(&["restart", SERVICE_NAME])?;
+    println!("Restarted {}", SERVICE_NAME);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
 pub fn is_installed() -> bool {
     service_file_path().map(|p| p.exists()).unwrap_or(false)
 }
@@ -306,6 +313,21 @@ pub fn status() -> Result<()> {
 }
 
 #[cfg(target_os = "macos")]
+pub fn restart() -> Result<()> {
+    use anyhow::Context;
+    let plist = plist_path()?;
+    let _ = std::process::Command::new("launchctl")
+        .args(["unload", &plist.to_string_lossy()])
+        .output();
+    std::process::Command::new("launchctl")
+        .args(["load", &plist.to_string_lossy()])
+        .output()
+        .context("Failed to run launchctl load")?;
+    println!("Restarted {}", PLIST_LABEL);
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
 pub fn is_installed() -> bool {
     plist_path().map(|p| p.exists()).unwrap_or(false)
 }
@@ -324,6 +346,11 @@ pub fn uninstall() -> Result<()> {
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn status() -> Result<()> {
+    anyhow::bail!("Service management is not supported on this platform")
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn restart() -> Result<()> {
     anyhow::bail!("Service management is not supported on this platform")
 }
 


### PR DESCRIPTION
## Summary
- `agent-portal login` — authenticate via browser device flow, save token to config
- `agent-portal install` — install as a persistent system service (systemd/launchd)
- `agent-portal update` — update binary from GitHub releases, restart service if running
- Install script no longer auto-installs system service; shows next steps instead
- Frontend setup instructions updated to 3-step flow: install, login, install service

## Test plan
- [ ] `agent-portal login` prompts device flow, saves token
- [ ] `agent-portal install` installs system service
- [ ] `agent-portal update` updates binary and restarts service
- [ ] Install script downloads binary + config but does NOT start service
- [ ] Frontend shows 3-step setup (install, login, service)
- [ ] `agent-portal` (no subcommand) still starts the daemon as before
- [ ] `agent-portal service uninstall/status` still work