### PR TITLE
Rename default app title to "Agent Portal"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.19"
+version = "1.3.20"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -226,7 +226,7 @@ async fn main() -> anyhow::Result<()> {
     let app_title = if args.dev_mode {
         "⚠️ INSECURE DEV MODE ⚠️".to_string()
     } else {
-        env::var("APP_TITLE").unwrap_or_else(|_| "Claude Code Sessions".to_string())
+        env::var("APP_TITLE").unwrap_or_else(|_| "Agent Portal".to_string())
     };
 
     // Email access control (optional)

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -55,7 +55,7 @@ pub fn dashboard_page() -> Html {
     let is_admin = use_state(|| false);
     let voice_enabled = use_state(|| false);
     let current_user_id = use_state(|| None::<String>);
-    let app_title = use_state(|| "Claude Code Sessions".to_string());
+    let app_title = use_state(|| "Agent Portal".to_string());
     let activated_sessions = use_state(HashSet::<Uuid>::new);
     let activity_timestamps = use_state(HashMap::<Uuid, Vec<(f64, String)>>::new);
     let initial_focus_set = use_state(|| false);

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -392,7 +392,7 @@ pub enum DevicePollResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     /// Custom title for the app (displayed in top bar)
-    /// Defaults to "Claude Code Sessions" if not configured
+    /// Defaults to "Agent Portal" if not configured; override with APP_TITLE env var
     pub app_title: String,
 }
 


### PR DESCRIPTION
## Summary
- Default header title changes from "Claude Code Sessions" to "Agent Portal"
- Still configurable via `APP_TITLE` environment variable
- Dev mode still overrides with the insecure warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)