### PR TITLE
Fix tasks drawer pull-tab clipped off-screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.20
+
+- Fix tasks drawer pull-tab clipped by overflow:hidden on drawer container
+
 ## 1.3.19
 
 - Add `agent-portal login` subcommand for explicit authentication

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.19"
+version = "1.3.20"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/tasks-sidebar.css
+++ b/frontend/styles/tasks-sidebar.css
@@ -13,7 +13,6 @@
     pointer-events: none;
     transition: width 0.25s ease-in-out;
     width: 0;
-    overflow: hidden;
     animation: tabSlideIn 0.35s ease-out;
 }
 


### PR DESCRIPTION
## Summary
- Remove `overflow: hidden` from `.tasks-drawer` container
- The pull-tab (`.tasks-tab-hint`) is positioned at `right: 100%` (outside the drawer), so the drawer's own overflow was clipping it
- Parent `.session-view-scroll-area` already has `overflow: hidden` which handles panel clipping

## Test plan
- [ ] Task pull-tab visible on right side when tasks are running
- [ ] Drawer opens/closes with smooth width transition
- [ ] Panel content doesn't leak when drawer is closed