### PR TITLE
Add CSRF state verification to OAuth web login callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "1.3.19"
+version = "1.3.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.19"
+version = "1.3.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.19"
+version = "1.3.21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.19"
+version = "1.3.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.19"
+version = "1.3.21"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.19"
+version = "1.3.21"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.20"
+version = "1.3.21"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -19,8 +19,10 @@ use crate::{
 
 use shared::protocol::SESSION_COOKIE_NAME;
 
+const OAUTH_CSRF_COOKIE: &str = "oauth_csrf";
+
 /// Regular web login - redirects to Google OAuth
-pub async fn login(State(app_state): State<Arc<AppState>>) -> impl IntoResponse {
+pub async fn login(State(app_state): State<Arc<AppState>>, cookies: Cookies) -> impl IntoResponse {
     let client = match &app_state.oauth_basic_client {
         Some(c) => c,
         None => return Redirect::temporary("/api/auth/dev-login").into_response(),
@@ -32,7 +34,16 @@ pub async fn login(State(app_state): State<Arc<AppState>>) -> impl IntoResponse 
         .add_scope(Scope::new("email".to_string()))
         .add_scope(Scope::new("profile".to_string()));
 
-    let (auth_url, _csrf_token) = auth_request.url();
+    let (auth_url, csrf_token) = auth_request.url();
+
+    // Store the CSRF token in a short-lived signed cookie so we can verify it on callback.
+    let mut csrf_cookie = Cookie::new(OAUTH_CSRF_COOKIE, csrf_token.secret().clone());
+    csrf_cookie.set_path("/api/auth/google/callback");
+    csrf_cookie.set_http_only(true);
+    csrf_cookie.set_secure(!app_state.dev_mode);
+    csrf_cookie.set_same_site(SameSite::Lax);
+    csrf_cookie.set_max_age(tower_cookies::cookie::time::Duration::minutes(10));
+    cookies.signed(&app_state.cookie_key).add(csrf_cookie);
 
     Redirect::temporary(auth_url.as_str()).into_response()
 }
@@ -123,6 +134,35 @@ pub async fn callback(
         .oauth_basic_client
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    // Verify CSRF state token for regular web logins.
+    // Device flow uses a deterministic "device:{code}" state so we skip it there.
+    let is_device_flow = query
+        .state
+        .as_deref()
+        .is_some_and(|s| s.starts_with("device:"));
+
+    if !is_device_flow {
+        let csrf_cookie = cookies
+            .signed(&app_state.cookie_key)
+            .get(OAUTH_CSRF_COOKIE)
+            .ok_or_else(|| {
+                error!("OAuth callback: missing CSRF cookie");
+                StatusCode::FORBIDDEN
+            })?;
+
+        let state_value = query.state.as_deref().unwrap_or("");
+        if csrf_cookie.value() != state_value {
+            error!("OAuth callback: CSRF token mismatch");
+            return Err(StatusCode::FORBIDDEN);
+        }
+
+        // Consume the CSRF cookie
+        let mut remove_csrf = Cookie::new(OAUTH_CSRF_COOKIE, "");
+        remove_csrf.set_path("/api/auth/google/callback");
+        remove_csrf.set_max_age(tower_cookies::cookie::time::Duration::ZERO);
+        cookies.signed(&app_state.cookie_key).add(remove_csrf);
+    }
 
     // Exchange code for token
     let token: oauth2::StandardTokenResponse<


### PR DESCRIPTION
## Summary
- CSRF token generated in `/api/auth/google` was previously discarded; now stored in a short-lived signed `HttpOnly` cookie
- `/api/auth/google/callback` verifies the `state` param against the cookie before doing the token exchange, returning `403` on mismatch
- Cookie is scoped to the callback path, expires in 10 minutes, and is consumed after verification
- Device flow (`state` starts with `"device:"`) is exempt since it uses a server-generated code

## Test plan
- [ ] Log in via Google OAuth — should work normally
- [ ] Device flow login — should work normally
- [ ] Tampering with the `state` query param on the callback URL returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)