### PR TITLE
Fix sparkline tick subpixel rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.21
+
+- Fix sparkline tick subpixel rendering artifacts via GPU compositing
+
 ## 1.3.20
 
 - Fix tasks drawer pull-tab clipped by overflow:hidden on drawer container

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.20"
+version = "1.3.21"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -186,6 +186,7 @@
     height: 100%;
     opacity: 1;
     border-radius: 1px;
+    transform: translateZ(0);
 }
 
 .sparkline-tick.tick-assistant { background: var(--accent); }
@@ -201,6 +202,7 @@
     height: 100%;
     opacity: 0.5;
     border-radius: 1px;
+    transform: translateZ(0);
 }
 
 .sparkline-range.tick-compaction { background: var(--text-secondary); }


### PR DESCRIPTION
## Summary
- Add `transform: translateZ(0)` to `.sparkline-tick` and `.sparkline-range` to promote them to GPU compositor layers
- Prevents subpixel rendering artifacts that made ticks appear to shrink/expand as they drift across the sparkline bar

## Test plan
- [ ] Observe sparkline ticks maintain consistent 3px width as they move across the bar
- [ ] Verify sparkline ranges (compaction, tasks) render without visual artifacts