### PR TITLE
Fix launcher rustls crypto provider panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.22
+
+- Fix launcher crash: install ring crypto provider for rustls 0.23
+
 ## 1.3.21
 
 - Fix sparkline tick subpixel rendering artifacts via GPU compositing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "1.3.21"
+version = "1.3.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -20,6 +20,7 @@ dependencies = [
  "hostname",
  "portal-auth",
  "portal-update",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "shared",
@@ -423,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.21"
+version = "1.3.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.21"
+version = "1.3.22"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -735,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.21"
+version = "1.3.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -1289,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.21"
+version = "1.3.22"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3644,6 +3645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki 0.103.9",
  "subtle",
@@ -3956,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.21"
+version = "1.3.22"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.21"
+version = "1.3.22"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -44,3 +44,4 @@ claude-session-lib = { version = "0.1.0", path = "../claude-session-lib" }
 ws-bridge = { workspace = true, features = ["native-client"] }
 portal-update = { path = "../portal-update" }
 tokio-util.workspace = true
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -69,6 +69,10 @@ const BINARY_PREFIX: &str = "agent-portal";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     let args = Args::parse();
 
     tracing_subscriber::registry()


### PR DESCRIPTION
## Summary
- Install `ring` as the rustls 0.23 crypto provider at launcher startup
- Fixes panic: `Could not automatically determine the process-level CryptoProvider`
- Root cause: `ws-bridge` pulls in `tokio-tungstenite` with default features which include `rustls-tls-webpki-roots`, but rustls 0.23 decoupled crypto providers and requires explicit installation

## Test plan
- [ ] `agent-portal` starts without panicking
- [ ] WebSocket connection to backend succeeds over TLS