### PR TITLE
Fix result message duplicating text content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.23
+
+- Fix result message duplicating previous assistant message text
+
 ## 1.3.22
 
 - Fix launcher crash: install ring crypto provider for rustls 0.23

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "1.3.22"
+version = "1.3.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.22"
+version = "1.3.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.22"
+version = "1.3.23"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.22"
+version = "1.3.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.22"
+version = "1.3.23"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.22"
+version = "1.3.23"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.22"
+version = "1.3.23"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -861,21 +861,6 @@ pub fn render_result_message(msg: &ResultMessage) -> Html {
 
     html! {
         <div class={classes!("claude-message", "result-message", status_class)}>
-            {
-                if let Some(result_text) = msg.result.as_deref() {
-                    if !result_text.is_empty() {
-                        html! {
-                            <div class="message-body">
-                                <div class="result-text">{ render_markdown(result_text) }</div>
-                            </div>
-                        }
-                    } else {
-                        html! {}
-                    }
-                } else {
-                    html! {}
-                }
-            }
             <div class="result-stats-bar">
                 <span class={classes!("result-status", status_class)}>
                     { if is_error { "✗" } else { "✓" } }


### PR DESCRIPTION
## Summary
- Remove `msg.result` text rendering from result messages
- The result field contains a copy of the previous assistant message's text, causing duplication
- Result messages now only show the stats bar (checkmark, duration, tokens, turns)

## Test plan
- [ ] Final result message no longer duplicates the preceding assistant message text
- [ ] Stats bar (checkmark, duration, tokens, turns) still renders correctly
- [ ] Error result messages still display properly