### PR TITLE
Show server version in bottom bar; move Report a Bug to top bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "1.3.23"
+version = "1.3.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.23"
+version = "1.3.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.23"
+version = "1.3.24"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.23"
+version = "1.3.24"
 dependencies = [
  "anyhow",
  "clap",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.23"
+version = "1.3.24"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.23"
+version = "1.3.24"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.24"
+version = "1.3.25"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ EXPOSE 3000
 #   APP_TITLE             Text shown in the dashboard header (default: "Agent Portal")
 #   ALLOWED_EMAIL_DOMAIN  Restrict login to one email domain (e.g. "company.com")
 #   ALLOWED_EMAILS        Comma-separated list of allowed emails (e.g. "a@b.com,c@d.com")
+#   PORTAL_MAX_IMAGE_MB   Max image size proxies will inline in MB (default: 10)
 #   HOST                  Bind address (default: 0.0.0.0)
 #   PORT                  Listen port (default: 3000)
 #   RUST_LOG              Log level, e.g. "info" or "debug" (default: "info")

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -11,5 +11,6 @@ use std::sync::Arc;
 pub async fn get_config(State(app_state): State<Arc<AppState>>) -> Json<AppConfig> {
     Json(AppConfig {
         app_title: app_state.app_title.clone(),
+        server_version: env!("CARGO_PKG_VERSION").to_string(),
     })
 }

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -56,6 +56,7 @@ pub fn dashboard_page() -> Html {
     let voice_enabled = use_state(|| false);
     let current_user_id = use_state(|| None::<String>);
     let app_title = use_state(|| "Agent Portal".to_string());
+    let server_version = use_state(String::new);
     let activated_sessions = use_state(HashSet::<Uuid>::new);
     // Activity buffer: mutations don't trigger page re-renders.
     // SessionRail reads this on its own 100 ms tick instead.
@@ -135,15 +136,17 @@ pub fn dashboard_page() -> Html {
         });
     }
 
-    // Fetch app configuration (title, etc.)
+    // Fetch app configuration (title, version, etc.)
     {
         let app_title = app_title.clone();
+        let server_version = server_version.clone();
         use_effect_with((), move |_| {
             spawn_local(async move {
                 let api_endpoint = utils::api_url("/api/config");
                 if let Ok(response) = Request::get(&api_endpoint).send().await {
                     if let Ok(config) = response.json::<AppConfig>().await {
                         app_title.set(config.app_title);
+                        server_version.set(config.server_version);
                     }
                 }
             });
@@ -629,6 +632,14 @@ pub fn dashboard_page() -> Html {
                     <button class="header-button" onclick={go_to_settings.clone()}>
                         { "Settings" }
                     </button>
+                    <a
+                        href="https://github.com/meawoppl/claude-code-portal/issues/new"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="header-button"
+                    >
+                        { "Report a Bug" }
+                    </a>
                     <button class="header-button logout" onclick={do_logout.clone()}>
                         { "Logout" }
                     </button>
@@ -759,14 +770,9 @@ pub fn dashboard_page() -> Html {
                                 }
                             }
                         </div>
-                        <a
-                            href="https://github.com/meawoppl/claude-code-portal/issues/new"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="bug-report-link"
-                        >
-                            { "🐛 Report a Bug" }
-                        </a>
+                        if !(*server_version).is_empty() {
+                            <span class="server-version">{ format!("v{}", *server_version) }</span>
+                        }
                     </div>
                 </>
             }

--- a/frontend/styles/dashboard.css
+++ b/frontend/styles/dashboard.css
@@ -46,6 +46,7 @@
     cursor: pointer;
     font-size: 0.9rem;
     transition: all 0.2s;
+    text-decoration: none;
 }
 
 .header-button:hover {

--- a/frontend/styles/keyboard.css
+++ b/frontend/styles/keyboard.css
@@ -53,19 +53,12 @@
 }
 
 /* Bug report link in keyboard hints bar */
-.keyboard-hints .bug-report-link {
-    font-size: 0.75rem;
+.keyboard-hints .server-version {
+    font-size: 0.7rem;
     color: var(--text-secondary);
-    text-decoration: none;
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    transition: color 0.2s, background 0.2s;
+    opacity: 0.5;
     white-space: nowrap;
-}
-
-.keyboard-hints .bug-report-link:hover {
-    color: var(--warning);
-    background: rgba(0, 0, 0, 0.3);
+    margin-left: auto;
 }
 
 /* ==========================================================================

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -394,6 +394,8 @@ pub struct AppConfig {
     /// Custom title for the app (displayed in top bar)
     /// Defaults to "Agent Portal" if not configured; override with APP_TITLE env var
     pub app_title: String,
+    /// Backend server version string (e.g. "1.3.24")
+    pub server_version: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- **Server version in bottom bar**: `/api/config` now returns `server_version` (from `CARGO_PKG_VERSION`); displayed as `v1.3.25` in the bottom-right of the keyboard hints bar, subtle/dimmed
- **Report a Bug moved to top header**: Removed from bottom bar, added as a link styled like the other header buttons (between Settings and Logout)
- **CSS cleanup**: Replaced `.bug-report-link` styles with `.server-version` styles; added `text-decoration: none` to `.header-button` so `<a>` tags render consistently with `<button>` tags
- **Dockerfile docs**: Added `PORTAL_MAX_IMAGE_MB` to the optional env vars comment block

## Test plan
- [ ] Bottom bar shows `v1.3.25` on the right side
- [ ] "Report a Bug" appears in the top header and opens GitHub issues in a new tab
- [ ] No visual regression on header button styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)