### PR TITLE
Keep shutdown banner until server sends data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.25
+
+- Keep server shutdown banner until first message received from reconnected server
+
 ## 1.3.24
 
 - Remove unused dead code methods from CommandHistory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "anyhow",
  "clap",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/frontend/src/hooks/use_client_websocket.rs
+++ b/frontend/src/hooks/use_client_websocket.rs
@@ -61,7 +61,6 @@ pub fn use_client_websocket() -> UseClientWebSocket {
                     match ws_bridge::yew_client::connect_to::<ClientEndpoint>(&ws_endpoint) {
                         Ok(conn) => {
                             attempt = 0; // Reset on successful connection
-                            shutdown_reason.set(None); // Clear shutdown banner
                             let (_sender, mut receiver) = conn.split();
 
                             while let Some(result) = receiver.recv().await {
@@ -72,6 +71,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
                                             session_costs: _,
                                         } => {
                                             total_spend.set(total_spend_usd);
+                                            shutdown_reason.set(None);
                                         }
                                         ServerToClient::ServerShutdown {
                                             reason,
@@ -84,7 +84,9 @@ pub fn use_client_websocket() -> UseClientWebSocket {
                                             );
                                             shutdown_reason.set(Some(reason));
                                         }
-                                        _ => {}
+                                        _ => {
+                                            shutdown_reason.set(None);
+                                        }
                                     },
                                     Err(e) => {
                                         log::error!("Client WebSocket error: {:?}", e);


### PR DESCRIPTION
## Summary
- Shutdown banner now persists until the server actually sends a message after reconnecting
- Previously cleared on TCP connection success, before server was confirmed operational
- Banner clears on first `UserSpendUpdate` or other non-shutdown message

## Test plan
- [ ] Restart server while dashboard is open — banner should appear and persist through reconnection attempts
- [ ] Banner should clear once server is fully back and sends spend update
- [ ] Normal WebSocket disconnects (without server shutdown) should not show banner