### PR TITLE
Fix launch dialog to always open at home directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "anyhow",
  "clap",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.24"
+version = "1.3.25"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.25"
+version = "1.3.26"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -71,11 +71,8 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                         if let Some(first) = data.first() {
                             let lid = first.launcher_id;
                             selected_launcher.set(Some(lid));
-                            // Start at the launcher's working directory, fall back to home
-                            let initial_path = first
-                                .working_directory
-                                .clone()
-                                .unwrap_or_else(|| "~".to_string());
+                            // Always start at home — don't carry over last-used directory
+                            let initial_path = "~".to_string();
                             fetch_directories(
                                 lid,
                                 initial_path,
@@ -187,16 +184,12 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let dir_entries = dir_entries.clone();
         let dir_loading = dir_loading.clone();
         let dir_error = dir_error.clone();
-        let launchers = launchers.clone();
         Callback::from(move |e: Event| {
             if let Some(select) = e.target_dyn_into::<web_sys::HtmlSelectElement>() {
                 if let Ok(id) = select.value().parse::<Uuid>() {
                     selected_launcher.set(Some(id));
-                    let path = launchers
-                        .iter()
-                        .find(|l| l.launcher_id == id)
-                        .and_then(|l| l.working_directory.clone())
-                        .unwrap_or_else(|| "~".to_string());
+                    // Always start at home — don't carry over last-used directory
+                    let path = "~".to_string();
                     current_path.set(path.clone());
                     fetch_directories(
                         id,


### PR DESCRIPTION
## Summary

- Launch dialog was seeding the initial path from `launcher.working_directory`, which persisted the last-used directory server-side and carried it over on every subsequent dialog open
- Now always starts at `"~"` regardless of launcher state, so each open is fresh from home
- Also removed the now-unused `launchers.clone()` in the launcher-change callback

## Test plan
- [ ] Open launch dialog → starts at home directory
- [ ] Navigate to a subdirectory, launch a session, reopen dialog → back at home

🤖 Generated with [Claude Code](https://claude.com/claude-code)