### PR TITLE
Fix Shift+Tab keyboard hint text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.26
+
+- Fix Shift+Tab keyboard hint text
+
 ## 1.3.25
 
 - Keep server shutdown banner until first message received from reconnected server

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.25"
+version = "1.3.26"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -760,7 +760,7 @@ pub fn dashboard_page() -> Html {
                                     html! {
                                         <>
                                             <span>{ "Esc = nav mode" }</span>
-                                            <span>{ "Shift+Tab = next (skip paused)" }</span>
+                                            <span>{ "Shift+Tab = next paused" }</span>
                                             if *voice_enabled {
                                                 <span>{ "Ctrl+M = voice" }</span>
                                             }


### PR DESCRIPTION
## Summary
- Update Shift+Tab hint from "next (skip paused)" to "next paused"

## Test plan
- [ ] Verify keyboard hints display correctly at bottom of dashboard