### PR TITLE
Convert admin and settings to in-dashboard modals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "1.3.25"
+version = "1.3.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.25"
+version = "1.3.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.25"
+version = "1.3.27"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.25"
+version = "1.3.27"
 dependencies = [
  "anyhow",
  "clap",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.25"
+version = "1.3.27"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.25"
+version = "1.3.27"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.26"
+version = "1.3.27"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -30,12 +30,28 @@ pub enum Route {
     AccessDenied,
 }
 
+/// Wrapper for /admin route — provides back-navigation on_close callback
+#[function_component(AdminRoute)]
+fn admin_route() -> Html {
+    let navigator = use_navigator().unwrap();
+    let on_close = Callback::from(move |_| navigator.push(&Route::Dashboard));
+    html! { <AdminPage on_close={on_close} /> }
+}
+
+/// Wrapper for /settings route — provides back-navigation on_close callback
+#[function_component(SettingsRoute)]
+fn settings_route() -> Html {
+    let navigator = use_navigator().unwrap();
+    let on_close = Callback::from(move |_| navigator.push(&Route::Dashboard));
+    html! { <SettingsPage on_close={on_close} /> }
+}
+
 fn switch(routes: Route) -> Html {
     match routes {
         Route::Home => html! { <SplashPage /> },
         Route::Dashboard => html! { <DashboardPage /> },
-        Route::Settings => html! { <SettingsPage /> },
-        Route::Admin => html! { <AdminPage /> },
+        Route::Settings => html! { <SettingsRoute /> },
+        Route::Admin => html! { <AdminRoute /> },
         Route::Banned => html! { <BannedPage /> },
         Route::AccessDenied => html! { <AccessDeniedPage /> },
     }

--- a/frontend/src/pages/admin.rs
+++ b/frontend/src/pages/admin.rs
@@ -353,8 +353,13 @@ fn raw_message_row(props: &RawMessageRowProps) -> Html {
 // Main Admin Page Component
 // ============================================================================
 
+#[derive(Properties, PartialEq)]
+pub struct AdminPageProps {
+    pub on_close: Callback<()>,
+}
+
 #[function_component(AdminPage)]
-pub fn admin_page() -> Html {
+pub fn admin_page(props: &AdminPageProps) -> Html {
     let active_tab = use_state(|| AdminTab::Overview);
     let stats = use_state(|| None::<AdminStats>);
     let users = use_state(Vec::<AdminUserInfo>::new);
@@ -915,8 +920,8 @@ pub fn admin_page() -> Html {
 
     // Back to dashboard
     let go_back = {
-        let navigator = navigator.clone();
-        Callback::from(move |_| navigator.push(&Route::Dashboard))
+        let on_close = props.on_close.clone();
+        Callback::from(move |_| on_close.emit(()))
     };
 
     html! {

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -8,8 +8,9 @@ use super::types::{
 };
 use crate::components::{LaunchDialog, ProxyTokenSetup};
 use crate::hooks::{use_client_websocket, use_keyboard_nav, use_sessions, KeyboardNavConfig};
+use crate::pages::admin::AdminPage;
+use crate::pages::settings::SettingsPage;
 use crate::utils;
-use crate::Route;
 use gloo_net::http::Request;
 use shared::{AppConfig, SessionInfo};
 use std::collections::HashSet;
@@ -17,7 +18,6 @@ use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::MouseEvent;
 use yew::prelude::*;
-use yew_router::prelude::*;
 
 // =============================================================================
 // Dashboard Page - Main Orchestrating Component
@@ -25,8 +25,6 @@ use yew_router::prelude::*;
 
 #[function_component(DashboardPage)]
 pub fn dashboard_page() -> Html {
-    let navigator = use_navigator().unwrap();
-
     // Use the sessions hook for fetching and polling
     let sessions_hook = use_sessions();
     let sessions = sessions_hook.sessions.clone();
@@ -45,6 +43,8 @@ pub fn dashboard_page() -> Html {
     // UI state
     let show_new_session = use_state(|| false);
     let show_launch_dialog = use_state(|| false);
+    let show_admin = use_state(|| false);
+    let show_settings = use_state(|| false);
     let focused_index = use_state(|| 0usize);
     let awaiting_sessions = use_state(HashSet::<Uuid>::new);
     let paused_sessions = use_state(load_paused_sessions);
@@ -275,15 +275,25 @@ pub fn dashboard_page() -> Html {
         on_activate,
     });
 
-    // Navigation callbacks
+    // Modal open callbacks
     let go_to_admin = {
-        let navigator = navigator.clone();
-        Callback::from(move |_| navigator.push(&Route::Admin))
+        let show_admin = show_admin.clone();
+        Callback::from(move |_| show_admin.set(true))
     };
 
     let go_to_settings = {
-        let navigator = navigator.clone();
-        Callback::from(move |_| navigator.push(&Route::Settings))
+        let show_settings = show_settings.clone();
+        Callback::from(move |_| show_settings.set(true))
+    };
+
+    let close_admin = {
+        let show_admin = show_admin.clone();
+        Callback::from(move |_: ()| show_admin.set(false))
+    };
+
+    let close_settings = {
+        let show_settings = show_settings.clone();
+        Callback::from(move |_: ()| show_settings.set(false))
     };
 
     let do_logout = Callback::from(move |_| {
@@ -775,6 +785,20 @@ pub fn dashboard_page() -> Html {
                         }
                     </div>
                 </>
+            }
+
+            // Admin modal — full-page overlay preserves dashboard state
+            if *show_admin {
+                <div class="full-page-modal">
+                    <AdminPage on_close={close_admin.clone()} />
+                </div>
+            }
+
+            // Settings modal — full-page overlay preserves dashboard state
+            if *show_settings {
+                <div class="full-page-modal">
+                    <SettingsPage on_close={close_settings.clone()} />
+                </div>
             }
 
             // Leave confirmation modal

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -105,13 +105,13 @@ pub fn save_inactive_hidden(hidden: bool) {
     }
 }
 
-/// Load cost display preference from localStorage (default: shown)
+/// Load cost display preference from localStorage (default: hidden)
 pub fn load_show_cost() -> bool {
     web_sys::window()
         .and_then(|w| w.local_storage().ok().flatten())
         .and_then(|storage| storage.get_item(SHOW_COST_STORAGE_KEY).ok().flatten())
-        .map(|v| v != "false")
-        .unwrap_or(true)
+        .map(|v| v == "true")
+        .unwrap_or(false)
 }
 
 /// Save cost display preference to localStorage

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -1,7 +1,6 @@
 use crate::audio::{self, EventSound, SoundConfig, SoundEvent, Waveform, STORAGE_KEY};
 use crate::components::ShareDialog;
 use crate::utils;
-use crate::Route;
 use gloo_net::http::Request;
 use shared::{
     CreateProxyTokenRequest, CreateProxyTokenResponse, ProxyTokenInfo, ProxyTokenListResponse,
@@ -10,7 +9,6 @@ use shared::{
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
-use yew_router::prelude::*;
 
 /// Settings page tabs
 #[derive(Clone, Copy, PartialEq)]
@@ -479,9 +477,13 @@ struct NewTokenForm {
     expires_in_days: u32,
 }
 
+#[derive(Properties, PartialEq)]
+pub struct SettingsPageProps {
+    pub on_close: Callback<()>,
+}
+
 #[function_component(SettingsPage)]
-pub fn settings_page() -> Html {
-    let navigator = use_navigator().unwrap();
+pub fn settings_page(props: &SettingsPageProps) -> Html {
     let active_tab = use_state(|| SettingsTab::Sessions);
 
     // Token state
@@ -789,10 +791,8 @@ pub fn settings_page() -> Html {
 
     // Back to dashboard
     let go_back = {
-        let navigator = navigator.clone();
-        Callback::from(move |_| {
-            navigator.push(&Route::Dashboard);
-        })
+        let on_close = props.on_close.clone();
+        Callback::from(move |_| on_close.emit(()))
     };
 
     // Count expiring tokens (within 7 days)

--- a/frontend/styles/dashboard.css
+++ b/frontend/styles/dashboard.css
@@ -86,6 +86,18 @@
     animation: scaleIn 0.2s ease-out;
 }
 
+/* Full-page modal overlay — used for admin and settings panels */
+.full-page-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+    overflow-y: auto;
+    animation: fadeIn 0.15s ease-out;
+}
+
 .modal-content .proxy-setup {
     margin: 0;
 }


### PR DESCRIPTION
## Summary
- Admin and Settings pages now render as full-page fixed overlays within `DashboardPage` instead of navigating to a new route
- This preserves the `ActivityRef` (sparkline tick history) which was previously destroyed when the dashboard unmounted on route change
- Direct URL navigation to `/admin` and `/settings` still works via thin wrapper components that provide a back-nav callback
- Hides the `$` cost indicator by default (user can opt-in via localStorage)

## Test plan
- [ ] Click Admin button → admin panel slides over dashboard, back button closes it
- [ ] Click Settings button → settings panel slides over dashboard, back button closes it
- [ ] Generate activity ticks in a session, navigate to admin, return — ticks are preserved
- [ ] Direct navigation to `/admin` and `/settings` URLs still works
- [ ] Cost indicator is hidden by default on fresh session

🤖 Generated with [Claude Code](https://claude.com/claude-code)