### PR TITLE
Prevent duplicate launchers per host-user and fix ~ expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.33
+
+- Prevent duplicate launchers per host-user and fix tilde expansion
+
 ## 1.3.32
 
 - Launcher cleanup: fix task abort, URL dedup, send error logging, config path

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.32"
+version = "1.3.33"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -41,6 +41,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                                         let _ = ws_sender
                                             .send(ServerToLauncher::LauncherRegisterAck {
                                                 success: false,
+                                                fatal: true,
                                                 launcher_id,
                                                 error: Some("Authentication failed".to_string()),
                                             })
@@ -54,6 +55,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                             let _ = ws_sender
                                 .send(ServerToLauncher::LauncherRegisterAck {
                                     success: false,
+                                    fatal: false,
                                     launcher_id,
                                     error: Some("Database error".to_string()),
                                 })
@@ -67,6 +69,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                     let _ = ws_sender
                         .send(ServerToLauncher::LauncherRegisterAck {
                             success: false,
+                            fatal: true,
                             launcher_id,
                             error: Some("No auth token provided".to_string()),
                         })
@@ -91,12 +94,37 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
         }
     };
 
+    // Reject duplicate: only one launcher per (hostname, user) is allowed
+    if let Some(existing_name) = app_state
+        .session_manager
+        .find_duplicate_launcher(&hostname, user_id)
+    {
+        warn!(
+            "Rejecting duplicate launcher '{}' from {} (user {}) — '{}' already connected",
+            launcher_name, hostname, user_id, existing_name
+        );
+        let _ = ws_sender
+            .send(ServerToLauncher::LauncherRegisterAck {
+                success: false,
+                launcher_id,
+                fatal: true,
+                error: Some(format!(
+                    "A launcher named '{}' is already connected from this host. \
+                     Stop the existing instance before starting a new one.",
+                    existing_name
+                )),
+            })
+            .await;
+        return;
+    }
+
     // Send RegisterAck
     let _ = ws_sender
         .send(ServerToLauncher::LauncherRegisterAck {
             success: true,
             launcher_id,
             error: None,
+            fatal: false,
         })
         .await;
 

--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -229,6 +229,17 @@ impl SessionManager {
         ids
     }
 
+    /// Returns the name of an existing launcher with the same hostname and user_id, if any.
+    pub fn find_duplicate_launcher(&self, hostname: &str, user_id: Uuid) -> Option<String> {
+        self.launchers
+            .iter()
+            .find(|entry| {
+                let c = entry.value();
+                c.user_id == user_id && c.hostname == hostname
+            })
+            .map(|entry| entry.value().launcher_name.clone())
+    }
+
     pub fn register_launcher(&self, launcher_id: Uuid, connection: LauncherConnection) {
         info!(
             "Registering launcher: {} ({})",

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -58,14 +58,23 @@ pub async fn run_launcher_loop(
                 let ack_ok = loop {
                     match ws_receiver.recv().await {
                         Some(Ok(ServerToLauncher::LauncherRegisterAck {
-                            success, error, ..
+                            success,
+                            error,
+                            fatal,
+                            ..
                         })) => {
                             if success {
                                 info!("Registration successful");
-                                break true;
+                                break Some(true);
                             } else {
-                                error!("Registration failed: {}", error.unwrap_or_default());
-                                break false;
+                                let msg = error.unwrap_or_default();
+                                if fatal {
+                                    error!("Registration rejected (fatal): {}", msg);
+                                    break None; // signal: exit, do not retry
+                                } else {
+                                    error!("Registration failed: {}", msg);
+                                    break Some(false);
+                                }
                             }
                         }
                         Some(Ok(_)) => continue,
@@ -73,15 +82,22 @@ pub async fn run_launcher_loop(
                             warn!("Decode error during registration: {}", e);
                             continue;
                         }
-                        None => break false,
+                        None => break Some(false),
                     }
                 };
 
-                if !ack_ok {
-                    warn!("Registration failed, will retry");
-                    tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
-                    continue;
+                match ack_ok {
+                    None => {
+                        // Fatal rejection — exit immediately, do not retry
+                        return Err(anyhow::anyhow!("Fatal registration error, exiting"));
+                    }
+                    Some(false) => {
+                        warn!("Registration failed, will retry");
+                        tokio::time::sleep(backoff).await;
+                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        continue;
+                    }
+                    Some(true) => {} // fall through to main loop
                 }
 
                 // Reconcile expected sessions: launch any that aren't running
@@ -227,10 +243,11 @@ pub async fn run_launcher_loop(
 }
 
 fn list_directory(path: &str, request_id: Uuid) -> LauncherToServer {
-    // Resolve ~ to home directory
+    // Resolve ~ to home directory (trailing slash ensures the dir itself is listed,
+    // not treated as a filter prefix against its parent)
     let resolved = if path == "~" || path == "~/" {
         dirs::home_dir()
-            .map(|p| p.to_string_lossy().to_string())
+            .map(|p| format!("{}/", p.to_string_lossy()))
             .unwrap_or_else(|| "/".to_string())
     } else if let Some(rest) = path.strip_prefix("~/") {
         dirs::home_dir()

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -377,6 +377,9 @@ pub enum ServerToLauncher {
         launcher_id: Uuid,
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
+        /// If true the launcher must not retry — it should exit immediately
+        #[serde(default)]
+        fatal: bool,
     },
 
     /// Request to launch a new proxy instance


### PR DESCRIPTION
## Summary

- Adds `fatal: bool` to `LauncherRegisterAck` so the launcher can distinguish unrecoverable errors (exit immediately) from transient ones (retry with backoff)
- Backend rejects a second launcher connecting from the same hostname + user_id pair, returning `fatal: true`; auth failures are also fatal; DB errors remain non-fatal (retryable)
- Adds `SessionManager::find_duplicate_launcher` to detect already-connected instances before registration completes
- Launcher exits cleanly on a fatal ack instead of spinning in the retry loop
- Fixes tilde expansion in `list_directory`: appends a trailing `/` so the resolved home path is treated as the directory to list, not a filter prefix against its parent (`/home` filtering by `user`)

## Test plan

- [ ] Start a launcher, verify it registers successfully
- [ ] Start a second launcher from the same host/user — verify it logs a fatal error and exits instead of retrying
- [ ] Verify the first launcher continues running normally
- [ ] Auth failure (bad token) — verify launcher exits immediately rather than retrying
- [ ] DB error — verify launcher retries with backoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)