### PR TITLE
Add Tab completion to launch dialog path input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.35
+
+- Add bash-style Tab completion to launch dialog path input
+
 ## 1.3.34
 
 - Fix launch dialog bugs and refactor DirBrowser

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.34"
+version = "1.3.35"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -181,6 +181,58 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         })
     };
 
+    let on_path_keydown = {
+        let selected_launcher = selected_launcher.clone();
+        let dir = dir.clone();
+        Callback::from(move |e: KeyboardEvent| {
+            if e.key() != "Tab" || e.shift_key() {
+                return;
+            }
+            e.prevent_default();
+
+            let path = (*dir.path).clone();
+            if path.ends_with('/') || path.is_empty() {
+                return;
+            }
+
+            let base = match path.rfind('/') {
+                Some(idx) => &path[..=idx],
+                None => "",
+            };
+
+            let entries = &*dir.entries;
+            if entries.is_empty() {
+                return;
+            }
+
+            // Longest common prefix of all entry names
+            let first = &entries[0].name;
+            let mut len = first.len();
+            for entry in entries.iter().skip(1) {
+                len = first
+                    .chars()
+                    .zip(entry.name.chars())
+                    .take(len)
+                    .take_while(|(a, b)| a == b)
+                    .count();
+            }
+            let lcp = &first[..len];
+
+            let completed = if entries.len() == 1 && entries[0].is_dir {
+                format!("{}{}/", base, lcp)
+            } else {
+                format!("{}{}", base, lcp)
+            };
+
+            if completed != path {
+                dir.path.set(completed.clone());
+                if let Some(lid) = *selected_launcher {
+                    dir.fetch(lid, completed, false);
+                }
+            }
+        })
+    };
+
     let on_args_input = {
         let extra_args = extra_args.clone();
         Callback::from(move |e: InputEvent| {
@@ -470,6 +522,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                             class="dir-path-input"
                             value={(*dir.path).clone()}
                             oninput={on_path_input}
+                            onkeydown={on_path_keydown}
                         />
                         <div class="dir-breadcrumb">
                             { breadcrumbs.iter().enumerate().map(|(i, (full_path, label))| {


### PR DESCRIPTION
## Summary
- Adds bash-style Tab completion to the directory path input in the launch dialog
- Single match: completes fully (adds trailing `/` for directories)
- Multiple matches: completes to the longest common prefix
- Uses the already-loaded directory entries from the debounced fetch — no extra API calls needed
- Shift+Tab is ignored to avoid conflicting with existing session navigation

## Test plan
- [ ] Open launch dialog, type partial path (e.g. `/home/user/Doc`), press Tab — completes to `Documents/` if it's the only match
- [ ] Type a prefix with multiple matches — Tab completes to longest common prefix
- [ ] Path ending with `/` — Tab does nothing (no prefix to complete)
- [ ] Shift+Tab — does not trigger completion (passes through normally)