### PR TITLE
Add agent install under Service in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.36
+
+- Add agent install setup under Service section in Credentials settings tab
+
 ## 1.3.35
 
 - Add bash-style Tab completion to launch dialog path input

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.35"
+version = "1.3.36"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -1,5 +1,5 @@
 use crate::audio::{self, EventSound, SoundConfig, SoundEvent, Waveform, STORAGE_KEY};
-use crate::components::ShareDialog;
+use crate::components::{ProxyTokenSetup, ShareDialog};
 use crate::utils;
 use gloo_net::http::Request;
 use shared::{
@@ -954,6 +954,16 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                                 { "Credentials expired for more than 7 days are automatically deleted." }
                             </p>
                         }
+                    </section>
+
+                    <section class="service-section">
+                        <div class="section-header">
+                            <h2>{ "Service" }</h2>
+                            <p class="section-description">
+                                { "Install and configure the agent on your machines." }
+                            </p>
+                        </div>
+                        <ProxyTokenSetup />
                     </section>
                 }
 


### PR DESCRIPTION
## Summary
- Adds the `ProxyTokenSetup` (agent install instructions) component under a new "Service" sub-heading in the Credentials settings tab
- Users can now find install/login/service setup steps directly from Settings > Credentials

## Test plan
- [ ] Open Settings > Credentials tab
- [ ] Verify "Service" section appears below the token management section
- [ ] Verify install/login/service commands render correctly with platform selector