### PR TITLE
Move install under service subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.37
+
+- Move install under service subcommand (`agent-portal service install`)
+
 ## 1.3.36
 
 - Add agent install setup under Service section in Credentials settings tab

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.36"
+version = "1.3.37"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/proxy_token_setup.rs
+++ b/frontend/src/components/proxy_token_setup.rs
@@ -77,8 +77,8 @@ pub fn proxy_token_setup() -> Html {
         Platform::Windows => ".\\agent-portal.exe login".to_string(),
     };
     let service_command = match *selected_platform {
-        Platform::Linux | Platform::MacOS => "agent-portal install".to_string(),
-        Platform::Windows => ".\\agent-portal.exe install".to_string(),
+        Platform::Linux | Platform::MacOS => "agent-portal service install".to_string(),
+        Platform::Windows => ".\\agent-portal.exe service install".to_string(),
     };
 
     html! {

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -44,8 +44,6 @@ struct Args {
 enum Command {
     /// Authenticate with the backend server via browser
     Login,
-    /// Install agent-portal as a persistent system service
-    Install,
     /// Update agent-portal to the latest version (restarts service if running)
     Update,
     /// Manage the launcher system service
@@ -91,7 +89,6 @@ async fn main() -> anyhow::Result<()> {
     // Handle subcommands before the daemon startup path
     match args.command {
         Some(Command::Login) => return cmd_login(&args).await,
-        Some(Command::Install) => return service::install(),
         Some(Command::Update) => return cmd_update().await,
         Some(Command::Service { action }) => {
             return match action {
@@ -109,7 +106,7 @@ async fn main() -> anyhow::Result<()> {
     if !args.no_update && !service::is_installed() {
         eprintln!();
         eprintln!("  Tip: Install agent-portal as a system service for persistent operation:");
-        eprintln!("    agent-portal install");
+        eprintln!("    agent-portal service install");
         eprintln!();
     }
 


### PR DESCRIPTION
## Summary
- Remove top-level `agent-portal install` command — install now only lives under `agent-portal service install`
- Update the startup tip message to reference `agent-portal service install`
- Update `ProxyTokenSetup` component to show `agent-portal service install`

## Test plan
- [ ] `agent-portal service install` works
- [ ] `agent-portal service uninstall` works
- [ ] `agent-portal service status` works
- [ ] `agent-portal install` is no longer a valid command
- [ ] ProxyTokenSetup shows updated command