### PR TITLE
Add machine setup button to launch dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.38
+
+- Add "Add machine" button to launch dialog for setting up new launchers
+- Remove Service section from settings Credentials tab
+
 ## 1.3.37
 
 - Move install under service subcommand (`agent-portal service install`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.37"
+version = "1.3.38"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -136,6 +136,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     let skip_permissions = use_state(|| false);
     let launching = use_state(|| false);
     let error_msg = use_state(|| None::<String>);
+    let show_setup = use_state(|| false);
     let debounce_handle = use_mut_ref(|| None::<Timeout>);
 
     // Fetch launchers on mount
@@ -368,6 +369,13 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         Callback::from(move |_| on_close.emit(()))
     };
 
+    let toggle_setup = {
+        let show_setup = show_setup.clone();
+        Callback::from(move |_: MouseEvent| {
+            show_setup.set(!*show_setup);
+        })
+    };
+
     // Close on Escape key
     {
         let on_close = props.on_close.clone();
@@ -507,6 +515,13 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                             </select>
                         </div>
                     </div>
+
+                    <button class="launch-add-machine" onclick={toggle_setup}>
+                        { if *show_setup { "Hide setup" } else { "+ Add machine" } }
+                    </button>
+                    if *show_setup {
+                        <ProxyTokenSetup />
+                    }
 
                     if *agent_type == shared::AgentType::Codex {
                         <div class="launch-note launch-note-warn">

--- a/frontend/src/pages/settings.rs
+++ b/frontend/src/pages/settings.rs
@@ -1,5 +1,5 @@
 use crate::audio::{self, EventSound, SoundConfig, SoundEvent, Waveform, STORAGE_KEY};
-use crate::components::{ProxyTokenSetup, ShareDialog};
+use crate::components::ShareDialog;
 use crate::utils;
 use gloo_net::http::Request;
 use shared::{
@@ -954,16 +954,6 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                                 { "Credentials expired for more than 7 days are automatically deleted." }
                             </p>
                         }
-                    </section>
-
-                    <section class="service-section">
-                        <div class="section-header">
-                            <h2>{ "Service" }</h2>
-                            <p class="section-description">
-                                { "Install and configure the agent on your machines." }
-                            </p>
-                        </div>
-                        <ProxyTokenSetup />
                     </section>
                 }
 

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -366,6 +366,23 @@
     line-height: 1.5;
 }
 
+.launch-add-machine {
+    background: none;
+    border: 1px dashed var(--border);
+    color: var(--text-secondary);
+    padding: 0.4rem 0.8rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    width: 100%;
+    margin-bottom: 0.5rem;
+}
+
+.launch-add-machine:hover {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+}
+
 .launch-no-launchers code {
     background: var(--bg-dark);
     padding: 0.15rem 0.4rem;


### PR DESCRIPTION
## Summary
- Adds "+ Add machine" toggle button in the launch dialog (when launchers exist) that reveals the `ProxyTokenSetup` install instructions
- Removes the Service section from the settings Credentials tab (moved to launch dialog instead)
- Users can now set up new machines directly from the launcher menu

## Test plan
- [ ] Open launch dialog with existing launchers — see "+ Add machine" button
- [ ] Click button — reveals install/login/service setup steps
- [ ] Click "Hide setup" — collapses the instructions
- [ ] Settings > Credentials no longer shows Service section
- [ ] No launchers state still shows ProxyTokenSetup as before