### PR TITLE
Persist launcher sessions across reboots

### DIFF
--- a/launcher/src/config.rs
+++ b/launcher/src/config.rs
@@ -47,21 +47,49 @@ pub fn load_config() -> LauncherConfig {
     }
 }
 
-pub fn save_auth_token(token: &str) -> anyhow::Result<()> {
+fn save_config(config: &LauncherConfig) -> anyhow::Result<()> {
     let path = config_path();
-    let mut config: LauncherConfig = match std::fs::read_to_string(&path) {
-        Ok(contents) => toml::from_str(&contents).unwrap_or_default(),
-        Err(_) => LauncherConfig::default(),
-    };
-
-    config.auth_token = Some(token.to_string());
-
-    let contents = toml::to_string_pretty(&config)?;
+    let contents = toml::to_string_pretty(config)?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(&path, contents)?;
-    tracing::info!("Saved auth token to {}", path.display());
+    tracing::debug!("Saved config to {}", path.display());
+    Ok(())
+}
+
+pub fn save_auth_token(token: &str) -> anyhow::Result<()> {
+    let mut config = load_config();
+    config.auth_token = Some(token.to_string());
+    save_config(&config)?;
+    tracing::info!("Saved auth token to {}", config_path().display());
+    Ok(())
+}
+
+pub fn add_session(session: &ExpectedSession) -> anyhow::Result<()> {
+    let mut config = load_config();
+    if config
+        .sessions
+        .iter()
+        .any(|s| s.working_directory == session.working_directory)
+    {
+        tracing::debug!("Session already in config: {}", session.working_directory);
+        return Ok(());
+    }
+    config.sessions.push(session.clone());
+    save_config(&config)
+}
+
+pub fn remove_session(working_directory: &str) -> anyhow::Result<()> {
+    let mut config = load_config();
+    let before = config.sessions.len();
+    config
+        .sessions
+        .retain(|s| s.working_directory != working_directory);
+    if config.sessions.len() < before {
+        save_config(&config)?;
+        tracing::debug!("Removed session from config: {}", working_directory);
+    }
     Ok(())
 }
 

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -1,4 +1,4 @@
-use crate::config::ExpectedSession;
+use crate::config::{self, ExpectedSession};
 use crate::process_manager::{ProcessManager, SessionExited};
 use shared::{LauncherEndpoint, LauncherToServer, ServerToLauncher};
 use std::collections::HashMap;
@@ -19,7 +19,7 @@ pub async fn run_launcher_loop(
     auth_token: Option<&str>,
     mut process_manager: ProcessManager,
     mut exit_rx: mpsc::UnboundedReceiver<SessionExited>,
-    expected_sessions: Vec<ExpectedSession>,
+    mut expected_sessions: Vec<ExpectedSession>,
 ) -> anyhow::Result<()> {
     process_manager.set_launcher_id(launcher_id);
     let mut backoff = Duration::from_secs(1);
@@ -143,6 +143,7 @@ pub async fn run_launcher_loop(
                                         msg,
                                         &mut ws_sender,
                                         &mut process_manager,
+                                        &mut expected_sessions,
                                     ).await;
                                 }
                                 Some(Err(e)) => {
@@ -184,13 +185,17 @@ pub async fn run_launcher_loop(
                                 break;
                             }
 
-                            // Schedule restart if this was an expected session
                             if let Some(dir) = exited_dir {
-                                if let Some(expected) = expected_sessions.iter().find(|s| s.working_directory == dir) {
-                                    // restart_counts is never reset after a successful run.
-                                    // This is intentional: MAX_RESTART_ATTEMPTS is a
-                                    // total lifetime cap per directory, not a per-window
-                                    // counter. Fail-fast rather than retry indefinitely.
+                                let is_clean_exit = exited.exit_code == Some(0);
+                                if is_clean_exit {
+                                    // Clean exit: remove from expected sessions
+                                    expected_sessions.retain(|s| s.working_directory != dir);
+                                    if let Err(e) = config::remove_session(&dir) {
+                                        warn!("Failed to remove session from config: {}", e);
+                                    }
+                                    info!("Session exited cleanly, removed from expected: {}", dir);
+                                } else if let Some(expected) = expected_sessions.iter().find(|s| s.working_directory == dir) {
+                                    // Non-clean exit: try to restart
                                     let count = restart_counts.entry(dir.clone()).or_insert(0);
                                     *count += 1;
                                     if *count <= MAX_RESTART_ATTEMPTS {
@@ -209,6 +214,10 @@ pub async fn run_launcher_loop(
                                             "Expected session exceeded max restarts ({}): {}",
                                             MAX_RESTART_ATTEMPTS, dir
                                         );
+                                        expected_sessions.retain(|s| s.working_directory != dir);
+                                        if let Err(e) = config::remove_session(&dir) {
+                                            warn!("Failed to remove session from config: {}", e);
+                                        }
                                     }
                                 }
                             }
@@ -323,6 +332,7 @@ async fn handle_message(
     msg: ServerToLauncher,
     ws_sender: &mut ws_bridge::WsSender<LauncherToServer>,
     process_manager: &mut ProcessManager,
+    expected_sessions: &mut Vec<ExpectedSession>,
 ) {
     match msg {
         ServerToLauncher::LaunchSession {
@@ -350,13 +360,31 @@ async fn handle_message(
                 .await;
 
             let response = match result {
-                Ok(session_id) => LauncherToServer::LaunchSessionResult {
-                    request_id,
-                    success: true,
-                    session_id: Some(session_id),
-                    pid: None,
-                    error: None,
-                },
+                Ok(session_id) => {
+                    // Persist so this session survives launcher restarts
+                    if !expected_sessions
+                        .iter()
+                        .any(|s| s.working_directory == working_directory)
+                    {
+                        let expected = ExpectedSession {
+                            working_directory: working_directory.clone(),
+                            session_name: session_name.clone(),
+                            agent_type,
+                            claude_args: claude_args.clone(),
+                        };
+                        if let Err(e) = config::add_session(&expected) {
+                            warn!("Failed to persist session to config: {}", e);
+                        }
+                        expected_sessions.push(expected);
+                    }
+                    LauncherToServer::LaunchSessionResult {
+                        request_id,
+                        success: true,
+                        session_id: Some(session_id),
+                        pid: None,
+                        error: None,
+                    }
+                }
                 Err(e) => {
                     error!("Failed to spawn: {}", e);
                     LauncherToServer::LaunchSessionResult {
@@ -375,7 +403,14 @@ async fn handle_message(
         }
         ServerToLauncher::StopSession { session_id } => {
             info!("Stop request for session {}", session_id);
+            let working_dir = process_manager.session_working_directory(&session_id);
             process_manager.stop(&session_id).await;
+            if let Some(dir) = working_dir {
+                expected_sessions.retain(|s| s.working_directory != dir);
+                if let Err(e) = config::remove_session(&dir) {
+                    warn!("Failed to remove session from config: {}", e);
+                }
+            }
         }
         ServerToLauncher::ListDirectories { request_id, path } => {
             let response = list_directory(&path, request_id);


### PR DESCRIPTION
## Summary
- Dynamically launched sessions (from frontend UI) are now saved to `launcher.toml` so they survive launcher restarts
- Sessions are removed from config on clean exit (code 0), explicit stop, or after exceeding max restart attempts (3)
- Refactored `save_auth_token` to reuse new `save_config` helper

## Test plan
- [ ] Launch a session via the frontend, verify it appears in `~/.config/claude-portal/launcher.toml`
- [ ] Restart the launcher, verify the session is relaunched automatically
- [ ] Stop a session, verify it's removed from `launcher.toml`
- [ ] Let a session exit cleanly, verify it's removed from config
- [ ] `cargo test -p agent-portal` passes