### PR TITLE
Compact proxy connect/reconnect message

### DIFF
--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -416,15 +416,8 @@ async fn run_single_connection(session: &mut SessionState<'_>) -> ConnectionResu
         };
 
         let short_id = &session.config.session_id.to_string()[..8];
-        let mut text = format!(
-            "{}\n\n\
-             | | |\n\
-             |---|---|\n\
-             | Name | `{}` |\n\
-             | Host | `{}` |\n\
-             | Directory | `{}` |\n\
-             | Agent | {} |\n\
-             | ID | `{}…` |",
+        let text = format!(
+            "{} — `{}` on `{}` in `{}` ({} `{}…`)",
             status_line,
             session.config.session_name,
             hostname,
@@ -432,10 +425,6 @@ async fn run_single_connection(session: &mut SessionState<'_>) -> ConnectionResu
             config_with_branch.agent_type,
             short_id,
         );
-
-        if let Some(ref branch) = config_with_branch.git_branch {
-            text.push_str(&format!("\n| Branch | `{}` |", branch));
-        }
 
         let portal_content = shared::PortalMessage::text(text).to_json();
         let seq = {


### PR DESCRIPTION
## Summary
- Replaces the multi-line markdown table in the proxy connect/reconnect portal message with a single inline line
- Removes git branch from the message

**Before:**
```
**Session started**

| | |
|---|---|
| Name | `hostname-20260226` |
| Host | `myhost` |
| Directory | `/home/user/project` |
| Agent | claude |
| ID | `a1b2c3d4…` |
| Branch | `main` |
```

**After:**
```
**Session started** — `hostname-20260226` on `myhost` in `/home/user/project` (claude `a1b2c3d4…`)
```

## Test plan
- [ ] Start a proxy session, verify the connect message is a single line
- [ ] Disconnect/reconnect, verify the reconnect message is also compact