### PR TITLE
Fix Shift+Tab keyboard hint label

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -738,7 +738,7 @@ pub fn dashboard_page() -> Html {
                                     html! {
                                         <>
                                             <span>{ "Esc = nav mode" }</span>
-                                            <span>{ "Shift+Tab = next paused" }</span>
+                                            <span>{ "Shift+Tab = next active" }</span>
                                             if *voice_enabled {
                                                 <span>{ "Ctrl+M = voice" }</span>
                                             }


### PR DESCRIPTION
## Summary
- Fix bottom bar hint: "Shift+Tab = next paused" → "Shift+Tab = next active"
- The shortcut skips paused sessions and jumps to the next active one

## Test plan
- [ ] Verify bottom bar shows "Shift+Tab = next active" in input mode