### PR TITLE
Align input prompt with textarea text

### DIFF
--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -16,6 +16,7 @@
     color: var(--accent);
     font-weight: bold;
     font-size: 1.1rem;
+    padding-bottom: 0.5rem;
 }
 
 .session-view-input .message-input {


### PR DESCRIPTION
## Summary
- Add bottom padding to the `>` prompt so it aligns with the textarea text baseline

## Test plan
- [ ] Verify `>` prompt is vertically centered with the first line of text in the input