### PR TITLE
Document why max_sessions limit exists

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -24,7 +24,11 @@ struct Args {
     #[arg(long)]
     name: Option<String>,
 
-    /// Maximum concurrent sessions
+    /// Maximum concurrent sessions. Each session spawns a Claude CLI child
+    /// process with its own memory and CPU footprint, so unbounded concurrency
+    /// can exhaust system resources and degrade performance for every session.
+    /// The default of 20 is a conservative starting point for a typical
+    /// developer machine; tune upward on larger hosts if needed.
     #[arg(long, default_value_t = 20)]
     max_sessions: usize,
 

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -78,6 +78,10 @@ impl ProcessManager {
         claude_args: &[String],
         agent_type: shared::AgentType,
     ) -> anyhow::Result<Uuid> {
+        // Enforce the concurrency cap. Each session is a long-lived Claude CLI
+        // process consuming memory, CPU, and a WebSocket connection. Without a
+        // limit, a burst of launch requests could starve the host of resources
+        // and degrade every running session.
         if self.tasks.len() >= self.max_sessions {
             anyhow::bail!(
                 "At session limit ({}/{})",


### PR DESCRIPTION
## Summary
- Added doc comments on the `max_sessions` CLI arg in `launcher/src/main.rs` explaining that each session spawns a Claude CLI process with its own memory/CPU footprint, and that the default of 20 is a conservative starting point for a typical developer machine.
- Added a code comment at the enforcement check in `launcher/src/process_manager.rs` explaining why the concurrency cap is necessary (prevent resource exhaustion from unbounded launch requests).

Closes #496

## Test plan
- [x] `cargo clippy -p agent-portal` passes with no warnings
- [x] `cargo fmt` applied
- Documentation-only change, no behavioral impact