### PR TITLE
Fix subagent completion handling in history path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 ## 1.3.40
 
 - Review and update all docs for accuracy across 15 files
+- Fix subagent completion handling in history loading path to preserve task data
+- Replace catch-all status mapping with explicit CCTaskStatus variant matching
 
 ## 1.3.38
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -394,21 +394,33 @@ impl Component for SessionView {
                                 entry.total_tokens = Some(progress.usage.total_tokens);
                             } else if let Some(notif) = sys.as_task_notification() {
                                 msg_type = "task_end".to_string();
-                                if let Some(entry) = self.active_tasks.get_mut(&notif.task_id) {
-                                    entry.status = match notif.status {
-                                        shared::CCTaskStatus::Failed => TaskStatus::Failed,
-                                        _ => TaskStatus::Completed,
-                                    };
-                                    let ts = js_sys::Date::parse(&msg.created_at);
-                                    entry.completed_at =
-                                        Some(if ts.is_finite() { ts } else { 0.0 });
-                                    if let Some(usage) = &notif.usage {
-                                        entry.duration_ms = Some(usage.duration_ms);
-                                        entry.tool_uses = Some(usage.tool_uses);
-                                        entry.total_tokens = Some(usage.total_tokens);
-                                    }
+                                let ts = js_sys::Date::parse(&msg.created_at);
+                                let completed_at = if ts.is_finite() { ts } else { 0.0 };
+                                let entry = self
+                                    .active_tasks
+                                    .entry(notif.task_id.clone())
+                                    .or_insert_with(|| TaskEntry {
+                                        task_type: "local_agent".to_string(),
+                                        description: notif.summary.clone(),
+                                        started_at: completed_at,
+                                        status: TaskStatus::Running,
+                                        duration_ms: None,
+                                        tool_uses: None,
+                                        total_tokens: None,
+                                        completed_at: None,
+                                        current_activity: None,
+                                        last_tool_name: None,
+                                    });
+                                entry.status = match notif.status {
+                                    shared::CCTaskStatus::Completed => TaskStatus::Completed,
+                                    shared::CCTaskStatus::Failed => TaskStatus::Failed,
+                                };
+                                entry.completed_at = Some(completed_at);
+                                if let Some(usage) = &notif.usage {
+                                    entry.duration_ms = Some(usage.duration_ms);
+                                    entry.tool_uses = Some(usage.tool_uses);
+                                    entry.total_tokens = Some(usage.total_tokens);
                                 }
-                                // If we never saw task_started (truncated), just ignore the notification
                             }
                         }
                         // Fallback: detect task completion from tool_result in user messages
@@ -1155,8 +1167,8 @@ impl SessionView {
                                 last_tool_name: None,
                             });
                         entry.status = match notif.status {
+                            shared::CCTaskStatus::Completed => TaskStatus::Completed,
                             shared::CCTaskStatus::Failed => TaskStatus::Failed,
-                            _ => TaskStatus::Completed,
                         };
                         entry.completed_at = Some(js_sys::Date::now());
                         if let Some(usage) = &notif.usage {


### PR DESCRIPTION
## Summary

Closes #475

- **Issue 1**: History loading path now uses `entry().or_insert_with()` for task notifications (matching the live handler), so tasks whose `task_started` was truncated from history still get a proper `TaskEntry` with status, completed_at, duration, tool_uses, and total_tokens populated before display.
- **Issue 2**: Replaced `_ => TaskStatus::Completed` catch-all with explicit `CCTaskStatus::Completed => TaskStatus::Completed` in both the history and live paths, so the compiler will flag any new variants added to `CCTaskStatus` upstream.
- **Issue 3**: `task_progress` rendering as `html! {}` is intentional -- no change needed.

## Test plan

- [ ] Load a session with historical subagent tasks and verify the sidebar shows completed tasks with duration/token stats
- [ ] Verify live subagent task lifecycle still works (start -> progress -> complete)
- [ ] `cargo check -p frontend --target wasm32-unknown-unknown` passes