### PR TITLE
Add Loom demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A web portal that extends [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with session sharing, remote access, and collaborative features. Run Claude Code on powerful machines and access it from anywhere through your browser.
 
+<div style="position: relative; padding-bottom: 48.975188781014026%; height: 0;"><iframe src="https://www.loom.com/embed/38bdd5406c2443ff8c978d5d5b01e967" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+
 ## Features
 
 - **Remote Access**: Run Claude Code on dedicated machines, access from any browser


### PR DESCRIPTION
## Summary
- Adds embedded Loom demo video to the top of the README, between the intro paragraph and Features section

## Test plan
- [ ] Verify the video embed renders correctly on GitHub