### PR TITLE
Add SessionTerminated for clean session stops

### DIFF
--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -291,15 +291,14 @@ impl SessionManager {
         false
     }
 
-    /// Stop a directly-connected proxy by sending it a shutdown message.
-    /// The proxy will disconnect, and the session will be marked as disconnected in the DB.
+    /// Stop a directly-connected proxy by sending it a termination message.
+    /// The proxy will disconnect without attempting to reconnect.
     /// Returns true if the session was found and the message was sent.
     pub fn disconnect_session(&self, session_id: Uuid) -> bool {
         let key = session_id.to_string();
         if let Some(sender) = self.sessions.get(&key) {
-            let _ = sender.send(ServerToProxy::ServerShutdown {
+            let _ = sender.send(ServerToProxy::SessionTerminated {
                 reason: "Session stopped by user".to_string(),
-                reconnect_delay_ms: 30_000,
             });
             true
         } else {

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -117,6 +117,8 @@ pub enum ConnectionResult {
     SessionNotFound,
     /// Server is shutting down gracefully, includes suggested reconnect delay
     ServerShutdown(Duration),
+    /// Session was terminated by the server (do not reconnect)
+    SessionTerminated,
 }
 
 /// Result from the connection loop
@@ -239,6 +241,8 @@ struct ConnectionState {
     disconnect_rx: tokio::sync::oneshot::Receiver<()>,
     /// Receiver for graceful server shutdown signal
     graceful_shutdown_rx: mpsc::UnboundedReceiver<GracefulShutdown>,
+    /// Receiver for session terminated signal (do not reconnect)
+    session_terminated_rx: tokio::sync::oneshot::Receiver<()>,
     /// When the connection was established
     connection_start: Instant,
     /// Buffer for pending outputs
@@ -317,6 +321,11 @@ pub async fn run_connection_loop(
                 );
 
                 tokio::time::sleep(delay).await;
+            }
+            ConnectionResult::SessionTerminated => {
+                info!("Session terminated by server, not reconnecting");
+                session.persist_buffer().await;
+                return Ok(LoopResult::NormalExit);
             }
         }
     }
@@ -582,6 +591,9 @@ async fn run_message_loop(
     // Channel for file upload events from backend
     let (file_upload_tx, file_upload_rx) = mpsc::unbounded_channel::<FileUploadEvent>();
 
+    // Channel for session terminated signal (do not reconnect)
+    let (session_terminated_tx, session_terminated_rx) = tokio::sync::oneshot::channel::<()>();
+
     // Wrap ws_write for sharing
     let ws_write = std::sync::Arc::new(tokio::sync::Mutex::new(ws_write));
 
@@ -617,6 +629,7 @@ async fn run_message_loop(
         disconnect_tx,
         wiggum_tx,
         graceful_shutdown_tx,
+        session_terminated_tx,
         heartbeat.clone(),
         file_upload_tx,
     );
@@ -629,6 +642,7 @@ async fn run_message_loop(
         ws_write: ws_write.clone(),
         disconnect_rx,
         graceful_shutdown_rx,
+        session_terminated_rx,
         connection_start,
         output_buffer: session.output_buffer.clone(),
         wiggum_rx,
@@ -676,6 +690,11 @@ async fn run_main_loop(
                 }
                 let mut ws = state.ws_write.lock().await;
                 let _ = ws.send(ProxyToServer::Heartbeat).await;
+            }
+
+            _ = &mut state.session_terminated_rx => {
+                info!("Session terminated by server");
+                return ConnectionResult::SessionTerminated;
             }
 
             _ = &mut state.disconnect_rx => {

--- a/claude-session-lib/src/proxy_session/ws_reader.rs
+++ b/claude-session-lib/src/proxy_session/ws_reader.rs
@@ -39,6 +39,8 @@ pub(super) enum WsMessageResult {
     Disconnect,
     /// Server requested graceful shutdown with specified delay in ms
     GracefulShutdown(u64),
+    /// Session was terminated by the server (do not reconnect)
+    SessionTerminated,
 }
 
 /// Spawn the WebSocket reader task
@@ -52,6 +54,7 @@ pub(super) fn spawn_ws_reader(
     disconnect_tx: tokio::sync::oneshot::Sender<()>,
     wiggum_tx: mpsc::UnboundedSender<String>,
     graceful_shutdown_tx: mpsc::UnboundedSender<GracefulShutdown>,
+    session_terminated_tx: tokio::sync::oneshot::Sender<()>,
     heartbeat: crate::heartbeat::HeartbeatTracker,
     file_upload_tx: mpsc::UnboundedSender<FileUploadEvent>,
 ) -> tokio::task::JoinHandle<()> {
@@ -77,6 +80,10 @@ pub(super) fn spawn_ws_reader(
                             let _ = graceful_shutdown_tx.send(GracefulShutdown {
                                 reconnect_delay_ms: delay_ms,
                             });
+                            break;
+                        }
+                        WsMessageResult::SessionTerminated => {
+                            let _ = session_terminated_tx.send(());
                             break;
                         }
                     }
@@ -224,6 +231,10 @@ async fn handle_ws_message(
                 reason, reconnect_delay_ms
             );
             return WsMessageResult::GracefulShutdown(reconnect_delay_ms);
+        }
+        ServerToProxy::SessionTerminated { reason } => {
+            info!("Session terminated by server: {}", reason);
+            return WsMessageResult::SessionTerminated;
         }
         ServerToProxy::FileUploadStart(shared::FileUploadStartFields {
             upload_id,

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -197,6 +197,8 @@ pub enum WsEvent {
     Disconnect,
     /// Server requested graceful shutdown with reconnect delay
     GracefulShutdown(u64),
+    /// Session was terminated by the server (do not reconnect)
+    SessionTerminated,
 }
 
 /// Spawn a WebSocket reader task (raw tokio-tungstenite).
@@ -328,6 +330,11 @@ async fn handle_ws_text_message(
                 reason, reconnect_delay_ms
             );
             let _ = event_tx.send(WsEvent::GracefulShutdown(reconnect_delay_ms));
+            false // stop reading
+        }
+        ServerToProxy::SessionTerminated { reason } => {
+            info!("Session terminated by server: {}", reason);
+            let _ = event_tx.send(WsEvent::SessionTerminated);
             false // stop reading
         }
         _ => true,

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -467,6 +467,12 @@ async fn run_shim_loop(
                 );
                 tokio::time::sleep(delay).await;
             }
+            ShimConnectionResult::SessionTerminated => {
+                info!("Session terminated by server, not reconnecting");
+                stdout_reader_task.abort();
+                stdin_reader_task.abort();
+                return;
+            }
         }
     }
 }
@@ -475,6 +481,7 @@ enum ShimConnectionResult {
     ClaudeExited,
     Disconnected,
     ServerShutdown(Duration),
+    SessionTerminated,
 }
 
 /// Run the message loop for a single WebSocket connection.
@@ -581,6 +588,9 @@ async fn run_shim_connection(
                         break ShimConnectionResult::ServerShutdown(
                             Duration::from_millis(delay_ms)
                         );
+                    }
+                    Some(WsEvent::SessionTerminated) => {
+                        break ShimConnectionResult::SessionTerminated;
                     }
                     Some(WsEvent::Disconnect) | None => {
                         info!("Portal WebSocket disconnected");

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -168,11 +168,14 @@ pub enum ServerToProxy {
     /// A single chunk of a file upload (base64-encoded, ~1KB decoded)
     FileUploadChunk(FileUploadChunkFields),
 
-    /// Server is shutting down
+    /// Server is shutting down (proxy should reconnect after delay)
     ServerShutdown {
         reason: String,
         reconnect_delay_ms: u64,
     },
+
+    /// Session has been terminated (proxy should NOT reconnect)
+    SessionTerminated { reason: String },
 }
 
 // =============================================================================
@@ -607,5 +610,17 @@ mod tests {
         let _: ServerToProxy = serde_json::from_str(json).unwrap();
         let _: ServerToClient = serde_json::from_str(json).unwrap();
         let _: ServerToLauncher = serde_json::from_str(json).unwrap();
+    }
+
+    #[test]
+    fn wire_compat_session_terminated() {
+        let json = r#"{"type":"SessionTerminated","reason":"Session stopped by user"}"#;
+        let msg: ServerToProxy = serde_json::from_str(json).unwrap();
+        match msg {
+            ServerToProxy::SessionTerminated { reason } => {
+                assert_eq!(reason, "Session stopped by user");
+            }
+            _ => panic!("Wrong variant"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `SessionTerminated` variant to `ServerToProxy` wire protocol
- When a user stops a session, the backend now sends `SessionTerminated` instead of `ServerShutdown`
- The proxy recognizes this as a terminal signal and exits cleanly without attempting to reconnect
- Previously, stopped sessions would log "reconnecting in 30000ms" and waste resources trying to reconnect

## Changes
- `shared/src/endpoints.rs`: New `SessionTerminated { reason }` variant + serialization test
- `backend/session_manager.rs`: `disconnect_session()` sends `SessionTerminated` instead of `ServerShutdown`
- `claude-session-lib/ws_reader.rs`: Handle new variant, signal via oneshot channel
- `claude-session-lib/mod.rs`: New `ConnectionResult::SessionTerminated` exits the reconnection loop
- `proxy/shim.rs`: Handle in shim path, break loop on termination
- `proxy/session.rs`: Forward as `WsEvent::SessionTerminated`

## Test plan
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace` clean
- [ ] Stop a session from the frontend — proxy should exit cleanly with "Session terminated by server" log, no reconnect attempts