### PR TITLE
Add repo URL to pill menu with 3-state display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.41
+
+- Add repo URL to pill menu with 3-state display: PR link, repo link, or "No Repository Detected"
+- Proxy detects GitHub repo URL via `gh repo view` and sends it alongside branch/PR info
+
 ## 1.3.40
 
 - Review and update all docs for accuracy across 15 files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.40"
+version = "1.3.41"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/2026-02-27-221207_add_repo_url_to_sessions/down.sql
+++ b/backend/migrations/2026-02-27-221207_add_repo_url_to_sessions/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN repo_url;

--- a/backend/migrations/2026-02-27-221207_add_repo_url_to_sessions/up.sql
+++ b/backend/migrations/2026-02-27-221207_add_repo_url_to_sessions/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN repo_url VARCHAR(512);

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -98,6 +98,7 @@ fn handle_proxy_message(
             hostname,
             launcher_id,
             agent_type,
+            repo_url,
         }) => {
             let key = claude_session_id.to_string();
             *session_key = Some(key.clone());
@@ -117,6 +118,7 @@ fn handle_proxy_message(
                 hostname: hostname.as_deref().unwrap_or("unknown"),
                 launcher_id,
                 agent_type,
+                repo_url: &repo_url,
             };
             let result = register_or_update_session(app_state, &params);
 
@@ -186,6 +188,7 @@ fn handle_proxy_message(
             session_id: update_session_id,
             git_branch,
             pr_url,
+            repo_url,
         } => {
             handle_session_update(
                 session_manager,
@@ -195,6 +198,7 @@ fn handle_proxy_message(
                 update_session_id,
                 git_branch,
                 pr_url,
+                repo_url,
             );
         }
         ProxyToServer::InputAck {
@@ -207,6 +211,7 @@ fn handle_proxy_message(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_session_update(
     session_manager: &SessionManager,
     session_key: &Option<SessionId>,
@@ -215,6 +220,7 @@ fn handle_session_update(
     update_session_id: Uuid,
     git_branch: Option<String>,
     pr_url: Option<String>,
+    repo_url: Option<String>,
 ) {
     let Some(current_session_id) = db_session_id else {
         return;
@@ -243,14 +249,15 @@ fn handle_session_update(
         .set((
             sessions::git_branch.eq(&git_branch),
             sessions::pr_url.eq(&pr_url),
+            sessions::repo_url.eq(&repo_url),
         ))
         .execute(&mut conn)
     {
         error!("Failed to update session metadata: {}", e);
     } else {
         info!(
-            "Updated session {}: branch={:?} pr_url={:?}",
-            current_session_id, git_branch, pr_url
+            "Updated session {}: branch={:?} pr_url={:?} repo_url={:?}",
+            current_session_id, git_branch, pr_url, repo_url
         );
 
         if let Some(ref key) = session_key {
@@ -260,6 +267,7 @@ fn handle_session_update(
                     session_id: current_session_id,
                     git_branch,
                     pr_url,
+                    repo_url,
                 },
             );
         }

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -26,6 +26,7 @@ pub struct RegistrationParams<'a> {
     pub hostname: &'a str,
     pub launcher_id: Option<Uuid>,
     pub agent_type: AgentType,
+    pub repo_url: &'a Option<String>,
 }
 
 /// Register or update a session in the database.
@@ -82,6 +83,7 @@ pub fn register_or_update_session(
                 sessions::git_branch.eq(params.git_branch),
                 sessions::client_version.eq(params.client_version),
                 sessions::hostname.eq(params.hostname),
+                sessions::repo_url.eq(params.repo_url),
             ))
             .execute(&mut conn)
         {
@@ -146,6 +148,7 @@ fn create_new_session(
         hostname: params.hostname.to_string(),
         launcher_id: params.launcher_id,
         agent_type: params.agent_type.as_str().to_string(),
+        repo_url: params.repo_url.clone(),
     };
 
     match diesel::insert_into(sessions::table)

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -55,6 +55,7 @@ pub struct Session {
     pub launcher_id: Option<Uuid>,
     pub pr_url: Option<String>,
     pub agent_type: String,
+    pub repo_url: Option<String>,
 }
 
 #[derive(Debug, Insertable)]
@@ -83,6 +84,7 @@ pub struct NewSessionWithId {
     pub hostname: String,
     pub launcher_id: Option<Uuid>,
     pub agent_type: String,
+    pub repo_url: Option<String>,
 }
 
 #[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -124,6 +124,8 @@ diesel::table! {
         pr_url -> Nullable<Varchar>,
         #[max_length = 16]
         agent_type -> Varchar,
+        #[max_length = 512]
+        repo_url -> Nullable<Varchar>,
     }
 }
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -16,7 +16,7 @@ use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use output_forwarder::{get_git_branch, get_pr_url, spawn_output_forwarder};
+use output_forwarder::{get_git_branch, get_pr_url, get_repo_url, spawn_output_forwarder};
 use wiggum::{handle_session_event_with_wiggum, WiggumState};
 use ws_reader::{spawn_ws_reader, FileReceiveState, FileUploadEvent};
 
@@ -353,18 +353,21 @@ async fn run_single_connection(session: &mut SessionState<'_>) -> ConnectionResu
         Err(duration) => return ConnectionResult::Disconnected(duration),
     };
 
-    // Look up PR URL for the current branch and send as SessionUpdate
-    if let Some(ref branch) = config_with_branch.git_branch {
-        let pr_url = get_pr_url(&session.config.working_directory, branch);
-        if pr_url.is_some() {
-            let update_msg = ProxyToServer::SessionUpdate {
-                session_id: config_with_branch.session_id,
-                git_branch: config_with_branch.git_branch.clone(),
-                pr_url,
-            };
-            if conn.send(update_msg).await.is_err() {
-                error!("Failed to send initial PR URL update");
-            }
+    // Look up PR URL and repo URL for the current branch and send as SessionUpdate
+    let repo_url = get_repo_url(&session.config.working_directory);
+    let pr_url = config_with_branch
+        .git_branch
+        .as_deref()
+        .and_then(|b| get_pr_url(&session.config.working_directory, b));
+    if pr_url.is_some() || repo_url.is_some() {
+        let update_msg = ProxyToServer::SessionUpdate {
+            session_id: config_with_branch.session_id,
+            git_branch: config_with_branch.git_branch.clone(),
+            pr_url,
+            repo_url,
+        };
+        if conn.send(update_msg).await.is_err() {
+            error!("Failed to send initial session update");
         }
     }
 
@@ -508,6 +511,7 @@ async fn register_session(
         hostname: Some(hostname),
         launcher_id: config.launcher_id,
         agent_type: config.agent_type,
+        repo_url: get_repo_url(&config.working_directory),
     });
 
     if conn.send(register_msg).await.is_err() {
@@ -603,9 +607,10 @@ async fn run_message_loop(
     // Channel to signal WebSocket disconnection
     let (disconnect_tx, disconnect_rx) = tokio::sync::oneshot::channel::<()>();
 
-    // Shared state for tracking git branch and PR URL updates
+    // Shared state for tracking git branch, PR URL, and repo URL updates
     let current_branch = Arc::new(Mutex::new(config.git_branch.clone()));
     let current_pr_url = Arc::new(Mutex::new(None::<String>));
+    let current_repo_url = Arc::new(Mutex::new(None::<String>));
 
     // Spawn output forwarder task with buffer
     let output_task = spawn_output_forwarder(
@@ -615,6 +620,7 @@ async fn run_message_loop(
         config.working_directory.clone(),
         current_branch,
         current_pr_url,
+        current_repo_url,
         session.output_buffer.clone(),
         max_image_mb,
     );

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -28,6 +28,7 @@ pub fn spawn_output_forwarder(
     working_directory: String,
     current_branch: Arc<Mutex<Option<String>>>,
     current_pr_url: Arc<Mutex<Option<String>>>,
+    current_repo_url: Arc<Mutex<Option<String>>>,
     output_buffer: Arc<Mutex<PendingOutputBuffer>>,
     max_image_mb: Option<u32>,
 ) -> tokio::task::JoinHandle<()> {
@@ -55,6 +56,7 @@ pub fn spawn_output_forwarder(
                     &working_directory,
                     &current_branch,
                     &current_pr_url,
+                    &current_repo_url,
                 )
                 .await;
             }
@@ -146,6 +148,22 @@ pub(super) fn get_git_branch(cwd: &str) -> Option<String> {
     }
 }
 
+/// Look up the GitHub repository URL using the `gh` CLI
+pub(super) fn get_repo_url(cwd: &str) -> Option<String> {
+    let output = std::process::Command::new("gh")
+        .args(["repo", "view", "--json", "url", "-q", ".url"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 /// Look up the GitHub PR URL for a branch using the `gh` CLI
 pub(super) fn get_pr_url(cwd: &str, branch: &str) -> Option<String> {
     if branch == "main" || branch == "master" || branch.starts_with("detached:") {
@@ -204,19 +222,23 @@ async fn check_and_send_branch_update(
     working_directory: &str,
     current_branch: &Arc<Mutex<Option<String>>>,
     current_pr_url: &Arc<Mutex<Option<String>>>,
+    current_repo_url: &Arc<Mutex<Option<String>>>,
 ) {
     let new_branch = get_git_branch(working_directory);
     let new_pr_url = new_branch
         .as_deref()
         .and_then(|b| get_pr_url(working_directory, b));
+    let new_repo_url = get_repo_url(working_directory);
 
     let mut branch_guard = current_branch.lock().await;
     let mut pr_guard = current_pr_url.lock().await;
+    let mut repo_guard = current_repo_url.lock().await;
 
     let branch_changed = *branch_guard != new_branch;
     let pr_changed = *pr_guard != new_pr_url;
+    let repo_changed = *repo_guard != new_repo_url;
 
-    if branch_changed || pr_changed {
+    if branch_changed || pr_changed || repo_changed {
         if branch_changed {
             debug!(
                 "Git branch changed: {:?} -> {:?}",
@@ -228,15 +250,18 @@ async fn check_and_send_branch_update(
         }
         *branch_guard = new_branch.clone();
         *pr_guard = new_pr_url.clone();
+        *repo_guard = new_repo_url.clone();
 
         // Drop locks before acquiring ws lock
         drop(branch_guard);
         drop(pr_guard);
+        drop(repo_guard);
 
         let update_msg = ProxyToServer::SessionUpdate {
             session_id,
             git_branch: new_branch,
             pr_url: new_pr_url,
+            repo_url: new_repo_url,
         };
 
         let mut ws = ws_write.lock().await;

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -497,11 +497,17 @@ pub fn dashboard_page() -> Html {
         let set_sessions = sessions_hook.set_sessions.clone();
         let sessions = sessions.clone();
         Callback::from(
-            move |(session_id, branch, pr_url): (Uuid, Option<String>, Option<String>)| {
+            move |(session_id, branch, pr_url, repo_url): (
+                Uuid,
+                Option<String>,
+                Option<String>,
+                Option<String>,
+            )| {
                 let mut updated = sessions.clone();
                 if let Some(session) = updated.iter_mut().find(|s| s.id == session_id) {
                     session.git_branch = branch;
                     session.pr_url = pr_url;
+                    session.repo_url = repo_url;
                 }
                 set_sessions.emit(updated);
             },

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -382,7 +382,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             html! {}
         };
 
-        let pr_option = if let Some(ref url) = session.pr_url {
+        let repo_option = if let Some(ref url) = session.pr_url {
             let pr_number = url.rsplit('/').next().unwrap_or("").to_string();
             let label = if pr_number.is_empty() {
                 "Open PR".to_string()
@@ -397,8 +397,21 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     <span class="option-hint">{ "GitHub" }</span>
                 </a>
             }
+        } else if let Some(ref url) = session.repo_url {
+            let href = url.clone();
+            html! {
+                <a class="pill-menu-option pr-link" href={href} target="_blank"
+                   onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                    { "Open Repository" }
+                    <span class="option-hint">{ "GitHub" }</span>
+                </a>
+            }
         } else {
-            html! {}
+            html! {
+                <span class="pill-menu-option disabled">
+                    { "No Repository Detected" }
+                </span>
+            }
         };
 
         let share_option = if session.my_role == "owner" {
@@ -430,7 +443,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     <span class="option-hint">{ short_id }</span>
                 </button>
                 { share_option }
-                { pr_option }
+                { repo_option }
                 <button
                     type="button"
                     class={classes!("pill-menu-option", "pause", is_paused.then_some("active"))}

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -54,7 +54,8 @@ pub struct SessionViewProps {
     pub on_cost_change: Callback<(Uuid, f64)>,
     pub on_connected_change: Callback<(Uuid, bool)>,
     pub on_message_sent: Callback<Uuid>,
-    pub on_branch_change: Callback<(Uuid, Option<String>, Option<String>)>,
+    #[allow(clippy::type_complexity)]
+    pub on_branch_change: Callback<(Uuid, Option<String>, Option<String>, Option<String>)>,
     #[prop_or_default]
     pub on_activity: Callback<(Uuid, String, f64)>,
     #[prop_or(false)]
@@ -80,7 +81,7 @@ pub enum SessionViewMsg {
     DenyPermission,
     PermissionSelectUp,
     PermissionSelectDown,
-    BranchChanged(Option<String>, Option<String>),
+    BranchChanged(Option<String>, Option<String>, Option<String>),
     PermissionConfirm,
     PermissionSelectAndConfirm(usize),
     HistoryUp,
@@ -526,11 +527,11 @@ impl Component for SessionView {
                     .emit((session_id, is_awaiting));
                 false
             }
-            SessionViewMsg::BranchChanged(branch, pr_url) => {
+            SessionViewMsg::BranchChanged(branch, pr_url, repo_url) => {
                 let session_id = ctx.props().session.id;
                 ctx.props()
                     .on_branch_change
-                    .emit((session_id, branch, pr_url));
+                    .emit((session_id, branch, pr_url, repo_url));
                 false
             }
             SessionViewMsg::HistoryUp => {
@@ -989,9 +990,9 @@ impl SessionView {
                     .send_message(SessionViewMsg::PermissionRequest(perm));
                 false
             }
-            WsEvent::BranchChanged(branch, pr_url) => {
+            WsEvent::BranchChanged(branch, pr_url, repo_url) => {
                 ctx.link()
-                    .send_message(SessionViewMsg::BranchChanged(branch, pr_url));
+                    .send_message(SessionViewMsg::BranchChanged(branch, pr_url, repo_url));
                 false
             }
         }

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -18,7 +18,7 @@ pub enum WsEvent {
     Output(String),
     HistoryBatch(Vec<String>),
     Permission(PendingPermission),
-    BranchChanged(Option<String>, Option<String>),
+    BranchChanged(Option<String>, Option<String>, Option<String>),
 }
 
 /// Connect to WebSocket and start receiving messages.
@@ -48,6 +48,7 @@ pub fn connect_websocket(
                     hostname: None,
                     launcher_id: None,
                     agent_type: Default::default(),
+                    repo_url: None,
                 });
 
                 if sender.send(register_msg).await.is_err() {
@@ -132,8 +133,9 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
             session_id: _,
             git_branch,
             pr_url,
+            repo_url,
         } => {
-            on_event.emit(WsEvent::BranchChanged(git_branch, pr_url));
+            on_event.emit(WsEvent::BranchChanged(git_branch, pr_url, repo_url));
         }
         _ => {}
     }

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -400,6 +400,15 @@ a.pill-menu-option.pr-link:hover {
     background: rgba(122, 162, 247, 0.15);
 }
 
+.pill-menu-option.disabled {
+    color: var(--text-muted);
+    cursor: default;
+}
+
+.pill-menu-option.disabled:hover {
+    background: transparent;
+}
+
 .pill-menu-option .option-hint {
     font-size: 0.7rem;
     font-weight: 400;

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -98,6 +98,7 @@ pub async fn register_with_backend(
         hostname: Some(hostname),
         launcher_id: config.launcher_id,
         agent_type: config.agent_type,
+        repo_url: get_repo_url(&config.working_directory),
     });
 
     if let Err(e) = conn.send(&register_msg).await {
@@ -181,6 +182,22 @@ pub fn get_git_branch(cwd: &str) -> Option<String> {
     } else {
         Some(branch)
     }
+}
+
+/// Get the GitHub repository URL using the `gh` CLI.
+pub fn get_repo_url(cwd: &str) -> Option<String> {
+    let output = std::process::Command::new("gh")
+        .args(["repo", "view", "--json", "url", "-q", ".url"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// Events produced by the WebSocket reader for the shim's select loop.

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -33,6 +33,8 @@ pub struct RegisterFields {
     pub launcher_id: Option<Uuid>,
     #[serde(default)]
     pub agent_type: AgentType,
+    #[serde(default)]
+    pub repo_url: Option<String>,
 }
 
 /// Fields for a permission response (shared by server-to-proxy and client-to-server).
@@ -114,6 +116,8 @@ pub enum ProxyToServer {
         git_branch: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none", default)]
         pr_url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        repo_url: Option<String>,
     },
 
     /// Acknowledge receipt of input messages
@@ -249,6 +253,8 @@ pub enum ServerToClient {
         git_branch: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none", default)]
         pr_url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        repo_url: Option<String>,
     },
 
     /// User spend data update
@@ -446,6 +452,7 @@ mod tests {
             hostname: None,
             launcher_id: None,
             agent_type: AgentType::Claude,
+            repo_url: None,
         });
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"Register""#));

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -202,6 +202,9 @@ pub struct SessionInfo {
     /// GitHub PR URL for the current branch
     #[serde(default)]
     pub pr_url: Option<String>,
+    /// GitHub repository URL
+    #[serde(default)]
+    pub repo_url: Option<String>,
     /// Which agent CLI backs this session (claude or codex)
     #[serde(default)]
     pub agent_type: AgentType,


### PR DESCRIPTION
## Summary
- Adds `repo_url` field throughout the stack (shared types, DB migration, backend handlers, proxy detection, frontend)
- Pill menu now shows three states: "Open PR #XXX" when a PR exists, "Open Repository" when only a repo is detected, or "No Repository Detected" when there's no git repo
- Proxy detects repo URL via `gh repo view --json url` alongside existing branch/PR detection

## Test plan
- [ ] Verify pill menu shows "Open PR #XXX" for sessions with an active PR
- [ ] Verify pill menu shows "Open Repository" for sessions in a git repo without a PR
- [ ] Verify pill menu shows "No Repository Detected" for sessions not in a git repo
- [ ] Run database migration successfully