### PR TITLE
Fix oneshot drop race in session reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.47
+
+- Fix oneshot drop race causing launcher sessions to not reconnect on server restart
+
 ## 1.3.46
 
 - Show proxy version badge in session pill, color-coded by staleness

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.46"
+version = "1.3.47"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -669,6 +669,12 @@ async fn run_message_loop(
     result
 }
 
+/// Receive from a oneshot, returning `Some(T)` on success or `None` if the sender was dropped.
+/// This prevents `tokio::select!` from treating a dropped sender as a valid signal.
+async fn recv_option(rx: &mut tokio::sync::oneshot::Receiver<()>) -> Option<()> {
+    rx.await.ok()
+}
+
 /// Run the main select loop
 ///
 /// The Claude session internally uses a dedicated drain task to continuously
@@ -698,7 +704,7 @@ async fn run_main_loop(
                 let _ = ws.send(ProxyToServer::Heartbeat).await;
             }
 
-            _ = &mut state.session_terminated_rx => {
+            Some(()) = recv_option(&mut state.session_terminated_rx) => {
                 info!("Session terminated by server");
                 return ConnectionResult::SessionTerminated;
             }


### PR DESCRIPTION
## Summary
- Fix `tokio::select!` race where a dropped oneshot sender caused launcher sessions to permanently exit instead of reconnecting on server restart
- When the ws_reader ends after receiving `ServerShutdown`, it drops `session_terminated_tx` — the oneshot receiver resolved with `Err` which `select!` treated as a valid "session terminated" signal
- Wrap the oneshot in `recv_option()` so only an explicit `Ok(())` send triggers the termination path

## Test plan
- [x] `cargo test --workspace` passes (120 tests)
- [x] `cargo clippy --workspace` clean
- [ ] Deploy and verify launcher sessions survive a server restart