### PR TITLE
Fix session reconnect race with connection generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.48
+
+- Fix session reconnect race: old connection cleanup no longer overwrites newer connection's registration
+
 ## 1.3.47
 
 - Fix oneshot drop race causing launcher sessions to not reconnect on server restart

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "1.3.46"
+version = "1.3.47"
 dependencies = [
  "anyhow",
  "chrono",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.46"
+version = "1.3.47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.46"
+version = "1.3.47"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.46"
+version = "1.3.47"
 dependencies = [
  "anyhow",
  "clap",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.46"
+version = "1.3.47"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.46"
+version = "1.3.47"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.47"
+version = "1.3.48"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -597,7 +597,9 @@ pub async fn delete_session(
 
     // Remove from session manager (disconnect if connected)
     let session_key = session_id.to_string();
-    app_state.session_manager.unregister_session(&session_key);
+    app_state
+        .session_manager
+        .unregister_session(&session_key, None);
 
     // Delete session and all associated data, recording costs
     super::helpers::delete_session_with_data(&mut conn, &session, true)

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -20,6 +20,7 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
 
     let mut session_key: Option<SessionId> = None;
     let mut db_session_id: Option<Uuid> = None;
+    let mut connection_gen: Option<u64> = None;
 
     let send_task = tokio::spawn(async move {
         while let Some(msg) = rx.recv().await {
@@ -40,6 +41,7 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
                     &tx,
                     &mut session_key,
                     &mut db_session_id,
+                    &mut connection_gen,
                 );
             }
             Err(e) => {
@@ -49,26 +51,36 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
         }
     }
 
-    // Cleanup - mark session as disconnected in DB
-    if let Some(session_id) = db_session_id {
-        match db_pool.get() {
-            Ok(mut conn) => {
-                use crate::schema::sessions;
-                let _ = diesel::update(sessions::table.find(session_id))
-                    .set(sessions::status.eq("disconnected"))
-                    .execute(&mut conn);
-            }
-            Err(e) => {
-                error!(
-                    "Failed to get database connection for session disconnect cleanup: {}",
-                    e
-                );
+    // Cleanup — only if no newer connection has taken over this session.
+    // A reconnecting proxy may have already registered a new connection,
+    // in which case our generation will be stale and we must skip cleanup
+    // to avoid overwriting the new connection's state.
+    let is_stale = session_key
+        .as_ref()
+        .zip(connection_gen)
+        .is_some_and(|(key, gen)| !session_manager.is_current_connection(key, gen));
+
+    if !is_stale {
+        if let Some(session_id) = db_session_id {
+            match db_pool.get() {
+                Ok(mut conn) => {
+                    use crate::schema::sessions;
+                    let _ = diesel::update(sessions::table.find(session_id))
+                        .set(sessions::status.eq("disconnected"))
+                        .execute(&mut conn);
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to get database connection for session disconnect cleanup: {}",
+                        e
+                    );
+                }
             }
         }
-    }
 
-    if let Some(key) = session_key {
-        session_manager.unregister_session(&key);
+        if let Some(key) = session_key {
+            session_manager.unregister_session(&key, connection_gen);
+        }
     }
 
     send_task.abort();
@@ -83,6 +95,7 @@ fn handle_proxy_message(
     tx: &ProxySender,
     session_key: &mut Option<SessionId>,
     db_session_id: &mut Option<Uuid>,
+    connection_gen: &mut Option<u64>,
 ) {
     match proxy_msg {
         ProxyToServer::Register(shared::RegisterFields {
@@ -103,7 +116,8 @@ fn handle_proxy_message(
             let key = claude_session_id.to_string();
             *session_key = Some(key.clone());
 
-            session_manager.register_session(key.clone(), tx.clone());
+            let gen = session_manager.register_session(key.clone(), tx.clone());
+            *connection_gen = Some(gen);
 
             let params = RegistrationParams {
                 claude_session_id,

--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -1,6 +1,7 @@
 use dashmap::{DashMap, DashSet};
 use shared::{LauncherToServer, ServerToClient, ServerToLauncher, ServerToProxy};
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
@@ -46,6 +47,10 @@ pub struct SessionManager {
     pub pending_dir_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
     /// Tracks who sent the last input for each session (session_id → (user_id, display_name))
     pub last_input_sender: Arc<DashMap<Uuid, (Uuid, String)>>,
+    /// Monotonic counter for connection generations (prevents stale cleanup)
+    gen_counter: Arc<AtomicU64>,
+    /// Current connection generation per session
+    connection_gen: Arc<DashMap<SessionId, u64>>,
 }
 
 impl Default for SessionManager {
@@ -60,6 +65,8 @@ impl Default for SessionManager {
             launchers: Arc::new(DashMap::new()),
             pending_dir_requests: Arc::new(DashMap::new()),
             last_input_sender: Arc::new(DashMap::new()),
+            gen_counter: Arc::new(AtomicU64::new(1)),
+            connection_gen: Arc::new(DashMap::new()),
         }
     }
 }
@@ -69,8 +76,12 @@ impl SessionManager {
         Self::default()
     }
 
-    pub fn register_session(&self, session_key: SessionId, sender: ProxySender) {
-        info!("Registering session: {}", session_key);
+    /// Register a proxy connection for a session. Returns a generation number
+    /// that must be passed to `unregister_session` to prevent stale cleanup
+    /// from removing a newer connection.
+    pub fn register_session(&self, session_key: SessionId, sender: ProxySender) -> u64 {
+        let gen = self.gen_counter.fetch_add(1, Ordering::Relaxed);
+        info!("Registering session: {} (gen={})", session_key, gen);
 
         let pending_count = self.replay_pending_messages(&session_key, &sender);
         if pending_count > 0 {
@@ -80,7 +91,9 @@ impl SessionManager {
             );
         }
 
+        self.connection_gen.insert(session_key.clone(), gen);
         self.sessions.insert(session_key, sender);
+        gen
     }
 
     fn replay_pending_messages(&self, session_key: &SessionId, sender: &ProxySender) -> usize {
@@ -109,9 +122,34 @@ impl SessionManager {
         replayed
     }
 
-    pub fn unregister_session(&self, session_key: &SessionId) {
+    /// Unregister a proxy connection. If `gen` is provided, only removes the
+    /// entry when it matches the current generation — preventing a stale
+    /// connection's cleanup from removing a newer connection's registration.
+    /// Pass `None` to force removal (e.g. admin delete).
+    pub fn unregister_session(&self, session_key: &SessionId, gen: Option<u64>) {
+        if let Some(expected) = gen {
+            if let Some(current) = self.connection_gen.get(session_key) {
+                if *current != expected {
+                    info!(
+                        "Skipping stale unregister for session {} (gen {} != current {})",
+                        session_key, expected, *current
+                    );
+                    return;
+                }
+            }
+        }
         info!("Unregistering session: {}", session_key);
+        self.connection_gen.remove(session_key);
         self.sessions.remove(session_key);
+    }
+
+    /// Check whether the given generation is still the current connection for
+    /// this session. Used by cleanup code to avoid overwriting a newer
+    /// connection's DB status.
+    pub fn is_current_connection(&self, session_key: &SessionId, gen: u64) -> bool {
+        self.connection_gen
+            .get(session_key)
+            .is_none_or(|current| *current == gen)
     }
 
     pub fn add_web_client(&self, session_key: SessionId, sender: WebClientSender) {
@@ -405,11 +443,58 @@ mod tests {
         let mgr = SessionManager::new();
         let (tx, _rx) = mpsc::unbounded_channel();
 
+        let gen = mgr.register_session("s1".into(), tx);
+        assert!(mgr.sessions.contains_key("s1"));
+
+        mgr.unregister_session(&"s1".into(), Some(gen));
+        assert!(!mgr.sessions.contains_key("s1"));
+    }
+
+    #[test]
+    fn unregister_force_removes_without_gen() {
+        let mgr = SessionManager::new();
+        let (tx, _rx) = mpsc::unbounded_channel();
+
         mgr.register_session("s1".into(), tx);
         assert!(mgr.sessions.contains_key("s1"));
 
-        mgr.unregister_session(&"s1".into());
+        mgr.unregister_session(&"s1".into(), None);
         assert!(!mgr.sessions.contains_key("s1"));
+    }
+
+    #[test]
+    fn stale_unregister_is_noop() {
+        let mgr = SessionManager::new();
+        let (tx1, _rx1) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
+
+        // Old connection registers
+        let old_gen = mgr.register_session("s1".into(), tx1);
+
+        // New connection registers (simulates reconnect)
+        let _new_gen = mgr.register_session("s1".into(), tx2);
+
+        // Old connection's cleanup tries to unregister with stale gen
+        mgr.unregister_session(&"s1".into(), Some(old_gen));
+
+        // Session should still be registered with the new sender
+        assert!(mgr.sessions.contains_key("s1"));
+        assert!(mgr.send_to_session(&"s1".into(), make_heartbeat()));
+        assert!(matches!(rx2.try_recv().unwrap(), ServerToProxy::Heartbeat));
+    }
+
+    #[test]
+    fn is_current_connection_checks_gen() {
+        let mgr = SessionManager::new();
+        let (tx1, _rx1) = mpsc::unbounded_channel();
+
+        let gen1 = mgr.register_session("s1".into(), tx1);
+        assert!(mgr.is_current_connection(&"s1".into(), gen1));
+
+        let (tx2, _rx2) = mpsc::unbounded_channel();
+        let gen2 = mgr.register_session("s1".into(), tx2);
+        assert!(!mgr.is_current_connection(&"s1".into(), gen1));
+        assert!(mgr.is_current_connection(&"s1".into(), gen2));
     }
 
     #[test]
@@ -546,8 +631,8 @@ mod tests {
         let mgr = SessionManager::new();
         let (tx, _rx) = mpsc::unbounded_channel();
 
-        mgr.register_session("s1".into(), tx);
-        mgr.unregister_session(&"s1".into());
+        let gen = mgr.register_session("s1".into(), tx);
+        mgr.unregister_session(&"s1".into(), Some(gen));
 
         mgr.send_to_session(&"s1".into(), make_output(1));
         mgr.send_to_session(&"s1".into(), make_output(2));


### PR DESCRIPTION
## Summary

- Adds a monotonic generation counter to `SessionManager` so stale connection cleanup can't overwrite a newer connection's registration
- On server restart, old proxy handlers' cleanup no longer marks reconnected sessions as "disconnected" or removes their sender from the session manager
- Gates both DB status update and `SessionManager` unregister behind a generation check

## Test plan

- [x] New unit tests: `stale_unregister_is_noop`, `is_current_connection_checks_gen`, `unregister_force_removes_without_gen`
- [x] Existing tests updated and passing
- [ ] Deploy and verify sessions stay active after server restart with multiple proxies connected