### PR TITLE
Add Linux aarch64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,29 @@ jobs:
           name: proxy-linux-x86_64
           path: target/release/claude-portal
 
+  build-proxy-linux-aarch64:
+    name: Build Proxy (Linux aarch64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.92.0
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "proxy-linux-aarch64"
+
+      - name: Build proxy
+        run: cargo build -p claude-portal --release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: proxy-linux-aarch64
+          path: target/release/claude-portal
+
   build-proxy-macos-arm64:
     name: Build Proxy (macOS ARM64)
     runs-on: macos-14
@@ -231,6 +254,29 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: launcher-linux-x86_64
+          path: target/release/agent-portal
+
+  build-launcher-linux-aarch64:
+    name: Build Launcher (Linux aarch64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.92.0
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "launcher-linux-aarch64"
+
+      - name: Build launcher
+        run: cargo build -p agent-portal --release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: launcher-linux-aarch64
           path: target/release/agent-portal
 
   build-launcher-macos-arm64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,43 @@ jobs:
           name: agent-portal-linux-x86_64
           path: target/release/agent-portal-linux-x86_64
 
+  build-linux-aarch64:
+    name: Build (Linux aarch64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.92.0
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-linux-aarch64"
+
+      - name: Build proxy
+        run: cargo build -p claude-portal --release
+
+      - name: Build launcher
+        run: cargo build -p agent-portal --release
+
+      - name: Rename binaries
+        run: |
+          mv target/release/claude-portal target/release/claude-portal-linux-aarch64
+          mv target/release/agent-portal target/release/agent-portal-linux-aarch64
+
+      - name: Upload proxy artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-portal-linux-aarch64
+          path: target/release/claude-portal-linux-aarch64
+
+      - name: Upload launcher artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-portal-linux-aarch64
+          path: target/release/agent-portal-linux-aarch64
+
   build-macos-arm64:
     name: Build (macOS ARM64)
     runs-on: macos-14
@@ -171,7 +208,7 @@ jobs:
 
   release:
     name: Create Release
-    needs: [build-linux, build-macos-arm64, build-macos-intel, build-windows]
+    needs: [build-linux, build-linux-aarch64, build-macos-arm64, build-macos-intel, build-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -187,15 +224,17 @@ jobs:
         run: |
           mkdir -p release
           mv binaries/claude-portal-linux-x86_64/claude-portal-linux-x86_64 release/
+          mv binaries/claude-portal-linux-aarch64/claude-portal-linux-aarch64 release/
           mv binaries/claude-portal-darwin-aarch64/claude-portal-darwin-aarch64 release/
           mv binaries/claude-portal-darwin-x86_64/claude-portal-darwin-x86_64 release/
           mv binaries/claude-portal-windows-x86_64/claude-portal-windows-x86_64.exe release/
           mv binaries/agent-portal-linux-x86_64/agent-portal-linux-x86_64 release/
+          mv binaries/agent-portal-linux-aarch64/agent-portal-linux-aarch64 release/
           mv binaries/agent-portal-darwin-aarch64/agent-portal-darwin-aarch64 release/
           mv binaries/agent-portal-darwin-x86_64/agent-portal-darwin-x86_64 release/
           mv binaries/agent-portal-windows-x86_64/agent-portal-windows-x86_64.exe release/
-          chmod +x release/claude-portal-linux-x86_64 release/claude-portal-darwin-*
-          chmod +x release/agent-portal-linux-x86_64 release/agent-portal-darwin-*
+          chmod +x release/claude-portal-linux-* release/claude-portal-darwin-*
+          chmod +x release/agent-portal-linux-* release/agent-portal-darwin-*
           ls -la release/
 
       - name: Delete existing latest release
@@ -221,6 +260,7 @@ jobs:
             | Platform | Binary |
             |----------|--------|
             | Linux (x86_64) | `claude-portal-linux-x86_64` |
+            | Linux (aarch64) | `claude-portal-linux-aarch64` |
             | macOS (Apple Silicon M1+) | `claude-portal-darwin-aarch64` |
             | macOS (Intel) | `claude-portal-darwin-x86_64` |
             | Windows (x86_64) | `claude-portal-windows-x86_64.exe` |
@@ -229,15 +269,18 @@ jobs:
             | Platform | Binary |
             |----------|--------|
             | Linux (x86_64) | `agent-portal-linux-x86_64` |
+            | Linux (aarch64) | `agent-portal-linux-aarch64` |
             | macOS (Apple Silicon M1+) | `agent-portal-darwin-aarch64` |
             | macOS (Intel) | `agent-portal-darwin-x86_64` |
             | Windows (x86_64) | `agent-portal-windows-x86_64.exe` |
           files: |
             release/claude-portal-linux-x86_64
+            release/claude-portal-linux-aarch64
             release/claude-portal-darwin-aarch64
             release/claude-portal-darwin-x86_64
             release/claude-portal-windows-x86_64.exe
             release/agent-portal-linux-x86_64
+            release/agent-portal-linux-aarch64
             release/agent-portal-darwin-aarch64
             release/agent-portal-darwin-x86_64
             release/agent-portal-windows-x86_64.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.49
+
+- Add Linux aarch64 support (CI builds, auto-update, install script)
+
 ## 1.3.48
 
 - Fix session reconnect race: old connection cleanup no longer overwrites newer connection's registration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.48"
+version = "1.3.49"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The **portal** refers to the complete system: backend server, web frontend, and 
 | Platform | Status |
 |----------|--------|
 | Linux (x86_64) | Tested |
+| Linux (aarch64) | Builds in CI |
 | macOS (Apple Silicon) | Builds in CI |
 | macOS (Intel) | Builds in CI |
 | Windows (x86_64) | Builds in CI |

--- a/backend/src/handlers/downloads.rs
+++ b/backend/src/handlers/downloads.rs
@@ -69,9 +69,12 @@ else
                 x86_64|amd64)
                     BINARY_NAME="agent-portal-linux-x86_64"
                     ;;
+                aarch64|arm64)
+                    BINARY_NAME="agent-portal-linux-aarch64"
+                    ;;
                 *)
                     echo "Error: Unsupported Linux architecture: ${{ARCH}}"
-                    echo "Supported: x86_64"
+                    echo "Supported: x86_64, aarch64"
                     exit 1
                     ;;
             esac

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -187,6 +187,7 @@ Admins can access the admin dashboard at `/admin` which provides:
 | Platform | Status | Notes |
 |----------|--------|-------|
 | Linux (x86_64) | Tested | Primary development platform |
+| Linux (aarch64) | Untested | Builds in CI, PRs welcome |
 | macOS (Apple Silicon) | Untested | Builds in CI, PRs welcome |
 | macOS (Intel) | Untested | Builds in CI, PRs welcome |
 | Windows (x86_64) | Untested | Builds in CI, PRs welcome |

--- a/portal-update/src/lib.rs
+++ b/portal-update/src/lib.rs
@@ -45,6 +45,8 @@ impl Platform {
     pub fn current(binary_prefix: &str) -> Self {
         let (os, arch) = if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
             ("linux", "x86_64")
+        } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+            ("linux", "aarch64")
         } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
             ("darwin", "aarch64")
         } else if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
@@ -57,6 +59,7 @@ impl Platform {
 
         let binary_name = match (os, arch) {
             ("linux", "x86_64") => format!("{}-linux-x86_64", binary_prefix),
+            ("linux", "aarch64") => format!("{}-linux-aarch64", binary_prefix),
             ("darwin", "aarch64") => format!("{}-darwin-aarch64", binary_prefix),
             ("darwin", "x86_64") => format!("{}-darwin-x86_64", binary_prefix),
             ("windows", "x86_64") => format!("{}-windows-x86_64.exe", binary_prefix),


### PR DESCRIPTION
## Summary
- Add Linux aarch64 platform detection to portal-update auto-updater
- Add aarch64/arm64 case to install script served by backend
- Add native ARM64 CI build jobs using `ubuntu-24.04-arm` runners (proxy + launcher)
- Add native ARM64 release build job producing `*-linux-aarch64` binaries
- Update platform support tables in README and DEPLOYING docs

## Test plan
- [ ] CI aarch64 build jobs pass on GitHub's ARM runners
- [ ] Release workflow produces `claude-portal-linux-aarch64` and `agent-portal-linux-aarch64` artifacts
- [ ] Install script correctly detects `aarch64` on Linux ARM machines