### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+- Version bump to 2.0.1
+
 ## 1.3.49
 
 - Add Linux aarch64 support (CI builds, auto-update, install script)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "1.3.47"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "1.3.47"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "1.3.47"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "1.3.47"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "1.3.47"
+version = "2.0.1"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.3.47"
+version = "2.0.1"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "1.3.49"
+version = "2.0.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/portal-auth/Cargo.toml
+++ b/portal-auth/Cargo.toml
@@ -11,6 +11,6 @@ hostname = "0.4"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-shared = { version = "1.1.2", path = "../shared" }
+shared = { path = "../shared" }
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"


### PR DESCRIPTION
## Summary
- Bump workspace version from 1.3.49 to 2.0.1
- Remove pinned version constraint on `shared` in portal-auth (path dependency doesn't need it)

## Test plan
- [ ] CI passes