### PR TITLE
Bake user PATH into service unit files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.3
+
+- Bake user's PATH into systemd/launchd service so spawned agents can find `claude`
+
 ## 2.0.2
 
 - Fix install script: `agent-portal install` → `agent-portal service install`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/launcher/src/service.rs
+++ b/launcher/src/service.rs
@@ -16,6 +16,7 @@ fn service_file_path() -> Result<std::path::PathBuf> {
 
 #[cfg(target_os = "linux")]
 fn generate_unit(binary_path: &str) -> String {
+    let path = std::env::var("PATH").unwrap_or_default();
     format!(
         r#"[Unit]
 Description=Agent Launcher
@@ -24,6 +25,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+Environment=PATH={path}
 ExecStart={binary_path} --no-update
 Restart=on-failure
 RestartSec=5
@@ -174,6 +176,7 @@ fn log_dir() -> String {
 #[cfg(target_os = "macos")]
 fn generate_plist(binary_path: &str) -> String {
     let log_dir = log_dir();
+    let path = std::env::var("PATH").unwrap_or_default();
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -186,6 +189,11 @@ fn generate_plist(binary_path: &str) -> String {
         <string>{binary_path}</string>
         <string>--no-update</string>
     </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{path}</string>
+    </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>


### PR DESCRIPTION
## Summary
- Capture the user's `PATH` at `agent-portal service install` time and embed it in the systemd unit / launchd plist
- Fixes: systemd's minimal PATH doesn't include `~/.local/bin` where `claude` is typically installed, causing `No such file or directory` when launching sessions

## Test plan
- [ ] CI passes
- [ ] On Linux aarch64: `agent-portal service uninstall && agent-portal service install`, verify unit file contains PATH with `~/.local/bin`
- [ ] Launch a session and confirm `claude` is found