### PR TITLE
Fix multiline input flattened in message rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.4
+
+- Fix multiline user input getting flattened when rendered in message history
+
 ## 2.0.3
 
 - Bake user's PATH into systemd/launchd service so spawned agents can find `claude`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.3"
+version = "2.0.4"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -10,6 +10,12 @@ use shared::ToolResultContent;
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
+/// Convert single newlines to markdown hard breaks (trailing two spaces)
+/// so that user-typed line breaks are preserved when rendered as markdown.
+fn preserve_user_newlines(text: &str) -> String {
+    text.replace('\n', "  \n")
+}
+
 // --- Message renderers ---
 
 pub fn render_assistant_group(messages: &[String]) -> Html {
@@ -107,7 +113,7 @@ pub fn render_user_message(msg: &UserMessage, current_user_id: Option<&str>) -> 
                     <span class="message-type-badge user">{ &label }</span>
                 </div>
                 <div class="message-body">
-                    <div class="user-text">{ render_markdown(text) }</div>
+                    <div class="user-text">{ render_markdown(&preserve_user_newlines(text)) }</div>
                 </div>
             </div>
         }
@@ -142,7 +148,7 @@ pub fn render_user_message(msg: &UserMessage, current_user_id: Option<&str>) -> 
                         <span class="message-type-badge user">{ &label }</span>
                     </div>
                     <div class="message-body">
-                        <div class="user-text">{ render_markdown(&text_content) }</div>
+                        <div class="user-text">{ render_markdown(&preserve_user_newlines(&text_content)) }</div>
                     </div>
                 </div>
             }


### PR DESCRIPTION
## Summary
- Single newlines in user input were being collapsed to spaces by the markdown renderer (pulldown-cmark `SoftBreak` → space)
- Added `preserve_user_newlines()` that converts `\n` to `  \n` (markdown hard breaks) before rendering user messages
- Applied to both user message rendering paths in `renderers.rs`

Closes #544

## Test plan
- [ ] Paste multiline text into a session and verify line breaks are preserved in message history
- [ ] Verify markdown features (lists, code blocks, links) still render correctly in user messages