### PR TITLE
Fix crates reporting 0.1.0 instead of workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "0.1.0"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3023,7 +3023,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "0.1.0"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "colored",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "0.1.0"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "hex",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.4"
+version = "2.0.5"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "claude-session-lib"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Library for managing Claude Code sessions"
 license = "MIT"
 

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -39,8 +39,8 @@ hostname = "0.4"
 chrono = { workspace = true, features = ["std", "clock"] }
 toml = "1.0.1"
 dirs = "6.0.0"
-portal-auth = { version = "0.1.0", path = "../portal-auth" }
-claude-session-lib = { version = "0.1.0", path = "../claude-session-lib" }
+portal-auth = { path = "../portal-auth" }
+claude-session-lib = { path = "../claude-session-lib" }
 ws-bridge = { workspace = true, features = ["native-client"] }
 portal-update = { path = "../portal-update" }
 tokio-util.workspace = true

--- a/portal-auth/Cargo.toml
+++ b/portal-auth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "portal-auth"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Device flow authentication for Claude Portal"
 
 [dependencies]

--- a/portal-update/Cargo.toml
+++ b/portal-update/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "portal-update"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Self-update functionality for Claude Portal binaries"
 
 [dependencies]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -64,7 +64,7 @@ chrono = { workspace = true, features = ["std", "clock"] }
 
 # Self-update
 portal-update = { path = "../portal-update" }
-claude-session-lib = { version = "0.1.0", path = "../claude-session-lib" }
+claude-session-lib = { path = "../claude-session-lib" }
 portal-auth = { path = "../portal-auth" }
 base64 = "0.22"
 


### PR DESCRIPTION
## Summary
- `claude-session-lib`, `portal-auth`, and `portal-update` had hardcoded `version = "0.1.0"` instead of `version.workspace = true`, causing the frontend to display `v0.1.0` for launcher-spawned sessions
- Root cause: `claude-session-lib` uses `env!("CARGO_PKG_VERSION")` to set `client_version` during session registration, which resolved to the crate's own `0.1.0` instead of the workspace `2.0.x`
- Also cleans up stale `version = "0.1.0"` pins on path dependencies in launcher and proxy Cargo.toml

## Test plan
- [ ] Build `agent-portal` and verify version is `2.0.5`
- [ ] Launch a session via `agent-portal` and confirm the frontend shows correct version instead of `v0.1.0`
- [ ] Verify `cargo check -p claude-portal` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)