### PR TITLE
Fix session stop unreliability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.6"
+version = "2.0.7"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -197,12 +197,14 @@ pub async fn stop_session(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    let stopped = app_state
+    // Try both paths — launcher-managed and direct proxy connection.
+    // Don't short-circuit: the launcher may claim the session but fail to deliver.
+    let via_launcher = app_state
         .session_manager
-        .stop_session_on_launcher(session_id)
-        || app_state.session_manager.disconnect_session(session_id);
+        .stop_session_on_launcher(session_id);
+    let via_proxy = app_state.session_manager.disconnect_session(session_id);
 
-    if stopped {
+    if via_launcher || via_proxy {
         Ok(StatusCode::ACCEPTED)
     } else {
         Err(StatusCode::NOT_FOUND)

--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -335,10 +335,11 @@ impl SessionManager {
     pub fn disconnect_session(&self, session_id: Uuid) -> bool {
         let key = session_id.to_string();
         if let Some(sender) = self.sessions.get(&key) {
-            let _ = sender.send(ServerToProxy::SessionTerminated {
-                reason: "Session stopped by user".to_string(),
-            });
-            true
+            sender
+                .send(ServerToProxy::SessionTerminated {
+                    reason: "Session stopped by user".to_string(),
+                })
+                .is_ok()
         } else {
             false
         }


### PR DESCRIPTION
## Summary
- Fix `disconnect_session()` silently ignoring send errors (`let _ =`) while returning `true` — now properly returns `send().is_ok()`
- Fix `stop_session` using short-circuit `||` which skipped the direct proxy disconnect when the launcher path claimed success — now tries both paths

These two bugs explain why stopping a session from the frontend took multiple clicks.

## Test plan
- [ ] Stop a launcher-managed session — should stop on first click
- [ ] Stop a directly-connected proxy session — should stop on first click
- [ ] Stop a session where the proxy has already disconnected — should return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)