### PR TITLE
Simplify stop_session to single primary path

### DIFF
--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -197,14 +197,14 @@ pub async fn stop_session(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    // Try both paths — launcher-managed and direct proxy connection.
-    // Don't short-circuit: the launcher may claim the session but fail to deliver.
-    let via_launcher = app_state
+    // The proxy always connects directly, so disconnect_session() is the
+    // primary kill path. Also tell the launcher to clean up the process.
+    let stopped = app_state.session_manager.disconnect_session(session_id);
+    app_state
         .session_manager
         .stop_session_on_launcher(session_id);
-    let via_proxy = app_state.session_manager.disconnect_session(session_id);
 
-    if via_launcher || via_proxy {
+    if stopped {
         Ok(StatusCode::ACCEPTED)
     } else {
         Err(StatusCode::NOT_FOUND)


### PR DESCRIPTION
## Summary
- The proxy always connects directly to the backend, so `disconnect_session()` is the real kill path
- `stop_session_on_launcher()` is now fire-and-forget cleanup, not an alternative path
- Simplifies the logic from two competing paths to one primary + one supplementary

Follow-up to #549.

## Test plan
- [ ] Stop a launcher-managed session — proxy gets terminated, launcher cleans up process
- [ ] Stop a direct session — proxy gets terminated as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)