### PR TITLE
Fix message body spacing and restore comfortable padding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.7"
+version = "2.0.8"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -224,7 +224,6 @@
     background: rgba(99, 102, 241, 0.1);
     border-left: 3px solid var(--accent);
     border-radius: 0 4px 4px 0;
-    margin: 0.5rem 0;
     font-family: var(--font-mono);
     font-size: 0.85rem;
     overflow: hidden;
@@ -271,7 +270,6 @@
     background: rgba(34, 197, 94, 0.1);
     border-left: 3px solid var(--success);
     border-radius: 0 4px 4px 0;
-    margin: 0.5rem 0;
     font-family: var(--font-mono);
     font-size: 0.85rem;
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -13,14 +13,17 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.35rem 0.75rem;
+    padding: 0.4rem 0.85rem;
     background: rgba(0, 0, 0, 0.2);
     border-bottom: 1px solid var(--border);
     flex-wrap: wrap;
 }
 
 .claude-message .message-body {
-    padding: 0.7rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.85rem;
 }
 
 /* Message Type Badges */

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -570,12 +570,12 @@
 
     /* Messages even more compact */
     .session-view-messages {
-        padding: 0.35rem;
-        gap: 0.35rem;
+        padding: 0.5rem;
+        gap: 0.4rem;
     }
 
     .claude-message .message-body {
-        padding: 0.35rem;
+        padding: 0.5rem;
     }
 
     /* Tool renders ultra-compact */

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -139,9 +139,9 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.6rem;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 0.75rem 1rem;
+    padding: 0.85rem 1.25rem;
     min-width: 0; /* Allow flex child to shrink below content size */
 }


### PR DESCRIPTION
## Summary
- Add `display: flex; flex-direction: column; gap: 0.5rem` to `.message-body` for consistent spacing between content blocks
- Remove per-item `margin: 0.5rem 0` from `.tool-use` and `.tool-result` (flex gap handles it)
- Bump padding back up from over-compacted values (body: 0.7→0.85rem, header: 0.35→0.4rem, container: 0.75→0.85rem)

## Test plan
- [ ] Tool use blocks within assistant messages have visible spacing
- [ ] Text content has breathing room from adjacent tool blocks
- [ ] Mobile layout still looks reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)