### PR TITLE
Revert CSS spacing changes back to original

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.8"
+version = "2.0.9"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -224,6 +224,7 @@
     background: rgba(99, 102, 241, 0.1);
     border-left: 3px solid var(--accent);
     border-radius: 0 4px 4px 0;
+    margin: 0.5rem 0;
     font-family: var(--font-mono);
     font-size: 0.85rem;
     overflow: hidden;
@@ -270,6 +271,7 @@
     background: rgba(34, 197, 94, 0.1);
     border-left: 3px solid var(--success);
     border-radius: 0 4px 4px 0;
+    margin: 0.5rem 0;
     font-family: var(--font-mono);
     font-size: 0.85rem;
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -3,6 +3,7 @@
    ========================================================================== */
 
 .claude-message {
+    margin-bottom: 1rem;
     border-radius: 8px;
     overflow: hidden;
     background: var(--bg-darker);
@@ -12,27 +13,24 @@
 .claude-message .message-header {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.4rem 0.85rem;
+    gap: 0.75rem;
+    padding: 0.5rem 1rem;
     background: rgba(0, 0, 0, 0.2);
     border-bottom: 1px solid var(--border);
     flex-wrap: wrap;
 }
 
 .claude-message .message-body {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    padding: 0.85rem;
+    padding: 1rem;
 }
 
 /* Message Type Badges */
 .message-type-badge {
     display: inline-flex;
     align-items: center;
-    padding: 0.15rem 0.4rem;
+    padding: 0.25rem 0.6rem;
     border-radius: 4px;
-    font-size: 0.7rem;
+    font-size: 0.75rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;

--- a/frontend/styles/session-cards.css
+++ b/frontend/styles/session-cards.css
@@ -87,10 +87,11 @@
 
 /* Messages inside portal use same styles but are scaled */
 .portal-terminal-content .messages {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
     padding: 0;
+}
+
+.portal-terminal-content .claude-message {
+    margin-bottom: 0.5rem;
 }
 
 .empty-terminal {

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -253,6 +253,9 @@
     }
 
     /* ---- Messages ---- */
+    .claude-message {
+        margin-bottom: 0.75rem;
+    }
 
     .claude-message .message-header {
         padding: 0.4rem 0.75rem;
@@ -571,7 +574,6 @@
     /* Messages even more compact */
     .session-view-messages {
         padding: 0.5rem;
-        gap: 0.4rem;
     }
 
     .claude-message .message-body {

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -137,11 +137,8 @@
 
 .session-view-messages {
     flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 0.85rem 1.25rem;
+    padding: 1rem 1.5rem;
     min-width: 0; /* Allow flex child to shrink below content size */
 }

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -468,6 +468,7 @@
 
 /* Result Message - Compact stats bar */
 .result-message {
+    margin-bottom: 0.5rem;
     border: none;
     background: transparent;
 }
@@ -475,8 +476,8 @@
 .result-message .result-stats-bar {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.3rem 0.5rem;
+    gap: 0.75rem;
+    padding: 0.4rem 0.75rem;
     background: rgba(0, 0, 0, 0.15);
     border-radius: 4px;
     font-size: 0.8rem;


### PR DESCRIPTION
## Summary
Reverts all CSS changes from PRs #548 and #551 back to the pre-change state. The compact spacing changes caused message bodies to collapse and content to not render properly.

## Test plan
- [ ] Messages render with original spacing
- [ ] All content blocks visible within messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)