### PR TITLE
Pin messages to bottom of scroll container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.0.5"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.0.5"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.0.5"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.0.5"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.0.5"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.0.5"
+version = "2.0.7"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3023,7 +3023,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.0.5"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "colored",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.0.5"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "hex",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.0.5"
+version = "2.0.7"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.9"
+version = "2.0.10"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -137,8 +137,11 @@
 
 .session-view-messages {
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 1rem 1.5rem;
+    padding: 1rem 1.5rem 0.25rem;
     min-width: 0; /* Allow flex child to shrink below content size */
 }


### PR DESCRIPTION
## Summary
- Use `justify-content: flex-end` on `.session-view-messages` so messages pin to the bottom of the viewport (standard chat-app pattern)
- Reduce bottom padding from 1rem to 0.25rem to minimize gap between last message and input bar

## Test plan
- [ ] Verify messages appear pinned to bottom when few messages present
- [ ] Verify scrolling still works normally when messages overflow
- [ ] Verify no layout issues on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)