### PR TITLE
Revert flex-end on message container

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.10"
+version = "2.0.11"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -137,11 +137,8 @@
 
 .session-view-messages {
     flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 1rem 1.5rem 0.25rem;
+    padding: 1rem 1.5rem;
     min-width: 0; /* Allow flex child to shrink below content size */
 }


### PR DESCRIPTION
## Summary
- Reverts the `justify-content: flex-end` change from PR #553 which broke message rendering
- `justify-content: flex-end` on a scrollable flex container causes content to overflow above the top edge and become inaccessible/collapsed
- Restores original `overflow-y: auto` layout without flex

## Test plan
- [ ] Verify messages render correctly with visible content
- [ ] Verify scrolling works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)