### PR TITLE
Remove bottom padding on message container

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.11"
+version = "2.0.12"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -139,6 +139,6 @@
     flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 1rem 1.5rem;
+    padding: 1rem 1.5rem 0;
     min-width: 0; /* Allow flex child to shrink below content size */
 }


### PR DESCRIPTION
## Summary
- Remove bottom padding on `.session-view-messages` to reduce gap between last message and input bar

## Test plan
- [ ] Verify last message sits closer to the input bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)