### PR TITLE
Reduce message body vertical padding by half

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.12"
+version = "2.0.13"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -21,7 +21,7 @@
 }
 
 .claude-message .message-body {
-    padding: 1rem;
+    padding: 0.5rem 1rem;
 }
 
 /* Message Type Badges */


### PR DESCRIPTION
## Summary
- Halve top/bottom padding on `.message-body` (1rem → 0.5rem), keeping horizontal padding at 1rem

## Test plan
- [ ] Verify messages look more compact vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)