### PR TITLE
Add copy button to markdown code blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.13"
+version = "2.0.14"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -4,7 +4,11 @@
 //! Supports: headings, bold, italic, strikethrough, links, code blocks,
 //! inline code, blockquotes, lists, and tables.
 
+use gloo::timers::callback::Timeout;
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::window;
 use yew::prelude::*;
 
 /// Render markdown text as HTML
@@ -174,7 +178,7 @@ fn render_heading(level: pulldown_cmark::HeadingLevel, inner: Html) -> Html {
     }
 }
 
-/// Render a code block with optional language class
+/// Render a code block with optional language class and copy button
 fn render_code_block(kind: &CodeBlockKind, inner_events: &[Event]) -> Html {
     let code_text = extract_text(inner_events);
     let lang_class = match kind {
@@ -186,8 +190,65 @@ fn render_code_block(kind: &CodeBlockKind, inner_events: &[Event]) -> Html {
     };
 
     html! {
+        <CodeBlock code_text={code_text} lang_class={lang_class} />
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct CodeBlockProps {
+    code_text: String,
+    lang_class: Option<String>,
+}
+
+#[function_component(CodeBlock)]
+fn code_block(props: &CodeBlockProps) -> Html {
+    let copied = use_state(|| false);
+
+    let on_copy = {
+        let code_text = props.code_text.clone();
+        let copied = copied.clone();
+
+        Callback::from(move |_: MouseEvent| {
+            let code_text = code_text.clone();
+            let copied = copied.clone();
+
+            spawn_local(async move {
+                if let Some(window) = window() {
+                    let navigator = window.navigator();
+                    let clipboard = js_sys::Reflect::get(&navigator, &"clipboard".into())
+                        .ok()
+                        .and_then(|v| v.dyn_into::<web_sys::Clipboard>().ok());
+
+                    if let Some(clipboard) = clipboard {
+                        let promise = clipboard.write_text(&code_text);
+                        let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+
+                        copied.set(true);
+                        let copied_reset = copied.clone();
+                        Timeout::new(2000, move || {
+                            copied_reset.set(false);
+                        })
+                        .forget();
+                    }
+                }
+            });
+        })
+    };
+
+    let button_class = if *copied {
+        "code-copy-button copied"
+    } else {
+        "code-copy-button"
+    };
+
+    let button_label = if *copied { "Copied!" } else { "Copy" };
+
+    html! {
         <pre class="md-code-block">
-            <code class={classes!("md-code", lang_class)}>{ code_text }</code>
+            <button class={button_class} onclick={on_copy} title="Copy to clipboard">
+                { button_label }
+            </button>
+            <code class={classes!("md-code", props.lang_class.clone())}>{ &props.code_text }</code>
         </pre>
     }
 }

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -103,6 +103,7 @@
 
 /* Code blocks */
 .md-code-block {
+    position: relative;
     margin: 0.75rem 0;
     background: var(--bg-darker);
     border: 1px solid var(--border);
@@ -118,6 +119,36 @@
     line-height: 1.5;
     color: var(--text-primary);
     white-space: pre;
+}
+
+.code-copy-button {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    padding: 0.2rem 0.5rem;
+    background: var(--border);
+    border: none;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s;
+}
+
+.md-code-block:hover .code-copy-button {
+    opacity: 1;
+}
+
+.code-copy-button:hover {
+    background: var(--accent);
+    color: white;
+}
+
+.code-copy-button.copied {
+    opacity: 1;
+    background: var(--success);
+    color: white;
 }
 
 /* Blockquotes */


### PR DESCRIPTION
## Summary
- Add a "Copy" button in the top-right corner of fenced code blocks
- Button appears on hover, copies code text to clipboard on click
- Shows "Copied!" feedback for 2 seconds after copying
- Reuses existing clipboard API pattern from `copy_command.rs`

## Test plan
- [ ] Hover over a code block — "Copy" button appears in top-right
- [ ] Click "Copy" — text is copied to clipboard, button shows "Copied!"
- [ ] After 2 seconds, button reverts to "Copy"
- [ ] Inline code (single backticks) should NOT show a copy button

🤖 Generated with [Claude Code](https://claude.com/claude-code)