### PR TITLE
Improve WASM loading speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -40,6 +40,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -124,6 +139,18 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-lock"
@@ -424,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -564,6 +591,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +642,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -681,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -714,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -736,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -779,6 +829,26 @@ dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -1300,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2514,6 +2584,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,7 +3139,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "anyhow",
  "colored",
@@ -3074,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "anyhow",
  "hex",
@@ -3990,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -4684,6 +4764,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
  "futures-core",
@@ -5882,3 +5963,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.16"
+version = "2.0.17"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -15,7 +15,7 @@ tokio-util = "0.7"
 # Web framework
 axum = { version = "0.7", features = ["ws"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "fs", "trace", "compression-full"] }
 
 # Database
 diesel = { version = "2.2", features = ["postgres", "r2d2", "chrono", "uuid", "serde_json", "numeric"] }
@@ -62,3 +62,10 @@ uuid = { version = "1.11", features = ["v4", "serde", "js"] }
 
 # WebSocket bridge
 ws-bridge = "0.1.1"
+
+# Optimize release builds for size (especially important for WASM)
+[profile.release]
+lto = true
+codegen-units = 1
+opt-level = "z"
+strip = true

--- a/backend/src/embedded_assets.rs
+++ b/backend/src/embedded_assets.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::Body,
-    http::{header, StatusCode, Uri},
+    http::{header, HeaderValue, StatusCode, Uri},
     response::{IntoResponse, Response},
 };
 use rust_embed::RustEmbed;
@@ -8,6 +8,17 @@ use rust_embed::RustEmbed;
 #[derive(RustEmbed)]
 #[folder = "../frontend/dist"]
 pub struct FrontendAssets;
+
+/// Assets with content hashes in filenames can be cached indefinitely.
+/// index.html must always be revalidated so the browser picks up new hashes.
+fn cache_header(path: &str) -> HeaderValue {
+    if path == "index.html" {
+        HeaderValue::from_static("no-cache")
+    } else {
+        // 1 year — the hash in the filename guarantees cache busting
+        HeaderValue::from_static("public, max-age=31536000, immutable")
+    }
+}
 
 /// Serve embedded frontend assets with SPA fallback
 pub async fn serve_embedded_frontend(uri: Uri) -> Response {
@@ -23,7 +34,13 @@ fn serve_asset(path: &str) -> Response {
             let mime = mime_guess::from_path(path).first_or_octet_stream();
             (
                 StatusCode::OK,
-                [(header::CONTENT_TYPE, mime.as_ref())],
+                [
+                    (
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_str(mime.as_ref()).unwrap(),
+                    ),
+                    (header::CACHE_CONTROL, cache_header(path)),
+                ],
                 Body::from(content.data.to_vec()),
             )
                 .into_response()
@@ -33,7 +50,10 @@ fn serve_asset(path: &str) -> Response {
             match FrontendAssets::get("index.html") {
                 Some(content) => (
                     StatusCode::OK,
-                    [(header::CONTENT_TYPE, "text/html")],
+                    [
+                        (header::CONTENT_TYPE, HeaderValue::from_static("text/html")),
+                        (header::CACHE_CONTROL, cache_header("index.html")),
+                    ],
                     Body::from(content.data.to_vec()),
                 )
                     .into_response(),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -17,6 +17,7 @@ use oauth2::{basic::BasicClient, AuthUrl, ClientId, ClientSecret, RedirectUrl, T
 use shared::WsEndpoint;
 use std::{env, sync::Arc};
 use tower_cookies::{CookieManagerLayer, Key};
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::{Any, CorsLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -443,7 +444,10 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Serving embedded frontend assets");
 
     // Add CORS and cookie management
-    let app = app.layer(CookieManagerLayer::new()).layer(cors);
+    let app = app
+        .layer(CompressionLayer::new())
+        .layer(CookieManagerLayer::new())
+        .layer(cors);
 
     // Spawn background task to broadcast user spend updates
     {


### PR DESCRIPTION
## Summary
- Add **gzip/brotli compression** via `CompressionLayer` — the 11 MB WASM binary compresses to ~2-3 MB over the wire (~75% reduction)
- Add **Cache-Control headers** — hashed assets (JS, WASM, CSS) get `immutable, max-age=1yr`; `index.html` gets `no-cache` so browsers always pick up new hashes
- Add **release profile optimizations** — LTO, single codegen unit, `opt-level = "z"`, strip debug symbols for smaller binaries

## Test plan
- [ ] Verify `Content-Encoding: br` or `gzip` in response headers for WASM/JS/CSS assets
- [ ] Verify `Cache-Control: public, max-age=31536000, immutable` on hashed assets
- [ ] Verify `Cache-Control: no-cache` on `index.html`
- [ ] Confirm page loads noticeably faster on slow connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)