### PR TITLE
Add loading spinner while WASM downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.0.17"
+version = "2.0.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.0.17"
+version = "2.0.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.0.17"
+version = "2.0.18"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.0.17"
+version = "2.0.18"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.0.17"
+version = "2.0.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.0.17"
+version = "2.0.18"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3139,7 +3139,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.0.17"
+version = "2.0.18"
 dependencies = [
  "anyhow",
  "colored",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.0.17"
+version = "2.0.18"
 dependencies = [
  "anyhow",
  "hex",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.0.17"
+version = "2.0.18"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.17"
+version = "2.0.18"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,6 +21,33 @@
     <!-- General meta -->
     <meta name="description" content="Rich, interactive agent sessions. Visually pleasant and easy to multitask between many sessions." />
 
+    <!-- Loading spinner (inline so it renders before any external assets) -->
+    <style>
+        #loading {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            background: #1a1b26;
+            color: #7f849c;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-size: 0.95rem;
+            gap: 1.2rem;
+        }
+        .spinner {
+            width: 36px;
+            height: 36px;
+            border: 3px solid #292e42;
+            border-top-color: #7aa2f7;
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+        }
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+    </style>
+
     <link data-trunk rel="rust" data-wasm-opt="z" />
     <!-- CSS files split for maintainability -->
     <link data-trunk rel="css" href="styles/base.css" />
@@ -47,5 +74,10 @@
     <link data-trunk rel="copy-file" href="assets/wiggum.png" />
     <link data-trunk rel="copy-file" href="assets/og-preview.svg" />
 </head>
-<body></body>
+<body>
+    <div id="loading">
+        <div class="spinner"></div>
+        <p>Loading&hellip;</p>
+    </div>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- Add a CSS-only loading spinner that displays instantly while the ~11 MB WASM binary downloads
- Uses inline `<style>` in `index.html` — zero external dependencies, renders before any assets load
- Matches the app's dark theme (`#1a1b26` bg, `#7aa2f7` accent spinner)
- Yew replaces the `<body>` content on mount, so the spinner disappears automatically

## Test plan
- [ ] Open the app — spinner appears immediately on blank page
- [ ] Spinner disappears when the app finishes loading
- [ ] Throttle network in DevTools to verify it looks good during slow loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)