### PR TITLE
Pre-compress embedded assets at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -26,7 +26,7 @@ dependencies = [
  "shared",
  "tokio",
  "tokio-util",
- "toml 1.0.3+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -451,13 +451,14 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.7.9",
  "axum-sessions",
  "bigdecimal",
+ "brotli",
  "chrono",
  "clap",
  "claude-codes",
@@ -467,6 +468,7 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "dotenvy",
+ "flate2",
  "futures-util",
  "google-cognitive-apis",
  "hex",
@@ -731,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -764,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -780,13 +782,13 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
- "which 8.0.0",
+ "which 8.0.2",
  "ws-bridge",
 ]
 
 [[package]]
 name = "cli-tools"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "anyhow",
  "clap",
@@ -1271,12 +1273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2352,7 +2348,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -2646,9 +2642,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -3139,7 +3135,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "anyhow",
  "colored",
@@ -3154,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "anyhow",
  "hex",
@@ -4070,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -4156,12 +4152,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4443,7 +4439,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4499,7 +4495,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.9.2",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tokio-util",
  "whoami",
@@ -4590,14 +4586,14 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.14",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
@@ -4605,7 +4601,7 @@ dependencies = [
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.14",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4649,7 +4645,7 @@ version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow 0.7.14",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5013,9 +5009,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5283,13 +5279,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
- "env_home",
- "rustix 1.1.4",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -5441,15 +5435,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5481,28 +5466,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5518,12 +5486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5534,12 +5496,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5554,22 +5510,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5584,12 +5528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5600,12 +5538,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5620,12 +5552,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5638,12 +5564,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5654,9 +5574,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winreg"
@@ -5667,12 +5587,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
@@ -5880,18 +5794,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.18"
+version = "2.0.19"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -79,4 +79,6 @@ google-cognitive-apis = { version = "0.2.2", features = ["speech-to-text"] }
 md5 = "0.8.0"
 rust-embed = { version = "8.11.0", features = ["axum", "mime-guess"] }
 mime_guess = "2.0.5"
+brotli = "8.0"
+flate2 = "1.0"
 ws-bridge = { workspace = true, features = ["server"] }

--- a/backend/src/embedded_assets.rs
+++ b/backend/src/embedded_assets.rs
@@ -1,64 +1,137 @@
 use axum::{
     body::Body,
-    http::{header, HeaderValue, StatusCode, Uri},
+    http::{header, HeaderMap, HeaderValue, StatusCode, Uri},
     response::{IntoResponse, Response},
 };
 use rust_embed::RustEmbed;
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::OnceLock;
 
 #[derive(RustEmbed)]
 #[folder = "../frontend/dist"]
 pub struct FrontendAssets;
 
-/// Assets with content hashes in filenames can be cached indefinitely.
-/// index.html must always be revalidated so the browser picks up new hashes.
-fn cache_header(path: &str) -> HeaderValue {
-    if path == "index.html" {
+struct CompressedAsset {
+    raw: Vec<u8>,
+    brotli: Vec<u8>,
+    gzip: Vec<u8>,
+    mime: String,
+    is_index: bool,
+}
+
+static CACHE: OnceLock<HashMap<String, CompressedAsset>> = OnceLock::new();
+
+/// Pre-compress all embedded assets at startup.
+/// Call this before starting the server so the first request is fast.
+pub fn init_cache() {
+    CACHE.get_or_init(|| {
+        let mut map = HashMap::new();
+        let mut total_raw = 0u64;
+        let mut total_br = 0u64;
+
+        for path in FrontendAssets::iter() {
+            if let Some(content) = FrontendAssets::get(&path) {
+                let raw = content.data.to_vec();
+                let mime = mime_guess::from_path(&*path)
+                    .first_or_octet_stream()
+                    .to_string();
+                let is_index = *path == *"index.html";
+
+                // Brotli compress (quality 11 = max)
+                let brotli_buf = {
+                    let mut buf = Vec::new();
+                    {
+                        let mut writer = brotli::CompressorWriter::new(&mut buf, 4096, 11, 22);
+                        writer.write_all(&raw).unwrap();
+                    }
+                    buf
+                };
+
+                // Gzip compress (best)
+                let gzip_buf = {
+                    let mut encoder =
+                        flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+                    encoder.write_all(&raw).unwrap();
+                    encoder.finish().unwrap()
+                };
+
+                total_raw += raw.len() as u64;
+                total_br += brotli_buf.len() as u64;
+
+                map.insert(
+                    path.to_string(),
+                    CompressedAsset {
+                        raw,
+                        brotli: brotli_buf,
+                        gzip: gzip_buf,
+                        mime,
+                        is_index,
+                    },
+                );
+            }
+        }
+
+        tracing::info!(
+            "Pre-compressed {} assets: {:.1} MB raw -> {:.1} MB brotli ({:.0}% reduction)",
+            map.len(),
+            total_raw as f64 / 1_048_576.0,
+            total_br as f64 / 1_048_576.0,
+            (1.0 - total_br as f64 / total_raw as f64) * 100.0
+        );
+
+        map
+    });
+}
+
+fn cache_control(is_index: bool) -> HeaderValue {
+    if is_index {
         HeaderValue::from_static("no-cache")
     } else {
-        // 1 year — the hash in the filename guarantees cache busting
         HeaderValue::from_static("public, max-age=31536000, immutable")
     }
 }
 
-/// Serve embedded frontend assets with SPA fallback
-pub async fn serve_embedded_frontend(uri: Uri) -> Response {
+/// Serve pre-compressed embedded frontend assets with SPA fallback.
+/// Checks Accept-Encoding and returns brotli/gzip/raw accordingly.
+pub async fn serve_embedded_frontend(uri: Uri, headers: HeaderMap) -> Response {
     let path = uri.path().trim_start_matches('/');
     let path = if path.is_empty() { "index.html" } else { path };
 
-    serve_asset(path)
-}
+    let cache = CACHE.get().expect("asset cache not initialized");
 
-fn serve_asset(path: &str) -> Response {
-    match FrontendAssets::get(path) {
-        Some(content) => {
-            let mime = mime_guess::from_path(path).first_or_octet_stream();
-            (
-                StatusCode::OK,
-                [
-                    (
-                        header::CONTENT_TYPE,
-                        HeaderValue::from_str(mime.as_ref()).unwrap(),
-                    ),
-                    (header::CACHE_CONTROL, cache_header(path)),
-                ],
-                Body::from(content.data.to_vec()),
-            )
-                .into_response()
-        }
-        None => {
-            // SPA fallback: serve index.html for any unknown path
-            match FrontendAssets::get("index.html") {
-                Some(content) => (
-                    StatusCode::OK,
-                    [
-                        (header::CONTENT_TYPE, HeaderValue::from_static("text/html")),
-                        (header::CACHE_CONTROL, cache_header("index.html")),
-                    ],
-                    Body::from(content.data.to_vec()),
-                )
-                    .into_response(),
-                None => (StatusCode::NOT_FOUND, "Frontend not found").into_response(),
+    let accept = headers
+        .get(header::ACCEPT_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    // Look up the exact path, fall back to index.html for SPA routing
+    let asset = cache.get(path).or_else(|| cache.get("index.html"));
+
+    match asset {
+        Some(asset) => {
+            let (body, encoding) = if accept.contains("br") {
+                (asset.brotli.as_slice(), Some("br"))
+            } else if accept.contains("gzip") {
+                (asset.gzip.as_slice(), Some("gzip"))
+            } else {
+                (asset.raw.as_slice(), None)
+            };
+
+            let mut resp = Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, &asset.mime)
+                .header(header::CACHE_CONTROL, cache_control(asset.is_index))
+                .body(Body::from(body.to_vec()))
+                .unwrap();
+
+            if let Some(enc) = encoding {
+                resp.headers_mut()
+                    .insert(header::CONTENT_ENCODING, HeaderValue::from_static(enc));
             }
+
+            resp
         }
+        None => (StatusCode::NOT_FOUND, "Frontend not found").into_response(),
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -441,6 +441,8 @@ async fn main() -> anyhow::Result<()> {
         // Serve embedded frontend assets with SPA fallback
         .fallback(axum::routing::get(embedded_assets::serve_embedded_frontend));
 
+    // Pre-compress all embedded assets at startup (brotli + gzip)
+    embedded_assets::init_cache();
     tracing::info!("Serving embedded frontend assets");
 
     // Add CORS and cookie management


### PR DESCRIPTION
## Summary
- Pre-compress all embedded frontend assets (brotli + gzip) at server startup into an in-memory `HashMap`
- Serve the pre-compressed variant directly based on `Accept-Encoding` header
- Sets `Content-Encoding` so `CompressionLayer` skips these (still compresses API JSON responses)
- Eliminates per-request compression CPU for the 11 MB WASM binary and all static assets
- Logs compression stats at startup (e.g., "Pre-compressed 24 assets: 11.2 MB raw -> 2.1 MB brotli (81% reduction)")

## Test plan
- [ ] Server starts and logs pre-compression stats
- [ ] `curl -H 'Accept-Encoding: br' -sI http://localhost:3000/` shows `Content-Encoding: br`
- [ ] `curl -H 'Accept-Encoding: gzip' -sI http://localhost:3000/` shows `Content-Encoding: gzip`
- [ ] SPA fallback still works (e.g., `/dashboard` serves index.html)
- [ ] Hashed assets still get `Cache-Control: public, max-age=31536000, immutable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)