### PR TITLE
Show portal feedback for slash commands and fix textarea bounce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.0.19"
+version = "2.0.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.0.19"
+version = "2.0.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.0.19"
+version = "2.0.20"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.0.19"
+version = "2.0.20"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.0.19"
+version = "2.0.20"
 dependencies = [
  "anyhow",
  "clap",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.0.19"
+version = "2.0.20"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3135,7 +3135,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.0.19"
+version = "2.0.20"
 dependencies = [
  "anyhow",
  "colored",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.0.19"
+version = "2.0.20"
 dependencies = [
  "anyhow",
  "hex",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.0.19"
+version = "2.0.20"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.19"
+version = "2.0.20"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -5,7 +5,9 @@ use crate::AppState;
 use axum::extract::ws::WebSocket;
 use diesel::prelude::*;
 use shared::api::RawMessageFallback;
-use shared::{ClientEndpoint, ClientToServer, SendMode, ServerToClient, ServerToProxy};
+use shared::{
+    ClientEndpoint, ClientToServer, PortalMessage, SendMode, ServerToClient, ServerToProxy,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -362,6 +364,39 @@ fn handle_web_input(
         session_manager
             .last_input_sender
             .insert(session_id, (user_id, display_name));
+    }
+
+    // For slash commands, broadcast a portal message so the user sees feedback
+    if let serde_json::Value::String(text) = &content {
+        if text.starts_with('/') {
+            let portal = PortalMessage::text(format!("`{}`", text));
+            session_manager.broadcast_to_web_clients(
+                key,
+                ServerToClient::ClaudeOutput {
+                    content: portal.to_json(),
+                    sender_user_id: None,
+                    sender_name: None,
+                },
+            );
+            // Store in DB so it appears in history
+            if let Ok(mut conn) = db_pool.get() {
+                use crate::schema::{messages, sessions};
+                if let Ok(session) = sessions::table
+                    .find(session_id)
+                    .first::<crate::models::Session>(&mut conn)
+                {
+                    let new_message = crate::models::NewMessage {
+                        session_id,
+                        role: "portal".to_string(),
+                        content: serde_json::to_string(&portal.to_json()).unwrap_or_default(),
+                        user_id: session.user_id,
+                    };
+                    let _ = diesel::insert_into(messages::table)
+                        .values(&new_message)
+                        .execute(&mut conn);
+                }
+            }
+        }
     }
 
     let seq = match db_pool.get() {

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -868,7 +868,10 @@ impl Component for SessionView {
         let handle_input = link.callback(|e: InputEvent| {
             let input: HtmlTextAreaElement = e.target_unchecked_into();
             let el: &Element = input.as_ref();
-            el.set_attribute("style", "height: auto").ok();
+            // Measure content height with overflow hidden to prevent scrollbar
+            // from narrowing the text area and causing layout bounce.
+            el.set_attribute("style", "height: 0; overflow-y: hidden")
+                .ok();
             el.set_attribute("style", &format!("height: {}px", input.scroll_height()))
                 .ok();
             SessionViewMsg::UpdateInput(input.value())
@@ -1018,7 +1021,8 @@ impl SessionView {
             if text.is_empty() {
                 elem.remove_attribute("style").ok();
             } else {
-                elem.set_attribute("style", "height: auto").ok();
+                elem.set_attribute("style", "height: 0; overflow-y: hidden")
+                    .ok();
                 elem.set_attribute("style", &format!("height: {}px", el.scroll_height()))
                     .ok();
             }


### PR DESCRIPTION
## Summary
- Broadcast a `PortalMessage` when a user sends a `/` command so it renders in the message stream and persists in history
- Fix textarea auto-resize bounce by measuring with `height: 0; overflow-y: hidden` instead of `height: auto`, preventing scrollbar-induced layout instability

## Test plan
- [ ] Send a `/` command (e.g. `/compact`) and verify a portal message appears in the chat
- [ ] Type multi-line text in the input and verify the session bar and messages don't bounce
- [ ] Verify slash command messages appear in history on page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)