### PR TITLE
Add click-to-expand for truncated content and preserve input on reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3135,7 +3135,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "anyhow",
  "colored",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "anyhow",
  "hex",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.20"
+version = "2.0.21"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/expandable.rs
+++ b/frontend/src/components/expandable.rs
@@ -1,0 +1,134 @@
+use super::message_renderer::truncate_str;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct ExpandableTextProps {
+    pub full_text: AttrValue,
+    pub max_len: usize,
+    /// Wrapper element tag: "pre", "div", or "span"
+    #[prop_or("pre".into())]
+    pub tag: AttrValue,
+    #[prop_or_default]
+    pub class: Classes,
+}
+
+/// Character-based expandable text. Shows truncated content with a clickable
+/// toggle to reveal the full text. If the text fits within `max_len`, renders
+/// as-is with no toggle.
+#[function_component(ExpandableText)]
+pub fn expandable_text(props: &ExpandableTextProps) -> Html {
+    let expanded = use_state(|| false);
+    let text = &*props.full_text;
+
+    if text.len() <= props.max_len {
+        return match props.tag.as_str() {
+            "span" => html! { <span class={props.class.clone()}>{ text }</span> },
+            "div" => html! { <div class={props.class.clone()}>{ text }</div> },
+            _ => html! { <pre class={props.class.clone()}>{ text }</pre> },
+        };
+    }
+
+    let remaining = text.len() - props.max_len;
+
+    let toggle = {
+        let expanded = expanded.clone();
+        Callback::from(move |e: MouseEvent| {
+            e.stop_propagation();
+            expanded.set(!*expanded);
+        })
+    };
+
+    let (display, toggle_label) = if *expanded {
+        (text.to_string(), "show less".to_string())
+    } else {
+        (
+            truncate_str(text, props.max_len).to_string(),
+            format!("... {} more chars", remaining),
+        )
+    };
+
+    match props.tag.as_str() {
+        "span" => html! {
+            <span class={props.class.clone()}>
+                { &display }
+                <span class="expandable-toggle" onclick={toggle}>{ toggle_label }</span>
+            </span>
+        },
+        "div" => html! {
+            <div class={props.class.clone()}>
+                { &display }
+                <span class="expandable-toggle" onclick={toggle}>{ toggle_label }</span>
+            </div>
+        },
+        _ => html! {
+            <pre class={props.class.clone()}>
+                { &display }
+                <span class="expandable-toggle" onclick={toggle}>{ toggle_label }</span>
+            </pre>
+        },
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct ExpandableLinesProps {
+    pub content: AttrValue,
+    pub max_lines: usize,
+    #[prop_or_default]
+    pub class: Classes,
+}
+
+/// Line-based expandable content for file previews. Shows the first N lines
+/// with a clickable toggle to reveal all lines.
+#[function_component(ExpandableLines)]
+pub fn expandable_lines(props: &ExpandableLinesProps) -> Html {
+    let expanded = use_state(|| false);
+    let content = &*props.content;
+    let all_lines: Vec<&str> = content.lines().collect();
+    let total = all_lines.len();
+
+    if total <= props.max_lines {
+        return html! {
+            <pre class={classes!(props.class.clone(), "write-content")}>
+                { for all_lines.iter().enumerate().map(|(i, line)| html! {
+                    <div class="write-line">
+                        <span class="line-number">{ format!("{:>4}", i + 1) }</span>
+                        <span class="line-content">{ *line }</span>
+                    </div>
+                })}
+            </pre>
+        };
+    }
+
+    let toggle = {
+        let expanded = expanded.clone();
+        Callback::from(move |e: MouseEvent| {
+            e.stop_propagation();
+            expanded.set(!*expanded);
+        })
+    };
+
+    let visible = if *expanded {
+        &all_lines[..]
+    } else {
+        &all_lines[..props.max_lines]
+    };
+    let remaining = total - props.max_lines;
+
+    html! {
+        <pre class={classes!(props.class.clone(), "write-content")}>
+            { for visible.iter().enumerate().map(|(i, line)| html! {
+                <div class="write-line">
+                    <span class="line-number">{ format!("{:>4}", i + 1) }</span>
+                    <span class="line-content">{ *line }</span>
+                </div>
+            })}
+            <div class="write-truncated expandable-toggle" onclick={toggle}>
+                { if *expanded {
+                    "show less".to_string()
+                } else {
+                    format!("... {} more lines", remaining)
+                }}
+            </div>
+        </pre>
+    }
+}

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -1,7 +1,8 @@
 //! Rendering functions for each message type.
 
 use super::types::*;
-use super::{format_duration, shorten_model_name, truncate_str};
+use super::{format_duration, shorten_model_name};
+use crate::components::expandable::ExpandableText;
 use crate::components::markdown::render_markdown;
 use crate::components::tool_renderers::render_tool_use;
 use serde::Deserialize;
@@ -655,14 +656,9 @@ pub fn render_content_blocks(blocks: &[ContentBlock]) -> Html {
                             let class = if *is_error { "tool-result error" } else { "tool-result" };
                             match content {
                                 Some(ToolResultContent::Text(s)) => {
-                                    let display = if s.len() > 500 {
-                                        format!("{}...", truncate_str(s, 500))
-                                    } else {
-                                        s.clone()
-                                    };
                                     html! {
                                         <div class={class}>
-                                            <pre class="tool-result-content">{ display }</pre>
+                                            <ExpandableText full_text={s.clone()} max_len={500} class="tool-result-content" />
                                         </div>
                                     }
                                 }
@@ -820,12 +816,7 @@ fn render_structured_block(block: &Value) -> Html {
         }
         "text" => {
             let text = block.get("text").and_then(|t| t.as_str()).unwrap_or("");
-            let display = if text.len() > 500 {
-                format!("{}...", truncate_str(text, 500))
-            } else {
-                text.to_string()
-            };
-            html! { <pre class="tool-result-content">{ display }</pre> }
+            html! { <ExpandableText full_text={text.to_string()} max_len={500} class="tool-result-content" /> }
         }
         _ => {
             let json = serde_json::to_string_pretty(block).unwrap_or_default();

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -1,6 +1,7 @@
 pub mod codex_renderer;
 mod copy_command;
 mod diff;
+pub mod expandable;
 mod launch_dialog;
 mod markdown;
 pub mod message_renderer;

--- a/frontend/src/components/tool_renderers/edit.rs
+++ b/frontend/src/components/tool_renderers/edit.rs
@@ -2,6 +2,7 @@ use serde_json::Value;
 use yew::prelude::*;
 
 use crate::components::diff::render_diff_lines;
+use crate::components::expandable::ExpandableLines;
 
 pub fn render_edit_tool(input: &Value) -> Html {
     let file_path = input
@@ -51,9 +52,7 @@ pub fn render_write_tool(input: &Value) -> Html {
         .unwrap_or("unknown file");
     let content = input.get("content").and_then(|v| v.as_str()).unwrap_or("");
 
-    let preview_lines: Vec<&str> = content.lines().take(20).collect();
     let total_lines = content.lines().count();
-    let truncated = total_lines > 20;
 
     html! {
         <div class="tool-use write-tool">
@@ -64,29 +63,7 @@ pub fn render_write_tool(input: &Value) -> Html {
                 <span class="write-size">{ format!("({} lines, {} bytes)", total_lines, content.len()) }</span>
             </div>
             <div class="write-preview">
-                <pre class="write-content">
-                    {
-                        preview_lines.iter().enumerate().map(|(i, line)| {
-                            html! {
-                                <div class="write-line">
-                                    <span class="line-number">{ format!("{:>4}", i + 1) }</span>
-                                    <span class="line-content">{ *line }</span>
-                                </div>
-                            }
-                        }).collect::<Html>()
-                    }
-                    {
-                        if truncated {
-                            html! {
-                                <div class="write-truncated">
-                                    { format!("... {} more lines", total_lines - 20) }
-                                </div>
-                            }
-                        } else {
-                            html! {}
-                        }
-                    }
-                </pre>
+                <ExpandableLines content={content.to_string()} max_lines={20} />
             </div>
         </div>
     }

--- a/frontend/src/components/tool_renderers/mod.rs
+++ b/frontend/src/components/tool_renderers/mod.rs
@@ -16,7 +16,7 @@ use self::search::{
     render_glob_tool, render_grep_tool, render_webfetch_tool, render_websearch_tool,
 };
 use self::task::render_task_tool;
-use super::message_renderer::truncate_str;
+use super::expandable::ExpandableText;
 
 /// Render a tool use block with special handling for various tools
 pub fn render_tool_use(name: &str, input: &Value) -> Html {
@@ -73,149 +73,45 @@ fn render_read_tool(input: &Value) -> Html {
 
 /// Generic tool renderer for unrecognized tools
 fn render_generic_tool(name: &str, input: &Value) -> Html {
-    let input_preview = format_tool_input(name, input);
+    let args_html = render_generic_args(input);
     html! {
         <div class="tool-use">
             <div class="tool-use-header">
                 <span class="tool-icon">{ "⚡" }</span>
                 <span class="tool-name">{ name }</span>
             </div>
-            <pre class="tool-args">{ input_preview }</pre>
+            <div class="tool-args">{ args_html }</div>
         </div>
     }
 }
 
-pub fn format_tool_input(tool_name: &str, input: &Value) -> String {
-    match tool_name {
-        "Bash" => input
-            .get("command")
-            .and_then(|v| v.as_str())
-            .map(|s| format!("$ {}", s))
-            .unwrap_or_else(|| format_generic_input(input)),
-        "Read" => {
-            let path = input
-                .get("file_path")
-                .and_then(|v| v.as_str())
-                .unwrap_or("?");
-            let mut result = path.to_string();
-            if let Some(offset) = input.get("offset").and_then(|v| v.as_i64()) {
-                if let Some(limit) = input.get("limit").and_then(|v| v.as_i64()) {
-                    result.push_str(&format!(" [lines {}-{}]", offset, offset + limit));
-                }
-            }
-            result
-        }
-        "Edit" => {
-            let path = input
-                .get("file_path")
-                .and_then(|v| v.as_str())
-                .unwrap_or("?");
-            let old_len = input
-                .get("old_string")
-                .and_then(|v| v.as_str())
-                .map(|s| s.len())
-                .unwrap_or(0);
-            let new_len = input
-                .get("new_string")
-                .and_then(|v| v.as_str())
-                .map(|s| s.len())
-                .unwrap_or(0);
-            format!("{}\n-{} chars +{} chars", path, old_len, new_len)
-        }
-        "Write" => {
-            let path = input
-                .get("file_path")
-                .and_then(|v| v.as_str())
-                .unwrap_or("?");
-            let content_len = input
-                .get("content")
-                .and_then(|v| v.as_str())
-                .map(|s| s.len())
-                .unwrap_or(0);
-            format!("{} ({} bytes)", path, content_len)
-        }
-        "Glob" => {
-            let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("?");
-            let path = input.get("path").and_then(|v| v.as_str());
-            match path {
-                Some(p) => format!("{} in {}", pattern, p),
-                None => pattern.to_string(),
-            }
-        }
-        "Grep" => {
-            let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("?");
-            let path = input.get("path").and_then(|v| v.as_str());
-            let glob = input.get("glob").and_then(|v| v.as_str());
-            let mut result = format!("/{}/", pattern);
-            if let Some(g) = glob {
-                result.push_str(&format!(" --glob={}", g));
-            }
-            if let Some(p) = path {
-                result.push_str(&format!(" in {}", p));
-            }
-            result
-        }
-        "Task" => {
-            let desc = input
-                .get("description")
-                .and_then(|v| v.as_str())
-                .unwrap_or("?");
-            let agent = input
-                .get("subagent_type")
-                .and_then(|v| v.as_str())
-                .unwrap_or("agent");
-            format!("[{}] {}", agent, desc)
-        }
-        "WebFetch" => input
-            .get("url")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| format_generic_input(input)),
-        "WebSearch" => input
-            .get("query")
-            .and_then(|v| v.as_str())
-            .map(|s| format!("\"{}\"", s))
-            .unwrap_or_else(|| format_generic_input(input)),
-        "TodoWrite" => input
-            .get("todos")
-            .and_then(|v| v.as_array())
-            .map(|arr| format!("{} items", arr.len()))
-            .unwrap_or_else(|| format_generic_input(input)),
-        "AskUserQuestion" => input
-            .get("questions")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                format!(
-                    "{} question{}",
-                    arr.len(),
-                    if arr.len() == 1 { "" } else { "s" }
-                )
-            })
-            .unwrap_or_else(|| format_generic_input(input)),
-        _ => format_generic_input(input),
-    }
-}
-
-fn format_generic_input(input: &Value) -> String {
+/// Render generic tool arguments as expandable Html.
+fn render_generic_args(input: &Value) -> Html {
     if let Some(obj) = input.as_object() {
-        let parts: Vec<String> = obj
+        let entries: Vec<(&String, &Value)> = obj
             .iter()
             .filter(|(_, v)| v.is_string() || v.is_number() || v.is_boolean())
             .take(3)
-            .map(|(k, v)| {
-                let val = match v {
-                    Value::String(s) => truncate_str(s, 40).to_string(),
-                    other => other.to_string(),
-                };
-                format!("{}={}", k, val)
-            })
             .collect();
-        if parts.is_empty() {
-            "...".to_string()
-        } else {
-            parts.join(", ")
+        if entries.is_empty() {
+            return html! { "..." };
+        }
+        html! {
+            { for entries.into_iter().map(|(k, v)| {
+                match v {
+                    Value::String(s) => html! {
+                        <span class="tool-arg-entry">
+                            { format!("{}=", k) }
+                            <ExpandableText full_text={s.clone()} max_len={40} tag="span" />
+                        </span>
+                    },
+                    other => html! {
+                        <span class="tool-arg-entry">{ format!("{}={}", k, other) }</span>
+                    },
+                }
+            })}
         }
     } else {
-        "...".to_string()
+        html! { "..." }
     }
 }

--- a/frontend/src/components/tool_renderers/search.rs
+++ b/frontend/src/components/tool_renderers/search.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 use yew::prelude::*;
 
-use crate::components::message_renderer::truncate_str;
+use crate::components::expandable::ExpandableText;
 
 pub fn render_glob_tool(input: &Value) -> Html {
     let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("?");
@@ -98,7 +98,7 @@ pub fn render_webfetch_tool(input: &Value) -> Html {
             </div>
             {
                 if let Some(p) = prompt {
-                    html! { <div class="webfetch-prompt">{ truncate_str(p, 100) }</div> }
+                    html! { <ExpandableText full_text={p.to_string()} max_len={100} class="webfetch-prompt" tag="div" /> }
                 } else {
                     html! {}
                 }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -165,6 +165,8 @@ pub struct SessionView {
     tab_anim: Option<&'static str>,
     /// Whether the drawer is still visible during departure animation
     tab_departing: bool,
+    /// Tracks textarea content so it can be restored after reconnection re-renders
+    input_text: String,
 }
 
 impl Component for SessionView {
@@ -246,6 +248,7 @@ impl Component for SessionView {
             task_tick_handle: None,
             tab_anim: None,
             tab_departing: false,
+            input_text: String::new(),
         }
     }
 
@@ -267,6 +270,15 @@ impl Component for SessionView {
         if first_render && ctx.props().focused {
             if let Some(input) = self.input_ref.cast::<HtmlTextAreaElement>() {
                 let _ = input.focus();
+            }
+        }
+
+        // Restore textarea content if it was cleared during a re-render (e.g. reconnection)
+        if !self.input_text.is_empty() {
+            if let Some(el) = self.input_ref.cast::<HtmlTextAreaElement>() {
+                if el.value().is_empty() {
+                    self.set_input_text(&self.input_text.clone());
+                }
             }
         }
 
@@ -304,9 +316,10 @@ impl Component for SessionView {
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             SessionViewMsg::WsEvent(event) => self.handle_ws_event(ctx, event),
-            SessionViewMsg::UpdateInput(_value) => {
+            SessionViewMsg::UpdateInput(value) => {
                 // Textarea is uncontrolled — the DOM already has the new value.
-                // No re-render needed; we read from the DOM at send time.
+                // Track in state so we can restore after reconnection re-renders.
+                self.input_text = value;
                 false
             }
             SessionViewMsg::SendInput => self.handle_send_input_with_mode(ctx, SendMode::Normal),
@@ -1084,6 +1097,7 @@ impl SessionView {
 
         self.command_history.push(input.clone());
         self.set_input_text("");
+        self.input_text.clear();
 
         let session_id = ctx.props().session.id;
         ctx.props().on_message_sent.emit(session_id);

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -802,3 +802,28 @@
     border-left: 3px solid var(--error);
 }
 
+/* ==========================================================================
+   Expandable Text / Lines
+   ========================================================================== */
+
+.expandable-toggle {
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 0.8em;
+    user-select: none;
+    transition: color 0.15s;
+}
+
+.expandable-toggle:hover {
+    color: var(--accent);
+}
+
+.tool-arg-entry {
+    white-space: nowrap;
+}
+
+.tool-arg-entry + .tool-arg-entry::before {
+    content: ", ";
+    color: var(--text-muted);
+}
+


### PR DESCRIPTION
## Summary
- New `ExpandableText` and `ExpandableLines` Yew components for click-to-expand truncated content
- All 5 truncation sites now have expand/collapse toggles: tool results (500 chars), structured blocks (500 chars), generic tool args (40 chars), WebFetch prompts (100 chars), Write tool previews (20 lines)
- Track textarea content in component state so it survives reconnection re-renders

## Test plan
- [ ] Verify long tool results show "... N more chars" that expands on click
- [ ] Verify Write tool "... N more lines" expands to show full file
- [ ] Verify expanded content collapses back on second click
- [ ] Verify textarea input preserved across WebSocket reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)