### PR TITLE
Fix slow typing by removing per-keystroke CheckAwaiting

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -393,6 +393,10 @@ pub fn dashboard_page() -> Html {
     let on_awaiting_change = {
         let awaiting_sessions = awaiting_sessions.clone();
         Callback::from(move |(session_id, is_awaiting): (Uuid, bool)| {
+            let currently_awaiting = awaiting_sessions.contains(&session_id);
+            if currently_awaiting == is_awaiting {
+                return;
+            }
             let mut set = (*awaiting_sessions).clone();
             if is_awaiting {
                 set.insert(session_id);

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -114,6 +114,8 @@ pub enum SessionViewMsg {
     DragEnter,
     /// User dragged files out of the input area
     DragLeave,
+    /// No-op (used by keydown/paste handlers that need to return a message)
+    Noop,
     /// Toggle the tasks sidebar panel
     ToggleTasksPanel,
     /// 1-second tick to update task elapsed times and clean up completed tasks
@@ -841,6 +843,7 @@ impl Component for SessionView {
                 self.drag_hover = false;
                 true
             }
+            SessionViewMsg::Noop => false,
             SessionViewMsg::ToggleTasksPanel => {
                 self.tasks_panel_open = !self.tasks_panel_open;
                 true
@@ -904,7 +907,7 @@ impl Component for SessionView {
                 }
                 "Enter" => {
                     // Shift+Enter inserts newline (default behavior)
-                    SessionViewMsg::CheckAwaiting
+                    SessionViewMsg::Noop
                 }
                 "ArrowUp" => {
                     e.prevent_default();
@@ -914,7 +917,7 @@ impl Component for SessionView {
                     e.prevent_default();
                     SessionViewMsg::HistoryDown
                 }
-                _ => SessionViewMsg::CheckAwaiting,
+                _ => SessionViewMsg::Noop,
             }
         });
 
@@ -934,7 +937,7 @@ impl Component for SessionView {
                     return SessionViewMsg::FilesSelected(files);
                 }
             }
-            SessionViewMsg::CheckAwaiting
+            SessionViewMsg::Noop
         });
 
         let handle_dragover = link.callback(|e: DragEvent| {


### PR DESCRIPTION
## Summary
- Every keystroke in the textarea fired `CheckAwaiting`, which iterated all messages parsing each as JSON, then unconditionally called `awaiting_sessions.set()` triggering a full dashboard re-render
- Replaced `CheckAwaiting` with `Noop` in keydown/paste handlers — `CheckAwaiting` is already called when messages arrive, permissions are handled, etc.
- Added early-return guard in `on_awaiting_change` callback to skip `.set()` when awaiting state hasn't actually changed

## Test plan
- [ ] Verify typing in the prompt bar is responsive with many messages in a session
- [ ] Verify awaiting state still updates correctly when Claude finishes responding
- [ ] Verify Shift+Enter still inserts newlines
- [ ] Verify paste still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)