### PR TITLE
Rename Pause/Unpause to Hide/Show

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "anyhow",
  "clap",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3128,7 +3128,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "anyhow",
  "colored",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "anyhow",
  "hex",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.23"
+version = "2.0.24"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -22,8 +22,8 @@ This guide covers how to use Claude Code Portal once it's set up.
 
 - **Active sessions** show a green indicator
 - **Disconnected sessions** are greyed out but remain accessible for history
-- **Paused sessions** are dimmed and excluded from rotation
-- Click the pause button on any session to toggle pause state
+- **Hidden sessions** are dimmed and excluded from rotation
+- Click the hide button on any session to toggle hidden state
 
 ## Running the CLI
 

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -12,8 +12,8 @@ pub struct KeyboardNavConfig {
     pub sessions: Vec<SessionInfo>,
     /// Currently focused session index
     pub focused_index: usize,
-    /// Set of paused session IDs
-    pub paused_sessions: HashSet<Uuid>,
+    /// Set of hidden session IDs
+    pub hidden_sessions: HashSet<Uuid>,
     /// Set of connected session IDs
     pub connected_sessions: HashSet<Uuid>,
     /// Whether inactive sessions are hidden
@@ -37,7 +37,7 @@ pub struct UseKeyboardNav {
 /// Edit Mode (default):
 /// - Typing works normally
 /// - Escape -> Nav Mode
-/// - Shift+Tab -> next active session (skips paused)
+/// - Shift+Tab -> next active session (skips hidden)
 ///
 /// Nav Mode:
 /// - Arrow keys / hjkl navigate sessions
@@ -56,7 +56,7 @@ pub struct UseKeyboardNav {
 /// let nav = use_keyboard_nav(KeyboardNavConfig {
 ///     sessions: sessions.clone(),
 ///     focused_index: *focused_index,
-///     paused_sessions: paused.clone(),
+///     hidden_sessions: hidden.clone(),
 ///     connected_sessions: connected.clone(),
 ///     inactive_hidden: *inactive_hidden,
 ///     on_select: on_select.clone(),
@@ -77,7 +77,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let nav_mode = nav_mode.clone();
         let sessions = config.sessions.clone();
         let focused_index = config.focused_index;
-        let paused_sessions = config.paused_sessions.clone();
+        let hidden_sessions = config.hidden_sessions.clone();
         let connected_sessions = config.connected_sessions.clone();
         let inactive_hidden = config.inactive_hidden;
         let on_select = config.on_select.clone();
@@ -87,7 +87,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
             let in_nav_mode = *nav_mode;
             let len = sessions.len();
 
-            // Helper: navigate to next non-paused session
+            // Helper: navigate to next non-hidden session
             let navigate_to_next_active = |current: usize| -> Option<usize> {
                 if len == 0 {
                     return None;
@@ -95,7 +95,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                 for i in 1..=len {
                     let idx = (current + i) % len;
                     if let Some(session) = sessions.get(idx) {
-                        if !paused_sessions.contains(&session.id) {
+                        if !hidden_sessions.contains(&session.id) {
                             return Some(idx);
                         }
                     }
@@ -103,30 +103,30 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                 None
             };
 
-            // Helper: navigate by delta, skipping paused sessions
+            // Helper: navigate by delta, skipping hidden sessions
             let navigate_by_delta = |current: usize, delta: i32| -> Option<usize> {
                 if len == 0 {
                     return None;
                 }
 
-                let non_paused_count = sessions
+                let non_hidden_count = sessions
                     .iter()
-                    .filter(|s| !paused_sessions.contains(&s.id))
+                    .filter(|s| !hidden_sessions.contains(&s.id))
                     .count();
 
-                // If all sessions are paused, allow normal navigation
-                if non_paused_count == 0 {
+                // If all sessions are hidden, allow normal navigation
+                if non_hidden_count == 0 {
                     return Some((current as i32 + delta).rem_euclid(len as i32) as usize);
                 }
 
-                // Skip paused sessions when navigating
+                // Skip hidden sessions when navigating
                 let step = if delta > 0 { 1 } else { len - 1 };
                 let mut new_index = current;
 
                 for _ in 0..len {
                     new_index = (new_index + step) % len;
                     if let Some(session) = sessions.get(new_index) {
-                        if !paused_sessions.contains(&session.id) {
+                        if !hidden_sessions.contains(&session.id) {
                             return Some(new_index);
                         }
                     }
@@ -197,8 +197,8 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                                 // Add active sessions first
                                 for (idx, session) in sessions.iter().enumerate() {
                                     let is_connected = connected_sessions.contains(&session.id);
-                                    let is_paused = paused_sessions.contains(&session.id);
-                                    if is_connected && !is_paused {
+                                    let is_hidden = hidden_sessions.contains(&session.id);
+                                    if is_connected && !is_hidden {
                                         visible_indices.push(idx);
                                     }
                                 }
@@ -207,8 +207,8 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                                 if !inactive_hidden {
                                     for (idx, session) in sessions.iter().enumerate() {
                                         let is_connected = connected_sessions.contains(&session.id);
-                                        let is_paused = paused_sessions.contains(&session.id);
-                                        if !is_connected || is_paused {
+                                        let is_hidden = hidden_sessions.contains(&session.id);
+                                        if !is_connected || is_hidden {
                                             visible_indices.push(idx);
                                         }
                                     }

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -3,8 +3,8 @@
 use super::session_rail::{ActivityRef, SessionRail};
 use super::session_view::SessionView;
 use super::types::{
-    load_inactive_hidden, load_paused_sessions, load_show_cost, save_inactive_hidden,
-    save_paused_sessions, save_show_cost,
+    load_hidden_sessions, load_inactive_hidden, load_show_cost, save_hidden_sessions,
+    save_inactive_hidden, save_show_cost,
 };
 use crate::components::LaunchDialog;
 use crate::hooks::{use_client_websocket, use_keyboard_nav, use_sessions, KeyboardNavConfig};
@@ -46,7 +46,7 @@ pub fn dashboard_page() -> Html {
     let show_settings = use_state(|| false);
     let focused_index = use_state(|| 0usize);
     let awaiting_sessions = use_state(HashSet::<Uuid>::new);
-    let paused_sessions = use_state(load_paused_sessions);
+    let hidden_sessions = use_state(load_hidden_sessions);
     let inactive_hidden = use_state(load_inactive_hidden);
     let show_cost = use_state(load_show_cost);
     let connected_sessions = use_state(HashSet::<Uuid>::new);
@@ -176,10 +176,10 @@ pub fn dashboard_page() -> Html {
         sorted
     };
 
-    // On initial load, focus first non-paused session and activate all non-paused sessions
+    // On initial load, focus first non-hidden session and activate all non-hidden sessions
     {
         let active_sessions = active_sessions.clone();
-        let paused_sessions = paused_sessions.clone();
+        let hidden_sessions = hidden_sessions.clone();
         let focused_index = focused_index.clone();
         let initial_focus_set = initial_focus_set.clone();
         let activated_sessions = activated_sessions.clone();
@@ -188,17 +188,17 @@ pub fn dashboard_page() -> Html {
             (active_sessions.len(), loading),
             move |(session_count, is_loading)| {
                 if !*initial_focus_set && !*is_loading && *session_count > 0 {
-                    let first_non_paused_idx = active_sessions
+                    let first_non_hidden_idx = active_sessions
                         .iter()
-                        .position(|s| !paused_sessions.contains(&s.id))
+                        .position(|s| !hidden_sessions.contains(&s.id))
                         .unwrap_or(0);
 
-                    focused_index.set(first_non_paused_idx);
+                    focused_index.set(first_non_hidden_idx);
 
-                    // Activate all non-paused sessions so they load in background
+                    // Activate all non-hidden sessions so they load in background
                     let mut activated = (*activated_sessions).clone();
                     for s in &active_sessions {
-                        if !paused_sessions.contains(&s.id) {
+                        if !hidden_sessions.contains(&s.id) {
                             activated.insert(s.id);
                         }
                     }
@@ -267,7 +267,7 @@ pub fn dashboard_page() -> Html {
     let keyboard_nav = use_keyboard_nav(KeyboardNavConfig {
         sessions: active_sessions.clone(),
         focused_index: *focused_index,
-        paused_sessions: (*paused_sessions).clone(),
+        hidden_sessions: (*hidden_sessions).clone(),
         connected_sessions: (*connected_sessions).clone(),
         inactive_hidden: *inactive_hidden,
         on_select: on_select_session.clone(),
@@ -447,17 +447,17 @@ pub fn dashboard_page() -> Html {
         })
     };
 
-    let on_toggle_pause = {
-        let paused_sessions = paused_sessions.clone();
+    let on_toggle_hidden = {
+        let hidden_sessions = hidden_sessions.clone();
         Callback::from(move |session_id: Uuid| {
-            let mut set = (*paused_sessions).clone();
+            let mut set = (*hidden_sessions).clone();
             if set.contains(&session_id) {
                 set.remove(&session_id);
             } else {
                 set.insert(session_id);
             }
-            save_paused_sessions(&set);
-            paused_sessions.set(set);
+            save_hidden_sessions(&set);
+            hidden_sessions.set(set);
         })
     };
 
@@ -521,7 +521,7 @@ pub fn dashboard_page() -> Html {
     // Computed values
     let waiting_count = awaiting_sessions
         .iter()
-        .filter(|id| !paused_sessions.contains(id))
+        .filter(|id| !hidden_sessions.contains(id))
         .count();
 
     // Update browser tab title
@@ -680,7 +680,7 @@ pub fn dashboard_page() -> Html {
                         sessions={active_sessions.clone()}
                         focused_index={*focused_index}
                         awaiting_sessions={(*awaiting_sessions).clone()}
-                        paused_sessions={(*paused_sessions).clone()}
+                        hidden_sessions={(*hidden_sessions).clone()}
                         inactive_hidden={*inactive_hidden}
                         connected_sessions={(*connected_sessions).clone()}
                         nav_mode={keyboard_nav.nav_mode}
@@ -688,7 +688,7 @@ pub fn dashboard_page() -> Html {
                         server_version={(*server_version).clone()}
                         on_select={on_select_session.clone()}
                         on_leave={on_leave.clone()}
-                        on_toggle_pause={on_toggle_pause.clone()}
+                        on_toggle_hidden={on_toggle_hidden.clone()}
                         on_toggle_inactive_hidden={on_toggle_inactive_hidden.clone()}
                         on_stop={on_stop.clone()}
                     />

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -201,7 +201,7 @@ pub struct SessionRailProps {
     pub sessions: Vec<SessionInfo>,
     pub focused_index: usize,
     pub awaiting_sessions: HashSet<Uuid>,
-    pub paused_sessions: HashSet<Uuid>,
+    pub hidden_sessions: HashSet<Uuid>,
     pub inactive_hidden: bool,
     pub connected_sessions: HashSet<Uuid>,
     pub nav_mode: bool,
@@ -212,7 +212,7 @@ pub struct SessionRailProps {
     pub server_version: String,
     pub on_select: Callback<usize>,
     pub on_leave: Callback<Uuid>,
-    pub on_toggle_pause: Callback<Uuid>,
+    pub on_toggle_hidden: Callback<Uuid>,
     pub on_toggle_inactive_hidden: Callback<MouseEvent>,
     pub on_stop: Callback<Uuid>,
 }
@@ -320,7 +320,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     };
 
     let dropdown_content = if let Some(session) = open_session {
-        let is_paused = props.paused_sessions.contains(&session.id);
+        let is_hidden = props.hidden_sessions.contains(&session.id);
         let is_connected = props.connected_sessions.contains(&session.id);
 
         let on_stop = {
@@ -340,12 +340,12 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         };
         let confirming_stop = *stop_confirm;
 
-        let on_pause = {
-            let on_toggle_pause = props.on_toggle_pause.clone();
+        let on_hide = {
+            let on_toggle_hidden = props.on_toggle_hidden.clone();
             let session_id = session.id;
             let menu_session = menu_session.clone();
             Callback::from(move |_: MouseEvent| {
-                on_toggle_pause.emit(session_id);
+                on_toggle_hidden.emit(session_id);
                 menu_session.set(None);
             })
         };
@@ -360,15 +360,15 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             })
         };
 
-        let pause_label = if is_paused {
-            "Unpause Session"
+        let hide_label = if is_hidden {
+            "Show Session"
         } else {
-            "Pause Session"
+            "Hide Session"
         };
-        let pause_hint = if is_paused {
-            "Resume rotation"
+        let hide_hint = if is_hidden {
+            "Show in rotation"
         } else {
-            "Skip in rotation"
+            "Hide from rotation"
         };
 
         let stop_option = if is_connected && session.status == shared::SessionStatus::Active {
@@ -488,11 +488,11 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 { repo_option }
                 <button
                     type="button"
-                    class={classes!("pill-menu-option", "pause", is_paused.then_some("active"))}
-                    onclick={on_pause}
+                    class={classes!("pill-menu-option", "hide", is_hidden.then_some("active"))}
+                    onclick={on_hide}
                 >
-                    { pause_label }
-                    <span class="option-hint">{ pause_hint }</span>
+                    { hide_label }
+                    <span class="option-hint">{ hide_hint }</span>
                 </button>
                 { leave_option }
                 { stop_option }
@@ -509,7 +509,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
      -> Html {
         let is_focused = index == props.focused_index;
         let is_awaiting = props.awaiting_sessions.contains(&session.id);
-        let is_paused = props.paused_sessions.contains(&session.id);
+        let is_hidden = props.hidden_sessions.contains(&session.id);
         let is_connected = props.connected_sessions.contains(&session.id);
 
         let on_click = {
@@ -551,7 +551,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             "session-pill",
             if is_focused { Some("focused") } else { None },
             if is_awaiting { Some("awaiting") } else { None },
-            if is_paused { Some("paused") } else { None },
+            if is_hidden { Some("hidden") } else { None },
             if in_nav_mode { Some("nav-mode") } else { None },
             if is_status_disconnected {
                 Some("status-disconnected")
@@ -683,8 +683,8 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     }
                 }
                 {
-                    if is_paused {
-                        html! { <span class="pill-paused-badge">{ "ᴾ" }</span> }
+                    if is_hidden {
+                        html! { <span class="pill-hidden-badge">{ "ᴴ" }</span> }
                     } else {
                         html! {}
                     }
@@ -705,14 +705,14 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         }
     };
 
-    // Split sessions into visible (not paused) vs hidden (paused only)
-    let (visible_indices, paused_indices): (Vec<_>, Vec<_>) =
+    // Split sessions into visible vs hidden
+    let (visible_indices, hidden_indices): (Vec<_>, Vec<_>) =
         props.sessions.iter().enumerate().partition(|(_, session)| {
-            let is_paused = props.paused_sessions.contains(&session.id);
-            !is_paused
+            let is_hidden = props.hidden_sessions.contains(&session.id);
+            !is_hidden
         });
 
-    let paused_count = paused_indices.len();
+    let hidden_count = hidden_indices.len();
     let visible_count = visible_indices.len();
 
     // Container with position:relative holds the rail + dropdown.
@@ -738,7 +738,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 }).collect::<Html>() }
 
                 {
-                    if paused_count > 0 {
+                    if hidden_count > 0 {
                         let toggle_class = classes!(
                             "session-rail-divider",
                             if props.inactive_hidden { Some("collapsed") } else { None }
@@ -746,9 +746,9 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                         html! {
                             <div class={toggle_class} onclick={props.on_toggle_inactive_hidden.clone()}>
                                 <span class="divider-line"></span>
-                                <button class="divider-toggle" title={if props.inactive_hidden { "Show paused sessions" } else { "Hide paused sessions" }}>
+                                <button class="divider-toggle" title={if props.inactive_hidden { "Show hidden sessions" } else { "Collapse hidden sessions" }}>
                                     { if props.inactive_hidden {
-                                        format!("▶ {}", paused_count)
+                                        format!("▶ {}", hidden_count)
                                     } else {
                                         "◀".to_string()
                                     }}
@@ -762,7 +762,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
 
                 {
                     if !props.inactive_hidden {
-                        paused_indices.iter().enumerate().map(|(display_idx, (index, session))| {
+                        hidden_indices.iter().enumerate().map(|(display_idx, (index, session))| {
                             render_pill(*index, session, Some(visible_count + display_idx))
                         }).collect::<Html>()
                     } else {

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -10,8 +10,8 @@ use uuid::Uuid;
 /// Key is question index, value is the selected answer(s)
 pub type QuestionAnswers = HashMap<usize, String>;
 
-/// Storage key for paused sessions in localStorage
-pub const PAUSED_SESSIONS_STORAGE_KEY: &str = "claude-portal-paused-sessions";
+/// Storage key for hidden sessions in localStorage
+pub const HIDDEN_SESSIONS_STORAGE_KEY: &str = "claude-portal-hidden-sessions";
 
 /// Storage key for inactive hidden state in localStorage
 pub const INACTIVE_HIDDEN_STORAGE_KEY: &str = "claude-portal-inactive-hidden";
@@ -121,22 +121,22 @@ pub fn save_show_cost(show: bool) {
     }
 }
 
-/// Load paused session IDs from localStorage
-pub fn load_paused_sessions() -> HashSet<Uuid> {
+/// Load hidden session IDs from localStorage
+pub fn load_hidden_sessions() -> HashSet<Uuid> {
     web_sys::window()
         .and_then(|w| w.local_storage().ok().flatten())
-        .and_then(|storage| storage.get_item(PAUSED_SESSIONS_STORAGE_KEY).ok().flatten())
+        .and_then(|storage| storage.get_item(HIDDEN_SESSIONS_STORAGE_KEY).ok().flatten())
         .and_then(|json| serde_json::from_str::<Vec<String>>(&json).ok())
         .map(|ids| ids.iter().filter_map(|s| Uuid::parse_str(s).ok()).collect())
         .unwrap_or_default()
 }
 
-/// Save paused session IDs to localStorage
-pub fn save_paused_sessions(paused: &HashSet<Uuid>) {
+/// Save hidden session IDs to localStorage
+pub fn save_hidden_sessions(hidden: &HashSet<Uuid>) {
     if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
-        let ids: Vec<String> = paused.iter().map(|id| id.to_string()).collect();
+        let ids: Vec<String> = hidden.iter().map(|id| id.to_string()).collect();
         if let Ok(json) = serde_json::to_string(&ids) {
-            let _ = storage.set_item(PAUSED_SESSIONS_STORAGE_KEY, &json);
+            let _ = storage.set_item(HIDDEN_SESSIONS_STORAGE_KEY, &json);
         }
     }
 }

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -86,7 +86,7 @@
     }
 
     .pill-stop,
-    .pill-pause,
+    .pill-hide,
     .pill-leave,
     .pill-delete {
         width: 20px;
@@ -99,7 +99,7 @@
         padding: 0.1rem 0.3rem;
     }
 
-    .pill-paused-badge {
+    .pill-hidden-badge {
         font-size: 0.6rem;
     }
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -220,8 +220,8 @@
 .sparkline-range.tick-compaction { background: var(--text-secondary); }
 .sparkline-range.tick-task { background: #bb9af7; }
 
-.session-pill.paused .sparkline-tick,
-.session-pill.paused .sparkline-range {
+.session-pill.hidden .sparkline-tick,
+.session-pill.hidden .sparkline-range {
     opacity: 0.2;
 }
 
@@ -262,36 +262,36 @@
     color: var(--text-secondary);
 }
 
-/* Paused session styling - more greyed out, no awaiting highlight */
-.session-pill.paused {
+/* Hidden session styling - more greyed out, no awaiting highlight */
+.session-pill.hidden {
     opacity: 0.35;
     border-style: dashed;
     filter: grayscale(50%);
 }
 
-.session-pill.paused:hover {
+.session-pill.hidden:hover {
     opacity: 0.55;
     filter: grayscale(30%);
 }
 
-.session-pill.paused.focused {
+.session-pill.hidden.focused {
     opacity: 0.5;
     filter: grayscale(40%);
 }
 
-/* Paused sessions should NOT show awaiting (red) highlighting */
-.session-pill.paused.awaiting {
+/* Hidden sessions should NOT show awaiting (red) highlighting */
+.session-pill.hidden.awaiting {
     border-color: var(--border);
     animation: none;
     box-shadow: none;
 }
 
-.session-pill.paused.focused.awaiting {
+.session-pill.hidden.focused.awaiting {
     border-color: var(--text-secondary);
     background: rgba(127, 132, 156, 0.15);
 }
 
-.pill-paused-badge {
+.pill-hidden-badge {
     font-size: 0.7rem;
     color: var(--text-secondary);
     font-weight: 600;
@@ -409,11 +409,11 @@
     font-weight: 600;
 }
 
-.pill-menu-option.pause.active {
+.pill-menu-option.hide.active {
     color: var(--success);
 }
 
-.pill-menu-option.pause.active:hover {
+.pill-menu-option.hide.active:hover {
     background: rgba(158, 206, 106, 0.15);
 }
 


### PR DESCRIPTION
## Summary
- Renames all "pause/unpause" terminology to "hide/show" across the codebase
- Updates Rust identifiers, CSS classes, UI strings, localStorage keys, and docs
- Version bump to 2.0.24

## Changes
- `paused_sessions` → `hidden_sessions` (state, props, config fields)
- `on_toggle_pause` → `on_toggle_hidden` (callbacks)
- `is_paused` → `is_hidden` (local variables)
- CSS classes: `.paused` → `.hidden`, `.pill-paused-badge` → `.pill-hidden-badge`, `.pause.active` → `.hide.active`
- UI strings: "Pause Session" → "Hide Session", "Unpause Session" → "Show Session"
- localStorage key: `claude-portal-paused-sessions` → `claude-portal-hidden-sessions`
- Badge superscript: "ᴾ" → "ᴴ"

## Test plan
- [ ] Sessions can be hidden/shown via dropdown menu
- [ ] Hidden sessions are dimmed and excluded from keyboard rotation
- [ ] Hidden sessions section can be expanded/collapsed
- [ ] State persists across page reloads (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)