### PR TITLE
Add scheduled tasks foundation (phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.0.24"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.0.24"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.0.24"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.0.24"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.0.24"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.0.24"
+version = "2.1.0"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3128,7 +3128,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.0.24"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.0.24"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.0.24"
+version = "2.1.0"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.0.24"
+version = "2.1.0"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/2026-03-10-210000_add_scheduled_tasks/down.sql
+++ b/backend/migrations/2026-03-10-210000_add_scheduled_tasks/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sessions DROP COLUMN scheduled_task_id;
+DROP TABLE IF EXISTS scheduled_tasks;

--- a/backend/migrations/2026-03-10-210000_add_scheduled_tasks/up.sql
+++ b/backend/migrations/2026-03-10-210000_add_scheduled_tasks/up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE scheduled_tasks (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID NOT NULL REFERENCES users(id),
+    name            VARCHAR(255) NOT NULL,
+    cron_expression VARCHAR(128) NOT NULL,
+    timezone        VARCHAR(64) NOT NULL DEFAULT 'UTC',
+    hostname        VARCHAR(255),
+    working_directory TEXT NOT NULL,
+    prompt          TEXT NOT NULL,
+    claude_args     JSONB NOT NULL DEFAULT '[]',
+    agent_type      VARCHAR(16) NOT NULL DEFAULT 'claude',
+    enabled         BOOLEAN NOT NULL DEFAULT true,
+    max_runtime_minutes INTEGER NOT NULL DEFAULT 30,
+    last_session_id UUID REFERENCES sessions(id) ON DELETE SET NULL,
+    last_run_at     TIMESTAMP,
+    next_run_at     TIMESTAMP,
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_scheduled_tasks_user_id ON scheduled_tasks(user_id);
+
+ALTER TABLE sessions ADD COLUMN scheduled_task_id UUID REFERENCES scheduled_tasks(id) ON DELETE SET NULL;

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod launchers;
 pub mod messages;
 pub mod proxy_tokens;
 pub mod retention;
+pub mod scheduled_tasks;
 pub mod sessions;
 pub mod sound_settings;
 pub mod voice;

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -1,0 +1,411 @@
+//! Scheduled Task Management Handlers
+//!
+//! CRUD endpoints for managing scheduled (cron) tasks.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use diesel::prelude::*;
+use shared::api::{
+    CreateScheduledTaskRequest, ScheduledTaskInfo, ScheduledTaskListResponse,
+    UpdateScheduledTaskRequest,
+};
+use shared::{AgentType, ScheduledTaskConfig, ServerToLauncher};
+use std::sync::Arc;
+use tower_cookies::Cookies;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use crate::{
+    models::{NewScheduledTask, ScheduledTask},
+    schema::scheduled_tasks,
+    AppState,
+};
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+/// Extract user_id from session cookie (same pattern as proxy_tokens)
+async fn get_user_id_from_session(
+    app_state: &AppState,
+    cookies: &Cookies,
+) -> Result<Uuid, StatusCode> {
+    if app_state.dev_mode {
+        let mut conn = app_state
+            .db_pool
+            .get()
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        use crate::schema::users;
+        let user: crate::models::User = users::table
+            .filter(users::email.eq("testing@testing.local"))
+            .first(&mut conn)
+            .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+        return Ok(user.id);
+    }
+
+    let session_cookie = cookies
+        .signed(&app_state.cookie_key)
+        .get(shared::protocol::SESSION_COOKIE_NAME)
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    session_cookie
+        .value()
+        .parse()
+        .map_err(|_| StatusCode::UNAUTHORIZED)
+}
+
+/// Convert a ScheduledTask model to a ScheduledTaskInfo API response.
+fn task_to_info(t: ScheduledTask) -> ScheduledTaskInfo {
+    ScheduledTaskInfo {
+        id: t.id,
+        name: t.name,
+        cron_expression: t.cron_expression,
+        timezone: t.timezone,
+        hostname: t.hostname,
+        working_directory: t.working_directory,
+        prompt: t.prompt,
+        claude_args: serde_json::from_value(t.claude_args).unwrap_or_default(),
+        agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
+        enabled: t.enabled,
+        max_runtime_minutes: t.max_runtime_minutes,
+        last_session_id: t.last_session_id,
+        last_run_at: t.last_run_at.map(|dt| dt.and_utc().to_rfc3339()),
+        next_run_at: t.next_run_at.map(|dt| dt.and_utc().to_rfc3339()),
+        created_at: t.created_at.and_utc().to_rfc3339(),
+        updated_at: t.updated_at.and_utc().to_rfc3339(),
+    }
+}
+
+/// Convert a ScheduledTask model to a ScheduledTaskConfig protocol message.
+fn task_to_config(t: &ScheduledTask) -> ScheduledTaskConfig {
+    ScheduledTaskConfig {
+        id: t.id,
+        name: t.name.clone(),
+        cron_expression: t.cron_expression.clone(),
+        timezone: t.timezone.clone(),
+        working_directory: t.working_directory.clone(),
+        prompt: t.prompt.clone(),
+        claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
+        agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
+        enabled: t.enabled,
+        max_runtime_minutes: t.max_runtime_minutes,
+        last_session_id: t.last_session_id,
+    }
+}
+
+/// Send ScheduleSync to all connected launchers for a user.
+/// Filters tasks by launcher hostname.
+fn send_schedule_sync(app_state: &AppState, user_id: Uuid) {
+    let tasks: Vec<ScheduledTask> = match app_state.db_pool.get() {
+        Ok(mut conn) => scheduled_tasks::table
+            .filter(scheduled_tasks::user_id.eq(user_id))
+            .filter(scheduled_tasks::enabled.eq(true))
+            .load(&mut conn)
+            .unwrap_or_default(),
+        Err(e) => {
+            error!("Failed to get DB connection for ScheduleSync: {}", e);
+            return;
+        }
+    };
+
+    let launchers = app_state.session_manager.get_launchers_for_user(&user_id);
+    for launcher in launchers {
+        let filtered: Vec<ScheduledTaskConfig> = tasks
+            .iter()
+            .filter(|t| t.hostname.is_none() || t.hostname.as_deref() == Some(&launcher.hostname))
+            .map(task_to_config)
+            .collect();
+
+        if app_state.session_manager.send_to_launcher(
+            &launcher.launcher_id,
+            ServerToLauncher::ScheduleSync { tasks: filtered },
+        ) {
+            info!(
+                "Sent ScheduleSync to launcher '{}' ({})",
+                launcher.launcher_name, launcher.launcher_id
+            );
+        }
+    }
+}
+
+// ============================================================================
+// Core handlers
+// ============================================================================
+
+/// GET /api/scheduled-tasks
+async fn list_tasks(
+    State(app_state): State<Arc<AppState>>,
+    user_id: Uuid,
+) -> Result<Json<ScheduledTaskListResponse>, StatusCode> {
+    let mut conn = app_state
+        .db_pool
+        .get()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let tasks: Vec<ScheduledTask> = scheduled_tasks::table
+        .filter(scheduled_tasks::user_id.eq(user_id))
+        .order(scheduled_tasks::created_at.desc())
+        .load(&mut conn)
+        .map_err(|e| {
+            error!("Failed to list scheduled tasks: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let infos: Vec<ScheduledTaskInfo> = tasks.into_iter().map(task_to_info).collect();
+    Ok(Json(ScheduledTaskListResponse { tasks: infos }))
+}
+
+/// POST /api/scheduled-tasks
+async fn create_task(
+    State(app_state): State<Arc<AppState>>,
+    user_id: Uuid,
+    Json(req): Json<CreateScheduledTaskRequest>,
+) -> Result<Json<ScheduledTaskInfo>, StatusCode> {
+    // Basic cron validation: must have 5 space-separated fields
+    let fields: Vec<&str> = req.cron_expression.split_whitespace().collect();
+    if fields.len() != 5 {
+        warn!("Invalid cron expression: {}", req.cron_expression);
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let mut conn = app_state
+        .db_pool
+        .get()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let new_task = NewScheduledTask {
+        user_id,
+        name: req.name,
+        cron_expression: req.cron_expression,
+        timezone: req.timezone,
+        hostname: req.hostname,
+        working_directory: req.working_directory,
+        prompt: req.prompt,
+        claude_args: serde_json::to_value(req.claude_args).unwrap_or_default(),
+        agent_type: req.agent_type.as_str().to_string(),
+        max_runtime_minutes: req.max_runtime_minutes,
+    };
+
+    let saved: ScheduledTask = diesel::insert_into(scheduled_tasks::table)
+        .values(&new_task)
+        .get_result(&mut conn)
+        .map_err(|e| {
+            error!("Failed to create scheduled task: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    info!("Created scheduled task '{}' ({})", saved.name, saved.id);
+
+    // Notify connected launchers
+    send_schedule_sync(&app_state, user_id);
+
+    Ok(Json(task_to_info(saved)))
+}
+
+/// PATCH /api/scheduled-tasks/:id
+async fn update_task(
+    State(app_state): State<Arc<AppState>>,
+    user_id: Uuid,
+    Path(task_id): Path<Uuid>,
+    Json(req): Json<UpdateScheduledTaskRequest>,
+) -> Result<Json<ScheduledTaskInfo>, StatusCode> {
+    let mut conn = app_state
+        .db_pool
+        .get()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Verify ownership
+    let existing: ScheduledTask = scheduled_tasks::table
+        .filter(scheduled_tasks::id.eq(task_id))
+        .filter(scheduled_tasks::user_id.eq(user_id))
+        .first(&mut conn)
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+
+    // Validate cron if provided
+    if let Some(ref cron) = req.cron_expression {
+        let fields: Vec<&str> = cron.split_whitespace().collect();
+        if fields.len() != 5 {
+            warn!("Invalid cron expression in update: {}", cron);
+            return Err(StatusCode::BAD_REQUEST);
+        }
+    }
+
+    // Apply updates field by field (load-modify-save pattern)
+    let name = req.name.unwrap_or(existing.name);
+    let cron_expression = req.cron_expression.unwrap_or(existing.cron_expression);
+    let timezone = req.timezone.unwrap_or(existing.timezone);
+    let hostname = match req.hostname {
+        Some(h) => h,
+        None => existing.hostname,
+    };
+    let working_directory = req.working_directory.unwrap_or(existing.working_directory);
+    let prompt = req.prompt.unwrap_or(existing.prompt);
+    let claude_args = req
+        .claude_args
+        .map(|args| serde_json::to_value(args).unwrap_or_default())
+        .unwrap_or(existing.claude_args);
+    let agent_type = req
+        .agent_type
+        .map(|at| at.as_str().to_string())
+        .unwrap_or(existing.agent_type);
+    let enabled = req.enabled.unwrap_or(existing.enabled);
+    let max_runtime_minutes = req
+        .max_runtime_minutes
+        .unwrap_or(existing.max_runtime_minutes);
+
+    let updated: ScheduledTask = diesel::update(
+        scheduled_tasks::table
+            .filter(scheduled_tasks::id.eq(task_id))
+            .filter(scheduled_tasks::user_id.eq(user_id)),
+    )
+    .set((
+        scheduled_tasks::name.eq(&name),
+        scheduled_tasks::cron_expression.eq(&cron_expression),
+        scheduled_tasks::timezone.eq(&timezone),
+        scheduled_tasks::hostname.eq(&hostname),
+        scheduled_tasks::working_directory.eq(&working_directory),
+        scheduled_tasks::prompt.eq(&prompt),
+        scheduled_tasks::claude_args.eq(&claude_args),
+        scheduled_tasks::agent_type.eq(&agent_type),
+        scheduled_tasks::enabled.eq(enabled),
+        scheduled_tasks::max_runtime_minutes.eq(max_runtime_minutes),
+        scheduled_tasks::updated_at.eq(diesel::dsl::now),
+    ))
+    .get_result(&mut conn)
+    .map_err(|e| {
+        error!("Failed to update scheduled task: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    info!("Updated scheduled task '{}' ({})", updated.name, updated.id);
+
+    // Notify connected launchers
+    send_schedule_sync(&app_state, user_id);
+
+    Ok(Json(task_to_info(updated)))
+}
+
+/// DELETE /api/scheduled-tasks/:id
+async fn delete_task(
+    State(app_state): State<Arc<AppState>>,
+    user_id: Uuid,
+    Path(task_id): Path<Uuid>,
+) -> Result<StatusCode, StatusCode> {
+    let mut conn = app_state
+        .db_pool
+        .get()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Verify ownership
+    let task: ScheduledTask = scheduled_tasks::table
+        .filter(scheduled_tasks::id.eq(task_id))
+        .filter(scheduled_tasks::user_id.eq(user_id))
+        .first(&mut conn)
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+
+    // Clear scheduled_task_id on any sessions referencing this task
+    use crate::schema::sessions;
+    let _ = diesel::update(sessions::table.filter(sessions::scheduled_task_id.eq(task_id)))
+        .set(sessions::scheduled_task_id.eq(None::<Uuid>))
+        .execute(&mut conn);
+
+    diesel::delete(scheduled_tasks::table.filter(scheduled_tasks::id.eq(task_id)))
+        .execute(&mut conn)
+        .map_err(|e| {
+            error!("Failed to delete scheduled task: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    info!("Deleted scheduled task '{}' ({})", task.name, task_id);
+
+    // Notify connected launchers
+    send_schedule_sync(&app_state, user_id);
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// GET /api/scheduled-tasks/:id/runs
+async fn list_runs(
+    State(app_state): State<Arc<AppState>>,
+    user_id: Uuid,
+    Path(task_id): Path<Uuid>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let mut conn = app_state
+        .db_pool
+        .get()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Verify task ownership
+    let _task: ScheduledTask = scheduled_tasks::table
+        .filter(scheduled_tasks::id.eq(task_id))
+        .filter(scheduled_tasks::user_id.eq(user_id))
+        .first(&mut conn)
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+
+    use crate::schema::sessions;
+    let runs: Vec<crate::models::Session> = sessions::table
+        .filter(sessions::scheduled_task_id.eq(task_id))
+        .order(sessions::created_at.desc())
+        .limit(50)
+        .load(&mut conn)
+        .map_err(|e| {
+            error!("Failed to list runs for task {}: {}", task_id, e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(serde_json::to_value(runs).unwrap_or_default()))
+}
+
+// ============================================================================
+// Wrapper handlers (extract user_id from session cookie)
+// ============================================================================
+
+pub async fn list_tasks_handler(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+) -> Result<Json<ScheduledTaskListResponse>, StatusCode> {
+    let user_id = get_user_id_from_session(&app_state, &cookies).await?;
+    list_tasks(State(app_state), user_id).await
+}
+
+pub async fn create_task_handler(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Json(req): Json<CreateScheduledTaskRequest>,
+) -> Result<Json<ScheduledTaskInfo>, StatusCode> {
+    let user_id = get_user_id_from_session(&app_state, &cookies).await?;
+    create_task(State(app_state), user_id, Json(req)).await
+}
+
+pub async fn update_task_handler(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path(task_id): Path<Uuid>,
+    Json(req): Json<UpdateScheduledTaskRequest>,
+) -> Result<Json<ScheduledTaskInfo>, StatusCode> {
+    let user_id = get_user_id_from_session(&app_state, &cookies).await?;
+    update_task(State(app_state), user_id, Path(task_id), Json(req)).await
+}
+
+pub async fn delete_task_handler(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path(task_id): Path<Uuid>,
+) -> Result<StatusCode, StatusCode> {
+    let user_id = get_user_id_from_session(&app_state, &cookies).await?;
+    delete_task(State(app_state), user_id, Path(task_id)).await
+}
+
+pub async fn list_runs_handler(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path(task_id): Path<Uuid>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let user_id = get_user_id_from_session(&app_state, &cookies).await?;
+    list_runs(State(app_state), user_id, Path(task_id)).await
+}

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -1,5 +1,9 @@
 use axum::extract::ws::WebSocket;
-use shared::{LauncherEndpoint, LauncherToServer, ServerToClient, ServerToLauncher};
+use diesel::prelude::*;
+use shared::{
+    AgentType, LauncherEndpoint, LauncherToServer, ScheduledTaskConfig, ServerToClient,
+    ServerToLauncher, ServerToProxy,
+};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -130,6 +134,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
 
     // Create channel for sending messages to this launcher
     let (tx, mut rx) = mpsc::unbounded_channel::<ServerToLauncher>();
+    let tx_for_sync = tx.clone();
 
     app_state.session_manager.register_launcher(
         launcher_id,
@@ -147,6 +152,52 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
         "Launcher '{}' registered for user {}",
         launcher_name, user_id
     );
+
+    // Send initial ScheduleSync with the user's scheduled tasks
+    if let Ok(mut db_conn) = app_state.db_pool.get() {
+        use crate::schema::scheduled_tasks;
+        let launcher_hostname = app_state
+            .session_manager
+            .launchers
+            .get(&launcher_id)
+            .map(|l| l.hostname.clone())
+            .unwrap_or_default();
+
+        let tasks: Vec<crate::models::ScheduledTask> = scheduled_tasks::table
+            .filter(scheduled_tasks::user_id.eq(user_id))
+            .filter(scheduled_tasks::enabled.eq(true))
+            .load(&mut db_conn)
+            .unwrap_or_default();
+
+        let task_configs: Vec<ScheduledTaskConfig> = tasks
+            .iter()
+            .filter(|t| t.hostname.is_none() || t.hostname.as_deref() == Some(&launcher_hostname))
+            .map(|t| ScheduledTaskConfig {
+                id: t.id,
+                name: t.name.clone(),
+                cron_expression: t.cron_expression.clone(),
+                timezone: t.timezone.clone(),
+                working_directory: t.working_directory.clone(),
+                prompt: t.prompt.clone(),
+                claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
+                agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
+                enabled: t.enabled,
+                max_runtime_minutes: t.max_runtime_minutes,
+                last_session_id: t.last_session_id,
+            })
+            .collect();
+
+        if !task_configs.is_empty() {
+            let count = task_configs.len();
+            let _ = tx_for_sync.send(ServerToLauncher::ScheduleSync {
+                tasks: task_configs,
+            });
+            info!(
+                "Sent initial ScheduleSync with {} tasks to launcher '{}'",
+                count, launcher_name
+            );
+        }
+    }
 
     // Main message loop
     loop {
@@ -294,6 +345,89 @@ fn handle_launcher_message(
                     );
                 }
             }
+        }
+        LauncherToServer::InjectInput {
+            session_id,
+            content,
+        } => {
+            info!(
+                "InjectInput for session {} from launcher {}",
+                session_id, launcher_id
+            );
+            let session_key = session_id.to_string();
+            let content_value = serde_json::Value::String(content);
+
+            // Set sender attribution to "Scheduler"
+            app_state
+                .session_manager
+                .last_input_sender
+                .insert(session_id, (user_id, "Scheduler".to_string()));
+
+            // Sequence and send (same pipeline as web client input)
+            if let Ok(mut db_conn) = app_state.db_pool.get() {
+                use crate::schema::{pending_inputs, sessions};
+
+                let next_seq: i64 = diesel::update(sessions::table.find(session_id))
+                    .set(sessions::input_seq.eq(sessions::input_seq + 1))
+                    .returning(sessions::input_seq)
+                    .get_result(&mut db_conn)
+                    .unwrap_or(0);
+
+                if next_seq > 0 {
+                    let new_input = crate::models::NewPendingInput {
+                        session_id,
+                        seq_num: next_seq,
+                        content: serde_json::to_string(&content_value).unwrap_or_default(),
+                    };
+                    let _ = diesel::insert_into(pending_inputs::table)
+                        .values(&new_input)
+                        .execute(&mut db_conn);
+
+                    app_state.session_manager.send_to_session(
+                        &session_key,
+                        ServerToProxy::SequencedInput {
+                            session_id,
+                            seq: next_seq,
+                            content: content_value,
+                            send_mode: None,
+                        },
+                    );
+                }
+            }
+        }
+        LauncherToServer::ScheduledRunStarted {
+            task_id,
+            session_id,
+        } => {
+            info!(
+                "Scheduled run started: task={}, session={}",
+                task_id, session_id
+            );
+            if let Ok(mut db_conn) = app_state.db_pool.get() {
+                use crate::schema::scheduled_tasks;
+                let _ = diesel::update(
+                    scheduled_tasks::table
+                        .filter(scheduled_tasks::id.eq(task_id))
+                        .filter(scheduled_tasks::user_id.eq(user_id)),
+                )
+                .set((
+                    scheduled_tasks::last_run_at.eq(diesel::dsl::now),
+                    scheduled_tasks::last_session_id.eq(session_id),
+                    scheduled_tasks::updated_at.eq(diesel::dsl::now),
+                ))
+                .execute(&mut db_conn);
+            }
+        }
+        LauncherToServer::ScheduledRunCompleted {
+            task_id,
+            session_id,
+            exit_code,
+            duration_secs,
+        } => {
+            info!(
+                "Scheduled run completed: task={}, session={}, exit={:?}, duration={}s",
+                task_id, session_id, exit_code, duration_secs
+            );
         }
         LauncherToServer::LauncherRegister { .. } => {}
     }

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -112,6 +112,7 @@ fn handle_proxy_message(
             launcher_id,
             agent_type,
             repo_url,
+            scheduled_task_id,
         }) => {
             let key = claude_session_id.to_string();
             *session_key = Some(key.clone());
@@ -133,6 +134,7 @@ fn handle_proxy_message(
                 launcher_id,
                 agent_type,
                 repo_url: &repo_url,
+                scheduled_task_id,
             };
             let result = register_or_update_session(app_state, &params);
 

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -27,6 +27,7 @@ pub struct RegistrationParams<'a> {
     pub launcher_id: Option<Uuid>,
     pub agent_type: AgentType,
     pub repo_url: &'a Option<String>,
+    pub scheduled_task_id: Option<Uuid>,
 }
 
 /// Register or update a session in the database.
@@ -149,6 +150,7 @@ fn create_new_session(
         launcher_id: params.launcher_id,
         agent_type: params.agent_type.as_str().to_string(),
         repo_url: params.repo_url.clone(),
+        scheduled_task_id: params.scheduled_task_id,
     };
 
     match diesel::insert_into(sessions::table)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -346,6 +346,21 @@ async fn main() -> anyhow::Result<()> {
             "/api/proxy-tokens/:id",
             axum::routing::delete(handlers::proxy_tokens::revoke_token_handler),
         )
+        // Scheduled task management endpoints
+        .route(
+            "/api/scheduled-tasks",
+            get(handlers::scheduled_tasks::list_tasks_handler)
+                .post(handlers::scheduled_tasks::create_task_handler),
+        )
+        .route(
+            "/api/scheduled-tasks/:id",
+            axum::routing::patch(handlers::scheduled_tasks::update_task_handler)
+                .delete(handlers::scheduled_tasks::delete_task_handler),
+        )
+        .route(
+            "/api/scheduled-tasks/:id/runs",
+            get(handlers::scheduled_tasks::list_runs_handler),
+        )
         // Sound settings
         .route(
             "/api/settings/sound",

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -56,6 +56,7 @@ pub struct Session {
     pub pr_url: Option<String>,
     pub agent_type: String,
     pub repo_url: Option<String>,
+    pub scheduled_task_id: Option<Uuid>,
 }
 
 #[derive(Debug, Insertable)]
@@ -85,6 +86,7 @@ pub struct NewSessionWithId {
     pub launcher_id: Option<Uuid>,
     pub agent_type: String,
     pub repo_url: Option<String>,
+    pub scheduled_task_id: Option<Uuid>,
 }
 
 #[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]
@@ -222,4 +224,46 @@ pub struct NewPendingInput {
     pub session_id: Uuid,
     pub seq_num: i64,
     pub content: String,
+}
+
+// ============================================================================
+// Scheduled Task Models
+// ============================================================================
+
+#[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]
+#[diesel(table_name = crate::schema::scheduled_tasks)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ScheduledTask {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub name: String,
+    pub cron_expression: String,
+    pub timezone: String,
+    pub hostname: Option<String>,
+    pub working_directory: String,
+    pub prompt: String,
+    pub claude_args: serde_json::Value,
+    pub agent_type: String,
+    pub enabled: bool,
+    pub max_runtime_minutes: i32,
+    pub last_session_id: Option<Uuid>,
+    pub last_run_at: Option<NaiveDateTime>,
+    pub next_run_at: Option<NaiveDateTime>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = crate::schema::scheduled_tasks)]
+pub struct NewScheduledTask {
+    pub user_id: Uuid,
+    pub name: String,
+    pub cron_expression: String,
+    pub timezone: String,
+    pub hostname: Option<String>,
+    pub working_directory: String,
+    pub prompt: String,
+    pub claude_args: serde_json::Value,
+    pub agent_type: String,
+    pub max_runtime_minutes: i32,
 }

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -78,6 +78,33 @@ diesel::table! {
 }
 
 diesel::table! {
+    scheduled_tasks (id) {
+        id -> Uuid,
+        user_id -> Uuid,
+        #[max_length = 255]
+        name -> Varchar,
+        #[max_length = 128]
+        cron_expression -> Varchar,
+        #[max_length = 64]
+        timezone -> Varchar,
+        #[max_length = 255]
+        hostname -> Nullable<Varchar>,
+        working_directory -> Text,
+        prompt -> Text,
+        claude_args -> Jsonb,
+        #[max_length = 16]
+        agent_type -> Varchar,
+        enabled -> Bool,
+        max_runtime_minutes -> Int4,
+        last_session_id -> Nullable<Uuid>,
+        last_run_at -> Nullable<Timestamp>,
+        next_run_at -> Nullable<Timestamp>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     sessions (id) {
         id -> Uuid,
         user_id -> Uuid,
@@ -110,6 +137,7 @@ diesel::table! {
         agent_type -> Varchar,
         #[max_length = 512]
         repo_url -> Nullable<Varchar>,
+        scheduled_task_id -> Nullable<Uuid>,
     }
 }
 
@@ -139,6 +167,7 @@ diesel::joinable!(messages -> users (user_id));
 diesel::joinable!(pending_inputs -> sessions (session_id));
 diesel::joinable!(pending_permission_requests -> sessions (session_id));
 diesel::joinable!(proxy_auth_tokens -> users (user_id));
+diesel::joinable!(scheduled_tasks -> users (user_id));
 diesel::joinable!(session_members -> sessions (session_id));
 diesel::joinable!(session_members -> users (user_id));
 diesel::joinable!(sessions -> users (user_id));
@@ -149,6 +178,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     pending_inputs,
     pending_permission_requests,
     proxy_auth_tokens,
+    scheduled_tasks,
     session_members,
     sessions,
     users,

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -47,6 +47,8 @@ pub struct ProxySessionConfig {
     pub launcher_id: Option<Uuid>,
     /// Which agent CLI to use
     pub agent_type: shared::AgentType,
+    /// If this session was started by a scheduled task
+    pub scheduled_task_id: Option<Uuid>,
 }
 
 /// Exponential backoff helper
@@ -512,6 +514,7 @@ async fn register_session(
         launcher_id: config.launcher_id,
         agent_type: config.agent_type,
         repo_url: get_repo_url(&config.working_directory),
+        scheduled_task_id: config.scheduled_task_id,
     });
 
     if conn.send(register_msg).await.is_err() {

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -49,6 +49,7 @@ pub fn connect_websocket(
                     launcher_id: None,
                     agent_type: Default::default(),
                     repo_url: None,
+                    scheduled_task_id: None,
                 });
 
                 if sender.send(register_msg).await.is_err() {

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -120,6 +120,7 @@ impl ProcessManager {
             replaces_session_id: None,
             launcher_id: self.launcher_id,
             agent_type,
+            scheduled_task_id: None,
         };
 
         let exit_tx = self.exit_tx.clone();

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -396,6 +396,7 @@ async fn main() -> Result<()> {
         replaces_session_id: None,
         launcher_id: None,
         agent_type,
+        scheduled_task_id: None,
     };
 
     // Branch: shim mode or normal proxy mode

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -99,6 +99,7 @@ pub async fn register_with_backend(
         launcher_id: config.launcher_id,
         agent_type: config.agent_type,
         repo_url: get_repo_url(&config.working_directory),
+        scheduled_task_id: config.scheduled_task_id,
     });
 
     if let Err(e) = conn.send(&register_msg).await {

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -194,6 +194,89 @@ pub struct SoundSettingsResponse {
     pub sound_config: Option<serde_json::Value>,
 }
 
+// =============================================================================
+// Scheduled Tasks API Types
+// =============================================================================
+
+/// Request to create a scheduled task
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateScheduledTaskRequest {
+    pub name: String,
+    pub cron_expression: String,
+    #[serde(default = "default_timezone")]
+    pub timezone: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    pub working_directory: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub claude_args: Vec<String>,
+    #[serde(default)]
+    pub agent_type: crate::AgentType,
+    #[serde(default = "default_max_runtime")]
+    pub max_runtime_minutes: i32,
+}
+
+fn default_timezone() -> String {
+    "UTC".to_string()
+}
+
+fn default_max_runtime() -> i32 {
+    30
+}
+
+/// Request to update a scheduled task (all fields optional)
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UpdateScheduledTaskRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cron_expression: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<Option<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_directory: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_args: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_type: Option<crate::AgentType>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_runtime_minutes: Option<i32>,
+}
+
+/// Info about a scheduled task (returned by list/create endpoints)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduledTaskInfo {
+    pub id: uuid::Uuid,
+    pub name: String,
+    pub cron_expression: String,
+    pub timezone: String,
+    pub hostname: Option<String>,
+    pub working_directory: String,
+    pub prompt: String,
+    pub claude_args: Vec<String>,
+    pub agent_type: crate::AgentType,
+    pub enabled: bool,
+    pub max_runtime_minutes: i32,
+    pub last_session_id: Option<uuid::Uuid>,
+    pub last_run_at: Option<String>,
+    pub next_run_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Response listing scheduled tasks
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduledTaskListResponse {
+    pub tasks: Vec<ScheduledTaskInfo>,
+}
+
 /// API endpoint definitions
 pub mod endpoints {
     pub const HEALTH: &str = "/";
@@ -204,6 +287,7 @@ pub mod endpoints {
     pub const DEVICE_CODE: &str = "/auth/device/code";
     pub const DEVICE_POLL: &str = "/auth/device/poll";
     pub const SOUND_SETTINGS: &str = "/api/settings/sound";
+    pub const SCHEDULED_TASKS: &str = "/api/scheduled-tasks";
 
     pub fn session(id: &str) -> String {
         format!("/api/sessions/{}", id)

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -35,6 +35,27 @@ pub struct RegisterFields {
     pub agent_type: AgentType,
     #[serde(default)]
     pub repo_url: Option<String>,
+    #[serde(default)]
+    pub scheduled_task_id: Option<Uuid>,
+}
+
+/// Configuration for a scheduled task, sent from backend to launcher via ScheduleSync.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduledTaskConfig {
+    pub id: Uuid,
+    pub name: String,
+    pub cron_expression: String,
+    pub timezone: String,
+    pub working_directory: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub claude_args: Vec<String>,
+    #[serde(default)]
+    pub agent_type: AgentType,
+    pub enabled: bool,
+    pub max_runtime_minutes: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_session_id: Option<Uuid>,
 }
 
 /// Fields for a permission response (shared by server-to-proxy and client-to-server).
@@ -374,6 +395,20 @@ pub enum LauncherToServer {
         #[serde(default)]
         agent_type: AgentType,
     },
+
+    /// Inject input into a session on behalf of the scheduler
+    InjectInput { session_id: Uuid, content: String },
+
+    /// Report that a scheduled task run has started
+    ScheduledRunStarted { task_id: Uuid, session_id: Uuid },
+
+    /// Report that a scheduled task run has completed
+    ScheduledRunCompleted {
+        task_id: Uuid,
+        session_id: Uuid,
+        exit_code: Option<i32>,
+        duration_secs: u64,
+    },
 }
 
 /// Messages the backend sends to the launcher.
@@ -416,6 +451,9 @@ pub enum ServerToLauncher {
         reason: String,
         reconnect_delay_ms: u64,
     },
+
+    /// Sync scheduled task definitions to the launcher
+    ScheduleSync { tasks: Vec<ScheduledTaskConfig> },
 }
 
 #[cfg(test)]
@@ -453,6 +491,7 @@ mod tests {
             launcher_id: None,
             agent_type: AgentType::Claude,
             repo_url: None,
+            scheduled_task_id: None,
         });
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"Register""#));
@@ -629,5 +668,69 @@ mod tests {
             }
             _ => panic!("Wrong variant"),
         }
+    }
+
+    #[test]
+    fn schedule_sync_roundtrip() {
+        let msg = ServerToLauncher::ScheduleSync {
+            tasks: vec![ScheduledTaskConfig {
+                id: Uuid::nil(),
+                name: "nightly audit".into(),
+                cron_expression: "0 3 * * *".into(),
+                timezone: "UTC".into(),
+                working_directory: "/home/user/project".into(),
+                prompt: "Check deps".into(),
+                claude_args: vec![],
+                agent_type: AgentType::Claude,
+                enabled: true,
+                max_runtime_minutes: 30,
+                last_session_id: None,
+            }],
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"ScheduleSync""#));
+        let parsed: ServerToLauncher = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ServerToLauncher::ScheduleSync { tasks } => {
+                assert_eq!(tasks.len(), 1);
+                assert_eq!(tasks[0].name, "nightly audit");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn inject_input_roundtrip() {
+        let msg = LauncherToServer::InjectInput {
+            session_id: Uuid::nil(),
+            content: "Check for updates".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"InjectInput""#));
+        let _: LauncherToServer = serde_json::from_str(&json).unwrap();
+    }
+
+    #[test]
+    fn scheduled_run_started_roundtrip() {
+        let msg = LauncherToServer::ScheduledRunStarted {
+            task_id: Uuid::nil(),
+            session_id: Uuid::nil(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"ScheduledRunStarted""#));
+        let _: LauncherToServer = serde_json::from_str(&json).unwrap();
+    }
+
+    #[test]
+    fn scheduled_run_completed_roundtrip() {
+        let msg = LauncherToServer::ScheduledRunCompleted {
+            task_id: Uuid::nil(),
+            session_id: Uuid::nil(),
+            exit_code: Some(0),
+            duration_secs: 120,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"ScheduledRunCompleted""#));
+        let _: LauncherToServer = serde_json::from_str(&json).unwrap();
     }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -211,6 +211,9 @@ pub struct SessionInfo {
     /// Proxy client version string (e.g. "1.3.39")
     #[serde(default)]
     pub client_version: Option<String>,
+    /// Scheduled task ID if this session was spawned by a scheduled task
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduled_task_id: Option<Uuid>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- **Database migration**: `scheduled_tasks` table with cron expression, timezone, hostname pinning, and prompt fields; `scheduled_task_id` FK on `sessions`
- **Protocol types**: `ScheduledTaskConfig`, `ScheduleSync` (server→launcher), `InjectInput`/`ScheduledRunStarted`/`ScheduledRunCompleted` (launcher→server) with serde roundtrip tests
- **Backend CRUD API**: `GET/POST/PATCH/DELETE /api/scheduled-tasks` with ownership enforcement and automatic `ScheduleSync` push to connected launchers
- **Launcher socket**: sends `ScheduleSync` on connect (filtered by hostname), handles `InjectInput` (reuses sequenced input pipeline), tracks run lifecycle
- **Registration plumbing**: `scheduled_task_id` flows through `RegisterFields` → `RegistrationParams` → `NewSessionWithId` → DB
- **Version bump**: 2.0.24 → 2.1.0

This is the foundation layer for scheduled tasks (cron jobs). Phase 2 will add the launcher-side scheduler, and phase 3 the frontend UI.

## Test plan
- [x] `cargo check -p backend` passes (no code errors)
- [x] `cargo build` succeeds for all non-backend crates
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --workspace` — all 88 tests pass (including 4 new serde roundtrip tests)
- [x] `cargo build --target wasm32-unknown-unknown -p shared` — WASM compat verified
- [x] Migration naming convention check passes
- [ ] CI builds with libpq-dev (backend linking)
- [ ] Run migration against test DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)