### PR TITLE
Add launcher scheduler for scheduled tasks (phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,12 +10,14 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "chrono",
+ "chrono-tz",
  "clap",
  "claude-session-lib",
+ "croner",
  "dirs",
  "hostname",
  "portal-auth",
@@ -451,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -675,6 +677,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -765,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -787,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -962,6 +974,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1100,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1365,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3060,12 +3114,30 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3128,7 +3200,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "colored",
@@ -3143,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -4059,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -4181,6 +4253,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -4483,7 +4576,7 @@ dependencies = [
  "log",
  "parking_lot",
  "percent-encoding",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -60,6 +60,7 @@ pub async fn launch_session(
         session_name: None,
         claude_args: req.claude_args,
         agent_type: req.agent_type,
+        scheduled_task_id: None,
     };
 
     if !app_state

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -312,6 +312,7 @@ fn handle_launcher_message(
             session_name,
             claude_args,
             agent_type,
+            scheduled_task_id,
         } => {
             info!(
                 "Launcher requested launch: dir={}, name={:?}",
@@ -327,6 +328,7 @@ fn handle_launcher_message(
                         session_name,
                         claude_args,
                         agent_type,
+                        scheduled_task_id,
                     };
                     if !app_state
                         .session_manager

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -37,6 +37,10 @@ hostname = "0.4"
 
 # Time
 chrono = { workspace = true, features = ["std", "clock"] }
+chrono-tz = "0.10"
+
+# Cron expression parsing
+croner = "3"
 toml = "1.0.1"
 dirs = "6.0.0"
 portal-auth = { path = "../portal-auth" }

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -1,5 +1,6 @@
 use crate::config::{self, ExpectedSession};
-use crate::process_manager::{ProcessManager, SessionExited};
+use crate::process_manager::{ProcessManager, SessionExited, SpawnParams};
+use crate::scheduler::Scheduler;
 use shared::{LauncherEndpoint, LauncherToServer, ServerToLauncher};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
@@ -23,6 +24,7 @@ pub async fn run_launcher_loop(
 ) -> anyhow::Result<()> {
     process_manager.set_launcher_id(launcher_id);
     let mut backoff = Duration::from_secs(1);
+    let mut scheduler = Scheduler::new();
 
     loop {
         info!("Connecting to backend: {}", backend_url);
@@ -119,6 +121,7 @@ pub async fn run_launcher_loop(
                             session_name: expected.session_name.clone(),
                             claude_args: expected.claude_args.clone(),
                             agent_type: expected.agent_type,
+                            scheduled_task_id: None,
                         };
                         if ws_sender.send(request).await.is_err() {
                             warn!("Failed to send expected session launch request");
@@ -135,6 +138,17 @@ pub async fn run_launcher_loop(
                 let start = Instant::now();
 
                 loop {
+                    let sched_dur = scheduler
+                        .next_fire_duration()
+                        .unwrap_or(Duration::from_secs(3600));
+                    let prompt_dur = scheduler
+                        .next_prompt_duration()
+                        .unwrap_or(Duration::from_secs(3600));
+                    let sched_sleep = tokio::time::sleep(sched_dur);
+                    let prompt_sleep = tokio::time::sleep(prompt_dur);
+                    tokio::pin!(sched_sleep);
+                    tokio::pin!(prompt_sleep);
+
                     tokio::select! {
                         result = ws_receiver.recv() => {
                             match result {
@@ -144,6 +158,7 @@ pub async fn run_launcher_loop(
                                         &mut ws_sender,
                                         &mut process_manager,
                                         &mut expected_sessions,
+                                        &mut scheduler,
                                     ).await;
                                 }
                                 Some(Err(e)) => {
@@ -167,6 +182,11 @@ pub async fn run_launcher_loop(
                                 warn!("Failed to send heartbeat");
                                 break;
                             }
+
+                            // Enforce max runtime on scheduled sessions
+                            for session_id in scheduler.timed_out_sessions() {
+                                process_manager.stop(&session_id).await;
+                            }
                         }
 
                         Some(exited) = exit_rx.recv() => {
@@ -183,6 +203,20 @@ pub async fn run_launcher_loop(
                             if ws_sender.send(msg).await.is_err() {
                                 warn!("Failed to send session exited notification");
                                 break;
+                            }
+
+                            // Report scheduled run completion
+                            if let Some(run_info) = scheduler.on_session_exited(&exited.session_id) {
+                                let completed = LauncherToServer::ScheduledRunCompleted {
+                                    task_id: run_info.task_id,
+                                    session_id: exited.session_id,
+                                    exit_code: exited.exit_code,
+                                    duration_secs: run_info.started_at.elapsed().as_secs(),
+                                };
+                                if ws_sender.send(completed).await.is_err() {
+                                    warn!("Failed to send ScheduledRunCompleted");
+                                    break;
+                                }
                             }
 
                             if let Some(dir) = exited_dir {
@@ -231,10 +265,61 @@ pub async fn run_launcher_loop(
                                 session_name: session.session_name,
                                 claude_args: session.claude_args,
                                 agent_type: session.agent_type,
+                                scheduled_task_id: None,
                             };
                             if ws_sender.send(request).await.is_err() {
                                 warn!("Failed to send session restart request");
                                 break;
+                            }
+                        }
+
+                        // Scheduler: fire due tasks
+                        _ = &mut sched_sleep => {
+                            for task_to_fire in scheduler.fire_due_tasks() {
+                                info!(
+                                    "Firing scheduled task '{}' ({})",
+                                    task_to_fire.config.name, task_to_fire.config.id
+                                );
+                                let msg = LauncherToServer::RequestLaunch {
+                                    request_id: task_to_fire.request_id,
+                                    working_directory: task_to_fire.config.working_directory.clone(),
+                                    session_name: Some(task_to_fire.config.name.clone()),
+                                    claude_args: task_to_fire.config.claude_args.clone(),
+                                    agent_type: task_to_fire.config.agent_type,
+                                    scheduled_task_id: Some(task_to_fire.config.id),
+                                };
+                                if ws_sender.send(msg).await.is_err() {
+                                    warn!("Failed to send RequestLaunch for scheduled task");
+                                    break;
+                                }
+                            }
+                        }
+
+                        // Scheduler: send pending prompts after delay
+                        _ = &mut prompt_sleep => {
+                            for (session_id, task_id, content) in scheduler.ready_prompts() {
+                                info!(
+                                    "Injecting prompt for task {} into session {}",
+                                    task_id, session_id
+                                );
+
+                                let started = LauncherToServer::ScheduledRunStarted {
+                                    task_id,
+                                    session_id,
+                                };
+                                if ws_sender.send(started).await.is_err() {
+                                    warn!("Failed to send ScheduledRunStarted");
+                                    break;
+                                }
+
+                                let inject = LauncherToServer::InjectInput {
+                                    session_id,
+                                    content,
+                                };
+                                if ws_sender.send(inject).await.is_err() {
+                                    warn!("Failed to send InjectInput");
+                                    break;
+                                }
                             }
                         }
                     }
@@ -333,6 +418,7 @@ async fn handle_message(
     ws_sender: &mut ws_bridge::WsSender<LauncherToServer>,
     process_manager: &mut ProcessManager,
     expected_sessions: &mut Vec<ExpectedSession>,
+    scheduler: &mut Scheduler,
 ) {
     match msg {
         ServerToLauncher::LaunchSession {
@@ -344,38 +430,56 @@ async fn handle_message(
             agent_type,
             ..
         } => {
+            // Check if this is a scheduled launch
+            let (resume_session_id, scheduled_task_id, is_scheduled) = if let Some((
+                resume_id,
+                task_id,
+            )) =
+                scheduler.get_pending_launch_info(&request_id)
+            {
+                (resume_id, Some(task_id), true)
+            } else {
+                (None, None, false)
+            };
+
             info!(
-                "Launch request: dir={}, name={:?}, agent={}",
-                working_directory, session_name, agent_type
+                "Launch request: dir={}, name={:?}, agent={}, scheduled={}",
+                working_directory, session_name, agent_type, is_scheduled
             );
 
             let result = process_manager
-                .spawn(
-                    &auth_token,
-                    &working_directory,
-                    session_name.as_deref(),
-                    &claude_args,
+                .spawn(SpawnParams {
+                    auth_token,
+                    working_directory: working_directory.clone(),
+                    session_name: session_name.clone(),
+                    claude_args: claude_args.clone(),
                     agent_type,
-                )
+                    scheduled_task_id,
+                    resume_session_id,
+                })
                 .await;
 
             let response = match result {
                 Ok(session_id) => {
-                    // Persist so this session survives launcher restarts
-                    if !expected_sessions
-                        .iter()
-                        .any(|s| s.working_directory == working_directory)
-                    {
-                        let expected = ExpectedSession {
-                            working_directory: working_directory.clone(),
-                            session_name: session_name.clone(),
-                            agent_type,
-                            claude_args: claude_args.clone(),
-                        };
-                        if let Err(e) = config::add_session(&expected) {
-                            warn!("Failed to persist session to config: {}", e);
+                    if is_scheduled {
+                        scheduler.on_session_spawned(request_id, session_id);
+                    } else {
+                        // Persist so this session survives launcher restarts
+                        if !expected_sessions
+                            .iter()
+                            .any(|s| s.working_directory == working_directory)
+                        {
+                            let expected = ExpectedSession {
+                                working_directory: working_directory.clone(),
+                                session_name: session_name.clone(),
+                                agent_type,
+                                claude_args: claude_args.clone(),
+                            };
+                            if let Err(e) = config::add_session(&expected) {
+                                warn!("Failed to persist session to config: {}", e);
+                            }
+                            expected_sessions.push(expected);
                         }
-                        expected_sessions.push(expected);
                     }
                     LauncherToServer::LaunchSessionResult {
                         request_id,
@@ -387,6 +491,9 @@ async fn handle_message(
                 }
                 Err(e) => {
                     error!("Failed to spawn: {}", e);
+                    if is_scheduled {
+                        scheduler.clear_pending_launch(&request_id);
+                    }
                     LauncherToServer::LaunchSessionResult {
                         request_id,
                         success: false,
@@ -417,6 +524,10 @@ async fn handle_message(
             if ws_sender.send(response).await.is_err() {
                 warn!("Failed to send list directories result");
             }
+        }
+        ServerToLauncher::ScheduleSync { tasks } => {
+            info!("Received ScheduleSync with {} task(s)", tasks.len());
+            scheduler.update_tasks(tasks);
         }
         ServerToLauncher::ServerShutdown { reason, .. } => {
             info!("Server shutting down: {}", reason);

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod connection;
 mod process_manager;
+mod scheduler;
 mod service;
 
 use clap::{Parser, Subcommand};

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -21,6 +21,16 @@ struct ManagedTask {
     working_directory: String,
 }
 
+pub struct SpawnParams {
+    pub auth_token: String,
+    pub working_directory: String,
+    pub session_name: Option<String>,
+    pub claude_args: Vec<String>,
+    pub agent_type: shared::AgentType,
+    pub scheduled_task_id: Option<Uuid>,
+    pub resume_session_id: Option<Uuid>,
+}
+
 pub struct ProcessManager {
     tasks: HashMap<Uuid, ManagedTask>,
     backend_url: String,
@@ -70,14 +80,7 @@ impl ProcessManager {
             .map(|t| t.working_directory.clone())
     }
 
-    pub async fn spawn(
-        &mut self,
-        auth_token: &str,
-        working_directory: &str,
-        session_name: Option<&str>,
-        claude_args: &[String],
-        agent_type: shared::AgentType,
-    ) -> anyhow::Result<Uuid> {
+    pub async fn spawn(&mut self, params: SpawnParams) -> anyhow::Result<Uuid> {
         // Enforce the concurrency cap. Each session is a long-lived Claude CLI
         // process consuming memory, CPU, and a WebSocket connection. Without a
         // limit, a burst of launch requests could starve the host of resources
@@ -90,12 +93,18 @@ impl ProcessManager {
             );
         }
 
-        let wd = std::path::Path::new(working_directory);
+        let wd = std::path::Path::new(&params.working_directory);
         if !wd.is_dir() {
-            anyhow::bail!("Working directory does not exist: {}", working_directory);
+            anyhow::bail!(
+                "Working directory does not exist: {}",
+                params.working_directory
+            );
         }
 
-        let session_id = Uuid::new_v4();
+        let (session_id, resume) = match params.resume_session_id {
+            Some(id) => (id, true),
+            None => (Uuid::new_v4(), false),
+        };
         let default_name = {
             let hostname = hostname::get()
                 .ok()
@@ -104,23 +113,27 @@ impl ProcessManager {
             let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
             format!("{}-{}", hostname, timestamp)
         };
-        let name = session_name.unwrap_or(&default_name).to_string();
+        let name = params
+            .session_name
+            .as_deref()
+            .unwrap_or(&default_name)
+            .to_string();
 
-        let git_branch = get_git_branch(working_directory);
+        let git_branch = get_git_branch(&params.working_directory);
 
         let proxy_config = ProxySessionConfig {
             backend_url: self.backend_url.clone(),
             session_id,
             session_name: name.clone(),
-            auth_token: Some(auth_token.to_string()),
-            working_directory: working_directory.to_string(),
-            resume: false,
+            auth_token: Some(params.auth_token),
+            working_directory: params.working_directory.clone(),
+            resume,
             git_branch,
-            claude_args: claude_args.to_vec(),
+            claude_args: params.claude_args,
             replaces_session_id: None,
             launcher_id: self.launcher_id,
-            agent_type,
-            scheduled_task_id: None,
+            agent_type: params.agent_type,
+            scheduled_task_id: params.scheduled_task_id,
         };
 
         let exit_tx = self.exit_tx.clone();
@@ -137,7 +150,7 @@ impl ProcessManager {
 
         info!(
             "Spawned session task: session_id={}, session_name={}, dir={}",
-            session_id, name, working_directory
+            session_id, name, params.working_directory
         );
 
         self.tasks.insert(
@@ -145,7 +158,7 @@ impl ProcessManager {
             ManagedTask {
                 handle,
                 cancel,
-                working_directory: working_directory.to_string(),
+                working_directory: params.working_directory,
             },
         );
 

--- a/launcher/src/scheduler.rs
+++ b/launcher/src/scheduler.rs
@@ -1,0 +1,413 @@
+use chrono::{DateTime, Utc};
+use shared::ScheduledTaskConfig;
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+/// Delay before sending the prompt after session spawn.
+/// Gives the proxy time to connect and register the session row.
+const PROMPT_DELAY: Duration = Duration::from_secs(5);
+
+struct ActiveTask {
+    config: ScheduledTaskConfig,
+    next_fire: Option<DateTime<Utc>>,
+}
+
+pub struct PendingLaunch {
+    pub task_id: Uuid,
+    pub last_session_id: Option<Uuid>,
+    prompt: String,
+}
+
+struct PendingPrompt {
+    session_id: Uuid,
+    task_id: Uuid,
+    prompt: String,
+    send_at: Instant,
+}
+
+pub struct RunningInfo {
+    pub task_id: Uuid,
+    pub started_at: Instant,
+    max_runtime: Duration,
+}
+
+pub struct TaskToFire {
+    pub request_id: Uuid,
+    pub config: ScheduledTaskConfig,
+}
+
+pub struct Scheduler {
+    tasks: Vec<ActiveTask>,
+    pending_launches: HashMap<Uuid, PendingLaunch>,
+    running: HashMap<Uuid, RunningInfo>,
+    pending_prompts: Vec<PendingPrompt>,
+}
+
+impl Scheduler {
+    pub fn new() -> Self {
+        Self {
+            tasks: Vec::new(),
+            pending_launches: HashMap::new(),
+            running: HashMap::new(),
+            pending_prompts: Vec::new(),
+        }
+    }
+
+    /// Replace task configs from ScheduleSync. Preserves running session state.
+    pub fn update_tasks(&mut self, configs: Vec<ScheduledTaskConfig>) {
+        let running_task_ids: HashSet<Uuid> = self.running.values().map(|r| r.task_id).collect();
+
+        self.tasks = configs
+            .into_iter()
+            .map(|config| {
+                let next_fire = if config.enabled && !running_task_ids.contains(&config.id) {
+                    compute_next_fire(&config.cron_expression, &config.timezone)
+                } else {
+                    None
+                };
+                if let Some(ref next) = next_fire {
+                    info!("Task '{}': next fire at {}", config.name, next);
+                }
+                ActiveTask { config, next_fire }
+            })
+            .collect();
+
+        info!("Schedule updated: {} task(s)", self.tasks.len());
+    }
+
+    /// Duration until the next task fires. None if no tasks are scheduled.
+    pub fn next_fire_duration(&self) -> Option<Duration> {
+        let now = Utc::now();
+        self.tasks
+            .iter()
+            .filter_map(|t| t.next_fire)
+            .filter_map(|next| {
+                if next <= now {
+                    Some(Duration::ZERO)
+                } else {
+                    (next - now).to_std().ok()
+                }
+            })
+            .min()
+    }
+
+    /// Duration until the next pending prompt is ready. None if no prompts pending.
+    pub fn next_prompt_duration(&self) -> Option<Duration> {
+        let now = Instant::now();
+        self.pending_prompts
+            .iter()
+            .map(|p| p.send_at.saturating_duration_since(now))
+            .min()
+    }
+
+    /// Find and return tasks that are due to fire. Advances next_fire times.
+    pub fn fire_due_tasks(&mut self) -> Vec<TaskToFire> {
+        let now = Utc::now();
+        let running_task_ids: HashSet<Uuid> = self.running.values().map(|r| r.task_id).collect();
+
+        let mut to_fire = Vec::new();
+        let mut new_pending = Vec::new();
+
+        for task in &mut self.tasks {
+            let Some(next) = task.next_fire else {
+                continue;
+            };
+            if next > now {
+                continue;
+            }
+
+            if running_task_ids.contains(&task.config.id) {
+                info!(
+                    "Skipping task '{}': previous run still active",
+                    task.config.name
+                );
+                task.next_fire =
+                    compute_next_fire(&task.config.cron_expression, &task.config.timezone);
+                continue;
+            }
+
+            let request_id = Uuid::new_v4();
+            new_pending.push((
+                request_id,
+                PendingLaunch {
+                    task_id: task.config.id,
+                    last_session_id: task.config.last_session_id,
+                    prompt: task.config.prompt.clone(),
+                },
+            ));
+            to_fire.push(TaskToFire {
+                request_id,
+                config: task.config.clone(),
+            });
+
+            info!("Firing task '{}' ({})", task.config.name, task.config.id);
+            task.next_fire = compute_next_fire(&task.config.cron_expression, &task.config.timezone);
+            if let Some(ref next) = task.next_fire {
+                info!("Task '{}': next fire at {}", task.config.name, next);
+            }
+        }
+
+        for (request_id, launch) in new_pending {
+            self.pending_launches.insert(request_id, launch);
+        }
+
+        to_fire
+    }
+
+    /// Check if a request_id corresponds to a scheduled launch.
+    /// Returns (last_session_id, task_id) if so.
+    pub fn get_pending_launch_info(&self, request_id: &Uuid) -> Option<(Option<Uuid>, Uuid)> {
+        self.pending_launches
+            .get(request_id)
+            .map(|p| (p.last_session_id, p.task_id))
+    }
+
+    /// Called after a scheduled session is spawned successfully.
+    pub fn on_session_spawned(&mut self, request_id: Uuid, session_id: Uuid) {
+        if let Some(pending) = self.pending_launches.remove(&request_id) {
+            self.pending_prompts.push(PendingPrompt {
+                session_id,
+                task_id: pending.task_id,
+                prompt: pending.prompt,
+                send_at: Instant::now() + PROMPT_DELAY,
+            });
+
+            let max_minutes = self
+                .tasks
+                .iter()
+                .find(|t| t.config.id == pending.task_id)
+                .map(|t| t.config.max_runtime_minutes)
+                .unwrap_or(30);
+
+            self.running.insert(
+                session_id,
+                RunningInfo {
+                    task_id: pending.task_id,
+                    started_at: Instant::now(),
+                    max_runtime: Duration::from_secs(max_minutes as u64 * 60),
+                },
+            );
+        }
+    }
+
+    /// Remove a pending launch that failed.
+    pub fn clear_pending_launch(&mut self, request_id: &Uuid) {
+        self.pending_launches.remove(request_id);
+    }
+
+    /// Return prompts that are ready to send. Removes them from the queue.
+    /// Returns (session_id, task_id, prompt_content).
+    pub fn ready_prompts(&mut self) -> Vec<(Uuid, Uuid, String)> {
+        let now = Instant::now();
+        let mut ready = Vec::new();
+        self.pending_prompts.retain(|p| {
+            if p.send_at <= now {
+                ready.push((p.session_id, p.task_id, p.prompt.clone()));
+                false
+            } else {
+                true
+            }
+        });
+        ready
+    }
+
+    /// Called when a session exits. Returns RunningInfo if it was a scheduled session.
+    pub fn on_session_exited(&mut self, session_id: &Uuid) -> Option<RunningInfo> {
+        self.pending_prompts.retain(|p| p.session_id != *session_id);
+        self.running.remove(session_id)
+    }
+
+    /// Return session_ids that have exceeded their max runtime.
+    pub fn timed_out_sessions(&self) -> Vec<Uuid> {
+        self.running
+            .iter()
+            .filter(|(_, info)| info.started_at.elapsed() >= info.max_runtime)
+            .map(|(session_id, info)| {
+                warn!(
+                    "Scheduled session {} (task {}) exceeded max runtime of {}m",
+                    session_id,
+                    info.task_id,
+                    info.max_runtime.as_secs() / 60
+                );
+                *session_id
+            })
+            .collect()
+    }
+}
+
+fn compute_next_fire(cron_expr: &str, timezone: &str) -> Option<DateTime<Utc>> {
+    let cron = match croner::Cron::from_str(cron_expr) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Invalid cron expression '{}': {}", cron_expr, e);
+            return None;
+        }
+    };
+
+    let tz: chrono_tz::Tz = match timezone.parse() {
+        Ok(t) => t,
+        Err(_) => {
+            error!("Invalid timezone '{}', falling back to UTC", timezone);
+            chrono_tz::UTC
+        }
+    };
+
+    let now = Utc::now().with_timezone(&tz);
+    match cron.find_next_occurrence(&now, false) {
+        Ok(next) => Some(next.with_timezone(&Utc)),
+        Err(e) => {
+            error!(
+                "Failed to compute next fire time for '{}': {}",
+                cron_expr, e
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::AgentType;
+
+    fn make_task(name: &str, cron: &str) -> ScheduledTaskConfig {
+        ScheduledTaskConfig {
+            id: Uuid::new_v4(),
+            name: name.to_string(),
+            cron_expression: cron.to_string(),
+            timezone: "UTC".to_string(),
+            working_directory: "/tmp".to_string(),
+            prompt: "test prompt".to_string(),
+            claude_args: vec![],
+            agent_type: AgentType::Claude,
+            enabled: true,
+            max_runtime_minutes: 30,
+            last_session_id: None,
+        }
+    }
+
+    #[test]
+    fn update_tasks_computes_next_fire() {
+        let mut scheduler = Scheduler::new();
+        let task = make_task("test", "0 3 * * *");
+        scheduler.update_tasks(vec![task]);
+        assert_eq!(scheduler.tasks.len(), 1);
+        assert!(scheduler.tasks[0].next_fire.is_some());
+    }
+
+    #[test]
+    fn disabled_task_has_no_next_fire() {
+        let mut scheduler = Scheduler::new();
+        let mut task = make_task("test", "0 3 * * *");
+        task.enabled = false;
+        scheduler.update_tasks(vec![task]);
+        assert_eq!(scheduler.tasks.len(), 1);
+        assert!(scheduler.tasks[0].next_fire.is_none());
+    }
+
+    #[test]
+    fn next_fire_duration_returns_none_when_empty() {
+        let scheduler = Scheduler::new();
+        assert!(scheduler.next_fire_duration().is_none());
+    }
+
+    #[test]
+    fn compute_next_fire_with_utc() {
+        let result = compute_next_fire("* * * * *", "UTC");
+        assert!(result.is_some());
+        assert!(result.unwrap() > Utc::now());
+    }
+
+    #[test]
+    fn compute_next_fire_with_timezone() {
+        let result = compute_next_fire("0 3 * * *", "America/New_York");
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn compute_next_fire_invalid_cron() {
+        let result = compute_next_fire("invalid", "UTC");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn compute_next_fire_invalid_timezone_falls_back_to_utc() {
+        let result = compute_next_fire("0 3 * * *", "Invalid/Timezone");
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn overlap_policy_skips_running_task() {
+        let mut scheduler = Scheduler::new();
+        let task = make_task("test", "* * * * *"); // fires every minute
+        let task_id = task.id;
+        scheduler.update_tasks(vec![task]);
+
+        // Force next_fire into the past so the task would be due
+        scheduler.tasks[0].next_fire = Some(Utc::now() - chrono::Duration::seconds(1));
+
+        // Simulate a running session for this task
+        scheduler.running.insert(
+            Uuid::new_v4(),
+            RunningInfo {
+                task_id,
+                started_at: Instant::now(),
+                max_runtime: Duration::from_secs(1800),
+            },
+        );
+
+        // Should not fire — overlap policy: skip
+        let fired = scheduler.fire_due_tasks();
+        assert!(fired.is_empty());
+    }
+
+    #[test]
+    fn pending_prompt_lifecycle() {
+        let mut scheduler = Scheduler::new();
+        let task = make_task("test", "* * * * *");
+        let task_id = task.id;
+        scheduler.update_tasks(vec![task]);
+
+        // Force next_fire into the past so fire_due_tasks() finds it due
+        scheduler.tasks[0].next_fire = Some(Utc::now() - chrono::Duration::seconds(1));
+
+        // Simulate firing and spawning
+        let to_fire = scheduler.fire_due_tasks();
+        assert!(!to_fire.is_empty());
+        let request_id = to_fire[0].request_id;
+
+        let session_id = Uuid::new_v4();
+        scheduler.on_session_spawned(request_id, session_id);
+
+        // Prompt not ready yet (PROMPT_DELAY hasn't elapsed)
+        assert!(scheduler.ready_prompts().is_empty());
+        assert!(scheduler.next_prompt_duration().is_some());
+
+        // Verify running session is tracked
+        assert!(scheduler.running.contains_key(&session_id));
+        assert_eq!(scheduler.running[&session_id].task_id, task_id);
+    }
+
+    #[test]
+    fn session_exit_clears_running_state() {
+        let mut scheduler = Scheduler::new();
+        let session_id = Uuid::new_v4();
+        let task_id = Uuid::new_v4();
+        scheduler.running.insert(
+            session_id,
+            RunningInfo {
+                task_id,
+                started_at: Instant::now(),
+                max_runtime: Duration::from_secs(1800),
+            },
+        );
+
+        let info = scheduler.on_session_exited(&session_id);
+        assert!(info.is_some());
+        assert_eq!(info.unwrap().task_id, task_id);
+        assert!(!scheduler.running.contains_key(&session_id));
+    }
+}

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -394,6 +394,8 @@ pub enum LauncherToServer {
         claude_args: Vec<String>,
         #[serde(default)]
         agent_type: AgentType,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scheduled_task_id: Option<Uuid>,
     },
 
     /// Inject input into a session on behalf of the scheduler
@@ -438,6 +440,8 @@ pub enum ServerToLauncher {
         claude_args: Vec<String>,
         #[serde(default)]
         agent_type: AgentType,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scheduled_task_id: Option<Uuid>,
     },
 
     /// Request to stop a running session
@@ -589,6 +593,7 @@ mod tests {
             session_name: Some("my-session".into()),
             claude_args: vec!["--verbose".into()],
             agent_type: AgentType::Claude,
+            scheduled_task_id: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"LaunchSession""#));
@@ -630,6 +635,7 @@ mod tests {
             session_name: Some("my-project".into()),
             claude_args: vec!["--verbose".into()],
             agent_type: AgentType::Claude,
+            scheduled_task_id: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"RequestLaunch""#));


### PR DESCRIPTION
## Summary
- Adds `launcher/src/scheduler.rs` — cron-based task scheduler with overlap prevention, delayed prompt injection (5s after spawn), and max runtime enforcement
- Introduces `SpawnParams` struct in `ProcessManager` to replace 7+ individual arguments
- Plumbs `scheduled_task_id` through `LauncherToServer::RequestLaunch`, `ServerToLauncher::LaunchSession`, and the full launch flow
- Integrates scheduler into the launcher connection loop with `ScheduleSync` handling, timer-driven task firing, and `ScheduledRunStarted`/`ScheduledRunCompleted` reporting
- Supports session resume via `last_session_id` from `ScheduleSync` configs
- Version bump 2.1.1 → 2.1.2

Builds on phase 1 (#570) and phase 1.5 (#572).

## Test plan
- [x] 9 new unit tests in `scheduler.rs` (cron parsing, overlap policy, prompt lifecycle, session exit cleanup)
- [x] `cargo test --workspace --exclude backend` — 21 tests pass
- [x] `cargo clippy --workspace --exclude backend` — no warnings
- [x] `cargo build --target wasm32-unknown-unknown -p shared` — WASM compatible
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)