### PR TITLE
Add frontend UI for scheduled tasks (phase 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3200,7 +3200,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "anyhow",
  "colored",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -4131,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.1.2"
+version = "2.1.3"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -683,6 +683,13 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     }
                 }
                 {
+                    if session.scheduled_task_id.is_some() {
+                        html! { <span class="pill-agent-badge cron">{ "Cron" }</span> }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
                     if is_hidden {
                         html! { <span class="pill-hidden-badge">{ "ᴴ" }</span> }
                     } else {

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -1,10 +1,13 @@
 mod sessions_panel;
 mod sounds_panel;
+mod tasks_panel;
 mod tokens_panel;
 
 use sessions_panel::SessionsPanel;
+use shared::api::ScheduledTaskInfo;
 use shared::{ProxyTokenInfo, SessionInfo};
 use sounds_panel::SoundsPanel;
+use tasks_panel::TasksPanel;
 use tokens_panel::{count_expiring_tokens, TokensPanel};
 use yew::prelude::*;
 
@@ -12,6 +15,7 @@ use yew::prelude::*;
 enum SettingsTab {
     Sessions,
     Tokens,
+    Tasks,
     Sounds,
 }
 
@@ -27,6 +31,7 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
     // Counts for tab badges (updated when panels load their data)
     let session_count = use_state(|| 0usize);
     let expiring_token_count = use_state(|| 0usize);
+    let task_count = use_state(|| 0usize);
 
     let on_sessions_loaded = {
         let session_count = session_count.clone();
@@ -42,6 +47,13 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
         })
     };
 
+    let on_tasks_loaded = {
+        let task_count = task_count.clone();
+        Callback::from(move |tasks: Vec<ScheduledTaskInfo>| {
+            task_count.set(tasks.len());
+        })
+    };
+
     let on_sessions_tab = {
         let active_tab = active_tab.clone();
         Callback::from(move |_| active_tab.set(SettingsTab::Sessions))
@@ -50,6 +62,11 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
     let on_tokens_tab = {
         let active_tab = active_tab.clone();
         Callback::from(move |_| active_tab.set(SettingsTab::Tokens))
+    };
+
+    let on_tasks_tab = {
+        let active_tab = active_tab.clone();
+        Callback::from(move |_| active_tab.set(SettingsTab::Tasks))
     };
 
     let on_sounds_tab = {
@@ -96,6 +113,15 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                     }
                 </button>
                 <button
+                    class={classes!("tab-button", (*active_tab == SettingsTab::Tasks).then_some("active"))}
+                    onclick={on_tasks_tab}
+                >
+                    { "Tasks" }
+                    if *task_count > 0 {
+                        <span class="count-badge">{ *task_count }</span>
+                    }
+                </button>
+                <button
                     class={classes!("tab-button", (*active_tab == SettingsTab::Sounds).then_some("active"))}
                     onclick={on_sounds_tab}
                 >
@@ -106,6 +132,9 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
             <main class="settings-content">
                 if *active_tab == SettingsTab::Tokens {
                     <TokensPanel on_tokens_loaded={on_tokens_loaded} />
+                }
+                if *active_tab == SettingsTab::Tasks {
+                    <TasksPanel on_tasks_loaded={on_tasks_loaded} />
                 }
                 if *active_tab == SettingsTab::Sounds {
                     <SoundsPanel />

--- a/frontend/src/pages/settings/tasks_panel.rs
+++ b/frontend/src/pages/settings/tasks_panel.rs
@@ -1,0 +1,598 @@
+use crate::utils;
+use gloo_net::http::Request;
+use shared::api::{
+    CreateScheduledTaskRequest, ScheduledTaskInfo, ScheduledTaskListResponse,
+    UpdateScheduledTaskRequest,
+};
+use shared::LauncherInfo;
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+/// Fetch scheduled tasks from API
+async fn fetch_tasks() -> Option<Vec<ScheduledTaskInfo>> {
+    let url = utils::api_url("/api/scheduled-tasks");
+    match Request::get(&url).send().await {
+        Ok(response) => {
+            if response.status() == 401 {
+                if let Some(window) = web_sys::window() {
+                    let _ = window.location().set_href("/api/auth/logout");
+                }
+                return None;
+            }
+            response
+                .json::<ScheduledTaskListResponse>()
+                .await
+                .ok()
+                .map(|r| r.tasks)
+        }
+        Err(e) => {
+            log::error!("Failed to fetch scheduled tasks: {:?}", e);
+            None
+        }
+    }
+}
+
+/// Fetch connected launchers for hostname dropdown
+async fn fetch_launchers() -> Vec<LauncherInfo> {
+    match Request::get("/api/launchers").send().await {
+        Ok(resp) => resp.json::<Vec<LauncherInfo>>().await.unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[derive(Clone, Default)]
+struct TaskForm {
+    name: String,
+    cron_expression: String,
+    timezone: String,
+    hostname: String,
+    working_directory: String,
+    prompt: String,
+    max_runtime_minutes: i32,
+}
+
+impl TaskForm {
+    fn from_task(task: &ScheduledTaskInfo) -> Self {
+        Self {
+            name: task.name.clone(),
+            cron_expression: task.cron_expression.clone(),
+            timezone: task.timezone.clone(),
+            hostname: task.hostname.clone(),
+            working_directory: task.working_directory.clone(),
+            prompt: task.prompt.clone(),
+            max_runtime_minutes: task.max_runtime_minutes,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
+enum FormMode {
+    Create,
+    Edit(Uuid),
+}
+
+#[derive(Properties, PartialEq)]
+pub struct TasksPanelProps {
+    pub on_tasks_loaded: Callback<Vec<ScheduledTaskInfo>>,
+}
+
+#[function_component(TasksPanel)]
+pub fn tasks_panel(props: &TasksPanelProps) -> Html {
+    let tasks = use_state(Vec::<ScheduledTaskInfo>::new);
+    let loading = use_state(|| true);
+    let form_mode = use_state(|| None::<FormMode>);
+    let form = use_state(TaskForm::default);
+    let launchers = use_state(Vec::<LauncherInfo>::new);
+    let confirm_action = use_state(|| None::<(String, Callback<MouseEvent>)>);
+    let error_msg = use_state(|| None::<String>);
+
+    let reload_tasks = {
+        let tasks = tasks.clone();
+        let loading = loading.clone();
+        let on_tasks_loaded = props.on_tasks_loaded.clone();
+        Callback::from(move |_| {
+            let tasks = tasks.clone();
+            let loading = loading.clone();
+            let on_tasks_loaded = on_tasks_loaded.clone();
+            spawn_local(async move {
+                if let Some(list) = fetch_tasks().await {
+                    on_tasks_loaded.emit(list.clone());
+                    tasks.set(list);
+                }
+                loading.set(false);
+            });
+        })
+    };
+
+    // Initial fetch
+    {
+        let reload_tasks = reload_tasks.clone();
+        let launchers = launchers.clone();
+        use_effect_with((), move |_| {
+            reload_tasks.emit(());
+            spawn_local(async move {
+                launchers.set(fetch_launchers().await);
+            });
+            || ()
+        });
+    }
+
+    let open_create = {
+        let form_mode = form_mode.clone();
+        let form = form.clone();
+        let error_msg = error_msg.clone();
+        let launchers = launchers.clone();
+        Callback::from(move |_| {
+            let new_form = TaskForm {
+                timezone: "UTC".to_string(),
+                max_runtime_minutes: 30,
+                hostname: launchers
+                    .first()
+                    .map(|l| l.hostname.clone())
+                    .unwrap_or_default(),
+                ..Default::default()
+            };
+            form.set(new_form);
+            error_msg.set(None);
+            form_mode.set(Some(FormMode::Create));
+        })
+    };
+
+    let open_edit = {
+        let form_mode = form_mode.clone();
+        let form = form.clone();
+        let tasks = tasks.clone();
+        let error_msg = error_msg.clone();
+        Callback::from(move |task_id: Uuid| {
+            if let Some(task) = tasks.iter().find(|t| t.id == task_id) {
+                form.set(TaskForm::from_task(task));
+                error_msg.set(None);
+                form_mode.set(Some(FormMode::Edit(task_id)));
+            }
+        })
+    };
+
+    let close_form = {
+        let form_mode = form_mode.clone();
+        let error_msg = error_msg.clone();
+        Callback::from(move |_| {
+            form_mode.set(None);
+            error_msg.set(None);
+        })
+    };
+
+    let on_submit = {
+        let form = form.clone();
+        let form_mode = form_mode.clone();
+        let reload_tasks = reload_tasks.clone();
+        let error_msg = error_msg.clone();
+        Callback::from(move |e: SubmitEvent| {
+            e.prevent_default();
+            let data = (*form).clone();
+            let mode = (*form_mode).clone();
+            let reload_tasks = reload_tasks.clone();
+            let form_mode = form_mode.clone();
+            let error_msg = error_msg.clone();
+
+            if data.name.trim().is_empty() || data.cron_expression.trim().is_empty() {
+                return;
+            }
+
+            spawn_local(async move {
+                let result = match mode {
+                    Some(FormMode::Create) => {
+                        let body = CreateScheduledTaskRequest {
+                            name: data.name.trim().to_string(),
+                            cron_expression: data.cron_expression.trim().to_string(),
+                            timezone: data.timezone.clone(),
+                            hostname: data.hostname.clone(),
+                            working_directory: data.working_directory.clone(),
+                            prompt: data.prompt.clone(),
+                            claude_args: vec![],
+                            agent_type: shared::AgentType::Claude,
+                            max_runtime_minutes: data.max_runtime_minutes,
+                        };
+                        Request::post(&utils::api_url("/api/scheduled-tasks"))
+                            .json(&body)
+                            .unwrap()
+                            .send()
+                            .await
+                    }
+                    Some(FormMode::Edit(id)) => {
+                        let body = UpdateScheduledTaskRequest {
+                            name: Some(data.name.trim().to_string()),
+                            cron_expression: Some(data.cron_expression.trim().to_string()),
+                            timezone: Some(data.timezone.clone()),
+                            hostname: Some(data.hostname.clone()),
+                            working_directory: Some(data.working_directory.clone()),
+                            prompt: Some(data.prompt.clone()),
+                            max_runtime_minutes: Some(data.max_runtime_minutes),
+                            ..Default::default()
+                        };
+                        Request::patch(&utils::api_url(&format!("/api/scheduled-tasks/{}", id)))
+                            .json(&body)
+                            .unwrap()
+                            .send()
+                            .await
+                    }
+                    None => return,
+                };
+
+                match result {
+                    Ok(resp) if resp.status() >= 200 && resp.status() < 300 => {
+                        form_mode.set(None);
+                        reload_tasks.emit(());
+                    }
+                    Ok(resp) => {
+                        let msg = resp.text().await.unwrap_or_default();
+                        error_msg.set(Some(format!("Error ({}): {}", resp.status(), msg)));
+                    }
+                    Err(e) => {
+                        error_msg.set(Some(format!("Request failed: {:?}", e)));
+                    }
+                }
+            });
+        })
+    };
+
+    let on_toggle_enabled = {
+        let tasks = tasks.clone();
+        let reload_tasks = reload_tasks.clone();
+        Callback::from(move |task_id: Uuid| {
+            let tasks = tasks.clone();
+            let reload_tasks = reload_tasks.clone();
+            let enabled = tasks
+                .iter()
+                .find(|t| t.id == task_id)
+                .map(|t| t.enabled)
+                .unwrap_or(true);
+
+            spawn_local(async move {
+                let body = UpdateScheduledTaskRequest {
+                    enabled: Some(!enabled),
+                    ..Default::default()
+                };
+                let _ = Request::patch(&utils::api_url(&format!(
+                    "/api/scheduled-tasks/{}",
+                    task_id
+                )))
+                .json(&body)
+                .unwrap()
+                .send()
+                .await;
+                reload_tasks.emit(());
+            });
+        })
+    };
+
+    let on_delete = {
+        let confirm_action = confirm_action.clone();
+        let reload_tasks = reload_tasks.clone();
+        Callback::from(move |task_id: Uuid| {
+            let confirm_action_inner = confirm_action.clone();
+            let reload_tasks = reload_tasks.clone();
+
+            let action = Callback::from(move |_: MouseEvent| {
+                let confirm_action_inner = confirm_action_inner.clone();
+                let reload_tasks = reload_tasks.clone();
+                spawn_local(async move {
+                    let _ = Request::delete(&utils::api_url(&format!(
+                        "/api/scheduled-tasks/{}",
+                        task_id
+                    )))
+                    .send()
+                    .await;
+                    confirm_action_inner.set(None);
+                    reload_tasks.emit(());
+                });
+            });
+
+            confirm_action.set(Some((
+                "Delete this scheduled task? This cannot be undone.".to_string(),
+                action,
+            )));
+        })
+    };
+
+    let cancel_confirm = {
+        let confirm_action = confirm_action.clone();
+        Callback::from(move |_| {
+            confirm_action.set(None);
+        })
+    };
+
+    // Form input handlers
+    let set_field = |field: &'static str| {
+        let form = form.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            let mut f = (*form).clone();
+            match field {
+                "name" => f.name = input.value(),
+                "cron_expression" => f.cron_expression = input.value(),
+                "timezone" => f.timezone = input.value(),
+                "hostname" => f.hostname = input.value(),
+                "working_directory" => f.working_directory = input.value(),
+                "max_runtime_minutes" => {
+                    f.max_runtime_minutes = input.value().parse().unwrap_or(30)
+                }
+                _ => {}
+            }
+            form.set(f);
+        })
+    };
+
+    let on_prompt_input = {
+        let form = form.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: web_sys::HtmlTextAreaElement = e.target_unchecked_into();
+            let mut f = (*form).clone();
+            f.prompt = input.value();
+            form.set(f);
+        })
+    };
+
+    let on_hostname_select = {
+        let form = form.clone();
+        Callback::from(move |e: Event| {
+            let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
+            let mut f = (*form).clone();
+            f.hostname = select.value();
+            form.set(f);
+        })
+    };
+
+    // Collect unique hostnames from launchers
+    let hostnames: Vec<String> = {
+        let mut names: Vec<String> = launchers.iter().map(|l| l.hostname.clone()).collect();
+        names.sort();
+        names.dedup();
+        names
+    };
+
+    html! {
+        <>
+            <section class="tasks-section">
+                <div class="section-header">
+                    <h2>{ "Scheduled Tasks" }</h2>
+                    <p class="section-description">
+                        { "Configure recurring agent tasks that run on a cron schedule." }
+                    </p>
+                    if form_mode.is_some() {
+                        <button class="create-button" onclick={close_form.clone()}>
+                            { "Cancel" }
+                        </button>
+                    } else {
+                        <button class="create-button" onclick={open_create}>
+                            { "+ New Task" }
+                        </button>
+                    }
+                </div>
+
+                if let Some(mode) = &*form_mode {
+                    <div class="create-token-form">
+                        <h3 class="task-form-title">
+                            { if matches!(mode, FormMode::Create) { "Create Task" } else { "Edit Task" } }
+                        </h3>
+                        if let Some(err) = &*error_msg {
+                            <div class="task-form-error">{ err }</div>
+                        }
+                        <form class="task-form" onsubmit={on_submit}>
+                            <div class="form-group">
+                                <label for="task-name">{ "Name" }</label>
+                                <input
+                                    type="text"
+                                    id="task-name"
+                                    placeholder="e.g., Nightly Code Review"
+                                    value={form.name.clone()}
+                                    oninput={set_field("name")}
+                                    required=true
+                                />
+                            </div>
+                            <div class="task-form-row">
+                                <div class="form-group">
+                                    <label for="task-cron">{ "Cron Expression" }</label>
+                                    <input
+                                        type="text"
+                                        id="task-cron"
+                                        placeholder="0 3 * * *"
+                                        value={form.cron_expression.clone()}
+                                        oninput={set_field("cron_expression")}
+                                        required=true
+                                    />
+                                    <span class="form-hint">{ "min hour dom month dow" }</span>
+                                </div>
+                                <div class="form-group">
+                                    <label for="task-tz">{ "Timezone" }</label>
+                                    <input
+                                        type="text"
+                                        id="task-tz"
+                                        placeholder="UTC"
+                                        value={form.timezone.clone()}
+                                        oninput={set_field("timezone")}
+                                    />
+                                </div>
+                                <div class="form-group">
+                                    <label for="task-runtime">{ "Max Runtime (min)" }</label>
+                                    <input
+                                        type="number"
+                                        id="task-runtime"
+                                        min="1"
+                                        max="1440"
+                                        value={form.max_runtime_minutes.to_string()}
+                                        oninput={set_field("max_runtime_minutes")}
+                                    />
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label for="task-hostname">{ "Launcher Host" }</label>
+                                if hostnames.is_empty() {
+                                    <input
+                                        type="text"
+                                        id="task-hostname"
+                                        placeholder="hostname"
+                                        value={form.hostname.clone()}
+                                        oninput={set_field("hostname")}
+                                        required=true
+                                    />
+                                } else {
+                                    <select id="task-hostname" onchange={on_hostname_select}>
+                                        { for hostnames.iter().map(|h| {
+                                            html! {
+                                                <option
+                                                    value={h.clone()}
+                                                    selected={*h == form.hostname}
+                                                >{ h }</option>
+                                            }
+                                        }) }
+                                    </select>
+                                }
+                            </div>
+                            <div class="form-group">
+                                <label for="task-dir">{ "Working Directory" }</label>
+                                <input
+                                    type="text"
+                                    id="task-dir"
+                                    placeholder="/home/user/project"
+                                    value={form.working_directory.clone()}
+                                    oninput={set_field("working_directory")}
+                                    required=true
+                                />
+                            </div>
+                            <div class="form-group">
+                                <label for="task-prompt">{ "Prompt" }</label>
+                                <textarea
+                                    id="task-prompt"
+                                    rows="4"
+                                    placeholder="What should the agent do each run?"
+                                    value={form.prompt.clone()}
+                                    oninput={on_prompt_input}
+                                    required=true
+                                />
+                            </div>
+                            <button type="submit" class="submit-button">
+                                { if matches!(mode, FormMode::Create) { "Create Task" } else { "Save Changes" } }
+                            </button>
+                        </form>
+                    </div>
+                }
+
+                if *loading {
+                    <div class="loading">
+                        <div class="spinner"></div>
+                        <p>{ "Loading tasks..." }</p>
+                    </div>
+                } else if tasks.is_empty() {
+                    <div class="empty-state">
+                        <p>{ "No scheduled tasks. Create one to run agents on a cron schedule." }</p>
+                    </div>
+                } else {
+                    <div class="task-cards">
+                        { for tasks.iter().map(|task| {
+                            let task_id = task.id;
+                            let on_edit = open_edit.clone();
+                            let on_toggle = on_toggle_enabled.clone();
+                            let on_del = on_delete.clone();
+                            html! {
+                                <TaskCard
+                                    key={task.id.to_string()}
+                                    task={task.clone()}
+                                    on_edit={Callback::from(move |_| on_edit.emit(task_id))}
+                                    on_toggle={Callback::from(move |_| on_toggle.emit(task_id))}
+                                    on_delete={Callback::from(move |_| on_del.emit(task_id))}
+                                />
+                            }
+                        }) }
+                    </div>
+                }
+            </section>
+
+            if let Some((message, action)) = &*confirm_action {
+                <div class="modal-overlay" onclick={cancel_confirm.clone()}>
+                    <div class="confirm-modal" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                        <p>{ message }</p>
+                        <div class="confirm-actions">
+                            <button class="cancel-button" onclick={cancel_confirm.clone()}>
+                                { "Cancel" }
+                            </button>
+                            <button class="confirm-button" onclick={action.clone()}>
+                                { "Delete" }
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            }
+        </>
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct TaskCardProps {
+    task: ScheduledTaskInfo,
+    on_edit: Callback<()>,
+    on_toggle: Callback<()>,
+    on_delete: Callback<()>,
+}
+
+#[function_component(TaskCard)]
+fn task_card(props: &TaskCardProps) -> Html {
+    let task = &props.task;
+
+    let status_class = if task.enabled {
+        "task-status active"
+    } else {
+        "task-status disabled"
+    };
+
+    html! {
+        <div class={classes!("task-card", (!task.enabled).then_some("task-card-disabled"))}>
+            <div class="task-card-header">
+                <div class="task-card-title-row">
+                    <span class="task-card-name">{ &task.name }</span>
+                    <span class={status_class}>
+                        { if task.enabled { "Active" } else { "Disabled" } }
+                    </span>
+                </div>
+                <div class="task-card-meta">
+                    <code class="task-cron-badge">{ &task.cron_expression }</code>
+                    <span class="task-tz">{ &task.timezone }</span>
+                </div>
+            </div>
+            <div class="task-card-body">
+                <div class="task-card-detail">
+                    <span class="task-detail-label">{ "Host" }</span>
+                    <span class="task-detail-value">{ &task.hostname }</span>
+                </div>
+                <div class="task-card-detail">
+                    <span class="task-detail-label">{ "Directory" }</span>
+                    <span class="task-detail-value task-dir-value">{ &task.working_directory }</span>
+                </div>
+                <div class="task-card-detail">
+                    <span class="task-detail-label">{ "Prompt" }</span>
+                    <span class="task-detail-value task-prompt-value">{ &task.prompt }</span>
+                </div>
+                if let Some(last_run) = &task.last_run_at {
+                    <div class="task-card-detail">
+                        <span class="task-detail-label">{ "Last Run" }</span>
+                        <span class="task-detail-value">{ utils::format_timestamp(last_run) }</span>
+                    </div>
+                }
+            </div>
+            <div class="task-card-actions">
+                <button class="task-action-btn edit-btn" onclick={props.on_edit.reform(|_| ())}>
+                    { "Edit" }
+                </button>
+                <button
+                    class={classes!("task-action-btn", if task.enabled { "disable-btn" } else { "enable-btn" })}
+                    onclick={props.on_toggle.reform(|_| ())}
+                >
+                    { if task.enabled { "Disable" } else { "Enable" } }
+                </button>
+                <button class="task-action-btn delete-btn" onclick={props.on_delete.reform(|_| ())}>
+                    { "Delete" }
+                </button>
+            </div>
+        </div>
+    }
+}

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -310,6 +310,11 @@
     background: rgba(0, 170, 68, 0.15);
 }
 
+.pill-agent-badge.cron {
+    color: var(--accent);
+    background: rgba(125, 207, 255, 0.15);
+}
+
 /* Version staleness badge */
 .pill-version-badge {
     font-size: 0.6rem;

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -679,3 +679,248 @@
     }
 }
 
+/* =============================================================================
+   Scheduled Tasks Tab
+   ============================================================================= */
+
+.tasks-section .empty-state,
+.tasks-section .loading {
+    text-align: center;
+    padding: 3rem;
+    color: var(--text-secondary);
+}
+
+.task-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.task-form-title {
+    margin: 0 0 1rem 0;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+}
+
+.task-form-error {
+    background: rgba(247, 118, 142, 0.15);
+    border: 1px solid var(--error);
+    color: var(--error);
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    margin-bottom: 0.5rem;
+}
+
+.task-form-row {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.task-form-row .form-group {
+    flex: 1;
+    min-width: 140px;
+}
+
+.form-hint {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+}
+
+.form-group textarea {
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    font-family: var(--font-mono);
+    resize: vertical;
+    min-height: 80px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.form-group textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.form-group select {
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    width: 100%;
+}
+
+.form-group select:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+/* Task Cards */
+.task-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.task-card {
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem;
+    transition: border-color 0.2s;
+}
+
+.task-card:hover {
+    border-color: var(--text-secondary);
+}
+
+.task-card-disabled {
+    opacity: 0.6;
+}
+
+.task-card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.task-card-title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.task-card-name {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.task-card-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.task-cron-badge {
+    background: rgba(125, 207, 255, 0.15);
+    color: var(--accent);
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-family: var(--font-mono);
+}
+
+.task-tz {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+}
+
+.task-status {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.task-status.active {
+    background: rgba(158, 206, 106, 0.2);
+    color: var(--success);
+}
+
+.task-status.disabled {
+    background: rgba(127, 132, 156, 0.2);
+    color: var(--text-secondary);
+}
+
+.task-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 0.75rem;
+}
+
+.task-card-detail {
+    display: flex;
+    gap: 0.75rem;
+    font-size: 0.85rem;
+}
+
+.task-detail-label {
+    color: var(--text-secondary);
+    min-width: 70px;
+    flex-shrink: 0;
+}
+
+.task-detail-value {
+    color: var(--text-primary);
+}
+
+.task-dir-value {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+}
+
+.task-prompt-value {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 500px;
+}
+
+.task-card-actions {
+    display: flex;
+    gap: 0.5rem;
+    border-top: 1px solid var(--border);
+    padding-top: 0.75rem;
+}
+
+.task-action-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    padding: 0.25rem 0.75rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    transition: all 0.2s;
+}
+
+.task-action-btn:hover {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+}
+
+.task-action-btn.edit-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.task-action-btn.enable-btn:hover {
+    border-color: var(--success);
+    color: var(--success);
+}
+
+.task-action-btn.disable-btn:hover {
+    border-color: #e0af68;
+    color: #e0af68;
+}
+
+.task-action-btn.delete-btn:hover {
+    border-color: var(--error);
+    color: var(--error);
+}
+

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -250,7 +250,7 @@ pub struct UpdateScheduledTaskRequest {
 }
 
 /// Info about a scheduled task (returned by list/create endpoints)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScheduledTaskInfo {
     pub id: uuid::Uuid,
     pub name: String,


### PR DESCRIPTION
## Summary
- Adds `frontend/src/pages/settings/tasks_panel.rs` — full CRUD panel for scheduled tasks with card-based layout
- New "Tasks" tab in Settings page with task count badge
- Create/edit form: name, cron expression, timezone, hostname (dropdown from connected launchers), working directory, prompt textarea, max runtime
- Enable/disable toggle, delete with confirmation modal
- "Cron" badge on session pills in the dashboard rail for sessions spawned by scheduled tasks
- CSS for task cards, form, and cron badge in `settings.css` and `session-rail.css`
- `ScheduledTaskInfo` now derives `PartialEq` (required by Yew Properties)
- Version bump 2.1.2 → 2.1.3

Builds on phase 1 (#570), phase 1.5 (#572), and phase 2 (#573).

## Test plan
- [x] `cargo check --workspace --exclude backend` — clean
- [x] `cargo clippy --workspace --exclude backend` — no warnings
- [x] `cargo build --target wasm32-unknown-unknown -p shared` — WASM compatible
- [x] All existing tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)