### PR TITLE
Remove unnecessary Option wrappers, gate stop on tasks

### DIFF
--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -144,7 +144,7 @@ fn handle_proxy_message(
                 success: result.success,
                 session_id: claude_session_id,
                 error: result.error,
-                max_image_mb: Some(app_state.max_image_mb),
+                max_image_mb: app_state.max_image_mb,
             });
 
             info!(

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -488,11 +488,11 @@ async fn connect_to_backend(
 }
 
 /// Register session with the backend and wait for acknowledgment.
-/// On success, returns the backend-provided max_image_mb (if any).
+/// On success, returns the backend-provided max_image_mb.
 async fn register_session(
     conn: &mut NativeConnection,
     config: &ProxySessionConfig,
-) -> Result<Option<u32>, Duration> {
+) -> Result<u32, Duration> {
     info!("Registering session...");
 
     let hostname = hostname::get()
@@ -544,7 +544,7 @@ async fn register_session(
 
     match ack_timeout {
         Ok(Some((true, _, max_image_mb))) => {
-            info!("Session registered (max_image_mb: {:?})", max_image_mb);
+            info!("Session registered (max_image_mb: {})", max_image_mb);
             Ok(max_image_mb)
         }
         Ok(Some((false, error, _))) => {
@@ -561,7 +561,7 @@ async fn register_session(
             info!(
                 "No RegisterAck received (timeout), assuming success for backwards compatibility"
             );
-            Ok(None)
+            Ok(10)
         }
     }
 }
@@ -571,7 +571,7 @@ async fn run_message_loop(
     session: &mut SessionState<'_>,
     config: &ProxySessionConfig,
     conn: NativeConnection,
-    max_image_mb: Option<u32>,
+    max_image_mb: u32,
 ) -> ConnectionResult {
     let connection_start = Instant::now();
     let session_id = config.session_id;

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -30,9 +30,9 @@ pub fn spawn_output_forwarder(
     current_pr_url: Arc<Mutex<Option<String>>>,
     current_repo_url: Arc<Mutex<Option<String>>>,
     output_buffer: Arc<Mutex<PendingOutputBuffer>>,
-    max_image_mb: Option<u32>,
+    max_image_mb: u32,
 ) -> tokio::task::JoinHandle<()> {
-    let max_bytes = max_image_mb.unwrap_or(DEFAULT_MAX_IMAGE_MB) as usize * 1024 * 1024;
+    let max_bytes = max_image_mb as usize * 1024 * 1024;
     tokio::spawn(async move {
         let mut message_count: u64 = 0;
         let mut pending_git_check = false;
@@ -270,9 +270,6 @@ async fn check_and_send_branch_update(
         }
     }
 }
-
-/// Default max image size in MB (used when backend doesn't provide a value)
-const DEFAULT_MAX_IMAGE_MB: u32 = 10;
 
 /// Return the MIME type for a supported image extension, or None.
 fn image_mime_type(path: &str) -> Option<&'static str> {

--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -356,7 +356,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                     <div class="sched-body">
                         // Existing tasks list
                         if tasks.is_empty() && form_mode.is_none() {
-                            <p class="sched-empty">{ "No scheduled tasks for this directory." }</p>
+                            <p class="sched-empty">{ "No scheduled tasks for this session." }</p>
                         }
                         { for tasks.iter().map(|task| {
                             let task_id = task.id;

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -7,12 +7,15 @@ use crate::components::{ScheduleDialog, ShareDialog};
 use crate::utils;
 use gloo::events::EventListener;
 use gloo::timers::callback::Interval;
+use gloo_net::http::Request;
+use shared::api::ScheduledTaskListResponse;
 use shared::SessionInfo;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use uuid::Uuid;
 use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::spawn_local;
 use web_sys::{Element, HtmlElement, WheelEvent};
 use yew::prelude::*;
 
@@ -227,6 +230,37 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     let copied_id = use_state(|| false);
     let share_session_id = use_state(|| None::<Uuid>);
     let schedule_session = use_state(|| None::<SessionInfo>);
+    let stop_has_tasks = use_state(|| false);
+
+    // Fetch scheduled task status when dropdown opens for a session
+    {
+        let stop_has_tasks = stop_has_tasks.clone();
+        let menu_id = *menu_session;
+        let sessions = props.sessions.clone();
+        use_effect_with(menu_id, move |menu_id| {
+            if let Some(sid) = menu_id {
+                if let Some(session) = sessions.iter().find(|s| s.id == *sid) {
+                    let wd = session.working_directory.clone();
+                    let stop_has_tasks = stop_has_tasks.clone();
+                    spawn_local(async move {
+                        let url = utils::api_url("/api/scheduled-tasks");
+                        if let Ok(resp) = Request::get(&url).send().await {
+                            if let Ok(data) = resp.json::<ScheduledTaskListResponse>().await {
+                                let has = data
+                                    .tasks
+                                    .iter()
+                                    .any(|t| t.working_directory == wd && t.enabled);
+                                stop_has_tasks.set(has);
+                            }
+                        }
+                    });
+                }
+            } else {
+                stop_has_tasks.set(false);
+            }
+            || ()
+        });
+    }
 
     // Independent 100 ms tick that drives sparkline redraws.
     // Accumulation happens externally via ActivityRef mutations; this timer
@@ -373,19 +407,36 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         };
 
         let stop_option = if is_connected && session.status == shared::SessionStatus::Active {
-            let (stop_label, stop_hint) = if confirming_stop {
-                ("Click again to confirm", "This will terminate the process")
+            if *stop_has_tasks {
+                // Block stop — open schedule dialog so user can delete tasks first
+                let schedule_session = schedule_session.clone();
+                let session_clone = session.clone();
+                let menu_session = menu_session.clone();
+                let on_click = Callback::from(move |_: MouseEvent| {
+                    schedule_session.set(Some(session_clone.clone()));
+                    menu_session.set(None);
+                });
+                html! {
+                    <button type="button" class="pill-menu-option stop blocked" onclick={on_click}>
+                        { "Delete Scheduled Tasks First" }
+                        <span class="option-hint">{ "Opens task manager" }</span>
+                    </button>
+                }
             } else {
-                ("Stop Session", "Terminate process")
-            };
-            html! {
-                <button type="button"
-                    class={classes!("pill-menu-option", "stop", confirming_stop.then_some("confirming"))}
-                    onclick={on_stop}
-                >
-                    { stop_label }
-                    <span class="option-hint">{ stop_hint }</span>
-                </button>
+                let (stop_label, stop_hint) = if confirming_stop {
+                    ("Click again to confirm", "This will terminate the process")
+                } else {
+                    ("Stop Session", "Terminate process")
+                };
+                html! {
+                    <button type="button"
+                        class={classes!("pill-menu-option", "stop", confirming_stop.then_some("confirming"))}
+                        onclick={on_stop}
+                    >
+                        { stop_label }
+                        <span class="option-hint">{ stop_hint }</span>
+                    </button>
+                }
             }
         } else {
             html! {}

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -158,8 +158,7 @@ pub enum ServerToProxy {
         session_id: Uuid,
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        max_image_mb: Option<u32>,
+        max_image_mb: u32,
     },
 
     /// Keepalive heartbeat

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -190,8 +190,7 @@ pub struct SessionInfo {
     pub status: SessionStatus,
     pub last_activity: String,
     pub created_at: String,
-    #[serde(default)]
-    pub updated_at: Option<String>,
+    pub updated_at: String,
     #[serde(default)]
     pub git_branch: Option<String>,
     /// The current user's role in this session (owner, editor, viewer)


### PR DESCRIPTION
## Summary
- Remove `Option` from `SessionInfo::updated_at` (DB column is non-null `NaiveDateTime`)
- Remove `Option` from `RegisterAck::max_image_mb` (server always sends it)
- Remove `DEFAULT_MAX_IMAGE_MB` constant from proxy (no longer needed)
- Block "Stop Session" when active scheduled tasks exist for the working directory — clicking opens the schedule dialog so user can delete them first
- Fix empty state text in schedule dialog

## Test plan
- [ ] Verify sessions still deserialize correctly (updated_at is always present)
- [ ] Verify proxy registers and receives max_image_mb as u32
- [ ] Verify "Stop Session" is blocked when scheduled tasks exist, opens task manager
- [ ] Verify "Stop Session" works normally when no scheduled tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)