### PR TITLE
Remove all doctests from the workspace

### DIFF
--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -11,51 +11,10 @@
 //! - `SessionSnapshot` - Serializable session state for persistence
 //! - `OutputBuffer` - Buffer for replay on session restore
 //!
-//! # Example
+//! # Usage
 //!
-//! ```ignore
-//! use claude_session_lib::{Session, SessionConfig, SessionEvent, PermissionResponse};
-//! use uuid::Uuid;
-//!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let config = SessionConfig {
-//!         session_id: Uuid::new_v4(),
-//!         working_directory: std::env::current_dir()?,
-//!         session_name: "my-session".to_string(),
-//!         resume: false,
-//!         claude_path: None,
-//!     };
-//!
-//!     let mut session = Session::new(config).await?;
-//!
-//!     // Send initial input
-//!     session.send_input(serde_json::json!("Hello!")).await?;
-//!
-//!     // Process events
-//!     while let Some(event) = session.next_event().await {
-//!         match event {
-//!             SessionEvent::Output(output) => {
-//!                 println!("Claude: {:?}", output);
-//!             }
-//!             SessionEvent::PermissionRequest { request_id, tool_name, .. } => {
-//!                 // Auto-approve for this example
-//!                 session.respond_permission(&request_id, PermissionResponse::allow()).await?;
-//!             }
-//!             SessionEvent::Exited { code } => {
-//!                 println!("Session exited with code {}", code);
-//!                 break;
-//!             }
-//!             SessionEvent::Error(e) => {
-//!                 eprintln!("Error: {}", e);
-//!                 break;
-//!             }
-//!         }
-//!     }
-//!
-//!     Ok(())
-//! }
-//! ```
+//! Create a `SessionConfig`, spawn a `Session`, and loop over `SessionEvent`s.
+//! Handle `Output`, `PermissionRequest`, `Exited`, and `Error` variants as needed.
 
 pub mod buffer;
 pub mod error;

--- a/frontend/src/hooks/use_client_websocket.rs
+++ b/frontend/src/hooks/use_client_websocket.rs
@@ -30,15 +30,6 @@ fn calculate_backoff(attempt: u32) -> u32 {
 /// # Returns
 /// * `UseClientWebSocket` - The current spend data and shutdown status
 ///
-/// # Example
-/// ```ignore
-/// let ws = use_client_websocket();
-/// if let Some(reason) = &ws.shutdown_reason {
-///     // Show shutdown banner
-/// }
-/// // Display total spend
-/// html! { <span>{ format!("${:.2}", ws.total_spend) }</span> }
-/// ```
 #[hook]
 pub fn use_client_websocket() -> UseClientWebSocket {
     let total_spend = use_state(|| 0.0f64);

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -51,24 +51,6 @@ pub struct UseKeyboardNav {
 /// # Returns
 /// * `UseKeyboardNav` - The current mode and keydown handler
 ///
-/// # Example
-/// ```ignore
-/// let nav = use_keyboard_nav(KeyboardNavConfig {
-///     sessions: sessions.clone(),
-///     focused_index: *focused_index,
-///     hidden_sessions: hidden.clone(),
-///     connected_sessions: connected.clone(),
-///     inactive_hidden: *inactive_hidden,
-///     on_select: on_select.clone(),
-///     on_activate: on_activate.clone(),
-/// });
-///
-/// html! {
-///     <div onkeydown={nav.on_keydown.clone()}>
-///         { if nav.nav_mode { "NAV" } else { "EDIT" } }
-///     </div>
-/// }
-/// ```
 #[hook]
 pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
     let nav_mode = use_state(|| false);

--- a/frontend/src/hooks/use_sessions.rs
+++ b/frontend/src/hooks/use_sessions.rs
@@ -26,15 +26,6 @@ pub struct UseSessions {
 /// # Returns
 /// * `UseSessions` - The current sessions, loading state, and control callbacks
 ///
-/// # Example
-/// ```ignore
-/// let sessions = use_sessions();
-/// if sessions.loading {
-///     // Show loading indicator
-/// } else {
-///     // Render session list
-/// }
-/// ```
 #[hook]
 pub fn use_sessions() -> UseSessions {
     let sessions = use_state(Vec::<SessionInfo>::new);


### PR DESCRIPTION
## Summary
- Remove all 4 ignored doctests (they were never executed as tests)
- Replace with brief prose descriptions where appropriate
- Affected files: `claude-session-lib/src/lib.rs`, 3 frontend hooks

None of the doctests were convertible to meaningful unit tests — the 3 frontend hooks require a Yew component context, and the crate-level example was purely illustrative.

## Test plan
- [x] `cargo test --workspace --exclude backend` — all pass, no more ignored doctests

🤖 Generated with [Claude Code](https://claude.com/claude-code)