### PR TITLE
Escape closes modals + default --dangerously-skip-permissions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.1.5"
+version = "2.1.6"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -6,6 +6,7 @@ use shared::api::{
 };
 use shared::{LauncherInfo, SessionInfo};
 use uuid::Uuid;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
@@ -66,6 +67,24 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
     let hostname = props.session.hostname.clone();
 
     let folder = utils::extract_folder(&working_directory);
+
+    // Close on Escape
+    {
+        let on_close = props.on_close.clone();
+        use_effect_with((), move |_| {
+            let listener = gloo::events::EventListener::new(
+                &gloo::utils::document(),
+                "keydown",
+                move |event| {
+                    let e: &web_sys::KeyboardEvent = event.unchecked_ref();
+                    if e.key() == "Escape" {
+                        on_close.emit(());
+                    }
+                },
+            );
+            move || drop(listener)
+        });
+    }
 
     // Fetch launcher version for this session's hostname
     {
@@ -193,7 +212,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                             hostname: host,
                             working_directory: wd,
                             prompt: data.prompt.clone(),
-                            claude_args: vec![],
+                            claude_args: vec!["--dangerously-skip-permissions".to_string()],
                             agent_type: shared::AgentType::Claude,
                             max_runtime_minutes: data.max_runtime_minutes,
                         };

--- a/frontend/src/components/share_dialog.rs
+++ b/frontend/src/components/share_dialog.rs
@@ -1,6 +1,8 @@
+use gloo::events::EventListener;
 use gloo_net::http::Request;
 use shared::api::{AddMemberRequest, UpdateMemberRoleRequest};
 use uuid::Uuid;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::HtmlInputElement;
 use yew::prelude::*;
@@ -47,6 +49,8 @@ pub struct ShareDialog {
     email_input: String,
     new_role: String,
     error: Option<String>,
+    #[allow(dead_code)] // RAII guard — must be held to keep listener active
+    _escape_listener: Option<EventListener>,
 }
 
 impl Component for ShareDialog {
@@ -55,12 +59,20 @@ impl Component for ShareDialog {
 
     fn create(ctx: &Context<Self>) -> Self {
         ctx.link().send_message(ShareDialogMsg::LoadMembers);
+        let on_close = ctx.props().on_close.clone();
+        let listener = EventListener::new(&gloo::utils::document(), "keydown", move |event| {
+            let e: &web_sys::KeyboardEvent = event.unchecked_ref();
+            if e.key() == "Escape" {
+                on_close.emit(());
+            }
+        });
         Self {
             members: Vec::new(),
             loading: true,
             email_input: String::new(),
             new_role: "viewer".to_string(),
             error: None,
+            _escape_listener: Some(listener),
         }
     }
 

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -64,8 +64,16 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let inactive_hidden = config.inactive_hidden;
         let on_select = config.on_select.clone();
         let on_activate = config.on_activate.clone();
-
         Callback::from(move |e: KeyboardEvent| {
+            // Don't handle keyboard nav when a modal overlay is open
+            if gloo::utils::document()
+                .query_selector(".sched-overlay, .share-dialog-overlay")
+                .ok()
+                .flatten()
+                .is_some()
+            {
+                return;
+            }
             let in_nav_mode = *nav_mode;
             let len = sessions.len();
 


### PR DESCRIPTION
## Summary
- Escape key now closes ScheduleDialog and ShareDialog instead of toggling keyboard nav mode
- Keyboard navigation is fully suppressed when any modal overlay is open (DOM-based detection via `.sched-overlay, .share-dialog-overlay`)
- Scheduled tasks now default to `--dangerously-skip-permissions` flag for unattended execution

## Test plan
- [ ] Open schedule dialog, press Escape — dialog closes
- [ ] Open share dialog, press Escape — dialog closes
- [ ] With either dialog open, arrow keys / hjkl don't change session selection
- [ ] Create a scheduled task — verify it includes `--dangerously-skip-permissions` in args

🤖 Generated with [Claude Code](https://claude.com/claude-code)