### PR TITLE
Triple-Escape interrupt + claude-codes 2.1.52

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -728,9 +728,9 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.51"
+version = "2.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6ec8a841ec95644b5cfaa2545e7a79fd74483bcc131cd94777271e3d3cdd3e"
+checksum = "a8e31455ac644adf66d92d35a9257a0f1aa003024587cf37efb2a5c843db59f3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3200,7 +3200,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "anyhow",
  "colored",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "anyhow",
  "hex",
@@ -4131,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.1.6"
+version = "2.1.7"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -40,7 +40,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = "2.1.51"
+claude-codes = "2.1.52"
 
 # Codex CLI integration
 codex-codes = { version = "0.101.0", default-features = false, features = ["types"] }

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -172,6 +172,15 @@ fn handle_web_client_message(
             }
             false
         }
+        ClientToServer::Interrupt => {
+            if let Some(ref key) = session_key {
+                info!("Web client sending interrupt to session");
+                session_manager.send_to_session(key, ServerToProxy::Interrupt);
+            } else {
+                warn!("Web client tried to send Interrupt without registered session");
+            }
+            false
+        }
     }
 }
 

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -22,6 +22,8 @@ pub struct KeyboardNavConfig {
     pub on_select: Callback<usize>,
     /// Callback to activate a session (mark it as having been viewed)
     pub on_activate: Callback<Uuid>,
+    /// Callback when triple-Escape interrupt is triggered
+    pub on_interrupt: Callback<()>,
 }
 
 /// Return value from the use_keyboard_nav hook.
@@ -31,6 +33,9 @@ pub struct UseKeyboardNav {
     /// Callback to handle keydown events
     pub on_keydown: Callback<KeyboardEvent>,
 }
+
+/// Max time window (ms) for 3 Escape presses to trigger an interrupt.
+const TRIPLE_ESCAPE_WINDOW_MS: f64 = 600.0;
 
 /// Hook for managing two-mode keyboard navigation.
 ///
@@ -45,18 +50,16 @@ pub struct UseKeyboardNav {
 /// - Enter/Escape/i -> Edit Mode
 /// - w -> next waiting session
 ///
-/// # Arguments
-/// * `config` - Configuration containing sessions, focused index, and callbacks
-///
-/// # Returns
-/// * `UseKeyboardNav` - The current mode and keydown handler
-///
+/// Triple-Escape (within 600ms) sends an interrupt to the focused session.
 #[hook]
 pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
     let nav_mode = use_state(|| false);
+    // Track timestamps of recent Escape presses for triple-Escape detection
+    let escape_times = use_mut_ref(Vec::<f64>::new);
 
     let on_keydown = {
         let nav_mode = nav_mode.clone();
+        let escape_times = escape_times.clone();
         let sessions = config.sessions.clone();
         let focused_index = config.focused_index;
         let hidden_sessions = config.hidden_sessions.clone();
@@ -64,6 +67,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let inactive_hidden = config.inactive_hidden;
         let on_select = config.on_select.clone();
         let on_activate = config.on_activate.clone();
+        let on_interrupt = config.on_interrupt.clone();
         Callback::from(move |e: KeyboardEvent| {
             // Don't handle keyboard nav when a modal overlay is open
             if gloo::utils::document()
@@ -134,6 +138,23 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                     on_select.emit(new_idx);
                 }
                 return;
+            }
+
+            // Track Escape presses for triple-Escape interrupt detection
+            if e.key() == "Escape" {
+                let now = js_sys::Date::now();
+                let mut times = escape_times.borrow_mut();
+                times.push(now);
+                // Keep only presses within the time window
+                times.retain(|&t| now - t <= TRIPLE_ESCAPE_WINDOW_MS);
+                if times.len() >= 3 {
+                    times.clear();
+                    e.prevent_default();
+                    // Return to edit mode and fire interrupt
+                    nav_mode.set(false);
+                    on_interrupt.emit(());
+                    return;
+                }
             }
 
             if in_nav_mode {

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -263,6 +263,16 @@ pub fn dashboard_page() -> Html {
         })
     };
 
+    // Interrupt signal counter — incremented by triple-Escape, passed to focused SessionView
+    let interrupt_signal = use_state(|| 0u32);
+
+    let on_interrupt = {
+        let interrupt_signal = interrupt_signal.clone();
+        Callback::from(move |()| {
+            interrupt_signal.set(*interrupt_signal + 1);
+        })
+    };
+
     // Use the keyboard navigation hook
     let keyboard_nav = use_keyboard_nav(KeyboardNavConfig {
         sessions: active_sessions.clone(),
@@ -272,6 +282,7 @@ pub fn dashboard_page() -> Html {
         inactive_hidden: *inactive_hidden,
         on_select: on_select_session.clone(),
         on_activate,
+        on_interrupt,
     });
 
     // Modal open callbacks
@@ -716,6 +727,7 @@ pub fn dashboard_page() -> Html {
                                                 on_activity={on_activity.clone()}
                                                 voice_enabled={*voice_enabled}
                                                 current_user_id={(*current_user_id).clone()}
+                                                interrupt_signal={*interrupt_signal}
                                             />
                                         </div>
                                     }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -62,6 +62,8 @@ pub struct SessionViewProps {
     pub voice_enabled: bool,
     #[prop_or_default]
     pub current_user_id: Option<String>,
+    #[prop_or(0)]
+    pub interrupt_signal: u32,
 }
 
 /// Messages for the SessionView component
@@ -124,6 +126,8 @@ pub enum SessionViewMsg {
     ClearTabPulse,
     /// Finish the departure animation and hide the drawer
     FinishDeparture,
+    /// Send an interrupt to stop the current Claude response
+    Interrupt,
 }
 
 /// SessionView - Main terminal view for a single session
@@ -254,7 +258,7 @@ impl Component for SessionView {
         }
     }
 
-    fn changed(&mut self, ctx: &Context<Self>, _old_props: &Self::Properties) -> bool {
+    fn changed(&mut self, ctx: &Context<Self>, old_props: &Self::Properties) -> bool {
         let now_focused = ctx.props().focused;
         let became_focused = now_focused && !self.was_focused;
         self.was_focused = now_focused;
@@ -263,6 +267,14 @@ impl Component for SessionView {
             if let Some(input) = self.input_ref.cast::<HtmlTextAreaElement>() {
                 let _ = input.focus();
             }
+        }
+
+        // Detect interrupt signal change on the focused session
+        if now_focused
+            && ctx.props().interrupt_signal != old_props.interrupt_signal
+            && ctx.props().interrupt_signal > 0
+        {
+            ctx.link().send_message(SessionViewMsg::Interrupt);
         }
 
         true
@@ -856,6 +868,13 @@ impl Component for SessionView {
                 self.tab_departing = false;
                 self.tasks_panel_open = false;
                 true
+            }
+            SessionViewMsg::Interrupt => {
+                if let Some(ref sender) = self.ws_sender {
+                    log::info!("Sending interrupt to session");
+                    send_message(sender, ClientToServer::Interrupt);
+                }
+                false
             }
             SessionViewMsg::TaskTick => {
                 let now = js_sys::Date::now();

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -217,6 +217,8 @@ pub enum WsEvent {
     GracefulShutdown(u64),
     /// Session was terminated by the server (do not reconnect)
     SessionTerminated,
+    /// Interrupt the current Claude response
+    Interrupt,
 }
 
 /// Spawn a WebSocket reader task (raw tokio-tungstenite).
@@ -354,6 +356,10 @@ async fn handle_ws_text_message(
             info!("Session terminated by server: {}", reason);
             let _ = event_tx.send(WsEvent::SessionTerminated);
             false // stop reading
+        }
+        ServerToProxy::Interrupt => {
+            info!("Interrupt received from server");
+            event_tx.send(WsEvent::Interrupt).is_ok()
         }
         _ => true,
     }

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -592,6 +592,19 @@ async fn run_shim_connection(
                     Some(WsEvent::SessionTerminated) => {
                         break ShimConnectionResult::SessionTerminated;
                     }
+                    Some(WsEvent::Interrupt) => {
+                        info!("Sending interrupt to Claude");
+                        let mut stdin = claude_stdin.lock().await;
+                        let input = ClaudeInput::interrupt();
+                        if let Ok(json_line) = serde_json::to_string(&input) {
+                            if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
+                                error!("Failed to write interrupt to claude: {}", e);
+                                break ShimConnectionResult::ClaudeExited;
+                            }
+                            let _ = stdin.write_all(b"\n").await;
+                            let _ = stdin.flush().await;
+                        }
+                    }
                     Some(WsEvent::Disconnect) | None => {
                         info!("Portal WebSocket disconnected");
                         break ShimConnectionResult::Disconnected;

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -200,6 +200,9 @@ pub enum ServerToProxy {
 
     /// Session has been terminated (proxy should NOT reconnect)
     SessionTerminated { reason: String },
+
+    /// Interrupt the current Claude response
+    Interrupt,
 }
 
 // =============================================================================
@@ -236,6 +239,9 @@ pub enum ClientToServer {
 
     /// A single chunk of a file upload
     FileUploadChunk(FileUploadChunkFields),
+
+    /// Interrupt the current Claude response
+    Interrupt,
 }
 
 /// Messages the backend sends to the frontend.


### PR DESCRIPTION
## Summary
- Update `claude-codes` crate from 2.1.51 → 2.1.52 (adds `ClaudeInput::interrupt()`)
- Pressing Escape 3 times within 600ms sends an interrupt to the focused session's Claude process
- Full interrupt pipeline: `ClientToServer::Interrupt` → backend relay → `ServerToProxy::Interrupt` → proxy writes `{"subtype":"interrupt"}` to Claude stdin
- Gracefully stops Claude's current response without killing the session

## How it works
1. Keyboard nav hook tracks Escape timestamps via `use_mut_ref`
2. On 3rd Escape within 600ms window, fires `on_interrupt` callback
3. Dashboard page increments `interrupt_signal` state counter
4. Focused `SessionView` detects prop change in `changed()`, sends `ClientToServer::Interrupt` over WebSocket
5. Backend relays to proxy via `ServerToProxy::Interrupt`
6. Proxy writes `ClaudeInput::interrupt()` JSON to claude's stdin

## Test plan
- [ ] Press Escape 3 times quickly (< 600ms) on a running session — Claude should stop responding
- [ ] Press Escape slowly (> 600ms apart) — normal nav mode toggle, no interrupt
- [ ] Verify interrupt doesn't fire when a modal is open
- [ ] Session should remain connected after interrupt (not killed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)