### PR TITLE
Fix install script source hint for zsh users

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.1.8"
+version = "2.1.9"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/downloads.rs
+++ b/backend/src/handlers/downloads.rs
@@ -174,14 +174,14 @@ add_to_path() {{
 echo "Adding to PATH..."
 
 # Try common shell rc files
-UPDATED=0
-if add_to_path "${{HOME}}/.bashrc"; then UPDATED=1; fi
-if add_to_path "${{HOME}}/.zshrc"; then UPDATED=1; fi
-if add_to_path "${{HOME}}/.profile"; then UPDATED=1; fi
+UPDATED_FILE=""
+if add_to_path "${{HOME}}/.bashrc"; then UPDATED_FILE="${{HOME}}/.bashrc"; fi
+if add_to_path "${{HOME}}/.zshrc"; then UPDATED_FILE="${{HOME}}/.zshrc"; fi
+if add_to_path "${{HOME}}/.profile"; then UPDATED_FILE="${{HOME}}/.profile"; fi
 
-if [ "${{UPDATED}}" -eq 1 ]; then
+if [ -n "${{UPDATED_FILE}}" ]; then
     echo ""
-    echo "PATH updated! Restart your shell or run: source ~/.bashrc"
+    echo "PATH updated! Restart your shell or run: source ${{UPDATED_FILE}}"
 else
     echo "PATH already configured or no rc files found."
 fi


### PR DESCRIPTION
## Summary
- Install script hardcoded `source ~/.bashrc` even when it updated `~/.zshrc`
- Now tells users to source whichever rc file was actually modified
- Bump version to 2.1.9

## Test plan
- [ ] `curl ... | bash` on macOS (zsh) shows `source ~/.zshrc`
- [ ] On Linux (bash) still shows `source ~/.bashrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)