### PR TITLE
Fix session rail scroll rate on macOS trackpads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -59,6 +59,10 @@ web-sys = { workspace = true, features = [
     "DataTransferItem",
     "DataTransferItemList",
     "DragEvent",
+    "ScrollBehavior",
+    "ScrollIntoViewOptions",
+    "ScrollLogicalPosition",
+    "ScrollToOptions",
 ] }
 
 # Utility libraries for WASM

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -286,21 +286,39 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         use_effect_with(focused_index, move |_| {
             if let Some(rail) = rail_ref.cast::<Element>() {
                 if let Some(child) = rail.children().item(focused_index as u32) {
-                    child.scroll_into_view();
+                    let opts = web_sys::ScrollIntoViewOptions::new();
+                    opts.set_behavior(web_sys::ScrollBehavior::Smooth);
+                    opts.set_block(web_sys::ScrollLogicalPosition::Nearest);
+                    opts.set_inline(web_sys::ScrollLogicalPosition::Nearest);
+                    child.scroll_into_view_with_scroll_into_view_options(&opts);
                 }
             }
             || ()
         });
     }
 
-    // Handle wheel event to translate vertical scroll to horizontal
+    // Handle wheel event to translate vertical scroll to horizontal.
+    // We directly set scrollLeft so that macOS trackpad inertia feels
+    // immediate rather than fighting CSS scroll-behavior: smooth.
     let on_wheel = {
         let rail_ref = rail_ref.clone();
         Callback::from(move |e: WheelEvent| {
             if let Some(rail) = rail_ref.cast::<HtmlElement>() {
+                let dx = e.delta_x();
+                let dy = e.delta_y();
+                // Use whichever axis has the larger delta — this lets both
+                // vertical scroll-wheel and horizontal trackpad swipes work
+                // naturally. Raw pixel values are used (no multiplier) so the
+                // scroll rate matches the rest of macOS.
+                let delta = if dx.abs() > dy.abs() { dx } else { dy };
+                if delta.abs() < 0.5 {
+                    return;
+                }
                 e.prevent_default();
-                let delta = e.delta_y();
-                rail.set_scroll_left(rail.scroll_left() + (delta * 3.0) as i32);
+                let opts = web_sys::ScrollToOptions::new();
+                opts.set_left(f64::from(rail.scroll_left()) + delta);
+                opts.set_behavior(web_sys::ScrollBehavior::Instant);
+                rail.scroll_to_with_scroll_to_options(&opts);
             }
         })
     };

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -9,7 +9,6 @@
     background: var(--bg-darker);
     border-bottom: 1px solid var(--border);
     overflow-x: auto;
-    scroll-behavior: smooth;
     scrollbar-width: thin;
     scrollbar-color: var(--border) transparent;
 }


### PR DESCRIPTION
## Summary
- Remove 3x `deltaY` multiplier so scroll speed matches native OS behavior
- Handle `deltaX` for horizontal trackpad swipes instead of swallowing them
- Remove `scroll-behavior: smooth` from CSS that fought with programmatic `scrollTo`
- Use `ScrollToOptions` with instant behavior for responsive feel

## Test plan
- [ ] Verify horizontal scroll on macOS trackpad feels proportional to other page scrolls
- [ ] Verify vertical scroll wheel still translates to horizontal rail scroll
- [ ] Verify horizontal trackpad swipe works natively on the rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)