### PR TITLE
Fix schedule dialog checkbox inline layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/schedule-dialog.css
+++ b/frontend/styles/schedule-dialog.css
@@ -264,6 +264,22 @@
     min-height: 70px;
 }
 
+.sched-checkbox {
+    flex-direction: row;
+    align-items: center;
+}
+
+.sched-checkbox label {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    cursor: pointer;
+}
+
+.sched-checkbox input[type="checkbox"] {
+    width: auto;
+}
+
 .sched-field input:focus,
 .sched-field textarea:focus {
     outline: none;


### PR DESCRIPTION
## Summary
- Add `.sched-checkbox` CSS to keep the `--dangerously-skip-permissions` checkbox and its label on the same line
- Override `.sched-field`'s `flex-direction: column` for checkbox fields

## Test plan
- [ ] Open the Schedule Task dialog from a session pill menu
- [ ] Verify the checkbox and `--dangerously-skip-permissions` text are on the same line

🤖 Generated with [Claude Code](https://claude.com/claude-code)