### PR TITLE
Fix Codex sessions failing from launcher service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.3
+
+- Fix Codex sessions failing to start from launcher: resolve binary path via `which` before spawning
+
 ## 2.2.2
 
 - Add favicon and browser tab icon for link previews

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -33,6 +33,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "which 8.0.2",
  "ws-bridge",
 ]
 
@@ -454,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -745,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -778,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -800,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1420,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3201,7 +3202,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "colored",
@@ -3216,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -4132,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "cli-tools", "claude-sessio
 resolver = "2"
 
 [workspace.package]
-version = "2.2.2"
+version = "2.2.3"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -50,3 +50,4 @@ portal-update = { path = "../portal-update" }
 reqwest = { version = "0.12", features = ["json"] }
 tokio-util.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+which = "8"

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -197,12 +197,25 @@ async fn run_session_task(
     cancel: CancellationToken,
 ) -> Option<i32> {
     loop {
+        let binary_name = match config.agent_type {
+            shared::AgentType::Codex => "codex",
+            _ => "claude",
+        };
+        let resolved_path = which::which(binary_name).ok();
+        if resolved_path.is_none() {
+            error!(
+                "'{}' not found on PATH – cannot start {:?} session",
+                binary_name, config.agent_type
+            );
+            return Some(1);
+        }
+
         let claude_config = SessionConfig {
             session_id: config.session_id,
             working_directory: PathBuf::from(&config.working_directory),
             session_name: config.session_name.clone(),
             resume: config.resume,
-            claude_path: None,
+            claude_path: resolved_path,
             extra_args: config.claude_args.clone(),
             agent_type: config.agent_type,
         };


### PR DESCRIPTION
## Summary
- Launcher passed `claude_path: None` to SessionConfig, which fell back to bare `"codex"` binary name
- The launchd/systemd service environment doesn't always have `codex` on PATH despite PR #543 baking the user PATH in
- Now resolves the full binary path via `which` before spawning, matching the agent type (codex vs claude)
- Fails with a clear error if the binary isn't found

## Test plan
- [ ] Start a Codex session via the launcher service on macOS
- [ ] Start a Claude session via the launcher service (regression check)
- [ ] Verify clear error message when binary is missing from PATH