### PR TITLE
Rename claude-code-portal to agent-portal across codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # CLAUDE.md - AI Assistant Instructions
 
-This file contains instructions for AI assistants (like Claude) working on the claude-code-portal codebase. It documents the architecture, conventions, and common tasks.
+This file contains instructions for AI assistants (like Claude) working on the agent-portal codebase. It documents the architecture, conventions, and common tasks.
 
 ## Project Overview
 
-claude-code-portal is a web-based proxy system for Claude Code sessions built with:
+agent-portal is a web-based proxy system for Claude Code sessions built with:
 - **Backend**: Rust + Axum + PostgreSQL + Diesel ORM
 - **Frontend**: Rust + Yew (WebAssembly)
 - **Proxy**: Rust CLI wrapper for claude binary
@@ -22,7 +22,7 @@ We maintain **[meawoppl/rust-code-agent-sdks](https://github.com/meawoppl/rust-c
 ### Workspace Structure
 
 ```
-claude-code-portal/
+agent-portal/
 ├── shared/              # WASM-compatible common types
 ├── backend/             # Axum server (native only)
 ├── frontend/            # Yew WASM app (WASM target)
@@ -534,7 +534,7 @@ sessions::table.filter(sessions::id.eq(...))
 **Fix**:
 1. Check backend is running: `curl http://localhost:3000/`
 2. Verify WebSocket URL: should be `ws://localhost:3000` (not `wss://`)
-3. Check backend logs: `tail -f /tmp/claude-code-portal-backend.log`
+3. Check backend logs: `tail -f /tmp/agent-portal-backend.log`
 4. Try dev mode authentication: backend with `--dev-mode`
 
 ## Code Conventions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.2.3"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -29,11 +29,10 @@ dependencies = [
  "shared",
  "tokio",
  "tokio-util",
- "toml 1.0.7+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
- "which 8.0.2",
  "ws-bridge",
 ]
 
@@ -72,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "1.0.0"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -87,15 +86,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.14"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
@@ -455,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.2.3"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -642,9 +641,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -690,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -700,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -712,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -724,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claude-codes"
@@ -746,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.2.3"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -779,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.2.3"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -801,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "cli-tools"
-version = "2.2.3"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -831,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -1421,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.2.3"
+version = "2.2.1"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2977,9 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2995,9 +2994,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",
@@ -3027,9 +3026,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -3202,7 +3201,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portal-auth"
-version = "2.2.3"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -3217,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.2.3"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -3898,9 +3897,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.29"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -4133,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.2.3"
+version = "2.2.1"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -4399,9 +4398,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.27.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -4502,9 +4501,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4679,17 +4678,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.7+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4709,9 +4708,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
@@ -4729,18 +4728,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -4949,9 +4948,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.23"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5665,12 +5664,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "winreg"

--- a/PROXY_AUTH.md
+++ b/PROXY_AUTH.md
@@ -7,7 +7,7 @@ The proxy CLI authenticates users through an OAuth device flow, similar to how `
 1. **First Run**: When you run `claude-portal` for the first time in a directory, it will:
    - Display a link and verification code
    - Wait for you to authenticate in your browser
-   - Store the auth token in `~/.config/claude-code-portal/config.json`
+   - Store the auth token in `~/.config/agent-portal/config.json`
 
 2. **Subsequent Runs**: The proxy automatically uses the cached authentication
 
@@ -75,8 +75,8 @@ $ claude-portal --reauth  # Force new authentication
 ### Config File Location
 
 The config file is stored at:
-- **Linux/Mac**: `~/.config/claude-code-portal/config.json`
-- **Windows**: `%APPDATA%\claude-code-portal\config.json`
+- **Linux/Mac**: `~/.config/agent-portal/config.json`
+- **Windows**: `%APPDATA%\agent-portal\config.json`
 
 ### Config File Format
 
@@ -153,14 +153,14 @@ claude-portal
 
 ```bash
 # Linux/Mac
-cat ~/.config/claude-code-portal/config.json | jq
+cat ~/.config/agent-portal/config.json | jq
 ```
 
 ### Manually edit config
 
 ```bash
 # Open in editor
-vim ~/.config/claude-code-portal/config.json
+vim ~/.config/agent-portal/config.json
 ```
 
 ## Security Considerations

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ A web portal that extends [Claude Code](https://docs.anthropic.com/en/docs/claud
 
 ```bash
 # Clone the repository
-git clone https://github.com/meawoppl/claude-code-portal.git
-cd claude-code-portal
+git clone https://github.com/meawoppl/agent-portal.git
+cd agent-portal
 
 # Start everything (auto-installs dependencies)
 ./scripts/dev.sh start
@@ -100,7 +100,7 @@ The **portal** refers to the complete system: backend server, web frontend, and 
 | macOS (Intel) | Builds in CI |
 | Windows (x86_64) | Builds in CI |
 
-Pre-built binaries available from [GitHub Releases](https://github.com/meawoppl/claude-code-portal/releases/latest).
+Pre-built binaries available from [GitHub Releases](https://github.com/meawoppl/agent-portal/releases/latest).
 
 ## Technologies
 
@@ -139,5 +139,5 @@ MIT License - see [LICENSE](LICENSE) file for details
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/meawoppl/claude-code-portal/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/meawoppl/claude-code-portal/discussions)
+- **Issues**: [GitHub Issues](https://github.com/meawoppl/agent-portal/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/meawoppl/agent-portal/discussions)

--- a/TEST_UPDATED.md
+++ b/TEST_UPDATED.md
@@ -129,7 +129,7 @@ Terminal 4 should show:
 
 ```bash
 # Check config file was created
-cat ~/.config/claude-code-portal/config.json
+cat ~/.config/agent-portal/config.json
 
 # Should show:
 {
@@ -190,7 +190,7 @@ cargo run -p proxy
 - [ ] Proxy shows OAuth device flow on first run
 - [ ] Can open device URL and complete OAuth
 - [ ] Proxy receives auth token after OAuth
-- [ ] Config file created at `~/.config/claude-code-portal/config.json`
+- [ ] Config file created at `~/.config/agent-portal/config.json`
 - [ ] Config contains auth token
 - [ ] Second run uses cached auth (no OAuth prompt)
 - [ ] Web UI shows login with Google
@@ -219,15 +219,15 @@ The code expires after 5 minutes. Get a new one by running the proxy again.
 
 Check permissions on `~/.config/` directory:
 ```bash
-mkdir -p ~/.config/claude-code-portal
-chmod 700 ~/.config/claude-code-portal
+mkdir -p ~/.config/agent-portal
+chmod 700 ~/.config/agent-portal
 ```
 
 ### Token not working
 
 Delete config and re-authenticate:
 ```bash
-rm ~/.config/claude-code-portal/config.json
+rm ~/.config/agent-portal/config.json
 cargo run -p proxy
 ```
 
@@ -240,5 +240,5 @@ cargo run -p proxy
 docker-compose down -v
 
 # Remove config (optional)
-rm -rf ~/.config/claude-code-portal
+rm -rf ~/.config/agent-portal
 ```

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting Guide
 
-Common issues and solutions for claude-code-portal development.
+Common issues and solutions for agent-portal development.
 
 ## diesel CLI Installation Issues
 
@@ -87,7 +87,7 @@ brew install trunk
 **Solution:**
 ```bash
 # Check if container is running
-docker ps | grep claude-code-portal
+docker ps | grep agent-portal
 
 # Start database
 docker-compose -f docker-compose.test.yml up -d db
@@ -194,7 +194,7 @@ cargo run -p backend -- --dev-mode
 curl http://localhost:3000/
 
 # Check backend logs
-tail -f /tmp/claude-code-portal-backend.log
+tail -f /tmp/agent-portal-backend.log
 
 # Verify WebSocket endpoint
 wscat -c ws://localhost:3000/ws/session
@@ -260,7 +260,7 @@ chmod +x scripts/*.sh
 If everything is broken, try a full cleanup:
 ```bash
 ./scripts/clean.sh
-rm -rf ~/.config/claude-code-portal/  # Remove cached auth
+rm -rf ~/.config/agent-portal/  # Remove cached auth
 cargo clean
 cd frontend && trunk clean && cd ..
 ./scripts/install-deps.sh
@@ -297,7 +297,7 @@ RUST_LOG=debug cargo run -p backend -- --dev-mode
 RUST_LOG=debug cargo run -p proxy
 
 # View all logs
-tail -f /tmp/claude-code-portal-*.log
+tail -f /tmp/agent-portal-*.log
 ```
 
 ### Test database connection manually
@@ -321,8 +321,8 @@ If you're still stuck:
 
 1. Check the logs:
    ```bash
-   tail -f /tmp/claude-code-portal-backend.log
-   tail -f /tmp/claude-code-portal-proxy.log
+   tail -f /tmp/agent-portal-backend.log
+   tail -f /tmp/agent-portal-proxy.log
    ```
 
 2. Enable verbose output:

--- a/backend/src/handlers/downloads.rs
+++ b/backend/src/handlers/downloads.rs
@@ -43,7 +43,7 @@ CONFIG_DIR="${{HOME}}/.config/claude-portal"
 BIN_NAME="agent-portal"
 BIN_PATH="${{CONFIG_DIR}}/${{BIN_NAME}}"
 CONFIG_FILE="${{CONFIG_DIR}}/launcher.toml"
-GITHUB_RELEASE_URL="https://github.com/meawoppl/claude-code-portal/releases/download/latest"
+GITHUB_RELEASE_URL="https://github.com/meawoppl/agent-portal/releases/download/latest"
 BACKEND_URL="{backend_url}"
 
 echo "Agent Portal Installer"

--- a/claude-session-lib/src/output_buffer.rs
+++ b/claude-session-lib/src/output_buffer.rs
@@ -115,7 +115,7 @@ impl PendingOutputBuffer {
 
     /// Get the path for a session's buffer file
     fn buffer_path(session_id: Uuid) -> Result<PathBuf> {
-        let config_dir = directories::ProjectDirs::from("com", "anthropic", "claude-code-portal")
+        let config_dir = directories::ProjectDirs::from("com", "anthropic", "agent-portal")
             .context("Failed to determine config directory")?
             .config_dir()
             .to_path_buf();

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -682,7 +682,7 @@ async fn recv_option(rx: &mut tokio::sync::oneshot::Receiver<()>) -> Option<()> 
 ///
 /// The Claude session internally uses a dedicated drain task to continuously
 /// read stdout, so there's no risk of buffer starvation in this select! loop.
-/// See: https://github.com/meawoppl/claude-code-portal/issues/278
+/// See: https://github.com/meawoppl/agent-portal/issues/278
 async fn run_main_loop(
     claude_session: &mut ClaudeSession,
     input_rx: &mut mpsc::UnboundedReceiver<String>,

--- a/docs/AUTH_FLOWS.md
+++ b/docs/AUTH_FLOWS.md
@@ -1,6 +1,6 @@
 # Authentication Flows - Complete Reference
 
-This document provides exhaustive detail on every authentication pathway in claude-code-portal. There are **TWO COMPLETELY SEPARATE** authentication systems that share some infrastructure but serve different purposes.
+This document provides exhaustive detail on every authentication pathway in agent-portal. There are **TWO COMPLETELY SEPARATE** authentication systems that share some infrastructure but serve different purposes.
 
 ---
 
@@ -196,7 +196,7 @@ Allow the CLI tool (proxy binary) to authenticate without requiring a browser on
 Step 1.1: User runs CLI command that requires authentication
           Example: claude-portal --backend-url wss://example.com
           ↓
-          CLI checks for cached token in ~/.config/claude-code-portal/config.json
+          CLI checks for cached token in ~/.config/agent-portal/config.json
           ├── Token exists and valid → Use it, skip device flow
           └── No token or expired → Start device flow
 
@@ -377,7 +377,7 @@ Step 4.3: CLI receives "complete" response
           }
 
 Step 4.4: CLI stores credentials
-          Write to ~/.config/claude-code-portal/config.json:
+          Write to ~/.config/agent-portal/config.json:
           {
             "backend_url": "wss://example.com",
             "auth_token": "eyJhbGciOiJIUzI1NiIs...",

--- a/docs/CODEX_SUPPORT.md
+++ b/docs/CODEX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Codex Support Plan
 
-This document plans what would need to change in claude-code-portal to support OpenAI Codex CLI sessions alongside Claude Code sessions. Both agent SDKs ([claude-codes](https://crates.io/crates/claude-codes) and [codex-codes](https://crates.io/crates/codex-codes)) are maintained in the same [repository](https://github.com/meawoppl/rust-code-agent-sdks).
+This document plans what would need to change in agent-portal to support OpenAI Codex CLI sessions alongside Claude Code sessions. Both agent SDKs ([claude-codes](https://crates.io/crates/claude-codes) and [codex-codes](https://crates.io/crates/codex-codes)) are maintained in the same [repository](https://github.com/meawoppl/rust-code-agent-sdks).
 
 ## Protocol Comparison
 

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-This guide covers deploying claude-code-portal to production.
+This guide covers deploying agent-portal to production.
 
 ## Prerequisites
 
@@ -192,7 +192,7 @@ Admins can access the admin dashboard at `/admin` which provides:
 | macOS (Intel) | Untested | Builds in CI, PRs welcome |
 | Windows (x86_64) | Untested | Builds in CI, PRs welcome |
 
-Pre-built binaries for all platforms are available from [GitHub Releases](https://github.com/meawoppl/claude-code-portal/releases/latest).
+Pre-built binaries for all platforms are available from [GitHub Releases](https://github.com/meawoppl/agent-portal/releases/latest).
 
 ## Troubleshooting
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-This guide covers setting up a development environment and contributing to claude-code-portal.
+This guide covers setting up a development environment and contributing to agent-portal.
 
 ## Prerequisites
 
@@ -33,8 +33,8 @@ The fastest way to get a dev environment running:
 
 ```bash
 # Clone the repository
-git clone https://github.com/meawoppl/claude-code-portal.git
-cd claude-code-portal
+git clone https://github.com/meawoppl/agent-portal.git
+cd agent-portal
 
 # Start everything (auto-installs dependencies)
 ./scripts/dev.sh start
@@ -120,7 +120,7 @@ cargo run -p proxy -- --backend-url ws://localhost:3000
 ## Project Structure
 
 ```
-claude-code-portal/
+agent-portal/
 ├── Cargo.toml              # Workspace definition
 ├── Cargo.lock              # Dependency lock file
 │
@@ -357,7 +357,7 @@ psql $DATABASE_URL
 lsof -i :3000
 
 # Check logs
-tail -f /tmp/claude-code-portal-backend.log
+tail -f /tmp/agent-portal-backend.log
 ```
 
 **Frontend won't build:**

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -18,7 +18,7 @@ docker-compose down
 ## Building the Image
 
 ```bash
-docker build -f backend/Dockerfile -t claude-code-portal-backend .
+docker build -f backend/Dockerfile -t agent-portal-backend .
 ```
 
 ## Running with Environment Variables
@@ -68,24 +68,24 @@ Run the container with the env file:
 
 ```bash
 docker run -d \
-  --name claude-code-portal-backend \
+  --name agent-portal-backend \
   -p 3000:3000 \
   --env-file .env \
-  claude-code-portal-backend
+  agent-portal-backend
 ```
 
 Or pass variables directly:
 
 ```bash
 docker run -d \
-  --name claude-code-portal-backend \
+  --name agent-portal-backend \
   -p 3000:3000 \
   -e DATABASE_URL="postgresql://..." \
   -e GOOGLE_CLIENT_ID="..." \
   -e GOOGLE_CLIENT_SECRET="..." \
   -e GOOGLE_REDIRECT_URI="https://your-domain.com/api/auth/google/callback" \
   -e SESSION_SECRET="$(openssl rand -base64 32)" \
-  claude-code-portal-backend
+  agent-portal-backend
 ```
 
 ## Docker Compose
@@ -98,7 +98,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
-    container_name: claude-code-portal-backend
+    container_name: agent-portal-backend
     ports:
       - "3000:3000"
     env_file:
@@ -165,7 +165,7 @@ docker buildx create --use
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
   -f backend/Dockerfile \
-  -t your-registry/claude-code-portal-backend:latest \
+  -t your-registry/agent-portal-backend:latest \
   --push \
   .
 ```
@@ -205,7 +205,7 @@ docker buildx build \
 
 Check logs:
 ```bash
-docker logs claude-code-portal-backend
+docker logs agent-portal-backend
 ```
 
 Common causes:
@@ -217,7 +217,7 @@ Common causes:
 
 Test connectivity:
 ```bash
-docker run --rm --env-file .env claude-code-portal-backend \
+docker run --rm --env-file .env agent-portal-backend \
   bash -c 'psql $DATABASE_URL -c "SELECT 1"'
 ```
 
@@ -225,7 +225,7 @@ docker run --rm --env-file .env claude-code-portal-backend \
 
 Test the endpoint:
 ```bash
-docker exec claude-code-portal-backend curl -f http://localhost:3000/
+docker exec agent-portal-backend curl -f http://localhost:3000/
 ```
 
 ## Production Checklist

--- a/docs/INSTALL_FLOW.md
+++ b/docs/INSTALL_FLOW.md
@@ -81,7 +81,7 @@ curl -fsSL "http://localhost:3000/api/download/install.sh?init_url=http%3A%2F%2F
 
 When the user runs the curl command, the backend generates a bash script that:
 
-1. **Downloads the binary** to `~/.config/claude-code-portal/claude-portal`
+1. **Downloads the binary** to `~/.config/agent-portal/claude-portal`
 2. **Makes it executable**
 3. **Adds to PATH** in `.bashrc`/`.zshrc`/`.profile`
 4. **Runs initialization** (if init_url was provided):
@@ -97,7 +97,7 @@ When `claude-portal --init <url>` runs, it:
 2. **Extracts the backend URL** (converts `http://` to `ws://` for WebSocket)
 3. **Decodes the base64 config** from the `/p/{config}` path
 4. **Extracts the JWT token** from the config
-5. **Saves to config file** (`~/.config/claude-code-portal/claude-code-portal/config.json`):
+5. **Saves to config file** (`~/.config/agent-portal/agent-portal/config.json`):
    ```json
    {
      "sessions": {

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -6,8 +6,8 @@ This guide covers using the `dev.sh` script to quickly set up a local developmen
 
 ```bash
 # Clone and start
-git clone https://github.com/meawoppl/claude-code-portal.git
-cd claude-code-portal
+git clone https://github.com/meawoppl/agent-portal.git
+cd agent-portal
 ./scripts/dev.sh start
 ```
 
@@ -52,7 +52,7 @@ Access the database directly:
 ### Backend
 
 - **URL**: http://localhost:3000
-- **Log file**: `/tmp/claude-code-portal-backend.log`
+- **Log file**: `/tmp/agent-portal-backend.log`
 - **Mode**: Dev mode (OAuth bypassed)
 - **Test user**: `testing@testing.local`
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -128,7 +128,7 @@ Terminal 4 should show:
 
 ```bash
 # Check config file was created
-cat ~/.config/claude-code-portal/config.json
+cat ~/.config/agent-portal/config.json
 
 # Should show:
 {
@@ -190,7 +190,7 @@ cargo run -p proxy
 - [ ] Proxy shows OAuth device flow on first run
 - [ ] Can open device URL and complete OAuth
 - [ ] Proxy receives auth token after OAuth
-- [ ] Config file created at `~/.config/claude-code-portal/config.json`
+- [ ] Config file created at `~/.config/agent-portal/config.json`
 - [ ] Config contains auth token
 - [ ] Second run uses cached auth (no OAuth prompt)
 - [ ] Web UI shows login with Google
@@ -219,15 +219,15 @@ The code expires after 15 minutes. Get a new one by running the proxy again.
 
 Check permissions on `~/.config/` directory:
 ```bash
-mkdir -p ~/.config/claude-code-portal
-chmod 700 ~/.config/claude-code-portal
+mkdir -p ~/.config/agent-portal
+chmod 700 ~/.config/agent-portal
 ```
 
 ### Token not working
 
 Delete config and re-authenticate:
 ```bash
-rm ~/.config/claude-code-portal/config.json
+rm ~/.config/agent-portal/config.json
 cargo run -p proxy
 ```
 
@@ -240,5 +240,5 @@ cargo run -p proxy
 docker-compose down -v
 
 # Remove config (optional)
-rm -rf ~/.config/claude-code-portal
+rm -rf ~/.config/agent-portal
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -44,7 +44,7 @@ To authenticate, visit: https://your-portal.com/api/auth/device
 Enter code: ABC-123
 ```
 
-Open the URL in your browser, sign in with Google, and enter the code. Credentials are cached in `~/.config/claude-code-portal/config.json`.
+Open the URL in your browser, sign in with Google, and enter the code. Credentials are cached in `~/.config/agent-portal/config.json`.
 
 ### CLI Options
 

--- a/docs/VSCODE_SETUP.md
+++ b/docs/VSCODE_SETUP.md
@@ -4,7 +4,7 @@ Route Claude Code extension sessions through the portal so they appear on the da
 
 ## Prerequisites
 
-- `claude-portal` binary installed (from [GitHub Releases](https://github.com/meawoppl/claude-code-portal/releases/latest) or built from source)
+- `claude-portal` binary installed (from [GitHub Releases](https://github.com/meawoppl/agent-portal/releases/latest) or built from source)
 - Portal backend running (locally or remotely)
 
 ## Setup
@@ -32,7 +32,7 @@ Once authenticated, all future sessions (terminal and VS Code) reuse the stored 
 
 **Important**: The auth token is stored per-working-directory. The shim uses a cross-directory fallback, so authenticating from *any* directory is sufficient for VS Code sessions to work.
 
-**Config location on macOS**: `~/Library/Application Support/com.anthropic.claude-code-portal/config.json` (not `~/.config/`). The proxy uses the `directories` crate which follows OS-standard paths.
+**Config location on macOS**: `~/Library/Application Support/com.anthropic.agent-portal/config.json` (not `~/.config/`). The proxy uses the `directories` crate which follows OS-standard paths.
 
 ### 2. Create the shim script
 
@@ -92,7 +92,7 @@ The portal binary is printing non-JSON to stdout. Ensure you have the latest bin
 
 ```bash
 # Rebuild from source
-cd /path/to/claude-code-portal
+cd /path/to/agent-portal
 cargo build --release -p claude-portal
 cp target/release/claude-portal ~/.claude/claude-portal
 ```
@@ -111,8 +111,8 @@ The shim crashed before launching claude. Common causes:
 The shim launched claude but couldn't register with the portal. Check:
 
 1. **Auth token exists**: Check the config file for `auth_token` entries:
-   - macOS: `cat ~/Library/Application\ Support/com.anthropic.claude-code-portal/config.json`
-   - Linux: `cat ~/.config/claude-code-portal/config.json`
+   - macOS: `cat ~/Library/Application\ Support/com.anthropic.agent-portal/config.json`
+   - Linux: `cat ~/.config/agent-portal/config.json`
 2. **Backend is reachable**: `curl https://your-portal-server/` should return HTML
 3. **WebSocket connects**: Check stderr output (visible in VS Code output panel > Claude Code)
 

--- a/docs/proxy-internals.md
+++ b/docs/proxy-internals.md
@@ -6,7 +6,7 @@ This document describes the internal architecture and message flow of the `claud
 
 The proxy acts as a bridge between:
 1. **Claude CLI** - The local Claude Code command-line tool
-2. **Backend WebSocket** - The claude-code-portal backend server
+2. **Backend WebSocket** - The agent-portal backend server
 3. **Web Interface** - Users interacting via browser
 
 ```
@@ -60,7 +60,7 @@ The proxy communicates with the backend using typed per-endpoint enums defined i
 ### Startup Sequence
 
 1. **Parse Configuration**
-   - Load saved auth from `~/.config/claude-code-portal/config.json`
+   - Load saved auth from `~/.config/agent-portal/config.json`
    - Parse CLI arguments (`--init`, `--backend-url`, etc.)
 
 2. **Authentication**
@@ -129,8 +129,8 @@ let mut claude_session = Session::new(claude_config).await?;
 ## Configuration Storage
 
 Config is stored in the OS-standard config directory (via the `directories` crate):
-- Linux: `~/.config/claude-code-portal/config.json`
-- macOS: `~/Library/Application Support/com.anthropic.claude-code-portal/config.json`
+- Linux: `~/.config/agent-portal/config.json`
+- macOS: `~/Library/Application Support/com.anthropic.agent-portal/config.json`
 
 ```json
 {

--- a/docs/proxy-login-flow.md
+++ b/docs/proxy-login-flow.md
@@ -1,6 +1,6 @@
 # Proxy Binary Login Flow
 
-This document describes how the `claude-portal` CLI authenticates with the claude-code-portal backend.
+This document describes how the `claude-portal` CLI authenticates with the agent-portal backend.
 
 ## Overview
 
@@ -52,7 +52,7 @@ The simplest way to authenticate the proxy is using a pre-generated JWT token fr
 │     - Extracts optional session prefix                              │
 │                     │                                                │
 │                     ▼                                                │
-│  6. Saves to ~/.config/claude-code-portal/config.json                         │
+│  6. Saves to ~/.config/agent-portal/config.json                         │
 │                     │                                                │
 │                     ▼                                                │
 │  ✓ Configuration saved for user@example.com                         │
@@ -252,7 +252,7 @@ In dev mode:
 Credentials are stored in:
 
 ```
-~/.config/claude-code-portal/config.json
+~/.config/agent-portal/config.json
 ```
 
 Structure:

--- a/frontend/src/components/proxy_token_setup.rs
+++ b/frontend/src/components/proxy_token_setup.rs
@@ -115,14 +115,14 @@ pub fn proxy_token_setup() -> Html {
                             <p class="note warning-note">
                                 <span class="note-icon">{ "!" }</span>
                                 { "Windows support is experimental and largely untested. " }
-                                <a href="https://github.com/meawoppl/claude-code-portal/issues" target="_blank">
+                                <a href="https://github.com/meawoppl/agent-portal/issues" target="_blank">
                                     { "Please report issues!" }
                                 </a>
                             </p>
                             <p class="note windows-note">
                                 <span class="note-icon">{ "!" }</span>
                                 { "Download Windows binary from " }
-                                <a href="https://github.com/meawoppl/claude-code-portal/releases/latest" target="_blank">
+                                <a href="https://github.com/meawoppl/agent-portal/releases/latest" target="_blank">
                                     { "GitHub releases" }
                                 </a>
                             </p>

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -773,7 +773,7 @@ pub fn dashboard_page() -> Html {
                         </div>
                         <div class="hints-right">
                             <a
-                                href="https://github.com/meawoppl/claude-code-portal/issues/new"
+                                href="https://github.com/meawoppl/agent-portal/issues/new"
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 class="bug-report-link"

--- a/frontend/src/pages/splash.rs
+++ b/frontend/src/pages/splash.rs
@@ -120,7 +120,7 @@ pub fn splash_page() -> Html {
                 <div class="splash-footer">
                     <span class="version">{ format!("v{}", VERSION) }</span>
                     <a
-                        href="https://github.com/meawoppl/claude-code-portal"
+                        href="https://github.com/meawoppl/agent-portal"
                         target="_blank"
                         rel="noopener noreferrer"
                         class="footer-link"
@@ -129,7 +129,7 @@ pub fn splash_page() -> Html {
                         { "GitHub" }
                     </a>
                     <a
-                        href="https://github.com/meawoppl/claude-code-portal/issues/new"
+                        href="https://github.com/meawoppl/agent-portal/issues/new"
                         target="_blank"
                         rel="noopener noreferrer"
                         class="footer-link bug-report"

--- a/portal-update/src/lib.rs
+++ b/portal-update/src/lib.rs
@@ -13,7 +13,7 @@ use tracing::info;
 use tracing::warn;
 
 /// GitHub repository for releases
-const GITHUB_REPO: &str = "meawoppl/claude-code-portal";
+const GITHUB_REPO: &str = "meawoppl/agent-portal";
 
 /// Result of an update check
 #[derive(Debug)]
@@ -123,7 +123,7 @@ pub async fn check_for_update(binary_prefix: &str, check_only: bool) -> Result<U
     info!("Platform: {} {}", platform.os, platform.arch);
 
     let client = reqwest::Client::builder()
-        .user_agent("claude-portal")
+        .user_agent("agent-portal")
         .build()
         .context("Failed to create HTTP client")?;
 

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -135,7 +135,7 @@ impl Drop for ConfigLock {
 
 impl ProxyConfig {
     pub fn config_path() -> Result<PathBuf> {
-        let config_dir = directories::ProjectDirs::from("com", "anthropic", "claude-code-portal")
+        let config_dir = directories::ProjectDirs::from("com", "anthropic", "agent-portal")
             .context("Failed to determine config directory")?
             .config_dir()
             .to_path_buf();

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -29,7 +29,7 @@ QUICK START:\n  \
 2. Run: claude-portal --init <token-url>\n  \
 3. Start coding: claude-portal [claude args]\n\n\
 CONFIG:\n  \
-Configuration is stored in ~/.config/claude-code-portal/config.json and includes\n  \
+Configuration is stored in ~/.config/agent-portal/config.json and includes\n  \
 the backend URL and authentication tokens per working directory."
 )]
 #[command(after_help = "EXAMPLES:\n  \

--- a/proxy/src/update.rs
+++ b/proxy/src/update.rs
@@ -1,4 +1,4 @@
-//! Auto-update functionality for the claude-portal binary.
+//! Auto-update functionality for the agent-portal binary.
 //!
 //! Thin wrapper around `portal_update` with the correct binary prefix.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -94,7 +94,7 @@ This script:
 - Stops Docker containers and removes volumes
 - Cleans cargo build artifacts
 - Removes log files
-- Optionally removes ~/.config/claude-code-portal/
+- Optionally removes ~/.config/agent-portal/
 
 **Usage:**
 ```bash
@@ -163,13 +163,13 @@ cargo run -p proxy -- \
 ## Log Files
 
 Scripts write logs to `/tmp/`:
-- `/tmp/claude-code-portal-backend.log` - Backend logs
-- `/tmp/claude-code-portal-proxy.log` - Proxy logs
+- `/tmp/agent-portal-backend.log` - Backend logs
+- `/tmp/agent-portal-proxy.log` - Proxy logs
 
 View logs:
 ```bash
-tail -f /tmp/claude-code-portal-backend.log
-tail -f /tmp/claude-code-portal-proxy.log
+tail -f /tmp/agent-portal-backend.log
+tail -f /tmp/agent-portal-proxy.log
 ```
 
 ## Troubleshooting
@@ -178,7 +178,7 @@ tail -f /tmp/claude-code-portal-proxy.log
 
 ```bash
 # Check if database is running
-docker ps | grep claude-code-portal
+docker ps | grep agent-portal
 
 # If not, start it
 docker-compose -f docker-compose.test.yml up -d db

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -30,10 +30,10 @@ rm -f /tmp/claude-portal-*.log
 success "Logs removed"
 
 log "Removing test config (optional)..."
-read -p "Remove ~/.config/claude-code-portal/config.json? (y/N) " -n 1 -r
+read -p "Remove ~/.config/agent-portal/config.json? (y/N) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-    rm -rf ~/.config/claude-code-portal/
+    rm -rf ~/.config/agent-portal/
     success "Config removed"
 fi
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -14,7 +14,7 @@ NC='\033[0m' # No Color
 # PID file locations
 PID_DIR="/tmp/claude-portal-dev"
 BACKEND_PID_FILE="$PID_DIR/backend.pid"
-DB_CONTAINER="claude-portal-db"
+DB_CONTAINER="agent-portal-db"
 
 # Log file locations
 BACKEND_LOG="/tmp/claude-portal-backend.log"
@@ -191,7 +191,7 @@ stop_all() {
 # Show status
 show_status() {
     echo ""
-    echo "Claude Code Portal Development Environment Status"
+    echo "Agent Portal Development Environment Status"
     echo "=================================================="
     echo ""
 
@@ -252,7 +252,7 @@ show_logs() {
 do_start() {
     echo ""
     echo "╔═══════════════════════════════════════════════════════════╗"
-    echo "║     Starting Claude Code Portal Development Environment   ║"
+    echo "║       Starting Agent Portal Development Environment       ║"
     echo "╚═══════════════════════════════════════════════════════════╝"
     echo ""
 
@@ -263,7 +263,7 @@ do_start() {
 
     echo ""
     echo "╔═══════════════════════════════════════════════════════════╗"
-    echo "║        ✅ Claude Code Portal Dev Environment Ready        ║"
+    echo "║          ✅ Agent Portal Dev Environment Ready            ║"
     echo "╚═══════════════════════════════════════════════════════════╝"
     echo ""
     echo "  🌐 Web Interface:  http://localhost:3000/"
@@ -298,7 +298,7 @@ nuke_db() {
     stop_all
 
     log "Removing database volume..."
-    docker volume rm claude-code-portal_test_postgres_data 2>/dev/null || true
+    docker volume rm agent-portal_test_postgres_data 2>/dev/null || true
 
     success "Database nuked. Run './scripts/dev.sh start' to recreate."
 }


### PR DESCRIPTION
## Summary
- Update all references from the old project name `claude-code-portal` to `agent-portal` across source code, scripts, and documentation
- GitHub URLs, config paths (`~/.config/`), Docker names, log file paths, and macOS `ProjectDirs` paths all updated
- 31 files changed, pure find-and-replace — no logic changes

## Test plan
- [x] `cargo check --workspace` passes
- [ ] CI passes (clippy, fmt, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)