### PR TITLE
Remove dead code from shared and backend

### DIFF
--- a/backend/src/speech.rs
+++ b/backend/src/speech.rs
@@ -77,12 +77,6 @@ impl SpeechService {
         Self { config }
     }
 
-    /// Create a new speech service with default configuration
-    #[allow(dead_code)]
-    pub fn with_defaults() -> Self {
-        Self::new(SpeechConfig::default())
-    }
-
     /// Start a streaming recognition session
     ///
     /// Returns a tuple of:
@@ -234,20 +228,4 @@ async fn run_recognition(
     let _ = recognize_task.await;
 
     Ok(())
-}
-
-/// Check if Google Cloud credentials are available
-#[allow(dead_code)]
-pub fn credentials_available(path: Option<&str>) -> bool {
-    match path {
-        Some(p) => std::path::Path::new(p).exists(),
-        None => {
-            // Check for application default credentials
-            if let Ok(adc_path) = std::env::var("GOOGLE_APPLICATION_CREDENTIALS") {
-                std::path::Path::new(&adc_path).exists()
-            } else {
-                false
-            }
-        }
-    }
 }

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -2,9 +2,6 @@
 
 use serde::{Deserialize, Serialize};
 
-// Re-export types from parent module for convenience
-pub use crate::{DevicePollResponse, MessageInfo, SessionInfo, UserInfo};
-
 /// API error types
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ApiError {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -362,14 +362,6 @@ impl std::fmt::Debug for PortalContent {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MessageInfo {
-    pub id: Uuid,
-    pub role: MessageRole,
-    pub content: String,
-    pub created_at: String,
-}
-
 // ============================================================================
 // Device Flow Types (shared between backend and proxy)
 // ============================================================================


### PR DESCRIPTION
## Summary
- Remove unused `MessageInfo` struct from shared
- Remove stale re-exports in `shared/src/api.rs` (leftover from cli-tools)
- Remove dead `speech::with_defaults()` and `speech::credentials_available()` from backend

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace` — no warnings
- [x] `cargo test --workspace` — 173 tests pass