### PR TITLE
Replace stale CC-Proxy naming with Agent Portal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # =============================================================================
-# CC-Proxy Backend Configuration
+# Agent Portal Backend Configuration
 # =============================================================================
 # Copy this file to .env and fill in your actual values
 # DO NOT commit .env to version control
@@ -9,7 +9,7 @@
 # Database Configuration (NeonDB / PostgreSQL)
 # -----------------------------------------------------------------------------
 # Format: postgresql://user:password@host:port/database?sslmode=require
-# For local testing with docker-compose: postgresql://ccproxy:dev_password_change_in_production@localhost:5432/ccproxy
+# For local testing with docker-compose: postgresql://claude_portal:dev_password_change_in_production@localhost:5432/claude_portal
 DATABASE_URL=postgresql://user:password@hostname/database
 
 # -----------------------------------------------------------------------------

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     id: deployment
     attributes:
       label: Deployment Type
-      description: How are you using cc-proxy?
+      description: How are you using Agent Portal?
       options:
         - txcl.io (hosted service)
         - Self-hosted with my own config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.3
+
+- Replace stale "CC-Proxy" / "cc-proxy" references with "Agent Portal" / "agent-portal" across codebase
+- Remove stale cli-tools entry from docs/DEVELOPING.md directory listing
+
 ## 2.3.2
 
 - Add unified AppError type for backend handlers with structured error responses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.3.2"
+version = "2.3.3"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/fix_migration_names.sql
+++ b/backend/migrations/fix_migration_names.sql
@@ -9,7 +9,7 @@
 -- suffix, we changed the version identifier.
 --
 -- Usage: Run this via docker exec or psql:
---   docker exec <container> psql -U ccproxy -f /path/to/fix_migration_names.sql
+--   docker exec <container> psql -U claude_portal -f /path/to/fix_migration_names.sql
 --   -- or --
 --   psql $DATABASE_URL -f backend/migrations/fix_migration_names.sql
 --

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -29,8 +29,8 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use handlers::websocket::SessionManager;
 
 #[derive(Parser, Debug, Clone)]
-#[command(name = "cc-proxy-backend")]
-#[command(about = "CC-Proxy backend server")]
+#[command(name = "agent-portal-backend")]
+#[command(about = "Agent Portal backend server")]
 struct Args {
     /// Enable development mode (bypasses OAuth, creates test user)
     #[arg(long)]

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -171,7 +171,6 @@ agent-portal/
 ├── claude-session-lib/     # Library for managing Claude CLI sessions
 ├── portal-auth/            # Shared OAuth device flow client
 ├── portal-update/          # Shared auto-update logic
-├── cli-tools/              # Developer CLI tools (poke, etc.)
 │
 ├── scripts/                # Helper scripts
 │   ├── dev.sh              # Development environment

--- a/frontend/lint/package.json
+++ b/frontend/lint/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "cc-proxy-css-lint",
+  "name": "agent-portal-css-lint",
   "version": "0.1.0",
   "private": true,
-  "description": "CSS linting for cc-proxy frontend",
+  "description": "CSS linting for agent-portal frontend",
   "scripts": {
     "lint:css": "stylelint \"../styles/**/*.css\"",
     "lint:css:fix": "stylelint \"../styles/**/*.css\" --fix"

--- a/scripts/test-dev.sh
+++ b/scripts/test-dev.sh
@@ -193,7 +193,7 @@ done
 
 echo ""
 echo "╔══════════════════════════════════════════════════════╗"
-echo "║          ✅ CC-Proxy Test Environment Running        ║"
+echo "║       ✅ Agent Portal Test Environment Running        ║"
 echo "╚══════════════════════════════════════════════════════╝"
 echo ""
 echo "  🌐 Web Interface:  http://localhost:3000/"

--- a/scripts/test-oauth.sh
+++ b/scripts/test-oauth.sh
@@ -113,7 +113,7 @@ PROXY_PID=$!
 
 echo ""
 echo "╔══════════════════════════════════════════════════════╗"
-echo "║       ✅ CC-Proxy Test Environment (OAuth Mode)      ║"
+echo "║     ✅ Agent Portal Test Environment (OAuth Mode)     ║"
 echo "╚══════════════════════════════════════════════════════╝"
 echo ""
 echo "  🌐 Web Interface:  http://localhost:3000/app/"


### PR DESCRIPTION
## Summary

- Replace all stale "CC-Proxy" / "cc-proxy" / "ccproxy" references with "Agent Portal" / "agent-portal" across the codebase
- Update clap command attributes in `backend/src/main.rs`
- Fix stale naming in `.env.example`, shell scripts, issue templates, `package.json`, and migration SQL comments
- Remove stale `cli-tools/` entry from `docs/DEVELOPING.md` directory listing
- Bump version to 2.3.3

## Files changed

- `backend/src/main.rs` — clap command name/about
- `.env.example` — header comment and docker-compose example URL
- `scripts/test-oauth.sh` — banner text
- `scripts/test-dev.sh` — banner text
- `frontend/lint/package.json` — package name and description
- `.github/ISSUE_TEMPLATE/bug_report.yml` — deployment dropdown description
- `backend/migrations/fix_migration_names.sql` — usage comment
- `docs/DEVELOPING.md` — remove stale cli-tools line
- `Cargo.toml` — version bump to 2.3.3
- `CHANGELOG.md` — add 2.3.3 entry

## Test plan

- [x] `cargo clippy` passes on all buildable packages
- [x] `cargo test` passes (53 tests)
- [x] `cargo fmt` applied
- [x] No remaining cc-proxy/CC-Proxy references outside of changelog