### PR TITLE
Change tasks drawer from overlay to push layout

### DIFF
--- a/frontend/styles/tasks-sidebar.css
+++ b/frontend/styles/tasks-sidebar.css
@@ -2,18 +2,16 @@
    Tasks Sidebar Overlay — "window shade" drawer with pull-tab
    ========================================================================== */
 
-/* --- Drawer wrapper (positions the whole unit) --- */
+/* --- Drawer wrapper (flex sibling of messages — pushes chat to make room) --- */
 .tasks-drawer {
-    position: absolute;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    z-index: 20;
     display: flex;
+    flex-shrink: 0;
     pointer-events: none;
     transition: width 0.25s ease-in-out;
     width: 0;
+    overflow: hidden;
     animation: tabSlideIn 0.35s ease-out;
+    position: relative; /* anchor the pull-tab */
 }
 
 .tasks-drawer.open {


### PR DESCRIPTION
## Summary
- Tasks sidebar now uses flex layout instead of absolute positioning
- When open, it pushes the chat area narrower instead of covering it
- Chat content remains fully visible and readable while viewing tasks

## Test plan
- [ ] Open a session with active sub-agents/background tasks
- [ ] Click the tasks tab — chat should shrink, not be covered
- [ ] Close the drawer — chat should expand back smoothly
- [ ] Verify pull-tab still anchors correctly to the drawer edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)