### PR TITLE
Fix send bar not clearing after attachment send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.4
+
+- Fix send bar not clearing after sending with attachments
+
 ## 2.3.3
 
 - Consolidate remaining duplicate user ID extraction into shared auth module

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "anyhow",
  "hex",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.3.3"
+version = "2.3.4"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -702,6 +702,7 @@ impl Component for SessionView {
                 let sender = self.ws_sender.clone();
                 let user_input = self.get_input_text().trim().to_string();
                 self.set_input_text("");
+                self.input_text.clear();
                 if !user_input.is_empty() {
                     self.command_history.push(user_input.clone());
                 }


### PR DESCRIPTION
## Summary
- Fix the send bar text reappearing after sending a message with attachments
- The `FilesSelected` handler cleared the DOM textarea but not the `input_text` state field, so `rendered()` would restore the old text on the next render cycle

One-line fix: add `self.input_text.clear()` to match the normal send path.

## Test plan
- [ ] Type a message, attach a file, send — input bar should clear
- [ ] Send again without attachment — should still work as before