### PR TITLE
Fix admin stats SQL type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.5
+
+- Fix admin stats endpoint returning empty body due to SQL type mismatch (COALESCE returns numeric, Diesel expects float8)
+
 ## 2.3.4
 
 - Fix send bar not clearing after sending with attachments

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "anyhow",
  "hex",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.3.4"
+version = "2.3.5"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -173,7 +173,7 @@ pub async fn get_stats(
     let session_stats: SessionStats = diesel::sql_query(
         "SELECT COUNT(*) as total, \
          COUNT(*) FILTER (WHERE status = 'active') as active_count, \
-         COALESCE(SUM(total_cost_usd), 0.0) as spend_usd, \
+         COALESCE(SUM(total_cost_usd), 0.0)::float8 as spend_usd, \
          COALESCE(SUM(input_tokens), 0) as sum_input_tokens, \
          COALESCE(SUM(output_tokens), 0) as sum_output_tokens, \
          COALESCE(SUM(cache_creation_tokens), 0) as sum_cache_creation_tokens, \
@@ -189,7 +189,7 @@ pub async fn get_stats(
     // Query 3: Deleted session cost/token sums in one pass
     let deleted_stats: DeletedCostStats = diesel::sql_query(
         "SELECT \
-         COALESCE(SUM(cost_usd), 0.0) as spend_usd, \
+         COALESCE(SUM(cost_usd), 0.0)::float8 as spend_usd, \
          COALESCE(SUM(input_tokens), 0) as sum_input_tokens, \
          COALESCE(SUM(output_tokens), 0) as sum_output_tokens, \
          COALESCE(SUM(cache_creation_tokens), 0) as sum_cache_creation_tokens, \


### PR DESCRIPTION
## Summary
- Fix the admin overview tab showing "Failed to parse stats: EOF while parsing a value"
- The collapsed SQL queries from #597 used `COALESCE(SUM(float8_col), 0.0)` — PostgreSQL returns `numeric` type for the `0.0` literal, but Diesel expected `float8`, causing deserialization to fail silently
- The handler returned a bare `StatusCode::INTERNAL_SERVER_ERROR` (empty body), and the frontend tried to parse it as JSON
- Fix: add `::float8` casts to the COALESCE expressions

## Test plan
- [ ] Open admin tab — overview stats should load without error