### PR TITLE
Auto-cleanup cron sessions, hide from rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.6
+
+- Auto-delete completed cron sessions to prevent UI clutter (costs preserved)
+- Hide cron sessions by default in the session rail
+
 ## 2.3.5
 
 - Fix admin stats endpoint returning empty body due to SQL type mismatch (COALESCE returns numeric, Diesel expects float8)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.3.5"
+version = "2.3.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.3.5"
+version = "2.3.6"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.3.5"
+version = "2.3.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.3.5"
+version = "2.3.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.3.5"
+version = "2.3.6"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.3.5"
+version = "2.3.6"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.3.5"
+version = "2.3.6"
 dependencies = [
  "anyhow",
  "hex",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.3.5"
+version = "2.3.6"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.3.5"
+version = "2.3.6"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -476,6 +476,37 @@ fn handle_launcher_message(
                 "Scheduled run completed: task={}, session={}, exit={:?}, duration={}s",
                 task_id, session_id, exit_code, duration_secs
             );
+
+            // Auto-delete completed scheduled sessions to avoid cluttering the UI.
+            // Costs are preserved in deleted_session_costs.
+            if let Ok(mut db_conn) = app_state.db_pool.get() {
+                use crate::schema::sessions;
+                match sessions::table
+                    .find(session_id)
+                    .first::<crate::models::Session>(&mut db_conn)
+                {
+                    Ok(session) => {
+                        if let Err(e) = super::super::helpers::delete_session_with_data(
+                            &mut db_conn,
+                            &session,
+                            true,
+                        ) {
+                            error!(
+                                "Failed to auto-delete scheduled session {}: {:?}",
+                                session_id, e
+                            );
+                        } else {
+                            info!("Auto-deleted completed scheduled session {}", session_id);
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Could not find scheduled session {} for cleanup: {}",
+                            session_id, e
+                        );
+                    }
+                }
+            }
         }
         LauncherToServer::LauncherRegister { .. } => {}
     }

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -846,10 +846,12 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         }
     };
 
-    // Split sessions into visible vs hidden
+    // Split sessions into visible vs hidden.
+    // Cron sessions default to hidden alongside manually-hidden sessions.
     let (visible_indices, hidden_indices): (Vec<_>, Vec<_>) =
         props.sessions.iter().enumerate().partition(|(_, session)| {
-            let is_hidden = props.hidden_sessions.contains(&session.id);
+            let is_hidden =
+                props.hidden_sessions.contains(&session.id) || session.scheduled_task_id.is_some();
             !is_hidden
         });
 


### PR DESCRIPTION
## Summary
- Auto-delete completed scheduled sessions when `ScheduledRunCompleted` fires (costs preserved in `deleted_session_costs`)
- Default cron sessions to the hidden section in the session rail so they don't clutter the main view

## Test plan
- [ ] Run a cron-scheduled task and verify the session is deleted from the DB after completion
- [ ] Verify costs are preserved in `deleted_session_costs` after auto-delete
- [ ] Verify cron sessions appear in the hidden/collapsed section of the session rail
- [ ] Verify manually-hidden sessions still work as before