### PR TITLE
Fix awaiting-input detection, skip noise types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.7
+
+- Fix awaiting-input detection to skip noise message types (portal, error, system, rate_limit_event)
+- Extract shared `is_claude_awaiting` function used by both REST load and WebSocket paths
+
 ## 2.3.6
 
 - Auto-delete completed cron sessions to prevent UI clutter (costs preserved)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.3.6"
+version = "2.3.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.3.6"
+version = "2.3.7"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.3.6"
+version = "2.3.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.3.6"
+version = "2.3.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.3.6"
+version = "2.3.7"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.3.6"
+version = "2.3.7"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.3.6"
+version = "2.3.7"
 dependencies = [
  "anyhow",
  "hex",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.3.6"
+version = "2.3.7"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.3.6"
+version = "2.3.7"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -16,6 +16,21 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::{ClipboardEvent, DragEvent, Element, HtmlTextAreaElement, KeyboardEvent};
 use yew::prelude::*;
 
+/// Check if a Claude session is awaiting user input by scanning messages
+/// backwards. Skips noise types (portal, error, system, rate_limit_event)
+/// and returns true if "result" is found before "user" or "assistant".
+fn is_claude_awaiting(messages: impl DoubleEndedIterator<Item = impl AsRef<str>>) -> bool {
+    messages
+        .rev()
+        .find_map(|msg| {
+            serde_json::from_str::<serde_json::Value>(msg.as_ref())
+                .ok()
+                .and_then(|p| p.get("type")?.as_str().map(String::from))
+                .filter(|t| t == "result" || t == "assistant" || t == "user")
+        })
+        .is_some_and(|t| t == "result")
+}
+
 #[derive(Debug, Clone, PartialEq)]
 enum TaskStatus {
     Running,
@@ -191,16 +206,7 @@ impl Component for SessionView {
 
             if let Ok(response) = Request::get(&api_endpoint).send().await {
                 if let Ok(data) = response.json::<MessagesResponse>().await {
-                    let is_awaiting = data.messages.last().is_some_and(|msg| {
-                        serde_json::from_str::<serde_json::Value>(&msg.content)
-                            .ok()
-                            .and_then(|p| {
-                                p.get("type")
-                                    .and_then(|t| t.as_str())
-                                    .map(|t| t == "result")
-                            })
-                            .unwrap_or(false)
-                    });
+                    let is_awaiting = is_claude_awaiting(data.messages.iter().map(|m| &m.content));
                     on_awaiting_change.emit((session_id, is_awaiting));
 
                     last_message_time = data.messages.last().map(|m| m.created_at.clone());
@@ -582,20 +588,7 @@ impl Component for SessionView {
                         })
                         .unwrap_or(false)
                 } else {
-                    // For Claude: search backwards for "result" or "assistant"
-                    // Late-arriving proxy messages or tool completions can land
-                    // after a result, so checking only .last() would incorrectly
-                    // show the session as still working.
-                    self.messages
-                        .iter()
-                        .rev()
-                        .find_map(|msg| {
-                            serde_json::from_str::<serde_json::Value>(msg)
-                                .ok()
-                                .and_then(|p| p.get("type")?.as_str().map(String::from))
-                                .filter(|t| t == "result" || t == "assistant")
-                        })
-                        .is_some_and(|t| t == "result")
+                    is_claude_awaiting(self.messages.iter())
                 };
                 let is_awaiting = is_result_awaiting || self.pending_permission.is_some();
                 let session_id = ctx.props().session.id;


### PR DESCRIPTION
## Summary
- Extract shared `is_claude_awaiting()` function used by both REST message load and WebSocket `CheckAwaiting` paths
- Scan backwards for `result` before `user`/`assistant`, skipping noise types (`portal`, `error`, `system`, `rate_limit_event`) that previously confused the logic
- Initial REST load was only checking `.last()` — now uses the same backwards scan

## Test plan
- [ ] Verify sessions correctly show "awaiting" badge when Claude produces a `result`
- [ ] Verify sessions don't false-positive on trailing `portal`/`error`/`rate_limit_event` messages
- [ ] Verify sessions clear awaiting state when user sends a message