### PR TITLE
Add service start, stop, restart subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.8
+
+- Add `agent-portal service start`, `stop`, and `restart` subcommands
+
 ## 2.3.7
 
 - Fix awaiting-input detection to skip noise message types (portal, error, system, rate_limit_event)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.3.7"
+version = "2.3.8"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -67,6 +67,12 @@ enum ServiceAction {
     Uninstall,
     /// Show the current service status
     Status,
+    /// Start the launcher service
+    Start,
+    /// Stop the launcher service
+    Stop,
+    /// Restart the launcher service
+    Restart,
     /// Upload system info, build info, and logs to an unlisted paste
     Pastebin,
 }
@@ -103,6 +109,9 @@ async fn main() -> anyhow::Result<()> {
                 ServiceAction::Install => service::install(),
                 ServiceAction::Uninstall => service::uninstall(),
                 ServiceAction::Status => service::status(),
+                ServiceAction::Start => service::start(),
+                ServiceAction::Stop => service::stop(),
+                ServiceAction::Restart => service::restart(),
                 ServiceAction::Pastebin => pastebin::upload_diagnostics().await,
             };
         }

--- a/launcher/src/service.rs
+++ b/launcher/src/service.rs
@@ -142,6 +142,26 @@ pub fn status() -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
+pub fn start() -> Result<()> {
+    if !is_installed() {
+        anyhow::bail!("Service is not installed. Run 'agent-portal service install' first.");
+    }
+    systemctl(&["start", SERVICE_NAME])?;
+    println!("Started {}", SERVICE_NAME);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn stop() -> Result<()> {
+    if !is_installed() {
+        anyhow::bail!("Service is not installed.");
+    }
+    systemctl(&["stop", SERVICE_NAME])?;
+    println!("Stopped {}", SERVICE_NAME);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
 pub fn restart() -> Result<()> {
     systemctl(&["restart", SERVICE_NAME])?;
     println!("Restarted {}", SERVICE_NAME);
@@ -321,6 +341,36 @@ pub fn status() -> Result<()> {
 }
 
 #[cfg(target_os = "macos")]
+pub fn start() -> Result<()> {
+    use anyhow::Context;
+    if !is_installed() {
+        anyhow::bail!("Service is not installed. Run 'agent-portal service install' first.");
+    }
+    let plist = plist_path()?;
+    std::process::Command::new("launchctl")
+        .args(["load", &plist.to_string_lossy()])
+        .output()
+        .context("Failed to run launchctl load")?;
+    println!("Started {}", PLIST_LABEL);
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn stop() -> Result<()> {
+    use anyhow::Context;
+    if !is_installed() {
+        anyhow::bail!("Service is not installed.");
+    }
+    let plist = plist_path()?;
+    std::process::Command::new("launchctl")
+        .args(["unload", &plist.to_string_lossy()])
+        .output()
+        .context("Failed to run launchctl unload")?;
+    println!("Stopped {}", PLIST_LABEL);
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
 pub fn restart() -> Result<()> {
     use anyhow::Context;
     let plist = plist_path()?;
@@ -354,6 +404,16 @@ pub fn uninstall() -> Result<()> {
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn status() -> Result<()> {
+    anyhow::bail!("Service management is not supported on this platform")
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn start() -> Result<()> {
+    anyhow::bail!("Service management is not supported on this platform")
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn stop() -> Result<()> {
     anyhow::bail!("Service management is not supported on this platform")
 }
 


### PR DESCRIPTION
## Summary
- Add `agent-portal service start` to start the installed service
- Add `agent-portal service stop` to stop the running service
- Add `agent-portal service restart` to restart the service
- Works on Linux (systemd) and macOS (launchd), errors on unsupported platforms
- Bump version to 2.3.8

## Test plan
- [ ] `agent-portal service --help` shows all new subcommands
- [ ] `agent-portal service start` starts the systemd/launchd service
- [ ] `agent-portal service stop` stops it
- [ ] `agent-portal service restart` does a full restart
- [ ] Running start/stop without install gives a clear error