### PR TITLE
Defer stale session cleanup on backend startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.9
+
+- Defer stale session cleanup on backend startup to give proxies time to reconnect, fixing sessions disappearing from the pills menu after a backend restart
+
 ## 2.3.8
 
 - Add `agent-portal service start`, `stop`, and `restart` subcommands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.3.7"
+version = "2.3.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.3.7"
+version = "2.3.9"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.3.7"
+version = "2.3.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.3.7"
+version = "2.3.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.3.7"
+version = "2.3.9"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.3.7"
+version = "2.3.9"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.3.7"
+version = "2.3.9"
 dependencies = [
  "anyhow",
  "hex",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.3.7"
+version = "2.3.9"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.3.8"
+version = "2.3.9"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -355,6 +355,11 @@ impl SessionManager {
         }
     }
 
+    /// Return the set of session keys that currently have a registered proxy connection.
+    pub fn registered_session_keys(&self) -> Vec<SessionId> {
+        self.sessions.iter().map(|r| r.key().clone()).collect()
+    }
+
     pub fn register_dir_request(&self, request_id: Uuid) -> oneshot::Receiver<LauncherToServer> {
         let (tx, rx) = oneshot::channel();
         self.pending_dir_requests.insert(request_id, tx);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -161,21 +161,74 @@ async fn main() -> anyhow::Result<()> {
     // Create session manager for WebSocket connections
     let session_manager = SessionManager::new();
 
-    // Cleanup stale sessions on startup (mark all "active" sessions as "disconnected"
-    // since they can't be active if we just started)
+    // Deferred stale session cleanup: wait for proxies to reconnect before
+    // marking unreconnected sessions as disconnected. Without this grace
+    // period, a backend restart would immediately hide all sessions from the
+    // frontend (which only shows status="active") and users would have to
+    // restart launchers to get sessions back.
     {
-        use diesel::prelude::*;
-        use schema::sessions::dsl::*;
-        let mut conn = pool.get()?;
-        let updated = diesel::update(sessions.filter(status.eq("active")))
-            .set(status.eq("disconnected"))
-            .execute(&mut conn)?;
-        if updated > 0 {
+        let startup_pool = pool.clone();
+        let startup_manager = session_manager.clone();
+        tokio::spawn(async move {
+            const RECONNECT_GRACE_SECS: u64 = shared::protocol::MAX_RECONNECT_BACKOFF_SECS * 2;
             tracing::info!(
-                "Marked {} stale sessions as disconnected on startup",
-                updated
+                "Waiting {}s for proxies to reconnect before cleaning stale sessions",
+                RECONNECT_GRACE_SECS
             );
-        }
+            tokio::time::sleep(std::time::Duration::from_secs(RECONNECT_GRACE_SECS)).await;
+
+            let connected_keys: std::collections::HashSet<String> = startup_manager
+                .registered_session_keys()
+                .into_iter()
+                .collect();
+
+            let Ok(mut conn) = startup_pool.get() else {
+                tracing::error!("Failed to get DB connection for stale session cleanup");
+                return;
+            };
+
+            use diesel::prelude::*;
+            use schema::sessions;
+
+            let active_sessions: Vec<(uuid::Uuid,)> = match sessions::table
+                .filter(sessions::status.eq("active"))
+                .select((sessions::id,))
+                .load(&mut conn)
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!("Failed to query active sessions for cleanup: {}", e);
+                    return;
+                }
+            };
+
+            let stale_ids: Vec<uuid::Uuid> = active_sessions
+                .into_iter()
+                .map(|(id,)| id)
+                .filter(|id| !connected_keys.contains(&id.to_string()))
+                .collect();
+
+            if stale_ids.is_empty() {
+                tracing::info!("No stale sessions to clean up after reconnect grace period");
+                return;
+            }
+
+            match diesel::update(sessions::table.filter(sessions::id.eq_any(&stale_ids)))
+                .set(sessions::status.eq("disconnected"))
+                .execute(&mut conn)
+            {
+                Ok(updated) => {
+                    tracing::info!(
+                        "Marked {} stale sessions as disconnected ({}s grace period elapsed)",
+                        updated,
+                        RECONNECT_GRACE_SECS
+                    );
+                }
+                Err(e) => {
+                    tracing::error!("Failed to mark stale sessions as disconnected: {}", e);
+                }
+            }
+        });
     }
 
     // Get base URL from env or construct from host/port

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -65,7 +65,7 @@ impl Backoff {
         Self {
             current: 1,
             initial: 1,
-            max: 30,
+            max: shared::protocol::MAX_RECONNECT_BACKOFF_SECS,
             multiplier: 2,
             stable_threshold: 30,
         }

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -9,7 +9,7 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
-const MAX_BACKOFF: Duration = Duration::from_secs(30);
+const MAX_BACKOFF: Duration = Duration::from_secs(shared::protocol::MAX_RECONNECT_BACKOFF_SECS);
 const RESTART_DELAY: Duration = Duration::from_secs(5);
 const MAX_RESTART_ATTEMPTS: u32 = 3;
 

--- a/shared/src/protocol.rs
+++ b/shared/src/protocol.rs
@@ -10,3 +10,8 @@ pub const MAX_PENDING_MESSAGE_AGE_SECS: u64 = 300;
 
 /// Device authorization code lifetime in seconds (5 minutes).
 pub const DEVICE_CODE_EXPIRES_SECS: u64 = 300;
+
+/// Maximum reconnection backoff for proxies and launchers (in seconds).
+/// Used by proxy/launcher to cap exponential backoff, and by the backend
+/// to determine how long to wait before cleaning up stale sessions.
+pub const MAX_RECONNECT_BACKOFF_SECS: u64 = 30;


### PR DESCRIPTION
## Summary

- On backend startup, instead of immediately marking all active sessions as disconnected, wait `2 × MAX_RECONNECT_BACKOFF_SECS` (60s) for proxies to reconnect before cleaning up
- After the grace period, only sessions that haven't re-registered are marked disconnected
- Extract `MAX_RECONNECT_BACKOFF_SECS` into `shared::protocol` so proxy, launcher, and backend all use the same constant

Fixes sessions disappearing from the pills menu after a backend restart, requiring a manual launcher restart to recover.

## Test plan

- [x] Full workspace builds
- [x] All tests pass
- [x] No clippy warnings
- [ ] Deploy backend, verify sessions persist across a backend restart without needing to restart launchers