### PR TITLE
Animate upload bar fill and collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.10
+
+- Upload progress bar fills over 1.5s minimum and collapses with animation after completion
+
 ## 2.3.9
 
 - Defer stale session cleanup on backend startup to give proxies time to reconnect, fixing sessions disappearing from the pills menu after a backend restart

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.3.9"
+version = "2.3.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.3.9"
+version = "2.3.10"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.3.9"
+version = "2.3.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.3.9"
+version = "2.3.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.3.9"
+version = "2.3.10"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.3.9"
+version = "2.3.10"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.3.9"
+version = "2.3.10"
 dependencies = [
  "anyhow",
  "hex",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.3.9"
+version = "2.3.10"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.3.9"
+version = "2.3.10"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -131,6 +131,8 @@ pub enum SessionViewMsg {
     DragEnter,
     /// User dragged files out of the input area
     DragLeave,
+    /// Dismiss the upload bar after completion
+    UploadDismiss,
     /// No-op (used by keydown/paste handlers that need to return a message)
     Noop,
     /// Toggle the tasks sidebar panel
@@ -175,6 +177,9 @@ pub struct SessionView {
     file_input_ref: NodeRef,
     upload_progress: Option<f32>,
     upload_files: Vec<(String, u64)>,
+    upload_departing: bool,
+    #[allow(dead_code)]
+    upload_dismiss_timer: Option<Timeout>,
     drag_hover: bool,
     active_tasks: HashMap<String, TaskEntry>,
     /// Maps tool_use_id → task_id for fallback task completion via tool_result
@@ -253,6 +258,8 @@ impl Component for SessionView {
             file_input_ref: NodeRef::default(),
             upload_progress: None,
             upload_files: Vec::new(),
+            upload_departing: false,
+            upload_dismiss_timer: None,
             drag_hover: false,
             active_tasks: HashMap::new(),
             tool_use_to_task: HashMap::new(),
@@ -831,14 +838,29 @@ impl Component for SessionView {
                 true
             }
             SessionViewMsg::FileUploaded(_filename) => {
-                self.upload_progress = None;
-                self.upload_files.clear();
+                self.upload_progress = Some(1.0);
+                self.upload_departing = false;
+                let link = ctx.link().clone();
+                self.upload_dismiss_timer = Some(Timeout::new(2_000, move || {
+                    link.send_message(SessionViewMsg::UploadDismiss);
+                }));
                 true
             }
-            SessionViewMsg::FileUploadError(err) => {
+            SessionViewMsg::UploadDismiss => {
+                self.upload_departing = true;
+                self.upload_dismiss_timer = None;
+                let link = ctx.link().clone();
+                // Clear after the CSS collapse animation finishes
+                self.upload_dismiss_timer = Some(Timeout::new(400, move || {
+                    link.send_message(SessionViewMsg::FileUploadError("dismiss".into()));
+                }));
+                true
+            }
+            SessionViewMsg::FileUploadError(_err) => {
                 self.upload_progress = None;
                 self.upload_files.clear();
-                gloo::console::error!("File upload error:", &err);
+                self.upload_departing = false;
+                self.upload_dismiss_timer = None;
                 true
             }
             SessionViewMsg::DragEnter => {
@@ -1566,8 +1588,11 @@ impl SessionView {
             None => return html! {},
         };
 
+        let complete = progress >= 1.0;
         let file_count = self.upload_files.len();
-        let header = if file_count == 1 {
+        let header = if complete {
+            "Upload complete".to_string()
+        } else if file_count == 1 {
             "Uploading 1 file...".to_string()
         } else {
             format!("Uploading {} files...", file_count)
@@ -1591,8 +1616,14 @@ impl SessionView {
         let pct = (progress * 100.0) as u32;
         let fill_style = format!("width: {}%", pct);
 
+        let bar_class = if self.upload_departing {
+            "upload-bar departing"
+        } else {
+            "upload-bar"
+        };
+
         html! {
-            <div class="upload-bar">
+            <div class={bar_class}>
                 <div class="upload-bar-header">{ header }</div>
                 { files_html }
                 <div class="upload-bar-track">
@@ -1668,7 +1699,7 @@ impl SessionView {
             "send-mode-dropdown"
         };
 
-        let is_uploading = self.upload_progress.is_some();
+        let is_uploading = self.upload_progress.is_some_and(|p| p < 1.0);
 
         html! {
             <div class="send-button-container">

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -351,6 +351,16 @@
     border-top: 1px solid var(--border);
     font-size: 0.78rem;
     color: var(--text-secondary);
+    max-height: 120px;
+    opacity: 1;
+    overflow: hidden;
+    transition: max-height 0.35s ease, opacity 0.35s ease, padding 0.35s ease;
+}
+
+.upload-bar.departing {
+    max-height: 0;
+    opacity: 0;
+    padding: 0 12px;
 }
 
 .upload-bar-header {
@@ -376,7 +386,7 @@
     height: 100%;
     background: var(--accent);
     border-radius: 2px;
-    transition: width 0.2s ease;
+    transition: width 1.5s ease;
 }
 
 /* Drop hint — shown as subtle static label, prominent on drag-hover */


### PR DESCRIPTION
## Summary

- Progress bar fill transition changed from 0.2s to 1.5s so fast uploads still show a satisfying fill animation
- After upload completes, bar shows "Upload complete" for 2 seconds then collapses out with a smooth max-height/opacity transition
- Send button re-enables immediately on completion (doesn't wait for bar dismissal)

## Test plan

- [ ] Upload a small file, verify the bar fills smoothly over ~1.5s
- [ ] Verify "Upload complete" header appears after upload finishes
- [ ] Verify bar collapses away after ~2s with animation
- [ ] Verify send button re-enables as soon as upload completes