### PR TITLE
Render assistant group messages incrementally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.12
+
+- Render each message in assistant groups as its own component so only new messages re-render
+- Revert thread_local expanded state hack (no longer needed)
+
 ## 2.3.11
 
 - Fix expanded "... more chars" content collapsing when new messages arrive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "anyhow",
  "hex",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.3.11"
+version = "2.3.12"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/expandable.rs
+++ b/frontend/src/components/expandable.rs
@@ -1,18 +1,5 @@
 use super::message_renderer::truncate_str;
-use std::cell::RefCell;
-use std::collections::HashSet;
-use std::hash::{Hash, Hasher};
 use yew::prelude::*;
-
-thread_local! {
-    static EXPANDED_SET: RefCell<HashSet<u64>> = RefCell::new(HashSet::new());
-}
-
-fn content_hash(s: &str) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    s.hash(&mut hasher);
-    hasher.finish()
-}
 
 #[derive(Properties, PartialEq)]
 pub struct ExpandableTextProps {
@@ -30,9 +17,7 @@ pub struct ExpandableTextProps {
 /// as-is with no toggle.
 #[function_component(ExpandableText)]
 pub fn expandable_text(props: &ExpandableTextProps) -> Html {
-    let render_trigger = use_state(|| 0u32);
-    let hash = content_hash(&props.full_text);
-    let expanded = EXPANDED_SET.with(|set| set.borrow().contains(&hash));
+    let expanded = use_state(|| false);
     let text = &*props.full_text;
 
     if text.len() <= props.max_len {
@@ -46,20 +31,14 @@ pub fn expandable_text(props: &ExpandableTextProps) -> Html {
     let remaining = text.len() - props.max_len;
 
     let toggle = {
-        let render_trigger = render_trigger.clone();
+        let expanded = expanded.clone();
         Callback::from(move |e: MouseEvent| {
             e.stop_propagation();
-            EXPANDED_SET.with(|set| {
-                let mut s = set.borrow_mut();
-                if !s.remove(&hash) {
-                    s.insert(hash);
-                }
-            });
-            render_trigger.set(*render_trigger + 1);
+            expanded.set(!*expanded);
         })
     };
 
-    let (display, toggle_label) = if expanded {
+    let (display, toggle_label) = if *expanded {
         (text.to_string(), "show less".to_string())
     } else {
         (
@@ -102,9 +81,7 @@ pub struct ExpandableLinesProps {
 /// with a clickable toggle to reveal all lines.
 #[function_component(ExpandableLines)]
 pub fn expandable_lines(props: &ExpandableLinesProps) -> Html {
-    let render_trigger = use_state(|| 0u32);
-    let hash = content_hash(&props.content);
-    let expanded = EXPANDED_SET.with(|set| set.borrow().contains(&hash));
+    let expanded = use_state(|| false);
     let content = &*props.content;
     let all_lines: Vec<&str> = content.lines().collect();
     let total = all_lines.len();
@@ -123,20 +100,14 @@ pub fn expandable_lines(props: &ExpandableLinesProps) -> Html {
     }
 
     let toggle = {
-        let render_trigger = render_trigger.clone();
+        let expanded = expanded.clone();
         Callback::from(move |e: MouseEvent| {
             e.stop_propagation();
-            EXPANDED_SET.with(|set| {
-                let mut s = set.borrow_mut();
-                if !s.remove(&hash) {
-                    s.insert(hash);
-                }
-            });
-            render_trigger.set(*render_trigger + 1);
+            expanded.set(!*expanded);
         })
     };
 
-    let visible = if expanded {
+    let visible = if *expanded {
         &all_lines[..]
     } else {
         &all_lines[..props.max_lines]
@@ -152,7 +123,7 @@ pub fn expandable_lines(props: &ExpandableLinesProps) -> Html {
                 </div>
             })}
             <div class="write-truncated expandable-toggle" onclick={toggle}>
-                { if expanded {
+                { if *expanded {
                     "show less".to_string()
                 } else {
                     format!("... {} more lines", remaining)

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -20,7 +20,6 @@ fn preserve_user_newlines(text: &str) -> String {
 // --- Message renderers ---
 
 pub fn render_assistant_group(messages: &[String]) -> Html {
-    let mut all_blocks: Vec<ContentBlock> = Vec::new();
     let mut total_output_tokens: u64 = 0;
     let mut total_input_tokens: u64 = 0;
     let mut total_cache_read: u64 = 0;
@@ -28,33 +27,20 @@ pub fn render_assistant_group(messages: &[String]) -> Html {
     let mut model_name = String::new();
 
     for json in messages {
-        match serde_json::from_str::<ClaudeMessage>(json) {
-            Ok(ClaudeMessage::Assistant(msg)) => {
-                if let Some(message) = &msg.message {
-                    if let Some(blocks) = &message.content {
-                        all_blocks.extend(blocks.clone());
-                    }
-                    if let Some(usage) = &message.usage {
-                        total_output_tokens += usage.output_tokens.unwrap_or(0);
-                        total_input_tokens += usage.input_tokens.unwrap_or(0);
-                        total_cache_read += usage.cache_read_input_tokens.unwrap_or(0);
-                        total_cache_created += usage.cache_creation_input_tokens.unwrap_or(0);
-                    }
-                    if model_name.is_empty() {
-                        if let Some(m) = &message.model {
-                            model_name = m.clone();
-                        }
+        if let Ok(ClaudeMessage::Assistant(msg)) = serde_json::from_str::<ClaudeMessage>(json) {
+            if let Some(message) = &msg.message {
+                if let Some(usage) = &message.usage {
+                    total_output_tokens += usage.output_tokens.unwrap_or(0);
+                    total_input_tokens += usage.input_tokens.unwrap_or(0);
+                    total_cache_read += usage.cache_read_input_tokens.unwrap_or(0);
+                    total_cache_created += usage.cache_creation_input_tokens.unwrap_or(0);
+                }
+                if model_name.is_empty() {
+                    if let Some(m) = &message.model {
+                        model_name = m.clone();
                     }
                 }
             }
-            Ok(ClaudeMessage::User(msg)) => {
-                if let Some(message) = &msg.message {
-                    if let Some(blocks) = &message.content {
-                        all_blocks.extend(blocks.clone());
-                    }
-                }
-            }
-            _ => {}
         }
     }
 
@@ -95,10 +81,32 @@ pub fn render_assistant_group(messages: &[String]) -> Html {
                 }
             </div>
             <div class="message-body">
-                { render_content_blocks(&all_blocks) }
+                { for messages.iter().map(|json| {
+                    html! { <GroupedMessageContent json={json.clone()} /> }
+                })}
             </div>
         </div>
     }
+}
+
+/// Renders the content blocks for a single message within an assistant group.
+/// Each message is its own component so Yew preserves it across re-renders
+/// when new messages are appended to the group.
+#[derive(Properties, PartialEq)]
+struct GroupedMessageContentProps {
+    json: String,
+}
+
+#[function_component(GroupedMessageContent)]
+fn grouped_message_content(props: &GroupedMessageContentProps) -> Html {
+    let blocks = match serde_json::from_str::<ClaudeMessage>(&props.json) {
+        Ok(ClaudeMessage::Assistant(msg)) => {
+            msg.message.and_then(|m| m.content).unwrap_or_default()
+        }
+        Ok(ClaudeMessage::User(msg)) => msg.message.and_then(|m| m.content).unwrap_or_default(),
+        _ => return html! {},
+    };
+    render_content_blocks(&blocks)
 }
 
 pub fn render_user_message(msg: &UserMessage, current_user_id: Option<&str>) -> Html {


### PR DESCRIPTION
## Summary

- Each message within an assistant group is now rendered as its own `GroupedMessageContent` component instead of flattening all blocks into one list
- When new messages stream in, Yew's diffing skips unchanged messages — only the new/last message renders
- Reverts the thread_local expanded state hack from #611 since it's no longer needed — component-local `use_state` is preserved correctly now

Net -16 lines.

## Test plan

- [ ] Verify assistant messages render identically (text, tool use, tool results, images)
- [ ] Expand a "... more chars" block, confirm it stays expanded as new messages arrive
- [ ] Verify aggregated header (model name, token counts, message count) still updates
- [ ] Verify grouped tool results still display inline within the assistant group