### PR TITLE
Fix pill scroll-into-view on keyboard nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.9
+
+- Fix pill scroll-into-view when tabbing to off-screen sessions
+
 ## 2.4.8
 
 - Purge expired device flow codes every 60 seconds (#615)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.8"
+version = "2.4.9"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -288,7 +288,8 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         let focused_index = props.focused_index;
         use_effect_with(focused_index, move |_| {
             if let Some(rail) = rail_ref.cast::<Element>() {
-                if let Some(child) = rail.children().item(focused_index as u32) {
+                let selector = format!("[data-index=\"{}\"]", focused_index);
+                if let Ok(Some(child)) = rail.query_selector(&selector) {
                     let opts = web_sys::ScrollIntoViewOptions::new();
                     opts.set_behavior(web_sys::ScrollBehavior::Smooth);
                     opts.set_block(web_sys::ScrollLogicalPosition::Nearest);
@@ -742,7 +743,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         };
 
         html! {
-            <div class={pill_class} onclick={on_click} key={session.id.to_string()}>
+            <div class={pill_class} onclick={on_click} key={session.id.to_string()} data-index={index.to_string()}>
                 {
                     if let Some(num) = &number_annotation {
                         html! { <span class="pill-number">{ num }</span> }


### PR DESCRIPTION
## Summary

The scroll-into-view effect used `rail.children().item(focused_index)` to find the pill DOM element. This broke when the rail has non-pill children (the divider between active/hidden sessions), causing the child index to not match the session index.

Fix: add `data-index` attribute to each pill, then query with `querySelector('[data-index="N"]')` instead of positional child indexing.

## Test plan

- [ ] Tab/arrow between pills — off-screen pills scroll smoothly into view
- [ ] Works across the active/hidden divider boundary
- [ ] Smooth scroll animation, minimal movement (Nearest positioning)