### PR TITLE
Add token renewal and message timestamp tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.10
+
+- Add token renewal button in settings credentials panel
+- Add local-time tooltip on message headers
+
 ## 2.4.9
 
 - Fix pill scroll-into-view when tabbing to off-screen sessions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.3.11"
+version = "2.4.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -18,6 +18,7 @@ dependencies = [
  "clap",
  "claude-session-lib",
  "croner",
+ "directories",
  "dirs",
  "hostname",
  "portal-auth",
@@ -25,6 +26,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rustls 0.23.37",
  "serde",
+ "serde_json",
  "shared",
  "tokio",
  "tokio-util",
@@ -58,6 +60,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -247,49 +255,14 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "base64 0.22.1",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "itoa 1.0.17",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded 0.7.1",
- "sha1",
- "sync_wrapper 1.0.2",
- "tokio",
- "tokio-tungstenite",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core 0.5.6",
+ "base64 0.22.1",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -303,11 +276,17 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded 0.7.1",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -329,27 +308,6 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
@@ -364,34 +322,32 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "backend"
-version = "2.3.11"
+version = "2.4.10"
 dependencies = [
  "anyhow",
- "axum 0.7.9",
+ "axum 0.8.8",
  "bigdecimal",
- "brotli",
  "chrono",
  "clap",
  "claude-codes",
- "dashmap 6.1.0",
+ "dashmap",
  "diesel",
  "diesel_migrations",
  "dotenvy",
- "flate2",
  "futures-util",
  "google-cognitive-apis",
- "governor",
+ "governor 0.8.1",
  "hex",
  "jsonwebtoken 9.3.1",
- "mime_guess",
+ "memory-serve",
  "oauth2",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.12.28",
- "rust-embed",
  "serde",
  "serde_json",
  "sha2",
@@ -622,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.3.11"
+version = "2.4.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -651,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.3.11"
+version = "2.4.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -740,7 +696,7 @@ dependencies = [
  "base64 0.22.1",
  "hmac",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "subtle",
  "time",
@@ -851,19 +807,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -1142,6 +1085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.3.11"
+version = "2.4.10"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -1208,7 +1157,6 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1230,17 +1178,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1335,9 +1272,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1800,7 +1739,7 @@ dependencies = [
  "serde_path_to_error",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.8.3",
  "tonic-build",
 ]
 
@@ -1820,22 +1759,48 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.6.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
 dependencies = [
  "cfg-if",
- "dashmap 5.5.3",
- "futures",
+ "dashmap",
+ "futures-sink",
  "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.9.2",
  "smallvec",
  "spinning_top",
+ "web-time",
+]
+
+[[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -1894,7 +1859,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1902,6 +1867,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -2116,6 +2086,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2525,6 +2508,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memory-serve"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b5bbad2035f57b1e95f66da606832edd935b47d82312e38e1ccffbcfb8a427"
+dependencies = [
+ "axum 0.8.8",
+ "brotli",
+ "flate2",
+ "mime_guess",
+ "sha256",
+ "tracing",
+ "urlencoding",
+ "walkdir",
+]
+
+[[package]]
 name = "migrations_internals"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,7 +2696,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http 0.2.12",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -2904,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.3.11"
+version = "2.4.10"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.3.11"
+version = "2.4.10"
 dependencies = [
  "anyhow",
  "hex",
@@ -3163,8 +3162,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3174,7 +3183,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3184,6 +3203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3370,42 +3398,6 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
-name = "rust-embed"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
-dependencies = [
- "axum 0.8.8",
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.117",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
-dependencies = [
- "mime_guess",
- "sha2",
- "walkdir",
-]
 
 [[package]]
 name = "rustix"
@@ -3749,6 +3741,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha256"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f880fc8562bdeb709793f00eb42a2ad0e672c4f883bbe59122b926eca935c8f6"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "hex",
+ "sha2",
+ "tokio",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3759,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.3.11"
+version = "2.4.10"
 dependencies = [
  "claude-codes",
  "serde",
@@ -4190,9 +4195,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -4316,7 +4321,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost",
@@ -4331,6 +4336,35 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum 0.8.8",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.3",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4357,7 +4391,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -4374,9 +4408,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4384,12 +4421,11 @@ dependencies = [
 
 [[package]]
 name = "tower-cookies"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd0118512cf0b3768f7fcccf0bef1ae41d68f2b45edc1e77432b36c97c56c6d"
+checksum = "151b5a3e3c45df17466454bb74e9ecedecc955269bdedbf4d150dfa393b55a36"
 dependencies = [
- "async-trait",
- "axum-core 0.4.5",
+ "axum-core 0.5.6",
  "cookie",
  "futures-util",
  "http 1.4.0",
@@ -4442,16 +4478,17 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_governor"
-version = "0.4.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea939ea6cfa7c4880f3e7422616624f97a567c16df67b53b11f0d03917a8e46"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
 dependencies = [
- "axum 0.7.9",
+ "axum 0.8.8",
  "forwarded-header-value",
- "governor",
+ "governor 0.10.4",
  "http 1.4.0",
  "pin-project",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "tonic 0.14.5",
  "tower 0.5.3",
  "tracing",
 ]
@@ -4549,22 +4586,21 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http 1.4.0",
  "httparse",
  "log",
  "native-tls",
- "rand",
+ "rand 0.9.2",
  "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -4823,6 +4859,16 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5287,11 +5333,11 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "ws-bridge"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5765bbc08de71c8ea49296899cad5c45178c650068a76863a56f74be079fb77"
+checksum = "a015f6a6f0feed64878c23b4f6e911187084d5037ac749406260cd29a94e3239"
 dependencies = [
- "axum 0.7.9",
+ "axum 0.8.8",
  "futures-util",
  "gloo-net 0.6.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.9"
+version = "2.4.10"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -9,6 +9,7 @@ pub enum AppError {
     DbQuery(String),
     Unauthorized,
     Forbidden,
+    BadRequest(&'static str),
     NotFound(&'static str),
     Internal(String),
 }
@@ -26,6 +27,7 @@ impl IntoResponse for AppError {
             }
             AppError::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized"),
             AppError::Forbidden => (StatusCode::FORBIDDEN, "Forbidden"),
+            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, *msg),
             AppError::NotFound(what) => (StatusCode::NOT_FOUND, *what),
             AppError::Internal(e) => {
                 tracing::error!("Internal error: {}", e);

--- a/backend/src/handlers/proxy_tokens.rs
+++ b/backend/src/handlers/proxy_tokens.rs
@@ -11,7 +11,7 @@ use axum::{
 use diesel::prelude::*;
 use shared::{
     CreateProxyTokenRequest, CreateProxyTokenResponse, ProxyInitConfig, ProxyTokenInfo,
-    ProxyTokenListResponse,
+    ProxyTokenListResponse, RenewProxyTokenRequest,
 };
 use std::sync::Arc;
 use tower_cookies::Cookies;
@@ -154,6 +154,82 @@ pub async fn revoke_token_handler(
 
     info!("Revoked proxy token {}", token_id);
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// POST /api/proxy-tokens/:id/renew - Renew a token with a new expiration
+pub async fn renew_token_handler(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path(token_id): Path<Uuid>,
+    Json(req): Json<RenewProxyTokenRequest>,
+) -> Result<Json<CreateProxyTokenResponse>, AppError> {
+    let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
+
+    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+
+    let existing: ProxyAuthToken = proxy_auth_tokens::table
+        .filter(proxy_auth_tokens::id.eq(token_id))
+        .filter(proxy_auth_tokens::user_id.eq(user_id))
+        .first(&mut conn)
+        .map_err(|_| AppError::NotFound("proxy token"))?;
+
+    if existing.revoked {
+        return Err(AppError::BadRequest("Cannot renew a revoked token"));
+    }
+
+    use crate::schema::users;
+    let user: User = users::table
+        .find(user_id)
+        .first(&mut conn)
+        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+
+    let new_token_id = Uuid::new_v4();
+    let expires_at = chrono::Utc::now() + chrono::Duration::days(req.expires_in_days as i64);
+
+    let jwt_secret = app_state.jwt_secret.as_bytes();
+    let token = create_proxy_token(
+        jwt_secret,
+        new_token_id,
+        user_id,
+        &user.email,
+        req.expires_in_days,
+    )
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let token_hash = hash_token(&token);
+
+    diesel::update(
+        proxy_auth_tokens::table
+            .filter(proxy_auth_tokens::id.eq(token_id))
+            .filter(proxy_auth_tokens::user_id.eq(user_id)),
+    )
+    .set((
+        proxy_auth_tokens::token_hash.eq(&token_hash),
+        proxy_auth_tokens::expires_at.eq(expires_at.naive_utc()),
+    ))
+    .execute(&mut conn)
+    .map_err(|e| AppError::DbQuery(e.to_string()))?;
+
+    let config = ProxyInitConfig {
+        token: token.clone(),
+        session_name_prefix: None,
+    };
+    let encoded_config = config
+        .encode()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    let init_url = format!("{}/p/{}", app_state.public_url, encoded_config);
+
+    info!(
+        "Renewed proxy token '{}' for user {}",
+        existing.name, user.email
+    );
+
+    Ok(Json(CreateProxyTokenResponse {
+        id: token_id,
+        token,
+        init_url,
+        expires_at: expires_at.to_rfc3339(),
+    }))
 }
 
 /// Verify a proxy token and return the user_id if valid

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -451,6 +451,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/proxy-tokens/{id}",
             axum::routing::delete(handlers::proxy_tokens::revoke_token_handler),
         )
+        .route(
+            "/api/proxy-tokens/{id}/renew",
+            post(handlers::proxy_tokens::renew_token_handler),
+        )
         // Scheduled task management endpoints
         .route(
             "/api/scheduled-tasks",

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -7,6 +7,19 @@ use yew::prelude::*;
 
 use types::{ClaudeMessage, ContentBlock};
 
+/// Extract `_created_at` from a raw JSON message string and format it as local time.
+fn extract_local_timestamp(json: &str) -> Option<String> {
+    let val: Value = serde_json::from_str(json).ok()?;
+    let iso = val.get("_created_at")?.as_str()?;
+    let ms = js_sys::Date::parse(iso);
+    if ms.is_nan() {
+        return None;
+    }
+    let date = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ms));
+    date.to_locale_string("default", &js_sys::Object::new())
+        .as_string()
+}
+
 /// A group of messages to render together
 #[derive(Debug, Clone, PartialEq)]
 pub enum MessageGroup {
@@ -85,18 +98,23 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
         };
     }
 
+    let ts = extract_local_timestamp(&props.json);
     let parsed: Result<ClaudeMessage, _> = serde_json::from_str(&props.json);
 
     match parsed {
-        Ok(ClaudeMessage::System(msg)) => renderers::render_system_message(&msg),
-        Ok(ClaudeMessage::Assistant(msg)) => renderers::render_assistant_message(&msg),
+        Ok(ClaudeMessage::System(msg)) => renderers::render_system_message(&msg, ts.as_deref()),
+        Ok(ClaudeMessage::Assistant(msg)) => {
+            renderers::render_assistant_message(&msg, ts.as_deref())
+        }
         Ok(ClaudeMessage::Result(msg)) => renderers::render_result_message(&msg),
         Ok(ClaudeMessage::User(msg)) => {
-            renderers::render_user_message(&msg, props.current_user_id.as_deref())
+            renderers::render_user_message(&msg, props.current_user_id.as_deref(), ts.as_deref())
         }
-        Ok(ClaudeMessage::Error(msg)) => renderers::render_error_message(&msg),
-        Ok(ClaudeMessage::Portal(msg)) => renderers::render_portal_message(&msg),
-        Ok(ClaudeMessage::RateLimitEvent(msg)) => renderers::render_rate_limit_event(&msg),
+        Ok(ClaudeMessage::Error(msg)) => renderers::render_error_message(&msg, ts.as_deref()),
+        Ok(ClaudeMessage::Portal(msg)) => renderers::render_portal_message(&msg, ts.as_deref()),
+        Ok(ClaudeMessage::RateLimitEvent(msg)) => {
+            renderers::render_rate_limit_event(&msg, ts.as_deref())
+        }
         Ok(ClaudeMessage::Unknown) | Err(_) => render_raw_json(&props.json),
     }
 }
@@ -118,7 +136,12 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
         MessageGroup::Single(json) => {
             html! { <MessageRenderer json={json.clone()} session_id={props.session_id} agent_type={props.agent_type} current_user_id={props.current_user_id.clone()} /> }
         }
-        MessageGroup::AssistantGroup(messages) => renderers::render_assistant_group(messages),
+        MessageGroup::AssistantGroup(messages) => {
+            let ts = messages
+                .first()
+                .and_then(|json| extract_local_timestamp(json));
+            renderers::render_assistant_group(messages, ts.as_deref())
+        }
     }
 }
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -19,7 +19,7 @@ fn preserve_user_newlines(text: &str) -> String {
 
 // --- Message renderers ---
 
-pub fn render_assistant_group(messages: &[String]) -> Html {
+pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> Html {
     let mut total_output_tokens: u64 = 0;
     let mut total_input_tokens: u64 = 0;
     let mut total_cache_read: u64 = 0;
@@ -52,7 +52,7 @@ pub fn render_assistant_group(messages: &[String]) -> Html {
 
     html! {
         <div class="claude-message assistant-message">
-            <div class="message-header">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge assistant">{ "Assistant" }</span>
                 {
                     if count > 1 {
@@ -109,7 +109,11 @@ fn grouped_message_content(props: &GroupedMessageContentProps) -> Html {
     render_content_blocks(&blocks)
 }
 
-pub fn render_user_message(msg: &UserMessage, current_user_id: Option<&str>) -> Html {
+pub fn render_user_message(
+    msg: &UserMessage,
+    current_user_id: Option<&str>,
+    timestamp: Option<&str>,
+) -> Html {
     let label = match &msg.sender {
         Some(sender) if current_user_id != Some(sender.user_id.as_str()) => sender.name.clone(),
         _ => "You".to_string(),
@@ -118,7 +122,7 @@ pub fn render_user_message(msg: &UserMessage, current_user_id: Option<&str>) -> 
     if let Some(text) = &msg.content {
         html! {
             <div class="claude-message user-message">
-                <div class="message-header">
+                <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                     <span class="message-type-badge user">{ &label }</span>
                 </div>
                 <div class="message-body">
@@ -153,7 +157,7 @@ pub fn render_user_message(msg: &UserMessage, current_user_id: Option<&str>) -> 
         } else if !text_content.is_empty() {
             html! {
                 <div class="claude-message user-message">
-                    <div class="message-header">
+                    <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                         <span class="message-type-badge user">{ &label }</span>
                     </div>
                     <div class="message-body">
@@ -169,9 +173,9 @@ pub fn render_user_message(msg: &UserMessage, current_user_id: Option<&str>) -> 
     }
 }
 
-pub fn render_error_message(msg: &ErrorMessage) -> Html {
+pub fn render_error_message(msg: &ErrorMessage, timestamp: Option<&str>) -> Html {
     if msg.is_overload() {
-        return render_overload_error(msg);
+        return render_overload_error(msg, timestamp);
     }
 
     let message = msg.display_message();
@@ -179,7 +183,7 @@ pub fn render_error_message(msg: &ErrorMessage) -> Html {
 
     html! {
         <div class="claude-message error-message-display">
-            <div class="message-header">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge result error">{ "Error" }</span>
                 {
                     if let Some(err_type) = error_type {
@@ -196,10 +200,10 @@ pub fn render_error_message(msg: &ErrorMessage) -> Html {
     }
 }
 
-pub fn render_portal_message(msg: &PortalMessage) -> Html {
+pub fn render_portal_message(msg: &PortalMessage, timestamp: Option<&str>) -> Html {
     html! {
         <div class="claude-message portal-message">
-            <div class="message-header">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge portal">{ "Portal" }</span>
             </div>
             <div class="message-body">
@@ -266,12 +270,12 @@ fn format_file_size(bytes: u64) -> String {
     }
 }
 
-fn render_overload_error(msg: &ErrorMessage) -> Html {
+fn render_overload_error(msg: &ErrorMessage, timestamp: Option<&str>) -> Html {
     let request_id = msg.request_id.as_deref().unwrap_or("unknown");
 
     html! {
         <div class="claude-message overload-message">
-            <div class="message-header">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge overload">{ "API Busy" }</span>
             </div>
             <div class="message-body">
@@ -292,7 +296,7 @@ fn render_overload_error(msg: &ErrorMessage) -> Html {
     }
 }
 
-pub fn render_rate_limit_event(msg: &RateLimitEventMessage) -> Html {
+pub fn render_rate_limit_event(msg: &RateLimitEventMessage, timestamp: Option<&str>) -> Html {
     let info = msg.rate_limit_info.as_ref();
     let status = info.and_then(|i| i.status.as_deref()).unwrap_or("unknown");
     let rate_type = info
@@ -322,7 +326,7 @@ pub fn render_rate_limit_event(msg: &RateLimitEventMessage) -> Html {
 
     html! {
         <div class="claude-message rate-limit-message">
-            <div class="message-header">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge rate-limit">{ "Rate Limit" }</span>
             </div>
             <div class="message-body">
@@ -363,7 +367,7 @@ pub fn render_rate_limit_event(msg: &RateLimitEventMessage) -> Html {
     }
 }
 
-pub fn render_system_message(msg: &SystemMessage) -> Html {
+pub fn render_system_message(msg: &SystemMessage, timestamp: Option<&str>) -> Html {
     let subtype = msg.subtype.as_deref().unwrap_or("system");
 
     // Check if this is a compaction-related message via subtype or status field
@@ -387,7 +391,7 @@ pub fn render_system_message(msg: &SystemMessage) -> Html {
     }
 
     if subtype == "task_started" {
-        return render_task_started(msg);
+        return render_task_started(msg, timestamp);
     }
 
     if subtype == "task_progress" {
@@ -395,7 +399,7 @@ pub fn render_system_message(msg: &SystemMessage) -> Html {
     }
 
     if subtype == "task_notification" {
-        return render_task_notification(msg);
+        return render_task_notification(msg, timestamp);
     }
 
     if subtype == "init" || subtype == "status" {
@@ -403,7 +407,7 @@ pub fn render_system_message(msg: &SystemMessage) -> Html {
     }
 
     html! {
-        <div class="claude-message system-message compact">
+        <div class="claude-message system-message compact" title={timestamp.unwrap_or_default().to_string()}>
             <span class="message-type-badge system">{ subtype }</span>
         </div>
     }
@@ -502,7 +506,7 @@ fn render_compaction_completed(msg: &SystemMessage) -> Html {
     }
 }
 
-fn render_task_started(msg: &SystemMessage) -> Html {
+fn render_task_started(msg: &SystemMessage, timestamp: Option<&str>) -> Html {
     let extra = msg.extra.as_ref();
     let description = extra
         .and_then(|v| v.get("description").and_then(|d| d.as_str()))
@@ -522,7 +526,7 @@ fn render_task_started(msg: &SystemMessage) -> Html {
 
     html! {
         <div class="claude-message task-message compact" title={format!("Task ID: {}", task_id)}>
-            <div class="message-header">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge task">{ "Task Started" }</span>
                 <span class="task-type-badge">{ type_label }</span>
                 <span class="task-description-inline">{ description }</span>
@@ -531,7 +535,7 @@ fn render_task_started(msg: &SystemMessage) -> Html {
     }
 }
 
-fn render_task_notification(msg: &SystemMessage) -> Html {
+fn render_task_notification(msg: &SystemMessage, timestamp: Option<&str>) -> Html {
     let extra = msg.extra.as_ref();
     let typed_status = extra
         .and_then(|v| v.get("status"))
@@ -557,7 +561,7 @@ fn render_task_notification(msg: &SystemMessage) -> Html {
     html! {
         <div class={classes!("claude-message", "task-message", status_class)}
              title={format!("Task ID: {}", task_id)}>
-            <div class="message-header">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class={classes!("message-type-badge", "task", status_class)}>
                     { if is_failed { "Task Failed" } else { "Task Completed" } }
                 </span>
@@ -590,7 +594,7 @@ fn render_task_notification(msg: &SystemMessage) -> Html {
     }
 }
 
-pub fn render_assistant_message(msg: &AssistantMessage) -> Html {
+pub fn render_assistant_message(msg: &AssistantMessage, timestamp: Option<&str>) -> Html {
     let blocks = msg
         .message
         .as_ref()
@@ -620,7 +624,7 @@ pub fn render_assistant_message(msg: &AssistantMessage) -> Html {
 
     html! {
         <div class="claude-message assistant-message">
-            <div class="message-header">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge assistant">{ "Assistant" }</span>
                 {
                     if let Some(short_name) = shorten_model_name(model) {

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -514,12 +514,12 @@ impl Component for SessionView {
                 self.messages = messages
                     .into_iter()
                     .map(|m| {
-                        // Inject _sender into user messages from API metadata
-                        if m.role == "user" && (m.user_id.is_some() || m.sender_name.is_some()) {
-                            if let Ok(mut val) =
-                                serde_json::from_str::<serde_json::Value>(&m.content)
-                            {
-                                if let Some(obj) = val.as_object_mut() {
+                        if let Ok(mut val) = serde_json::from_str::<serde_json::Value>(&m.content) {
+                            if let Some(obj) = val.as_object_mut() {
+                                // Inject _sender into user messages from API metadata
+                                if m.role == "user"
+                                    && (m.user_id.is_some() || m.sender_name.is_some())
+                                {
                                     obj.insert(
                                         "_sender".to_string(),
                                         serde_json::json!({
@@ -528,8 +528,13 @@ impl Component for SessionView {
                                         }),
                                     );
                                 }
-                                return val.to_string();
+                                // Inject _created_at for tooltip display
+                                obj.insert(
+                                    "_created_at".to_string(),
+                                    serde_json::Value::String(m.created_at.clone()),
+                                );
                             }
+                            return val.to_string();
                         }
                         m.content
                     })
@@ -1341,6 +1346,22 @@ impl SessionView {
         ctx.props()
             .on_activity
             .emit((ctx.props().session.id, msg_type, js_sys::Date::now()));
+        // Inject _created_at for tooltip display
+        let output = if let Ok(mut val) = serde_json::from_str::<serde_json::Value>(&output) {
+            if let Some(obj) = val.as_object_mut() {
+                let now_iso = js_sys::Date::new_0()
+                    .to_iso_string()
+                    .as_string()
+                    .unwrap_or_default();
+                obj.insert(
+                    "_created_at".to_string(),
+                    serde_json::Value::String(now_iso),
+                );
+            }
+            val.to_string()
+        } else {
+            output
+        };
         self.messages.push(output);
         if self.messages.len() > MAX_MESSAGES_PER_SESSION {
             let excess = self.messages.len() - MAX_MESSAGES_PER_SESSION;

--- a/frontend/src/pages/settings/tokens_panel.rs
+++ b/frontend/src/pages/settings/tokens_panel.rs
@@ -2,6 +2,7 @@ use crate::utils;
 use gloo_net::http::Request;
 use shared::{
     CreateProxyTokenRequest, CreateProxyTokenResponse, ProxyTokenInfo, ProxyTokenListResponse,
+    RenewProxyTokenRequest,
 };
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
@@ -60,12 +61,14 @@ pub async fn fetch_tokens_from_api() -> Option<Vec<ProxyTokenInfo>> {
 struct TokenRowProps {
     token: ProxyTokenInfo,
     on_revoke: Callback<Uuid>,
+    on_renew: Callback<Uuid>,
 }
 
 #[function_component(TokenRow)]
 fn token_row(props: &TokenRowProps) -> Html {
     let token = &props.token;
     let on_revoke = props.on_revoke.clone();
+    let on_renew = props.on_renew.clone();
     let token_id = token.id;
 
     let days_left = days_until_expiration(&token.expires_at);
@@ -104,6 +107,13 @@ fn token_row(props: &TokenRowProps) -> Html {
         on_revoke.emit(token_id);
     });
 
+    let on_renew_click = {
+        let on_renew = on_renew.clone();
+        Callback::from(move |_| {
+            on_renew.emit(token_id);
+        })
+    };
+
     html! {
         <tr class={if token.revoked || is_expired { "token-row disabled" } else { "token-row" }}>
             <td class="token-name">{ &token.name }</td>
@@ -114,6 +124,11 @@ fn token_row(props: &TokenRowProps) -> Html {
             <td class="token-expires">{ utils::format_timestamp(&token.expires_at) }</td>
             <td class={status_class}>{ status_text }</td>
             <td class="token-actions">
+                if !token.revoked {
+                    <button class="renew-button" onclick={on_renew_click}>
+                        { "Renew" }
+                    </button>
+                }
                 if !token.revoked && !is_expired {
                     <button class="revoke-button" onclick={on_revoke_click}>
                         { "Revoke" }
@@ -207,6 +222,57 @@ pub fn tokens_panel(props: &TokensPanelProps) -> Html {
 
             confirm_action.set(Some((
                 "Revoke this token? Connected proxies will be disconnected.".to_string(),
+                action,
+            )));
+        })
+    };
+
+    let renewed_token = use_state(|| None::<CreateProxyTokenResponse>);
+
+    let on_renew_token = {
+        let confirm_action = confirm_action.clone();
+        let renewed_token = renewed_token.clone();
+        let fetch_tokens = fetch_tokens.clone();
+
+        Callback::from(move |token_id: Uuid| {
+            let confirm_action_inner = confirm_action.clone();
+            let renewed_token = renewed_token.clone();
+            let fetch_tokens = fetch_tokens.clone();
+
+            let action = Callback::from(move |_: MouseEvent| {
+                let confirm_action_inner = confirm_action_inner.clone();
+                let renewed_token = renewed_token.clone();
+                let fetch_tokens = fetch_tokens.clone();
+
+                spawn_local(async move {
+                    let api_endpoint =
+                        utils::api_url(&format!("/api/proxy-tokens/{}/renew", token_id));
+                    let request_body = RenewProxyTokenRequest {
+                        expires_in_days: 30,
+                    };
+
+                    match Request::post(&api_endpoint)
+                        .json(&request_body)
+                        .unwrap()
+                        .send()
+                        .await
+                    {
+                        Ok(response) => {
+                            if let Ok(data) = response.json::<CreateProxyTokenResponse>().await {
+                                renewed_token.set(Some(data));
+                                fetch_tokens.emit(());
+                            }
+                        }
+                        Err(e) => {
+                            log::error!("Failed to renew token: {:?}", e);
+                        }
+                    }
+                    confirm_action_inner.set(None);
+                });
+            });
+
+            confirm_action.set(Some((
+                "Renew this token for 30 days? You will need to update your proxy with the new token.".to_string(),
                 action,
             )));
         })
@@ -392,6 +458,7 @@ pub fn tokens_panel(props: &TokensPanelProps) -> Html {
                                             key={token.id.to_string()}
                                             token={token.clone()}
                                             on_revoke={on_revoke_token.clone()}
+                                            on_renew={on_renew_token.clone()}
                                         />
                                     }
                                 }) }
@@ -403,6 +470,36 @@ pub fn tokens_panel(props: &TokensPanelProps) -> Html {
                     </p>
                 }
             </section>
+
+            if let Some(token_response) = &*renewed_token {
+                <div class="modal-overlay" onclick={{
+                    let renewed_token = renewed_token.clone();
+                    Callback::from(move |_| renewed_token.set(None))
+                }}>
+                    <div class="confirm-modal token-renewed-modal" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                        <div class="token-created-success">
+                            <h3>{ "Token Renewed" }</h3>
+                            <p class="warning">
+                                { "Copy this token now. It will not be shown again!" }
+                            </p>
+                            <div class="token-display">
+                                <code>{ &token_response.token }</code>
+                            </div>
+                            <div class="init-url">
+                                <label>{ "Or use this initialization URL:" }</label>
+                                <code>{ &token_response.init_url }</code>
+                            </div>
+                            <p class="expires-info">
+                                { format!("Expires: {}", utils::format_timestamp(&token_response.expires_at)) }
+                            </p>
+                            <button onclick={{
+                                let renewed_token = renewed_token.clone();
+                                Callback::from(move |_| renewed_token.set(None))
+                            }}>{ "Done" }</button>
+                        </div>
+                    </div>
+                </div>
+            }
 
             if let Some((message, action)) = &*confirm_action {
                 <div class="modal-overlay" onclick={cancel_confirm.clone()}>

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -249,6 +249,30 @@
 }
 
 /* Action buttons - use specific selectors to override dashboard.css */
+.settings-container .renew-button {
+    background: transparent;
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    padding: 0.25rem 0.75rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    transition: all 0.2s;
+    position: static;
+    opacity: 1;
+    width: auto;
+    height: auto;
+    top: auto;
+    right: auto;
+    z-index: auto;
+    margin-right: 0.5rem;
+}
+
+.settings-container .renew-button:hover {
+    background: var(--accent);
+    color: white;
+}
+
 .settings-container .revoke-button,
 .settings-container .delete-button {
     background: transparent;

--- a/shared/src/proxy_tokens.rs
+++ b/shared/src/proxy_tokens.rs
@@ -82,6 +82,14 @@ pub struct CreateProxyTokenResponse {
     pub expires_at: String,
 }
 
+/// Request to renew an existing proxy token
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RenewProxyTokenRequest {
+    /// New token lifetime in days (default: 30)
+    #[serde(default = "default_expires_in_days")]
+    pub expires_in_days: u32,
+}
+
 /// Info about an existing proxy token (without the secret)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProxyTokenInfo {


### PR DESCRIPTION
## Summary
- Add "Renew" button to proxy credentials in settings (POST `/api/proxy-tokens/{id}/renew`)
- Add local-time tooltip on message headers (hover to see when each message was sent)

## Test plan
- [ ] Verify "Renew" button appears on non-revoked tokens in Settings > Credentials
- [ ] Verify renewing shows new token and init URL in modal
- [ ] Verify expired (non-revoked) tokens can be renewed
- [ ] Verify hovering message headers shows local timestamp tooltip
- [ ] Verify timestamps work for both history-loaded and real-time messages