### PR TITLE
Render new content blocks from CLI 2.1.117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.4.11
+
+- Bump claude-codes to 2.1.117
+- Render new content block types: ServerToolUse, WebSearchToolResult, McpToolUse, McpToolResult, CodeExecutionToolResult, ContainerUpload
+- Render web search citations on text blocks
+- Show unknown content blocks as collapsible JSON instead of silently dropping them
+
 ## 2.4.10
 
 - Add token renewal button in settings credentials panel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.10"
+version = "2.4.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.10"
+version = "2.4.11"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -561,9 +561,9 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.53"
+version = "2.1.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d928255084931ab050625cf6587928e8dcbf0336678b815dd7dd03298e5201"
+checksum = "f23967b5fb3249e0e950d27cfe32a029cad6967b232ae3e1b938d37b0ba23a4d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.10"
+version = "2.4.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.10"
+version = "2.4.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.10"
+version = "2.4.11"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.10"
+version = "2.4.11"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.10"
+version = "2.4.11"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.10"
+version = "2.4.11"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.10"
+version = "2.4.11"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -39,7 +39,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = "2.1.53"
+claude-codes = "2.1.117"
 
 # Codex CLI integration
 codex-codes = { version = "0.101.1", default-features = false, features = ["types"] }

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -443,6 +443,9 @@ fn log_claude_output(output: &ClaudeOutput) {
                     ContentBlock::Image(_) => {
                         debug!("← [assistant] image block");
                     }
+                    _ => {
+                        debug!("← [assistant] other block");
+                    }
                 }
             }
 

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -44,7 +44,7 @@ pub(super) async fn handle_session_event_with_wiggum(
     match event {
         Some(SessionEvent::Output(ref output)) => {
             // Check for wiggum completion before forwarding
-            let should_continue_wiggum = if let ClaudeOutput::Result(ref result) = output {
+            let should_continue_wiggum = if let ClaudeOutput::Result(ref result) = **output {
                 if let Some(ref state) = wiggum_state {
                     // Check if Claude responded with "DONE"
                     let is_done = check_wiggum_done(result);
@@ -62,7 +62,7 @@ pub(super) async fn handle_session_event_with_wiggum(
             };
 
             // Forward the output
-            if output_tx.send(output.clone()).is_err() {
+            if output_tx.send(*output.clone()).is_err() {
                 error!("Failed to forward Claude output");
                 return Some(ConnectionResult::Disconnected(connection_start.elapsed()));
             }
@@ -127,7 +127,7 @@ pub(super) async fn handle_session_event_with_wiggum(
                         }
                     }
                 }
-            } else if matches!(output, ClaudeOutput::Result(_)) && wiggum_state.is_some() {
+            } else if matches!(&**output, ClaudeOutput::Result(_)) && wiggum_state.is_some() {
                 // Send final completion portal message
                 if let Some(ref mut state) = wiggum_state {
                     let loop_duration = state.loop_start.elapsed();
@@ -161,7 +161,7 @@ pub(super) async fn handle_session_event_with_wiggum(
                 *wiggum_state = None;
             }
 
-            if matches!(output, ClaudeOutput::Result(_)) && wiggum_state.is_none() {
+            if matches!(&**output, ClaudeOutput::Result(_)) && wiggum_state.is_none() {
                 debug!("--- ready for input ---");
             }
             None

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -16,7 +16,7 @@ use crate::snapshot::{PendingPermission, SessionConfig, SessionSnapshot};
 #[derive(Debug)]
 pub enum SessionEvent {
     /// Claude produced output (excluding permission requests, which have their own event)
-    Output(ClaudeOutput),
+    Output(Box<ClaudeOutput>),
 
     /// Raw JSON output from a non-Claude agent (e.g. Codex JSONL).
     ///
@@ -492,7 +492,7 @@ impl Session {
                         continue;
                     }
 
-                    return Some(SessionEvent::Output(output));
+                    return Some(SessionEvent::Output(Box::new(output)));
                 }
                 Some(IoEvent::RawOutput(value)) => {
                     // Buffer the raw output

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -41,9 +41,15 @@ fn should_group_with_assistant(json: &str) -> bool {
             if let Some(message) = &msg.message {
                 if let Some(blocks) = &message.content {
                     return !blocks.is_empty()
-                        && blocks
-                            .iter()
-                            .all(|b| matches!(b, ContentBlock::ToolResult { .. }));
+                        && blocks.iter().all(|b| {
+                            matches!(
+                                b,
+                                ContentBlock::ToolResult { .. }
+                                    | ContentBlock::WebSearchToolResult { .. }
+                                    | ContentBlock::McpToolResult { .. }
+                                    | ContentBlock::CodeExecutionToolResult { .. }
+                            )
+                        });
                 }
             }
             false

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -136,7 +136,7 @@ pub fn render_user_message(
         let text_content: String = blocks
             .iter()
             .filter_map(|block| match block {
-                ContentBlock::Text { text } => Some(text.clone()),
+                ContentBlock::Text { text, .. } => Some(text.clone()),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -658,8 +658,13 @@ pub fn render_content_blocks(blocks: &[ContentBlock]) -> Html {
             {
                 blocks.iter().map(|block| {
                     match block {
-                        ContentBlock::Text { text } => {
-                            html! { <div class="assistant-text">{ render_markdown(text) }</div> }
+                        ContentBlock::Text { text, citations } => {
+                            html! {
+                                <div class="assistant-text">
+                                    { render_markdown(text) }
+                                    { render_citations(citations) }
+                                </div>
+                            }
                         }
                         ContentBlock::ToolUse { id: _, name, input } => {
                             render_tool_use(name, input)
@@ -695,7 +700,27 @@ pub fn render_content_blocks(blocks: &[ContentBlock]) -> Html {
                                 </div>
                             }
                         }
-                        ContentBlock::Other => html! {},
+                        ContentBlock::ServerToolUse { id: _, name, input } => {
+                            render_server_tool_use(name, input)
+                        }
+                        ContentBlock::WebSearchToolResult { tool_use_id: _, content } => {
+                            render_web_search_result(content)
+                        }
+                        ContentBlock::CodeExecutionToolResult { tool_use_id: _, content } => {
+                            render_code_execution_result(content)
+                        }
+                        ContentBlock::McpToolUse { id: _, name, server_name, input } => {
+                            render_mcp_tool_use(name, server_name.as_deref(), input)
+                        }
+                        ContentBlock::McpToolResult { tool_use_id: _, content, is_error } => {
+                            render_mcp_tool_result(content, is_error.unwrap_or(false))
+                        }
+                        ContentBlock::ContainerUpload { data } => {
+                            render_container_upload(data)
+                        }
+                        ContentBlock::Unknown(value) => {
+                            render_unknown_block(value)
+                        }
                     }
                 }).collect::<Html>()
             }
@@ -817,6 +842,165 @@ fn image_viewer(props: &ImageViewerProps) -> Html {
                 </div>
             }
         </>
+    }
+}
+
+fn render_citations(citations: &[Value]) -> Html {
+    if citations.is_empty() {
+        return html! {};
+    }
+    html! {
+        <div class="citation-list">
+            { for citations.iter().enumerate().map(|(i, cite)| {
+                let url = cite.get("url").and_then(|v| v.as_str()).unwrap_or("#");
+                let title = cite.get("title").and_then(|v| v.as_str())
+                    .or_else(|| cite.get("cited_text").and_then(|v| v.as_str()))
+                    .unwrap_or("source");
+                html! {
+                    <a class="citation-link"
+                       href={url.to_string()}
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       title={title.to_string()}>
+                        { format!("[{}]", i + 1) }
+                    </a>
+                }
+            })}
+        </div>
+    }
+}
+
+fn render_server_tool_use(name: &str, input: &Value) -> Html {
+    let badge_label = if name.contains("web_search") || name.contains("search") {
+        "Web Search"
+    } else {
+        "Server"
+    };
+    let args_summary = summarize_input(input);
+    html! {
+        <div class="tool-use server-tool-use">
+            <div class="tool-use-header">
+                <span class="tool-badge server">{ badge_label }</span>
+                <span class="tool-name">{ name }</span>
+                { if !args_summary.is_empty() {
+                    html! { <span class="tool-meta">{ args_summary }</span> }
+                } else {
+                    html! {}
+                }}
+            </div>
+        </div>
+    }
+}
+
+fn render_web_search_result(content: &Value) -> Html {
+    let preview = serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string());
+    html! {
+        <div class="tool-result web-search-result">
+            <div class="tool-use-header">
+                <span class="tool-badge server">{ "Web Search Result" }</span>
+            </div>
+            <ExpandableText full_text={preview} max_len={300} class="tool-result-content" />
+        </div>
+    }
+}
+
+fn render_code_execution_result(content: &Value) -> Html {
+    let preview = serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string());
+    html! {
+        <div class="tool-result code-execution-result">
+            <div class="tool-use-header">
+                <span class="tool-badge code-exec">{ "Code Execution" }</span>
+            </div>
+            <ExpandableText full_text={preview} max_len={500} class="tool-result-content" />
+        </div>
+    }
+}
+
+fn render_mcp_tool_use(name: &str, server_name: Option<&str>, input: &Value) -> Html {
+    let display_name = match server_name {
+        Some(server) => format!("{} > {}", server, name),
+        None => name.to_string(),
+    };
+    let args_summary = summarize_input(input);
+    html! {
+        <div class="tool-use mcp-tool-use">
+            <div class="tool-use-header">
+                <span class="tool-badge mcp">{ "MCP" }</span>
+                <span class="tool-name">{ display_name }</span>
+                { if !args_summary.is_empty() {
+                    html! { <span class="tool-meta">{ args_summary }</span> }
+                } else {
+                    html! {}
+                }}
+            </div>
+        </div>
+    }
+}
+
+fn render_mcp_tool_result(content: &Value, is_error: bool) -> Html {
+    let class = if is_error {
+        "tool-result mcp-tool-result error"
+    } else {
+        "tool-result mcp-tool-result"
+    };
+    let preview = serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string());
+    html! {
+        <div class={class}>
+            <div class="tool-use-header">
+                <span class={if is_error { "tool-badge mcp error" } else { "tool-badge mcp" }}>
+                    { if is_error { "MCP Error" } else { "MCP Result" } }
+                </span>
+            </div>
+            <ExpandableText full_text={preview} max_len={500} class="tool-result-content" />
+        </div>
+    }
+}
+
+fn render_container_upload(data: &Value) -> Html {
+    let preview = serde_json::to_string_pretty(data).unwrap_or_else(|_| data.to_string());
+    html! {
+        <div class="tool-use container-upload">
+            <div class="tool-use-header">
+                <span class="tool-badge container">{ "Container Upload" }</span>
+            </div>
+            <ExpandableText full_text={preview} max_len={300} class="tool-result-content" />
+        </div>
+    }
+}
+
+fn render_unknown_block(value: &Value) -> Html {
+    let preview = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+    html! {
+        <div class="tool-use unknown-block">
+            <div class="tool-use-header">
+                <span class="tool-badge unknown">{ "Unknown Block" }</span>
+            </div>
+            <ExpandableText full_text={preview} max_len={300} class="tool-result-content" />
+        </div>
+    }
+}
+
+fn summarize_input(input: &Value) -> String {
+    if let Some(obj) = input.as_object() {
+        let entries: Vec<String> = obj
+            .iter()
+            .filter(|(_, v)| v.is_string() || v.is_number() || v.is_boolean())
+            .take(3)
+            .map(|(k, v)| match v {
+                Value::String(s) => {
+                    let truncated = if s.len() > 40 {
+                        format!("{}...", super::truncate_str(s, 40))
+                    } else {
+                        s.clone()
+                    };
+                    format!("{}={}", k, truncated)
+                }
+                other => format!("{}={}", k, other),
+            })
+            .collect();
+        entries.join(", ")
+    } else {
+        String::new()
     }
 }
 

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -146,7 +146,11 @@ pub struct MessageContent {
 #[serde(tag = "type")]
 pub enum ContentBlock {
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+        #[serde(default)]
+        citations: Vec<Value>,
+    },
     #[serde(rename = "image")]
     Image { source: ImageSource },
     #[serde(rename = "tool_use")]
@@ -164,8 +168,49 @@ pub enum ContentBlock {
     },
     #[serde(rename = "thinking")]
     Thinking { thinking: String },
-    #[serde(other)]
-    Other,
+    #[serde(rename = "server_tool_use")]
+    ServerToolUse {
+        id: String,
+        name: String,
+        #[serde(default)]
+        input: Value,
+    },
+    #[serde(rename = "web_search_tool_result")]
+    WebSearchToolResult {
+        tool_use_id: String,
+        #[serde(default)]
+        content: Value,
+    },
+    #[serde(rename = "code_execution_tool_result")]
+    CodeExecutionToolResult {
+        tool_use_id: String,
+        #[serde(default)]
+        content: Value,
+    },
+    #[serde(rename = "mcp_tool_use")]
+    McpToolUse {
+        id: String,
+        name: String,
+        #[serde(default)]
+        server_name: Option<String>,
+        #[serde(default)]
+        input: Value,
+    },
+    #[serde(rename = "mcp_tool_result")]
+    McpToolResult {
+        tool_use_id: String,
+        #[serde(default)]
+        content: Value,
+        #[serde(default)]
+        is_error: Option<bool>,
+    },
+    #[serde(rename = "container_upload")]
+    ContainerUpload {
+        #[serde(flatten)]
+        data: Value,
+    },
+    #[serde(untagged)]
+    Unknown(Value),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -827,3 +827,99 @@
     color: var(--text-muted);
 }
 
+/* ==========================================================================
+   New Content Block Renderers
+   ========================================================================== */
+
+/* Server Tool Use / Web Search */
+.server-tool-use {
+    background: rgba(122, 162, 247, 0.08);
+    border-left-color: #7aa2f7;
+}
+
+.tool-badge.server {
+    background: rgba(122, 162, 247, 0.2);
+    color: #7aa2f7;
+}
+
+.web-search-result {
+    background: rgba(122, 162, 247, 0.05);
+    border-left-color: #7aa2f7;
+}
+
+/* MCP Tool Use / Result */
+.mcp-tool-use {
+    background: rgba(187, 154, 247, 0.08);
+    border-left-color: #bb9af7;
+}
+
+.mcp-tool-result {
+    background: rgba(187, 154, 247, 0.05);
+}
+
+.tool-badge.mcp {
+    background: rgba(187, 154, 247, 0.2);
+    color: #bb9af7;
+}
+
+.tool-badge.mcp.error {
+    background: rgba(247, 118, 142, 0.2);
+    color: var(--error);
+}
+
+/* Code Execution Result */
+.code-execution-result {
+    background: rgba(158, 206, 106, 0.05);
+    border-left-color: var(--success);
+}
+
+.tool-badge.code-exec {
+    background: rgba(158, 206, 106, 0.2);
+    color: var(--success);
+}
+
+/* Container Upload */
+.container-upload {
+    background: rgba(224, 175, 104, 0.08);
+    border-left-color: #e0af68;
+}
+
+.tool-badge.container {
+    background: rgba(224, 175, 104, 0.2);
+    color: #e0af68;
+}
+
+/* Unknown Block */
+.unknown-block {
+    background: rgba(127, 132, 156, 0.08);
+    border-left-color: var(--text-muted);
+}
+
+.tool-badge.unknown {
+    background: rgba(127, 132, 156, 0.2);
+    color: var(--text-secondary);
+}
+
+/* Citations */
+.citation-list {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
+}
+
+.citation-link {
+    font-size: 0.7rem;
+    color: var(--accent);
+    text-decoration: none;
+    padding: 0.05rem 0.2rem;
+    border-radius: 2px;
+    background: rgba(122, 162, 247, 0.1);
+    transition: background 0.15s;
+}
+
+.citation-link:hover {
+    background: rgba(122, 162, 247, 0.25);
+    text-decoration: underline;
+}
+

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 
 # Claude Code types (WASM-compatible, no tokio)
-claude-codes = { version = "2.1.51", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.117", default-features = false, features = ["types"] }
 
 # Typed WebSocket endpoints (core traits only — WASM-safe, no features needed)
 ws-bridge = { workspace = true }


### PR DESCRIPTION
## Summary
- Bump claude-codes from 2.1.53 to 2.1.117
- Add renderers for 6 new content block types: ServerToolUse, WebSearchToolResult, CodeExecutionToolResult, McpToolUse, McpToolResult, ContainerUpload
- Render web search citations as inline links on text blocks
- Replace silent `Other` catch-all with `Unknown(Value)` that shows collapsible JSON
- Group new tool result types with assistant messages

## Test plan
- [ ] Verify web search results render with "Web Search" / "Web Search Result" badges
- [ ] Verify MCP tool calls render with server name prefix
- [ ] Verify unknown content blocks show as collapsible JSON instead of being hidden
- [ ] Verify existing tool_use/tool_result rendering unchanged
- [ ] Verify text block citations render as numbered links when present