### PR TITLE
Enrich result stats bar with cost and badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.12
+
+- Show cost, stop reason, fast mode, errors, and permission denials in result stats bar
+- Add model usage breakdown to result timing tooltip
+
 ## 2.4.11
 
 - Bump claude-codes to 2.1.117

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.11"
+version = "2.4.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.11"
+version = "2.4.12"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.11"
+version = "2.4.12"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.11"
+version = "2.4.12"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.11"
+version = "2.4.12"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.11"
+version = "2.4.12"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.11"
+version = "2.4.12"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.11"
+version = "2.4.12"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.11"
+version = "2.4.12"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -1029,10 +1029,105 @@ pub fn render_result_message(msg: &ResultMessage) -> Html {
     let api_ms = msg.duration_api_ms.unwrap_or(0);
     let turns = msg.num_turns.unwrap_or(0);
 
-    let timing_tooltip = format!(
+    let mut timing_tooltip = format!(
         "Total: {}ms | API: {}ms | Turns: {}",
         duration_ms, api_ms, turns
     );
+
+    if let Some(model_usage) = &msg.model_usage {
+        if let Some(obj) = model_usage.as_object() {
+            for (model, cost) in obj {
+                if let Some(c) = cost.as_f64() {
+                    timing_tooltip.push_str(&format!(
+                        " | {}: ${:.4}",
+                        shorten_model_name(model).unwrap_or(model.clone()),
+                        c
+                    ));
+                }
+            }
+        }
+    }
+
+    let errors_tooltip = if !msg.errors.is_empty() {
+        msg.errors.join("\n")
+    } else {
+        String::new()
+    };
+
+    let denials_tooltip = if !msg.permission_denials.is_empty() {
+        msg.permission_denials
+            .iter()
+            .filter_map(|v| {
+                v.get("tool_name")
+                    .and_then(|t| t.as_str())
+                    .or_else(|| v.as_str())
+                    .map(|s| s.to_string())
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    } else {
+        String::new()
+    };
+
+    let extra_badges = html! {
+        <>
+            {
+                if let Some(cost) = msg.total_cost_usd {
+                    html! {
+                        <span class="stat-item cost" title="Total cost">
+                            { format!("${:.2}", cost) }
+                        </span>
+                    }
+                } else {
+                    html! {}
+                }
+            }
+            {
+                if msg.stop_reason.as_deref() == Some("max_tokens") {
+                    html! {
+                        <span class="stat-item stop-reason" title="Session stopped: max tokens reached">
+                            { "max tokens" }
+                        </span>
+                    }
+                } else {
+                    html! {}
+                }
+            }
+            {
+                if msg.fast_mode_state.as_deref() == Some("on") {
+                    html! {
+                        <span class="stat-item fast-mode" title="Fast mode enabled">
+                            { "Fast" }
+                        </span>
+                    }
+                } else {
+                    html! {}
+                }
+            }
+            {
+                if !msg.errors.is_empty() {
+                    html! {
+                        <span class="stat-item errors" title={errors_tooltip.clone()}>
+                            { format!("{} error{}", msg.errors.len(), if msg.errors.len() == 1 { "" } else { "s" }) }
+                        </span>
+                    }
+                } else {
+                    html! {}
+                }
+            }
+            {
+                if !msg.permission_denials.is_empty() {
+                    html! {
+                        <span class="stat-item denials" title={denials_tooltip.clone()}>
+                            { format!("{} denied", msg.permission_denials.len()) }
+                        </span>
+                    }
+                } else {
+                    html! {}
+                }
+            }
+        </>
+    };
 
     if is_error {
         if let Some(error_html) = try_render_api_error(msg.result.as_deref()) {
@@ -1045,6 +1140,7 @@ pub fn render_result_message(msg: &ResultMessage) -> Html {
                             <span class="stat-item duration" title={timing_tooltip.clone()}>
                                 { format_duration(duration_ms) }
                             </span>
+                            { extra_badges.clone() }
                         </div>
                     </div>
                 </>
@@ -1088,6 +1184,7 @@ pub fn render_result_message(msg: &ResultMessage) -> Html {
                         html! {}
                     }
                 }
+                { extra_badges }
             </div>
         </div>
     }

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -240,6 +240,15 @@ pub struct ResultMessage {
     pub total_cost_usd: Option<f64>,
     pub num_turns: Option<u64>,
     pub usage: Option<UsageInfo>,
+    pub stop_reason: Option<String>,
+    pub terminal_reason: Option<String>,
+    pub fast_mode_state: Option<String>,
+    #[serde(default)]
+    pub errors: Vec<String>,
+    pub model_usage: Option<Value>,
+    pub api_error_status: Option<u16>,
+    #[serde(default)]
+    pub permission_denials: Vec<Value>,
 }
 
 #[cfg(test)]

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -517,6 +517,26 @@
     color: var(--error);
 }
 
+.result-message .stat-item.stop-reason {
+    color: #e0af68;
+    font-weight: 500;
+}
+
+.result-message .stat-item.fast-mode {
+    color: var(--accent);
+    font-weight: 500;
+}
+
+.result-message .stat-item.errors {
+    color: var(--error);
+    font-weight: 500;
+}
+
+.result-message .stat-item.denials {
+    color: #e0af68;
+    font-weight: 500;
+}
+
 /* User Message */
 .user-message {
     border-left: 3px solid var(--accent);


### PR DESCRIPTION
## Summary
- Show total cost ($X.XX) in the result stats bar
- Show "max tokens" badge when session was truncated
- Show "Fast" badge when fast mode was enabled
- Show error count (red) and permission denial count (amber) badges
- Add per-model cost breakdown to the timing tooltip

## Test plan
- [ ] Verify cost badge appears on result messages
- [ ] Verify "max tokens" badge only appears when stop_reason is "max_tokens"
- [ ] Verify "Fast" badge appears when fast_mode_state is "on"
- [ ] Verify error/denial badges show count with tooltip details
- [ ] Verify existing result bar (duration, tokens, turns) unchanged