### PR TITLE
Enrich assistant headers with truncation and cache info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.13
+
+- Show truncation warning when assistant message hits max_tokens
+- Add service tier and inference region to model name tooltip
+- Add ephemeral cache details to usage tooltip
+
 ## 2.4.12
 
 - Show cost, stop reason, fast mode, errors, and permission denials in result stats bar

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.12"
+version = "2.4.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.12"
+version = "2.4.13"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.12"
+version = "2.4.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.12"
+version = "2.4.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.12"
+version = "2.4.13"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.12"
+version = "2.4.13"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.12"
+version = "2.4.13"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.12"
+version = "2.4.13"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.12"
+version = "2.4.13"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -17,6 +17,52 @@ fn preserve_user_newlines(text: &str) -> String {
     text.replace('\n', "  \n")
 }
 
+fn extract_ephemeral_cache(usage: &UsageInfo) -> (u64, u64) {
+    let mut e1h: u64 = 0;
+    let mut e5m: u64 = 0;
+    if let Some(cc) = &usage.cache_creation {
+        if let Some(v) = cc.get("ephemeral_1h_input_tokens").and_then(|v| v.as_u64()) {
+            e1h = v;
+        }
+        if let Some(v) = cc.get("ephemeral_5m_input_tokens").and_then(|v| v.as_u64()) {
+            e5m = v;
+        }
+    }
+    (e1h, e5m)
+}
+
+fn build_model_tooltip(model: &str, usage: Option<&UsageInfo>) -> String {
+    let mut parts = vec![model.to_string()];
+    if let Some(u) = usage {
+        if let Some(tier) = &u.service_tier {
+            parts.push(tier.clone());
+        }
+        if let Some(geo) = &u.inference_geo {
+            parts.push(geo.clone());
+        }
+    }
+    parts.join(" | ")
+}
+
+fn build_usage_tooltip(usage: Option<&UsageInfo>) -> String {
+    usage
+        .map(|u| {
+            let mut tooltip = format!(
+                "Input: {} | Output: {} | Cache read: {} | Cache created: {}",
+                u.input_tokens.unwrap_or(0),
+                u.output_tokens.unwrap_or(0),
+                u.cache_read_input_tokens.unwrap_or(0),
+                u.cache_creation_input_tokens.unwrap_or(0)
+            );
+            let (e1h, e5m) = extract_ephemeral_cache(u);
+            if e1h > 0 || e5m > 0 {
+                tooltip.push_str(&format!(" | Ephemeral 1h: {} | Ephemeral 5m: {}", e1h, e5m));
+            }
+            tooltip
+        })
+        .unwrap_or_default()
+}
+
 // --- Message renderers ---
 
 pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> Html {
@@ -24,7 +70,10 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
     let mut total_input_tokens: u64 = 0;
     let mut total_cache_read: u64 = 0;
     let mut total_cache_created: u64 = 0;
+    let mut total_ephemeral_1h: u64 = 0;
+    let mut total_ephemeral_5m: u64 = 0;
     let mut model_name = String::new();
+    let mut first_usage: Option<UsageInfo> = None;
 
     for json in messages {
         if let Ok(ClaudeMessage::Assistant(msg)) = serde_json::from_str::<ClaudeMessage>(json) {
@@ -34,6 +83,12 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
                     total_input_tokens += usage.input_tokens.unwrap_or(0);
                     total_cache_read += usage.cache_read_input_tokens.unwrap_or(0);
                     total_cache_created += usage.cache_creation_input_tokens.unwrap_or(0);
+                    let (e1h, e5m) = extract_ephemeral_cache(usage);
+                    total_ephemeral_1h += e1h;
+                    total_ephemeral_5m += e5m;
+                    if first_usage.is_none() {
+                        first_usage = Some(usage.clone());
+                    }
                 }
                 if model_name.is_empty() {
                     if let Some(m) = &message.model {
@@ -45,10 +100,17 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
     }
 
     let count = messages.len();
-    let usage_tooltip = format!(
+    let mut usage_tooltip = format!(
         "Input: {} | Output: {} | Cache read: {} | Cache created: {} | {} messages",
         total_input_tokens, total_output_tokens, total_cache_read, total_cache_created, count
     );
+    if total_ephemeral_1h > 0 || total_ephemeral_5m > 0 {
+        usage_tooltip.push_str(&format!(
+            " | Ephemeral 1h: {} | Ephemeral 5m: {}",
+            total_ephemeral_1h, total_ephemeral_5m
+        ));
+    }
+    let model_tooltip = build_model_tooltip(&model_name, first_usage.as_ref());
 
     html! {
         <div class="claude-message assistant-message">
@@ -63,7 +125,7 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
                 }
                 {
                     if let Some(short_name) = shorten_model_name(&model_name) {
-                        html! { <span class="model-name" title={model_name.clone()}>{ short_name }</span> }
+                        html! { <span class="model-name" title={model_tooltip.clone()}>{ short_name }</span> }
                     } else {
                         html! {}
                     }
@@ -609,18 +671,11 @@ pub fn render_assistant_message(msg: &AssistantMessage, timestamp: Option<&str>)
         .and_then(|m| m.model.as_ref())
         .map(|s| s.as_str())
         .unwrap_or("");
+    let stop_reason = msg.message.as_ref().and_then(|m| m.stop_reason.as_deref());
+    let is_truncated = stop_reason == Some("max_tokens");
 
-    let usage_tooltip = usage
-        .map(|u| {
-            format!(
-                "Input: {} | Output: {} | Cache read: {} | Cache created: {}",
-                u.input_tokens.unwrap_or(0),
-                u.output_tokens.unwrap_or(0),
-                u.cache_read_input_tokens.unwrap_or(0),
-                u.cache_creation_input_tokens.unwrap_or(0)
-            )
-        })
-        .unwrap_or_default();
+    let model_tooltip = build_model_tooltip(model, usage);
+    let usage_tooltip = build_usage_tooltip(usage);
 
     html! {
         <div class="claude-message assistant-message">
@@ -628,7 +683,14 @@ pub fn render_assistant_message(msg: &AssistantMessage, timestamp: Option<&str>)
                 <span class="message-type-badge assistant">{ "Assistant" }</span>
                 {
                     if let Some(short_name) = shorten_model_name(model) {
-                        html! { <span class="model-name" title={model.to_string()}>{ short_name }</span> }
+                        html! { <span class="model-name" title={model_tooltip}>{ short_name }</span> }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
+                    if is_truncated {
+                        html! { <span class="truncated-badge" title="Response was cut off (max_tokens)">{ "truncated" }</span> }
                     } else {
                         html! {}
                     }

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -138,6 +138,7 @@ pub struct MessageContent {
     pub id: Option<String>,
     pub model: Option<String>,
     pub role: Option<String>,
+    pub stop_reason: Option<String>,
     pub content: Option<Vec<ContentBlock>>,
     pub usage: Option<UsageInfo>,
 }
@@ -227,6 +228,9 @@ pub struct UsageInfo {
     pub output_tokens: Option<u64>,
     pub cache_read_input_tokens: Option<u64>,
     pub cache_creation_input_tokens: Option<u64>,
+    pub service_tier: Option<String>,
+    pub inference_geo: Option<String>,
+    pub cache_creation: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -176,6 +176,16 @@
     cursor: help;
 }
 
+.truncated-badge {
+    color: #e0af68;
+    font-size: 0.7rem;
+    font-weight: 500;
+    padding: 0.1rem 0.4rem;
+    background: rgba(224, 175, 104, 0.15);
+    border-radius: 3px;
+    cursor: help;
+}
+
 .assistant-message .usage-badge {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- Show "truncated" badge when assistant response was cut off by max_tokens
- Add service tier and inference region to model name tooltip
- Add ephemeral cache (1h/5m) details to usage tooltips
- Use helper functions for consistent tooltip formatting across single and grouped messages

## Test plan
- [ ] Verify "truncated" amber badge appears when stop_reason is "max_tokens"
- [ ] Verify model tooltip shows service tier and region when available
- [ ] Verify usage tooltip includes ephemeral cache counts when present
- [ ] Verify grouped assistant headers aggregate ephemeral cache correctly