### PR TITLE
Show session init info bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.14
+
+- Show session init info bar with model, version, fast mode, MCP servers, and tool count
+
 ## 2.4.13
 
 - Show truncation warning when assistant message hits max_tokens

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.13"
+version = "2.4.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.13"
+version = "2.4.14"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.13"
+version = "2.4.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.13"
+version = "2.4.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.13"
+version = "2.4.14"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.13"
+version = "2.4.14"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.13"
+version = "2.4.14"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.13"
+version = "2.4.14"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.13"
+version = "2.4.14"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -464,13 +464,55 @@ pub fn render_system_message(msg: &SystemMessage, timestamp: Option<&str>) -> Ht
         return render_task_notification(msg, timestamp);
     }
 
-    if subtype == "init" || subtype == "status" {
+    if subtype == "init" {
+        return render_init_bar(msg, timestamp);
+    }
+
+    if subtype == "status" {
         return html! {};
     }
 
     html! {
         <div class="claude-message system-message compact" title={timestamp.unwrap_or_default().to_string()}>
             <span class="message-type-badge system">{ subtype }</span>
+        </div>
+    }
+}
+
+fn render_init_bar(msg: &SystemMessage, timestamp: Option<&str>) -> Html {
+    let model_short = msg
+        .model
+        .as_deref()
+        .and_then(shorten_model_name)
+        .unwrap_or_default();
+    let version = msg.claude_code_version.as_deref().unwrap_or("");
+    let tool_count = msg.tools.as_ref().map(|t| t.len()).unwrap_or(0);
+    let mcp_count = msg.mcp_servers.as_ref().map(|s| s.len()).unwrap_or(0);
+    let fast_mode = msg
+        .extra
+        .as_ref()
+        .and_then(|v| v.get("fast_mode_state"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("off");
+
+    html! {
+        <div class="claude-message system-message compact" title={timestamp.unwrap_or_default().to_string()}>
+            <span class="message-type-badge system">{ "Session" }</span>
+            if !model_short.is_empty() {
+                <span class="init-badge">{ &model_short }</span>
+            }
+            if !version.is_empty() {
+                <span class="init-badge">{ format!("v{}", version) }</span>
+            }
+            if fast_mode == "on" {
+                <span class="init-badge fast">{ "Fast" }</span>
+            }
+            if mcp_count > 0 {
+                <span class="init-badge">{ format!("{} MCP", mcp_count) }</span>
+            }
+            if tool_count > 0 {
+                <span class="init-badge">{ format!("{} tools", tool_count) }</span>
+            }
         </div>
     }
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -88,6 +88,20 @@
     margin-left: 0.25rem;
 }
 
+.init-badge {
+    font-size: 0.7rem;
+    font-weight: 500;
+    padding: 0.1rem 0.4rem;
+    background: rgba(127, 132, 156, 0.2);
+    color: var(--text-secondary);
+    border-radius: 3px;
+}
+
+.init-badge.fast {
+    background: rgba(224, 175, 104, 0.2);
+    color: #e0af68;
+}
+
 /* System Message - Init */
 .system-message .message-subtype {
     color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- Show compact session init info bar instead of hiding init messages
- Displays: model name, CLI version, fast mode badge, MCP server count, tool count

## Test plan
- [ ] Verify init messages now show as a compact bar instead of being hidden
- [ ] Verify model name is shortened (e.g., "Opus 4.5")
- [ ] Verify "Fast" badge appears when fast_mode_state is "on"
- [ ] Verify MCP and tool counts are shown
- [ ] Verify status messages are still hidden