### PR TITLE
Linkify URLs in code blocks and tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.15
+
+- Linkify URLs in code blocks, tool results, expandable text, and thinking blocks
+
 ## 2.4.14
 
 - Show session init info bar with model, version, fast mode, MCP servers, and tool count

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.14"
+version = "2.4.15"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/expandable.rs
+++ b/frontend/src/components/expandable.rs
@@ -1,3 +1,4 @@
+use super::markdown::linkify_urls;
 use super::message_renderer::truncate_str;
 use yew::prelude::*;
 
@@ -22,9 +23,9 @@ pub fn expandable_text(props: &ExpandableTextProps) -> Html {
 
     if text.len() <= props.max_len {
         return match props.tag.as_str() {
-            "span" => html! { <span class={props.class.clone()}>{ text }</span> },
-            "div" => html! { <div class={props.class.clone()}>{ text }</div> },
-            _ => html! { <pre class={props.class.clone()}>{ text }</pre> },
+            "span" => html! { <span class={props.class.clone()}>{ linkify_urls(text) }</span> },
+            "div" => html! { <div class={props.class.clone()}>{ linkify_urls(text) }</div> },
+            _ => html! { <pre class={props.class.clone()}>{ linkify_urls(text) }</pre> },
         };
     }
 
@@ -50,19 +51,19 @@ pub fn expandable_text(props: &ExpandableTextProps) -> Html {
     match props.tag.as_str() {
         "span" => html! {
             <span class={props.class.clone()}>
-                { &display }
+                { linkify_urls(&display) }
                 <span class="expandable-toggle" onclick={toggle}>{ toggle_label }</span>
             </span>
         },
         "div" => html! {
             <div class={props.class.clone()}>
-                { &display }
+                { linkify_urls(&display) }
                 <span class="expandable-toggle" onclick={toggle}>{ toggle_label }</span>
             </div>
         },
         _ => html! {
             <pre class={props.class.clone()}>
-                { &display }
+                { linkify_urls(&display) }
                 <span class="expandable-toggle" onclick={toggle}>{ toggle_label }</span>
             </pre>
         },

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -248,7 +248,7 @@ fn code_block(props: &CodeBlockProps) -> Html {
             <button class={button_class} onclick={on_copy} title="Copy to clipboard">
                 { button_label }
             </button>
-            <code class={classes!("md-code", props.lang_class.clone())}>{ &props.code_text }</code>
+            <code class={classes!("md-code", props.lang_class.clone())}>{ linkify_urls(&props.code_text) }</code>
         </pre>
     }
 }
@@ -394,7 +394,7 @@ fn extract_text(events: &[Event]) -> String {
 
 /// Convert raw URLs in text to clickable links
 /// Handles http:// and https:// URLs that aren't already in markdown link syntax
-fn linkify_urls(text: &str) -> Html {
+pub fn linkify_urls(text: &str) -> Html {
     let mut parts: Vec<Html> = Vec::new();
     let mut remaining = text;
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -800,7 +800,7 @@ pub fn render_content_blocks(blocks: &[ContentBlock]) -> Html {
                             html! {
                                 <div class="thinking-block">
                                     <span class="thinking-label">{ "thinking" }</span>
-                                    <div class="thinking-content">{ thinking }</div>
+                                    <div class="thinking-content">{ crate::components::markdown::linkify_urls(thinking) }</div>
                                 </div>
                             }
                         }

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -4,7 +4,7 @@ mod cron_describe;
 mod diff;
 pub mod expandable;
 mod launch_dialog;
-mod markdown;
+pub(crate) mod markdown;
 pub mod message_renderer;
 mod proxy_token_setup;
 mod schedule_dialog;


### PR DESCRIPTION
## Summary
URLs in code blocks, tool results, expandable text, and thinking blocks were rendered as plain text. Now they're clickable links.

**What changed:**
- Made `linkify_urls` from the markdown module reusable (`pub`)
- Code blocks: URLs in fenced code blocks are now clickable
- `ExpandableText`: URLs in tool results, web search results, MCP results, etc. are now clickable
- Thinking blocks: URLs in extended thinking content are now clickable

## Test plan
- [ ] Verify URLs in code blocks (``` blocks) are clickable
- [ ] Verify URLs in tool result output (bash, read, etc.) are clickable
- [ ] Verify URLs in thinking blocks are clickable
- [ ] Verify existing markdown links `[text](url)` still work
- [ ] Verify bare URLs in regular text still work