### PR TITLE
Linkify URLs in inline code and error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.16
+
+- Linkify URLs in inline code spans, error messages, and file content previews
+
 ## 2.4.15
 
 - Linkify URLs in code blocks, tool results, expandable text, and thinking blocks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.14"
+version = "2.4.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.14"
+version = "2.4.15"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.14"
+version = "2.4.15"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.14"
+version = "2.4.15"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.14"
+version = "2.4.15"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.14"
+version = "2.4.15"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.14"
+version = "2.4.15"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.14"
+version = "2.4.15"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.15"
+version = "2.4.16"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/expandable.rs
+++ b/frontend/src/components/expandable.rs
@@ -93,7 +93,7 @@ pub fn expandable_lines(props: &ExpandableLinesProps) -> Html {
                 { for all_lines.iter().enumerate().map(|(i, line)| html! {
                     <div class="write-line">
                         <span class="line-number">{ format!("{:>4}", i + 1) }</span>
-                        <span class="line-content">{ *line }</span>
+                        <span class="line-content">{ linkify_urls(line) }</span>
                     </div>
                 })}
             </pre>
@@ -120,7 +120,7 @@ pub fn expandable_lines(props: &ExpandableLinesProps) -> Html {
             { for visible.iter().enumerate().map(|(i, line)| html! {
                 <div class="write-line">
                     <span class="line-number">{ format!("{:>4}", i + 1) }</span>
-                    <span class="line-content">{ *line }</span>
+                    <span class="line-content">{ linkify_urls(line) }</span>
                 </div>
             })}
             <div class="write-truncated expandable-toggle" onclick={toggle}>

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -48,7 +48,7 @@ fn render_event(events: &[Event]) -> (Html, usize) {
         Event::Start(tag) => render_tag(tag, events),
         Event::Text(text) => (linkify_urls(text), 1),
         Event::Code(code) => (
-            html! { <code class="md-inline-code">{ code.to_string() }</code> },
+            html! { <code class="md-inline-code">{ linkify_urls(code) }</code> },
             1,
         ),
         Event::SoftBreak => (html! { <>{" "}</> }, 1),

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -256,7 +256,7 @@ pub fn render_error_message(msg: &ErrorMessage, timestamp: Option<&str>) -> Html
                 }
             </div>
             <div class="message-body">
-                <div class="error-text">{ message }</div>
+                <div class="error-text">{ crate::components::markdown::linkify_urls(message) }</div>
             </div>
         </div>
     }
@@ -1359,7 +1359,7 @@ fn try_render_api_error(result_text: Option<&str>) -> Option<Html> {
                     <div class="error-icon">{ "⚠" }</div>
                     <div class="error-details">
                         <div class="error-type-display">{ display_type }</div>
-                        <div class="error-message-text">{ error_message }</div>
+                        <div class="error-message-text">{ crate::components::markdown::linkify_urls(error_message) }</div>
                     </div>
                 </div>
                 {


### PR DESCRIPTION
## Summary
URLs inside backtick inline code spans (`` `http://...` ``), error messages, API error details, and file content previews were rendered as plain text. Now they're clickable links.

**Fixed contexts:**
- Inline code (`` `https://example.com` ``) — the most common case, since Claude often wraps URLs in backticks
- Error message text
- Anthropic API error message text
- `ExpandableLines` file content previews (Write tool)

## Test plan
- [ ] Verify URLs inside backtick inline code are clickable
- [ ] Verify URLs in error messages are clickable
- [ ] Verify URLs in file content previews are clickable
- [ ] Verify non-URL inline code still renders normally