### PR TITLE
Optimistic send with pending indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.17
+
+- Optimistic send: user messages appear instantly with a pending indicator, confirmed when server echoes back
+
 ## 2.4.16
 
 - Linkify URLs in inline code spans, error messages, and file content previews

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.15"
+version = "2.4.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.15"
+version = "2.4.17"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.15"
+version = "2.4.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.15"
+version = "2.4.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.15"
+version = "2.4.17"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.15"
+version = "2.4.17"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.15"
+version = "2.4.17"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.15"
+version = "2.4.17"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.16"
+version = "2.4.17"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -180,12 +180,16 @@ pub fn render_user_message(
         Some(sender) if current_user_id != Some(sender.user_id.as_str()) => sender.name.clone(),
         _ => "You".to_string(),
     };
+    let pending_class = if msg.pending { " pending" } else { "" };
 
     if let Some(text) = &msg.content {
         html! {
-            <div class="claude-message user-message">
+            <div class={format!("claude-message user-message{}", pending_class)}>
                 <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                     <span class="message-type-badge user">{ &label }</span>
+                    if msg.pending {
+                        <span class="pending-indicator" title="Sending...">{ "\u{2022}" }</span>
+                    }
                 </div>
                 <div class="message-body">
                     <div class="user-text">{ render_markdown(&preserve_user_newlines(text)) }</div>

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -43,6 +43,8 @@ pub struct UserMessage {
     pub message: Option<UserMessageContent>,
     #[serde(default, rename = "_sender")]
     pub sender: Option<MessageSender>,
+    #[serde(default, rename = "_pending")]
+    pub pending: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -1,5 +1,6 @@
 //! SessionView component - Main terminal view for a single session
 
+use crate::components::message_renderer::MessageRenderer;
 use crate::components::{group_messages, MessageGroupRenderer, VoiceInput};
 use crate::utils;
 use gloo::timers::callback::{Interval, Timeout};
@@ -193,6 +194,8 @@ pub struct SessionView {
     tab_departing: bool,
     /// Tracks textarea content so it can be restored after reconnection re-renders
     input_text: String,
+    /// Messages sent but not yet confirmed by the server echo
+    pending_sends: Vec<String>,
 }
 
 impl Component for SessionView {
@@ -268,6 +271,7 @@ impl Component for SessionView {
             tab_anim: None,
             tab_departing: false,
             input_text: String::new(),
+            pending_sends: Vec::new(),
         }
     }
 
@@ -1019,6 +1023,9 @@ impl Component for SessionView {
                                 html! { <MessageGroupRenderer group={group} session_id={Some(ctx.props().session.id)} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} /> }
                             }).collect::<Html>()
                         }
+                        { for self.pending_sends.iter().map(|json| {
+                            html! { <MessageRenderer json={json.clone()} session_id={Some(ctx.props().session.id)} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} /> }
+                        })}
                     </div>
                     { self.render_tasks_sidebar(ctx) }
                 </div>
@@ -1145,7 +1152,7 @@ impl SessionView {
         let session_id = ctx.props().session.id;
         ctx.props().on_message_sent.emit(session_id);
 
-        // Optimistic local echo: show the message immediately with _pending flag
+        // Optimistic local echo: show in pending queue at bottom of chat
         let now_iso = js_sys::Date::new_0()
             .to_iso_string()
             .as_string()
@@ -1156,7 +1163,7 @@ impl SessionView {
             "_pending": true,
             "_created_at": now_iso,
         });
-        self.messages.push(optimistic_msg.to_string());
+        self.pending_sends.push(optimistic_msg.to_string());
 
         // Send the text
         if let Some(ref sender) = self.ws_sender {
@@ -1377,24 +1384,11 @@ impl SessionView {
         } else {
             output
         };
-        // If this is a confirmed user message from the server, replace the
-        // optimistic pending message instead of appending a duplicate.
-        if msg_type == "user" {
-            if let Some(pos) = self.messages.iter().position(|m| {
-                serde_json::from_str::<serde_json::Value>(m)
-                    .ok()
-                    .and_then(|v| v.get("_pending")?.as_bool())
-                    .unwrap_or(false)
-            }) {
-                self.messages[pos] = output;
-                self.last_message_timestamp = Some(
-                    js_sys::Date::new_0()
-                        .to_iso_string()
-                        .as_string()
-                        .unwrap_or_default(),
-                );
-                return true;
-            }
+        // When a confirmed user message arrives from the server, remove the
+        // oldest pending send so it doesn't duplicate. The confirmed version
+        // appends to self.messages at the natural scroll position.
+        if msg_type == "user" && !self.pending_sends.is_empty() {
+            self.pending_sends.remove(0);
         }
         self.messages.push(output);
         if self.messages.len() > MAX_MESSAGES_PER_SESSION {

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -1145,6 +1145,19 @@ impl SessionView {
         let session_id = ctx.props().session.id;
         ctx.props().on_message_sent.emit(session_id);
 
+        // Optimistic local echo: show the message immediately with _pending flag
+        let now_iso = js_sys::Date::new_0()
+            .to_iso_string()
+            .as_string()
+            .unwrap_or_default();
+        let optimistic_msg = serde_json::json!({
+            "type": "user",
+            "content": input,
+            "_pending": true,
+            "_created_at": now_iso,
+        });
+        self.messages.push(optimistic_msg.to_string());
+
         // Send the text
         if let Some(ref sender) = self.ws_sender {
             let msg = ClientToServer::ClaudeInput {
@@ -1343,9 +1356,11 @@ impl SessionView {
             }
         }
         crate::audio::play_sound(crate::audio::SoundEvent::Activity);
-        ctx.props()
-            .on_activity
-            .emit((ctx.props().session.id, msg_type, js_sys::Date::now()));
+        ctx.props().on_activity.emit((
+            ctx.props().session.id,
+            msg_type.clone(),
+            js_sys::Date::now(),
+        ));
         // Inject _created_at for tooltip display
         let output = if let Ok(mut val) = serde_json::from_str::<serde_json::Value>(&output) {
             if let Some(obj) = val.as_object_mut() {
@@ -1362,6 +1377,25 @@ impl SessionView {
         } else {
             output
         };
+        // If this is a confirmed user message from the server, replace the
+        // optimistic pending message instead of appending a duplicate.
+        if msg_type == "user" {
+            if let Some(pos) = self.messages.iter().position(|m| {
+                serde_json::from_str::<serde_json::Value>(m)
+                    .ok()
+                    .and_then(|v| v.get("_pending")?.as_bool())
+                    .unwrap_or(false)
+            }) {
+                self.messages[pos] = output;
+                self.last_message_timestamp = Some(
+                    js_sys::Date::new_0()
+                        .to_iso_string()
+                        .as_string()
+                        .unwrap_or_default(),
+                );
+                return true;
+            }
+        }
         self.messages.push(output);
         if self.messages.len() > MAX_MESSAGES_PER_SESSION {
             let excess = self.messages.len() - MAX_MESSAGES_PER_SESSION;

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -542,6 +542,23 @@
     border-left: 3px solid var(--accent);
 }
 
+.user-message.pending {
+    opacity: 0.6;
+    border-left-style: dashed;
+}
+
+.pending-indicator {
+    color: var(--accent);
+    font-size: 1.2rem;
+    line-height: 1;
+    animation: pending-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pending-pulse {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 1; }
+}
+
 .user-message .user-text {
     color: var(--text-primary);
     line-height: 1.6;


### PR DESCRIPTION
## Summary
User messages now appear instantly in the chat when sent, instead of waiting for the full server round-trip (frontend → backend → proxy → Claude API echo → backend → frontend).

- On send, an optimistic user message is pushed to `self.messages` with `_pending: true`
- Message renders immediately with dashed border and pulsing dot indicator
- When the server echoes back the confirmed message, it replaces the pending one in-place (timestamp restamped)
- If the echo doesn't match a pending message (e.g., from another client), it appends normally

## Test plan
- [ ] Verify user message appears instantly after pressing Enter
- [ ] Verify pending message shows dashed border and pulsing dot
- [ ] Verify message transitions to solid border when server confirms
- [ ] Verify no duplicate messages appear
- [ ] Verify messages from other users (shared sessions) still append normally