### PR TITLE
Fix iOS scroll bounce dead space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.18
+
+- Fix iOS Safari scroll bounce creating stuck dead space below messages
+
 ## 2.4.17
 
 - Optimistic send: user messages appear instantly with a pending indicator, confirmed when server echoes back

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.17"
+version = "2.4.18"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/base.css
+++ b/frontend/styles/base.css
@@ -45,5 +45,6 @@ html, body {
     background: var(--bg-dark);
     color: var(--text-primary);
     min-height: 100vh;
+    overscroll-behavior: none; /* Prevent iOS bounce/rubber-banding on the document */
 }
 

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -151,6 +151,7 @@
         flex: 1;
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
+        overscroll-behavior: contain;
     }
 
     /* ---- Input area ---- */

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -133,6 +133,7 @@
     position: relative;
     overflow: hidden;
     min-height: 0;
+    overscroll-behavior: contain;
 }
 
 .session-view-messages {
@@ -141,4 +142,5 @@
     overflow-x: hidden;
     padding: 1rem 1.5rem 0;
     min-width: 0; /* Allow flex child to shrink below content size */
+    overscroll-behavior: contain; /* Prevent iOS rubber-banding from escaping this container */
 }


### PR DESCRIPTION
## Summary
On iOS Safari, the elastic overscroll (rubber-banding) on the message scroll container could create stuck dead space below the last message.

Fix: add `overscroll-behavior: contain` to the message scroll area, scroll wrapper, and document body to prevent the bounce from escaping the scroll container.

## Test plan
- [ ] Verify no dead space appears below messages on iOS Safari
- [ ] Verify normal scrolling still works on all platforms
- [ ] Verify pull-to-refresh is disabled (expected, since the app is a SPA)