### PR TITLE
Fix iOS keyboard gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.19
+
+- Fix iOS keyboard gap: use position:fixed on mobile to track visual viewport
+
 ## 2.4.18
 
 - Fix iOS Safari scroll bounce creating stuck dead space below messages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.18"
+version = "2.4.19"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/base.css
+++ b/frontend/styles/base.css
@@ -45,6 +45,8 @@ html, body {
     background: var(--bg-dark);
     color: var(--text-primary);
     min-height: 100vh;
-    overscroll-behavior: none; /* Prevent iOS bounce/rubber-banding on the document */
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
 }
 

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -12,8 +12,13 @@
 
 /* --- Tablet + phone (max-width: 768px) ---------------------------------- */
 @media (max-width: 768px) {
-    /* Ensure dashboard fills exactly the viewport on mobile */
+    /* Ensure dashboard fills exactly the visual viewport on mobile.
+       position:fixed + inset:0 tracks the visual viewport on iOS Safari,
+       which correctly excludes the keyboard — unlike 100dvh which can lag. */
     .focus-flow-container {
+        position: fixed;
+        inset: 0;
+        height: auto;
         overflow: hidden;
     }
 


### PR DESCRIPTION
## Summary
On iOS Safari, opening the keyboard created a dead gap between the input bar and the keyboard. The `100dvh` height wasn't tracking the visual viewport resize fast enough.

Fix: On mobile (`max-width: 768px`), use `position: fixed; inset: 0` on the main container instead of `height: 100dvh`. This reliably tracks the visual viewport on iOS Safari, including when the keyboard opens/closes. Also set `height: 100%; overflow: hidden` on html/body to prevent the document from being scrollable behind the fixed container.

## Test plan
- [ ] Verify no gap between input bar and keyboard on iOS Safari
- [ ] Verify input bar is visible and usable when keyboard is open
- [ ] Verify scrolling messages still works on mobile
- [ ] Verify desktop layout is unaffected (position:fixed only applies at max-width: 768px)
- [ ] Verify other pages (settings, admin) still scroll normally