### PR TITLE
Match pending sends by content on echo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.20
+
+- Match pending sends by content when draining on server echo
+
 ## 2.4.19
 
 - Fix iOS keyboard gap: use position:fixed on mobile to track visual viewport

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.17"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.17"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.17"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.17"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.17"
+version = "2.4.20"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.17"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.17"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.17"
+version = "2.4.20"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.19"
+version = "2.4.20"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -1384,11 +1384,24 @@ impl SessionView {
         } else {
             output
         };
-        // When a confirmed user message arrives from the server, remove the
-        // oldest pending send so it doesn't duplicate. The confirmed version
-        // appends to self.messages at the natural scroll position.
+        // When a confirmed user message arrives from the server, find and remove
+        // the matching pending send by content so lost messages don't consume
+        // unrelated pending entries.
         if msg_type == "user" && !self.pending_sends.is_empty() {
-            self.pending_sends.remove(0);
+            let echo_content = serde_json::from_str::<serde_json::Value>(&output)
+                .ok()
+                .and_then(|v| v.get("content").cloned());
+            if let Some(ref echo) = echo_content {
+                if let Some(pos) = self.pending_sends.iter().position(|pending| {
+                    serde_json::from_str::<serde_json::Value>(pending)
+                        .ok()
+                        .and_then(|v| v.get("content").cloned())
+                        .as_ref()
+                        == Some(echo)
+                }) {
+                    self.pending_sends.remove(pos);
+                }
+            }
         }
         self.messages.push(output);
         if self.messages.len() > MAX_MESSAGES_PER_SESSION {


### PR DESCRIPTION
## Summary
The optimistic send drain was blindly removing the first pending message when any user echo arrived. If a message got lost (network drop, server error), the next echo would incorrectly consume an unrelated pending entry, hiding a real message.

Now the echo's `content` field is compared against each pending send's `content`. Only a matching entry is removed. If no match is found (e.g., a message from another user in a shared session), the pending queue is left unchanged.

## Test plan
- [ ] Verify normal send/echo still works (pending message appears, disappears on echo)
- [ ] Verify messages from other users in shared sessions don't consume pending entries
- [ ] Verify multiple rapid sends drain in correct order