### PR TITLE
Fix splash page scroll on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.32
+
+- Fix splash page not scrollable on mobile (overflow:hidden was on body instead of session container)
+
 ## 2.4.31
 
 - Add stable keys to grouped assistant messages to preserve expanded state on new messages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.31"
+version = "2.4.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.31"
+version = "2.4.32"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.31"
+version = "2.4.32"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.31"
+version = "2.4.32"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.31"
+version = "2.4.32"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.31"
+version = "2.4.32"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.31"
+version = "2.4.32"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.31"
+version = "2.4.32"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.31"
+version = "2.4.32"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/base.css
+++ b/frontend/styles/base.css
@@ -45,8 +45,6 @@ html, body {
     background: var(--bg-dark);
     color: var(--text-primary);
     min-height: 100vh;
-    height: 100%;
-    overflow: hidden;
     overscroll-behavior: none;
 }
 


### PR DESCRIPTION
## Summary
The iOS keyboard gap fix (2.4.18) added `overflow: hidden; height: 100%` to `html, body`. This prevented the splash/login page from scrolling on mobile, hiding the login button below the fold.

Fix: Remove `overflow: hidden` and `height: 100%` from the body. The session view already handles its own scroll containment via `position: fixed` on `.focus-flow-container` (mobile) and `overflow: hidden` on `.session-view-scroll-area` (all viewports). Other pages (splash, settings, admin) need normal document scrolling.

## Test plan
- [ ] Verify splash page scrolls to reveal the login button on mobile
- [ ] Verify iOS keyboard gap is still fixed in session view
- [ ] Verify settings and admin pages scroll normally