### PR TITLE
Fix false autolinks from angle-bracket syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.20
+
+- Fix false autolinks: angle-bracket Rust paths like `<crate::Type>` no longer render as clickable URLs
+
 ## 2.4.19
 
 - Fix iOS keyboard gap: use position:fixed on mobile to track visual viewport

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.17"
+version = "2.4.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.17"
+version = "2.4.19"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.17"
+version = "2.4.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.17"
+version = "2.4.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.17"
+version = "2.4.19"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.17"
+version = "2.4.19"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.17"
+version = "2.4.19"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.17"
+version = "2.4.19"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.19"
+version = "2.4.20"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -81,15 +81,22 @@ fn render_tag(tag: &Tag, events: &[Event]) -> (Html, usize) {
             dest_url, title, ..
         } => {
             let href = dest_url.to_string();
-            let title_attr = if title.is_empty() {
-                None
+            // Guard against false autolinks from angle-bracket syntax like
+            // <crate::path::Type> which pulldown-cmark interprets as URLs.
+            if !is_valid_url(&href) && !href.starts_with('#') && !href.starts_with('/') {
+                // Not a real URL — render as plain text with angle brackets
+                html! { <><>{"<"}</>{ inner_html }<>{">"}</></> }
             } else {
-                Some(title.to_string())
-            };
-            html! {
-                <a href={href} title={title_attr} target="_blank" rel="noopener noreferrer" class="md-link">
-                    { inner_html }
-                </a>
+                let title_attr = if title.is_empty() {
+                    None
+                } else {
+                    Some(title.to_string())
+                };
+                html! {
+                    <a href={href} title={title_attr} target="_blank" rel="noopener noreferrer" class="md-link">
+                        { inner_html }
+                    </a>
+                }
             }
         }
         Tag::Image {


### PR DESCRIPTION
## Summary
pulldown-cmark treats `<anything>` as a CommonMark autolink, creating `Tag::Link` events for Rust paths like `<crate::scene_galaxy::GalaxyInFrame>`. These rendered as broken clickable links.

Fix: validate the URL in the `Tag::Link` handler using the existing `is_valid_url()` function. If it's not a real URL (no http/https protocol, not a fragment `#` or relative path `/`), render as plain text with angle brackets instead of an `<a>` tag.

## Test plan
- [ ] Verify `<crate::path::Type>` renders as plain text, not a link
- [ ] Verify `<https://example.com>` still renders as a clickable link
- [ ] Verify `[text](https://example.com)` still works
- [ ] Verify `<user@email.com>` renders as plain text (not a mailto link)