### PR TITLE
Click to expand truncated bash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.21
+
+- Click truncated bash commands to expand full command text
+
 ## 2.4.20
 
 - Fix false autolinks: angle-bracket Rust paths like `<crate::Type>` no longer render as clickable URLs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.19"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.19"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.19"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.19"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.19"
+version = "2.4.20"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.19"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.19"
+version = "2.4.20"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.19"
+version = "2.4.20"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.20"
+version = "2.4.21"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/tool_renderers/bash.rs
+++ b/frontend/src/components/tool_renderers/bash.rs
@@ -1,7 +1,68 @@
+use crate::components::markdown::linkify_urls;
+use crate::components::message_renderer::format_duration;
 use serde_json::Value;
 use yew::prelude::*;
 
-use crate::components::message_renderer::format_duration;
+#[derive(Properties, PartialEq)]
+struct BashToolProps {
+    command: AttrValue,
+    description: Option<AttrValue>,
+    timeout_str: Option<AttrValue>,
+    background: bool,
+}
+
+#[function_component(BashTool)]
+fn bash_tool(props: &BashToolProps) -> Html {
+    let expanded = use_state(|| false);
+    let command = &*props.command;
+
+    let toggle = {
+        let expanded = expanded.clone();
+        Callback::from(move |_: MouseEvent| {
+            expanded.set(!*expanded);
+        })
+    };
+
+    let cmd_class = if *expanded {
+        "bash-command-inline expanded"
+    } else {
+        "bash-command-inline"
+    };
+
+    html! {
+        <div class="tool-use bash-tool">
+            <div class="tool-use-header">
+                <span class="tool-icon">{ "$" }</span>
+                <span class="tool-name">{ "Bash" }</span>
+                <code class={cmd_class} onclick={toggle} title="Click to expand">
+                    { linkify_urls(command) }
+                </code>
+                <span class="tool-header-spacer"></span>
+                {
+                    if props.background {
+                        html! { <span class="tool-badge background">{ "background" }</span> }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
+                    if let Some(t) = &props.timeout_str {
+                        html! { <span class="tool-meta timeout">{ format!("timeout={}", t) }</span> }
+                    } else {
+                        html! {}
+                    }
+                }
+            </div>
+            {
+                if let Some(desc) = &props.description {
+                    html! { <div class="bash-description">{ desc }</div> }
+                } else {
+                    html! {}
+                }
+            }
+        </div>
+    }
+}
 
 pub fn render_bash_tool(input: &Value) -> Html {
     let command = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
@@ -15,34 +76,11 @@ pub fn render_bash_tool(input: &Value) -> Html {
     let timeout_str = timeout.map(format_duration);
 
     html! {
-        <div class="tool-use bash-tool">
-            <div class="tool-use-header">
-                <span class="tool-icon">{ "$" }</span>
-                <span class="tool-name">{ "Bash" }</span>
-                <code class="bash-command-inline">{ command }</code>
-                <span class="tool-header-spacer"></span>
-                {
-                    if background {
-                        html! { <span class="tool-badge background">{ "background" }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
-                {
-                    if let Some(t) = timeout_str {
-                        html! { <span class="tool-meta timeout">{ format!("timeout={}", t) }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
-            </div>
-            {
-                if let Some(desc) = description {
-                    html! { <div class="bash-description">{ desc }</div> }
-                } else {
-                    html! {}
-                }
-            }
-        </div>
+        <BashTool
+            command={command.to_string()}
+            description={description.map(|s| AttrValue::from(s.to_string()))}
+            timeout_str={timeout_str.map(AttrValue::from)}
+            {background}
+        />
     }
 }

--- a/frontend/styles/tools.css
+++ b/frontend/styles/tools.css
@@ -297,6 +297,15 @@
 
 .bash-command-inline {
     max-width: 70%;
+    cursor: pointer;
+}
+
+.bash-command-inline.expanded {
+    white-space: pre-wrap;
+    overflow: visible;
+    text-overflow: unset;
+    max-width: none;
+    flex-basis: 100%;
 }
 
 .tool-header-spacer {


### PR DESCRIPTION
## Summary
Truncated bash commands (shown with CSS `text-overflow: ellipsis`) are now clickable to expand to the full command text. Click again to collapse.

Converted the bash tool renderer from a plain function to a Yew component with `use_state` for the expanded toggle. The `.bash-command-inline.expanded` class removes the truncation CSS (`white-space: pre-wrap`, `overflow: visible`, `max-width: none`).

## Test plan
- [ ] Verify long bash commands show truncated with `...`
- [ ] Verify clicking the truncated command expands to show the full text
- [ ] Verify clicking again collapses back to truncated
- [ ] Verify short commands that fit without truncation still look normal
- [ ] Verify URLs in commands are clickable (linkify_urls applied)