### PR TITLE
Fix stuck reconnect loop on replay failure (#650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.22
+
+- Fix stuck reconnect loop: drop pending messages after 5 consecutive replay failures (#650)
+
 ## 2.4.21
 
 - Click truncated bash commands to expand full command text

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.20"
+version = "2.4.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.20"
+version = "2.4.21"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.20"
+version = "2.4.21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.20"
+version = "2.4.21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.20"
+version = "2.4.21"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.20"
+version = "2.4.21"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.20"
+version = "2.4.21"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.20"
+version = "2.4.21"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.21"
+version = "2.4.22"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/output_buffer.rs
+++ b/claude-session-lib/src/output_buffer.rs
@@ -192,6 +192,12 @@ impl PendingOutputBuffer {
         self.state.pending.len()
     }
 
+    /// Drop all pending messages (used when replay fails repeatedly)
+    pub fn clear(&mut self) {
+        self.state.pending.clear();
+        self.dirty = true;
+    }
+
     /// Get the last acknowledged sequence number
     pub fn last_ack_seq(&self) -> u64 {
         self.state.last_ack_seq

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -167,6 +167,8 @@ pub struct SessionState<'a> {
     pub disconnected_at: Option<Instant>,
     /// Whether the last disconnect was a graceful server shutdown
     pub last_disconnect_graceful: bool,
+    /// Consecutive replay failures on the same pending messages
+    pub replay_failures: u32,
 }
 
 impl<'a> SessionState<'a> {
@@ -199,6 +201,7 @@ impl<'a> SessionState<'a> {
             first_connection: true,
             disconnected_at: None,
             last_disconnect_graceful: false,
+            replay_failures: 0,
         })
     }
 
@@ -373,26 +376,46 @@ async fn run_single_connection(session: &mut SessionState<'_>) -> ConnectionResu
         }
     }
 
-    // Replay pending messages after successful registration
+    // Replay pending messages after successful registration.
+    // If replay fails repeatedly (e.g., backend reset and rejects stale seqs),
+    // drop the pending messages after MAX_REPLAY_FAILURES to avoid an infinite loop.
+    const MAX_REPLAY_FAILURES: u32 = 5;
     {
-        let buf = session.output_buffer.lock().await;
+        let mut buf = session.output_buffer.lock().await;
         let pending_count = buf.pending_count();
         if pending_count > 0 {
-            debug!(
-                "Replaying {} pending messages after reconnect",
-                pending_count
-            );
-            for pending in buf.get_pending() {
-                let msg = ProxyToServer::SequencedOutput {
-                    seq: pending.seq,
-                    content: pending.content.clone(),
-                };
-                if conn.send(msg).await.is_err() {
-                    error!("Failed to replay pending message seq={}", pending.seq);
+            if session.replay_failures >= MAX_REPLAY_FAILURES {
+                error!(
+                    "Dropping {} pending messages after {} consecutive replay failures",
+                    pending_count, session.replay_failures
+                );
+                buf.clear();
+                session.replay_failures = 0;
+            } else {
+                debug!(
+                    "Replaying {} pending messages after reconnect (attempt {})",
+                    pending_count,
+                    session.replay_failures + 1
+                );
+                let mut replay_failed = false;
+                for pending in buf.get_pending() {
+                    let msg = ProxyToServer::SequencedOutput {
+                        seq: pending.seq,
+                        content: pending.content.clone(),
+                    };
+                    if conn.send(msg).await.is_err() {
+                        error!("Failed to replay pending message seq={}", pending.seq);
+                        session.replay_failures += 1;
+                        replay_failed = true;
+                        break;
+                    }
+                }
+                if replay_failed {
                     return ConnectionResult::Disconnected(Duration::ZERO);
                 }
+                debug!("Finished replaying pending messages");
+                session.replay_failures = 0;
             }
-            debug!("Finished replaying pending messages");
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes #650. After a backend blip, a session could enter an infinite reconnect loop if it had pending outbound messages that the backend consistently rejected (e.g., because the backend lost its session state during the restart).

The replay logic had no retry budget — it would fail, disconnect, reconnect, fail again, forever.

**Fix:** Track consecutive replay failures on `SessionState`. After 5 failures on the same pending messages, drop them with an `ERROR` log and continue. This accepts data loss for stale messages in exchange for recovering the session.

**Changes:**
- `SessionState.replay_failures: u32` — incremented on each failed replay, reset on success
- `PendingOutputBuffer::clear()` — new method to drop all pending messages
- After `MAX_REPLAY_FAILURES` (5), pending messages are cleared and the session continues normally

## Test plan
- [ ] Verify normal reconnect still replays pending messages successfully
- [ ] Verify that after 5 consecutive replay failures, pending messages are dropped and session recovers
- [ ] Verify replay_failures counter resets after a successful replay
- [ ] Verify the ERROR log includes the count of dropped messages