### PR TITLE
Limit launcher registrations to 10 per user (#617)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.24
+
+- Limit launcher registrations to 10 per user (#617)
+
 ## 2.4.23
 
 - Reduce spend broadcast interval from 5s to 30s and skip when no clients connected (#618, #614)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.21"
+version = "2.4.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.21"
+version = "2.4.24"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.21"
+version = "2.4.24"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.21"
+version = "2.4.24"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.21"
+version = "2.4.24"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.21"
+version = "2.4.24"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.21"
+version = "2.4.24"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.21"
+version = "2.4.24"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.23"
+version = "2.4.24"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -147,6 +147,35 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
         return;
     }
 
+    // Reject if user already has too many launchers
+    const MAX_LAUNCHERS_PER_USER: usize = 10;
+    let user_launcher_count = app_state
+        .session_manager
+        .launchers
+        .iter()
+        .filter(|entry| entry.value().user_id == user_id)
+        .count();
+
+    if user_launcher_count >= MAX_LAUNCHERS_PER_USER {
+        error!(
+            "User {} has {} launchers, rejecting new registration (max {})",
+            user_id, user_launcher_count, MAX_LAUNCHERS_PER_USER
+        );
+        let _ = ws_sender
+            .send(ServerToLauncher::LauncherRegisterAck {
+                success: false,
+                launcher_id,
+                fatal: true,
+                error: Some(format!(
+                    "You already have {} launchers connected (max {}). \
+                     Disconnect an existing launcher before starting a new one.",
+                    user_launcher_count, MAX_LAUNCHERS_PER_USER
+                )),
+            })
+            .await;
+        return;
+    }
+
     // Send RegisterAck
     let _ = ws_sender
         .send(ServerToLauncher::LauncherRegisterAck {


### PR DESCRIPTION
## Summary
Fixes #617. Adds a per-user limit of 10 launcher registrations. Before inserting a new launcher into the DashMap, the handler counts existing launchers for the same user_id and rejects with a fatal error if the limit is reached.

Prevents unbounded memory growth from a user (or spoofed client) registering unlimited launchers.

## Test plan
- [ ] Verify a user can register up to 10 launchers
- [ ] Verify the 11th registration is rejected with an error
- [ ] Verify existing duplicate-hostname check still works