### PR TITLE
Add timeout and delete cap to retention cleanup (#616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.25
+
+- Add 5-second query timeout to retention cleanup tasks (#616)
+- Cap retention deletes at 1000 messages per cycle to avoid long-running queries
+
 ## 2.4.24
 
 - Limit launcher registrations to 10 per user (#617)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.24"
+version = "2.4.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.24"
+version = "2.4.25"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.24"
+version = "2.4.25"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.24"
+version = "2.4.25"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.24"
+version = "2.4.25"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2903,7 +2903,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.24"
+version = "2.4.25"
 dependencies = [
  "anyhow",
  "colored",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.24"
+version = "2.4.25"
 dependencies = [
  "anyhow",
  "hex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.24"
+version = "2.4.25"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.24"
+version = "2.4.25"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/retention.rs
+++ b/backend/src/handlers/retention.rs
@@ -3,8 +3,12 @@
 use crate::schema::messages;
 use chrono::Utc;
 use diesel::prelude::*;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use uuid::Uuid;
+
+/// Maximum number of messages to delete in a single cleanup cycle.
+/// If more remain, they will be caught in the next 60-second cycle.
+const MAX_DELETES_PER_CYCLE: usize = 1000;
 
 /// Configuration for message retention policy
 #[derive(Clone, Copy, Debug)]
@@ -24,13 +28,18 @@ impl RetentionConfig {
     }
 }
 
-/// Truncate messages for a single session to the configured maximum
-/// Returns the number of deleted messages
+/// Truncate messages for a single session to the configured maximum.
+/// Deletes at most `budget` messages. Returns the number of deleted messages.
 pub fn truncate_session_messages(
     conn: &mut diesel::pg::PgConnection,
     session_id: Uuid,
     config: RetentionConfig,
+    budget: usize,
 ) -> Result<usize, diesel::result::Error> {
+    if budget == 0 {
+        return Ok(0);
+    }
+
     let total_count: i64 = messages::table
         .filter(messages::session_id.eq(session_id))
         .count()
@@ -40,13 +49,14 @@ pub fn truncate_session_messages(
         return Ok(0);
     }
 
-    let to_delete = total_count - config.max_messages_per_session;
+    let to_delete = (total_count - config.max_messages_per_session) as usize;
+    let capped = to_delete.min(budget);
 
     // Get the IDs of the oldest messages to delete
     let ids_to_delete: Vec<Uuid> = messages::table
         .filter(messages::session_id.eq(session_id))
         .order(messages::created_at.asc())
-        .limit(to_delete)
+        .limit(capped as i64)
         .select(messages::id)
         .load(conn)?;
 
@@ -65,21 +75,33 @@ pub fn truncate_session_messages(
     Ok(deleted)
 }
 
-/// Delete all messages older than the configured retention period
-/// Uses a single bulk delete query for efficiency
+/// Delete messages older than the configured retention period, up to the per-cycle cap.
 /// Returns the number of deleted messages
 pub fn delete_old_messages(
     conn: &mut diesel::pg::PgConnection,
     config: RetentionConfig,
+    budget: usize,
 ) -> Result<usize, diesel::result::Error> {
-    if config.retention_days == 0 {
+    if config.retention_days == 0 || budget == 0 {
         return Ok(0);
     }
 
     let cutoff = Utc::now().naive_utc() - chrono::Duration::days(config.retention_days as i64);
 
-    let deleted =
-        diesel::delete(messages::table.filter(messages::created_at.lt(cutoff))).execute(conn)?;
+    // Select IDs to delete, capped by remaining budget
+    let ids_to_delete: Vec<Uuid> = messages::table
+        .filter(messages::created_at.lt(cutoff))
+        .order(messages::created_at.asc())
+        .limit(budget as i64)
+        .select(messages::id)
+        .load(conn)?;
+
+    if ids_to_delete.is_empty() {
+        return Ok(0);
+    }
+
+    let deleted = diesel::delete(messages::table.filter(messages::id.eq_any(&ids_to_delete)))
+        .execute(conn)?;
 
     if deleted > 0 {
         info!(
@@ -94,24 +116,44 @@ pub fn delete_old_messages(
 /// Run the full retention cleanup process:
 /// 1. Delete messages older than retention_days
 /// 2. Truncate per-session message counts
+///
+/// Applies a 5-second statement timeout and caps total deletes at 1000 per cycle.
 pub fn run_retention_cleanup(
     conn: &mut diesel::pg::PgConnection,
     pending_session_ids: Vec<Uuid>,
     config: RetentionConfig,
 ) -> (usize, usize) {
+    // Set a 5-second timeout for cleanup queries
+    if let Err(e) = diesel::sql_query("SET LOCAL statement_timeout = '5000'").execute(conn) {
+        warn!(
+            "Failed to set statement_timeout for retention cleanup: {}",
+            e
+        );
+    }
+
+    let mut budget = MAX_DELETES_PER_CYCLE;
     let mut age_deleted = 0;
     let mut count_deleted = 0;
 
-    // First, bulk delete old messages
-    match delete_old_messages(conn, config) {
-        Ok(deleted) => age_deleted = deleted,
+    // First, bulk delete old messages (up to budget)
+    match delete_old_messages(conn, config, budget) {
+        Ok(deleted) => {
+            age_deleted = deleted;
+            budget = budget.saturating_sub(deleted);
+        }
         Err(e) => error!("Failed to delete old messages: {:?}", e),
     }
 
-    // Then truncate per-session counts
+    // Then truncate per-session counts (remaining budget)
     for session_id in pending_session_ids {
-        match truncate_session_messages(conn, session_id, config) {
-            Ok(deleted) => count_deleted += deleted,
+        if budget == 0 {
+            break;
+        }
+        match truncate_session_messages(conn, session_id, config, budget) {
+            Ok(deleted) => {
+                count_deleted += deleted;
+                budget = budget.saturating_sub(deleted);
+            }
             Err(e) => error!("Failed to truncate session {}: {:?}", session_id, e),
         }
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -811,6 +811,14 @@ async fn run_session_age_cleanup(app_state: &Arc<AppState>) {
         return;
     };
 
+    // Set a 5-second timeout for cleanup queries
+    if let Err(e) = diesel::sql_query("SET LOCAL statement_timeout = '5000'").execute(&mut conn) {
+        tracing::warn!(
+            "Failed to set statement_timeout for session age cleanup: {}",
+            e
+        );
+    }
+
     let cutoff = chrono::Utc::now().naive_utc() - chrono::Duration::days(i64::from(max_days));
 
     let old_sessions: Vec<models::Session> = match schema::sessions::table


### PR DESCRIPTION
## Summary
Fixes #616. Retention cleanup queries could run indefinitely, locking DB connections and starving other requests.

**Changes:**
- Add `SET LOCAL statement_timeout = '5000'` (5s) to both retention cleanup and session age cleanup before any queries
- Cap retention deletes at 1000 messages per cycle — remaining deletions are picked up in the next 60s cycle
- `SET LOCAL` scopes the timeout to the current transaction, so it doesn't affect other queries on the same connection

## Test plan
- [ ] Verify retention cleanup still deletes old messages
- [ ] Verify session age cleanup still removes old sessions
- [ ] Verify queries that exceed 5s are cancelled (hard to test without a large dataset)
- [ ] Verify normal API queries are not affected by the timeout