### PR TITLE
Serve images via HTTP instead of WebSocket (#655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.4.26
+
+- Serve large images via HTTP instead of WebSocket (partially addresses #655)
+- Backend extracts base64 images >64KB from portal messages, stores in memory, replaces with `/api/images/{uuid}` URLs
+- Frontend renders both URL and base64 image sources
+- Eliminates WS frame size issues for large images
+
 ## 2.4.25
 
 - Add 5-second query timeout to retention cleanup tasks (#616)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ version = "2.4.25"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
+ "base64 0.22.1",
  "bigdecimal",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.25"
+version = "2.4.26"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -75,6 +75,7 @@ memory-serve = "2.1"
 ws-bridge = { workspace = true, features = ["server"] }
 tower_governor = "0.8.0"
 governor = "0.8"
+base64 = "0.22.1"
 
 [build-dependencies]
 memory-serve = "2.1"

--- a/backend/src/handlers/images.rs
+++ b/backend/src/handlers/images.rs
@@ -1,0 +1,85 @@
+//! In-memory image store for serving uploaded images via HTTP.
+//!
+//! Images are extracted from portal messages by the WebSocket handler,
+//! stored in memory, and served at `/api/images/{id}`. This avoids
+//! sending large base64 blobs over WebSocket to web clients.
+
+use axum::{
+    extract::{Path, State},
+    http::{header, StatusCode},
+    response::IntoResponse,
+};
+use base64::Engine;
+use dashmap::DashMap;
+use std::sync::Arc;
+use tracing::debug;
+use uuid::Uuid;
+
+/// A stored image with its content type and raw bytes
+struct StoredImage {
+    content_type: String,
+    data: Vec<u8>,
+}
+
+/// In-memory image store
+#[derive(Clone, Default)]
+pub struct ImageStore {
+    images: Arc<DashMap<Uuid, StoredImage>>,
+}
+
+impl ImageStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store a base64-encoded image, returning the UUID key.
+    /// Returns None if the base64 data is invalid.
+    pub fn store_base64(&self, content_type: &str, base64_data: &str) -> Option<Uuid> {
+        let data = base64::engine::general_purpose::STANDARD
+            .decode(base64_data)
+            .ok()?;
+        let id = Uuid::new_v4();
+        debug!(
+            "Stored image {} ({}, {} bytes)",
+            id,
+            content_type,
+            data.len()
+        );
+        self.images.insert(
+            id,
+            StoredImage {
+                content_type: content_type.to_string(),
+                data,
+            },
+        );
+        Some(id)
+    }
+
+    /// Get the number of stored images
+    pub fn count(&self) -> usize {
+        self.images.len()
+    }
+}
+
+/// GET /api/images/{id} - Serve a stored image
+pub async fn serve_image(
+    State(app_state): State<Arc<crate::AppState>>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let image = app_state
+        .image_store
+        .images
+        .get(&id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, image.content_type.clone()),
+            (
+                header::CACHE_CONTROL,
+                "public, max-age=86400, immutable".to_string(),
+            ),
+        ],
+        image.data.clone(),
+    ))
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod device_flow;
 pub mod downloads;
 pub mod helpers;
+pub mod images;
 pub mod launchers;
 pub mod messages;
 pub mod proxy_tokens;

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -78,6 +78,7 @@ pub fn replay_pending_inputs_from_db(
 /// Handle Claude output (both legacy ClaudeOutput and new SequencedOutput).
 /// Broadcasts to web clients, deduplicates sequenced messages, stores in DB,
 /// and sends acknowledgments.
+#[allow(clippy::too_many_arguments)]
 pub fn handle_claude_output(
     session_manager: &SessionManager,
     session_key: &Option<String>,

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -86,6 +86,7 @@ pub fn handle_claude_output(
     tx: &ProxySender,
     content: serde_json::Value,
     seq: Option<u64>,
+    image_store: &crate::handlers::images::ImageStore,
 ) {
     // Deduplicate sequenced messages before broadcasting
     if let (Some(session_id), Some(seq_num)) = (db_session_id, seq) {
@@ -155,6 +156,10 @@ pub fn handle_claude_output(
             );
         }
     }
+
+    // Extract base64 images from portal messages and replace with URLs.
+    // This keeps WebSocket messages small — browsers fetch images via HTTP.
+    let content = extract_portal_images(content, image_store);
 
     // Broadcast output to all web clients with sender metadata alongside content
     if let Some(ref key) = session_key {
@@ -312,4 +317,49 @@ fn store_result_metadata(
             error!("Failed to update session tokens: {}", e);
         }
     }
+}
+
+/// If the content is a portal message with base64 image data, extract the image
+/// into the store and replace the data field with a URL path.
+fn extract_portal_images(
+    mut content: serde_json::Value,
+    image_store: &crate::handlers::images::ImageStore,
+) -> serde_json::Value {
+    // Only process portal messages
+    if content.get("type").and_then(|t| t.as_str()) != Some("portal") {
+        return content;
+    }
+
+    let Some(content_array) = content.get_mut("content").and_then(|c| c.as_array_mut()) else {
+        return content;
+    };
+
+    for item in content_array.iter_mut() {
+        if item.get("type").and_then(|t| t.as_str()) != Some("image") {
+            continue;
+        }
+
+        let media_type = item
+            .get("media_type")
+            .and_then(|m| m.as_str())
+            .unwrap_or("image/png")
+            .to_string();
+
+        let Some(data_str) = item.get("data").and_then(|d| d.as_str()) else {
+            continue;
+        };
+
+        // Only extract images larger than 64KB base64 (roughly 48KB decoded)
+        if data_str.len() < 65536 {
+            continue;
+        }
+
+        if let Some(id) = image_store.store_base64(&media_type, data_str) {
+            let url = format!("/api/images/{}", id);
+            item["data"] = serde_json::Value::String(url);
+            item["source_type"] = serde_json::Value::String("url".to_string());
+        }
+    }
+
+    content
 }

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -167,6 +167,7 @@ fn handle_proxy_message(
                 tx,
                 content,
                 None,
+                &app_state.image_store,
             );
         }
         ProxyToServer::SequencedOutput { seq, content } => {
@@ -178,6 +179,7 @@ fn handle_proxy_message(
                 tx,
                 content,
                 Some(seq),
+                &app_state.image_store,
             );
         }
         ProxyToServer::Heartbeat => {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -60,6 +60,8 @@ pub struct AppState {
     pub session_max_age_days: u32,
     /// Maximum image size in MB that proxies should inline (default: 10)
     pub max_image_mb: u32,
+    /// In-memory image store for serving images via HTTP instead of WebSocket
+    pub image_store: handlers::images::ImageStore,
 }
 
 #[tokio::main]
@@ -356,6 +358,7 @@ async fn main() -> anyhow::Result<()> {
         message_retention_days,
         session_max_age_days,
         max_image_mb,
+        image_store: handlers::images::ImageStore::new(),
     });
 
     // Setup CORS
@@ -455,6 +458,8 @@ async fn main() -> anyhow::Result<()> {
             "/api/proxy-tokens/{id}/renew",
             post(handlers::proxy_tokens::renew_token_handler),
         )
+        // Image serving endpoint (no auth — images are accessed by UUID)
+        .route("/api/images/{id}", get(handlers::images::serve_image))
         // Scheduled task management endpoints
         .route(
             "/api/scheduled-tasks",

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -287,9 +287,10 @@ fn render_portal_content(content: &shared::PortalContent) -> Html {
             data,
             file_path,
             file_size,
+            source_type,
         } => {
             let source = ImageSource {
-                source_type: "base64".to_string(),
+                source_type: source_type.clone().unwrap_or_else(|| "base64".to_string()),
                 media_type: media_type.clone(),
                 data: data.clone(),
             };
@@ -852,7 +853,12 @@ fn render_image_source(source: &ImageSource, filename: Option<String>) -> Html {
             </pre>
         };
     }
-    let src = format!("data:{};base64,{}", source.media_type, source.data);
+    // Support both URL sources (from backend image store) and base64 data URIs
+    let src = if source.source_type == "url" {
+        source.data.clone()
+    } else {
+        format!("data:{};base64,{}", source.media_type, source.data)
+    };
     html! {
         <ImageViewer src={src} media_type={source.media_type.clone()} {filename} />
     }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -300,6 +300,7 @@ impl PortalMessage {
                 data,
                 file_path: None,
                 file_size: None,
+                source_type: None,
             }],
         }
     }
@@ -317,6 +318,7 @@ impl PortalMessage {
                 data,
                 file_path,
                 file_size,
+                source_type: None,
             }],
         }
     }
@@ -339,6 +341,9 @@ pub enum PortalContent {
         file_path: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         file_size: Option<u64>,
+        /// "base64" (default) or "url" (served from /api/images/{id})
+        #[serde(default)]
+        source_type: Option<String>,
     },
 }
 
@@ -351,12 +356,14 @@ impl std::fmt::Debug for PortalContent {
                 data,
                 file_path,
                 file_size,
+                source_type,
             } => f
                 .debug_struct("Image")
                 .field("media_type", media_type)
-                .field("data", &format_args!("<{} bytes base64>", data.len()))
+                .field("data", &format_args!("<{} bytes>", data.len()))
                 .field("file_path", file_path)
                 .field("file_size", file_size)
+                .field("source_type", source_type)
                 .finish(),
         }
     }


### PR DESCRIPTION
## Summary
Partially addresses #655. Large images from Claude sessions are now served via HTTP (`GET /api/images/{uuid}`) instead of being embedded as base64 in WebSocket messages.

**How it works:**
1. When the backend receives a portal message containing a base64 image >64KB, it extracts the image data, stores it in an in-memory `ImageStore`, and replaces the `data` field with a URL path (`/api/images/{uuid}`)
2. The frontend detects `source_type: "url"` and renders an `<img>` tag pointing at the URL instead of constructing a data URI
3. The browser fetches the image via normal HTTP with `Cache-Control: public, max-age=86400, immutable`

**Benefits:**
- WebSocket messages stay small regardless of image size (no more frame-too-large disconnects)
- Browser handles image loading natively (streaming, caching, progress)
- No base64 encoding overhead (33% size savings)
- Multiple clients viewing the same session share the cached image

**Changes:**
- `backend/src/handlers/images.rs` — new `ImageStore` + `GET /api/images/{id}` endpoint
- `backend/src/handlers/websocket/message_handlers.rs` — `extract_portal_images()` intercepts portal messages
- `shared/src/lib.rs` — `PortalContent::Image` gains optional `source_type` field
- `frontend/.../renderers.rs` — `render_image_source()` handles URL sources

## Test plan
- [ ] Verify images from Claude sessions display correctly in the UI
- [ ] Verify small images (<64KB) still use inline base64 (no URL redirect)
- [ ] Verify large images are served at `/api/images/{uuid}` with correct content type
- [ ] Verify browser caching works (second load is instant)
- [ ] Verify multiple browser tabs show the same image without re-downloading