### PR TITLE
Render LaTeX math via KaTeX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.27
+
+- Render LaTeX math in messages via KaTeX (`$inline$`, `$$display$$`, `\(...\)`, `\[...\]`)
+
 ## 2.4.26
 
 - Serve large images via HTTP instead of WebSocket (partially addresses #655)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.25"
+version = "2.4.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.25"
+version = "2.4.26"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.25"
+version = "2.4.26"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.25"
+version = "2.4.26"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.25"
+version = "2.4.26"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.25"
+version = "2.4.26"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.25"
+version = "2.4.26"
 dependencies = [
  "anyhow",
  "hex",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.25"
+version = "2.4.26"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.26"
+version = "2.4.27"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,6 +24,14 @@
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
 
+    <!-- KaTeX for rendering LaTeX math in messages -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"
+          integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous" />
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"
+            integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
+            integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rF4+Pp4XXUokR6dwXyo" crossorigin="anonymous"></script>
+
     <!-- Loading spinner (inline so it renders before any external assets) -->
     <style>
         #loading {
@@ -75,6 +83,8 @@
     <link data-trunk rel="css" href="styles/admin.css" />
     <link data-trunk rel="css" href="styles/banned.css" />
     <link data-trunk rel="copy-file" href="pcm-processor.js" />
+    <link data-trunk rel="copy-file" href="katex-helper.js" />
+    <script defer src="/katex-helper.js"></script>
     <link data-trunk rel="copy-file" href="assets/wiggum.png" />
     <link data-trunk rel="copy-file" href="assets/og-preview.svg" />
     <link data-trunk rel="copy-file" href="assets/favicon.svg" />

--- a/frontend/katex-helper.js
+++ b/frontend/katex-helper.js
@@ -1,0 +1,26 @@
+// Helper exposed on window for Yew to call after rendering markdown.
+// Uses KaTeX's auto-render extension to find $...$ and $$...$$ in a DOM
+// element and replace them with rendered math.
+window.renderMathInNode = function(element) {
+    if (!element || typeof window.renderMathInElement !== 'function') {
+        return;
+    }
+    try {
+        window.renderMathInElement(element, {
+            delimiters: [
+                { left: '$$', right: '$$', display: true },
+                { left: '$', right: '$', display: false },
+                { left: '\\(', right: '\\)', display: false },
+                { left: '\\[', right: '\\]', display: true },
+            ],
+            // Don't try to render inside these elements (code blocks, inline code, etc.)
+            ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+            ignoredClasses: ['md-code-block', 'md-inline-code', 'tool-result-content', 'bash-command-inline'],
+            // Don't crash on bad math — just leave the source visible
+            throwOnError: false,
+            errorColor: '#cc6666',
+        });
+    } catch (e) {
+        // Auto-render not loaded yet or other failure — silently skip
+    }
+};

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -11,16 +11,50 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::window;
 use yew::prelude::*;
 
-/// Render markdown text as HTML
+/// Render markdown text as HTML, with a post-render hook that triggers KaTeX
+/// to render any LaTeX math expressions (`$...$`, `$$...$$`).
 pub fn render_markdown(text: &str) -> Html {
+    html! {
+        <MarkdownView text={text.to_string()} />
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct MarkdownViewProps {
+    text: String,
+}
+
+#[function_component(MarkdownView)]
+fn markdown_view(props: &MarkdownViewProps) -> Html {
+    let node_ref = use_node_ref();
+
+    // After render, call the JS helper to render math in this subtree
+    {
+        let node_ref = node_ref.clone();
+        use_effect_with(props.text.clone(), move |_| {
+            if let Some(node) = node_ref.cast::<web_sys::Element>() {
+                if let Some(window) = web_sys::window() {
+                    if let Ok(func) = js_sys::Reflect::get(&window, &"renderMathInNode".into()) {
+                        if let Ok(func) = func.dyn_into::<js_sys::Function>() {
+                            let _ = func.call1(&window, &node);
+                        }
+                    }
+                }
+            }
+            || ()
+        });
+    }
+
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
     options.insert(Options::ENABLE_STRIKETHROUGH);
 
-    let parser = Parser::new_ext(text, options);
+    let parser = Parser::new_ext(&props.text, options);
     let events: Vec<Event> = parser.collect();
 
-    render_events(&events)
+    html! {
+        <span ref={node_ref}>{ render_events(&events) }</span>
+    }
 }
 
 /// Convert pulldown-cmark events to Yew Html


### PR DESCRIPTION
## Summary
Adds KaTeX rendering for LaTeX math expressions in markdown messages. Supports `$inline$`, `$$display$$`, `\(...\)`, `\[...\]` delimiters.

**How it works:**
- KaTeX CSS + JS + auto-render extension loaded from CDN in `index.html`
- Small JS helper `katex-helper.js` exposes `window.renderMathInNode(element)` with sensible delimiter config and exclusions for code blocks
- `render_markdown` now wraps output in a `MarkdownView` Yew component that uses `use_effect` to call the helper after each render
- Math inside `<code>`, `<pre>`, and tool result content is skipped to avoid false positives

**Why KaTeX instead of MathJax:**
- ~250KB total vs ~2MB
- Synchronous rendering (no FOUC)
- Faster

## Test plan
- [ ] Verify `$E = mc^2$` renders inline
- [ ] Verify `$$\int_0^\infty e^{-x} dx$$` renders as a display block
- [ ] Verify dollar signs in prose ("cost is $5") don't trigger false rendering
- [ ] Verify math inside code blocks is left as plain text
- [ ] Verify malformed math doesn't crash (KaTeX throwOnError: false)