### PR TITLE
Arrow keys move cursor in multiline input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.28
+
+- Up/down arrows in input now move cursor between lines; history navigation only triggers at the first/last line
+
 ## 2.4.27
 
 - Render LaTeX math in messages via KaTeX (`$inline$`, `$$display$$`, `\(...\)`, `\[...\]`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.26"
+version = "2.4.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.26"
+version = "2.4.27"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.26"
+version = "2.4.27"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.26"
+version = "2.4.27"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.26"
+version = "2.4.27"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.26"
+version = "2.4.27"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.26"
+version = "2.4.27"
 dependencies = [
  "anyhow",
  "hex",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.26"
+version = "2.4.27"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.27"
+version = "2.4.28"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -954,12 +954,31 @@ impl Component for SessionView {
                     SessionViewMsg::Noop
                 }
                 "ArrowUp" => {
-                    e.prevent_default();
-                    SessionViewMsg::HistoryUp
+                    // Only trigger history if cursor is on the first line of the textarea.
+                    // Otherwise, let the arrow key move the cursor normally.
+                    let target: HtmlTextAreaElement = e.target_unchecked_into();
+                    let value = target.value();
+                    let cursor = target.selection_start().ok().flatten().unwrap_or(0) as usize;
+                    let on_first_line = !value[..cursor.min(value.len())].contains('\n');
+                    if on_first_line {
+                        e.prevent_default();
+                        SessionViewMsg::HistoryUp
+                    } else {
+                        SessionViewMsg::Noop
+                    }
                 }
                 "ArrowDown" => {
-                    e.prevent_default();
-                    SessionViewMsg::HistoryDown
+                    // Only trigger history if cursor is on the last line of the textarea.
+                    let target: HtmlTextAreaElement = e.target_unchecked_into();
+                    let value = target.value();
+                    let cursor = target.selection_start().ok().flatten().unwrap_or(0) as usize;
+                    let on_last_line = !value[cursor.min(value.len())..].contains('\n');
+                    if on_last_line {
+                        e.prevent_default();
+                        SessionViewMsg::HistoryDown
+                    } else {
+                        SessionViewMsg::Noop
+                    }
                 }
                 _ => SessionViewMsg::Noop,
             }


### PR DESCRIPTION
## Summary
Up/Down arrows in the message input now move the cursor between lines as expected. Command history navigation only triggers when the cursor is already on the first line (Up) or last line (Down) of the textarea.

**Detection logic:**
- Up: cursor is on the first line if the text before the cursor contains no `\n`
- Down: cursor is on the last line if the text after the cursor contains no `\n`

Single-line input behavior is unchanged (cursor is always on the first and last line, so arrows immediately trigger history).

## Test plan
- [ ] Verify single-line input: Up/Down navigate command history
- [ ] Verify multiline input: Up/Down move cursor between lines
- [ ] Verify multiline input: Up at the top line triggers history up
- [ ] Verify multiline input: Down at the bottom line triggers history down