### PR TITLE
Clear pending sends on assistant/result response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.29
+
+- Clear pending send queue when assistant/result arrives (fixes stuck pending state for slash commands)
+- Match pending sends by content on user echo so lost messages don't consume unrelated entries
+
 ## 2.4.28
 
 - Up/down arrows in input now move cursor between lines; history navigation only triggers at the first/last line

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.27"
+version = "2.4.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.27"
+version = "2.4.28"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.27"
+version = "2.4.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.27"
+version = "2.4.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.27"
+version = "2.4.28"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.27"
+version = "2.4.28"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.27"
+version = "2.4.28"
 dependencies = [
  "anyhow",
  "hex",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.27"
+version = "2.4.28"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.28"
+version = "2.4.29"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -1403,11 +1403,39 @@ impl SessionView {
         } else {
             output
         };
-        // When a confirmed user message arrives from the server, remove the
-        // oldest pending send so it doesn't duplicate. The confirmed version
-        // appends to self.messages at the natural scroll position.
-        if msg_type == "user" && !self.pending_sends.is_empty() {
-            self.pending_sends.remove(0);
+        // Drain pending sends when the server confirms our input.
+        // - "user" echo: match by content so a lost message doesn't consume
+        //   an unrelated pending entry.
+        // - "assistant"/"result": Claude is responding. Slash commands like
+        //   /cost, /status, /clear don't produce a user echo, so we use the
+        //   assistant/result response as the signal that the input was
+        //   received and clear all pending entries.
+        if !self.pending_sends.is_empty() {
+            match msg_type.as_str() {
+                "user" => {
+                    let echo_content = serde_json::from_str::<serde_json::Value>(&output)
+                        .ok()
+                        .and_then(|v| v.get("content").cloned());
+                    if let Some(ref echo) = echo_content {
+                        if let Some(pos) = self.pending_sends.iter().position(|pending| {
+                            serde_json::from_str::<serde_json::Value>(pending)
+                                .ok()
+                                .and_then(|v| v.get("content").cloned())
+                                .as_ref()
+                                == Some(echo)
+                        }) {
+                            self.pending_sends.remove(pos);
+                        }
+                    }
+                }
+                "assistant" | "result" => {
+                    // Claude is responding — any pending input was received.
+                    // Slash commands don't produce a user echo so this is
+                    // the only signal we get.
+                    self.pending_sends.clear();
+                }
+                _ => {}
+            }
         }
         self.messages.push(output);
         if self.messages.len() > MAX_MESSAGES_PER_SESSION {


### PR DESCRIPTION
## Summary
Slash commands (`/cost`, `/status`, `/clear`, etc.) don't produce a `user` echo from the proxy — they go straight to a `result` or `assistant` response. Without a user echo, the optimistic pending message stayed stuck with the dashed border + pulsing dot indefinitely.

**Fix:** When draining pending sends:
- On `user` echo: match by content (so a lost message doesn't consume an unrelated pending entry, fixing the issue from #645)
- On `assistant` / `result`: Claude is responding to our input, so clear all pending sends. This is the only signal we get for slash commands.

Supersedes the unmerged #645 (which only addressed content-matching, not slash commands).

## Test plan
- [ ] Verify regular messages: pending dot disappears when user echo arrives
- [ ] Verify slash commands: pending dot disappears when result/assistant arrives
- [ ] Verify multiple rapid sends drain correctly
- [ ] Verify lost messages don't drain unrelated pending entries (content matching still works)