### PR TITLE
Disable STT single-utterance mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.30
+
+- Disable Google STT single-utterance mode to prevent immediate session end on quiet/silent mic inputs (common on macOS)
+
 ## 2.4.29
 
 - Clear pending send queue when assistant/result arrives (fixes stuck pending state for slash commands)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.28"
+version = "2.4.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.28"
+version = "2.4.29"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.28"
+version = "2.4.29"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.28"
+version = "2.4.29"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.28"
+version = "2.4.29"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2904,7 +2904,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.28"
+version = "2.4.29"
 dependencies = [
  "anyhow",
  "colored",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.28"
+version = "2.4.29"
 dependencies = [
  "anyhow",
  "hex",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.28"
+version = "2.4.29"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.29"
+version = "2.4.30"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/speech.rs
+++ b/backend/src/speech.rs
@@ -50,7 +50,11 @@ impl Default for SpeechConfig {
             language_code: "en-US".to_string(),
             encoding: AudioEncoding::Linear16,
             interim_results: true,
-            single_utterance: true, // Auto-end when speaker stops, sends final result immediately
+            // Disabled: Google's single-utterance detector frequently fires
+            // immediately when input audio is quiet (common on macOS when the
+            // browser captures a wrong/silent input device). The client-side
+            // PCM worklet already auto-stops after 2s of silence post-speech.
+            single_utterance: false,
         }
     }
 }


### PR DESCRIPTION
## Summary
On macOS, voice input was immediately ending with "end of speech detected" because Google Cloud STT's `single_utterance: true` mode fires the moment it can't detect speech — common when the browser captures from a wrong/silent mic input device.

The client-side AudioWorklet already auto-stops after 2s of silence following actual speech detection, which is the more lenient and correct behavior.

**Change:** Set `single_utterance: false` in the speech config default. Recognition continues until either the user clicks stop or the worklet detects 2s of silence post-speech.

## Test plan
- [ ] Verify voice input no longer immediately ends on MBP
- [ ] Verify voice input still auto-stops after silence (client-side detection)
- [ ] Verify voice transcription still works end-to-end