### PR TITLE
Add clipboard copy button to message headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.33
+
+- Add clipboard copy button to message headers (assistant, user, portal) to copy raw markdown text
+
 ## 2.4.32
 
 - Fix splash page not scrollable on mobile (overflow:hidden was on body instead of session container)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.32"
+version = "2.4.33"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/copy_button.rs
+++ b/frontend/src/components/copy_button.rs
@@ -1,0 +1,68 @@
+//! Small reusable clipboard copy button.
+
+use gloo::timers::callback::Timeout;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::{window, MouseEvent};
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct CopyButtonProps {
+    pub text: AttrValue,
+    #[prop_or_default]
+    pub class: Classes,
+    /// Tooltip shown when not yet clicked
+    #[prop_or(AttrValue::from("Copy"))]
+    pub title: AttrValue,
+}
+
+#[function_component(CopyButton)]
+pub fn copy_button(props: &CopyButtonProps) -> Html {
+    let copied = use_state(|| false);
+
+    let on_click = {
+        let text = props.text.clone();
+        let copied = copied.clone();
+        Callback::from(move |e: MouseEvent| {
+            e.stop_propagation();
+            e.prevent_default();
+            let text = text.to_string();
+            let copied = copied.clone();
+            spawn_local(async move {
+                if let Some(window) = window() {
+                    let navigator = window.navigator();
+                    let clipboard = js_sys::Reflect::get(&navigator, &"clipboard".into())
+                        .ok()
+                        .and_then(|v| v.dyn_into::<web_sys::Clipboard>().ok());
+                    if let Some(clipboard) = clipboard {
+                        let promise = clipboard.write_text(&text);
+                        let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+                        copied.set(true);
+                        let reset = copied.clone();
+                        Timeout::new(1500, move || reset.set(false)).forget();
+                    }
+                }
+            });
+        })
+    };
+
+    let title = if *copied { "Copied!" } else { &*props.title };
+    let class = classes!(
+        "copy-button",
+        if *copied { "copied" } else { "" },
+        props.class.clone()
+    );
+
+    html! {
+        <button type="button" {class} onclick={on_click} title={title.to_string()} aria-label={title.to_string()}>
+            if *copied {
+                { "\u{2713}" }
+            } else {
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <rect x="4" y="4" width="9" height="10" rx="1.2" />
+                    <path d="M4 4V3a1 1 0 0 1 1-1h7a1 1 0 0 1 1 1v8" />
+                </svg>
+            }
+        </button>
+    }
+}

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -2,6 +2,7 @@
 
 use super::types::*;
 use super::{format_duration, shorten_model_name};
+use crate::components::copy_button::CopyButton;
 use crate::components::expandable::ExpandableText;
 use crate::components::markdown::render_markdown;
 use crate::components::tool_renderers::render_tool_use;
@@ -63,6 +64,52 @@ fn build_usage_tooltip(usage: Option<&UsageInfo>) -> String {
         .unwrap_or_default()
 }
 
+/// Extract concatenated raw text from a list of content blocks.
+/// Used for the message header copy button — pulls out text and thinking
+/// blocks as markdown, ignoring tool_use/tool_result internals.
+fn content_blocks_to_text(blocks: &[ContentBlock]) -> String {
+    let mut out = String::new();
+    for block in blocks {
+        match block {
+            ContentBlock::Text { text, .. } => {
+                if !out.is_empty() {
+                    out.push_str("\n\n");
+                }
+                out.push_str(text);
+            }
+            ContentBlock::Thinking { thinking } => {
+                if !out.is_empty() {
+                    out.push_str("\n\n");
+                }
+                out.push_str("<thinking>\n");
+                out.push_str(thinking);
+                out.push_str("\n</thinking>");
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Extract raw text from an assistant group's serialized JSON messages.
+fn extract_assistant_group_text(messages: &[String]) -> String {
+    let mut out = String::new();
+    for json in messages {
+        if let Ok(ClaudeMessage::Assistant(msg)) = serde_json::from_str::<ClaudeMessage>(json) {
+            if let Some(content) = msg.message.and_then(|m| m.content) {
+                let text = content_blocks_to_text(&content);
+                if !text.is_empty() {
+                    if !out.is_empty() {
+                        out.push_str("\n\n");
+                    }
+                    out.push_str(&text);
+                }
+            }
+        }
+    }
+    out
+}
+
 // --- Message renderers ---
 
 pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> Html {
@@ -111,11 +158,15 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
         ));
     }
     let model_tooltip = build_model_tooltip(&model_name, first_usage.as_ref());
+    let copy_text = extract_assistant_group_text(messages);
 
     html! {
         <div class="claude-message assistant-message">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge assistant">{ "Assistant" }</span>
+                if !copy_text.is_empty() {
+                    <CopyButton text={copy_text} title="Copy assistant text" />
+                }
                 {
                     if count > 1 {
                         html! { <span class="message-count" title={format!("{} consecutive messages", count)}>{ format!("{} messages", count) }</span> }
@@ -190,6 +241,7 @@ pub fn render_user_message(
                     if msg.pending {
                         <span class="pending-indicator" title="Sending...">{ "\u{2022}" }</span>
                     }
+                    <CopyButton text={text.clone()} title="Copy message" />
                 </div>
                 <div class="message-body">
                     <div class="user-text">{ render_markdown(&preserve_user_newlines(text)) }</div>
@@ -225,6 +277,7 @@ pub fn render_user_message(
                 <div class="claude-message user-message">
                     <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                         <span class="message-type-badge user">{ &label }</span>
+                        <CopyButton text={text_content.clone()} title="Copy message" />
                     </div>
                     <div class="message-body">
                         <div class="user-text">{ render_markdown(&preserve_user_newlines(&text_content)) }</div>
@@ -267,10 +320,22 @@ pub fn render_error_message(msg: &ErrorMessage, timestamp: Option<&str>) -> Html
 }
 
 pub fn render_portal_message(msg: &PortalMessage, timestamp: Option<&str>) -> Html {
+    let copy_text: String = msg
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            shared::PortalContent::Text { text } => Some(text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
     html! {
         <div class="claude-message portal-message">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge portal">{ "Portal" }</span>
+                if !copy_text.is_empty() {
+                    <CopyButton text={copy_text} title="Copy portal text" />
+                }
             </div>
             <div class="message-body">
                 { for msg.content.iter().map(render_portal_content) }
@@ -723,11 +788,15 @@ pub fn render_assistant_message(msg: &AssistantMessage, timestamp: Option<&str>)
 
     let model_tooltip = build_model_tooltip(model, usage);
     let usage_tooltip = build_usage_tooltip(usage);
+    let copy_text = content_blocks_to_text(&blocks);
 
     html! {
         <div class="claude-message assistant-message">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge assistant">{ "Assistant" }</span>
+                if !copy_text.is_empty() {
+                    <CopyButton text={copy_text} title="Copy assistant text" />
+                }
                 {
                     if let Some(short_name) = shorten_model_name(model) {
                         html! { <span class="model-name" title={model_tooltip}>{ short_name }</span> }

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod codex_renderer;
+pub mod copy_button;
 mod copy_command;
 mod cron_describe;
 mod diff;

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -20,6 +20,39 @@
     flex-wrap: wrap;
 }
 
+/* Copy button in message headers */
+.copy-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-muted);
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s, border-color 0.15s;
+    line-height: 0;
+}
+
+.copy-button:hover {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.06);
+    border-color: var(--border);
+}
+
+.copy-button.copied {
+    color: var(--success);
+    font-size: 0.85rem;
+    line-height: 1;
+}
+
+/* Push copy button to far right of header. If usage-badge or other
+   margin-left:auto siblings exist, this still aligns it on the right edge. */
+.message-header .copy-button:last-child {
+    margin-left: auto;
+}
+
 .claude-message .message-body {
     padding: 0.5rem 1rem;
 }


### PR DESCRIPTION
## Summary
Adds a clipboard copy button to message headers (Assistant, User, Portal) so users can grab the raw markdown text for pasting into other documents.

**What gets copied:**
- **Assistant group**: concatenated text of all assistant messages in the group (text + thinking blocks). Tool calls/results are skipped.
- **Single assistant**: same as above but for one message.
- **User**: the user's message text.
- **Portal**: portal text content (not images).

**UX:**
- Small clipboard SVG icon (14px) in each header
- Hover shows the full button outline
- After click, swaps to a green ✓ for 1.5 seconds
- Pushed to the right via `margin-left: auto` on `:last-child`
- New reusable `<CopyButton>` component in `frontend/src/components/copy_button.rs`

## Test plan
- [ ] Click copy on an assistant group → markdown is in clipboard
- [ ] Click copy on a user message → text is in clipboard
- [ ] Click copy on a portal message → portal text is in clipboard
- [ ] Verify the icon flips to ✓ then back
- [ ] Verify the button doesn't show on messages with no text content