### PR TITLE
Move copy button next to model name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.34
+
+- Place copy button next to model name in assistant headers (was at far right)
+
 ## 2.4.33
 
 - Add clipboard copy button to message headers (assistant, user, portal) to copy raw markdown text

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.32"
+version = "2.4.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.32"
+version = "2.4.33"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.32"
+version = "2.4.33"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.32"
+version = "2.4.33"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.32"
+version = "2.4.33"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.32"
+version = "2.4.33"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.32"
+version = "2.4.33"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.32"
+version = "2.4.33"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.33"
+version = "2.4.34"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -164,9 +164,6 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
         <div class="claude-message assistant-message">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge assistant">{ "Assistant" }</span>
-                if !copy_text.is_empty() {
-                    <CopyButton text={copy_text} title="Copy assistant text" />
-                }
                 {
                     if count > 1 {
                         html! { <span class="message-count" title={format!("{} consecutive messages", count)}>{ format!("{} messages", count) }</span> }
@@ -180,6 +177,9 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
                     } else {
                         html! {}
                     }
+                }
+                if !copy_text.is_empty() {
+                    <CopyButton text={copy_text} title="Copy assistant text" />
                 }
                 {
                     if total_input_tokens > 0 || total_output_tokens > 0 {
@@ -794,15 +794,15 @@ pub fn render_assistant_message(msg: &AssistantMessage, timestamp: Option<&str>)
         <div class="claude-message assistant-message">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge assistant">{ "Assistant" }</span>
-                if !copy_text.is_empty() {
-                    <CopyButton text={copy_text} title="Copy assistant text" />
-                }
                 {
                     if let Some(short_name) = shorten_model_name(model) {
                         html! { <span class="model-name" title={model_tooltip}>{ short_name }</span> }
                     } else {
                         html! {}
                     }
+                }
+                if !copy_text.is_empty() {
+                    <CopyButton text={copy_text} title="Copy assistant text" />
                 }
                 {
                     if is_truncated {

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -47,9 +47,11 @@
     line-height: 1;
 }
 
-/* Push copy button to far right of header. If usage-badge or other
-   margin-left:auto siblings exist, this still aligns it on the right edge. */
-.message-header .copy-button:last-child {
+/* On headers without a usage-badge (user/portal), push the copy button to
+   the right edge. On assistant headers, the copy button sits inline next to
+   the model name, with usage-badge taking margin-left:auto. */
+.user-message .message-header .copy-button,
+.portal-message .message-header .copy-button {
     margin-left: auto;
 }
 


### PR DESCRIPTION
## Summary
Reorders the assistant message header so the copy button sits inline next to the model name, instead of pushed to the far right.

**Before:** `[Assistant] [count] [model]              [Copy] [usage]`
**After:**  `[Assistant] [count] [model] [Copy]              [usage]`

User and portal headers (no usage badge) keep the copy button at the right edge for visual balance.