### PR TITLE
Add live 'time ago' label to assistant message headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.35
+
+- Show live-updating "X minutes ago" label on assistant message headers, with exact local time tooltip
+
 ## 2.4.34
 
 - Place copy button next to model name in assistant headers (was at far right)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.33"
+version = "2.4.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.33"
+version = "2.4.34"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.33"
+version = "2.4.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.33"
+version = "2.4.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.33"
+version = "2.4.34"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.33"
+version = "2.4.34"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.33"
+version = "2.4.34"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.33"
+version = "2.4.34"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.34"
+version = "2.4.35"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -20,6 +20,13 @@ fn extract_local_timestamp(json: &str) -> Option<String> {
         .as_string()
 }
 
+/// Extract the raw `_created_at` ISO string from a message JSON, for use with
+/// the live-updating TimeAgo component (which parses it itself).
+pub(super) fn extract_raw_iso(json: &str) -> Option<String> {
+    let val: Value = serde_json::from_str(json).ok()?;
+    val.get("_created_at")?.as_str().map(|s| s.to_string())
+}
+
 /// A group of messages to render together
 #[derive(Debug, Clone, PartialEq)]
 pub enum MessageGroup {
@@ -112,12 +119,13 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
     }
 
     let ts = extract_local_timestamp(&props.json);
+    let raw_iso = extract_raw_iso(&props.json);
     let parsed: Result<ClaudeMessage, _> = serde_json::from_str(&props.json);
 
     match parsed {
         Ok(ClaudeMessage::System(msg)) => renderers::render_system_message(&msg, ts.as_deref()),
         Ok(ClaudeMessage::Assistant(msg)) => {
-            renderers::render_assistant_message(&msg, ts.as_deref())
+            renderers::render_assistant_message(&msg, ts.as_deref(), raw_iso.as_deref())
         }
         Ok(ClaudeMessage::Result(msg)) => renderers::render_result_message(&msg),
         Ok(ClaudeMessage::User(msg)) => {

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -1,10 +1,11 @@
 //! Rendering functions for each message type.
 
 use super::types::*;
-use super::{format_duration, shorten_model_name};
+use super::{extract_raw_iso, format_duration, shorten_model_name};
 use crate::components::copy_button::CopyButton;
 use crate::components::expandable::ExpandableText;
 use crate::components::markdown::render_markdown;
+use crate::components::time_ago::TimeAgo;
 use crate::components::tool_renderers::render_tool_use;
 use serde::Deserialize;
 use serde_json::Value;
@@ -159,6 +160,8 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
     }
     let model_tooltip = build_model_tooltip(&model_name, first_usage.as_ref());
     let copy_text = extract_assistant_group_text(messages);
+    // ISO timestamp of the last message in the group, for the live "time ago" label
+    let last_iso = messages.last().and_then(|json| extract_raw_iso(json));
 
     html! {
         <div class="claude-message assistant-message">
@@ -191,6 +194,9 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
                     } else {
                         html! {}
                     }
+                }
+                if let Some(iso) = last_iso {
+                    <TimeAgo iso={iso} />
                 }
             </div>
             <div class="message-body">
@@ -768,7 +774,11 @@ fn render_task_notification(msg: &SystemMessage, timestamp: Option<&str>) -> Htm
     }
 }
 
-pub fn render_assistant_message(msg: &AssistantMessage, timestamp: Option<&str>) -> Html {
+pub fn render_assistant_message(
+    msg: &AssistantMessage,
+    timestamp: Option<&str>,
+    raw_iso: Option<&str>,
+) -> Html {
     let blocks = msg
         .message
         .as_ref()
@@ -821,6 +831,9 @@ pub fn render_assistant_message(msg: &AssistantMessage, timestamp: Option<&str>)
                     } else {
                         html! {}
                     }
+                }
+                if let Some(iso) = raw_iso {
+                    <TimeAgo iso={iso.to_string()} />
                 }
             </div>
             <div class="message-body">

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -10,6 +10,7 @@ pub mod message_renderer;
 mod proxy_token_setup;
 mod schedule_dialog;
 mod share_dialog;
+pub mod time_ago;
 mod tool_renderers;
 mod voice_input;
 

--- a/frontend/src/components/time_ago.rs
+++ b/frontend/src/components/time_ago.rs
@@ -1,0 +1,94 @@
+//! Live-updating "time ago" label.
+//!
+//! Renders a span like "a few seconds ago" / "5 minutes ago" / "2 hours ago"
+//! that re-renders every 30 seconds so the label stays accurate without
+//! repainting on every parent render. Tooltip shows the exact local time.
+
+use gloo::timers::callback::Interval;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct TimeAgoProps {
+    /// ISO 8601 timestamp string (e.g., "2026-05-06T10:32:15Z")
+    pub iso: AttrValue,
+    #[prop_or_default]
+    pub class: Classes,
+}
+
+#[function_component(TimeAgo)]
+pub fn time_ago(props: &TimeAgoProps) -> Html {
+    // tick state forces re-render when the interval fires
+    let tick = use_state(|| 0u32);
+
+    {
+        let tick = tick.clone();
+        use_effect_with((), move |_| {
+            let interval = Interval::new(30_000, move || {
+                tick.set(*tick + 1);
+            });
+            // Keep alive for the lifetime of the component
+            move || drop(interval)
+        });
+    }
+
+    let _ = *tick; // ensure dependency
+
+    let iso = &*props.iso;
+    let parsed_ms = js_sys::Date::parse(iso);
+    if parsed_ms.is_nan() {
+        return html! {};
+    }
+
+    let now_ms = js_sys::Date::now();
+    let diff_secs = ((now_ms - parsed_ms) / 1000.0).max(0.0) as i64;
+    let label = format_time_ago(diff_secs);
+
+    // Tooltip: full local time
+    let date = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(parsed_ms));
+    let local_time = date
+        .to_locale_string("default", &js_sys::Object::new())
+        .as_string()
+        .unwrap_or_default();
+
+    html! {
+        <span class={classes!("time-ago", props.class.clone())} title={local_time}>
+            { label }
+        </span>
+    }
+}
+
+fn format_time_ago(secs: i64) -> String {
+    if secs < 10 {
+        "just now".to_string()
+    } else if secs < 60 {
+        "a few seconds ago".to_string()
+    } else if secs < 3600 {
+        let m = secs / 60;
+        if m == 1 {
+            "1 minute ago".to_string()
+        } else {
+            format!("{} minutes ago", m)
+        }
+    } else if secs < 86_400 {
+        let h = secs / 3600;
+        if h == 1 {
+            "1 hour ago".to_string()
+        } else {
+            format!("{} hours ago", h)
+        }
+    } else if secs < 604_800 {
+        let d = secs / 86_400;
+        if d == 1 {
+            "1 day ago".to_string()
+        } else {
+            format!("{} days ago", d)
+        }
+    } else {
+        let w = secs / 604_800;
+        if w == 1 {
+            "1 week ago".to_string()
+        } else {
+            format!("{} weeks ago", w)
+        }
+    }
+}

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -55,6 +55,14 @@
     margin-left: auto;
 }
 
+/* Live-updating "X minutes ago" label in message headers */
+.time-ago {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    cursor: help;
+    white-space: nowrap;
+}
+
 .claude-message .message-body {
     padding: 0.5rem 1rem;
 }


### PR DESCRIPTION
## Summary
Adds a live-updating "time ago" label to assistant message headers, placed to the right of the token up/down counter.

**Format:**
- < 10s → "just now"
- < 60s → "a few seconds ago"
- < 1h → "X minutes ago"
- < 24h → "X hours ago"
- < 7d → "X days ago"
- ≥ 7d → "X weeks ago"

**Tooltip** on hover shows the exact local time (using `toLocaleString`).

**Update cadence:** every 30 seconds (guarantees minute-level accuracy without thrashing).

**Implementation:**
- New reusable `<TimeAgo iso={...} />` Yew component (`frontend/src/components/time_ago.rs`)
- Uses `gloo::timers::callback::Interval` + `use_state` to drive periodic re-renders
- For grouped messages, uses the **last** message's timestamp (most recent activity)
- For single assistant messages, uses that message's timestamp

## Test plan
- [ ] Verify "X minutes ago" shows on assistant headers next to token counts
- [ ] Hover the label → tooltip shows full local time
- [ ] Wait a minute → label updates without parent re-render
- [ ] Verify grouped messages show last-message timestamp (not first)