### PR TITLE
Left-justify copy button in user/portal headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.36
+
+- Left-justify copy button in user/portal message headers (was pushed to far right)
+
 ## 2.4.35
 
 - Show live-updating "X minutes ago" label on assistant message headers, with exact local time tooltip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.34"
+version = "2.4.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.34"
+version = "2.4.35"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.34"
+version = "2.4.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.34"
+version = "2.4.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.34"
+version = "2.4.35"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.34"
+version = "2.4.35"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.34"
+version = "2.4.35"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.34"
+version = "2.4.35"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.35"
+version = "2.4.36"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -47,13 +47,9 @@
     line-height: 1;
 }
 
-/* On headers without a usage-badge (user/portal), push the copy button to
-   the right edge. On assistant headers, the copy button sits inline next to
-   the model name, with usage-badge taking margin-left:auto. */
-.user-message .message-header .copy-button,
-.portal-message .message-header .copy-button {
-    margin-left: auto;
-}
+/* Copy button sits inline next to the message badge in all headers,
+   left-justified. On assistant headers the usage-badge has its own
+   margin-left:auto and naturally pushes itself to the right. */
 
 /* Live-updating "X minutes ago" label in message headers */
 .time-ago {


### PR DESCRIPTION
Copy button now sits next to the badge in all headers, matching the assistant header layout.