### PR TITLE
Move time-ago to bottom-right footer of assistant messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.37
+
+- Move "time ago" label from message header to small unobtrusive footer at bottom-right of assistant messages
+
 ## 2.4.36
 
 - Left-justify copy button in user/portal message headers (was pushed to far right)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.35"
+version = "2.4.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.35"
+version = "2.4.37"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.35"
+version = "2.4.37"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.35"
+version = "2.4.37"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.35"
+version = "2.4.37"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.35"
+version = "2.4.37"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.35"
+version = "2.4.37"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.35"
+version = "2.4.37"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.36"
+version = "2.4.37"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -195,15 +195,17 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
                         html! {}
                     }
                 }
-                if let Some(iso) = last_iso {
-                    <TimeAgo iso={iso} />
-                }
             </div>
             <div class="message-body">
                 { for messages.iter().enumerate().map(|(i, json)| {
                     html! { <GroupedMessageContent key={format!("m{}", i)} json={json.clone()} /> }
                 })}
             </div>
+            if let Some(iso) = last_iso {
+                <div class="message-footer">
+                    <TimeAgo iso={iso} />
+                </div>
+            }
         </div>
     }
 }
@@ -832,13 +834,15 @@ pub fn render_assistant_message(
                         html! {}
                     }
                 }
-                if let Some(iso) = raw_iso {
-                    <TimeAgo iso={iso.to_string()} />
-                }
             </div>
             <div class="message-body">
                 { render_content_blocks(&blocks) }
             </div>
+            if let Some(iso) = raw_iso {
+                <div class="message-footer">
+                    <TimeAgo iso={iso.to_string()} />
+                </div>
+            }
         </div>
     }
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -51,16 +51,25 @@
    left-justified. On assistant headers the usage-badge has its own
    margin-left:auto and naturally pushes itself to the right. */
 
-/* Live-updating "X minutes ago" label in message headers */
+/* Live-updating "X minutes ago" label */
 .time-ago {
     color: var(--text-muted);
-    font-size: 0.75rem;
+    font-size: 0.65rem;
     cursor: help;
     white-space: nowrap;
+    opacity: 0.6;
 }
 
 .claude-message .message-body {
     padding: 0.5rem 1rem;
+}
+
+/* Footer row for unobtrusive metadata (e.g. time-ago) */
+.claude-message .message-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0.15rem 1rem 0.35rem;
+    line-height: 1;
 }
 
 /* Message Type Badges */


### PR DESCRIPTION
## Summary
- Moved the live-updating "X minutes ago" label from the assistant message header into a small, right-aligned footer below the message body
- Made the label smaller and more muted (font-size 0.65rem, opacity 0.6) so it stays out of the way

## Test plan
- [ ] Assistant messages render with time-ago label at bottom-right
- [ ] Tooltip on hover still shows full local time
- [ ] Label updates every ~30s without re-rendering message body