### PR TITLE
Stream large images via chunked binary upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.5.0
+
+- Chunked image uploads over a new `/ws/session/upload` stream (#666)
+- Large images (>= 1 MB on disk) now stream from proxy to backend as raw binary chunks, bypassing the WS frame size cap that previously stuck sessions in reconnect loops
+- Avoids base64 encoding on the wire for large images — chunks are sent as native binary WebSocket frames
+- Backend reassembles chunks in an in-memory upload buffer, enforces `PORTAL_MAX_IMAGE_MB`, then publishes the image at `/api/images/{uuid}` like before
+- Proxy now rejects images over the cap locally (textual portal message) instead of queueing oversized payloads that fail forever on replay
+
 ## 2.4.37
 
 - Move "time ago" label from message header to small unobtrusive footer at bottom-right of assistant messages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.4.37"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.4.37"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.4.37"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.4.37"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.4.37"
+version = "2.5.0"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.4.37"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.4.37"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.4.37"
+version = "2.5.0"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.4.37"
+version = "2.5.0"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/images.rs
+++ b/backend/src/handlers/images.rs
@@ -12,7 +12,7 @@ use axum::{
 use base64::Engine;
 use dashmap::DashMap;
 use std::sync::Arc;
-use tracing::debug;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 /// A stored image with its content type and raw bytes
@@ -21,10 +21,52 @@ struct StoredImage {
     data: Vec<u8>,
 }
 
+/// An upload-in-progress: bytes accumulated so far, expected total, and limit.
+struct PendingUpload {
+    content_type: String,
+    expected_bytes: u64,
+    max_bytes: u64,
+    buffer: Vec<u8>,
+}
+
+/// Errors that can occur while accumulating a chunked upload.
+#[derive(Debug)]
+pub enum UploadError {
+    UnknownUpload,
+    SizeExceedsLimit { limit_bytes: u64 },
+    OffsetMismatch { expected: u64, got: u64 },
+    SizeMismatch { expected: u64, got: u64 },
+}
+
+impl std::fmt::Display for UploadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownUpload => write!(f, "unknown upload_id"),
+            Self::SizeExceedsLimit { limit_bytes } => {
+                let mb = *limit_bytes as f64 / (1024.0 * 1024.0);
+                write!(f, "upload exceeds size limit of {:.0} MB", mb)
+            }
+            Self::OffsetMismatch { expected, got } => {
+                write!(
+                    f,
+                    "chunk offset mismatch: expected {}, got {}",
+                    expected, got
+                )
+            }
+            Self::SizeMismatch { expected, got } => write!(
+                f,
+                "upload size mismatch: expected {} bytes, got {}",
+                expected, got
+            ),
+        }
+    }
+}
+
 /// In-memory image store
 #[derive(Clone, Default)]
 pub struct ImageStore {
     images: Arc<DashMap<Uuid, StoredImage>>,
+    pending: Arc<DashMap<Uuid, PendingUpload>>,
 }
 
 impl ImageStore {
@@ -53,6 +95,99 @@ impl ImageStore {
             },
         );
         Some(id)
+    }
+
+    /// Begin a chunked upload. Reserves an entry in the pending map and
+    /// fails up front if `expected_bytes` already exceeds the limit.
+    pub fn start_upload(
+        &self,
+        upload_id: Uuid,
+        content_type: &str,
+        expected_bytes: u64,
+        max_bytes: u64,
+    ) -> Result<(), UploadError> {
+        if expected_bytes > max_bytes {
+            return Err(UploadError::SizeExceedsLimit {
+                limit_bytes: max_bytes,
+            });
+        }
+        self.pending.insert(
+            upload_id,
+            PendingUpload {
+                content_type: content_type.to_string(),
+                expected_bytes,
+                max_bytes,
+                buffer: Vec::with_capacity(expected_bytes as usize),
+            },
+        );
+        Ok(())
+    }
+
+    /// Append a chunk at the given offset. Chunks must arrive in order
+    /// (offset must equal `buffer.len()`); we enforce that to keep the
+    /// accumulator a simple `Vec<u8>` without sparse reassembly.
+    pub fn append_chunk(
+        &self,
+        upload_id: Uuid,
+        offset: u64,
+        data: &[u8],
+    ) -> Result<(), UploadError> {
+        let mut entry = self
+            .pending
+            .get_mut(&upload_id)
+            .ok_or(UploadError::UnknownUpload)?;
+        let pending = entry.value_mut();
+        if pending.buffer.len() as u64 != offset {
+            return Err(UploadError::OffsetMismatch {
+                expected: pending.buffer.len() as u64,
+                got: offset,
+            });
+        }
+        let new_len = pending.buffer.len() as u64 + data.len() as u64;
+        if new_len > pending.max_bytes {
+            return Err(UploadError::SizeExceedsLimit {
+                limit_bytes: pending.max_bytes,
+            });
+        }
+        pending.buffer.extend_from_slice(data);
+        Ok(())
+    }
+
+    /// Finalize an upload, moving the accumulated bytes into the served
+    /// image store and returning the assigned image id.
+    pub fn finalize_upload(&self, upload_id: Uuid) -> Result<Uuid, UploadError> {
+        let (_, pending) = self
+            .pending
+            .remove(&upload_id)
+            .ok_or(UploadError::UnknownUpload)?;
+        let actual = pending.buffer.len() as u64;
+        if actual != pending.expected_bytes {
+            return Err(UploadError::SizeMismatch {
+                expected: pending.expected_bytes,
+                got: actual,
+            });
+        }
+        let id = Uuid::new_v4();
+        debug!(
+            "Stored image {} via chunked upload {} ({}, {} bytes)",
+            id, upload_id, pending.content_type, actual
+        );
+        self.images.insert(
+            id,
+            StoredImage {
+                content_type: pending.content_type,
+                data: pending.buffer,
+            },
+        );
+        Ok(id)
+    }
+
+    /// Drop a pending upload without finalizing — used when the connection
+    /// drops mid-stream or the client cancels.
+    pub fn abort_upload(&self, upload_id: Uuid) {
+        if self.pending.remove(&upload_id).is_some() {
+            warn!("Aborted in-progress image upload {}", upload_id);
+        }
     }
 
     /// Get the number of stored images

--- a/backend/src/handlers/websocket/image_upload_socket.rs
+++ b/backend/src/handlers/websocket/image_upload_socket.rs
@@ -1,0 +1,164 @@
+//! WebSocket handler for `/ws/session/upload`.
+//!
+//! Receives chunked image uploads from the proxy. The first message is
+//! `Start` (JSON text frame) carrying an auth token; subsequent `Chunk`
+//! frames are binary; `Complete` (JSON text) finalizes and the server
+//! responds with `Ack { image_url }`. The image is then served at the
+//! returned URL via the existing `/api/images/{id}` route.
+
+use crate::AppState;
+use axum::extract::ws::WebSocket;
+use shared::{ImageUploadClientMsg, ImageUploadEndpoint, ImageUploadServerMsg};
+use std::sync::Arc;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+const MAX_TOTAL_CHUNK_BYTES_LIMIT: u64 = 1024 * 1024 * 1024; // 1 GiB hard ceiling
+
+pub async fn handle_image_upload_socket(socket: WebSocket, app_state: Arc<AppState>) {
+    let conn = ws_bridge::server::into_connection::<ImageUploadEndpoint>(socket);
+    let (mut ws_sender, mut ws_receiver) = conn.split();
+
+    // The upload an authenticated session is currently working on.
+    // Set on the first valid Start message and used to abort on disconnect.
+    let mut active_upload: Option<Uuid> = None;
+
+    while let Some(result) = ws_receiver.recv().await {
+        let msg = match result {
+            Ok(m) => m,
+            Err(e) => {
+                warn!("Image upload WS decode error: {}", e);
+                continue;
+            }
+        };
+
+        match msg {
+            ImageUploadClientMsg::Start {
+                upload_id,
+                session_id,
+                auth_token,
+                media_type,
+                total_bytes,
+                file_path,
+            } => {
+                if !authorize_upload(&app_state, &auth_token) {
+                    let _ = ws_sender
+                        .send(ImageUploadServerMsg::Failed {
+                            upload_id,
+                            reason: "authentication failed".into(),
+                        })
+                        .await;
+                    break;
+                }
+
+                let max_bytes = (app_state.max_image_mb as u64)
+                    .saturating_mul(1024 * 1024)
+                    .min(MAX_TOTAL_CHUNK_BYTES_LIMIT);
+
+                match app_state.image_store.start_upload(
+                    upload_id,
+                    &media_type,
+                    total_bytes,
+                    max_bytes,
+                ) {
+                    Ok(()) => {
+                        info!(
+                            "Image upload started: id={} session={} media={} size={} path={:?}",
+                            upload_id, session_id, media_type, total_bytes, file_path
+                        );
+                        active_upload = Some(upload_id);
+                    }
+                    Err(e) => {
+                        warn!("Image upload rejected at Start: id={} {}", upload_id, e);
+                        let _ = ws_sender
+                            .send(ImageUploadServerMsg::Failed {
+                                upload_id,
+                                reason: e.to_string(),
+                            })
+                            .await;
+                    }
+                }
+            }
+            ImageUploadClientMsg::Chunk {
+                upload_id,
+                offset,
+                data,
+            } => {
+                if active_upload != Some(upload_id) {
+                    warn!(
+                        "Chunk for upload {} without a matching Start; ignoring",
+                        upload_id
+                    );
+                    let _ = ws_sender
+                        .send(ImageUploadServerMsg::Failed {
+                            upload_id,
+                            reason: "chunk received before Start".into(),
+                        })
+                        .await;
+                    continue;
+                }
+                if let Err(e) = app_state.image_store.append_chunk(upload_id, offset, &data) {
+                    warn!("Image upload chunk rejected: id={} {}", upload_id, e);
+                    app_state.image_store.abort_upload(upload_id);
+                    active_upload = None;
+                    let _ = ws_sender
+                        .send(ImageUploadServerMsg::Failed {
+                            upload_id,
+                            reason: e.to_string(),
+                        })
+                        .await;
+                }
+            }
+            ImageUploadClientMsg::Complete { upload_id } => {
+                if active_upload != Some(upload_id) {
+                    let _ = ws_sender
+                        .send(ImageUploadServerMsg::Failed {
+                            upload_id,
+                            reason: "complete for unknown upload".into(),
+                        })
+                        .await;
+                    continue;
+                }
+                match app_state.image_store.finalize_upload(upload_id) {
+                    Ok(image_id) => {
+                        let image_url = format!("/api/images/{}", image_id);
+                        info!("Image upload finalized: id={} -> {}", upload_id, image_url);
+                        active_upload = None;
+                        let _ = ws_sender
+                            .send(ImageUploadServerMsg::Ack {
+                                upload_id,
+                                image_url,
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        warn!("Image upload finalize failed: id={} {}", upload_id, e);
+                        active_upload = None;
+                        let _ = ws_sender
+                            .send(ImageUploadServerMsg::Failed {
+                                upload_id,
+                                reason: e.to_string(),
+                            })
+                            .await;
+                    }
+                }
+            }
+        }
+    }
+
+    // Clean up any in-progress upload if the socket dropped before Complete.
+    if let Some(upload_id) = active_upload {
+        app_state.image_store.abort_upload(upload_id);
+    }
+}
+
+fn authorize_upload(app_state: &AppState, auth_token: &str) -> bool {
+    let mut conn = match app_state.db_pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Image upload auth: failed to get DB conn: {}", e);
+            return false;
+        }
+    };
+    crate::handlers::proxy_tokens::verify_and_get_user(app_state, &mut conn, auth_token).is_ok()
+}

--- a/backend/src/handlers/websocket/mod.rs
+++ b/backend/src/handlers/websocket/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod image_upload_socket;
 pub mod launcher_socket;
 mod message_handlers;
 mod permissions;
@@ -27,6 +28,13 @@ pub async fn handle_session_websocket(
     State(app_state): State<Arc<AppState>>,
 ) -> Response {
     ws.on_upgrade(|socket| proxy_socket::handle_session_socket(socket, app_state))
+}
+
+pub async fn handle_image_upload_websocket(
+    ws: WebSocketUpgrade,
+    State(app_state): State<Arc<AppState>>,
+) -> Response {
+    ws.on_upgrade(|socket| image_upload_socket::handle_image_upload_socket(socket, app_state))
 }
 
 pub async fn handle_launcher_websocket(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -508,6 +508,10 @@ async fn main() -> anyhow::Result<()> {
             get(handlers::websocket::handle_session_websocket),
         )
         .route(
+            shared::ImageUploadEndpoint::PATH,
+            get(handlers::websocket::handle_image_upload_websocket),
+        )
+        .route(
             shared::ClientEndpoint::PATH,
             get(handlers::websocket::handle_web_client_websocket),
         )

--- a/claude-session-lib/src/proxy_session/image_uploader.rs
+++ b/claude-session-lib/src/proxy_session/image_uploader.rs
@@ -1,0 +1,105 @@
+//! Chunked image upload client.
+//!
+//! Opens a short-lived connection to `/ws/session/upload`, streams the raw
+//! image bytes in binary chunks, and returns the `/api/images/{id}` URL
+//! that the backend assigned. Used by the output forwarder when an image
+//! is too large to inline as base64 in a single WebSocket frame.
+
+use anyhow::{anyhow, Context, Result};
+use shared::{ImageUploadClientMsg, ImageUploadEndpoint, ImageUploadServerMsg};
+use std::time::Duration;
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+/// Maximum bytes per binary chunk frame. Keeps each frame well below the
+/// tokio-tungstenite default 64 MB cap with plenty of headroom for the
+/// 24-byte chunk header and protocol overhead.
+const CHUNK_SIZE: usize = 4 * 1024 * 1024;
+
+/// Hard timeout for finalize ACK. Should be quick once the last chunk lands.
+const ACK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Send an image to the backend over a fresh upload connection.
+///
+/// Returns the URL the backend assigned (e.g. `/api/images/abc-…`) which
+/// can be substituted into a portal message in place of inline base64.
+pub async fn upload_image(
+    backend_url: &str,
+    session_id: Uuid,
+    auth_token: &str,
+    media_type: &str,
+    file_path: Option<&str>,
+    bytes: &[u8],
+) -> Result<String> {
+    let upload_id = Uuid::new_v4();
+    let total_bytes = bytes.len() as u64;
+    debug!(
+        "Starting chunked image upload: id={} size={} chunks={}",
+        upload_id,
+        total_bytes,
+        bytes.len().div_ceil(CHUNK_SIZE)
+    );
+
+    let conn = ws_bridge::native_client::connect::<ImageUploadEndpoint>(backend_url)
+        .await
+        .context("connect to /ws/session/upload")?;
+    let (mut ws_write, mut ws_read) = conn.split();
+
+    let start_msg = ImageUploadClientMsg::Start {
+        upload_id,
+        session_id,
+        auth_token: auth_token.to_string(),
+        media_type: media_type.to_string(),
+        total_bytes,
+        file_path: file_path.map(|s| s.to_string()),
+    };
+    ws_write.send(start_msg).await.context("send Start frame")?;
+
+    let mut offset: u64 = 0;
+    for chunk in bytes.chunks(CHUNK_SIZE) {
+        let msg = ImageUploadClientMsg::Chunk {
+            upload_id,
+            offset,
+            data: chunk.to_vec(),
+        };
+        if let Err(e) = ws_write.send(msg).await {
+            return Err(anyhow!("send Chunk frame at offset {}: {}", offset, e));
+        }
+        offset += chunk.len() as u64;
+    }
+
+    ws_write
+        .send(ImageUploadClientMsg::Complete { upload_id })
+        .await
+        .context("send Complete frame")?;
+
+    let response = tokio::time::timeout(ACK_TIMEOUT, ws_read.recv())
+        .await
+        .map_err(|_| anyhow!("upload ack timeout after {:?}", ACK_TIMEOUT))?;
+
+    match response {
+        Some(Ok(ImageUploadServerMsg::Ack {
+            upload_id: u,
+            image_url,
+        })) => {
+            if u != upload_id {
+                return Err(anyhow!(
+                    "upload_id mismatch: expected {}, got {}",
+                    upload_id,
+                    u
+                ));
+            }
+            debug!("Image upload complete: id={} url={}", upload_id, image_url);
+            Ok(image_url)
+        }
+        Some(Ok(ImageUploadServerMsg::Failed {
+            upload_id: _,
+            reason,
+        })) => {
+            warn!("Image upload rejected by backend: {}", reason);
+            Err(anyhow!("upload rejected: {}", reason))
+        }
+        Some(Err(e)) => Err(anyhow!("upload socket decode error: {}", e)),
+        None => Err(anyhow!("upload socket closed before ack")),
+    }
+}

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -1,5 +1,6 @@
 //! Proxy session management and WebSocket connection handling.
 
+mod image_uploader;
 mod output_forwarder;
 mod wiggum;
 mod ws_reader;
@@ -643,6 +644,8 @@ async fn run_message_loop(
         output_rx,
         ws_write.clone(),
         session_id,
+        config.backend_url.clone(),
+        config.auth_token.clone(),
         config.working_directory.clone(),
         current_branch,
         current_pr_url,

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -15,7 +15,14 @@ use uuid::Uuid;
 
 use crate::output_buffer::PendingOutputBuffer;
 
+use super::image_uploader::upload_image;
 use super::{format_duration, truncate, SharedWsWrite};
+
+/// Images at or above this raw-byte size get sent via the chunked upload
+/// stream (`/ws/session/upload`) instead of inlined as base64 on the main
+/// session socket. Below it, the small-image fast path keeps a single
+/// round trip.
+const CHUNK_UPLOAD_THRESHOLD_BYTES: usize = 1024 * 1024;
 
 /// Spawn the output forwarder task
 ///
@@ -25,6 +32,8 @@ pub fn spawn_output_forwarder(
     mut output_rx: mpsc::UnboundedReceiver<ClaudeOutput>,
     ws_write: SharedWsWrite,
     session_id: Uuid,
+    backend_url: String,
+    auth_token: Option<String>,
     working_directory: String,
     current_branch: Arc<Mutex<Option<String>>>,
     current_pr_url: Arc<Mutex<Option<String>>>,
@@ -69,9 +78,9 @@ pub fn spawn_output_forwarder(
             // Track Read tool calls on image files from assistant messages
             track_image_reads(&output, &mut image_read_map);
 
-            // Check for image tool results in user messages and send portal messages
-            let portal_messages =
-                extract_image_portal_messages(&output, &mut image_read_map, max_bytes);
+            // Collect any image work items from user-message tool results
+            // (raw bytes for large images, base64 strings for small ones).
+            let image_items = extract_image_work_items(&output, &mut image_read_map, max_bytes);
 
             // Serialize and buffer with sequence number
             let content = serde_json::to_value(&output)
@@ -94,8 +103,53 @@ pub fn spawn_output_forwarder(
                 }
             }
 
-            // Send any image portal messages after the main output
-            for portal_msg in portal_messages {
+            // Resolve each image item into a portal message — uploading
+            // large images out-of-band first so the on-wire payload stays
+            // small — then send them after the main output.
+            let mut send_failed = false;
+            for item in image_items {
+                let portal_msg = match item {
+                    ImageWorkItem::Inline(msg) => msg,
+                    ImageWorkItem::TooLarge(msg) => msg,
+                    ImageWorkItem::Upload {
+                        file_path,
+                        file_size,
+                        media_type,
+                        bytes,
+                    } => {
+                        let result = match auth_token.as_deref() {
+                            Some(token) => {
+                                upload_image(
+                                    &backend_url,
+                                    session_id,
+                                    token,
+                                    &media_type,
+                                    Some(&file_path),
+                                    &bytes,
+                                )
+                                .await
+                            }
+                            None => Err(anyhow::anyhow!("no auth token available for upload")),
+                        };
+                        match result {
+                            Ok(url) => shared::PortalMessage {
+                                message_type: "portal".to_string(),
+                                content: vec![shared::PortalContent::Image {
+                                    media_type,
+                                    data: url,
+                                    file_path: Some(file_path),
+                                    file_size: Some(file_size),
+                                    source_type: Some("url".to_string()),
+                                }],
+                            },
+                            Err(e) => {
+                                warn!("Chunked image upload failed: {}", e);
+                                shared::PortalMessage::text(format!("Image upload failed: {}", e))
+                            }
+                        }
+                    }
+                };
+
                 let portal_content = portal_msg.to_json();
                 let portal_seq = {
                     let mut buf = output_buffer.lock().await;
@@ -108,12 +162,31 @@ pub fn spawn_output_forwarder(
                 let mut ws = ws_write.lock().await;
                 if ws.send(portal_ws_msg).await.is_err() {
                     error!("Failed to send image portal message");
+                    send_failed = true;
                     break;
                 }
+            }
+            if send_failed {
+                break;
             }
         }
         debug!("Output forwarder ended - channel closed");
     })
+}
+
+/// One unit of image work surfaced from a user-message tool result.
+enum ImageWorkItem {
+    /// Small image: data is already base64-encoded and ready to inline.
+    Inline(shared::PortalMessage),
+    /// Large image: raw bytes need to go through the chunked upload stream.
+    Upload {
+        file_path: String,
+        file_size: u64,
+        media_type: String,
+        bytes: Vec<u8>,
+    },
+    /// Image exceeded the hard cap; this is a textual rejection notice.
+    TooLarge(shared::PortalMessage),
 }
 
 /// Get the current git branch name, if in a git repository
@@ -312,19 +385,21 @@ fn track_image_reads(output: &ClaudeOutput, image_read_map: &mut HashMap<String,
     }
 }
 
-/// Check user messages for tool results that correspond to tracked image reads.
-/// For each match, reads the file from disk, base64-encodes it, and returns a PortalMessage.
-fn extract_image_portal_messages(
+/// Check user messages for tool results that correspond to tracked image
+/// reads. Reads each matching file from disk and classifies it for
+/// downstream delivery: inline base64 for small images, chunked upload
+/// for large ones, or a textual rejection if it exceeds the backend cap.
+fn extract_image_work_items(
     output: &ClaudeOutput,
     image_read_map: &mut HashMap<String, String>,
     max_image_bytes: usize,
-) -> Vec<shared::PortalMessage> {
+) -> Vec<ImageWorkItem> {
     let blocks = match output {
         ClaudeOutput::User(user) => &user.message.content,
         _ => return Vec::new(),
     };
 
-    let mut portal_messages = Vec::new();
+    let mut items = Vec::new();
 
     for block in blocks {
         if let ContentBlock::ToolResult(tr) = block {
@@ -337,26 +412,46 @@ fn extract_image_portal_messages(
 
                 match std::fs::read(&file_path) {
                     Ok(data) => {
+                        let file_size = data.len() as u64;
                         if data.len() > max_image_bytes {
                             let size_mb = data.len() as f64 / (1024.0 * 1024.0);
                             let limit_mb = max_image_bytes as f64 / (1024.0 * 1024.0);
-                            portal_messages.push(shared::PortalMessage::text(format!(
-                                "Image too large to display: **{:.1} MB** (limit is {:.0} MB)",
-                                size_mb, limit_mb
+                            warn!(
+                                "Image {} too large ({:.1} MB > {:.0} MB cap), skipping",
+                                file_path, size_mb, limit_mb
+                            );
+                            items.push(ImageWorkItem::TooLarge(shared::PortalMessage::text(
+                                format!(
+                                    "Image too large to display: **{:.1} MB** (limit is {:.0} MB)",
+                                    size_mb, limit_mb
+                                ),
                             )));
-                        } else {
-                            let file_size = data.len() as u64;
-                            let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
+                        } else if data.len() >= CHUNK_UPLOAD_THRESHOLD_BYTES {
                             debug!(
-                                "Sending image portal message for {} ({} bytes)",
+                                "Queueing chunked upload for {} ({} bytes)",
                                 file_path,
                                 data.len()
                             );
-                            portal_messages.push(shared::PortalMessage::image_with_info(
-                                mime.to_string(),
-                                encoded,
-                                Some(file_path.clone()),
-                                Some(file_size),
+                            items.push(ImageWorkItem::Upload {
+                                file_path: file_path.clone(),
+                                file_size,
+                                media_type: mime.to_string(),
+                                bytes: data,
+                            });
+                        } else {
+                            let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
+                            debug!(
+                                "Inlining image portal message for {} ({} bytes)",
+                                file_path,
+                                data.len()
+                            );
+                            items.push(ImageWorkItem::Inline(
+                                shared::PortalMessage::image_with_info(
+                                    mime.to_string(),
+                                    encoded,
+                                    Some(file_path.clone()),
+                                    Some(file_size),
+                                ),
                             ));
                         }
                     }
@@ -368,7 +463,7 @@ fn extract_image_portal_messages(
         }
     }
 
-    portal_messages
+    items
 }
 
 /// Log detailed information about Claude output

--- a/shared/src/image_upload.rs
+++ b/shared/src/image_upload.rs
@@ -1,0 +1,284 @@
+//! Chunked image upload protocol used on `/ws/session/upload`.
+//!
+//! Large images flow from the proxy to the backend on a dedicated WebSocket
+//! that mixes JSON-text control frames (`Start`, `Complete`, `Ack`, `Failed`)
+//! with raw-binary chunk frames. Sending raw bytes avoids the ~33% base64
+//! overhead, and chunking avoids the single-frame size cap that closes the
+//! main session socket on oversized payloads.
+//!
+//! Wire format for a chunk frame (`WsMessage::Binary`):
+//! ```text
+//!   [ upload_id : 16 bytes ][ offset : u64 LE : 8 bytes ][ raw image bytes ]
+//! ```
+//! Total header is 24 bytes; `data` is the remainder of the frame.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use ws_bridge::{DecodeError, EncodeError, WsCodec, WsEndpoint, WsMessage};
+
+const CHUNK_HEADER_LEN: usize = 24;
+
+pub struct ImageUploadEndpoint;
+
+impl WsEndpoint for ImageUploadEndpoint {
+    const PATH: &'static str = "/ws/session/upload";
+    type ServerMsg = ImageUploadServerMsg;
+    type ClientMsg = ImageUploadClientMsg;
+}
+
+/// Proxy -> backend messages on the image upload socket.
+///
+/// Deliberately does NOT derive `Serialize`/`Deserialize` — that would
+/// activate the blanket `WsCodec` impl and force everything through JSON,
+/// defeating the point of the binary chunk frames.
+#[derive(Debug, Clone)]
+pub enum ImageUploadClientMsg {
+    /// Announce a new upload. Sent as a JSON text frame.
+    Start {
+        upload_id: Uuid,
+        session_id: Uuid,
+        auth_token: String,
+        media_type: String,
+        total_bytes: u64,
+        file_path: Option<String>,
+    },
+    /// A slice of raw image bytes. Sent as a binary frame.
+    Chunk {
+        upload_id: Uuid,
+        offset: u64,
+        data: Vec<u8>,
+    },
+    /// Finalize the upload. Sent as a JSON text frame.
+    Complete { upload_id: Uuid },
+}
+
+/// Helper enum used only on the wire for text-frame variants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum ImageUploadCtrlMsg {
+    Start {
+        upload_id: Uuid,
+        session_id: Uuid,
+        auth_token: String,
+        media_type: String,
+        total_bytes: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        file_path: Option<String>,
+    },
+    Complete {
+        upload_id: Uuid,
+    },
+}
+
+impl WsCodec for ImageUploadClientMsg {
+    fn encode(&self) -> Result<WsMessage, EncodeError> {
+        match self {
+            Self::Chunk {
+                upload_id,
+                offset,
+                data,
+            } => {
+                let mut bytes = Vec::with_capacity(CHUNK_HEADER_LEN + data.len());
+                bytes.extend_from_slice(upload_id.as_bytes());
+                bytes.extend_from_slice(&offset.to_le_bytes());
+                bytes.extend_from_slice(data);
+                Ok(WsMessage::Binary(bytes))
+            }
+            Self::Start {
+                upload_id,
+                session_id,
+                auth_token,
+                media_type,
+                total_bytes,
+                file_path,
+            } => {
+                let ctrl = ImageUploadCtrlMsg::Start {
+                    upload_id: *upload_id,
+                    session_id: *session_id,
+                    auth_token: auth_token.clone(),
+                    media_type: media_type.clone(),
+                    total_bytes: *total_bytes,
+                    file_path: file_path.clone(),
+                };
+                Ok(WsMessage::Text(serde_json::to_string(&ctrl)?))
+            }
+            Self::Complete { upload_id } => {
+                let ctrl = ImageUploadCtrlMsg::Complete {
+                    upload_id: *upload_id,
+                };
+                Ok(WsMessage::Text(serde_json::to_string(&ctrl)?))
+            }
+        }
+    }
+
+    fn decode(msg: WsMessage) -> Result<Self, DecodeError> {
+        match msg {
+            WsMessage::Binary(bytes) => {
+                if bytes.len() < CHUNK_HEADER_LEN {
+                    return Err(DecodeError::InvalidData(format!(
+                        "image upload chunk frame too small: {} bytes (need >= {})",
+                        bytes.len(),
+                        CHUNK_HEADER_LEN
+                    )));
+                }
+                let upload_id = Uuid::from_slice(&bytes[..16]).map_err(|_| {
+                    DecodeError::InvalidData("bad upload_id in chunk header".into())
+                })?;
+                let offset = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
+                let data = bytes[CHUNK_HEADER_LEN..].to_vec();
+                Ok(Self::Chunk {
+                    upload_id,
+                    offset,
+                    data,
+                })
+            }
+            WsMessage::Text(text) => {
+                let ctrl: ImageUploadCtrlMsg = serde_json::from_str(&text)?;
+                Ok(match ctrl {
+                    ImageUploadCtrlMsg::Start {
+                        upload_id,
+                        session_id,
+                        auth_token,
+                        media_type,
+                        total_bytes,
+                        file_path,
+                    } => Self::Start {
+                        upload_id,
+                        session_id,
+                        auth_token,
+                        media_type,
+                        total_bytes,
+                        file_path,
+                    },
+                    ImageUploadCtrlMsg::Complete { upload_id } => Self::Complete { upload_id },
+                })
+            }
+        }
+    }
+}
+
+/// Backend -> proxy responses. JSON-only; uses the blanket `WsCodec` impl.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ImageUploadServerMsg {
+    /// Upload finalized; image is now retrievable at `image_url`.
+    Ack { upload_id: Uuid, image_url: String },
+    /// Upload rejected. Proxy should not retry the same upload_id.
+    Failed { upload_id: Uuid, reason: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_path() {
+        assert_eq!(ImageUploadEndpoint::PATH, "/ws/session/upload");
+    }
+
+    #[test]
+    fn chunk_roundtrip() {
+        let upload_id = Uuid::new_v4();
+        let msg = ImageUploadClientMsg::Chunk {
+            upload_id,
+            offset: 4096,
+            data: vec![0xde, 0xad, 0xbe, 0xef, 0x00, 0xff],
+        };
+        let frame = msg.encode().unwrap();
+        match frame {
+            WsMessage::Binary(ref bytes) => {
+                assert_eq!(bytes.len(), CHUNK_HEADER_LEN + 6);
+                assert_eq!(&bytes[..16], upload_id.as_bytes());
+                assert_eq!(u64::from_le_bytes(bytes[16..24].try_into().unwrap()), 4096);
+            }
+            _ => panic!("expected binary frame"),
+        }
+        let decoded = ImageUploadClientMsg::decode(frame).unwrap();
+        match decoded {
+            ImageUploadClientMsg::Chunk {
+                upload_id: u,
+                offset,
+                data,
+            } => {
+                assert_eq!(u, upload_id);
+                assert_eq!(offset, 4096);
+                assert_eq!(data, vec![0xde, 0xad, 0xbe, 0xef, 0x00, 0xff]);
+            }
+            _ => panic!("expected Chunk after decode"),
+        }
+    }
+
+    #[test]
+    fn start_roundtrip() {
+        let upload_id = Uuid::new_v4();
+        let session_id = Uuid::new_v4();
+        let msg = ImageUploadClientMsg::Start {
+            upload_id,
+            session_id,
+            auth_token: "tok".into(),
+            media_type: "image/png".into(),
+            total_bytes: 12_345,
+            file_path: Some("/tmp/x.png".into()),
+        };
+        let frame = msg.encode().unwrap();
+        match frame {
+            WsMessage::Text(ref text) => {
+                assert!(text.contains(r#""type":"Start""#));
+                assert!(text.contains(r#""media_type":"image/png""#));
+            }
+            _ => panic!("expected text frame"),
+        }
+        let decoded = ImageUploadClientMsg::decode(frame).unwrap();
+        match decoded {
+            ImageUploadClientMsg::Start {
+                upload_id: u,
+                media_type,
+                total_bytes,
+                file_path,
+                ..
+            } => {
+                assert_eq!(u, upload_id);
+                assert_eq!(media_type, "image/png");
+                assert_eq!(total_bytes, 12_345);
+                assert_eq!(file_path.as_deref(), Some("/tmp/x.png"));
+            }
+            _ => panic!("expected Start after decode"),
+        }
+    }
+
+    #[test]
+    fn complete_roundtrip() {
+        let upload_id = Uuid::new_v4();
+        let frame = ImageUploadClientMsg::Complete { upload_id }
+            .encode()
+            .unwrap();
+        let decoded = ImageUploadClientMsg::decode(frame).unwrap();
+        assert!(matches!(
+            decoded,
+            ImageUploadClientMsg::Complete { upload_id: u } if u == upload_id
+        ));
+    }
+
+    #[test]
+    fn server_msg_ack_json() {
+        let msg = ImageUploadServerMsg::Ack {
+            upload_id: Uuid::nil(),
+            image_url: "/api/images/abc".into(),
+        };
+        let frame = msg.encode().unwrap();
+        match frame {
+            WsMessage::Text(text) => {
+                assert!(text.contains(r#""type":"Ack""#));
+                assert!(text.contains("/api/images/abc"));
+            }
+            _ => panic!("expected text frame"),
+        }
+    }
+
+    #[test]
+    fn short_binary_frame_errors() {
+        let bad = WsMessage::Binary(vec![0; 10]);
+        let err = ImageUploadClientMsg::decode(bad).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidData(_)));
+    }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -9,6 +9,10 @@ pub use proxy_tokens::*;
 pub mod endpoints;
 pub use endpoints::*;
 
+// Chunked image upload protocol (mixed JSON + binary WS frames)
+pub mod image_upload;
+pub use image_upload::{ImageUploadClientMsg, ImageUploadEndpoint, ImageUploadServerMsg};
+
 // Protocol constants shared between backend and proxy
 pub mod protocol;
 


### PR DESCRIPTION
## Summary

Fixes #666 by moving large image payloads off the main `/ws/session` socket onto a dedicated `/ws/session/upload` stream that mixes JSON-text control frames with raw-binary chunk frames.

The previous code base64-encoded the image and pushed it through `SequencedOutput` as a single WebSocket message. A 33 MB image expands to ~46 MB base64; once you add JSON quoting and other content, the frame exceeded tokio-tungstenite's 64 MB default, the backend silently dropped it, and the proxy buffered + retried forever — wedging the session.

## What changed

- **New shared protocol** (`shared/src/image_upload.rs`): `ImageUploadEndpoint` with a custom `WsCodec` impl that emits `WsMessage::Binary` for `Chunk` variants and `WsMessage::Text` (JSON) for `Start`/`Complete`/`Ack`/`Failed`. Wire format for chunks: `[upload_id:16][offset:u64 LE:8][raw bytes...]`.
- **Backend handler** (`backend/src/handlers/websocket/image_upload_socket.rs`): accepts auth in the first `Start` frame, accumulates chunks in an in-memory upload buffer, enforces `PORTAL_MAX_IMAGE_MB`, then transfers the bytes into the existing image store and replies with the `/api/images/{uuid}` URL.
- **Proxy uploader** (`claude-session-lib/src/proxy_session/image_uploader.rs`): opens a short-lived upload connection, streams 4 MB binary chunks, awaits the ack, returns the URL.
- **Forwarder integration** (`output_forwarder.rs`): images ≥ 1 MB now go through chunked upload; smaller images keep the inline base64 fast path. Anything over the cap is rejected locally with a tool-error portal message instead of being queued.

Bumped to 2.5.0 since this adds a new endpoint.

## Test plan

- [x] `cargo test --workspace` — new round-trip tests for the binary chunk codec, all existing tests still pass
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo build --target wasm32-unknown-unknown -p frontend` — shared crate remains WASM-safe
- [ ] Manual: launch a session, ask Claude to Read an image > 1 MB, verify it shows up in the UI without the session reconnect loop from #666
- [ ] Manual: try an image > `PORTAL_MAX_IMAGE_MB` and confirm the agent gets a "too large" message instead of buffer-and-retry