### PR TITLE
Add pill rail orientation setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.1
+
+- Add Appearance tab in Settings with a horizontal-vs-vertical toggle for the session pill rail
+- Preference persists in browser localStorage (`claude-portal-rail-orientation`)
+- Vertical layout puts the pill rail down the left side; horizontal keeps the current top-bar layout
+
 ## 2.5.0
 
 - Chunked image uploads over a new `/ws/session/upload` stream (#666)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/mod.rs
+++ b/frontend/src/pages/dashboard/mod.rs
@@ -13,3 +13,4 @@ mod session_view;
 mod types;
 
 pub use page::DashboardPage;
+pub use types::{load_rail_orientation, save_rail_orientation, RailOrientation};

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -3,8 +3,8 @@
 use super::session_rail::{ActivityRef, SessionRail};
 use super::session_view::SessionView;
 use super::types::{
-    load_hidden_sessions, load_inactive_hidden, load_show_cost, save_hidden_sessions,
-    save_inactive_hidden, save_show_cost,
+    load_hidden_sessions, load_inactive_hidden, load_rail_orientation, load_show_cost,
+    save_hidden_sessions, save_inactive_hidden, save_show_cost,
 };
 use crate::components::LaunchDialog;
 use crate::hooks::{use_client_websocket, use_keyboard_nav, use_sessions, KeyboardNavConfig};
@@ -49,6 +49,7 @@ pub fn dashboard_page() -> Html {
     let hidden_sessions = use_state(load_hidden_sessions);
     let inactive_hidden = use_state(load_inactive_hidden);
     let show_cost = use_state(load_show_cost);
+    let rail_orientation = use_state(load_rail_orientation);
     let connected_sessions = use_state(HashSet::<Uuid>::new);
     let pending_leave = use_state(|| None::<Uuid>);
     let is_admin = use_state(|| false);
@@ -325,7 +326,14 @@ pub fn dashboard_page() -> Html {
 
     let close_settings = {
         let show_settings = show_settings.clone();
-        Callback::from(move |_: ()| show_settings.set(false))
+        let rail_orientation = rail_orientation.clone();
+        Callback::from(move |_: ()| {
+            // The Appearance panel may have changed this; re-sync from
+            // localStorage so the dashboard picks up the new value when
+            // the user navigates back.
+            rail_orientation.set(load_rail_orientation());
+            show_settings.set(false);
+        })
     };
 
     let do_logout = Callback::from(move |_| {
@@ -708,6 +716,7 @@ pub fn dashboard_page() -> Html {
                 </div>
             } else {
                 <>
+                    <div class={classes!("dashboard-body", rail_orientation.body_class())}>
                     // Session Rail
                     <SessionRail
                         sessions={active_sessions.clone()}
@@ -764,6 +773,7 @@ pub fn dashboard_page() -> Html {
                                 }
                             }).collect::<Html>()
                         }
+                    </div>
                     </div>
 
                     // Keyboard hints

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -19,6 +19,9 @@ pub const INACTIVE_HIDDEN_STORAGE_KEY: &str = "claude-portal-inactive-hidden";
 /// Storage key for cost display visibility in localStorage
 pub const SHOW_COST_STORAGE_KEY: &str = "claude-portal-show-cost";
 
+/// Storage key for session rail orientation in localStorage
+pub const RAIL_ORIENTATION_STORAGE_KEY: &str = "claude-portal-rail-orientation";
+
 /// Maximum number of messages to keep in frontend memory (matches backend limit)
 pub const MAX_MESSAGES_PER_SESSION: usize = 100;
 
@@ -118,6 +121,59 @@ pub fn load_show_cost() -> bool {
 pub fn save_show_cost(show: bool) {
     if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
         let _ = storage.set_item(SHOW_COST_STORAGE_KEY, if show { "true" } else { "false" });
+    }
+}
+
+/// Orientation of the session pill rail on the dashboard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RailOrientation {
+    Horizontal,
+    Vertical,
+}
+
+impl RailOrientation {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Horizontal => "horizontal",
+            Self::Vertical => "vertical",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "horizontal" => Some(Self::Horizontal),
+            "vertical" => Some(Self::Vertical),
+            _ => None,
+        }
+    }
+
+    /// CSS class applied to the dashboard body wrapper.
+    pub fn body_class(self) -> &'static str {
+        match self {
+            Self::Horizontal => "rail-horizontal",
+            Self::Vertical => "rail-vertical",
+        }
+    }
+}
+
+/// Load rail orientation preference from localStorage (default: horizontal).
+pub fn load_rail_orientation() -> RailOrientation {
+    web_sys::window()
+        .and_then(|w| w.local_storage().ok().flatten())
+        .and_then(|storage| {
+            storage
+                .get_item(RAIL_ORIENTATION_STORAGE_KEY)
+                .ok()
+                .flatten()
+        })
+        .and_then(|v| RailOrientation::from_str(&v))
+        .unwrap_or(RailOrientation::Horizontal)
+}
+
+/// Save rail orientation preference to localStorage.
+pub fn save_rail_orientation(orientation: RailOrientation) {
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.set_item(RAIL_ORIENTATION_STORAGE_KEY, orientation.as_str());
     }
 }
 

--- a/frontend/src/pages/settings/appearance_panel.rs
+++ b/frontend/src/pages/settings/appearance_panel.rs
@@ -1,0 +1,66 @@
+use crate::pages::dashboard::{load_rail_orientation, save_rail_orientation, RailOrientation};
+use yew::prelude::*;
+
+#[function_component(AppearancePanel)]
+pub fn appearance_panel() -> Html {
+    let orientation = use_state(load_rail_orientation);
+
+    let set_horizontal = {
+        let orientation = orientation.clone();
+        Callback::from(move |_: MouseEvent| {
+            save_rail_orientation(RailOrientation::Horizontal);
+            orientation.set(RailOrientation::Horizontal);
+        })
+    };
+
+    let set_vertical = {
+        let orientation = orientation.clone();
+        Callback::from(move |_: MouseEvent| {
+            save_rail_orientation(RailOrientation::Vertical);
+            orientation.set(RailOrientation::Vertical);
+        })
+    };
+
+    let is_horizontal = *orientation == RailOrientation::Horizontal;
+    let is_vertical = *orientation == RailOrientation::Vertical;
+
+    html! {
+        <section class="appearance-section">
+            <div class="section-header">
+                <h2>{ "Appearance" }</h2>
+                <p class="section-description">
+                    { "Layout preferences. Saved in this browser." }
+                </p>
+            </div>
+
+            <div class="appearance-setting">
+                <h3>{ "Session pill menu" }</h3>
+                <p class="setting-description">
+                    { "Place the session pills along the top of the page, or down the left side." }
+                </p>
+                <div class="orientation-choices">
+                    <button
+                        class={classes!("orientation-choice", is_horizontal.then_some("active"))}
+                        onclick={set_horizontal}
+                    >
+                        <div class="orientation-preview horizontal">
+                            <div class="preview-rail-h"></div>
+                            <div class="preview-body"></div>
+                        </div>
+                        <span class="orientation-label">{ "Horizontal (top)" }</span>
+                    </button>
+                    <button
+                        class={classes!("orientation-choice", is_vertical.then_some("active"))}
+                        onclick={set_vertical}
+                    >
+                        <div class="orientation-preview vertical">
+                            <div class="preview-rail-v"></div>
+                            <div class="preview-body"></div>
+                        </div>
+                        <span class="orientation-label">{ "Vertical (left)" }</span>
+                    </button>
+                </div>
+            </div>
+        </section>
+    }
+}

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -1,8 +1,10 @@
+mod appearance_panel;
 mod launchers_panel;
 mod sessions_panel;
 mod sounds_panel;
 mod tokens_panel;
 
+use appearance_panel::AppearancePanel;
 use launchers_panel::{count_expiring_launchers, LaunchersPanel};
 use sessions_panel::SessionsPanel;
 use shared::{LauncherInfo, ProxyTokenInfo, SessionInfo};
@@ -16,6 +18,7 @@ enum SettingsTab {
     Tokens,
     Launchers,
     Sounds,
+    Appearance,
 }
 
 #[derive(Properties, PartialEq)]
@@ -73,6 +76,11 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
         Callback::from(move |_| active_tab.set(SettingsTab::Sounds))
     };
 
+    let on_appearance_tab = {
+        let active_tab = active_tab.clone();
+        Callback::from(move |_| active_tab.set(SettingsTab::Appearance))
+    };
+
     let go_back = {
         let on_close = props.on_close.clone();
         Callback::from(move |_| on_close.emit(()))
@@ -126,6 +134,12 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                 >
                     { "Sounds" }
                 </button>
+                <button
+                    class={classes!("tab-button", (*active_tab == SettingsTab::Appearance).then_some("active"))}
+                    onclick={on_appearance_tab}
+                >
+                    { "Appearance" }
+                </button>
             </nav>
 
             <main class="settings-content">
@@ -140,6 +154,9 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                 }
                 if *active_tab == SettingsTab::Sessions {
                     <SessionsPanel on_sessions_loaded={on_sessions_loaded} />
+                }
+                if *active_tab == SettingsTab::Appearance {
+                    <AppearancePanel />
                 }
             </main>
         </div>

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -2,6 +2,19 @@
    Session Rail - Horizontal Carousel
    ========================================================================== */
 
+/* Wraps the rail + session views so we can swap the carousel orientation
+   without touching the rail or view components themselves. */
+.dashboard-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.dashboard-body.rail-vertical {
+    flex-direction: row;
+}
+
 .session-rail {
     display: flex;
     gap: 0.5rem;
@@ -9,6 +22,40 @@
     background: var(--bg-darker);
     border-bottom: 1px solid var(--border);
     overflow-x: auto;
+}
+
+/* Vertical rail: pills stack down the left, the views fill the remainder. */
+.dashboard-body.rail-vertical > .session-rail {
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.75rem 0.5rem;
+    border-right: 1px solid var(--border);
+    border-bottom: none;
+    overflow-x: visible;
+    overflow-y: auto;
+    width: 240px;
+    flex-shrink: 0;
+}
+
+.dashboard-body.rail-vertical > .session-rail .session-pill {
+    width: 100%;
+    white-space: normal;
+}
+
+/* Flip the active/inactive divider so it reads horizontally in vertical mode. */
+.dashboard-body.rail-vertical > .session-rail .session-rail-divider {
+    flex-direction: row;
+    align-self: stretch;
+    justify-content: center;
+    padding: 0.25rem 0;
+}
+
+.dashboard-body.rail-vertical > .session-rail .session-rail-divider .divider-line {
+    width: auto;
+    height: 1px;
+    flex: 1;
+    margin: 0 0.35rem;
+    align-self: center;
 }
 
 /* Divider between active and inactive sessions */

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -703,3 +703,111 @@
     }
 }
 
+/* ==========================================================================
+   Appearance panel
+   ========================================================================== */
+
+.appearance-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.appearance-setting {
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem;
+}
+
+.appearance-setting h3 {
+    margin: 0 0 0.25rem 0;
+    font-size: 1rem;
+    color: var(--text-primary);
+}
+
+.appearance-setting .setting-description {
+    margin: 0 0 1rem 0;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.orientation-choices {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.orientation-choice {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    color: var(--text-secondary);
+    font: inherit;
+}
+
+.orientation-choice:hover {
+    border-color: var(--text-secondary);
+    color: var(--text-primary);
+}
+
+.orientation-choice.active {
+    border-color: var(--accent);
+    background: rgba(122, 162, 247, 0.1);
+    color: var(--text-primary);
+}
+
+.orientation-label {
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+/* Schematic previews for the two orientations */
+.orientation-preview {
+    width: 120px;
+    height: 80px;
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    display: flex;
+    overflow: hidden;
+}
+
+.orientation-preview.horizontal {
+    flex-direction: column;
+}
+
+.orientation-preview.vertical {
+    flex-direction: row;
+}
+
+.orientation-preview .preview-rail-h {
+    height: 16px;
+    background: rgba(122, 162, 247, 0.4);
+    border-bottom: 1px solid var(--border);
+}
+
+.orientation-preview .preview-rail-v {
+    width: 26px;
+    background: rgba(122, 162, 247, 0.4);
+    border-right: 1px solid var(--border);
+}
+
+.orientation-preview .preview-body {
+    flex: 1;
+    background: repeating-linear-gradient(
+        45deg,
+        rgba(255, 255, 255, 0.02),
+        rgba(255, 255, 255, 0.02) 4px,
+        rgba(255, 255, 255, 0.04) 4px,
+        rgba(255, 255, 255, 0.04) 8px
+    );
+}
+


### PR DESCRIPTION
## Summary

Adds a new **Appearance** tab in Settings with a toggle that flips the session pill rail between its current horizontal placement (across the top) and a new vertical layout down the left side of the dashboard.

The preference is stored in `localStorage` (`claude-portal-rail-orientation`) and applied on dashboard mount. When the user changes it in Settings and navigates back, the dashboard re-reads the value and updates the layout.

## What changed

- **`frontend/src/pages/dashboard/types.rs`** — new `RailOrientation` enum and `load_rail_orientation` / `save_rail_orientation` helpers (mirrors the existing `load_show_cost` pattern).
- **`frontend/src/pages/settings/appearance_panel.rs`** — new panel with two radio-style cards, each showing a small schematic preview of the layout.
- **`frontend/src/pages/settings/mod.rs`** — adds the **Appearance** tab.
- **`frontend/src/pages/dashboard/page.rs`** — reads orientation on mount, wraps the rail + session views in `.dashboard-body.rail-horizontal|vertical`, re-syncs from localStorage when the settings panel closes.
- **`frontend/styles/session-rail.css`** — vertical rail styling: flex column, right border, fixed 240 px width, pills stretch full width.
- **`frontend/styles/settings.css`** — appearance panel + schematic preview styles.

No backend changes; the setting is purely browser-local.

Bumped to **2.5.1**.

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo clippy -p frontend --target wasm32-unknown-unknown` — clean
- [x] `trunk build` — success, assets bundle
- [ ] **Manual** (I cannot drive a browser from here): toggle the setting in Settings, return to dashboard, confirm pills move to the left rail and the session view fills the remaining width; toggle back and confirm horizontal layout is restored. Refresh the page and confirm the choice persists.