### PR TITLE
Pause auto-scroll on scroll-up; add jump-to-live pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.2
+
+- Pause auto-scroll when the user scrolls up to read older output; new messages no longer yank the view to the bottom
+- Show a floating "Jump to live ↓" pill in the messages area when tailing is paused; click to resume
+
 ## 2.5.1
 
 - Add Appearance tab in Settings with a horizontal-vs-vertical toggle for the session pill rail

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.1"
+version = "2.5.2"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -146,6 +146,12 @@ pub enum SessionViewMsg {
     FinishDeparture,
     /// Send an interrupt to stop the current Claude response
     Interrupt,
+    /// Scroll position crossed the at-bottom threshold. Sent by the scroll
+    /// listener only on transitions so we can re-render to show/hide the
+    /// jump-to-live pill. The actual flag lives on `should_autoscroll`.
+    AutoscrollChanged,
+    /// User clicked the "Jump to live" pill: resume tailing and scroll to bottom.
+    JumpToLive,
 }
 
 /// SessionView - Main terminal view for a single session
@@ -323,13 +329,21 @@ impl Component for SessionView {
             if first_render {
                 let should_autoscroll = self.should_autoscroll.clone();
                 let element_clone = element.clone();
+                let link = ctx.link().clone();
 
                 let closure = Closure::new(move || {
                     let scroll_top = element_clone.scroll_top();
                     let scroll_height = element_clone.scroll_height();
                     let client_height = element_clone.client_height();
                     let at_bottom = scroll_height - scroll_top - client_height < 50;
-                    *should_autoscroll.borrow_mut() = at_bottom;
+                    // Only dispatch a Yew re-render on a transition — scroll
+                    // events fire continuously and a per-event update would
+                    // wreck performance on long message lists.
+                    let mut current = should_autoscroll.borrow_mut();
+                    if *current != at_bottom {
+                        *current = at_bottom;
+                        link.send_message(SessionViewMsg::AutoscrollChanged);
+                    }
                 });
 
                 let _ = element
@@ -914,6 +928,18 @@ impl Component for SessionView {
                 }
                 true
             }
+            SessionViewMsg::AutoscrollChanged => {
+                // The scroll listener already updated `should_autoscroll`;
+                // returning true here just re-renders so the jump-to-live
+                // pill appears or disappears.
+                true
+            }
+            SessionViewMsg::JumpToLive => {
+                *self.should_autoscroll.borrow_mut() = true;
+                // rendered() will see the flag and snap to bottom on the
+                // next paint.
+                true
+            }
         }
     }
 
@@ -1033,6 +1059,12 @@ impl Component for SessionView {
             "session-view-input"
         };
 
+        let is_tailing = *self.should_autoscroll.borrow();
+        let on_jump_to_live = link.callback(|e: MouseEvent| {
+            e.stop_propagation();
+            SessionViewMsg::JumpToLive
+        });
+
         html! {
             <div class="session-view" onclick={close_dropdown}>
                 <div class="session-view-scroll-area">
@@ -1047,6 +1079,15 @@ impl Component for SessionView {
                             html! { <MessageRenderer key={format!("p{}", i)} json={json.clone()} session_id={Some(ctx.props().session.id)} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} /> }
                         })}
                     </div>
+                    if !is_tailing {
+                        <button
+                            class="jump-to-live-pill"
+                            onclick={on_jump_to_live}
+                            title="Resume live tailing of new messages"
+                        >
+                            { "Jump to live ↓" }
+                        </button>
+                    }
                     { self.render_tasks_sidebar(ctx) }
                 </div>
 

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -144,3 +144,32 @@
     min-width: 0; /* Allow flex child to shrink below content size */
     overscroll-behavior: contain; /* Prevent iOS rubber-banding from escaping this container */
 }
+
+/* Floating "Jump to live" pill shown when the user has scrolled up.
+   Clicking it re-arms auto-tailing and snaps the messages view to bottom. */
+.jump-to-live-pill {
+    position: absolute;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 5;
+    padding: 0.4rem 0.9rem;
+    background: var(--accent);
+    color: var(--bg-dark);
+    border: none;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+    transition: transform 0.12s ease, background 0.12s ease;
+}
+
+.jump-to-live-pill:hover {
+    background: var(--accent-hover);
+    transform: translateX(-50%) translateY(-1px);
+}
+
+.jump-to-live-pill:active {
+    transform: translateX(-50%) translateY(0);
+}


### PR DESCRIPTION
## Summary

When the user scrolls up to read earlier output, the messages view no longer yanks back to the bottom every time a new message arrives. A floating "Jump to live ↓" pill appears at the bottom of the message area while tailing is paused; clicking it resumes auto-scroll and snaps to the latest message.

## Mechanism

The infra was already 80% there: `session_view/component.rs:322` had a scroll listener that flipped a `should_autoscroll` flag based on a 50 px "at bottom" threshold, and only auto-scrolled when the flag was true. The missing pieces were

1. **Re-rendering when the flag flips.** The previous closure mutated a `RefCell<bool>` silently — Yew never knew, so the render couldn't react. Now the closure compares the new value against the cached previous one and dispatches `SessionViewMsg::AutoscrollChanged` only on transitions (no per-event re-render storm on long lists).
2. **The pill itself.** Rendered inside `.session-view-scroll-area` (which is already `position: relative`) when `should_autoscroll` is false. Click dispatches `SessionViewMsg::JumpToLive`, which sets the flag back to true; `rendered()` then snaps to bottom on the next paint via the existing scroll-to-bottom logic.

## What changed

- `frontend/src/pages/dashboard/session_view/component.rs`: two new `SessionViewMsg` variants (`AutoscrollChanged`, `JumpToLive`), transition-only dispatch in the scroll listener, pill rendered conditionally in the view.
- `frontend/styles/session-terminal.css`: `.jump-to-live-pill` — accent-colored pill centered above the input, with hover lift.

Bumped to **2.5.2**.

## Test plan

- [x] `cargo test --workspace`, `cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings`, `cargo fmt`
- [ ] **Manual**: scroll up in a long session, send a new message → view stays put, pill appears; click pill → snaps to bottom, pill disappears; scrolling back to within 50 px of bottom also auto-resumes tailing