### PR TITLE
Stabilize message group keys to preserve expand state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.3
+
+- Stabilize expand/collapse state of message components across new messages: bash command toggle, `ExpandableText` "... more chars", and image viewer no longer reset when later messages arrive
+- Keys for message groups and grouped messages now derive from `_created_at` instead of position, so inserting a user message between assistant groups stops invalidating later groups' identity
+
 ## 2.5.2
 
 - Pause auto-scroll when the user scrolls up to read older output; new messages no longer yank the view to the bottom

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.2"
+version = "2.5.3"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -37,9 +37,30 @@ pub enum MessageGroup {
 }
 
 impl MessageGroup {
-    /// Stable key for this group based on its position in the message list.
+    /// Stable key for this group derived from the first message's identity.
+    ///
+    /// A positional index would change whenever an earlier group gets added
+    /// or removed, causing Yew to throw away the group component and reset
+    /// internal state of every expandable/collapsible inside it (bash
+    /// command toggle, `ExpandableText`, image viewer, etc.). Using the
+    /// first message's `_created_at` keeps the key stable across reorderings.
+    /// `index` is used only as a fallback when no timestamp is present.
     pub fn key(&self, index: usize) -> yew::virtual_dom::Key {
-        yew::virtual_dom::Key::from(format!("g{}", index))
+        let first = match self {
+            MessageGroup::Single(json) => json,
+            MessageGroup::AssistantGroup(messages) => match messages.first() {
+                Some(j) => j,
+                None => return yew::virtual_dom::Key::from(format!("g{}", index)),
+            },
+        };
+        let prefix = match self {
+            MessageGroup::Single(_) => "s",
+            MessageGroup::AssistantGroup(_) => "g",
+        };
+        match extract_raw_iso(first) {
+            Some(iso) => yew::virtual_dom::Key::from(format!("{}-{}", prefix, iso)),
+            None => yew::virtual_dom::Key::from(format!("{}{}", prefix, index)),
+        }
     }
 }
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -198,7 +198,14 @@ pub fn render_assistant_group(messages: &[String], timestamp: Option<&str>) -> H
             </div>
             <div class="message-body">
                 { for messages.iter().enumerate().map(|(i, json)| {
-                    html! { <GroupedMessageContent key={format!("m{}", i)} json={json.clone()} /> }
+                    // Key by the message's `_created_at` when available, so
+                    // streaming/insert reordering doesn't reset expandable
+                    // state inside the body. Fall back to positional index
+                    // for messages predating the `_created_at` field.
+                    let key = extract_raw_iso(json)
+                        .map(|iso| format!("m-{}", iso))
+                        .unwrap_or_else(|| format!("m{}", i));
+                    html! { <GroupedMessageContent {key} json={json.clone()} /> }
                 })}
             </div>
             if let Some(iso) = last_iso {


### PR DESCRIPTION
## Summary

Fixes the long-standing issue where expand/collapse state in message components — the bash command toggle, `ExpandableText` "... more chars", image viewer expand — resets whenever a new message arrives.

## Root cause

Two layers of identity were derived from positional index:

1. `MessageGroup::key(index)` returned `g{index}` — when a new user message arrived between two assistant groups, every subsequent group's key shifted (`g2` → `g3` etc.), so Yew threw the group component away and recreated it from scratch, wiping every nested `use_state`.
2. The children of `render_assistant_group` were keyed `m{i}` positional — same shift problem when ordering within the group changed.

## Fix

Both keys now derive from the message's `_created_at` ISO timestamp (already present on every persisted/portal message):

- Group key: `g-{first message's _created_at}` for assistant groups, `s-{_created_at}` for singles. Positional index is kept as a fallback for any legacy messages without `_created_at`.
- Per-message key within an assistant group: `m-{_created_at}`.

State preservation is now structural — the keyed component identity survives reordering, insertion of unrelated messages, and streaming updates that re-evaluate the group's prop bag.

## Scope

This is the structural fix and should address the most common reproduction. Block-level keys (e.g. on individual `ToolUse`/`ToolResult` content blocks inside a single message) would be a further defensive step but aren't strictly necessary — content blocks within a message arrive append-only, so position-based matching still works.

Bumped to **2.5.3** (anticipating #669 lands as 2.5.2).

## Test plan

- [x] `cargo test --workspace`, `cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings`, `cargo fmt`
- [ ] **Manual**: in a long session, click to expand a bash command's truncated output; then trigger new messages (assistant turn + user message); verify the bash stays expanded
- [ ] **Manual**: same for `ExpandableText` ("... NNN more chars") in tool results
- [ ] **Manual**: open an image lightbox — well, that's modal so it's a separate code path, but worth confirming