### PR TITLE
Fix vertical pill rail not laying out as left column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.4
+
+- Fix vertical pill rail orientation: previous CSS selector targeted the wrong element (`.session-rail` is wrapped in `.session-rail-container`, so a direct-child combinator never matched); now styles the wrapper for the left-column layout
+
 ## 2.5.3
 
 - Stabilize expand/collapse state of message components across new messages: bash command toggle, `ExpandableText` "... more chars", and image viewer no longer reset when later messages arrive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.3"
+version = "2.5.4"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -24,33 +24,46 @@
     overflow-x: auto;
 }
 
-/* Vertical rail: pills stack down the left, the views fill the remainder. */
-.dashboard-body.rail-vertical > .session-rail {
+/* Vertical rail: pills stack down the left, the views fill the remainder.
+   The actual direct child of `.dashboard-body` is `.session-rail-container`
+   (which wraps the rail plus the floating dropdown and dialogs), so the
+   left-column box is applied to that wrapper. The inner `.session-rail` is
+   then styled via a descendant combinator to switch its flex direction
+   and scrolling axis. */
+.dashboard-body.rail-vertical > .session-rail-container {
+    width: 240px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--border);
+    overflow: hidden;
+}
+
+.dashboard-body.rail-vertical .session-rail {
+    flex: 1;
     flex-direction: column;
     gap: 0.35rem;
     padding: 0.75rem 0.5rem;
-    border-right: 1px solid var(--border);
     border-bottom: none;
     overflow-x: visible;
     overflow-y: auto;
-    width: 240px;
-    flex-shrink: 0;
+    width: auto;
 }
 
-.dashboard-body.rail-vertical > .session-rail .session-pill {
+.dashboard-body.rail-vertical .session-pill {
     width: 100%;
     white-space: normal;
 }
 
 /* Flip the active/inactive divider so it reads horizontally in vertical mode. */
-.dashboard-body.rail-vertical > .session-rail .session-rail-divider {
+.dashboard-body.rail-vertical .session-rail-divider {
     flex-direction: row;
     align-self: stretch;
     justify-content: center;
     padding: 0.25rem 0;
 }
 
-.dashboard-body.rail-vertical > .session-rail .session-rail-divider .divider-line {
+.dashboard-body.rail-vertical .session-rail-divider .divider-line {
     width: auto;
     height: 1px;
     flex: 1;


### PR DESCRIPTION
## Summary

The Appearance setting added in #668 lets you choose Horizontal or Vertical for the session pill rail, but vertical mode had no visible effect — pills remained across the top. Reported live by the user.

## Root cause

`SessionRail` actually renders this DOM (`session_rail.rs:878`):

```
<div class="session-rail-container">
  <div class="session-rail">…pills…</div>
  <div class="pill-dropdown">…</div>
  …dialogs…
</div>
```

`.session-rail` is **not** a direct child of `.dashboard-body` — it's wrapped in `.session-rail-container`. My PR #668 CSS used direct-child combinators like `.dashboard-body.rail-vertical > .session-rail { … }`, which never matched.

## Fix

Target the actual direct child for the layout box, and use a descendant combinator for the rail's internals:

- `.dashboard-body.rail-vertical > .session-rail-container` gets `width: 240px; flex-shrink: 0; display: flex; flex-direction: column; border-right; overflow: hidden;` — this is the new left column.
- `.dashboard-body.rail-vertical .session-rail` switches to `flex-direction: column`, fills the wrapper with `flex: 1`, and scrolls vertically.
- The pill, divider, and divider-line tweaks now use descendant combinators too.

Horizontal mode is unchanged.

Bumped to **2.5.4**.

## Test plan

- [x] `cargo build --workspace`
- [ ] **Manual**: in Settings → Appearance, switch to Vertical → pills should appear in a 240 px-wide column down the left side; the session view fills the rest. Switching back to Horizontal restores the top-bar layout.