### PR TITLE
Bump claude-codes 2.1.117 to 2.1.140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.7
+
+- Bump `claude-codes` 2.1.117 → 2.1.140 — fixes a latent proxy data-loss bug where the structured `tool_use_result` field (e.g. AskUserQuestion's `{questions, answers}`, Bash's `{stdout, stderr, exit_code}`) was being dropped by the typed serde round-trip in the proxy on the way to the frontend
+- Also picks up `UserMessage.timestamp` (CLI-emitted ISO-8601 timestamp echoed alongside tool results)
+
 ## 2.5.6
 
 - Force pills to actually stack vertically in vertical-rail mode (the previous fix laid out the wrapper as a left column but pills inside the rail still flowed horizontally on some browsers). Adds `!important` on `flex-direction: column` and `overflow-x/y` for the vertical rail, plus `align-items: stretch` so pills take full column width.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.6"
+version = "2.5.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.6"
+version = "2.5.7"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -562,9 +562,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.117"
+version = "2.1.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23967b5fb3249e0e950d27cfe32a029cad6967b232ae3e1b938d37b0ba23a4d"
+checksum = "46aa3a5f22bb526e7d1aba0bea447ece47a023093cd3c353b3c04381eaadb16b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.6"
+version = "2.5.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.6"
+version = "2.5.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.6"
+version = "2.5.7"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.6"
+version = "2.5.7"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.6"
+version = "2.5.7"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.6"
+version = "2.5.7"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.6"
+version = "2.5.7"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -39,7 +39,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = "2.1.117"
+claude-codes = "2.1.140"
 
 # Codex CLI integration
 codex-codes = { version = "0.101.1", default-features = false, features = ["types"] }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 
 # Claude Code types (WASM-compatible, no tokio)
-claude-codes = { version = "2.1.117", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.140", default-features = false, features = ["types"] }
 
 # Typed WebSocket endpoints (core traits only — WASM-safe, no features needed)
 ws-bridge = { workspace = true }


### PR DESCRIPTION
## Summary

Updates `claude-codes` from 2.1.117 to 2.1.140. The 23-patch bump is purely additive — no API surface changes — but it fixes a **latent data-loss bug in the proxy** that affects messages flowing to the frontend.

## What 2.1.140 changes

From the upstream CHANGELOG:

> Added: `UserMessage.tool_use_result` — `Option<serde_json::Value>` capturing the top-level structured tool result the CLI emits alongside `tool_result` content blocks (e.g. `{ questions, answers }` for `AskUserQuestion`, `{ stdout, stderr, exit_code }` for `Bash`). **Previously dropped during deserialization, which broke proxies relaying user messages to viewers that read the field.**

Also added: `UserMessage.timestamp` (CLI-emitted ISO-8601 timestamp on echoed tool results) and a typed accessor `UserMessage::tool_use_result_as<T>()`.

## Effect on this codebase

The proxy's output forwarder does this:

```rust
let content = serde_json::to_value(&output).unwrap_or(...);
```

where `output: ClaudeOutput`. Before 2.1.140, `UserMessage` had no `tool_use_result` field, so the typed parse + re-serialize round-trip silently dropped that field on the way to the WS. With 2.1.140 the field is captured and preserved.

The frontend doesn't currently *read* `tool_use_result` (it renders AskUserQuestion answers from the tool_result content block), so this bump doesn't add UI surface — it just plugs the data leak so the field is available to any future code (or downstream consumer) that wants it.

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo build --workspace` — clean
- [ ] Manual smoke: launch a session, trigger AskUserQuestion, answer it, confirm nothing regresses in the rendered conversation