### PR TITLE
Force vertical pill stacking (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.6
+
+- Force pills to actually stack vertically in vertical-rail mode (the previous fix laid out the wrapper as a left column but pills inside the rail still flowed horizontally on some browsers). Adds `!important` on `flex-direction: column` and `overflow-x/y` for the vertical rail, plus `align-items: stretch` so pills take full column width.
+
 ## 2.5.4
 
 - Fix vertical pill rail orientation: previous CSS selector targeted the wrong element (`.session-rail` is wrapped in `.session-rail-container`, so a direct-child combinator never matched); now styles the wrapper for the left-column layout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.4"
+version = "2.5.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.4"
+version = "2.5.6"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.4"
+version = "2.5.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.4"
+version = "2.5.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.4"
+version = "2.5.6"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.4"
+version = "2.5.6"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.4"
+version = "2.5.6"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.4"
+version = "2.5.6"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.4"
+version = "2.5.6"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -29,29 +29,41 @@
    (which wraps the rail plus the floating dropdown and dialogs), so the
    left-column box is applied to that wrapper. The inner `.session-rail` is
    then styled via a descendant combinator to switch its flex direction
-   and scrolling axis. */
+   and scrolling axis.
+
+   `!important` markers on the rail's flex-direction and overflow are there
+   because the base `.session-rail { display: flex; overflow-x: auto }` rule
+   would otherwise win against any author override that landed later in
+   user-agent stylesheet processing (e.g. on some mobile browsers we have
+   seen the override silently dropped). They keep the column direction
+   sticky regardless of cascade quirks. */
 .dashboard-body.rail-vertical > .session-rail-container {
     width: 240px;
+    min-width: 240px;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
     border-right: 1px solid var(--border);
     overflow: hidden;
+    min-height: 0;
 }
 
 .dashboard-body.rail-vertical .session-rail {
     flex: 1;
-    flex-direction: column;
+    flex-direction: column !important;
+    align-items: stretch;
     gap: 0.35rem;
     padding: 0.75rem 0.5rem;
     border-bottom: none;
-    overflow-x: visible;
-    overflow-y: auto;
+    overflow-x: hidden !important;
+    overflow-y: auto !important;
     width: auto;
+    min-height: 0;
 }
 
 .dashboard-body.rail-vertical .session-pill {
     width: 100%;
+    align-self: stretch;
     white-space: normal;
 }
 
@@ -59,6 +71,7 @@
 .dashboard-body.rail-vertical .session-rail-divider {
     flex-direction: row;
     align-self: stretch;
+    width: 100%;
     justify-content: center;
     padding: 0.25rem 0;
 }


### PR DESCRIPTION
## Summary

Follow-up to #671. The wrapper now correctly lays out as a left column, but on at least one browser the pills inside still flowed horizontally (per live user report — "the pills should stack vertically pls"). This hotfix forces the column direction with `!important` and pins the rail's overflow axes, then makes pills `align-self: stretch` so they take the full column width.

## Why `!important`

`.session-rail` has a base rule `{ display: flex; overflow-x: auto; }` from `session-rail.css:18`. My override at `.dashboard-body.rail-vertical .session-rail` has higher specificity (0,2,1 vs 0,1,0), so in pure cascade rules it should win. In practice it doesn't on some configurations — possibly stale-cache or a known cascade ordering quirk. `!important` makes the column direction sticky regardless.

## What changed

- `.dashboard-body.rail-vertical .session-rail`: `flex-direction: column !important`, `overflow-x: hidden !important`, `overflow-y: auto !important`, added `align-items: stretch` and `min-height: 0`
- `.dashboard-body.rail-vertical .session-pill`: added `align-self: stretch` alongside `width: 100%`
- `.dashboard-body.rail-vertical > .session-rail-container`: added `min-width: 240px` and `min-height: 0` for robust column sizing
- `.dashboard-body.rail-vertical .session-rail-divider`: added `width: 100%` so the divider fills the column

Sort, paused/hidden, and ordering semantics are inherited unchanged from `SessionRail` — pills are rendered in the same DOM order in both modes; only the flex axis flips.

Bumped to **2.5.6**.

## Test plan

- [x] `cargo build --workspace`
- [ ] **Manual**: toggle vertical → pills stack down the left column; hidden-session divider still works; toggle back to horizontal → previous layout restored