### PR TITLE
Pin rustup PATH on macOS CI runners to fix flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,15 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
 
+      # Some macos-14 runner image variants ship a preinstalled `rustup-init`
+      # ahead of `~/.cargo/bin` in PATH. When that wins, `cargo build` resolves
+      # to `rustup-init` instead of the rustup-managed cargo shim and dies
+      # with `error: unexpected argument 'build' found`. Forcing the rustup
+      # bin dir to the front of PATH for subsequent steps makes the build
+      # robust to that runner-image rollout.
+      - name: Ensure rustup PATH wins over preinstalled shim
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
@@ -287,6 +296,13 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
+
+      # See `build-proxy-macos-arm64` for the rationale — some macos-14
+      # runner image variants have `rustup-init` shadowing the rustup cargo
+      # shim in PATH, which makes `cargo build` fail with
+      # `unexpected argument 'build' found`.
+      - name: Ensure rustup PATH wins over preinstalled shim
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,14 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
 
+      # Some macos-14 runner image variants ship a preinstalled `rustup-init`
+      # ahead of `~/.cargo/bin` in PATH. When that wins, `cargo build` resolves
+      # to `rustup-init` and dies with `unexpected argument 'build' found`.
+      # Forcing the rustup bin dir to the front of PATH makes the build
+      # robust to that runner-image rollout.
+      - name: Ensure rustup PATH wins over preinstalled shim
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
@@ -135,6 +143,11 @@ jobs:
         uses: dtolnay/rust-toolchain@1.92.0
         with:
           targets: x86_64-apple-darwin
+
+      # See `build-macos-arm64` for the rationale — preinstalled `rustup-init`
+      # can shadow the rustup cargo shim on some macos-14 image variants.
+      - name: Ensure rustup PATH wins over preinstalled shim
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.8
+
+- CI: prepend `$HOME/.cargo/bin` to PATH on macOS jobs in `ci.yml` and `release.yml` to work around a `macos-14` runner image variant where a preinstalled `rustup-init` shadowed the rustup-managed `cargo` shim, causing intermittent `error: unexpected argument 'build' found` failures
+
 ## 2.5.7
 
 - Bump `claude-codes` 2.1.117 → 2.1.140 — fixes a latent proxy data-loss bug where the structured `tool_use_result` field (e.g. AskUserQuestion's `{questions, answers}`, Bash's `{stdout, stderr, exit_code}`) was being dropped by the typed serde round-trip in the proxy on the way to the frontend

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.7"
+version = "2.5.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.7"
+version = "2.5.8"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.7"
+version = "2.5.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.7"
+version = "2.5.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.7"
+version = "2.5.8"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.7"
+version = "2.5.8"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.7"
+version = "2.5.8"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.7"
+version = "2.5.8"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.7"
+version = "2.5.8"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## Summary

The `Build {Proxy,Launcher} (macOS ARM64)` jobs have been flaking intermittently with:

```
error: error: unexpected argument 'build' found
Usage: rustup-init[EXE] [OPTIONS]
```

That's `cargo build` resolving to `rustup-init` instead of the rustup-managed cargo shim. Same SHA, same workflow, same `macos-14` label — but some runner instances ship an image variant where a preinstalled `rustup-init` is ahead of `$HOME/.cargo/bin` in PATH, shadowing the cargo shim that `dtolnay/rust-toolchain` installs.

## Fix

Prepend `$HOME/.cargo/bin` to PATH for subsequent steps right after the toolchain install on every macOS job:

```yaml
- name: Ensure rustup PATH wins over preinstalled shim
  run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
```

`$GITHUB_PATH` writes a new front-of-PATH entry that persists for the remainder of the job, so `cargo` resolves to the rustup shim every time regardless of which image variant the runner picked up.

Applied to four macOS jobs (with a comment explaining the why on each, the first verbose and the others cross-referencing):

- `ci.yml`: `build-proxy-macos-arm64`, `build-launcher-macos-arm64`
- `release.yml`: `build-macos-arm64`, `build-macos-intel`

## Why not pin the runner image?

GitHub doesn't expose runner image SHAs as `runs-on` labels — `macos-14` always points to "current latest macos-14 image" and rolls forward when GitHub publishes refreshes. You can switch OS major version (`macos-13` / `macos-14` / `macos-15`), but you can't pin to a specific image build. Hardening the workflow PATH is durable across whatever image churn happens upstream.

Bumped to **2.5.8**.

## Test plan

- [x] Local YAML edits — no app code changed
- [ ] CI: this PR should pass macOS jobs reliably, including on a re-run; merge then watch the next few main runs to confirm the flake is gone