### PR TITLE
Rail position: add top/bottom/left/right options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.9
+
+- Expand the rail position setting from horizontal/vertical to four choices: **Top**, **Bottom**, **Left**, **Right**. Top is unchanged (default); Bottom places the rail under the input bar; Left and Right place the rail as a 240 px column on either side. Existing `horizontal`/`vertical` localStorage values are auto-migrated to `top`/`left`.
+
 ## 2.5.8
 
 - CI: prepend `$HOME/.cargo/bin` to PATH on macOS jobs in `ci.yml` and `release.yml` to work around a `macos-14` runner image variant where a preinstalled `rustup-init` shadowed the rustup-managed `cargo` shim, causing intermittent `error: unexpected argument 'build' found` failures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.5.9
 
 - Expand the rail position setting from horizontal/vertical to four choices: **Top**, **Bottom**, **Left**, **Right**. Top is unchanged (default); Bottom places the rail under the input bar; Left and Right place the rail as a 240 px column on either side. Existing `horizontal`/`vertical` localStorage values are auto-migrated to `top`/`left`.
+- Halve the left padding on the message stream (1.5 rem → 0.75 rem) so message bodies sit closer to the left edge.
 
 ## 2.5.8
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.8"
+version = "2.5.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.8"
+version = "2.5.9"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.8"
+version = "2.5.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.8"
+version = "2.5.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.8"
+version = "2.5.9"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.8"
+version = "2.5.9"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.8"
+version = "2.5.9"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.8"
+version = "2.5.9"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.8"
+version = "2.5.9"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/mod.rs
+++ b/frontend/src/pages/dashboard/mod.rs
@@ -13,4 +13,4 @@ mod session_view;
 mod types;
 
 pub use page::DashboardPage;
-pub use types::{load_rail_orientation, save_rail_orientation, RailOrientation};
+pub use types::{load_rail_position, save_rail_position, RailPosition};

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -3,7 +3,7 @@
 use super::session_rail::{ActivityRef, SessionRail};
 use super::session_view::SessionView;
 use super::types::{
-    load_hidden_sessions, load_inactive_hidden, load_rail_orientation, load_show_cost,
+    load_hidden_sessions, load_inactive_hidden, load_rail_position, load_show_cost,
     save_hidden_sessions, save_inactive_hidden, save_show_cost,
 };
 use crate::components::LaunchDialog;
@@ -49,7 +49,7 @@ pub fn dashboard_page() -> Html {
     let hidden_sessions = use_state(load_hidden_sessions);
     let inactive_hidden = use_state(load_inactive_hidden);
     let show_cost = use_state(load_show_cost);
-    let rail_orientation = use_state(load_rail_orientation);
+    let rail_position = use_state(load_rail_position);
     let connected_sessions = use_state(HashSet::<Uuid>::new);
     let pending_leave = use_state(|| None::<Uuid>);
     let is_admin = use_state(|| false);
@@ -326,12 +326,12 @@ pub fn dashboard_page() -> Html {
 
     let close_settings = {
         let show_settings = show_settings.clone();
-        let rail_orientation = rail_orientation.clone();
+        let rail_position = rail_position.clone();
         Callback::from(move |_: ()| {
             // The Appearance panel may have changed this; re-sync from
             // localStorage so the dashboard picks up the new value when
             // the user navigates back.
-            rail_orientation.set(load_rail_orientation());
+            rail_position.set(load_rail_position());
             show_settings.set(false);
         })
     };
@@ -716,7 +716,7 @@ pub fn dashboard_page() -> Html {
                 </div>
             } else {
                 <>
-                    <div class={classes!("dashboard-body", rail_orientation.body_class())}>
+                    <div class={classes!("dashboard-body", rail_position.body_class())}>
                     // Session Rail
                     <SessionRail
                         sessions={active_sessions.clone()}

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -124,25 +124,35 @@ pub fn save_show_cost(show: bool) {
     }
 }
 
-/// Orientation of the session pill rail on the dashboard.
+/// Where the session pill rail sits on the dashboard.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RailOrientation {
-    Horizontal,
-    Vertical,
+pub enum RailPosition {
+    Top,
+    Bottom,
+    Left,
+    Right,
 }
 
-impl RailOrientation {
+impl RailPosition {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Horizontal => "horizontal",
-            Self::Vertical => "vertical",
+            Self::Top => "top",
+            Self::Bottom => "bottom",
+            Self::Left => "left",
+            Self::Right => "right",
         }
     }
 
+    /// Parse a stored preference value. Accepts both the new four-value form
+    /// (`top`/`bottom`/`left`/`right`) and the legacy two-value form
+    /// (`horizontal` → top, `vertical` → left) so older browser local storage
+    /// entries keep working without forcing the user to re-pick.
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
-            "horizontal" => Some(Self::Horizontal),
-            "vertical" => Some(Self::Vertical),
+            "top" | "horizontal" => Some(Self::Top),
+            "bottom" => Some(Self::Bottom),
+            "left" | "vertical" => Some(Self::Left),
+            "right" => Some(Self::Right),
             _ => None,
         }
     }
@@ -150,14 +160,16 @@ impl RailOrientation {
     /// CSS class applied to the dashboard body wrapper.
     pub fn body_class(self) -> &'static str {
         match self {
-            Self::Horizontal => "rail-horizontal",
-            Self::Vertical => "rail-vertical",
+            Self::Top => "rail-top",
+            Self::Bottom => "rail-bottom",
+            Self::Left => "rail-left",
+            Self::Right => "rail-right",
         }
     }
 }
 
-/// Load rail orientation preference from localStorage (default: horizontal).
-pub fn load_rail_orientation() -> RailOrientation {
+/// Load rail position preference from localStorage (default: top).
+pub fn load_rail_position() -> RailPosition {
     web_sys::window()
         .and_then(|w| w.local_storage().ok().flatten())
         .and_then(|storage| {
@@ -166,14 +178,14 @@ pub fn load_rail_orientation() -> RailOrientation {
                 .ok()
                 .flatten()
         })
-        .and_then(|v| RailOrientation::from_str(&v))
-        .unwrap_or(RailOrientation::Horizontal)
+        .and_then(|v| RailPosition::from_str(&v))
+        .unwrap_or(RailPosition::Top)
 }
 
-/// Save rail orientation preference to localStorage.
-pub fn save_rail_orientation(orientation: RailOrientation) {
+/// Save rail position preference to localStorage.
+pub fn save_rail_position(position: RailPosition) {
     if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
-        let _ = storage.set_item(RAIL_ORIENTATION_STORAGE_KEY, orientation.as_str());
+        let _ = storage.set_item(RAIL_ORIENTATION_STORAGE_KEY, position.as_str());
     }
 }
 

--- a/frontend/src/pages/settings/appearance_panel.rs
+++ b/frontend/src/pages/settings/appearance_panel.rs
@@ -1,28 +1,16 @@
-use crate::pages::dashboard::{load_rail_orientation, save_rail_orientation, RailOrientation};
+use crate::pages::dashboard::{load_rail_position, save_rail_position, RailPosition};
 use yew::prelude::*;
+
+const ALL_POSITIONS: &[(RailPosition, &str)] = &[
+    (RailPosition::Top, "Top"),
+    (RailPosition::Bottom, "Bottom"),
+    (RailPosition::Left, "Left"),
+    (RailPosition::Right, "Right"),
+];
 
 #[function_component(AppearancePanel)]
 pub fn appearance_panel() -> Html {
-    let orientation = use_state(load_rail_orientation);
-
-    let set_horizontal = {
-        let orientation = orientation.clone();
-        Callback::from(move |_: MouseEvent| {
-            save_rail_orientation(RailOrientation::Horizontal);
-            orientation.set(RailOrientation::Horizontal);
-        })
-    };
-
-    let set_vertical = {
-        let orientation = orientation.clone();
-        Callback::from(move |_: MouseEvent| {
-            save_rail_orientation(RailOrientation::Vertical);
-            orientation.set(RailOrientation::Vertical);
-        })
-    };
-
-    let is_horizontal = *orientation == RailOrientation::Horizontal;
-    let is_vertical = *orientation == RailOrientation::Vertical;
+    let position = use_state(load_rail_position);
 
     html! {
         <section class="appearance-section">
@@ -36,31 +24,47 @@ pub fn appearance_panel() -> Html {
             <div class="appearance-setting">
                 <h3>{ "Session pill menu" }</h3>
                 <p class="setting-description">
-                    { "Place the session pills along the top of the page, or down the left side." }
+                    { "Pick where the session pill rail sits on the dashboard." }
                 </p>
                 <div class="orientation-choices">
-                    <button
-                        class={classes!("orientation-choice", is_horizontal.then_some("active"))}
-                        onclick={set_horizontal}
-                    >
-                        <div class="orientation-preview horizontal">
-                            <div class="preview-rail-h"></div>
-                            <div class="preview-body"></div>
-                        </div>
-                        <span class="orientation-label">{ "Horizontal (top)" }</span>
-                    </button>
-                    <button
-                        class={classes!("orientation-choice", is_vertical.then_some("active"))}
-                        onclick={set_vertical}
-                    >
-                        <div class="orientation-preview vertical">
-                            <div class="preview-rail-v"></div>
-                            <div class="preview-body"></div>
-                        </div>
-                        <span class="orientation-label">{ "Vertical (left)" }</span>
-                    </button>
+                    { for ALL_POSITIONS.iter().copied().map(|(pos, label)| {
+                        let active = *position == pos;
+                        let position_setter = position.clone();
+                        let on_click = Callback::from(move |_: MouseEvent| {
+                            save_rail_position(pos);
+                            position_setter.set(pos);
+                        });
+                        html! {
+                            <button
+                                key={pos.as_str()}
+                                class={classes!("orientation-choice", active.then_some("active"))}
+                                onclick={on_click}
+                            >
+                                <div class={classes!("orientation-preview", pos.as_str())}>
+                                    { preview_inner(pos) }
+                                </div>
+                                <span class="orientation-label">{ label }</span>
+                            </button>
+                        }
+                    })}
                 </div>
             </div>
         </section>
+    }
+}
+
+/// Schematic preview inside each choice button — a tiny mockup of the
+/// dashboard showing where the rail (accent stripe) sits relative to
+/// the message body (hatched pattern).
+fn preview_inner(pos: RailPosition) -> Html {
+    let rail_class = match pos {
+        RailPosition::Top | RailPosition::Bottom => "preview-rail-h",
+        RailPosition::Left | RailPosition::Right => "preview-rail-v",
+    };
+    html! {
+        <>
+            <div class={rail_class}></div>
+            <div class="preview-body"></div>
+        </>
     }
 }

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -2,8 +2,16 @@
    Session Rail - Horizontal Carousel
    ========================================================================== */
 
-/* Wraps the rail + session views so we can swap the carousel orientation
-   without touching the rail or view components themselves. */
+/* Wraps the rail + session views so we can swap the rail position without
+   touching the rail or view components themselves. Four positions:
+     rail-top    — rail above messages (default)
+     rail-bottom — rail under everything (below the input bar)
+     rail-left   — rail down the left side
+     rail-right  — rail down the right side
+   The DOM is `.dashboard-body > .session-rail-container > .session-rail`
+   (with `.session-views-container` as the rail-container's sibling). For
+   left/right we make the rail-container the column-sized flex item; for
+   top/bottom we flip the dashboard-body's main axis (column / column-reverse). */
 .dashboard-body {
     flex: 1;
     display: flex;
@@ -11,9 +19,10 @@
     min-height: 0;
 }
 
-.dashboard-body.rail-vertical {
-    flex-direction: row;
-}
+.dashboard-body.rail-top    { flex-direction: column; }
+.dashboard-body.rail-bottom { flex-direction: column-reverse; }
+.dashboard-body.rail-left   { flex-direction: row; }
+.dashboard-body.rail-right  { flex-direction: row-reverse; }
 
 .session-rail {
     display: flex;
@@ -24,31 +33,39 @@
     overflow-x: auto;
 }
 
-/* Vertical rail: pills stack down the left, the views fill the remainder.
+/* In bottom-position mode the rail sits under the views/input so the
+   horizontal divider line lives on its top edge instead of its bottom. */
+.dashboard-body.rail-bottom .session-rail {
+    border-bottom: none;
+    border-top: 1px solid var(--border);
+}
+
+/* Vertical positions (left/right): the rail becomes a 240px-wide column.
    The actual direct child of `.dashboard-body` is `.session-rail-container`
    (which wraps the rail plus the floating dropdown and dialogs), so the
-   left-column box is applied to that wrapper. The inner `.session-rail` is
-   then styled via a descendant combinator to switch its flex direction
-   and scrolling axis.
+   column-sized box is applied to that wrapper. The inner `.session-rail` is
+   then styled via a descendant combinator to switch its flex direction and
+   scrolling axis.
 
-   `!important` markers on the rail's flex-direction and overflow are there
-   because the base `.session-rail { display: flex; overflow-x: auto }` rule
-   would otherwise win against any author override that landed later in
-   user-agent stylesheet processing (e.g. on some mobile browsers we have
-   seen the override silently dropped). They keep the column direction
-   sticky regardless of cascade quirks. */
-.dashboard-body.rail-vertical > .session-rail-container {
+   `!important` on the rail's flex-direction and overflow keeps the column
+   direction sticky against the base rule's `overflow-x: auto`, which on
+   some browser cascades has shadowed the override. */
+.dashboard-body.rail-left  > .session-rail-container,
+.dashboard-body.rail-right > .session-rail-container {
     width: 240px;
     min-width: 240px;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
-    border-right: 1px solid var(--border);
     overflow: hidden;
     min-height: 0;
 }
 
-.dashboard-body.rail-vertical .session-rail {
+.dashboard-body.rail-left  > .session-rail-container { border-right: 1px solid var(--border); }
+.dashboard-body.rail-right > .session-rail-container { border-left:  1px solid var(--border); }
+
+.dashboard-body.rail-left .session-rail,
+.dashboard-body.rail-right .session-rail {
     flex: 1;
     flex-direction: column !important;
     align-items: stretch;
@@ -61,14 +78,17 @@
     min-height: 0;
 }
 
-.dashboard-body.rail-vertical .session-pill {
+.dashboard-body.rail-left .session-pill,
+.dashboard-body.rail-right .session-pill {
     width: 100%;
     align-self: stretch;
     white-space: normal;
 }
 
-/* Flip the active/inactive divider so it reads horizontally in vertical mode. */
-.dashboard-body.rail-vertical .session-rail-divider {
+/* Flip the active/inactive divider so it reads horizontally inside the
+   vertical column rather than vertically across it. */
+.dashboard-body.rail-left .session-rail-divider,
+.dashboard-body.rail-right .session-rail-divider {
     flex-direction: row;
     align-self: stretch;
     width: 100%;
@@ -76,7 +96,8 @@
     padding: 0.25rem 0;
 }
 
-.dashboard-body.rail-vertical .session-rail-divider .divider-line {
+.dashboard-body.rail-left .session-rail-divider .divider-line,
+.dashboard-body.rail-right .session-rail-divider .divider-line {
     width: auto;
     height: 1px;
     flex: 1;

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -140,7 +140,7 @@
     flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 1rem 1.5rem 0;
+    padding: 1rem 1.5rem 0 0.75rem;
     min-width: 0; /* Allow flex child to shrink below content size */
     overscroll-behavior: contain; /* Prevent iOS rubber-banding from escaping this container */
 }

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -769,7 +769,7 @@
     font-weight: 500;
 }
 
-/* Schematic previews for the two orientations */
+/* Schematic previews for each rail position */
 .orientation-preview {
     width: 120px;
     height: 80px;
@@ -780,13 +780,10 @@
     overflow: hidden;
 }
 
-.orientation-preview.horizontal {
-    flex-direction: column;
-}
-
-.orientation-preview.vertical {
-    flex-direction: row;
-}
+.orientation-preview.top    { flex-direction: column; }
+.orientation-preview.bottom { flex-direction: column-reverse; }
+.orientation-preview.left   { flex-direction: row; }
+.orientation-preview.right  { flex-direction: row-reverse; }
 
 .orientation-preview .preview-rail-h {
     height: 16px;
@@ -794,10 +791,20 @@
     border-bottom: 1px solid var(--border);
 }
 
+.orientation-preview.bottom .preview-rail-h {
+    border-bottom: none;
+    border-top: 1px solid var(--border);
+}
+
 .orientation-preview .preview-rail-v {
     width: 26px;
     background: rgba(122, 162, 247, 0.4);
     border-right: 1px solid var(--border);
+}
+
+.orientation-preview.right .preview-rail-v {
+    border-right: none;
+    border-left: 1px solid var(--border);
 }
 
 .orientation-preview .preview-body {


### PR DESCRIPTION
## Summary

Expand the Appearance setting from the two-choice horizontal/vertical toggle to four positions:

- **Top** (default) — current behaviour, rail above messages
- **Bottom** — rail sits at the bottom of the dashboard area, *below* the input bar (`flex-direction: column-reverse` on the wrapper)
- **Left** — rail down the left side, 240 px column (was the previous "vertical")
- **Right** — rail down the right side, 240 px column

Settings panel shows four schematic preview cards.

## Migration

The localStorage key stays `claude-portal-rail-orientation` for backward compatibility. The parser accepts both the new values and the legacy two-value form (`horizontal` → top, `vertical` → left), so existing users keep whatever they picked without having to re-choose. New writes always use the four-value form.

## Implementation notes

- `RailOrientation` enum renamed to `RailPosition` with four variants.
- `body_class()` returns `rail-{top,bottom,left,right}`; the dashboard-body wrapper switches its flex axis based on the class.
- Bottom uses `column-reverse` so the rail visually sits below the views without needing to restructure the DOM. The rail's horizontal divider moves from the bottom edge to the top edge in this position.
- Left/right share the same column-styling rules via grouped selectors; only the side border differs.

Bumped to **2.5.9**.

## Test plan

- [x] `cargo test --workspace`, `cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings`, `cargo fmt`
- [ ] **Manual**: cycle through all four positions in Settings → Appearance, confirm:
  - Top: unchanged
  - Bottom: rail at the bottom under the input bar
  - Left / Right: 240 px column on respective side
  - Refresh: choice persists
- [ ] **Manual migration check**: open the app with an old `vertical` localStorage value, confirm it loads as Left