### PR TITLE
Fix KaTeX math (#676), copy icon (#675), and input prompt spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.10
+
+- Fix #676 — LaTeX math no longer drops when a message mixes equations with markdown that contains `_` (e.g. `$\sigma_{1D}$`). Math regions (`$…$`, `$$…$$`, `\(…\)`, `\[…\]`) are now extracted before markdown parsing so pulldown-cmark can't split equation text on emphasis-meta characters; the math is restored verbatim in `Event::Text` so KaTeX auto-render can find the delimiters in a single DOM text node. Skips inline-code, fenced-code, and `$5`-style dollar amounts.
+- Fix #675 — Copy button icon swapped to the canonical Lucide two-overlapping-rectangles glyph so the copy affordance is immediately readable.
+- Tighten horizontal spacing between the `>` prompt and the input textarea (negative margin-right of 0.35 rem on `.input-prompt`).
+
 ## 2.5.9
 
 - Expand the rail position setting from horizontal/vertical to four choices: **Top**, **Bottom**, **Left**, **Right**. Top is unchanged (default); Bottom places the rail under the input bar; Left and Right place the rail as a 240 px column on either side. Existing `horizontal`/`vertical` localStorage values are auto-migrated to `top`/`left`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.9"
+version = "2.5.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.9"
+version = "2.5.10"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.9"
+version = "2.5.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.9"
+version = "2.5.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.9"
+version = "2.5.10"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.9"
+version = "2.5.10"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.9"
+version = "2.5.10"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.9"
+version = "2.5.10"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.9"
+version = "2.5.10"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/copy_button.rs
+++ b/frontend/src/components/copy_button.rs
@@ -58,9 +58,11 @@ pub fn copy_button(props: &CopyButtonProps) -> Html {
             if *copied {
                 { "\u{2713}" }
             } else {
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
-                    <rect x="4" y="4" width="9" height="10" rx="1.2" />
-                    <path d="M4 4V3a1 1 0 0 1 1-1h7a1 1 0 0 1 1 1v8" />
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2"
+                    stroke-linecap="round" stroke-linejoin="round">
+                    <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+                    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
                 </svg>
             }
         </button>

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -45,16 +45,180 @@ fn markdown_view(props: &MarkdownViewProps) -> Html {
         });
     }
 
+    // Protect math regions ($…$, $$…$$, \(…\), \[…\]) from pulldown-cmark by
+    // replacing them with private-use placeholders BEFORE parsing. Otherwise
+    // pulldown-cmark would interpret `_` inside an equation as emphasis (and
+    // `*`, etc.) which splits the math text across DOM elements and prevents
+    // KaTeX's auto-render from matching the surrounding delimiters.
+    let (pre_processed, math_blocks) = extract_math_placeholders(&props.text);
+
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
     options.insert(Options::ENABLE_STRIKETHROUGH);
 
-    let parser = Parser::new_ext(&props.text, options);
+    let parser = Parser::new_ext(&pre_processed, options);
     let events: Vec<Event> = parser.collect();
+    let events = restore_math_in_events(events, &math_blocks);
 
     html! {
         <span ref={node_ref}>{ render_events(&events) }</span>
     }
+}
+
+const MATH_OPEN: char = '\u{E000}';
+const MATH_CLOSE: char = '\u{E001}';
+
+/// Scan `text` for math regions (`$…$`, `$$…$$`, `\(…\)`, `\[…\]`) outside of
+/// inline-code spans and fenced code blocks, and replace each occurrence with a
+/// private-use placeholder of the form `\u{E000}MATH<idx>\u{E001}`. Returns the
+/// rewritten text plus the original math literals indexed by `<idx>`.
+fn extract_math_placeholders(text: &str) -> (String, Vec<String>) {
+    let bytes = text.as_bytes();
+    let mut output = String::with_capacity(text.len());
+    let mut math_blocks: Vec<String> = Vec::new();
+    let mut i = 0;
+    let mut in_code_fence = false;
+    let mut in_inline_code = false;
+
+    while i < bytes.len() {
+        // Fenced code block toggle (``` at start of a line or after a newline)
+        if bytes[i] == b'`' && bytes.get(i + 1) == Some(&b'`') && bytes.get(i + 2) == Some(&b'`') {
+            output.push_str("```");
+            i += 3;
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            let c = text[i..].chars().next().unwrap();
+            output.push(c);
+            i += c.len_utf8();
+            continue;
+        }
+        // Inline-code toggle
+        if bytes[i] == b'`' {
+            output.push('`');
+            i += 1;
+            in_inline_code = !in_inline_code;
+            continue;
+        }
+        if in_inline_code {
+            let c = text[i..].chars().next().unwrap();
+            output.push(c);
+            i += c.len_utf8();
+            continue;
+        }
+        // Display math: $$…$$
+        if bytes[i] == b'$' && bytes.get(i + 1) == Some(&b'$') {
+            if let Some(rel) = text[i + 2..].find("$$") {
+                let end = i + 2 + rel + 2;
+                emit_placeholder(&mut output, &mut math_blocks, &text[i..end]);
+                i = end;
+                continue;
+            }
+        }
+        // LaTeX-style display: \[…\]
+        if bytes[i] == b'\\' && bytes.get(i + 1) == Some(&b'[') {
+            if let Some(rel) = text[i + 2..].find("\\]") {
+                let end = i + 2 + rel + 2;
+                emit_placeholder(&mut output, &mut math_blocks, &text[i..end]);
+                i = end;
+                continue;
+            }
+        }
+        // LaTeX-style inline: \(…\)
+        if bytes[i] == b'\\' && bytes.get(i + 1) == Some(&b'(') {
+            if let Some(rel) = text[i + 2..].find("\\)") {
+                let end = i + 2 + rel + 2;
+                emit_placeholder(&mut output, &mut math_blocks, &text[i..end]);
+                i = end;
+                continue;
+            }
+        }
+        // Inline math: $…$ on a single line. Skip dollar amounts ("$5", "$100")
+        // by requiring the character after `$` not to be a digit or whitespace.
+        if bytes[i] == b'$' {
+            let line_end = text[i + 1..]
+                .find('\n')
+                .map(|n| i + 1 + n)
+                .unwrap_or(bytes.len());
+            if let Some(rel) = text[i + 1..line_end].find('$') {
+                let after = bytes.get(i + 1).copied();
+                let before_close_idx = i + 1 + rel;
+                let before_close = bytes.get(before_close_idx.saturating_sub(1)).copied();
+                let looks_like_money =
+                    matches!(after, Some(c) if c.is_ascii_digit() || c == b' ' || c == b'\t');
+                let trailing_money = matches!(before_close, Some(b' ') | Some(b'\t'));
+                if !looks_like_money && !trailing_money {
+                    let end = before_close_idx + 1;
+                    emit_placeholder(&mut output, &mut math_blocks, &text[i..end]);
+                    i = end;
+                    continue;
+                }
+            }
+        }
+
+        let c = text[i..].chars().next().unwrap();
+        output.push(c);
+        i += c.len_utf8();
+    }
+
+    (output, math_blocks)
+}
+
+fn emit_placeholder(output: &mut String, math_blocks: &mut Vec<String>, math: &str) {
+    let idx = math_blocks.len();
+    math_blocks.push(math.to_string());
+    output.push(MATH_OPEN);
+    output.push_str("MATH");
+    output.push_str(&idx.to_string());
+    output.push(MATH_CLOSE);
+}
+
+/// Walk the event stream and replace placeholders inside `Event::Text` (or the
+/// related `Event::Code` / `Event::Html` text variants where they may end up)
+/// with the original math literals so that KaTeX can find the `$`/`\(` delimiters.
+fn restore_math_in_events<'a>(events: Vec<Event<'a>>, math_blocks: &[String]) -> Vec<Event<'a>> {
+    events
+        .into_iter()
+        .map(|e| match e {
+            Event::Text(t) => {
+                if t.contains(MATH_OPEN) {
+                    Event::Text(restore_math(&t, math_blocks).into())
+                } else {
+                    Event::Text(t)
+                }
+            }
+            other => other,
+        })
+        .collect()
+}
+
+fn restore_math(text: &str, math_blocks: &[String]) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars();
+    while let Some(c) = chars.next() {
+        if c == MATH_OPEN {
+            let mut token = String::new();
+            for tc in chars.by_ref() {
+                if tc == MATH_CLOSE {
+                    break;
+                }
+                token.push(tc);
+            }
+            if let Some(n_str) = token.strip_prefix("MATH") {
+                if let Ok(idx) = n_str.parse::<usize>() {
+                    if let Some(math) = math_blocks.get(idx) {
+                        out.push_str(math);
+                        continue;
+                    }
+                }
+            }
+            // Malformed: drop silently
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// Convert pulldown-cmark events to Yew Html
@@ -736,5 +900,58 @@ mod tests {
             .iter()
             .any(|e| matches!(e, Event::Start(Tag::TableHead)));
         assert!(has_table_head, "Expected TableHead event");
+    }
+
+    #[test]
+    fn test_extract_math_inline_with_underscore() {
+        // The bug case: pulldown-cmark would otherwise treat `_{1D}` as emphasis,
+        // splitting the equation across an <em> element and breaking KaTeX.
+        let (out, blocks) = extract_math_placeholders("So $\\sigma_{1D}$ is small.");
+        assert_eq!(blocks, vec!["$\\sigma_{1D}$"]);
+        assert!(out.contains(MATH_OPEN));
+        assert!(out.contains(MATH_CLOSE));
+        assert!(!out.contains('_'));
+    }
+
+    #[test]
+    fn test_extract_math_display_block() {
+        let input = "Math: $$X(t)\\sim\\text{Pink}(0,1) \\quad S_{XX}(f)$$\nthen text.";
+        let (out, blocks) = extract_math_placeholders(input);
+        assert_eq!(blocks.len(), 1);
+        assert!(blocks[0].starts_with("$$") && blocks[0].ends_with("$$"));
+        assert!(out.contains("then text."));
+    }
+
+    #[test]
+    fn test_extract_math_round_trip() {
+        let input = "Inline $a_1 + b_2$ and display $$\\sigma_{XX}$$ done.";
+        let (out, blocks) = extract_math_placeholders(input);
+        // Restoring placeholders should reproduce the original text verbatim.
+        assert_eq!(restore_math(&out, &blocks), input);
+    }
+
+    #[test]
+    fn test_extract_math_skips_inline_code() {
+        // Math-looking syntax inside backticks must not be extracted.
+        let input = "Use `$1` as the price marker.";
+        let (out, blocks) = extract_math_placeholders(input);
+        assert!(
+            blocks.is_empty(),
+            "no math should be extracted from inline code: blocks={:?}",
+            blocks
+        );
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn test_extract_math_skips_dollar_amounts() {
+        // "$5 and $10" looks like inline math to a naïve scanner but isn't.
+        let input = "I have $5 and $10 left.";
+        let (_out, blocks) = extract_math_placeholders(input);
+        assert!(
+            blocks.is_empty(),
+            "money amounts shouldn't be extracted: blocks={:?}",
+            blocks
+        );
     }
 }

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -18,6 +18,7 @@
     font-weight: bold;
     font-size: 1.1rem;
     padding-bottom: 0.5rem;
+    margin-right: -0.35rem;
 }
 
 .session-view-input .message-input {


### PR DESCRIPTION
Bundle of three small fixes from this session.

## #676 — KaTeX equations don't render inside math-heavy messages

**Root cause.** Pulldown-cmark treats `_` and `*` as emphasis markers even *inside* `$…$` and `$$…$$` math regions. An expression like `\$\sigma_{1D}\$` gets parsed as `\$\sigma<em>{1D}</em>\$`, which splits the equation text across DOM elements. KaTeX's auto-render then can't find a contiguous `\$…\$` span to typeset.

**Fix.** Pre-process the markdown text before pulldown-cmark sees it: replace every math region with an opaque private-use placeholder (`\u{E000}MATH<idx>\u{E001}`), let the markdown parser do its thing, then restore the original math literal inside each `Event::Text` before rendering. The math reaches the DOM as a single text node and KaTeX picks it up.

Scanner skips fenced code blocks, inline-code spans, and `\$5`-style dollar amounts. Supports `\$…\$`, `\$\$…\$\$`, `\(…\)`, and `\[…\]` delimiters (same set the KaTeX auto-render is configured for).

Five new unit tests in `markdown.rs` covering:
- Inline math with underscore subscripts
- Display math with `_` in subscripts and tables
- Round-trip: extracted text round-tripped through `restore_math` is byte-identical to the original
- Math-looking syntax inside inline code is preserved as-is
- Dollar amounts (`\$5 and \$10 left.`) are not extracted

## #675 — Copy button icon

Swapped the bespoke L-shape SVG for the canonical Lucide \"Copy\" glyph (two overlapping rounded rectangles). Reads as a copy action immediately.

## Tighter input prompt

`-0.35 rem` margin-right on the `>` prompt so the textarea sits closer to it. The flex container's 0.75 rem gap still applies between other input bar items.

Bumped to **2.5.10**.

## Test plan

- [x] `cargo test --workspace` — all green, new math tests pass
- [x] `cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings` — clean
- [x] `cargo fmt`
- [ ] **Manual**: paste the failing message body from #676 into a session and confirm math renders
- [ ] **Manual**: verify copy button looks like a copy icon now and the resting tooltip says \"Copy\"
- [ ] **Manual**: confirm the `>` prompt sits visibly tighter against the textarea