### PR TITLE
Trim message stream + prompt margins; brighter active pill; shrink pill width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.5.11
+
+- Trim message stream right/bottom padding to match the previously-halved left side (1.5 rem → 0.75 rem right; bottom 0 → 0.5 rem)
+- Tighten the `>` input prompt on both sides (negative left margin to match the existing negative right margin)
+- Bright-red active pill indicator (was accent blue) so the focused session is immediately obvious
+- Pill text width shrunk by 20 % (150 → 120 px) and the `▼` menu toggle now sits above the text in stacking order (z-index 2) so it stays readable when folder/branch labels are long
+
 ## 2.5.10
 
 - Fix #676 — LaTeX math no longer drops when a message mixes equations with markdown that contains `_` (e.g. `$\sigma_{1D}$`). Math regions (`$…$`, `$$…$$`, `\(…\)`, `\[…\]`) are now extracted before markdown parsing so pulldown-cmark can't split equation text on emphasis-meta characters; the math is restored verbatim in `Event::Text` so KaTeX auto-render can find the delimiters in a single DOM text node. Skips inline-code, fenced-code, and `$5`-style dollar amounts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.10"
+version = "2.5.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.10"
+version = "2.5.11"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.10"
+version = "2.5.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.10"
+version = "2.5.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.10"
+version = "2.5.11"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.10"
+version = "2.5.11"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.10"
+version = "2.5.11"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.10"
+version = "2.5.11"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.10"
+version = "2.5.11"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -18,6 +18,7 @@
     font-weight: bold;
     font-size: 1.1rem;
     padding-bottom: 0.5rem;
+    margin-left: -0.35rem;
     margin-right: -0.35rem;
 }
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -166,9 +166,9 @@
 }
 
 .session-pill.focused {
-    border-color: var(--accent);
-    background: rgba(122, 162, 247, 0.2);
-    box-shadow: 0 0 0 2px rgba(122, 162, 247, 0.3);
+    border-color: #ff3b5c;
+    background: rgba(255, 59, 92, 0.18);
+    box-shadow: 0 0 0 2px rgba(255, 59, 92, 0.45);
 }
 
 .session-pill.awaiting {
@@ -202,8 +202,10 @@
 .pill-name {
     display: flex;
     flex-direction: column;
-    width: 150px;
+    width: 120px;
     overflow: hidden;
+    position: relative;
+    z-index: 1;
 }
 
 .pill-folder {
@@ -439,7 +441,8 @@
     color: #f7768e;
 }
 
-/* Pill menu toggle (▼ button) */
+/* Pill menu toggle (▼ button). Positioned above pill-name in stacking order
+   so overflowing folder/branch text can't visually cover the dropdown affordance. */
 .pill-menu-toggle {
     background: transparent;
     border: none;
@@ -450,6 +453,8 @@
     border-radius: 4px;
     transition: color 0.15s, background 0.15s;
     flex-shrink: 0;
+    position: relative;
+    z-index: 2;
 }
 
 .pill-menu-toggle:hover {

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -140,7 +140,7 @@
     flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 1rem 1.5rem 0 0.75rem;
+    padding: 1rem 0.75rem 0.5rem 0.75rem;
     min-width: 0; /* Allow flex child to shrink below content size */
     overscroll-behavior: contain; /* Prevent iOS rubber-banding from escaping this container */
 }


### PR DESCRIPTION
Bundle of UI polish from a single user pass.

## Message stream padding

Matched the previously-halved left padding on the other two soft edges:

- right: 1.5 rem → 0.75 rem
- bottom: 0 → 0.5 rem (was 0 — text was hugging the input bar)
- top + left: unchanged

## Input prompt (`>`)

`-0.35 rem` margin-left mirrors the existing margin-right, so the `>` is now tightened on both sides instead of only the textarea side.

## Active pill: bright red

`.session-pill.focused` switched from accent-blue (`var(--accent)`) to a punchy `#ff3b5c` with a stronger 45 % outer-glow. The focused/selected session pill is now immediately obvious at a glance.

Awaiting + focused (`.focused.awaiting`) is unchanged — still uses the existing red palette with the pulse animation.

## Pill width −20 %, menu toggle on top

- `.pill-name` width 150 → 120 px (20 % smaller; folder / hostname / branch get more aggressive ellipsis)
- `.pill-name` is `position: relative; z-index: 1`; `.pill-menu-toggle` is `position: relative; z-index: 2` — the `▼` menu affordance stays visually on top even when text is squeezed, matching the user's "text in a layer below the menu triangle" request.

Bumped to **2.5.11**.

## Test plan

- [x] `cargo build --workspace`, `cargo test --workspace`
- [ ] **Manual**: focused pill now reads as red; non-focused pills unchanged
- [ ] **Manual**: long folder/branch names ellipsize earlier; `▼` never gets eaten by overflowing text
- [ ] **Manual**: messages have visible breathing room at the bottom now, less white space on the right
- [ ] **Manual**: the `>` sits visibly closer to both edges of its slot in the input bar