### PR TITLE
Actually shrink pill width (chrome trim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.12
+
+- Actually shrink the session pill width — #680's `.pill-name` change only knocked ~14% off the outer pill since the surrounding chrome stayed the same size. Pill-name width 120 → 100 px, pill horizontal padding 0.75 → 0.55 rem, and inter-item gap 0.5 → 0.35 rem, for ~25% total outer-width reduction in horizontal mode.
+
 ## 2.5.11
 
 - Trim message stream right/bottom padding to match the previously-halved left side (1.5 rem → 0.75 rem right; bottom 0 → 0.5 rem)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.11"
+version = "2.5.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.11"
+version = "2.5.12"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.11"
+version = "2.5.12"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.11"
+version = "2.5.12"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.11"
+version = "2.5.12"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.11"
+version = "2.5.12"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.11"
+version = "2.5.12"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.11"
+version = "2.5.12"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.11"
+version = "2.5.12"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -148,8 +148,8 @@
     position: relative;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
+    gap: 0.35rem;
+    padding: 0.5rem 0.55rem;
     background: rgba(0, 0, 0, 0.3);
     border: 1px solid var(--border);
     border-radius: 20px;
@@ -202,7 +202,7 @@
 .pill-name {
     display: flex;
     flex-direction: column;
-    width: 120px;
+    width: 100px;
     overflow: hidden;
     position: relative;
     z-index: 1;


### PR DESCRIPTION
## Why a follow-up

PR #680 shrunk `.pill-name` from 150 → 120 px (the inner text-region), which only knocked ~14 % off the outer pill — the surrounding padding + gaps + status icon + menu toggle stayed the same size. The menu toggle visibly moved inward, but the pill outline barely changed.

This PR trims the chrome too, getting the visible reduction closer to the intended 20 % (actually closer to ~25 %):

- `.pill-name` width 120 → **100 px**
- `.session-pill` horizontal padding `0.75 rem` → **0.55 rem**
- `.session-pill` inter-item gap `0.5 rem` → **0.35 rem**

Vertical mode (`.rail-left` / `.rail-right`) is unaffected — pills there are `width: 100%` of the 240 px column.

Bumped to **2.5.12**.

## Test plan

- [x] `cargo build --workspace`
- [ ] **Manual**: pills in horizontal mode are visibly narrower than before this PR; menu toggle still readable; vertical mode unchanged