### PR TITLE
Fix pill width (150px both modes); trim message-to-input gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.13
+
+- Session pills now have an explicit **150 px** width in both horizontal and vertical rail modes — previous content-driven sizing kept getting pushed by long folder names hitting min-content widths inside the flex children. `.pill-name` is `flex: 1; min-width: 0` so it fills the remaining space and ellipsizes cleanly. Vertical-mode `width: 100%` override removed.
+- Trim the gap between the last visible message and the input bar: dropped the 0.5 rem bottom padding I added in 2.5.11 and shrunk the input form's top padding from 0.5 → 0.3 rem.
+
 ## 2.5.12
 
 - Actually shrink the session pill width — #680's `.pill-name` change only knocked ~14% off the outer pill since the surrounding chrome stayed the same size. Pill-name width 120 → 100 px, pill horizontal padding 0.75 → 0.55 rem, and inter-item gap 0.5 → 0.35 rem, for ~25% total outer-width reduction in horizontal mode.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.12"
+version = "2.5.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.12"
+version = "2.5.13"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.12"
+version = "2.5.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.12"
+version = "2.5.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.12"
+version = "2.5.13"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.12"
+version = "2.5.13"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.12"
+version = "2.5.13"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.12"
+version = "2.5.13"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.12"
+version = "2.5.13"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -6,7 +6,7 @@
     display: flex;
     align-items: flex-end;
     gap: 0.75rem;
-    padding: 0.5rem 1rem;
+    padding: 0.3rem 1rem 0.5rem;
     background: var(--bg-darker);
     border-top: 1px solid var(--border);
     position: relative;

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -80,8 +80,8 @@
 
 .dashboard-body.rail-left .session-pill,
 .dashboard-body.rail-right .session-pill {
-    width: 100%;
-    align-self: stretch;
+    /* Same 200px width as horizontal mode — set by the base `.session-pill`
+       rule above. We only need to allow per-pill text wrapping here. */
     white-space: normal;
 }
 
@@ -158,6 +158,13 @@
     transition: all 0.2s;
     flex-shrink: 0;
     overflow: hidden;
+    /* Fixed pill width used in both horizontal and vertical rail modes.
+       Earlier attempts at content-driven shrinking were swamped by long
+       folder names hitting their min-content widths inside the flex
+       children — pinning the outer box is the only reliable way to make
+       horizontal/vertical pills look identical. */
+    width: 150px;
+    box-sizing: border-box;
 }
 
 .session-pill:hover {
@@ -202,7 +209,8 @@
 .pill-name {
     display: flex;
     flex-direction: column;
-    width: 100px;
+    flex: 1;
+    min-width: 0;
     overflow: hidden;
     position: relative;
     z-index: 1;

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -140,7 +140,7 @@
     flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 1rem 0.75rem 0.5rem 0.75rem;
+    padding: 1rem 0.75rem 0 0.75rem;
     min-width: 0; /* Allow flex child to shrink below content size */
     overscroll-behavior: contain; /* Prevent iOS rubber-banding from escaping this container */
 }


### PR DESCRIPTION
## Pill width

Stop fighting content-driven sizing — pin the pill to **150 px** explicitly on `.session-pill` and let `.pill-name` `flex: 1; min-width: 0` fill the remainder. This makes pills:

- The **same size** in horizontal and vertical rail modes (per user ask). Vertical-mode's previous `width: 100%` override is removed.
- Actually that size (no more "menu toggle moved inward but pill stayed wide" because internal min-content was holding it open).
- Cleanly ellipsizing inside, since `min-width: 0` lets the flex child shrink below its intrinsic content width.

## Message-to-input gap

Two-tier shrink:
- `.session-view-messages` bottom padding `0.5 rem → 0` (removes the gap I added back in 2.5.11; messages now sit hard against the input separator).
- `.session-view-input` top padding `0.5 rem → 0.3 rem` (form pulls itself up to the separator).

Combined, the visible empty band between the last message and the textarea drops from ~1 rem to ~0.3 rem.

Bumped to **2.5.13**.

## Test plan

- [x] `cargo build --workspace`
- [ ] **Manual**: pills in horizontal and vertical modes are now visibly the same width (150 px); long folder names ellipsize without pushing the pill wider
- [ ] **Manual**: last message sits visibly closer to the typing bar