### PR TITLE
Voice STT: surface real errors instead of silent immediate VoiceEnded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.14
+
+- Surface speech-to-text errors instead of silently ending the recording. Previously, when the backend speech recognition task failed early (bad credentials, recognizer setup error, Google API rejecting the stream, …), the result channel just closed and the WebSocket handler blindly emitted `VoiceEnded`, so the user saw the mic button "return immediately" with no explanation. Now the recognition task reports its final status via a oneshot channel, and the handler emits `VoiceError` with the actual error string when something went wrong.
+
 ## 2.5.13
 
 - Session pills now have an explicit **150 px** width in both horizontal and vertical rail modes — previous content-driven sizing kept getting pushed by long folder names hitting min-content widths inside the flex children. `.pill-name` is `flex: 1; min-width: 0` so it fills the remaining space and ellipsizes cleanly. Vertical-mode `width: 100%` override removed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.13"
+version = "2.5.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.13"
+version = "2.5.14"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.13"
+version = "2.5.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.13"
+version = "2.5.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.13"
+version = "2.5.14"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.13"
+version = "2.5.14"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.13"
+version = "2.5.14"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.13"
+version = "2.5.14"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.13"
+version = "2.5.14"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/voice.rs
+++ b/backend/src/handlers/voice.rs
@@ -259,9 +259,8 @@ async fn handle_voice_socket(
                                                 );
                                             }
                                             _ => {
-                                                let _ = client_tx_clone.send(
-                                                    VoiceMessage::VoiceEnded { session_id },
-                                                );
+                                                let _ = client_tx_clone
+                                                    .send(VoiceMessage::VoiceEnded { session_id });
                                                 info!(
                                                     "Speech recognition stream ended for session {}",
                                                     session_id

--- a/backend/src/handlers/voice.rs
+++ b/backend/src/handlers/voice.rs
@@ -215,11 +215,15 @@ async fn handle_voice_socket(
 
                             // Start streaming recognition
                             match speech_service.start_streaming(Some(language_code)).await {
-                                Ok((audio_tx, mut result_rx)) => {
+                                Ok((audio_tx, mut result_rx, status_rx)) => {
                                     recognition_session =
                                         Some(VoiceRecognitionSession { audio_tx });
 
-                                    // Spawn task to forward transcription results to client
+                                    // Spawn task to forward transcription results to client.
+                                    // When the result stream closes we await the final status
+                                    // from the recognition task — if it errored, emit
+                                    // `VoiceError` so the user sees a real message instead of
+                                    // a silent immediate `VoiceEnded`.
                                     let client_tx_clone = client_tx.clone();
                                     tokio::spawn(async move {
                                         while let Some(result) = result_rx.recv().await {
@@ -238,14 +242,32 @@ async fn handle_voice_socket(
                                                 break;
                                             }
                                         }
-                                        // Recognition stream ended (e.g., single_utterance detected end of speech)
-                                        // Signal the frontend to stop recording
-                                        let _ = client_tx_clone
-                                            .send(VoiceMessage::VoiceEnded { session_id });
-                                        info!(
-                                            "Speech recognition stream ended for session {}",
-                                            session_id
-                                        );
+                                        match status_rx.await {
+                                            Ok(Some(err)) => {
+                                                warn!(
+                                                    "Speech recognition for session {} ended with error: {}",
+                                                    session_id, err
+                                                );
+                                                let _ = client_tx_clone.send(
+                                                    VoiceMessage::VoiceError {
+                                                        session_id,
+                                                        message: format!(
+                                                            "Speech recognition failed: {}",
+                                                            err
+                                                        ),
+                                                    },
+                                                );
+                                            }
+                                            _ => {
+                                                let _ = client_tx_clone.send(
+                                                    VoiceMessage::VoiceEnded { session_id },
+                                                );
+                                                info!(
+                                                    "Speech recognition stream ended for session {}",
+                                                    session_id
+                                                );
+                                            }
+                                        }
                                     });
 
                                     info!("Speech recognition session started for {}", session_id);

--- a/backend/src/speech.rs
+++ b/backend/src/speech.rs
@@ -86,6 +86,11 @@ impl SpeechService {
     /// Returns a tuple of:
     /// - A sender to push audio data (PCM16 bytes)
     /// - A receiver to get transcription results
+    /// - A receiver that yields a final status string when the session ends
+    ///   (either an error message or `None` meaning clean shutdown). Used by
+    ///   the WebSocket handler to distinguish "speech stream errored out" from
+    ///   "client stopped recording cleanly" and surface a real `VoiceError`
+    ///   instead of a silent `VoiceEnded`.
     ///
     /// The session ends when the audio sender is dropped.
     pub async fn start_streaming(
@@ -95,6 +100,7 @@ impl SpeechService {
         (
             mpsc::UnboundedSender<Vec<u8>>,
             mpsc::UnboundedReceiver<TranscriptionResult>,
+            tokio::sync::oneshot::Receiver<Option<String>>,
         ),
         String,
     > {
@@ -124,17 +130,32 @@ impl SpeechService {
         // Create channels for audio input and transcription output
         let (audio_tx, audio_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         let (result_tx, result_rx) = mpsc::unbounded_channel::<TranscriptionResult>();
+        let (status_tx, status_rx) = tokio::sync::oneshot::channel::<Option<String>>();
 
         // Spawn the recognition task
         let credentials = credentials_path.clone();
         tokio::spawn(async move {
-            match run_recognition(credentials, streaming_config, audio_rx, result_tx).await {
-                Ok(()) => info!("Speech recognition session completed"),
-                Err(e) => error!("Speech recognition error: {}", e),
-            }
+            let final_status = match run_recognition(
+                credentials,
+                streaming_config,
+                audio_rx,
+                result_tx,
+            )
+            .await
+            {
+                Ok(()) => {
+                    info!("Speech recognition session completed");
+                    None
+                }
+                Err(e) => {
+                    error!("Speech recognition error: {}", e);
+                    Some(e)
+                }
+            };
+            let _ = status_tx.send(final_status);
         });
 
-        Ok((audio_tx, result_rx))
+        Ok((audio_tx, result_rx, status_rx))
     }
 }
 

--- a/backend/src/speech.rs
+++ b/backend/src/speech.rs
@@ -135,23 +135,17 @@ impl SpeechService {
         // Spawn the recognition task
         let credentials = credentials_path.clone();
         tokio::spawn(async move {
-            let final_status = match run_recognition(
-                credentials,
-                streaming_config,
-                audio_rx,
-                result_tx,
-            )
-            .await
-            {
-                Ok(()) => {
-                    info!("Speech recognition session completed");
-                    None
-                }
-                Err(e) => {
-                    error!("Speech recognition error: {}", e);
-                    Some(e)
-                }
-            };
+            let final_status =
+                match run_recognition(credentials, streaming_config, audio_rx, result_tx).await {
+                    Ok(()) => {
+                        info!("Speech recognition session completed");
+                        None
+                    }
+                    Err(e) => {
+                        error!("Speech recognition error: {}", e);
+                        Some(e)
+                    }
+                };
             let _ = status_tx.send(final_status);
         });
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -158,11 +158,6 @@
     transition: all 0.2s;
     flex-shrink: 0;
     overflow: hidden;
-    /* Fixed pill width used in both horizontal and vertical rail modes.
-       Earlier attempts at content-driven shrinking were swamped by long
-       folder names hitting their min-content widths inside the flex
-       children — pinning the outer box is the only reliable way to make
-       horizontal/vertical pills look identical. */
     width: 150px;
     box-sizing: border-box;
 }


### PR DESCRIPTION
## Symptom

> On both iOS and macOS the STT button returns immediately.

User taps mic → recording starts → recording instantly ends, no transcript, no error message shown.

## Root cause

The voice WebSocket handler at \`backend/src/handlers/voice.rs:241\` had this flow:

\`\`\`rust
tokio::spawn(async move {
    while let Some(result) = result_rx.recv().await { /* forward */ }
    // Recognition stream ended (e.g., single_utterance detected end of speech)
    let _ = client_tx_clone.send(VoiceMessage::VoiceEnded { session_id });
});
\`\`\`

\`result_rx\` is the transcription-result channel from \`speech.rs::start_streaming\`. It closes when \`run_recognition\` returns — **for any reason**:

- Google credentials path missing or unreadable
- Recognizer creation failure (auth, network, gRPC)
- Streaming RPC immediately rejected by the API

In all those cases, \`result_tx\` is dropped, \`result_rx.recv\` returns \`None\`, the loop exits, and \`VoiceEnded\` is fired. The user sees the mic button "return immediately" with no error message.

The error was being logged on the server (line 133 in \`speech.rs\`) but never made it to the client.

## Fix

\`SpeechService::start_streaming\` now returns a third channel — a \`tokio::sync::oneshot::Receiver<Option<String>>\` — that carries the recognition task's final status (\`Some(error_string)\` on failure, \`None\` on clean shutdown).

In \`voice.rs\`, after the result-forwarding loop exits we await that status channel and emit either:

- \`VoiceError { message: "Speech recognition failed: <reason>" }\` if there was an error, or
- \`VoiceEnded\` if it ended cleanly (matching the previous behavior for normal completion)

That gives the user (and us) a real error string when STT actually fails. We can then diagnose whether it's bad credentials, a Google API change, an auth-token rotation, etc.

## Why we shipped 2.4.30 already and it's back

CHANGELOG note: 2.4.30 disabled Google's \`single_utterance\` mode to stop the API auto-ending on silence. That's still in place (\`single_utterance: false\` is the default, see \`speech.rs:53\`), so the current immediate-end isn't a recurrence of that bug — it's a different upstream failure (credentials / recognizer / network) being silently swallowed.

Bumped to **2.5.14**.

## Test plan

- [x] \`cargo build --workspace\`, \`cargo test --workspace\` — green
- [ ] **Manual (post-deploy)**: tap mic, observe the actual error message in the UI. That will tell us what's broken (credentials file path, GOOGLE_APPLICATION_CREDENTIALS env, API auth, etc.) and we can fix it as a follow-up.