### PR TITLE
Widen pills 20% (150→180px) and tighten vertical tray (240→200px)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.15
+
+- Pills are now 180 px wide (was 150 px, +20%) and the vertical rail tray shrinks from 240 → 200 px to match — no more dead space on the right of the column.
+
 ## 2.5.14
 
 - Surface speech-to-text errors instead of silently ending the recording. Previously, when the backend speech recognition task failed early (bad credentials, recognizer setup error, Google API rejecting the stream, …), the result channel just closed and the WebSocket handler blindly emitted `VoiceEnded`, so the user saw the mic button "return immediately" with no explanation. Now the recognition task reports its final status via a oneshot channel, and the handler emits `VoiceError` with the actual error string when something went wrong.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.14"
+version = "2.5.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.14"
+version = "2.5.15"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.14"
+version = "2.5.15"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.14"
+version = "2.5.15"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.14"
+version = "2.5.15"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.14"
+version = "2.5.15"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.14"
+version = "2.5.15"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.14"
+version = "2.5.15"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.14"
+version = "2.5.15"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -52,8 +52,8 @@
    some browser cascades has shadowed the override. */
 .dashboard-body.rail-left  > .session-rail-container,
 .dashboard-body.rail-right > .session-rail-container {
-    width: 240px;
-    min-width: 240px;
+    width: 200px;
+    min-width: 200px;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
@@ -158,7 +158,7 @@
     transition: all 0.2s;
     flex-shrink: 0;
     overflow: hidden;
-    width: 150px;
+    width: 180px;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
Pills are 20% wider (150 → **180 px**), and the vertical rail tray that holds them is shrunk to match (240 → **200 px**) — the previous tray was sized for the old 150 px pill and had visible dead space on the right side of the column.

Horizontal mode is unaffected by the tray change; the rail in that orientation is content-width with horizontal scroll, so wider pills just take more space in the strip.

Bumped to **2.5.15**.

## Test plan

- [x] \`cargo build --workspace\`
- [ ] **Manual**: vertical rail column now visibly snug to the wider pills (no empty right margin)
- [ ] **Manual**: horizontal rail unchanged in vibe; pills are 20% wider so a few less fit on screen before scrolling kicks in