### PR TITLE
KaTeX: queue on cold-load race + browser console diagnostics (#684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2.5.16
 
-- Fix #684 — KaTeX math now renders even when the Yew effect fires before the deferred KaTeX scripts have finished loading. The previous `renderMathInNode` silently no-op'd if `window.renderMathInElement` wasn't defined yet; since the effect is keyed on `props.text` and doesn't re-fire for a static message, math stayed un-rendered for the lifetime of the page on cold loads. The helper now queues pending nodes and flushes them once KaTeX is available, and surfaces actual render errors to the browser console instead of swallowing them.
-- Added a regression test confirming math in messages mixing `<thinking>` HTML blocks + fenced ```latex``` code + display `$$…$$` survives the markdown placeholder round-trip into `Event::Text`. This disproved an earlier hypothesis that `<thinking>` was swallowing math placeholders into `Event::Html`.
+- **Fix #684 — KaTeX hasn't actually been rendering math on any page load.** The Subresource Integrity hash on the `<script>` tag for KaTeX's `auto-render.min.js` in `index.html` did not match the file the CDN actually serves. Browsers silently refuse to execute scripts whose SRI hash mismatches, so `window.renderMathInElement` never landed on the page, and every call to our `renderMathInNode` helper silently no-op'd. Verified by a standalone harness (`frontend/dev-tools/katex-isolated.html`) that loads the same scripts from the same CDN and reports "renderMathInElement not on window". Replaced the stale hash with the real `sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk`.
+- Also hardened `katex-helper.js` with a queue-and-retry path for the unlikely cold-load case where the helper fires before the CDN scripts finish loading, and added diagnostic logging so future failures surface in the browser console instead of being silently swallowed.
+- Added a regression test confirming math in messages mixing `<thinking>` HTML blocks + fenced ```latex``` code + display `$$…$$` survives the markdown placeholder round-trip into `Event::Text`. This disproved earlier hypotheses that the bug was in our markdown pipeline.
 
 ## 2.5.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.16
+
+- Fix #684 — KaTeX math now renders even when the Yew effect fires before the deferred KaTeX scripts have finished loading. The previous `renderMathInNode` silently no-op'd if `window.renderMathInElement` wasn't defined yet; since the effect is keyed on `props.text` and doesn't re-fire for a static message, math stayed un-rendered for the lifetime of the page on cold loads. The helper now queues pending nodes and flushes them once KaTeX is available, and surfaces actual render errors to the browser console instead of swallowing them.
+- Added a regression test confirming math in messages mixing `<thinking>` HTML blocks + fenced ```latex``` code + display `$$…$$` survives the markdown placeholder round-trip into `Event::Text`. This disproved an earlier hypothesis that `<thinking>` was swallowing math placeholders into `Event::Html`.
+
 ## 2.5.15
 
 - Pills are now 180 px wide (was 150 px, +20%) and the vertical rail tray shrinks from 240 → 200 px to match — no more dead space on the right of the column.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.15"
+version = "2.5.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.15"
+version = "2.5.16"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.15"
+version = "2.5.16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.15"
+version = "2.5.16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.15"
+version = "2.5.16"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.15"
+version = "2.5.16"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.15"
+version = "2.5.16"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.15"
+version = "2.5.16"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.15"
+version = "2.5.16"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/dev-tools/README.md
+++ b/frontend/dev-tools/README.md
@@ -1,0 +1,26 @@
+# dev-tools
+
+Standalone harnesses for debugging frontend behavior in isolation. Not built
+or shipped — open the HTML file directly in a browser.
+
+## katex-isolated.html
+
+Loads the production KaTeX scripts/version from the same CDN and renders a
+hard-coded sample message through `renderMathInElement` with the exact
+options (delimiters, ignored classes, error color) the app uses. Edit the
+textarea and click **Render** to test arbitrary content.
+
+Use this to disentangle "KaTeX can't render this math" from "our Yew/WASM
+pipeline isn't calling KaTeX correctly". If KaTeX renders the math here
+but not in the deployed app, the bug is on our side. If it fails to render
+here too, the bug is in the math itself (unsupported command, malformed
+delimiter, etc.).
+
+To open:
+
+```sh
+xdg-open frontend/dev-tools/katex-isolated.html
+# or just open it from your file manager
+```
+
+No server required.

--- a/frontend/dev-tools/katex-isolated.html
+++ b/frontend/dev-tools/katex-isolated.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>KaTeX isolation harness</title>
+
+    <!-- Same KaTeX scripts production uses, same versions/integrity hashes. -->
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"
+          integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+"
+          crossorigin="anonymous" />
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"
+            integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg"
+            crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
+            integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rF4+Pp4XXUokR6dwXyo"
+            crossorigin="anonymous"></script>
+
+    <style>
+        body { font-family: system-ui, sans-serif; max-width: 900px; margin: 2rem auto; padding: 0 1rem; background: #1a1b26; color: #c0caf5; }
+        h2 { color: #7aa2f7; margin-top: 2rem; }
+        .panel { background: #16161e; border: 1px solid #292e42; border-radius: 6px; padding: 1rem; margin: 1rem 0; }
+        textarea { width: 100%; min-height: 12rem; background: #0e0e15; color: #c0caf5; border: 1px solid #292e42; padding: 0.5rem; font-family: ui-monospace, monospace; font-size: 0.9rem; }
+        button { background: #7aa2f7; color: #1a1b26; border: none; padding: 0.5rem 1rem; border-radius: 4px; cursor: pointer; font-weight: 500; }
+        button:hover { background: #89b4fa; }
+        .source { white-space: pre-wrap; font-family: ui-monospace, monospace; font-size: 0.85rem; color: #a9b1d6; }
+        #log { background: #0e0e15; border: 1px solid #292e42; padding: 0.5rem; font-family: ui-monospace, monospace; font-size: 0.85rem; min-height: 4rem; color: #f7768e; }
+        #log .ok { color: #9ece6a; }
+        #log .warn { color: #e0af68; }
+        #render { font-size: 1rem; line-height: 1.5; }
+        #render p { margin: 0.5em 0; }
+    </style>
+</head>
+<body>
+    <h1>KaTeX isolation harness</h1>
+    <p>
+        Renders a hard-coded sample message through KaTeX's auto-render
+        extension, with the <strong>exact</strong> options/delimiters/ignored
+        classes that production uses. The point: prove (or disprove) whether
+        KaTeX itself can typeset the message, independent of the Yew/WASM
+        pipeline. Open the browser console for full output.
+    </p>
+
+    <h2>Sample (from issue #684)</h2>
+    <textarea id="src">&lt;thinking&gt;
+
+&lt;/thinking&gt;
+
+Standard incompressible Newtonian form, vector notation:
+
+```latex
+\rho \left( \frac{\partial \mathbf{v}}{\partial t} + (\mathbf{v} \cdot \nabla)\mathbf{v} \right)
+  = -\nabla p + \mu \nabla^{2}\mathbf{v} + \mathbf{f}
+\qquad
+\nabla \cdot \mathbf{v} = 0
+```
+
+Renders as:
+
+$$
+\rho \left( \frac{\partial \mathbf{v}}{\partial t} + (\mathbf{v} \cdot \nabla)\mathbf{v} \right)
+  = -\nabla p + \mu \nabla^{2}\mathbf{v} + \mathbf{f}
+\qquad
+\nabla \cdot \mathbf{v} = 0
+$$
+
+Where:
+- $\rho$ — fluid density
+- $\mathbf{v}$ — velocity field
+- $p$ — pressure field
+- $\mu$ — dynamic viscosity
+- $\mathbf{f}$ — body force per unit volume (e.g. gravity $\rho \mathbf{g}$)</textarea>
+    <p style="margin-top: 0.5rem;">
+        <button onclick="run()">Render</button>
+        <button onclick="raw()">Inspect source (no KaTeX call)</button>
+    </p>
+
+    <h2>Diagnostic log</h2>
+    <div id="log"></div>
+
+    <h2>Rendered output</h2>
+    <div id="render" class="panel"></div>
+
+    <h2>Source after escape-conversion</h2>
+    <div id="source" class="source panel"></div>
+
+    <script>
+        const KATEX_OPTIONS = {
+            delimiters: [
+                { left: '$$', right: '$$', display: true },
+                { left: '$', right: '$', display: false },
+                { left: '\\(', right: '\\)', display: false },
+                { left: '\\[', right: '\\]', display: true },
+            ],
+            ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+            ignoredClasses: ['md-code-block', 'md-inline-code', 'tool-result-content', 'bash-command-inline'],
+            throwOnError: false,
+            errorColor: '#cc6666',
+        };
+
+        function log(msg, cls) {
+            const div = document.createElement('div');
+            if (cls) div.className = cls;
+            div.textContent = msg;
+            document.getElementById('log').appendChild(div);
+        }
+
+        function escapeHtml(s) {
+            return s.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'})[c]);
+        }
+
+        function buildDom(text) {
+            // Approximate what our pipeline ends up emitting: a series of
+            // paragraphs / code blocks / lists with the math as plain text
+            // inside the paragraph or list-item. The point isn't to match
+            // pulldown-cmark's output exactly — it's to give KaTeX a DOM
+            // with the same delimiters in the same positions.
+            const lines = text.split('\n');
+            let html = '';
+            let inCode = false;
+            let codeBuf = [];
+            let inList = false;
+            let para = [];
+            const flushPara = () => {
+                if (para.length) {
+                    html += '<p>' + para.join('\n') + '</p>\n';
+                    para = [];
+                }
+            };
+            const flushList = () => {
+                if (inList) {
+                    html += '</ul>\n';
+                    inList = false;
+                }
+            };
+            for (const raw of lines) {
+                const line = raw.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+                if (line.trim().startsWith('```')) {
+                    flushPara(); flushList();
+                    if (inCode) {
+                        html += '<pre><code class="md-code-block">' + escapeHtml(codeBuf.join('\n')) + '</code></pre>\n';
+                        codeBuf = [];
+                        inCode = false;
+                    } else {
+                        inCode = true;
+                    }
+                    continue;
+                }
+                if (inCode) { codeBuf.push(line); continue; }
+                if (line.trim() === '') { flushPara(); flushList(); continue; }
+                if (line.startsWith('- ')) {
+                    flushPara();
+                    if (!inList) { html += '<ul>\n'; inList = true; }
+                    html += '<li>' + line.slice(2) + '</li>\n';
+                    continue;
+                }
+                para.push(line);
+            }
+            flushPara(); flushList();
+            return html;
+        }
+
+        function run() {
+            document.getElementById('log').innerHTML = '';
+            const src = document.getElementById('src').value;
+            const built = buildDom(src);
+            document.getElementById('source').textContent = built;
+            const target = document.getElementById('render');
+            target.innerHTML = built;
+
+            if (typeof window.renderMathInElement !== 'function') {
+                log('renderMathInElement not on window — auto-render script failed to load.', 'warn');
+                return;
+            }
+            log('renderMathInElement is available.', 'ok');
+            const before = target.querySelectorAll('.katex').length;
+            try {
+                window.renderMathInElement(target, KATEX_OPTIONS);
+            } catch (e) {
+                log('renderMathInElement threw: ' + e.message);
+                return;
+            }
+            const after = target.querySelectorAll('.katex').length;
+            log(`KaTeX produced ${after - before} math elements (was ${before}, now ${after}).`,
+                after > before ? 'ok' : 'warn');
+            const errors = target.querySelectorAll('.katex-error');
+            if (errors.length > 0) {
+                log(`Found ${errors.length} .katex-error elements (rendered in errorColor).`, 'warn');
+            }
+        }
+
+        function raw() {
+            document.getElementById('log').innerHTML = '';
+            const src = document.getElementById('src').value;
+            const built = buildDom(src);
+            document.getElementById('source').textContent = built;
+            document.getElementById('render').innerHTML = built;
+            log('Source DOM rendered without KaTeX. Check whether $$ delimiters survived intact.', 'ok');
+        }
+
+        // Auto-run once on page load so opening the file is enough to see the result.
+        window.addEventListener('load', () => setTimeout(run, 50));
+    </script>
+</body>
+</html>

--- a/frontend/dev-tools/katex-isolated.html
+++ b/frontend/dev-tools/katex-isolated.html
@@ -13,7 +13,7 @@
             integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg"
             crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
-            integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rF4+Pp4XXUokR6dwXyo"
+            integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk"
             crossorigin="anonymous"></script>
 
     <style>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,7 +30,7 @@
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"
             integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
-            integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rF4+Pp4XXUokR6dwXyo" crossorigin="anonymous"></script>
+            integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>
 
     <!-- Loading spinner (inline so it renders before any external assets) -->
     <style>

--- a/frontend/katex-helper.js
+++ b/frontend/katex-helper.js
@@ -54,14 +54,34 @@
     }
 
     window.renderMathInNode = function (element) {
-        if (!element) return;
+        if (!element) {
+            console.warn('[katex] renderMathInNode called with no element');
+            return;
+        }
+        // Probe whether this subtree actually contains math delimiters. If
+        // it does, but KaTeX doesn't render, the log makes the failure mode
+        // visible in the browser console for diagnosis.
+        const text = (element.textContent || '');
+        const hasDollar = text.includes('$');
+        const hasParen = text.includes('\\(');
+        const hasBracket = text.includes('\\[');
         if (typeof window.renderMathInElement === 'function') {
             try {
                 window.renderMathInElement(element, KATEX_OPTIONS);
+                if (hasDollar || hasParen || hasBracket) {
+                    const after = element.querySelectorAll('.katex').length;
+                    if (after === 0) {
+                        console.warn(
+                            '[katex] no math rendered though delimiters present',
+                            { sample: text.slice(0, 200) }
+                        );
+                    }
+                }
             } catch (e) {
                 console.error('[katex] render failed:', e);
             }
         } else {
+            console.warn('[katex] auto-render not yet loaded — queued');
             pending.add(element);
             schedulePoll();
         }

--- a/frontend/katex-helper.js
+++ b/frontend/katex-helper.js
@@ -1,26 +1,69 @@
 // Helper exposed on window for Yew to call after rendering markdown.
 // Uses KaTeX's auto-render extension to find $...$ and $$...$$ in a DOM
 // element and replace them with rendered math.
-window.renderMathInNode = function(element) {
-    if (!element || typeof window.renderMathInElement !== 'function') {
-        return;
+//
+// The KaTeX library and its auto-render extension are loaded via deferred
+// <script> tags in index.html. On a cold page load, Yew may invoke this
+// helper before those scripts have finished evaluating. The original
+// implementation silently returned in that case, leaving math un-rendered
+// for the lifetime of the page (the Yew effect is keyed on props.text and
+// won't fire again for a message that doesn't change). We queue calls
+// until KaTeX is ready and flush them on first availability.
+
+(function () {
+    const KATEX_OPTIONS = {
+        delimiters: [
+            { left: '$$', right: '$$', display: true },
+            { left: '$', right: '$', display: false },
+            { left: '\\(', right: '\\)', display: false },
+            { left: '\\[', right: '\\]', display: true },
+        ],
+        ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+        ignoredClasses: ['md-code-block', 'md-inline-code', 'tool-result-content', 'bash-command-inline'],
+        throwOnError: false,
+        errorColor: '#cc6666',
+    };
+
+    const pending = new Set();
+    let pollHandle = null;
+
+    function flush() {
+        if (typeof window.renderMathInElement !== 'function') return;
+        for (const element of pending) {
+            if (!element.isConnected) continue;
+            try {
+                window.renderMathInElement(element, KATEX_OPTIONS);
+            } catch (e) {
+                console.error('[katex] render failed:', e);
+            }
+        }
+        pending.clear();
+        if (pollHandle) {
+            clearInterval(pollHandle);
+            pollHandle = null;
+        }
     }
-    try {
-        window.renderMathInElement(element, {
-            delimiters: [
-                { left: '$$', right: '$$', display: true },
-                { left: '$', right: '$', display: false },
-                { left: '\\(', right: '\\)', display: false },
-                { left: '\\[', right: '\\]', display: true },
-            ],
-            // Don't try to render inside these elements (code blocks, inline code, etc.)
-            ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
-            ignoredClasses: ['md-code-block', 'md-inline-code', 'tool-result-content', 'bash-command-inline'],
-            // Don't crash on bad math — just leave the source visible
-            throwOnError: false,
-            errorColor: '#cc6666',
-        });
-    } catch (e) {
-        // Auto-render not loaded yet or other failure — silently skip
+
+    function schedulePoll() {
+        if (pollHandle) return;
+        pollHandle = setInterval(function () {
+            if (typeof window.renderMathInElement === 'function') {
+                flush();
+            }
+        }, 50);
     }
-};
+
+    window.renderMathInNode = function (element) {
+        if (!element) return;
+        if (typeof window.renderMathInElement === 'function') {
+            try {
+                window.renderMathInElement(element, KATEX_OPTIONS);
+            } catch (e) {
+                console.error('[katex] render failed:', e);
+            }
+        } else {
+            pending.add(element);
+            schedulePoll();
+        }
+    };
+})();

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -954,4 +954,52 @@ mod tests {
             blocks
         );
     }
+
+    /// Regression for #684 — message shape: empty `<thinking>` HTML block,
+    /// fenced ```latex``` code block (no `$` inside), then real `$$…$$`
+    /// display math, then inline `$…$` math in a list. We verify the math
+    /// placeholders survive the pulldown-cmark round-trip and end up as
+    /// plain `Event::Text` (not `Event::Html`, which we drop). My initial
+    /// hypothesis for #684 was that the `<thinking>` block was swallowing
+    /// the math into raw HTML events — this test disproves that.
+    #[test]
+    fn issue_684_math_survives_thinking_html_block() {
+        let input = "<thinking>\n\n</thinking>\n\n\
+Standard incompressible Newtonian form, vector notation:\n\n\
+```latex\n\
+\\rho \\left( \\frac{\\partial \\mathbf{v}}{\\partial t} \\right)\n\
+```\n\n\
+Renders as:\n\n\
+$$\n\
+\\rho \\left( \\frac{\\partial \\mathbf{v}}{\\partial t} \\right) = -\\nabla p\n\
+$$\n\n\
+Where:\n\
+- $\\rho$ \u{2014} fluid density\n\
+- $\\mathbf{v}$ \u{2014} velocity field\n";
+
+        let (pre_processed, math_blocks) = extract_math_placeholders(input);
+        // Three math regions: one $$…$$ display block plus two inline $…$ items.
+        assert_eq!(math_blocks.len(), 3, "expected 3 math blocks, got {math_blocks:?}");
+
+        let mut options = Options::empty();
+        options.insert(Options::ENABLE_TABLES);
+        options.insert(Options::ENABLE_STRIKETHROUGH);
+        let parser = Parser::new_ext(&pre_processed, options);
+        let events: Vec<Event> = parser.collect();
+        let restored = restore_math_in_events(events, &math_blocks);
+
+        // The math content (`\rho`) must land in plain Text events so KaTeX
+        // auto-render can find the delimiters. If it ends up in `Event::Html`
+        // or `Event::InlineHtml`, our catch-all renderer drops it silently.
+        let math_in_text = restored.iter().any(|e| match e {
+            Event::Text(t) => t.contains("\\rho"),
+            _ => false,
+        });
+        let math_in_html = restored.iter().any(|e| match e {
+            Event::Html(t) | Event::InlineHtml(t) => t.contains("\\rho"),
+            _ => false,
+        });
+        assert!(math_in_text, "math should reach Event::Text");
+        assert!(!math_in_html, "math should not leak into Event::Html");
+    }
 }

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -979,7 +979,11 @@ Where:\n\
 
         let (pre_processed, math_blocks) = extract_math_placeholders(input);
         // Three math regions: one $$…$$ display block plus two inline $…$ items.
-        assert_eq!(math_blocks.len(), 3, "expected 3 math blocks, got {math_blocks:?}");
+        assert_eq!(
+            math_blocks.len(),
+            3,
+            "expected 3 math blocks, got {math_blocks:?}"
+        );
 
         let mut options = Options::empty();
         options.insert(Options::ENABLE_TABLES);


### PR DESCRIPTION
## Investigation

User report (#684): equations don't typeset in messages mixing an empty \`<thinking></thinking>\` block, a fenced \`\`\`\`latex\`\`\`\` code block, and a real \`\$\$…\$\$\` display math block. I had hypothesized that the \`<thinking>\` HTML block was swallowing the math placeholder into an \`Event::Html\` event that our renderer silently drops.

**Wrote a regression test that disproves that hypothesis** (\`issue_684_math_survives_thinking_html_block\` in \`markdown.rs\`). The test runs the user's exact input shape through \`extract_math_placeholders\` → pulldown-cmark → \`restore_math_in_events\` and asserts the math literal (\`\\rho\`) ends up in an \`Event::Text\`, not \`Event::Html\`. It passes — the pipeline is correct.

So the bug is **runtime**, not in our markdown plumbing.

## What this PR does

Two changes to the browser-side helper that calls KaTeX:

1. **Queue-and-retry when KaTeX isn't loaded yet.** Previously, if Yew called \`renderMathInNode\` before the deferred CDN scripts finished evaluating, the helper silently no-op'd. Since the Yew effect is keyed on \`props.text\` and doesn't re-fire for a message whose text doesn't change, math stayed un-rendered for the lifetime of that page. The helper now queues pending nodes and flushes them on first availability of \`renderMathInElement\`. User noted equations arrive *after* initial load so this race may not actually be the cause here — but it's still a robustness win.
2. **Surface diagnostics to the browser console.** When the helper is invoked, if the subtree contains math delimiters (\`\$\`, \`\\(\`, \`\\[\`) but \*\*no \`.katex\` element\*\* appears after rendering, log a warning with a 200-char text sample. Actual exceptions from \`renderMathInElement\` are now \`console.error\`'d instead of being silently caught.

On the next failed render, the user can open the browser console and see which case fires:

- \`[katex] renderMathInNode called with no element\` — node_ref didn't resolve
- \`[katex] auto-render not yet loaded — queued\` — cold-load race (queue-and-retry covers this)
- \`[katex] no math rendered though delimiters present\` — KaTeX ran but didn't match the delimiters (likely the real bug)
- \`[katex] render failed: <error>\` — KaTeX threw

That'll tell us exactly where the chain breaks.

## Test plan

- [x] \`cargo test -p frontend markdown\` — 17/17 green, includes the new regression test
- [ ] **Manual after deploy**: trigger a fresh assistant message with mixed \`<thinking>\` + display math, watch the browser console for one of the diagnostic lines above