### PR TITLE
Consolidate claude-codes pin to workspace dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.16"
+version = "2.5.17"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -39,7 +39,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = "2.1.140"
+claude-codes = { version = "2.1.140", default-features = false, features = ["types"] }
 
 # Codex CLI integration
 codex-codes = { version = "0.101.1", default-features = false, features = ["types"] }

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 shared = { path = "../shared" }
-claude-codes = { workspace = true }
+claude-codes = { workspace = true, features = ["async-client"] }
 codex-codes = { workspace = true, features = ["async-client"] }
 tokio = { workspace = true, features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -538,8 +538,50 @@ fn log_claude_output(output: &ClaudeOutput) {
                     ContentBlock::Image(_) => {
                         debug!("← [assistant] image block");
                     }
-                    _ => {
-                        debug!("← [assistant] other block");
+                    ContentBlock::ServerToolUse(stu) => {
+                        tool_count += 1;
+                        let input_preview = format_tool_input_json(&stu.input);
+                        debug!(
+                            "← [assistant] server_tool_use: {} {}",
+                            stu.name, input_preview
+                        );
+                    }
+                    ContentBlock::WebSearchToolResult(r) => {
+                        debug!("← [assistant] web_search_tool_result: {}", r.tool_use_id);
+                    }
+                    ContentBlock::CodeExecutionToolResult(r) => {
+                        debug!(
+                            "← [assistant] code_execution_tool_result: {}",
+                            r.tool_use_id
+                        );
+                    }
+                    ContentBlock::McpToolUse(mtu) => {
+                        tool_count += 1;
+                        let input_preview = format_tool_input_json(&mtu.input);
+                        let server = mtu.server_name.as_deref().unwrap_or("?");
+                        debug!(
+                            "← [assistant] mcp_tool_use: {}::{} {}",
+                            server, mtu.name, input_preview
+                        );
+                    }
+                    ContentBlock::McpToolResult(r) => {
+                        let status = if r.is_error.unwrap_or(false) {
+                            "error"
+                        } else {
+                            "ok"
+                        };
+                        debug!(
+                            "← [assistant] mcp_tool_result: {} ({})",
+                            r.tool_use_id, status
+                        );
+                    }
+                    ContentBlock::ContainerUpload(_) => {
+                        debug!("← [assistant] container_upload block");
+                    }
+                    ContentBlock::Unknown(v) => {
+                        let block_type =
+                            v.get("type").and_then(|t| t.as_str()).unwrap_or("unknown");
+                        debug!("← [assistant] unknown block: type={}", block_type);
                     }
                 }
             }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,8 +12,8 @@ serde_json = { workspace = true }
 # UUID
 uuid = { workspace = true }
 
-# Claude Code types (WASM-compatible, no tokio)
-claude-codes = { version = "2.1.140", default-features = false, features = ["types"] }
+# Claude Code types (WASM-compatible, no tokio — inherits types-only from workspace)
+claude-codes = { workspace = true }
 
 # Typed WebSocket endpoints (core traits only — WASM-safe, no features needed)
 ws-bridge = { workspace = true }


### PR DESCRIPTION
## Summary
- Promote the WASM-safe pin (`default-features = false, features = ["types"]`) to the workspace dep so future bumps only touch the workspace `Cargo.toml`.
- Drop `shared/`'s duplicate declaration in favor of `{ workspace = true }`.
- Add `features = ["async-client"]` to `claude-session-lib/`, which is the only consumer that uses `AsyncClient` from `claude-codes`.
- Replace the assistant `_ => "other block"` catch-all in `output_forwarder.rs` with explicit arms for every 2.1.140 `ContentBlock` variant (ServerToolUse, WebSearch/CodeExecution/Mcp results, McpToolUse, ContainerUpload, Unknown). Future variants now fail to compile instead of silently logging as "other block".

For native builds, feature unification still pulls `async-client` (and therefore `tokio`) into the shared compilation of `claude-codes`. For WASM, only `shared/` is in the dep graph, so it stays tokio-free — verified with `cargo build --target wasm32-unknown-unknown -p shared`.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo build --target wasm32-unknown-unknown -p shared` (no tokio in dep tree)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)