### PR TITLE
Inject portal features reminder at session start + compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.17
+
+- **Inject a "portal features reminder" into the agent at session start and after each context compaction.** Reminds the agent which portal-specific features are available (auto-formatted links, KaTeX, image rendering, AskUserQuestion, session sharing, etc.) so it can actually use them after a fresh start or a compaction-induced amnesia. The reminder is wrapped in `<system-reminder>` tags on the agent side and emitted as a collapsed `PortalContent::Reminder` block on the frontend so it doesn't clutter the transcript.
+- The reminder body lives in `claude-session-lib/portal_reminder.md` as a readable markdown file (baked into the binary via `include_str!`), and operators can override it at runtime by pointing `PORTAL_REMINDER_FILE` at a readable path. Missing/unreadable overrides log a warning and fall back to the bundled default. Documented in `Dockerfile`, `docs/DEPLOYING.md`, `docs/DOCKER.md`, and `CLAUDE.md`.
+- Extracted the duplicated "is this a compaction-end marker?" predicate into `shared::is_compaction_boundary(&CCSystemMessage)`. The Claude CLI emits this boundary under several subtype spellings (`compact_boundary`, `compaction`, `context_compaction`, `summary`) and three call sites were inlining the disjunction — they now all go through the shared helper.
+
 ## 2.5.16
 
 - **Fix #684 — KaTeX hasn't actually been rendering math on any page load.** The Subresource Integrity hash on the `<script>` tag for KaTeX's `auto-render.min.js` in `index.html` did not match the file the CDN actually serves. Browsers silently refuse to execute scripts whose SRI hash mismatches, so `window.renderMathInElement` never landed on the page, and every call to our `renderMathInNode` helper silently no-op'd. Verified by a standalone harness (`frontend/dev-tools/katex-isolated.html`) that loads the same scripts from the same CDN and reports "renderMathInElement not on window". Replaced the stale hash with the real `sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -711,6 +711,7 @@ When making changes, verify:
 | `MESSAGE_RETENTION_DAYS` | Days before message deletion | Optional (default: 30) |
 | `SESSION_MAX_AGE_DAYS` | Days before session deletion | Optional (default: 14) |
 | `PORTAL_MAX_IMAGE_MB` | Max image size for proxies | Optional (default: 10) |
+| `PORTAL_REMINDER_FILE` | Path to a markdown file overriding the bundled portal-features reminder (proxy/launcher side). Falls back to default if unset/unreadable. | Optional |
 | `GOOGLE_APPLICATION_CREDENTIALS` | GCP Speech-to-Text creds | Optional |
 
 Note: Dev mode is enabled via `--dev-mode` CLI flag, not an environment variable.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.16"
+version = "2.5.17"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.16"
+version = "2.5.17"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,12 @@ EXPOSE 3000
 #   HOST                  Bind address (default: 0.0.0.0)
 #   PORT                  Listen port (default: 3000)
 #   RUST_LOG              Log level, e.g. "info" or "debug" (default: "info")
+#
+# Proxy/launcher-side (read by claude-portal / agent-portal, not the backend):
+#   PORTAL_REMINDER_FILE  Path to a markdown file that overrides the bundled
+#                         "portal features reminder" injected at session start
+#                         and after each context compaction. Falls back to the
+#                         compiled-in default if the path is missing/unreadable.
 # =============================================================================
 
 # Health check

--- a/claude-session-lib/portal_reminder.md
+++ b/claude-session-lib/portal_reminder.md
@@ -1,0 +1,32 @@
+You're running inside the Agent Portal — a web frontend that renders your
+output to the user. Affordances worth knowing about so you can use them
+deliberately:
+
+- **Markdown**: bold, italic, headings, lists, tables, blockquotes, fenced
+  code blocks with syntax highlighting, and horizontal rules.
+- **Math**: LaTeX expressions are typeset by KaTeX. Use `$inline$` for
+  inline math, `$$display$$` (or `\[…\]`) for display math, and `\(…\)`
+  for inline. Tables and inline math compose freely.
+- **Links**: bare URLs (`https://…`) are auto-linked in plain text, in
+  fenced code blocks, in tool-result previews, and inside inline `code`
+  spans. You don't need to wrap URLs in markdown link syntax unless you
+  want custom anchor text.
+- **Images**: when you `Read` a `.png`, `.jpg`, `.gif`, `.webp`, or `.svg`
+  file, the portal displays it inline to the user. You can show the user
+  generated artwork or diagnostic plots just by `Read`ing the file.
+- **Structured prompts**: the `AskUserQuestion` tool renders as a
+  click-to-answer multiple-choice form (single- or multi-select). Prefer
+  it over open-ended free-text questions when the answer space is finite.
+- **Session context**: the user sees your working directory, git branch,
+  and PR URL (if one exists) in the session pill next to your output.
+  You don't need to repeat that context unless you're changing it.
+- **Mobile and desktop**: the portal runs on both. Prefer concise answers
+  and avoid extremely wide tables; long horizontal layouts force a
+  horizontal scroll on phones.
+- **Permission gating**: each tool call is gated by a user permission
+  dialog. Some tools may be pre-approved per the user's settings —
+  reuse a tool once it's approved rather than re-asking.
+- **Sharing and cron**: the user can share this session read-only with
+  others, and can schedule a prompt to re-run on a cron. Output you
+  produce here may be observed by other users or replayed in a future
+  scheduled run.

--- a/claude-session-lib/portal_reminder.md
+++ b/claude-session-lib/portal_reminder.md
@@ -14,6 +14,16 @@ deliberately:
 - **Images**: when you `Read` a `.png`, `.jpg`, `.gif`, `.webp`, or `.svg`
   file, the portal displays it inline to the user. You can show the user
   generated artwork or diagnostic plots just by `Read`ing the file.
+  **Prefer SVG** for plots, diagrams, charts, and any generated graphics
+  — it scales crisply on retina/mobile and stays small over the wire.
+  The portal renders on a dark Tokyo-Night background (`#1a1b26`), so
+  give SVGs a **transparent background** (no white `<rect>` fill) and
+  pick stroke/fill colors that read on dark — light grays for axes/grid
+  (`#c0caf5` text, `#565f89` muted), and accent hues that match the
+  palette (`#7aa2f7` blue, `#9ece6a` green, `#f7768e` red,
+  `#e0af68` orange, `#bb9af7` purple, `#7dcfff` teal). For matplotlib,
+  `plt.savefig(..., transparent=True)` plus `mpl.rcParams` color tweaks
+  is the easy path.
 - **Structured prompts**: the `AskUserQuestion` tool renders as a
   click-to-answer multiple-choice form (single- or multi-select). Prefer
   it over open-ended free-text questions when the answer space is finite.
@@ -23,9 +33,6 @@ deliberately:
 - **Mobile and desktop**: the portal runs on both. Prefer concise answers
   and avoid extremely wide tables; long horizontal layouts force a
   horizontal scroll on phones.
-- **Permission gating**: each tool call is gated by a user permission
-  dialog. Some tools may be pre-approved per the user's settings —
-  reuse a tool once it's approved rather than re-asking.
 - **Sharing and cron**: the user can share this session read-only with
   others, and can schedule a prompt to re-run on a cron. Output you
   produce here may be observed by other users or replayed in a future

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -2,8 +2,11 @@
 
 mod image_uploader;
 mod output_forwarder;
+mod portal_reminder;
 mod wiggum;
 mod ws_reader;
+
+pub(crate) use portal_reminder::inject_portal_reminder;
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -687,6 +690,16 @@ async fn run_message_loop(
         working_directory: config.working_directory.clone(),
         active_uploads: std::collections::HashMap::new(),
     };
+
+    // On the very first connection of this session, inject the portal
+    // features reminder. It primes the agent with a `<system-reminder>` on
+    // its stdin and emits a collapsed portal message for the user. On
+    // reconnects we skip — the agent's context is unchanged so the agent
+    // already has it; subsequent re-injections happen at compaction
+    // boundaries from inside `output_forwarder`.
+    if session.first_connection {
+        inject_portal_reminder(session.claude_session, &ws_write, &session.output_buffer).await;
+    }
 
     // Main loop
     let result = run_main_loop(session.claude_session, session.input_rx, &mut conn_state).await;

--- a/claude-session-lib/src/proxy_session/portal_reminder.rs
+++ b/claude-session-lib/src/proxy_session/portal_reminder.rs
@@ -1,0 +1,94 @@
+//! Portal features reminder injected at session start and after each
+//! compaction boundary.
+//!
+//! Two parallel streams off the same trigger:
+//! 1. The agent-facing copy is sent as user input wrapped in
+//!    `<system-reminder>…</system-reminder>` tags. Claude treats those tags
+//!    as out-of-band context rather than a real user message.
+//! 2. The user-facing copy is emitted as a `PortalContent::Reminder` and
+//!    rendered as a collapsed block on the frontend.
+//!
+//! The reminder body lives in `claude-session-lib/portal_reminder.md` as a
+//! readable markdown file and is baked into the binary via `include_str!`.
+//! Operators can override at runtime by pointing `PORTAL_REMINDER_FILE` at a
+//! readable path; on a missing or unreadable override we log a warning and
+//! fall back to the bundled default.
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::{error, info, warn};
+
+use crate::output_buffer::PendingOutputBuffer;
+use crate::session::Session as ClaudeSession;
+
+use super::SharedWsWrite;
+
+/// Bundled fallback body (relative to this file).
+const DEFAULT_BODY: &str = include_str!("../../portal_reminder.md");
+
+/// Resolve the reminder body. Honors `PORTAL_REMINDER_FILE` at call time so
+/// operators can hot-edit the file and have the next compaction pick it up
+/// without restarting the proxy.
+pub fn load_reminder_body() -> String {
+    match std::env::var("PORTAL_REMINDER_FILE") {
+        Ok(path) if !path.is_empty() => match std::fs::read_to_string(&path) {
+            Ok(body) => {
+                info!(
+                    "Loaded portal reminder override from PORTAL_REMINDER_FILE={} ({} bytes)",
+                    path,
+                    body.len()
+                );
+                body
+            }
+            Err(e) => {
+                warn!(
+                    "PORTAL_REMINDER_FILE={} is set but the file could not be read ({}); \
+                     falling back to the bundled portal reminder.",
+                    path, e
+                );
+                DEFAULT_BODY.to_string()
+            }
+        },
+        _ => DEFAULT_BODY.to_string(),
+    }
+}
+
+fn agent_facing(body: &str) -> String {
+    format!("<system-reminder>\n{}\n</system-reminder>", body.trim())
+}
+
+/// Inject the reminder on both streams: agent-bound (via stdin) and
+/// user-bound (as a sequenced portal message). Idempotency / "only on the
+/// right trigger" is the caller's responsibility — this function unconditionally
+/// fires both.
+pub async fn inject_portal_reminder(
+    claude_session: &mut ClaudeSession,
+    ws_write: &SharedWsWrite,
+    output_buffer: &Arc<Mutex<PendingOutputBuffer>>,
+) {
+    let body = load_reminder_body();
+
+    // Agent-bound: a single user-input message wrapped in <system-reminder>.
+    if let Err(e) = claude_session
+        .send_input(serde_json::Value::String(agent_facing(&body)))
+        .await
+    {
+        error!("Failed to inject portal reminder into agent stdin: {}", e);
+    }
+
+    // User-bound: a sequenced portal message rendered collapsed on the frontend.
+    let portal_msg = shared::PortalMessage::reminder("Portal features".to_string(), body);
+    let portal_content = portal_msg.to_json();
+    let seq = {
+        let mut buf = output_buffer.lock().await;
+        buf.push(portal_content.clone())
+    };
+    let ws_msg = shared::ProxyToServer::SequencedOutput {
+        seq,
+        content: portal_content,
+    };
+    let mut ws = ws_write.lock().await;
+    if let Err(e) = ws.send(ws_msg).await {
+        error!("Failed to send portal reminder message to backend: {}", e);
+    }
+}

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -61,10 +61,24 @@ pub(super) async fn handle_session_event_with_wiggum(
                 false
             };
 
+            // If this is a compaction-boundary system message, the agent's
+            // context has just been reset to a summary. Re-inject the portal
+            // features reminder so the agent has it in the fresh context.
+            // We check before forwarding so the reminder lands logically
+            // after the compaction-completed notice in the user's transcript.
+            let is_compaction_boundary = match &**output {
+                ClaudeOutput::System(sys) => shared::is_compaction_boundary(sys),
+                _ => false,
+            };
+
             // Forward the output
             if output_tx.send(*output.clone()).is_err() {
                 error!("Failed to forward Claude output");
                 return Some(ConnectionResult::Disconnected(connection_start.elapsed()));
+            }
+
+            if is_compaction_boundary {
+                super::inject_portal_reminder(claude_session, ws_write, output_buffer).await;
             }
 
             // Handle wiggum loop continuation

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -49,6 +49,10 @@ SESSION_SECRET=generate-a-random-32-char-secret-here
 
 # Optional - Image size limit for proxies
 # PORTAL_MAX_IMAGE_MB=10         # Max image size in MB to inline (default: 10)
+
+# Optional - Override the portal features reminder text (proxy/launcher side)
+# Falls back to the bundled default if the file is missing or unreadable.
+# PORTAL_REMINDER_FILE=/etc/agent-portal/portal_reminder.md
 ```
 
 ## Docker Deployment (Recommended)

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -198,6 +198,7 @@ docker buildx build \
 | `MESSAGE_RETENTION_DAYS` | `30` | Delete messages older than N days (0 = disabled) |
 | `SESSION_MAX_AGE_DAYS` | `14` | Delete sessions older than N days (0 = disabled) |
 | `PORTAL_MAX_IMAGE_MB` | `10` | Max image size in MB for proxy inlining |
+| `PORTAL_REMINDER_FILE` | _(unset)_ | Proxy/launcher-side: path to a markdown file that overrides the bundled portal-features reminder injected at session start and after each compaction. Falls back to default if missing/unreadable. |
 
 ## Troubleshooting
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -385,6 +385,45 @@ fn render_portal_content(content: &shared::PortalContent) -> Html {
                 </>
             }
         }
+        shared::PortalContent::Reminder { title, body } => {
+            html! { <PortalReminder title={title.clone()} body={body.clone()} /> }
+        }
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct PortalReminderProps {
+    title: AttrValue,
+    body: AttrValue,
+}
+
+/// Collapsed-by-default "Portal features reminder" block. Header is always
+/// visible; clicking it toggles the markdown body open/closed.
+#[function_component(PortalReminder)]
+fn portal_reminder(props: &PortalReminderProps) -> Html {
+    let expanded = use_state(|| false);
+    let on_toggle = {
+        let expanded = expanded.clone();
+        Callback::from(move |_: MouseEvent| expanded.set(!*expanded))
+    };
+    let header_class = if *expanded {
+        "portal-reminder-header expanded"
+    } else {
+        "portal-reminder-header"
+    };
+    html! {
+        <div class="portal-reminder">
+            <button type="button" class={header_class} onclick={on_toggle}>
+                <span class="portal-reminder-icon">{ "ⓘ" }</span>
+                <span class="portal-reminder-title">{ &*props.title }</span>
+                <span class="portal-reminder-toggle">{ if *expanded { "▾" } else { "▸" } }</span>
+            </button>
+            if *expanded {
+                <div class="portal-reminder-body">
+                    { render_markdown(&props.body) }
+                </div>
+            }
+        </div>
     }
 }
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -388,12 +388,7 @@ impl Component for SessionView {
                                 {
                                     msg_type = "compaction_start".to_string();
                                 }
-                            } else if sys.is_compact_boundary()
-                                || matches!(
-                                    sys.subtype.as_str(),
-                                    "compaction" | "context_compaction" | "summary"
-                                )
-                            {
+                            } else if shared::is_compaction_boundary(sys) {
                                 msg_type = "compaction_end".to_string();
                             } else if let Some(task) = sys.as_task_started() {
                                 msg_type = "task_start".to_string();
@@ -1251,12 +1246,7 @@ impl SessionView {
                         if status.status.as_ref().map(|s| s.as_str()) == Some("compacting") {
                             msg_type = "compaction_start".to_string();
                         }
-                    } else if sys.is_compact_boundary()
-                        || matches!(
-                            sys.subtype.as_str(),
-                            "compaction" | "context_compaction" | "summary"
-                        )
-                    {
+                    } else if shared::is_compaction_boundary(sys) {
                         msg_type = "compaction_end".to_string();
                     } else if let Some(task) = sys.as_task_started() {
                         msg_type = "task_start".to_string();

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -449,3 +449,63 @@
     font-size: 1rem;
     flex-shrink: 0;
 }
+
+/* ==========================================================================
+   Portal features reminder (collapsed-by-default block)
+   ========================================================================== */
+
+.portal-reminder {
+    margin: 0.35rem 0;
+    border: 1px solid rgba(125, 207, 255, 0.3);
+    border-radius: 6px;
+    background: rgba(125, 207, 255, 0.05);
+    overflow: hidden;
+}
+
+.portal-reminder-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    background: transparent;
+    border: none;
+    padding: 0.35rem 0.6rem;
+    color: #7dcfff;
+    font-size: 0.8rem;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.15s;
+}
+
+.portal-reminder-header:hover {
+    background: rgba(125, 207, 255, 0.08);
+}
+
+.portal-reminder-header.expanded {
+    border-bottom: 1px solid rgba(125, 207, 255, 0.2);
+}
+
+.portal-reminder-icon { font-size: 0.9rem; }
+
+.portal-reminder-title {
+    flex: 1;
+    font-weight: 500;
+}
+
+.portal-reminder-toggle {
+    color: rgba(125, 207, 255, 0.7);
+    font-size: 0.75rem;
+}
+
+.portal-reminder-body {
+    padding: 0.5rem 0.9rem;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    line-height: 1.55;
+}
+
+.portal-reminder-body p { margin: 0.35rem 0; }
+.portal-reminder-body p:first-child { margin-top: 0; }
+.portal-reminder-body p:last-child { margin-bottom: 0; }
+.portal-reminder-body code { font-size: 0.8em; }
+.portal-reminder-body ul { margin: 0.35rem 0; padding-left: 1.2rem; }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -504,8 +504,19 @@
     line-height: 1.55;
 }
 
-.portal-reminder-body p { margin: 0.35rem 0; }
-.portal-reminder-body p:first-child { margin-top: 0; }
-.portal-reminder-body p:last-child { margin-bottom: 0; }
-.portal-reminder-body code { font-size: 0.8em; }
-.portal-reminder-body ul { margin: 0.35rem 0; padding-left: 1.2rem; }
+.portal-reminder-body p {
+    margin: 0.35rem 0;
+}
+.portal-reminder-body p:first-child {
+    margin-top: 0;
+}
+.portal-reminder-body p:last-child {
+    margin-bottom: 0;
+}
+.portal-reminder-body code {
+    font-size: 0.8em;
+}
+.portal-reminder-body ul {
+    margin: 0.35rem 0;
+    padding-left: 1.2rem;
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -45,6 +45,19 @@ pub use claude_codes::io::{
 };
 pub use claude_codes::ClaudeOutput;
 
+/// Returns true when a system message marks the END of a context compaction.
+///
+/// The CLI uses several spellings depending on version and code path, so this
+/// helper centralizes the predicate. Callers should use this instead of
+/// inlining the disjunction.
+pub fn is_compaction_boundary(sys: &CCSystemMessage) -> bool {
+    sys.is_compact_boundary()
+        || matches!(
+            sys.subtype.as_str(),
+            "compaction" | "context_compaction" | "summary"
+        )
+}
+
 /// Which agent CLI backs a session
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
@@ -327,6 +340,16 @@ impl PortalMessage {
         }
     }
 
+    /// Build a collapsible "portal features reminder" message — same envelope
+    /// as text/image portal messages, rendered with a header bar and a
+    /// click-to-expand body on the frontend.
+    pub fn reminder(title: String, body: String) -> Self {
+        Self {
+            message_type: "portal".to_string(),
+            content: vec![PortalContent::Reminder { title, body }],
+        }
+    }
+
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or_default()
     }
@@ -349,6 +372,15 @@ pub enum PortalContent {
         #[serde(default)]
         source_type: Option<String>,
     },
+    /// Collapsible "portal features reminder" emitted at session start and
+    /// after compaction boundaries. The body is markdown — rendered through
+    /// the same pipeline as text portal messages — and lives behind a
+    /// click-to-expand header on the frontend so it doesn't clutter the
+    /// scrollback.
+    Reminder {
+        title: String,
+        body: String,
+    },
 }
 
 impl std::fmt::Debug for PortalContent {
@@ -368,6 +400,11 @@ impl std::fmt::Debug for PortalContent {
                 .field("file_path", file_path)
                 .field("file_size", file_size)
                 .field("source_type", source_type)
+                .finish(),
+            Self::Reminder { title, body } => f
+                .debug_struct("Reminder")
+                .field("title", title)
+                .field("body", &format_args!("<{} bytes>", body.len()))
                 .finish(),
         }
     }


### PR DESCRIPTION
## Summary

- Inject a custom **portal features reminder** into the agent at session start and after every context-compaction boundary, so the agent doesn't lose access to portal-specific affordances (auto-formatted links, KaTeX, image rendering, AskUserQuestion, session sharing, etc.) when its context is reset to a summary.
- Two parallel streams off the same trigger:
  - **Agent side**: a single stdin user-input message wrapped in \`<system-reminder>…</system-reminder>\` (out-of-band context).
  - **User side**: a new \`PortalContent::Reminder { title, body }\` rendered on the frontend as a collapsed click-to-expand block (teal accent, consistent with the existing portal palette).
- Body lives in \`claude-session-lib/portal_reminder.md\` (readable markdown, baked in via \`include_str!\`). Operators can override at runtime by pointing \`PORTAL_REMINDER_FILE\` at a readable path; missing/unreadable overrides log a warning and fall back to the bundled default. Documented in \`Dockerfile\`, \`docs/DEPLOYING.md\`, \`docs/DOCKER.md\`, and \`CLAUDE.md\`.
- Extracted \`shared::is_compaction_boundary(&CCSystemMessage)\` since the Claude CLI emits the same boundary under several subtype spellings (\`compact_boundary\`, \`compaction\`, \`context_compaction\`, \`summary\`) and three call sites were inlining the same disjunction.

## Test plan

- [ ] \`cargo build --workspace\` clean
- [ ] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] \`cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings\` clean
- [ ] \`cargo test --workspace --exclude backend\` passes
- [ ] Launch a proxy → confirm the reminder appears collapsed in the transcript at session start
- [ ] Trigger a compaction → confirm a second collapsed reminder lands after the compaction-completed marker
- [ ] Set \`PORTAL_REMINDER_FILE=/tmp/custom.md\` and confirm the override body is used; point it at a non-existent path and confirm the warning + fallback