### PR TITLE
Bump codex-codes 0.101.1 to 0.128.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.5.18
+
+- **Bump `codex-codes` 0.101.1 → 0.128.0.** Upstream restructured `ServerMessage` from the loose `{ method, params }` envelope into typed enums (`Notification(Notification)` and `Request { id, request: ServerRequest }`). Adapted the proxy's Codex dispatcher in `claude-session-lib/src/session.rs` to:
+  - Match `ServerMessage::Notification(notif)` and recover `(method, params)` via `notif.into_envelope()` — keeps the existing string-based downstream dispatch intact.
+  - Match `ServerMessage::Request { id, request }`, pull the method via `request.method()`, and serialize the typed param struct (`CmdExecApproval`, `FileChangeApproval`, or `Unknown`) back to a `Value` so the rest of the approval-flow code is unchanged.
+- Three new `Notification` variants are now modeled (`AccountRateLimitsUpdated`, `McpServerStartupStatusUpdated`, `RemoteControlStatusChanged`); they fall through to our existing `_ => Skip` arm via `notif.into_envelope()`, so they're handled implicitly without further code.
+
 ## 2.5.17
 
 - **Inject a "portal features reminder" into the agent at session start and after each context compaction.** Reminds the agent which portal-specific features are available (auto-formatted links, KaTeX, image rendering, AskUserQuestion, session sharing, etc.) so it can actually use them after a fresh start or a compaction-induced amnesia. The reminder is wrapped in `<system-reminder>` tags on the agent side and emitted as a collapsed `PortalContent::Reminder` block on the frontend so it doesn't clutter the transcript.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.101.1"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d315794186d340a6430afac04c41d8030a7144a7533844096c3bcb01e4cb2a8c"
+checksum = "338ed9393b28db6e82eac065a934ddec9b9f5ebd3210423bf419a2194f8895cd"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.17"
+version = "2.5.18"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -42,7 +42,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = { version = "2.1.140", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.101.1", default-features = false, features = ["types"] }
+codex-codes = { version = "0.128.0", default-features = false, features = ["types"] }
 
 # Frontend (Yew)
 yew = { version = "0.21", features = ["csr"] }

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -818,8 +818,14 @@ impl Session {
         event_tx: &mpsc::UnboundedSender<IoEvent>,
     ) -> (bool, bool) {
         match msg {
-            codex_codes::ServerMessage::Notification { method, params } => {
-                let params = params.unwrap_or(serde_json::Value::Null);
+            codex_codes::ServerMessage::Notification(notif) => {
+                let (method, params) = match notif.into_envelope() {
+                    Ok((m, p)) => (m, p.unwrap_or(serde_json::Value::Null)),
+                    Err(e) => {
+                        tracing::warn!("Codex notification envelope error: {}", e);
+                        return (true, false);
+                    }
+                };
 
                 match method.as_str() {
                     "thread/started" | "turn/started" | "thread/status/changed" => {
@@ -889,8 +895,19 @@ impl Session {
                     }
                 }
             }
-            codex_codes::ServerMessage::Request { id, method, params } => {
-                let params = params.unwrap_or_default();
+            codex_codes::ServerMessage::Request { id, request } => {
+                let method = request.method().to_string();
+                let params: serde_json::Value = match &request {
+                    codex_codes::ServerRequest::CmdExecApproval(p) => {
+                        serde_json::to_value(p).unwrap_or_default()
+                    }
+                    codex_codes::ServerRequest::FileChangeApproval(p) => {
+                        serde_json::to_value(p).unwrap_or_default()
+                    }
+                    codex_codes::ServerRequest::Unknown { params, .. } => {
+                        params.clone().unwrap_or_default()
+                    }
+                };
                 let request_id_str = Self::format_request_id(&id);
 
                 match method.as_str() {


### PR DESCRIPTION
## Summary

Bumps \`codex-codes\` from **0.101.1** to **0.128.0**. Upstream replaced the loose \`ServerMessage { method, params }\` envelope with typed enums:

- \`ServerMessage::Notification(Notification)\` — \`Notification\` is a closed enum with one variant per known method (\`ThreadStarted\`, \`TurnCompleted\`, etc.) plus an \`Unknown { method, params }\` catch-all.
- \`ServerMessage::Request { id, request: ServerRequest }\` — \`ServerRequest\` similarly enumerates the approval-flow request types.

The proxy dispatcher in \`claude-session-lib/src/session.rs\` was using string-based \`match method.as_str()\` dispatch downstream, so the minimum-disruption adaptation is:

- For notifications, call \`notif.into_envelope()\` to recover \`(method, params)\` and feed it into the existing string switch. Three new variants this version models (\`AccountRateLimitsUpdated\`, \`McpServerStartupStatusUpdated\`, \`RemoteControlStatusChanged\`) fall through to the existing \`_ => Skip\` arm — no behavior change for them.
- For requests, pull the method via \`request.method()\` and serialize the typed param struct back to a \`Value\` so the existing approval-flow code is unchanged.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings\` clean
- [x] \`cargo test --workspace --exclude backend\` passes (148 tests)
- [ ] Launch a Codex-backed session — confirm \`turn/completed\`, \`item/started\`, \`item/completed\`, and error notifications still surface to the frontend
- [ ] Trigger a \`Bash\` and a \`FileChange\` approval prompt — confirm both still render with the correct command/changes payload