### PR TITLE
Synthesize Codex user-input echo to clear pending sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.19
+
+- **Fix "Codex Raw" pending messages piling up at the bottom of the transcript.** Codex's app-server protocol doesn't echo user input back the way Claude's CLI does, so the frontend's optimistic-send pending entry never matched anything and accumulated on every send. The pending entries were rendered through the Codex renderer (which doesn't recognize the `{type: "user", _pending: true}` shape) and fell into the "Codex Raw" catch-all. Fix: `codex_io_task` now emits a synthetic user echo (parses as `ClaudeOutput::User` with a top-level `content` field) right before kicking off the Codex turn, so the frontend's existing content-match pending-clear path fires identically for both agents. Portal-reminder injections wrapped in `<system-reminder>` tags are filtered out of the echo path so they stay invisible to the user.
+
 ## 2.5.18
 
 - **Bump `codex-codes` 0.101.1 → 0.128.0.** Upstream restructured `ServerMessage` from the loose `{ method, params }` envelope into typed enums (`Notification(Notification)` and `Request { id, request: ServerRequest }`). Adapted the proxy's Codex dispatcher in `claude-session-lib/src/session.rs` to:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.17"
+version = "2.5.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.17"
+version = "2.5.19"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.17"
+version = "2.5.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.17"
+version = "2.5.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.17"
+version = "2.5.19"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.17"
+version = "2.5.19"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.17"
+version = "2.5.19"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.17"
+version = "2.5.19"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.18"
+version = "2.5.19"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -775,6 +775,25 @@ impl Session {
                             continue;
                         }
 
+                        // Codex's app-server protocol doesn't echo user input, so the
+                        // frontend's optimistic-send pending entry would never clear.
+                        // Synthesize an echo here in a shape that matches both the
+                        // ClaudeOutput::User parse (msg_type = "user") and the frontend's
+                        // content-based pending-match. Skip <system-reminder> wrappers
+                        // (portal reminder injection) — those shouldn't appear in the
+                        // user-facing transcript.
+                        if !prompt.starts_with("<system-reminder>") {
+                            let echo = serde_json::json!({
+                                "type": "user",
+                                "message": {
+                                    "role": "user",
+                                    "content": [{"type": "text", "text": prompt}]
+                                },
+                                "content": prompt,
+                            });
+                            let _ = event_tx.send(IoEvent::RawOutput(echo));
+                        }
+
                         tracing::info!("Starting Codex turn with {} chars", prompt.len());
 
                         match client


### PR DESCRIPTION
## Summary

Fixes a bug where every message sent to a Codex-backed session produced a stuck "Codex Raw" block at the bottom of the transcript.

**Root cause**: Codex's app-server protocol doesn't echo user input — there's no \`user\` notification mirroring what Claude's CLI emits. The frontend's optimistic-send logic pushes \`{type: "user", content, _pending: true}\` into a pending queue and clears entries when the server echoes back (or when an \`assistant\`/\`result\` message arrives). On Codex, neither signal ever lands in a shape the dispatch recognizes, so the pending entry sticks. The pending queue is rendered through the active agent's renderer; on Codex the unknown-shape entry falls into the \`render_raw_codex()\` "Codex Raw" catch-all and piles up.

**Fix**: \`codex_io_task\` now emits a synthetic user echo right before \`turn_start\`. The shape:

- Parses as \`ClaudeOutput::User\` (nested \`message: { role, content: [...] }\`) so the frontend dispatch sets \`msg_type = "user"\`.
- Carries a top-level \`content: <prompt>\` field so the existing content-match pending-clear branch fires.
- Skips the echo when the prompt starts with \`<system-reminder>\` — that's the portal-features reminder injection, which should stay invisible to the user.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --exclude backend\` (148 tests)
- [ ] Start a Codex session, send a message — confirm no "Codex Raw" block appears
- [ ] Send several messages back-to-back — confirm pending queue stays empty between turns
- [ ] Verify the portal-features reminder still injects on first connection but doesn't appear as a user message