### PR TITLE
Launchers panel: triple-click Update & Restart button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.5.20
+
+- **Add a triple-click "Update & Restart" button to the Launchers panel.** Lets an operator push a launcher to fetch the latest agent-portal release from GitHub and restart itself, straight from the dashboard. Three-stage confirmation prevents fat-finger accidents:
+  - **Click 1**: gray "Update & Restart" → yellow "Wait, really?"
+  - **Click 2**: yellow → red "Are you absolutely positively sure?"
+  - **Click 3**: red → muted "Restarting…" (POSTs `/api/launchers/:id/update`)
+- Backend translates the POST into a new `ServerToLauncher::UpdateAndRestart` WebSocket message; the launcher receives it, calls `portal_update::check_for_update` (the same path as the `agent-portal update` CLI subcommand), then `service::restart()` via systemctl/launchctl. If the launcher isn't running under a service manager it just exits and relies on an external supervisor to respawn.
+
 ## 2.5.19
 
 - **Fix "Codex Raw" pending messages piling up at the bottom of the transcript.** Codex's app-server protocol doesn't echo user input back the way Claude's CLI does, so the frontend's optimistic-send pending entry never matched anything and accumulated on every send. The pending entries were rendered through the Codex renderer (which doesn't recognize the `{type: "user", _pending: true}` shape) and fell into the "Codex Raw" catch-all. Fix: `codex_io_task` now emits a synthetic user echo (parses as `ClaudeOutput::User` with a top-level `content` field) right before kicking off the Codex turn, so the frontend's existing content-match pending-clear path fires identically for both agents. Portal-reminder injections wrapped in `<system-reminder>` tags are filtered out of the echo path so they stay invisible to the user.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.19"
+version = "2.5.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.19"
+version = "2.5.20"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.19"
+version = "2.5.20"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.19"
+version = "2.5.20"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.19"
+version = "2.5.20"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.19"
+version = "2.5.20"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.19"
+version = "2.5.20"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.19"
+version = "2.5.20"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.19"
+version = "2.5.20"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -235,3 +235,33 @@ pub async fn renew_launcher_token(
     info!("Manually renewed token for launcher {}", launcher_id);
     Ok(StatusCode::OK)
 }
+
+/// POST /api/launchers/:launcher_id/update - Tell the launcher to fetch the
+/// latest release, install it, and restart itself.
+pub async fn update_launcher(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path(launcher_id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    let user_id = extract_user_id(&app_state, &cookies)?;
+
+    let sender = {
+        let launcher = app_state
+            .session_manager
+            .launchers
+            .get(&launcher_id)
+            .ok_or(AppError::NotFound("Launcher not found"))?;
+        if launcher.user_id != user_id {
+            return Err(AppError::Forbidden);
+        }
+        launcher.sender.clone()
+    };
+
+    if sender.send(ServerToLauncher::UpdateAndRestart).is_err() {
+        warn!("Launcher {} disconnected while sending update", launcher_id);
+        return Err(AppError::Internal("Launcher disconnected".to_string()));
+    }
+
+    info!("Sent UpdateAndRestart to launcher {}", launcher_id);
+    Ok(StatusCode::OK)
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -534,6 +534,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/launchers/{launcher_id}/renew-token",
             post(handlers::launchers::renew_launcher_token),
         )
+        .route(
+            "/api/launchers/{launcher_id}/update",
+            post(handlers::launchers::update_launcher),
+        )
         // Admin dashboard routes (admin-only)
         .route("/api/admin/stats", get(handlers::admin::get_stats))
         .route("/api/admin/users", get(handlers::admin::list_users))

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -33,13 +33,17 @@ pub fn count_expiring_launchers(launchers: &[LauncherInfo]) -> usize {
 struct LauncherRowProps {
     launcher: LauncherInfo,
     on_renew: Callback<Uuid>,
+    on_update: Callback<Uuid>,
 }
 
 #[function_component(LauncherRow)]
 fn launcher_row(props: &LauncherRowProps) -> Html {
     let l = &props.launcher;
     let on_renew = props.on_renew.clone();
+    let on_update = props.on_update.clone();
     let launcher_id = l.launcher_id;
+    // Triple-click confirmation. 0=idle, 1=first prod, 2=last warning, 3=firing.
+    let update_step = use_state(|| 0u8);
 
     let (status_class, status_text) = if let Some(ref exp) = l.token_expires_at {
         let days = days_until_expiration(exp);
@@ -69,6 +73,29 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
         on_renew.emit(launcher_id);
     });
 
+    let (update_label, update_class) = match *update_step {
+        0 => ("Update & Restart", "update-button stage-0"),
+        1 => ("Wait, really?", "update-button stage-1"),
+        2 => (
+            "Are you absolutely positively sure?",
+            "update-button stage-2",
+        ),
+        _ => ("Restarting…", "update-button stage-3"),
+    };
+    let update_disabled = *update_step >= 3;
+
+    let on_update_click = {
+        let update_step = update_step.clone();
+        let on_update = on_update.clone();
+        Callback::from(move |_| {
+            let next = (*update_step).saturating_add(1);
+            update_step.set(next);
+            if next >= 3 {
+                on_update.emit(launcher_id);
+            }
+        })
+    };
+
     html! {
         <tr class="token-row">
             <td class="token-name">{ &l.launcher_name }</td>
@@ -85,6 +112,14 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
                         { "Renew Token" }
                     </button>
                 }
+                <button
+                    class={update_class}
+                    onclick={on_update_click}
+                    disabled={update_disabled}
+                    title="Pull the latest agent-portal release and restart this launcher"
+                >
+                    { update_label }
+                </button>
             </td>
         </tr>
     }
@@ -166,6 +201,35 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
         })
     };
 
+    let on_update = {
+        let renew_result = renew_result.clone();
+        Callback::from(move |launcher_id: Uuid| {
+            let renew_result = renew_result.clone();
+            spawn_local(async move {
+                let url = utils::api_url(&format!("/api/launchers/{}/update", launcher_id));
+                match Request::post(&url).send().await {
+                    Ok(resp) => {
+                        if resp.status() == 200 {
+                            renew_result.set(Some((
+                                true,
+                                "Update requested. The launcher will fetch the latest release and restart.".to_string(),
+                            )));
+                        } else {
+                            let text = resp.text().await.unwrap_or_default();
+                            renew_result.set(Some((
+                                false,
+                                format!("Update failed: {} {}", resp.status(), text),
+                            )));
+                        }
+                    }
+                    Err(e) => {
+                        renew_result.set(Some((false, format!("Update request failed: {:?}", e))));
+                    }
+                }
+            });
+        })
+    };
+
     html! {
         <section class="tokens-section">
             <div class="section-header">
@@ -212,6 +276,7 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
                                         key={l.launcher_id.to_string()}
                                         launcher={l.clone()}
                                         on_renew={on_renew.clone()}
+                                        on_update={on_update.clone()}
                                     />
                                 }
                             }) }

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -379,6 +379,40 @@
     background: var(--accent-hover);
 }
 
+/* Three-stage update-and-restart button — colors escalate to signal "are you sure?" */
+.update-button {
+    border: none;
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+    margin-left: 0.5rem;
+    transition: background 0.2s;
+}
+.update-button.stage-0 {
+    background: #7f849c;
+}
+.update-button.stage-0:hover {
+    background: #565f89;
+}
+.update-button.stage-1 {
+    background: #e0af68;
+    color: #1a1b26;
+}
+.update-button.stage-2 {
+    background: var(--error);
+}
+.update-button.stage-3 {
+    background: #565f89;
+    cursor: progress;
+}
+.update-button[disabled] {
+    cursor: not-allowed;
+    opacity: 0.85;
+}
+
 /* Token Created Success */
 .token-created-success {
     text-align: center;

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -549,6 +549,36 @@ async fn handle_message(
         ServerToLauncher::ServerShutdown { reason, .. } => {
             info!("Server shutting down: {}", reason);
         }
+        ServerToLauncher::UpdateAndRestart => {
+            info!("Received UpdateAndRestart request from dashboard");
+            tokio::spawn(async move {
+                match portal_update::check_for_update(crate::BINARY_PREFIX, false).await {
+                    Ok(portal_update::UpdateResult::UpToDate) => {
+                        info!("Already up to date; restarting service anyway");
+                    }
+                    Ok(portal_update::UpdateResult::Updated) => {
+                        info!("Update applied; restarting service");
+                    }
+                    Ok(portal_update::UpdateResult::UpdateAvailable { version, .. }) => {
+                        info!(
+                            "Update available ({}) but not applied; restarting anyway",
+                            version
+                        );
+                    }
+                    Err(e) => {
+                        error!("Update check failed: {}; restarting anyway", e);
+                    }
+                }
+                if crate::service::is_installed() {
+                    if let Err(e) = crate::service::restart() {
+                        error!("Service restart failed: {}", e);
+                    }
+                } else {
+                    info!("Service not installed; exiting so a supervisor can respawn");
+                    std::process::exit(0);
+                }
+            });
+        }
         other => {
             debug!("Unhandled message from server: {:?}", other);
         }

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -86,7 +86,7 @@ enum ServiceAction {
     Pastebin,
 }
 
-const BINARY_PREFIX: &str = "agent-portal";
+pub(crate) const BINARY_PREFIX: &str = "agent-portal";
 
 fn resolve_backend_url(args_url: Option<String>, config_url: Option<String>) -> String {
     args_url

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -466,6 +466,10 @@ pub enum ServerToLauncher {
 
     /// Push a renewed auth token to the launcher (auto-renewal or manual)
     TokenRenewed { token: String },
+
+    /// Tell the launcher to pull the latest release, install it, and restart
+    /// the agent-portal service. Triggered from the dashboard Launchers panel.
+    UpdateAndRestart,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Adds an "Update & Restart" button to each row of the Launchers panel that, on three escalating clicks, tells the launcher to fetch the latest agent-portal release and restart itself.

**Triple-click sequence** (per-row state):
- Click 1 — gray "Update & Restart" → yellow "Wait, really?"
- Click 2 — yellow → red "Are you absolutely positively sure?"
- Click 3 — red → muted "Restarting…" (fires the POST and disables further clicks)

**Plumbing**:
- New \`ServerToLauncher::UpdateAndRestart\` variant in \`shared/src/endpoints.rs\`.
- New \`POST /api/launchers/:launcher_id/update\` endpoint that validates ownership, then sends the WS message to the launcher.
- Launcher \`handle_message\` arm spawns a task that calls \`portal_update::check_for_update(BINARY_PREFIX, false)\` (same path as the \`agent-portal update\` CLI subcommand) then \`service::restart()\`. If the launcher isn't running under systemd/launchctl, it \`exit(0)\`s so an external supervisor can respawn.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings\`
- [x] \`cargo test --workspace --exclude backend\` (148 tests)
- [x] \`stylelint\` clean on \`frontend/styles/**/*.css\`
- [ ] Click the button three times in the Launchers panel — confirm color escalation and that the third click triggers the POST
- [ ] Confirm a launcher under systemd actually fetches and restarts (visible via launcher version field cycling in the panel)
- [ ] Confirm a launcher run outside a service manager exits cleanly on \`UpdateAndRestart\`