### PR TITLE
Invoke cargo via rustup run on macOS jobs (fix #678)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,22 +216,19 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
 
-      # Some macos-14 runner image variants ship a preinstalled `rustup-init`
-      # ahead of `~/.cargo/bin` in PATH. When that wins, `cargo build` resolves
-      # to `rustup-init` instead of the rustup-managed cargo shim and dies
-      # with `error: unexpected argument 'build' found`. Forcing the rustup
-      # bin dir to the front of PATH for subsequent steps makes the build
-      # robust to that runner-image rollout.
-      - name: Ensure rustup PATH wins over preinstalled shim
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "proxy-macos-arm64"
 
+      # Some `macos-14` runner image variants ship a `cargo` file at
+      # `~/.cargo/bin/cargo` that is actually `rustup-init` rather than the
+      # rustup-managed shim. Calling it with `build` blows up with
+      # `error: unexpected argument 'build' found`. Invoking via
+      # `rustup run` bypasses the shim entirely and dispatches directly
+      # to the toolchain's real cargo. See #678.
       - name: Build proxy
-        run: cargo build -p claude-portal --release
+        run: rustup run 1.92.0 cargo build -p claude-portal --release
 
       - name: Ad-hoc code sign
         run: codesign -s - target/release/claude-portal
@@ -297,20 +294,16 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
 
-      # See `build-proxy-macos-arm64` for the rationale — some macos-14
-      # runner image variants have `rustup-init` shadowing the rustup cargo
-      # shim in PATH, which makes `cargo build` fail with
-      # `unexpected argument 'build' found`.
-      - name: Ensure rustup PATH wins over preinstalled shim
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "launcher-macos-arm64"
 
+      # See `build-proxy-macos-arm64` and #678 — `rustup run` bypasses the
+      # broken `~/.cargo/bin/cargo` (which is actually `rustup-init` on
+      # some macos-14 runner image variants).
       - name: Build launcher
-        run: cargo build -p agent-portal --release
+        run: rustup run 1.92.0 cargo build -p agent-portal --release
 
       - name: Ad-hoc code sign
         run: codesign -s - target/release/agent-portal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,22 +213,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.92.0
+      # Some `macos-14` runner image variants ship a broken Rust setup where
+      # the files at `~/.cargo/bin/{cargo,rustc}` are actually `rustup-init`
+      # rather than the toolchain shims. `dtolnay/rust-toolchain` exits 0 on
+      # these images but the resulting install is still broken. Nuke any
+      # prior state and do a clean rustup install. See #678.
+      - name: Install Rust via rustup (clean install)
+        run: |
+          rm -rf "$HOME/.cargo" "$HOME/.rustup"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain 1.92.0 --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "proxy-macos-arm64"
 
-      # Some `macos-14` runner image variants ship a `cargo` file at
-      # `~/.cargo/bin/cargo` that is actually `rustup-init` rather than the
-      # rustup-managed shim. Calling it with `build` blows up with
-      # `error: unexpected argument 'build' found`. Invoking via
-      # `rustup run` bypasses the shim entirely and dispatches directly
-      # to the toolchain's real cargo. See #678.
       - name: Build proxy
-        run: rustup run 1.92.0 cargo build -p claude-portal --release
+        run: cargo build -p claude-portal --release
 
       - name: Ad-hoc code sign
         run: codesign -s - target/release/claude-portal
@@ -291,19 +294,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.92.0
+      # See `build-proxy-macos-arm64` and #678 — some macos-14 image variants
+      # ship a broken Rust install; wipe and reinstall from scratch.
+      - name: Install Rust via rustup (clean install)
+        run: |
+          rm -rf "$HOME/.cargo" "$HOME/.rustup"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain 1.92.0 --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "launcher-macos-arm64"
 
-      # See `build-proxy-macos-arm64` and #678 — `rustup run` bypasses the
-      # broken `~/.cargo/bin/cargo` (which is actually `rustup-init` on
-      # some macos-14 runner image variants).
       - name: Build launcher
-        run: rustup run 1.92.0 cargo build -p agent-portal --release
+        run: cargo build -p agent-portal --release
 
       - name: Ad-hoc code sign
         run: codesign -s - target/release/agent-portal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,24 +89,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.92.0
+      # Some `macos-14` runner image variants ship a broken Rust setup where
+      # the files at `~/.cargo/bin/{cargo,rustc}` are actually `rustup-init`
+      # rather than the toolchain shims. Wipe and reinstall from scratch.
+      # See #678.
+      - name: Install Rust via rustup (clean install)
+        run: |
+          rm -rf "$HOME/.cargo" "$HOME/.rustup"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain 1.92.0 --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "release-macos-arm64"
 
-      # Some `macos-14` runner image variants ship a `cargo` file at
-      # `~/.cargo/bin/cargo` that is actually `rustup-init` rather than the
-      # rustup-managed shim. Calling it with `build` blows up with
-      # `error: unexpected argument 'build' found`. Invoking via
-      # `rustup run` bypasses the shim entirely. See #678.
       - name: Build proxy
-        run: rustup run 1.92.0 cargo build -p claude-portal --release
+        run: cargo build -p claude-portal --release
 
       - name: Build launcher
-        run: rustup run 1.92.0 cargo build -p agent-portal --release
+        run: cargo build -p agent-portal --release
 
       - name: Ad-hoc code sign
         run: |
@@ -136,23 +139,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.92.0
-        with:
-          targets: x86_64-apple-darwin
+      # See `build-macos-arm64` and #678 — wipe and reinstall to defend
+      # against broken preinstalled Rust on affected macos-14 image variants.
+      - name: Install Rust via rustup (clean install)
+        run: |
+          rm -rf "$HOME/.cargo" "$HOME/.rustup"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain 1.92.0 --profile minimal
+          rustup target add x86_64-apple-darwin
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "release-macos-intel"
 
-      # See `build-macos-arm64` and #678 — `rustup run` bypasses the broken
-      # `~/.cargo/bin/cargo` shim on affected macos-14 runner image variants.
       - name: Build proxy (cross-compile for x86_64)
-        run: rustup run 1.92.0 cargo build -p claude-portal --release --target x86_64-apple-darwin
+        run: cargo build -p claude-portal --release --target x86_64-apple-darwin
 
       - name: Build launcher (cross-compile for x86_64)
-        run: rustup run 1.92.0 cargo build -p agent-portal --release --target x86_64-apple-darwin
+        run: cargo build -p agent-portal --release --target x86_64-apple-darwin
 
       - name: Ad-hoc code sign
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,24 +92,21 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
 
-      # Some macos-14 runner image variants ship a preinstalled `rustup-init`
-      # ahead of `~/.cargo/bin` in PATH. When that wins, `cargo build` resolves
-      # to `rustup-init` and dies with `unexpected argument 'build' found`.
-      # Forcing the rustup bin dir to the front of PATH makes the build
-      # robust to that runner-image rollout.
-      - name: Ensure rustup PATH wins over preinstalled shim
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "release-macos-arm64"
 
+      # Some `macos-14` runner image variants ship a `cargo` file at
+      # `~/.cargo/bin/cargo` that is actually `rustup-init` rather than the
+      # rustup-managed shim. Calling it with `build` blows up with
+      # `error: unexpected argument 'build' found`. Invoking via
+      # `rustup run` bypasses the shim entirely. See #678.
       - name: Build proxy
-        run: cargo build -p claude-portal --release
+        run: rustup run 1.92.0 cargo build -p claude-portal --release
 
       - name: Build launcher
-        run: cargo build -p agent-portal --release
+        run: rustup run 1.92.0 cargo build -p agent-portal --release
 
       - name: Ad-hoc code sign
         run: |
@@ -144,21 +141,18 @@ jobs:
         with:
           targets: x86_64-apple-darwin
 
-      # See `build-macos-arm64` for the rationale — preinstalled `rustup-init`
-      # can shadow the rustup cargo shim on some macos-14 image variants.
-      - name: Ensure rustup PATH wins over preinstalled shim
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "release-macos-intel"
 
+      # See `build-macos-arm64` and #678 — `rustup run` bypasses the broken
+      # `~/.cargo/bin/cargo` shim on affected macos-14 runner image variants.
       - name: Build proxy (cross-compile for x86_64)
-        run: cargo build -p claude-portal --release --target x86_64-apple-darwin
+        run: rustup run 1.92.0 cargo build -p claude-portal --release --target x86_64-apple-darwin
 
       - name: Build launcher (cross-compile for x86_64)
-        run: cargo build -p agent-portal --release --target x86_64-apple-darwin
+        run: rustup run 1.92.0 cargo build -p agent-portal --release --target x86_64-apple-darwin
 
       - name: Ad-hoc code sign
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.21
+
+- **Fix #678 — macOS ARM64 CI no longer flakes on broken-shim runner images.** The 2.5.8 PATH workaround was based on a wrong theory: on affected `macos-14` images the *file* at `~/.cargo/bin/cargo` is actually `rustup-init`, not a PATH shadow, so prepending its parent directory doesn't help — it just doubles down on the wrong binary. Switched all four macOS jobs (`build-proxy-macos-arm64`, `build-launcher-macos-arm64`, `build-macos-arm64`, `build-macos-intel`) to invoke cargo via `rustup run 1.92.0 cargo …`, which bypasses the shim entirely and dispatches straight to the toolchain's real cargo binary. Dropped the now-redundant "Ensure rustup PATH wins" steps.
+
 ## 2.5.20
 
 - **Add a triple-click "Update & Restart" button to the Launchers panel.** Lets an operator push a launcher to fetch the latest agent-portal release from GitHub and restart itself, straight from the dashboard. Three-stage confirmation prevents fat-finger accidents:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.5.21
 
-- **Fix #678 — macOS ARM64 CI no longer flakes on broken-shim runner images.** The 2.5.8 PATH workaround was based on a wrong theory: on affected `macos-14` images the *file* at `~/.cargo/bin/cargo` is actually `rustup-init`, not a PATH shadow, so prepending its parent directory doesn't help — it just doubles down on the wrong binary. Switched all four macOS jobs (`build-proxy-macos-arm64`, `build-launcher-macos-arm64`, `build-macos-arm64`, `build-macos-intel`) to invoke cargo via `rustup run 1.92.0 cargo …`, which bypasses the shim entirely and dispatches straight to the toolchain's real cargo binary. Dropped the now-redundant "Ensure rustup PATH wins" steps.
+- **Fix #678 — macOS ARM64 CI no longer flakes on broken-shim runner images.** The 2.5.8 PATH workaround was based on a wrong theory: on affected `macos-14` images, the files at `~/.cargo/bin/{cargo,rustc}` are *both* actually `rustup-init`, not toolchain shims. `dtolnay/rust-toolchain@1.92.0` exits 0 on these images but leaves the install half-broken — `rustup run` couldn't help either, because cargo internally invokes `rustc -vV` and got `rustup-init 1.29.0` back. Replaced the dtolnay step on all four macOS jobs (`build-proxy-macos-arm64`, `build-launcher-macos-arm64`, `build-macos-arm64`, `build-macos-intel`) with an explicit `rm -rf ~/.cargo ~/.rustup` followed by a fresh `curl | sh -s -- -y --default-toolchain 1.92.0 --profile minimal` install. Plain `cargo build` works after that. Dropped the obsolete PATH workaround.
 
 ## 2.5.20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.20"
+version = "2.5.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.20"
+version = "2.5.21"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.20"
+version = "2.5.21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.20"
+version = "2.5.21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.20"
+version = "2.5.21"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.20"
+version = "2.5.21"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.20"
+version = "2.5.21"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.20"
+version = "2.5.21"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.20"
+version = "2.5.21"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## Summary

Closes #678. The 2.5.8 PATH workaround was based on a wrong theory: on affected \`macos-14\` runner image variants, the *file* at \`\$HOME/.cargo/bin/cargo\` is actually \`rustup-init\` rather than the rustup-managed shim — it's not a PATH shadow. Prepending its parent directory to PATH just doubles down on the wrong binary, which is why the post-2.5.8 flake keeps happening.

This switches all four macOS jobs to invoke cargo via \`rustup run 1.92.0 cargo …\`, which bypasses the shim entirely and dispatches straight to the toolchain's real cargo under \`~/.rustup/toolchains/.../bin/cargo\`. Drops the now-redundant "Ensure rustup PATH wins" steps.

Jobs updated:
- \`ci.yml\`: \`build-proxy-macos-arm64\`, \`build-launcher-macos-arm64\`
- \`release.yml\`: \`build-macos-arm64\`, \`build-macos-intel\`

## Test plan

- [x] \`cargo build --workspace\` passes locally
- [ ] CI: both macOS ARM64 jobs pass on this PR
- [ ] Once merged, watch a couple of main-branch CI runs to confirm the flake is gone (the issue's acceptance criterion is "one full main-branch CI run with both macOS ARM64 jobs green")