### PR TITLE
Session pills: blue focus ring, drop pulsating red awaiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.5.24
+
+- **Session pill colors: blue focus ring, no more pulsating red on awaiting pills.** The 2.5.11 "bright-red active pill indicator" was too loud; the awaiting-pulse animation made it worse for any tab the agent was still chewing on. Now:
+  - **Focused pill**: accent-blue border + soft blue background tint + 2 px blue ring.
+  - **Awaiting pill** (agent still working): subtle orange border, no animation. The existing in-pill indicator glyph still picks up an orange tint to flag the state without the page strobing.
+  - **Focused + awaiting**: focus state dominates — keeps the blue ring/background; the indicator glyph alone signals "still working."
+- Dropped the `@keyframes awaitingPulse` rule.
+
 ## 2.5.23
 
 - **Fix #692 — portal reminder no longer bloats the user transcript.** Two parts:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.23"
+version = "2.5.24"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -168,28 +168,20 @@
 }
 
 .session-pill.focused {
-    border-color: #ff3b5c;
-    background: rgba(255, 59, 92, 0.18);
-    box-shadow: 0 0 0 2px rgba(255, 59, 92, 0.45);
+    border-color: var(--accent);
+    background: rgba(122, 162, 247, 0.18);
+    box-shadow: 0 0 0 2px rgba(122, 162, 247, 0.5);
 }
 
 .session-pill.awaiting {
-    border-color: var(--error);
-    animation: awaitingPulse 2s ease-in-out infinite;
-}
-
-@keyframes awaitingPulse {
-    0%, 100% {
-        box-shadow: 0 0 0 0 rgba(247, 118, 142, 0.4);
-    }
-    50% {
-        box-shadow: 0 0 0 4px rgba(247, 118, 142, 0.2);
-    }
+    border-color: #e0af68;
 }
 
 .session-pill.focused.awaiting {
-    border-color: var(--error);
-    background: rgba(247, 118, 142, 0.15);
+    /* Focus state dominates — keep the blue ring/background; the indicator
+       glyph alone signals "still waiting". */
+    border-color: var(--accent);
+    background: rgba(122, 162, 247, 0.18);
 }
 
 .pill-indicator {
@@ -198,7 +190,7 @@
 }
 
 .session-pill.awaiting .pill-indicator {
-    color: var(--error);
+    color: #e0af68;
 }
 
 .pill-name {


### PR DESCRIPTION
## Summary

Aesthetic tweak per request:

- **Focused pill**: was bright red (\`#ff3b5c\`) border + red background + red ring. Now accent-blue border + soft blue background tint + 2 px blue ring. The blue ring sits on the blue background to make the selected session immediately visually distinct without screaming.
- **Awaiting pill** (agent is still working): was red border + pulsating red box-shadow animation (\`@keyframes awaitingPulse\`). Now just a subtle orange border, no animation. The in-pill indicator glyph still picks up an orange tint to flag the state.
- **Focused + awaiting**: focus dominates — blue ring/background. The orange indicator glyph alone tells you the agent is still chewing.

Dropped the \`@keyframes awaitingPulse\` rule entirely.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`stylelint\` clean
- [ ] Visual check in browser: focused pill is clearly blue-ringed, no red pulsing on background tabs