### PR TITLE
Tolerate codex frame decode failures (fix #695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.22
+
+- **Fix #695 — codex sessions no longer die on typed-decode errors.** Codex CLI 0.130.0 emits at least one frame type (likely a notification with a `callId` field our bundled `codex-codes` 0.128.0 doesn't model) that fails strict deserialization. Previously the proxy turned that into `SessionError::CommunicationError` and killed the session; from the user's POV the agent just vanished mid-turn. Now `codex_io_task` matches on `codex_codes::Error::Json` specifically, logs a warning, and continues the loop so the rest of the session stays alive. Other error variants (I/O, protocol, server-closed) still terminate as before.
+
 ## 2.5.21
 
 - **Fix #678 — macOS ARM64 CI no longer flakes on broken-shim runner images.** The 2.5.8 PATH workaround was based on a wrong theory: on affected `macos-14` images, the files at `~/.cargo/bin/{cargo,rustc}` are *both* actually `rustup-init`, not toolchain shims. `dtolnay/rust-toolchain@1.92.0` exits 0 on these images but leaves the install half-broken — `rustup run` couldn't help either, because cargo internally invokes `rustc -vV` and got `rustup-init 1.29.0` back. Replaced the dtolnay step on all four macOS jobs (`build-proxy-macos-arm64`, `build-launcher-macos-arm64`, `build-macos-arm64`, `build-macos-intel`) with an explicit `rm -rf ~/.cargo ~/.rustup` followed by a fresh `curl | sh -s -- -y --default-toolchain 1.92.0 --profile minimal` install. Plain `cargo build` works after that. Dropped the obsolete PATH workaround.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.21"
+version = "2.5.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.21"
+version = "2.5.22"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.21"
+version = "2.5.22"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.21"
+version = "2.5.22"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.21"
+version = "2.5.22"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.21"
+version = "2.5.22"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.21"
+version = "2.5.22"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.21"
+version = "2.5.22"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.21"
+version = "2.5.22"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -743,6 +743,19 @@ impl Session {
                                 let _ = event_tx.send(IoEvent::Exited { code: 0 });
                                 break;
                             }
+                            Err(codex_codes::Error::Json(json_err)) => {
+                                // Newer codex CLI versions sometimes emit frames whose
+                                // typed param struct fails our bundled codex-codes
+                                // schema (e.g. #695 — missing field `callId` in codex
+                                // 0.130.0). Killing the session on every protocol
+                                // skew is too aggressive: skip the frame and stay
+                                // connected so the user doesn't lose the session.
+                                tracing::warn!(
+                                    "Codex frame failed typed decode (skipping): {}",
+                                    json_err
+                                );
+                                continue;
+                            }
                             Err(e) => {
                                 let _ = event_tx.send(IoEvent::Error(
                                     SessionError::CommunicationError(e.to_string()),


### PR DESCRIPTION
## Summary

Closes #695. Codex CLI 0.130.0 emits at least one frame whose typed param struct fails strict deserialization in our bundled \`codex-codes\` 0.128.0 (the reported case is "missing field \`callId\`"). The previous code surfaced that as a fatal \`SessionError::CommunicationError\` and tore the session down — from the user's POV the agent vanished mid-turn after a tool use.

Now \`codex_io_task\` matches on \`codex_codes::Error::Json\` specifically, logs a warning with the deserializer's error message (which usually names the missing/extra field and offset), and \`continue\`s the read loop. Other error variants (\`Io\`, \`JsonRpc\`, \`ServerClosed\`) still terminate the session as before.

Followups (tracked separately, not in this PR):
- The "log the offending JSON payload" ask from the issue would require either a codex-codes upstream change to surface the raw line, or wrapping the read pipeline ourselves. The error message alone is usually enough to diagnose.
- Surfacing the "newer than tested" warning in the portal UI is also separate.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace --exclude backend\`
- [ ] On a runner with codex CLI 0.130.0: launch a session, send a prompt that triggers a tool use, confirm the session stays alive and the agent continues normally (the bad frame is logged at WARN level instead)