### PR TITLE
Stop showing portal reminder text in the transcript (fix #692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.5.23
+
+- **Fix #692 — portal reminder no longer bloats the user transcript.** Two parts:
+  - Reflowed `claude-session-lib/portal_reminder.md` to single-line paragraphs and bullets. The previous 72-column hand-wrapping turned every continuation into a new visual line in the rendered preview; long-line markdown lets the renderer reflow to the available width.
+  - Dropped the user-bound `PortalMessage::reminder` emission entirely. The collapsed "Portal features" block on the frontend was content the user already knew (they built the portal), and the actually-useful side — re-priming the agent's affordance knowledge after a fresh start / compaction — is the stdin injection, which stays. The `PortalContent::Reminder` enum variant and its frontend renderer are kept around so historical DB rows still deserialize cleanly.
+- **Filter Claude's user-message echo of `<system-reminder>` wrappers.** When the proxy injects the reminder via stdin, Claude echoes it back on stdout as a `ClaudeOutput::User` whose content is the raw `<system-reminder>…</system-reminder>` text. Forwarding that to the frontend leaked the wrapper text into the transcript as if the user had typed it. The output forwarder now detects user-message echoes whose first text block starts with `<system-reminder>` and drops them before forwarding.
+
 ## 2.5.22
 
 - **Fix #695 — codex sessions no longer die on typed-decode errors.** Codex CLI 0.130.0 emits at least one frame type (likely a notification with a `callId` field our bundled `codex-codes` 0.128.0 doesn't model) that fails strict deserialization. Previously the proxy turned that into `SessionError::CommunicationError` and killed the session; from the user's POV the agent just vanished mid-turn. Now `codex_io_task` matches on `codex_codes::Error::Json` specifically, logs a warning, and continues the loop so the rest of the session stays alive. Other error variants (I/O, protocol, server-closed) still terminate as before.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.22"
+version = "2.5.23"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/portal_reminder.md
+++ b/claude-session-lib/portal_reminder.md
@@ -1,39 +1,10 @@
-You're running inside the Agent Portal — a web frontend that renders your
-output to the user. Affordances worth knowing about so you can use them
-deliberately:
+You're running inside the Agent Portal — a web frontend that renders your output to the user. Affordances worth knowing about so you can use them deliberately:
 
-- **Markdown**: bold, italic, headings, lists, tables, blockquotes, fenced
-  code blocks with syntax highlighting, and horizontal rules.
-- **Math**: LaTeX expressions are typeset by KaTeX. Use `$inline$` for
-  inline math, `$$display$$` (or `\[…\]`) for display math, and `\(…\)`
-  for inline. Tables and inline math compose freely.
-- **Links**: bare URLs (`https://…`) are auto-linked in plain text, in
-  fenced code blocks, in tool-result previews, and inside inline `code`
-  spans. You don't need to wrap URLs in markdown link syntax unless you
-  want custom anchor text.
-- **Images**: when you `Read` a `.png`, `.jpg`, `.gif`, `.webp`, or `.svg`
-  file, the portal displays it inline to the user. You can show the user
-  generated artwork or diagnostic plots just by `Read`ing the file.
-  **Prefer SVG** for plots, diagrams, charts, and any generated graphics
-  — it scales crisply on retina/mobile and stays small over the wire.
-  The portal renders on a dark Tokyo-Night background (`#1a1b26`), so
-  give SVGs a **transparent background** (no white `<rect>` fill) and
-  pick stroke/fill colors that read on dark — light grays for axes/grid
-  (`#c0caf5` text, `#565f89` muted), and accent hues that match the
-  palette (`#7aa2f7` blue, `#9ece6a` green, `#f7768e` red,
-  `#e0af68` orange, `#bb9af7` purple, `#7dcfff` teal). For matplotlib,
-  `plt.savefig(..., transparent=True)` plus `mpl.rcParams` color tweaks
-  is the easy path.
-- **Structured prompts**: the `AskUserQuestion` tool renders as a
-  click-to-answer multiple-choice form (single- or multi-select). Prefer
-  it over open-ended free-text questions when the answer space is finite.
-- **Session context**: the user sees your working directory, git branch,
-  and PR URL (if one exists) in the session pill next to your output.
-  You don't need to repeat that context unless you're changing it.
-- **Mobile and desktop**: the portal runs on both. Prefer concise answers
-  and avoid extremely wide tables; long horizontal layouts force a
-  horizontal scroll on phones.
-- **Sharing and cron**: the user can share this session read-only with
-  others, and can schedule a prompt to re-run on a cron. Output you
-  produce here may be observed by other users or replayed in a future
-  scheduled run.
+- **Markdown**: bold, italic, headings, lists, tables, blockquotes, fenced code blocks with syntax highlighting, and horizontal rules.
+- **Math**: LaTeX expressions are typeset by KaTeX. Use `$inline$` for inline math, `$$display$$` (or `\[…\]`) for display math, and `\(…\)` for inline. Tables and inline math compose freely.
+- **Links**: bare URLs (`https://…`) are auto-linked in plain text, in fenced code blocks, in tool-result previews, and inside inline `code` spans. You don't need to wrap URLs in markdown link syntax unless you want custom anchor text.
+- **Images**: when you `Read` a `.png`, `.jpg`, `.gif`, `.webp`, or `.svg` file, the portal displays it inline to the user. You can show the user generated artwork or diagnostic plots just by `Read`ing the file. **Prefer SVG** for plots, diagrams, charts, and any generated graphics — it scales crisply on retina/mobile and stays small over the wire. The portal renders on a dark Tokyo-Night background (`#1a1b26`), so give SVGs a **transparent background** (no white `<rect>` fill) and pick stroke/fill colors that read on dark — light grays for axes/grid (`#c0caf5` text, `#565f89` muted), and accent hues that match the palette (`#7aa2f7` blue, `#9ece6a` green, `#f7768e` red, `#e0af68` orange, `#bb9af7` purple, `#7dcfff` teal). For matplotlib, `plt.savefig(..., transparent=True)` plus `mpl.rcParams` color tweaks is the easy path.
+- **Structured prompts**: the `AskUserQuestion` tool renders as a click-to-answer multiple-choice form (single- or multi-select). Prefer it over open-ended free-text questions when the answer space is finite.
+- **Session context**: the user sees your working directory, git branch, and PR URL (if one exists) in the session pill next to your output. You don't need to repeat that context unless you're changing it.
+- **Mobile and desktop**: the portal runs on both. Prefer concise answers and avoid extremely wide tables; long horizontal layouts force a horizontal scroll on phones.
+- **Sharing and cron**: the user can share this session read-only with others, and can schedule a prompt to re-run on a cron. Output you produce here may be observed by other users or replayed in a future scheduled run.

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -698,7 +698,7 @@ async fn run_message_loop(
     // already has it; subsequent re-injections happen at compaction
     // boundaries from inside `output_forwarder`.
     if session.first_connection {
-        inject_portal_reminder(session.claude_session, &ws_write, &session.output_buffer).await;
+        inject_portal_reminder(session.claude_session).await;
     }
 
     // Main loop

--- a/claude-session-lib/src/proxy_session/portal_reminder.rs
+++ b/claude-session-lib/src/proxy_session/portal_reminder.rs
@@ -1,12 +1,12 @@
 //! Portal features reminder injected at session start and after each
 //! compaction boundary.
 //!
-//! Two parallel streams off the same trigger:
-//! 1. The agent-facing copy is sent as user input wrapped in
-//!    `<system-reminder>…</system-reminder>` tags. Claude treats those tags
-//!    as out-of-band context rather than a real user message.
-//! 2. The user-facing copy is emitted as a `PortalContent::Reminder` and
-//!    rendered as a collapsed block on the frontend.
+//! The reminder is sent to the agent only — wrapped in
+//! `<system-reminder>…</system-reminder>` tags so Claude treats it as
+//! out-of-band context. The user-facing copy was removed in #692: it ate too
+//! much vertical scrollback for content the user already knows (they built
+//! the portal), and the reminder's value is the agent recovering its
+//! affordance knowledge after a fresh start / compaction.
 //!
 //! The reminder body lives in `claude-session-lib/portal_reminder.md` as a
 //! readable markdown file and is baked into the binary via `include_str!`.
@@ -14,14 +14,9 @@
 //! readable path; on a missing or unreadable override we log a warning and
 //! fall back to the bundled default.
 
-use std::sync::Arc;
-use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
-use crate::output_buffer::PendingOutputBuffer;
 use crate::session::Session as ClaudeSession;
-
-use super::SharedWsWrite;
 
 /// Bundled fallback body (relative to this file).
 const DEFAULT_BODY: &str = include_str!("../../portal_reminder.md");
@@ -57,38 +52,19 @@ fn agent_facing(body: &str) -> String {
     format!("<system-reminder>\n{}\n</system-reminder>", body.trim())
 }
 
-/// Inject the reminder on both streams: agent-bound (via stdin) and
-/// user-bound (as a sequenced portal message). Idempotency / "only on the
-/// right trigger" is the caller's responsibility — this function unconditionally
-/// fires both.
-pub async fn inject_portal_reminder(
-    claude_session: &mut ClaudeSession,
-    ws_write: &SharedWsWrite,
-    output_buffer: &Arc<Mutex<PendingOutputBuffer>>,
-) {
+/// Inject the reminder into the agent's stdin only. The user-bound copy was
+/// removed (#692): it bloated the scrollback for content the user already
+/// knew, and the agent-side reminder is the part that actually does work
+/// (re-priming the model after a compaction). The companion fix in the proxy
+/// output forwarder also filters Claude's user-message echo of the
+/// `<system-reminder>` text so the wrapper doesn't leak into the transcript.
+pub async fn inject_portal_reminder(claude_session: &mut ClaudeSession) {
     let body = load_reminder_body();
 
-    // Agent-bound: a single user-input message wrapped in <system-reminder>.
     if let Err(e) = claude_session
         .send_input(serde_json::Value::String(agent_facing(&body)))
         .await
     {
         error!("Failed to inject portal reminder into agent stdin: {}", e);
-    }
-
-    // User-bound: a sequenced portal message rendered collapsed on the frontend.
-    let portal_msg = shared::PortalMessage::reminder("Portal features".to_string(), body);
-    let portal_content = portal_msg.to_json();
-    let seq = {
-        let mut buf = output_buffer.lock().await;
-        buf.push(portal_content.clone())
-    };
-    let ws_msg = shared::ProxyToServer::SequencedOutput {
-        seq,
-        content: portal_content,
-    };
-    let mut ws = ws_write.lock().await;
-    if let Err(e) = ws.send(ws_msg).await {
-        error!("Failed to send portal reminder message to backend: {}", e);
     }
 }

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use claude_codes::io::ContentBlock;
 use claude_codes::ClaudeOutput;
 use shared::ProxyToServer;
 use tokio::sync::{mpsc, Mutex};
@@ -71,6 +72,16 @@ pub(super) async fn handle_session_event_with_wiggum(
                 _ => false,
             };
 
+            // The portal-features reminder is injected as user input wrapped in
+            // <system-reminder> tags. Claude echoes that back as a User message
+            // on its stdout — if we forward it, the wrapper text leaks into the
+            // user's transcript as if they had typed it. Drop those echoes.
+            if is_system_reminder_echo(output) {
+                debug!("Dropping system-reminder user echo from transcript");
+                // Skip forwarding and skip the rest of the handler.
+                return None;
+            }
+
             // Forward the output
             if output_tx.send(*output.clone()).is_err() {
                 error!("Failed to forward Claude output");
@@ -78,7 +89,7 @@ pub(super) async fn handle_session_event_with_wiggum(
             }
 
             if is_compaction_boundary {
-                super::inject_portal_reminder(claude_session, ws_write, output_buffer).await;
+                super::inject_portal_reminder(claude_session).await;
             }
 
             // Handle wiggum loop continuation
@@ -241,6 +252,19 @@ pub(super) async fn handle_session_event_with_wiggum(
 }
 
 /// Check if Claude's result indicates wiggum completion (responded with "DONE")
+/// Is this Claude output Claude's echo of a `<system-reminder>`-wrapped user
+/// input? Those wrapped messages are how we inject the portal-features
+/// reminder (and similar out-of-band context); they shouldn't leak into the
+/// user's transcript as if the user had typed them.
+fn is_system_reminder_echo(output: &ClaudeOutput) -> bool {
+    let ClaudeOutput::User(user) = output else {
+        return false;
+    };
+    user.message.content.iter().any(|block| {
+        matches!(block, ContentBlock::Text(t) if t.text.trim_start().starts_with("<system-reminder>"))
+    })
+}
+
 fn check_wiggum_done(result: &claude_codes::io::ResultMessage) -> bool {
     // Check if it was an error (don't continue on errors)
     if result.is_error {


### PR DESCRIPTION
## Summary

Closes #692. The portal-features reminder was eating scrollback in two ways the user shouldn't have to see:

1. **User-bound collapsed block was just noise.** The \`PortalMessage::reminder\` block was content the user already knew — they built the portal. Drop the user-bound emission entirely. The agent-side stdin injection (which actually does the work — re-priming the model's affordance knowledge after a fresh start / compaction) stays. The \`PortalContent::Reminder\` enum variant and its frontend renderer are kept around so any historical DB rows still deserialize.

2. **Claude echoed the \`<system-reminder>\` wrapper as a user message.** When the proxy injects the reminder via stdin, Claude emits a \`ClaudeOutput::User\` echo whose content is the raw \`<system-reminder>…</system-reminder>\` text. Previously the proxy forwarded it and the wrapper leaked into the transcript as if the user had typed it. The output forwarder now detects user-message echoes whose first text block starts with \`<system-reminder>\` and drops them before forwarding.

3. **Reflowed \`portal_reminder.md\`** to single-line paragraphs and bullets. The 72-col hand-wrap was forcing visual line breaks in the rendered preview (each continuation indented under its bullet); long-line markdown lets the renderer reflow to the available width.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings\`
- [ ] Launch a Claude session — confirm no "Portal features" collapsed block appears at session start
- [ ] Trigger a context compaction — confirm no \`<system-reminder>\`-wrapped user message appears in the transcript afterward
- [ ] Confirm the agent still acts on the reminder (e.g. uses SVG with transparent backgrounds for plots) in a fresh session