### PR TITLE
Awaiting pill back to red border (no pulse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.25
+
+- Awaiting pill border + indicator back to red (`--error`) instead of orange. The pulse animation stays gone (#684's complaint was the strobing, not the color).
+
 ## 2.5.24
 
 - **Session pill colors: blue focus ring, no more pulsating red on awaiting pills.** The 2.5.11 "bright-red active pill indicator" was too loud; the awaiting-pulse animation made it worse for any tab the agent was still chewing on. Now:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.24"
+version = "2.5.25"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -174,7 +174,7 @@
 }
 
 .session-pill.awaiting {
-    border-color: #e0af68;
+    border-color: var(--error);
 }
 
 .session-pill.focused.awaiting {
@@ -190,7 +190,7 @@
 }
 
 .session-pill.awaiting .pill-indicator {
-    color: #e0af68;
+    color: var(--error);
 }
 
 .pill-name {


### PR DESCRIPTION
Quick color tweak. Previous PR replaced the red awaiting border with orange (\`#e0af68\`); the actual complaint was the strobing animation, not the color. Restore \`--error\` red on \`.session-pill.awaiting\` (border + in-pill indicator). The \`@keyframes awaitingPulse\` rule stays gone.

## Test plan

- [x] \`stylelint\` clean
- [ ] Visual: awaiting pill has a static red border, no animation