### PR TITLE
DRY message dispatch: user/portal render the same on both agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.28
+
+- **Stop rendering protocol-agnostic messages as "Codex Raw" blocks on Codex sessions.** The synthetic user-echo (PR #691, fixing the "Codex Raw" pile-up) and the backend's `Portal` envelope both have `type: "user"` / `type: "portal"` and parse cleanly as `ClaudeMessage` — but the old dispatch sent every message on a Codex session straight to the Codex renderer, which only knows codex-specific shapes (`item.*`, `turn.*`) and falls anything else through to the "raw JSON" catch-all. The user saw their own input echoed as a JSON dump. Dispatch now matches on the message shape first (any recognized `ClaudeMessage` variant renders the same on both agents) and only routes the remaining unknown-shape messages to the Codex renderer.
+
 ## 2.5.27
 
 - **Agent-type watermark behind session pills.** Each pill now shows the actual brand mark of the agent backing it — Anthropic's stylized burst behind Claude sessions, OpenAI's hex-knot behind Codex sessions — anchored to the left edge of the pill, clipped to the rounded silhouette via the existing `overflow: hidden`, sized to overflow the corner a bit. Light grey at 0.22 opacity, sits below the foreground text and indicators so legibility is unchanged. The old "Codex" text badge is removed since the watermark carries the same signal.
@@ -8,6 +12,7 @@
 ## 2.5.26
 
 - **Fix #703 — codex sessions no longer wedge after a typed-decode failure.** The 2.5.22 patch for #695 kept the session alive after `codex-codes` failed to deserialize a frame, but silently dropped the frame. When the lost frame was a server→client approval request (the `callId`-missing variant in codex 0.130.0's `item/{commandExecution,fileChange}/requestApproval`), codex blocked the turn waiting for a reply it would never get; the proxy stayed in `turn_active = true` and rejected every subsequent user prompt with `Received input while Codex turn is active`. From the user's POV the session looked alive but ignored them. Now, on `codex_codes::Error::Json` during an active turn, `claude-session-lib` (a) emits a `turn.failed` event to the frontend so the hang is visible, and (b) sends `turn/interrupt` so codex unblocks and emits `turn/completed` (Interrupted), which clears the flag through the normal path. If `turn_interrupt` itself errors, the flag is force-cleared to avoid a permanent wedge.
+>>>>>>> 5e07d51 (Share message-shape dispatch between Claude and Codex renderers)
 
 ## 2.5.25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.27"
+version = "2.5.28"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -133,31 +133,48 @@ pub struct MessageRendererProps {
 
 #[function_component(MessageRenderer)]
 pub fn message_renderer(props: &MessageRendererProps) -> Html {
-    if props.agent_type == shared::AgentType::Codex {
-        return html! {
-            <super::codex_renderer::CodexMessageRenderer json={props.json.clone()} />
-        };
-    }
-
     let ts = extract_local_timestamp(&props.json);
     let raw_iso = extract_raw_iso(&props.json);
     let parsed: Result<ClaudeMessage, _> = serde_json::from_str(&props.json);
 
+    // Dispatch on the message shape, not the agent. `User` (the proxy's
+    // synthetic echo) and `Portal` (the backend's portal-content envelope)
+    // are protocol-agnostic and must render the same way on Claude and
+    // Codex sessions — otherwise the Codex renderer's catch-all turns them
+    // into raw JSON blocks. Codex-specific shapes (`item.started`,
+    // `turn.completed`, …) don't match any `ClaudeMessage` variant and fall
+    // through to the codex renderer below.
     match parsed {
-        Ok(ClaudeMessage::System(msg)) => renderers::render_system_message(&msg, ts.as_deref()),
+        Ok(ClaudeMessage::System(msg)) => {
+            return renderers::render_system_message(&msg, ts.as_deref());
+        }
         Ok(ClaudeMessage::Assistant(msg)) => {
-            renderers::render_assistant_message(&msg, ts.as_deref(), raw_iso.as_deref())
+            return renderers::render_assistant_message(&msg, ts.as_deref(), raw_iso.as_deref());
         }
-        Ok(ClaudeMessage::Result(msg)) => renderers::render_result_message(&msg),
+        Ok(ClaudeMessage::Result(msg)) => return renderers::render_result_message(&msg),
         Ok(ClaudeMessage::User(msg)) => {
-            renderers::render_user_message(&msg, props.current_user_id.as_deref(), ts.as_deref())
+            return renderers::render_user_message(
+                &msg,
+                props.current_user_id.as_deref(),
+                ts.as_deref(),
+            );
         }
-        Ok(ClaudeMessage::Error(msg)) => renderers::render_error_message(&msg, ts.as_deref()),
-        Ok(ClaudeMessage::Portal(msg)) => renderers::render_portal_message(&msg, ts.as_deref()),
+        Ok(ClaudeMessage::Error(msg)) => {
+            return renderers::render_error_message(&msg, ts.as_deref());
+        }
+        Ok(ClaudeMessage::Portal(msg)) => {
+            return renderers::render_portal_message(&msg, ts.as_deref());
+        }
         Ok(ClaudeMessage::RateLimitEvent(msg)) => {
-            renderers::render_rate_limit_event(&msg, ts.as_deref())
+            return renderers::render_rate_limit_event(&msg, ts.as_deref());
         }
-        Ok(ClaudeMessage::Unknown) | Err(_) => render_raw_json(&props.json),
+        Ok(ClaudeMessage::Unknown) | Err(_) => {}
+    }
+
+    if props.agent_type == shared::AgentType::Codex {
+        html! { <super::codex_renderer::CodexMessageRenderer json={props.json.clone()} /> }
+    } else {
+        render_raw_json(&props.json)
     }
 }
 


### PR DESCRIPTION
Fixes the "Codex Raw JSON block" that appears when a user sends a message to a Codex session — the synthetic user-echo and the backend's portal envelope both parse cleanly as \`ClaudeMessage\`, but the old dispatch sent every message on a Codex session to the Codex renderer first, which only recognizes codex-specific shapes (\`item.*\`, \`turn.*\`) and drops everything else into the raw-JSON catch-all.

DRY refactor: match on the message *shape* first. Any recognized \`ClaudeMessage\` variant (\`System\`, \`Assistant\`, \`Result\`, \`User\`, \`Error\`, \`Portal\`, \`RateLimitEvent\`) renders via the protocol-agnostic Claude renderers on both agents. Only unknown-shape messages fall through to the Codex renderer (Claude sessions still fall back to \`render_raw_json\`).

## Test plan

- [x] \`cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings\`
- [ ] Send a message to a Codex session — confirm it renders as a normal user message, not a raw JSON block
- [ ] Confirm codex-specific output (\`item.completed\`, \`turn.completed\`, …) still renders correctly through the codex renderer