### PR TITLE
Interrupt codex turn on decode failure (fix #703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.26
+
+- **Fix #703 — codex sessions no longer wedge after a typed-decode failure.** The 2.5.22 patch for #695 kept the session alive after `codex-codes` failed to deserialize a frame, but silently dropped the frame. When the lost frame was a server→client approval request (the `callId`-missing variant in codex 0.130.0's `item/{commandExecution,fileChange}/requestApproval`), codex blocked the turn waiting for a reply it would never get; the proxy stayed in `turn_active = true` and rejected every subsequent user prompt with `Received input while Codex turn is active`. From the user's POV the session looked alive but ignored them. Now, on `codex_codes::Error::Json` during an active turn, `claude-session-lib` (a) emits a `turn.failed` event to the frontend so the hang is visible, and (b) sends `turn/interrupt` so codex unblocks and emits `turn/completed` (Interrupted), which clears the flag through the normal path. If `turn_interrupt` itself errors, the flag is force-cleared to avoid a permanent wedge.
+
 ## 2.5.25
 
 - Awaiting pill border + indicator back to red (`--error`) instead of orange. The pulse animation stays gone (#684's complaint was the strobing, not the color).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.22"
+version = "2.5.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.22"
+version = "2.5.26"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.22"
+version = "2.5.26"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.22"
+version = "2.5.26"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.22"
+version = "2.5.26"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2936,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.22"
+version = "2.5.26"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.22"
+version = "2.5.26"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.22"
+version = "2.5.26"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.25"
+version = "2.5.26"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -677,8 +677,8 @@ impl Session {
         event_tx: mpsc::UnboundedSender<IoEvent>,
     ) {
         use codex_codes::{
-            AppServerBuilder, AsyncClient as CodexAsyncClient, ThreadStartParams, TurnStartParams,
-            UserInput,
+            AppServerBuilder, AsyncClient as CodexAsyncClient, ThreadStartParams,
+            TurnInterruptParams, TurnStartParams, UserInput,
         };
 
         let codex_path = config.claude_path.as_deref().unwrap_or(Path::new("codex"));
@@ -744,16 +744,53 @@ impl Session {
                                 break;
                             }
                             Err(codex_codes::Error::Json(json_err)) => {
-                                // Newer codex CLI versions sometimes emit frames whose
-                                // typed param struct fails our bundled codex-codes
-                                // schema (e.g. #695 — missing field `callId` in codex
-                                // 0.130.0). Killing the session on every protocol
-                                // skew is too aggressive: skip the frame and stay
-                                // connected so the user doesn't lose the session.
+                                // Newer codex CLI versions emit frames whose typed
+                                // param struct fails our bundled codex-codes schema
+                                // (e.g. #695 — missing field `callId` in codex 0.130.0
+                                // approval requests). The frame is lost.
+                                //
+                                // If the lost frame was a server→client request (like
+                                // `item/{commandExecution,fileChange}/requestApproval`),
+                                // codex is now blocked on a reply we cannot send,
+                                // because we never saw the request id. Result: the
+                                // turn never completes, `turn_active` stays true, and
+                                // every subsequent user prompt gets dropped at the
+                                // "Received input while Codex turn is active" check.
+                                // (See #703.)
+                                //
+                                // We can't recover the lost reply. Interrupt the turn
+                                // so codex unblocks and emits `turn/completed`
+                                // (Interrupted), which flips `turn_active` back to
+                                // false through the normal path. Surface a
+                                // `turn.failed` event so the frontend doesn't sit on a
+                                // silent hang.
                                 tracing::warn!(
-                                    "Codex frame failed typed decode (skipping): {}",
+                                    "Codex frame failed typed decode: {}",
                                     json_err
                                 );
+                                let _ = event_tx.send(IoEvent::RawOutput(serde_json::json!({
+                                    "type": "turn.failed",
+                                    "error": {
+                                        "message": format!(
+                                            "Codex emitted a frame this client could not parse ({}). \
+                                             Interrupting the turn to recover — please retry.",
+                                            json_err
+                                        )
+                                    }
+                                })));
+                                if let Err(e) = client
+                                    .turn_interrupt(&TurnInterruptParams {
+                                        thread_id: thread_id.clone(),
+                                    })
+                                    .await
+                                {
+                                    tracing::error!(
+                                        "turn_interrupt after decode failure failed: {} \
+                                         — forcing turn_active=false to unwedge",
+                                        e
+                                    );
+                                    turn_active = false;
+                                }
                                 continue;
                             }
                             Err(e) => {


### PR DESCRIPTION
## Summary

- Fixes #703: codex sessions wedge after `codex-codes` fails to typed-decode a frame.
- The 2.5.22 patch (#697) prevented the session from dying on `Error::Json`, but silently dropped the frame. When the frame was a server→client approval request (the `callId`-missing variant in codex 0.130.0's `item/{commandExecution,fileChange}/requestApproval`), codex blocked the turn waiting for a reply we couldn't send; `turn_active` stayed true and every subsequent user prompt got rejected with `Received input while Codex turn is active`.
- On `codex_codes::Error::Json` during an active turn we now (a) emit `turn.failed` to the frontend so the hang is visible, (b) send `turn/interrupt` so codex unblocks and emits `turn/completed` (Interrupted) through the normal turn-end path, and (c) force-clear `turn_active` only as a last-ditch fallback if the interrupt request itself errors.

## Why interrupt instead of just continuing

The lost frame may be a Request awaiting our response. We can't reconstruct the request id from a typed-decode error, so we can't reply. Continuing without action means the turn waits forever. Interrupting is a no-op for harmless lost notifications and a recovery for blocking lost requests.

## Observed wedge (from #703)

`agent-portal[3191103]` journald around 19:11–19:16, session `50f6dad6-…`, workspace `fitsio-pure`, codex CLI 0.130.0, codex-codes 0.128.0:

```
19:11:33  WARN Codex frame failed typed decode (skipping): missing field `callId`
19:14:04  SequencedInput seq=3 content="is it working?"
19:14:04  WARN Received input while Codex turn is active     ← wedged
19:16:59  SequencedInput seq=4 content="workin?"
19:16:59  WARN Received input while Codex turn is active     ← still wedged
```

## Test plan

- [x] `cargo check -p claude-session-lib`
- [x] `cargo clippy -p claude-session-lib --all-targets -- -D warnings`
- [x] `cargo test -p claude-session-lib` (12/12 pass)
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [ ] Reproduce on a live codex session by sending a malformed frame; verify the proxy emits `turn.failed`, calls `turn/interrupt`, and accepts the next user prompt without a restart. (Hard to repro on demand because it depends on which codex CLI build is installed and which approval flow it triggers.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)