### PR TITLE
Auto-retry upstream-429 turns with full-jitter backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.29
+
+- **Auto-retry upstream-429 turns with full-jitter exponential backoff.** When Anthropic's API rate-limits a request, `claude --print` doesn't fail — it streams an assistant message starting with `API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited` and emits a `Result` with `is_error: true`. From the user's POV the session just ate a turn and went quiet. `claude_io_task` now caches the last user input, watches each turn for that exact shape, and on a match auto-retries with `delay ∈ [0, min(30, 2^attempt)]` seconds (full-jitter prevents N concurrent stuck sessions from re-firing in lockstep when the limit window resets). Up to 4 retries per user input; each retry emits a portal message announcing the wait and attempt count; on max-out we surface a final portal note asking the user to resend. If a new user input arrives during the backoff, it cancels the retry and runs normally — the user can always override automation. Counter resets on every fresh user input and on every successful turn.
+
 ## 2.5.28
 
 - **Stop rendering protocol-agnostic messages as "Codex Raw" blocks on Codex sessions.** The synthetic user-echo (PR #691, fixing the "Codex Raw" pile-up) and the backend's `Portal` envelope both have `type: "user"` / `type: "portal"` and parse cleanly as `ClaudeMessage` — but the old dispatch sent every message on a Codex session straight to the Codex renderer, which only knows codex-specific shapes (`item.*`, `turn.*`) and falls anything else through to the "raw JSON" catch-all. The user saw their own input echoed as a JSON dump. Dispatch now matches on the message shape first (any recognized `ClaudeMessage` variant renders the same on both agents) and only routes the remaining unknown-shape messages to the Codex renderer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.27"
+version = "2.5.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.27"
+version = "2.5.29"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.27"
+version = "2.5.29"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.27"
+version = "2.5.29"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -617,6 +617,7 @@ dependencies = [
  "codex-codes",
  "directories",
  "hostname",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "shared",
@@ -1169,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.27"
+version = "2.5.29"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2936,7 +2937,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.27"
+version = "2.5.29"
 dependencies = [
  "anyhow",
  "colored",
@@ -2951,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.27"
+version = "2.5.29"
 dependencies = [
  "anyhow",
  "hex",
@@ -3797,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.27"
+version = "2.5.29"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.28"
+version = "2.5.29"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -22,3 +22,4 @@ directories = "5.0"
 hostname = "0.4.2"
 which = "8.0.0"
 ws-bridge = { workspace = true, features = ["native-client"] }
+rand = "0.8"

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -238,15 +238,46 @@ impl Session {
         mut command_rx: mpsc::UnboundedReceiver<IoCommand>,
         event_tx: mpsc::UnboundedSender<IoEvent>,
     ) {
+        use claude_codes::io::ContentBlock;
+        use rand::Rng;
+        use std::time::Duration;
+
+        // Detector for the upstream-429 turn shape (see #?). When Anthropic's
+        // API rate-limits a request, `claude --print` doesn't fail — it streams
+        // an assistant message whose first text block starts with this prefix,
+        // then emits a Result with is_error=true. We retry that turn for the
+        // user with full-jitter exponential backoff.
+        const RATE_LIMIT_TEXT_PREFIX: &str = "API Error: Server is temporarily limiting requests";
+        const MAX_RATE_LIMIT_RETRIES: u32 = 4;
+        const RATE_LIMIT_BACKOFF_CAP_SECS: u64 = 30;
+
         // Take stderr so we can read it if Claude exits unexpectedly
         let mut stderr_reader = client.take_stderr();
+
+        // The most recent user input we sent — kept so we can re-issue it on
+        // a rate-limited turn without bothering the user.
+        let mut last_input: Option<ClaudeInput> = None;
+        // Consecutive rate-limited turns. Resets on success, on a new user
+        // input, and after a max-out give-up.
+        let mut rate_limit_attempts: u32 = 0;
+        // Set while an assistant frame in the current turn matched the
+        // rate-limit text prefix. Latched until the turn's Result frame so we
+        // can classify the whole turn on its terminator.
+        let mut current_turn_was_rate_limited = false;
 
         loop {
             tokio::select! {
                 // Handle incoming commands (input to send to Claude)
                 Some(cmd) = command_rx.recv() => {
                     let result = match cmd {
-                        IoCommand::Input(input) => client.send(&input).await,
+                        IoCommand::Input(input) => {
+                            // Each fresh user input gets its own retry budget.
+                            rate_limit_attempts = 0;
+                            current_turn_was_rate_limited = false;
+                            let r = client.send(&input).await;
+                            last_input = Some(input);
+                            r
+                        }
                         IoCommand::PermissionResponse(response) => {
                             client.send_control_response(response).await
                         }
@@ -261,9 +292,128 @@ impl Session {
                 result = client.receive() => {
                     match result {
                         Ok(output) => {
+                            // Classify the frame before forwarding so we can
+                            // decide whether the turn's terminator triggers an
+                            // auto-retry.
+                            match &output {
+                                ClaudeOutput::Assistant(asst) => {
+                                    let first_text = asst.message.content.iter().find_map(|b| {
+                                        if let ContentBlock::Text(t) = b {
+                                            Some(t.text.as_str())
+                                        } else {
+                                            None
+                                        }
+                                    });
+                                    if let Some(text) = first_text {
+                                        if text.starts_with(RATE_LIMIT_TEXT_PREFIX) {
+                                            current_turn_was_rate_limited = true;
+                                        }
+                                    }
+                                }
+                                ClaudeOutput::Result(r) if !r.is_error => {
+                                    // Successful turn — clear consecutive-failure state.
+                                    rate_limit_attempts = 0;
+                                    current_turn_was_rate_limited = false;
+                                }
+                                _ => {}
+                            }
+
+                            let is_rate_limit_terminator = matches!(
+                                &output,
+                                ClaudeOutput::Result(r) if r.is_error
+                            ) && current_turn_was_rate_limited;
+
                             if event_tx.send(IoEvent::Output(Box::new(output))).is_err() {
                                 // Receiver dropped, session ended
                                 break;
+                            }
+
+                            if !is_rate_limit_terminator {
+                                continue;
+                            }
+
+                            current_turn_was_rate_limited = false;
+                            let Some(input) = last_input.clone() else {
+                                continue;
+                            };
+
+                            if rate_limit_attempts >= MAX_RATE_LIMIT_RETRIES {
+                                let _ = event_tx.send(IoEvent::RawOutput(serde_json::json!({
+                                    "type": "portal",
+                                    "content": [{
+                                        "type": "text",
+                                        "text": format!(
+                                            "Rate-limited by upstream API {} times in a row \u{2014} not retrying. Send your message again to try once more.",
+                                            rate_limit_attempts
+                                        )
+                                    }]
+                                })));
+                                rate_limit_attempts = 0;
+                                continue;
+                            }
+
+                            rate_limit_attempts += 1;
+                            // Full-jitter exponential backoff:
+                            //   delay ∈ [0, min(cap, 2^attempt)] seconds.
+                            // attempt=1 -> [0,2]; 2 -> [0,4]; 3 -> [0,8]; 4 -> [0,16];
+                            // the cap saturates by attempt 5 but we max-out before that.
+                            let exp_cap = 2u64
+                                .saturating_pow(rate_limit_attempts)
+                                .min(RATE_LIMIT_BACKOFF_CAP_SECS);
+                            let delay_secs = {
+                                let mut rng = rand::thread_rng();
+                                rng.gen_range(0.0..=exp_cap as f64)
+                            };
+                            let _ = event_tx.send(IoEvent::RawOutput(serde_json::json!({
+                                "type": "portal",
+                                "content": [{
+                                    "type": "text",
+                                    "text": format!(
+                                        "Rate-limited by upstream API. Retrying in {:.1}s (attempt {}/{}).",
+                                        delay_secs, rate_limit_attempts, MAX_RATE_LIMIT_RETRIES
+                                    )
+                                }]
+                            })));
+
+                            // Wait for the backoff window, but let a new user
+                            // input cancel the retry and run normally.
+                            let sleep = tokio::time::sleep(Duration::from_secs_f64(delay_secs));
+                            tokio::pin!(sleep);
+                            tokio::select! {
+                                _ = &mut sleep => {
+                                    if let Err(e) = client.send(&input).await {
+                                        let _ = event_tx.send(IoEvent::Error(
+                                            SessionError::ClaudeError(e),
+                                        ));
+                                    }
+                                }
+                                Some(cmd) = command_rx.recv() => {
+                                    match cmd {
+                                        IoCommand::Input(new_input) => {
+                                            // User typed something while we were waiting
+                                            // — honor that, abandon the retry, and reset
+                                            // the budget for the new prompt.
+                                            rate_limit_attempts = 0;
+                                            let r = client.send(&new_input).await;
+                                            last_input = Some(new_input);
+                                            if let Err(e) = r {
+                                                let _ = event_tx.send(IoEvent::Error(
+                                                    SessionError::ClaudeError(e),
+                                                ));
+                                            }
+                                        }
+                                        IoCommand::PermissionResponse(response) => {
+                                            if let Err(e) =
+                                                client.send_control_response(response).await
+                                            {
+                                                let _ = event_tx.send(IoEvent::Error(
+                                                    SessionError::ClaudeError(e),
+                                                ));
+                                            }
+                                        }
+                                        IoCommand::CodexApproval { .. } => {}
+                                    }
+                                }
                             }
                         }
                         Err(e) => {


### PR DESCRIPTION
## Summary

When Anthropic's API rate-limits a request, `claude --print` doesn't fail — it streams an assistant message starting with `API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited` and emits a `Result` with `is_error: true`. From the user's POV the turn just vanishes. `claude_io_task` now detects that shape and auto-retries with full-jitter exponential backoff.

## Detection

Per-turn state machine in `claude_io_task`:

- An `Assistant` frame whose first text block starts with `"API Error: Server is temporarily limiting requests"` latches a per-turn flag.
- The turn's terminator (`Result(is_error: true)`) is the trigger.
- Successful `Result(is_error: false)` resets all state.

The matcher classifies on the assistant text rather than the result-error-message because the message-body of `Result` is more variable across claude versions.

## Backoff

`delay ∈ [0, min(30, 2^attempt)]` seconds — full jitter. Why jitter:

- **attempt 1** → [0, 2]
- **attempt 2** → [0, 4]
- **attempt 3** → [0, 8]
- **attempt 4** → [0, 16]
- cap saturates by attempt 5 but we max-out at 4 first.

Full jitter (vs equal-jitter or no-jitter) is the standard recommendation when N concurrent clients are all watching the same rate-limit window: without jitter they all wake up at $t + 2^k$ and re-hammer the limiter at the same instant. Random offset spreads them.

## User overrides

If a new user input arrives during the backoff window, the retry is cancelled and the new input runs immediately (with a fresh retry budget). The user can always override the automation by typing.

Counter also resets on every fresh user input and on every successful turn — so each prompt gets its own 4-attempt budget.

## What the user sees

For each retry, the proxy emits a synthetic portal frame:

> Rate-limited by upstream API. Retrying in 3.2s (attempt 2/4).

On max-out:

> Rate-limited by upstream API 4 times in a row — not retrying. Send your message again to try once more.

The original rate-limit assistant text and the errored `Result` are still emitted to the transcript — we add the retry note, we don't suppress the error. This is deliberate: silent retries mask org-level throttle issues, and the user might want to know the upstream is being mean.

## What it doesn't do

- **No retry-after honoring.** The upstream `claude` CLI doesn't surface `Retry-After` to the proxy; we have to guess. Random within $2^k$ is a reasonable guess.
- **No turn-level dedup.** If the rate-limit error mentions an already-billed turn (`cost: $0.76` in the journald lines), we still pay for the retried turn too. That's a property of the upstream behavior, not this PR.

## Test plan

- [x] `cargo check -p claude-session-lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p claude-session-lib` (12/12)
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [ ] Live test: trigger an actual upstream 429 (the launcher on this machine has been hitting them — natural test bed once 2.5.29 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)