### PR TITLE
Probe installed agents when launch dialog opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.5.31
+
+- **Probe installed agent CLIs when the launch dialog opens.** Previously the only signal that a launcher was missing `codex` or `claude` was a session that spawned then vanished within a second with a misleading `exited normally (code 0)` log. The launch dialog now asks the selected launcher to scan its PATH the moment the user opens it (and again on every launcher dropdown change), and surfaces the result inline:
+  - Agent dropdown labels show `Claude (not installed)` / `Codex (not installed)` when the binary isn't on the host's PATH.
+  - A red inline warning sits under the agent picker when the selected agent is missing.
+  - A grey "Checking installed agents..." note shows while the probe is in flight.
+- Plumbing:
+  - Extracted the `which` + `--version` probe into `claude_session_lib::probe` so it's reusable outside the spawn-time diagnostic.
+  - New `shared::AgentInstall { agent_type, installed, resolved_path, version }`.
+  - New WS request/response pair: `ServerToLauncher::ProbeAgents { request_id }` → `LauncherToServer::ProbeAgentsResult { request_id, agents }`.
+  - Backend correlates responses via a parallel `pending_probe_requests` map (mirrors the existing directory-listing pattern).
+  - New REST endpoint `GET /api/launchers/{id}/probe-agents` that triggers the round-trip and returns the install state with a 5 s timeout.
+
 ## 2.5.30
 
 - **Attach the raw Codex frame to typed-decode-failure portal messages.** When a codex frame fails our bundled `codex-codes` schema (the canonical `missing field 'callId'` mismatch with codex CLI 0.130.0's approval requests, see #703), the proxy interrupted the turn but left the user without the offending frame's content — making upstream bug reports hard to file. A new `CodexFrameCaptureLayer` tracing layer watches codex-codes' `[CLIENT] Received: <raw>` DEBUG events at runtime and stashes the last 8 frames in a process-wide ring buffer. On `Error::Json` the codex I/O task drains the most-recent entry (overwhelmingly the offending frame, since capture happens microseconds before the typed-decode failure on the same thread) and emits it as a portal message with a fenced JSON block, ready to copy-paste. The layer declares per-callsite `Interest::always()` only for `codex_codes::client_async` DEBUG events, so it sees them even when `RUST_LOG=info,…` would otherwise suppress them — without flooding journald (the fmt-layer EnvFilter is now per-layer, not global). Installed in both `launcher/src/main.rs` and `proxy/src/main.rs`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.30"
+version = "2.5.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.30"
+version = "2.5.31"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.30"
+version = "2.5.31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.30"
+version = "2.5.31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.30"
+version = "2.5.31"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2938,7 +2938,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.30"
+version = "2.5.31"
 dependencies = [
  "anyhow",
  "colored",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.30"
+version = "2.5.31"
 dependencies = [
  "anyhow",
  "hex",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.30"
+version = "2.5.31"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.30"
+version = "2.5.31"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -265,3 +265,61 @@ pub async fn update_launcher(
     info!("Sent UpdateAndRestart to launcher {}", launcher_id);
     Ok(StatusCode::OK)
 }
+
+#[derive(serde::Serialize)]
+pub struct ProbeAgentsResponse {
+    pub agents: Vec<shared::AgentInstall>,
+}
+
+/// GET /api/launchers/:launcher_id/probe-agents - Ask the launcher to (re-)scan
+/// its agent CLIs (`claude`, `codex`) and return install state. The frontend
+/// calls this when the launch dialog opens.
+pub async fn probe_agents(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path(launcher_id): Path<Uuid>,
+) -> Result<Json<ProbeAgentsResponse>, StatusCode> {
+    let user_id = extract_user_id(&app_state, &cookies).map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+    let sender = {
+        let launcher = app_state
+            .session_manager
+            .launchers
+            .get(&launcher_id)
+            .ok_or(StatusCode::NOT_FOUND)?;
+        if launcher.user_id != user_id {
+            return Err(StatusCode::FORBIDDEN);
+        }
+        launcher.sender.clone()
+    };
+
+    let request_id = Uuid::new_v4();
+    let rx = app_state.session_manager.register_probe_request(request_id);
+
+    if sender
+        .send(ServerToLauncher::ProbeAgents { request_id })
+        .is_err()
+    {
+        app_state
+            .session_manager
+            .pending_probe_requests
+            .remove(&request_id);
+        warn!("Launcher {} disconnected while probing agents", launcher_id);
+        return Err(StatusCode::BAD_GATEWAY);
+    }
+
+    match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
+        Ok(Ok(LauncherToServer::ProbeAgentsResult { agents, .. })) => {
+            Ok(Json(ProbeAgentsResponse { agents }))
+        }
+        Ok(Ok(_)) | Ok(Err(_)) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+        Err(_) => {
+            app_state
+                .session_manager
+                .pending_probe_requests
+                .remove(&request_id);
+            warn!("Probe agents timed out for launcher {}", launcher_id);
+            Err(StatusCode::GATEWAY_TIMEOUT)
+        }
+    }
+}

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -381,6 +381,11 @@ fn handle_launcher_message(
                 .session_manager
                 .complete_dir_request(request_id, msg);
         }
+        LauncherToServer::ProbeAgentsResult { request_id, .. } => {
+            app_state
+                .session_manager
+                .complete_probe_request(request_id, msg);
+        }
         LauncherToServer::RequestLaunch {
             request_id,
             working_directory,

--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -50,6 +50,7 @@ pub struct SessionManager {
     pub pending_truncations: Arc<DashSet<Uuid>>,
     pub launchers: Arc<DashMap<Uuid, LauncherConnection>>,
     pub pending_dir_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
+    pub pending_probe_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
     /// Tracks who sent the last input for each session (session_id → (user_id, display_name))
     pub last_input_sender: Arc<DashMap<Uuid, (Uuid, String)>>,
     /// Monotonic counter for connection generations (prevents stale cleanup)
@@ -69,6 +70,7 @@ impl Default for SessionManager {
             pending_truncations: Arc::new(DashSet::new()),
             launchers: Arc::new(DashMap::new()),
             pending_dir_requests: Arc::new(DashMap::new()),
+            pending_probe_requests: Arc::new(DashMap::new()),
             last_input_sender: Arc::new(DashMap::new()),
             gen_counter: Arc::new(AtomicU64::new(1)),
             connection_gen: Arc::new(DashMap::new()),
@@ -368,6 +370,18 @@ impl SessionManager {
 
     pub fn complete_dir_request(&self, request_id: Uuid, msg: LauncherToServer) {
         if let Some((_, tx)) = self.pending_dir_requests.remove(&request_id) {
+            let _ = tx.send(msg);
+        }
+    }
+
+    pub fn register_probe_request(&self, request_id: Uuid) -> oneshot::Receiver<LauncherToServer> {
+        let (tx, rx) = oneshot::channel();
+        self.pending_probe_requests.insert(request_id, tx);
+        rx
+    }
+
+    pub fn complete_probe_request(&self, request_id: Uuid, msg: LauncherToServer) {
+        if let Some((_, tx)) = self.pending_probe_requests.remove(&request_id) {
             let _ = tx.send(msg);
         }
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -538,6 +538,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/launchers/{launcher_id}/update",
             post(handlers::launchers::update_launcher),
         )
+        .route(
+            "/api/launchers/{launcher_id}/probe-agents",
+            get(handlers::launchers::probe_agents),
+        )
         // Admin dashboard routes (admin-only)
         .route("/api/admin/stats", get(handlers::admin::get_stats))
         .route("/api/admin/users", get(handlers::admin::list_users))

--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -21,6 +21,7 @@ pub mod codex_frame_capture;
 pub mod error;
 pub mod heartbeat;
 pub mod output_buffer;
+pub mod probe;
 pub mod proxy_session;
 pub mod session;
 pub mod snapshot;

--- a/claude-session-lib/src/probe.rs
+++ b/claude-session-lib/src/probe.rs
@@ -1,0 +1,71 @@
+//! Synchronous PATH-resolution + `--version` probes for the agent binaries
+//! the launcher can spawn. Used at launcher startup (sent in the register
+//! envelope) and on demand (refreshed when the user opens the launch dialog).
+
+use shared::AgentType;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+/// Result of probing one agent binary on the host.
+#[derive(Debug, Clone)]
+pub struct ProbeResult {
+    pub installed: bool,
+    pub resolved_path: Option<PathBuf>,
+    pub version: Option<String>,
+}
+
+/// Probe both supported agent CLIs. Cheap — each binary returns from
+/// `--version` in tens of milliseconds.
+pub fn probe_all_agents() -> Vec<(AgentType, ProbeResult)> {
+    [AgentType::Claude, AgentType::Codex]
+        .into_iter()
+        .map(|agent| (agent, probe_agent(agent)))
+        .collect()
+}
+
+/// Probe one agent. Returns the resolved binary path (via `which`) and the
+/// `--version` output trimmed. `installed` is true iff `--version` exited 0.
+pub fn probe_agent(agent: AgentType) -> ProbeResult {
+    let name = match agent {
+        AgentType::Claude => "claude",
+        AgentType::Codex => "codex",
+    };
+
+    let resolved_path = which::which(name).ok();
+    if resolved_path.is_none() {
+        return ProbeResult {
+            installed: false,
+            resolved_path: None,
+            version: None,
+        };
+    }
+
+    // Run with a short timeout so a misbehaving binary can't wedge the probe.
+    // We use std::process::Command synchronously here because the caller is
+    // a one-shot blocking probe at startup / on user demand — no async
+    // context required.
+    let version = match Command::new(name).arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let raw = String::from_utf8_lossy(&output.stdout);
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        Ok(_) | Err(_) => None,
+    };
+
+    ProbeResult {
+        installed: version.is_some(),
+        resolved_path,
+        version,
+    }
+}
+
+/// A maximum bound on how long a `probe_all_agents` call should take. Surfaced
+/// here so callers don't have to guess at the timeout for the request/response
+/// round-trip when probing via WS.
+pub const PROBE_TIMEOUT: Duration = Duration::from_secs(5);

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -3,7 +3,7 @@ use gloo::timers::callback::Timeout;
 use gloo_net::http::Request;
 use serde::Deserialize;
 use shared::api::LaunchRequest;
-use shared::{DirectoryEntry, LauncherInfo};
+use shared::{AgentInstall, AgentType, DirectoryEntry, LauncherInfo};
 use uuid::Uuid;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
@@ -17,6 +17,45 @@ const CONNECT_NEW: &str = "__install__";
 struct DirectoryListingResponse {
     entries: Vec<DirectoryEntry>,
     resolved_path: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ProbeAgentsResponse {
+    agents: Vec<AgentInstall>,
+}
+
+/// Fetch the current install state for both agent CLIs from the given launcher.
+/// Stores the result in `agents` and clears `probing` when done.
+fn probe_agents_for(
+    launcher_id: Uuid,
+    agents: UseStateHandle<Vec<AgentInstall>>,
+    probing: UseStateHandle<bool>,
+) {
+    probing.set(true);
+    spawn_local(async move {
+        let url = format!("/api/launchers/{}/probe-agents", launcher_id);
+        match Request::get(&url).send().await {
+            Ok(resp) if resp.ok() => {
+                if let Ok(body) = resp.json::<ProbeAgentsResponse>().await {
+                    agents.set(body.agents);
+                }
+            }
+            _ => {
+                // Probe failures: leave the install list empty. The UI will
+                // treat unknown as "not blocking" — better to let the user
+                // try and see the spawn-time error than to over-block.
+                agents.set(Vec::new());
+            }
+        }
+        probing.set(false);
+    });
+}
+
+fn agent_installed(installs: &[AgentInstall], agent_type: AgentType) -> Option<bool> {
+    installs
+        .iter()
+        .find(|a| a.agent_type == agent_type)
+        .map(|a| a.installed)
 }
 
 struct AgentConfig {
@@ -143,6 +182,8 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     let launching = use_state(|| false);
     let error_msg = use_state(|| None::<String>);
     let debounce_handle = use_mut_ref(|| None::<Timeout>);
+    let agent_installs = use_state(Vec::<AgentInstall>::new);
+    let probing_agents = use_state(|| false);
 
     // Fetch launchers on mount; auto-select install mode when none are connected
     {
@@ -150,6 +191,8 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let selected_launcher = selected_launcher.clone();
         let show_install = show_install.clone();
         let dir = dir.clone();
+        let agent_installs = agent_installs.clone();
+        let probing_agents = probing_agents.clone();
         use_effect_with((), move |_| {
             spawn_local(async move {
                 if let Ok(resp) = Request::get("/api/launchers").send().await {
@@ -158,6 +201,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                             let lid = first.launcher_id;
                             selected_launcher.set(Some(lid));
                             dir.fetch(lid, "~".to_string(), true);
+                            probe_agents_for(lid, agent_installs.clone(), probing_agents.clone());
                         } else {
                             show_install.set(true);
                         }
@@ -257,6 +301,8 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let selected_launcher = selected_launcher.clone();
         let show_install = show_install.clone();
         let dir = dir.clone();
+        let agent_installs = agent_installs.clone();
+        let probing_agents = probing_agents.clone();
         Callback::from(move |e: Event| {
             if let Some(select) = e.target_dyn_into::<web_sys::HtmlSelectElement>() {
                 if select.value() == CONNECT_NEW {
@@ -266,6 +312,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     show_install.set(false);
                     selected_launcher.set(Some(id));
                     dir.navigate(Some(id), "~".to_string());
+                    probe_agents_for(id, agent_installs.clone(), probing_agents.clone());
                 }
             }
         })
@@ -391,6 +438,22 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
     let cfg = agent_config(*agent_type);
 
+    // Per-agent install hints for the dropdown labels and the inline warning.
+    let claude_label = match agent_installed(&agent_installs, AgentType::Claude) {
+        Some(false) => "Claude (not installed)".to_string(),
+        _ => "Claude".to_string(),
+    };
+    let codex_label = match agent_installed(&agent_installs, AgentType::Codex) {
+        Some(false) => "Codex (not installed)".to_string(),
+        _ => "Codex".to_string(),
+    };
+    let selected_agent_missing = agent_installed(&agent_installs, *agent_type) == Some(false);
+    let still_probing = *probing_agents && agent_installs.is_empty();
+    let selected_agent_label = match *agent_type {
+        AgentType::Claude => "Claude",
+        AgentType::Codex => "Codex",
+    };
+
     // Pre-compute directory listing HTML
     let dir_listing_html = if *dir.loading {
         html! { <div class="dir-loading">{ "Loading..." }</div> }
@@ -502,16 +565,29 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     <div class="launch-field">
                         <label>{ "Agent" }</label>
                         <select class="launcher-select" onchange={on_agent_type_change}>
-                            <option value="claude" selected={*agent_type == shared::AgentType::Claude}>
-                                { "Claude" }
+                            <option value="claude" selected={*agent_type == AgentType::Claude}>
+                                { &claude_label }
                             </option>
-                            <option value="codex" selected={*agent_type == shared::AgentType::Codex}>
-                                { "Codex" }
+                            <option value="codex" selected={*agent_type == AgentType::Codex}>
+                                { &codex_label }
                             </option>
                         </select>
                     </div>
 
-                    if *agent_type == shared::AgentType::Codex {
+                    if selected_agent_missing {
+                        <div class="launch-note launch-note-warn">
+                            { format!(
+                                "{} isn't installed on this launcher — sessions will fail to start. Install it on the host and retry.",
+                                selected_agent_label,
+                            ) }
+                        </div>
+                    } else if still_probing {
+                        <div class="launch-note">
+                            { "Checking installed agents..." }
+                        </div>
+                    }
+
+                    if *agent_type == AgentType::Codex {
                         <div class="launch-note launch-note-warn">
                             { "Codex support is highly experimental." }
                         </div>

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -336,6 +336,23 @@ pub async fn run_launcher_loop(
     }
 }
 
+/// Probe both supported agent CLIs and convert into the wire shape used in
+/// `LauncherToServer::ProbeAgentsResult`. Runs `which::which` + `--version`
+/// synchronously, so callers must run this from a `spawn_blocking` task.
+fn probe_agents_for_response() -> Vec<shared::AgentInstall> {
+    claude_session_lib::probe::probe_all_agents()
+        .into_iter()
+        .map(|(agent_type, result)| shared::AgentInstall {
+            agent_type,
+            installed: result.installed,
+            resolved_path: result
+                .resolved_path
+                .map(|p| p.to_string_lossy().to_string()),
+            version: result.version,
+        })
+        .collect()
+}
+
 fn list_directory(path: &str, request_id: Uuid) -> LauncherToServer {
     // Resolve ~ to home directory (trailing slash ensures the dir itself is listed,
     // not treated as a filter prefix against its parent)
@@ -532,6 +549,17 @@ async fn handle_message(
             let response = list_directory(&path, request_id);
             if ws_sender.send(response).await.is_err() {
                 warn!("Failed to send list directories result");
+            }
+        }
+        ServerToLauncher::ProbeAgents { request_id } => {
+            // Synchronous probe in a blocking task so two `--version` spawns
+            // don't hold up the message loop.
+            let agents = tokio::task::spawn_blocking(probe_agents_for_response)
+                .await
+                .unwrap_or_default();
+            let response = shared::LauncherToServer::ProbeAgentsResult { request_id, agents };
+            if ws_sender.send(response).await.is_err() {
+                warn!("Failed to send probe agents result");
             }
         }
         ServerToLauncher::ScheduleSync { tasks } => {

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -3,7 +3,8 @@ use uuid::Uuid;
 pub use ws_bridge::WsEndpoint;
 
 use crate::{
-    AgentType, DirectoryEntry, PermissionSuggestion, SendMode, SessionCost, SessionStatus,
+    AgentInstall, AgentType, DirectoryEntry, PermissionSuggestion, SendMode, SessionCost,
+    SessionStatus,
 };
 
 // =============================================================================
@@ -389,6 +390,14 @@ pub enum LauncherToServer {
         resolved_path: Option<String>,
     },
 
+    /// On-demand agent install probe result. The launcher re-runs the
+    /// `which` + `--version` scan and sends back the fresh capabilities.
+    ProbeAgentsResult {
+        request_id: Uuid,
+        #[serde(default)]
+        agents: Vec<AgentInstall>,
+    },
+
     /// Request the backend to mint a token and launch a session
     RequestLaunch {
         request_id: Uuid,
@@ -454,6 +463,10 @@ pub enum ServerToLauncher {
 
     /// Request directory listing
     ListDirectories { request_id: Uuid, path: String },
+
+    /// Ask the launcher to (re-)probe its agent CLIs. The launcher replies
+    /// with `LauncherToServer::ProbeAgentsResult` carrying the fresh state.
+    ProbeAgents { request_id: Uuid },
 
     /// Server is shutting down
     ServerShutdown {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -180,6 +180,22 @@ pub struct DirectoryEntry {
     pub is_dir: bool,
 }
 
+/// Result of probing one agent CLI on a launcher host. Built at launcher
+/// startup (sent in `LauncherRegister`) and refreshed on demand via
+/// `ProbeAgents` when the user opens the launch dialog.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentInstall {
+    pub agent_type: AgentType,
+    /// True iff `<bin> --version` exited successfully.
+    pub installed: bool,
+    /// Absolute path the launcher's `which` lookup resolved to, when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_path: Option<String>,
+    /// `<bin> --version` stdout, trimmed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
 /// Info about a connected launcher daemon
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LauncherInfo {


### PR DESCRIPTION
Eliminates the "session vanished after one second with exit code 0" loop when a launcher host is missing the agent binary. Now the launch dialog asks the selected launcher to scan its PATH the moment the user opens it (and on every launcher-dropdown change), and surfaces the result inline.

## UI

- Agent dropdown labels show \`Claude (not installed)\` / \`Codex (not installed)\` when the binary isn't on the host's PATH.
- A red inline warning sits under the picker when the selected agent is missing.
- A grey "Checking installed agents..." note shows while the probe is in flight.

Warnings, not blocks — the user can still hit Launch (the probe might be momentarily stale, or they might want to see the spawn-time error).

## Plumbing

- **Probe helper**: extracted the existing \`which::which\` + \`<bin> --version\` logic out of \`session.rs\`'s spawn-time diagnostic into a new \`claude_session_lib::probe\` module so the same logic powers both the diagnostic and the new on-demand UI probe.
- **Shared type**: \`shared::AgentInstall { agent_type, installed, resolved_path, version }\`.
- **WS protocol**: \`ServerToLauncher::ProbeAgents { request_id }\` → \`LauncherToServer::ProbeAgentsResult { request_id, agents }\`.
- **Backend**: parallel \`pending_probe_requests\` map on \`SessionManager\` (mirrors the directory-listing pattern), \`register_probe_request\` / \`complete_probe_request\` helpers, and \`GET /api/launchers/{id}/probe-agents\` with a 5 s timeout.

Per the design discussion: no probe at launcher startup; only on demand when the dialog opens.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings\`
- [x] \`cargo test --workspace --exclude backend\` (149 tests)
- [ ] Open the launch dialog on a host that has both binaries — confirm dropdown labels read just "Claude" / "Codex" with no warning
- [ ] Open the launch dialog on a host with codex *not* installed — confirm "Codex (not installed)" in the dropdown and the red warning under the picker
- [ ] Switch launcher in the dropdown — confirm the probe re-fires