### PR TITLE
Bump codex-codes 0.128.0 to 0.129.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.32
+
+- **Bump `codex-codes` 0.128.0 → 0.129.1.** Upstream added eight new `ServerRequest` variants and roughly ten new `Notification` variants modeling codex CLI 0.130+ protocol additions (tool-input prompts, MCP elicitations, generic permission requests, dynamic tool calls, ChatGPT auth-token refresh, attestation, apply-patch approval, exec-command approval, plus plan/diff/reasoning delta notifications). Extended the proxy's `ServerRequest` match in `claude-session-lib/src/session.rs` to cover all of them — each new variant serializes its typed param struct back to `Value` so the downstream string-dispatch keeps working. New approval-type methods (`ApplyPatchApproval`, `ExecCommandApproval`, `PermissionsRequestApproval`, etc.) currently fall through to the existing `_ => warn!("Unknown Codex request: {}", method)` arm, which surfaces them as raw codex frames in the transcript — purpose-built UIs for each new approval type are a follow-up. New notifications flow through `notif.into_envelope()` and hit the existing string-dispatch's `_ => debug!` arm without code changes.
+
 ## 2.5.31
 
 - **Probe installed agent CLIs when the launch dialog opens.** Previously the only signal that a launcher was missing `codex` or `claude` was a session that spawned then vanished within a second with a misleading `exited normally (code 0)` log. The launch dialog now asks the selected launcher to scan its PATH the moment the user opens it (and again on every launcher dropdown change), and surfaces the result inline:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.128.0"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338ed9393b28db6e82eac065a934ddec9b9f5ebd3210423bf419a2194f8895cd"
+checksum = "4c7f2807b5ab62e25b9f1c5be1c054ff824413ed4c3d991e2c106673e6124dd3"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.31"
+version = "2.5.32"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -42,7 +42,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = { version = "2.1.140", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.128.0", default-features = false, features = ["types"] }
+codex-codes = { version = "0.129.1", default-features = false, features = ["types"] }
 
 # Frontend (Yew)
 yew = { version = "0.21", features = ["csr"] }

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -1150,11 +1150,43 @@ impl Session {
             }
             codex_codes::ServerMessage::Request { id, request } => {
                 let method = request.method().to_string();
+                // Codex 0.129 added several new server→client request variants
+                // (tool-input prompts, MCP elicitations, permission requests,
+                // tool-call requests, auth-token refresh, attestation, patch
+                // approval, exec approval). Until we add purpose-built UI for
+                // each, serialize the typed param struct back to a Value and
+                // let the downstream string-dispatch route it; unmodeled
+                // methods fall through to the warn! arm and surface as a raw
+                // codex frame, which is the user-visible safety net.
                 let params: serde_json::Value = match &request {
                     codex_codes::ServerRequest::CmdExecApproval(p) => {
                         serde_json::to_value(p).unwrap_or_default()
                     }
                     codex_codes::ServerRequest::FileChangeApproval(p) => {
+                        serde_json::to_value(p).unwrap_or_default()
+                    }
+                    codex_codes::ServerRequest::ToolRequestUserInput(p) => {
+                        serde_json::to_value(p).unwrap_or_default()
+                    }
+                    codex_codes::ServerRequest::McpServerElicitationRequest(p) => {
+                        serde_json::to_value(p).unwrap_or_default()
+                    }
+                    codex_codes::ServerRequest::PermissionsRequestApproval(p) => {
+                        serde_json::to_value(p).unwrap_or_default()
+                    }
+                    codex_codes::ServerRequest::ItemToolCall(p) => {
+                        serde_json::to_value(p).unwrap_or_default()
+                    }
+                    codex_codes::ServerRequest::ChatgptAuthTokensRefresh(p) => {
+                        serde_json::to_value(p).unwrap_or_default()
+                    }
+                    codex_codes::ServerRequest::AttestationGenerate(p) => {
+                        serde_json::to_value(p).unwrap_or_default()
+                    }
+                    codex_codes::ServerRequest::ApplyPatchApproval(p) => {
+                        serde_json::to_value(p).unwrap_or_default()
+                    }
+                    codex_codes::ServerRequest::ExecCommandApproval(p) => {
                         serde_json::to_value(p).unwrap_or_default()
                     }
                     codex_codes::ServerRequest::Unknown { params, .. } => {


### PR DESCRIPTION
Upstream \`codex-codes\` jumped from **0.128.0 → 0.129.1** to track codex CLI 0.130+, adding:

**8 new \`ServerRequest\` variants** (server→client requests requiring a reply):
- \`ToolRequestUserInput\` — tool prompts the user
- \`McpServerElicitationRequest\` — MCP server elicits data
- \`PermissionsRequestApproval\` — generic permission request
- \`ItemToolCall\` — dynamic tool call
- \`ChatgptAuthTokensRefresh\`
- \`AttestationGenerate\`
- \`ApplyPatchApproval\`
- \`ExecCommandApproval\`

**~10 new \`Notification\` variants** (server→client one-way):
- \`McpServerOauthLoginCompleted\`, \`FileChangePatchUpdated\`, \`PlanDelta\`, \`TurnPlanUpdated\`, \`TurnDiffUpdated\`, \`ReasoningSummaryPartAdded\`, \`ReasoningTextDelta\`, \`AccountLoginCompleted\`, \`DeprecationNotice\`, \`GuardianWarning\`

## What this PR does

Per the directive — "get the typing in, format it nicer in later PRs":

- Extended the existing \`ServerRequest\` match in \`claude-session-lib/src/session.rs\` to cover all 8 new variants. Each one serializes the typed param struct back to \`serde_json::Value\` via \`serde_json::to_value(p)\`, then the existing downstream string-dispatch handles it.
- New approval methods (\`apply-patch/approval\`, \`exec/approval\`, generic \`permissions/requestApproval\`, etc.) currently fall through to the existing \`_ => warn!("Unknown Codex request: {}", method)\` arm, which means they surface as raw codex frames in the transcript — visible to the user, copyable, but no purpose-built UI yet. **Follow-up PRs** can add specialized handling for each.
- New notifications need no code changes — they go through \`notif.into_envelope()\` and land in the existing string-dispatch's \`_ => debug!\` arm.

The session stays alive across all the new frame types; the user just sees them as raw JSON until we wire individual renderers.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings\`
- [x] \`cargo test --workspace --exclude backend\` (149 tests)
- [ ] On a host with codex CLI 0.130+: launch a session, exercise tool calls / patches / approvals — confirm session stays alive and the new request types surface as raw codex frames (not as fatal errors)

## Follow-up scope

Each new approval type wants its own purpose-built UI down the line — \`PermissionsRequestApproval\`, \`ApplyPatchApproval\`, \`ExecCommandApproval\` in particular. Track in a separate issue / PRs.