### PR TITLE
Drop stray CHANGELOG merge-conflict marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@
 ## 2.5.26
 
 - **Fix #703 — codex sessions no longer wedge after a typed-decode failure.** The 2.5.22 patch for #695 kept the session alive after `codex-codes` failed to deserialize a frame, but silently dropped the frame. When the lost frame was a server→client approval request (the `callId`-missing variant in codex 0.130.0's `item/{commandExecution,fileChange}/requestApproval`), codex blocked the turn waiting for a reply it would never get; the proxy stayed in `turn_active = true` and rejected every subsequent user prompt with `Received input while Codex turn is active`. From the user's POV the session looked alive but ignored them. Now, on `codex_codes::Error::Json` during an active turn, `claude-session-lib` (a) emits a `turn.failed` event to the frontend so the hang is visible, and (b) sends `turn/interrupt` so codex unblocks and emits `turn/completed` (Interrupted), which clears the flag through the normal path. If `turn_interrupt` itself errors, the flag is force-cleared to avoid a permanent wedge.
->>>>>>> 5e07d51 (Share message-shape dispatch between Claude and Codex renderers)
 
 ## 2.5.25
 


### PR DESCRIPTION
Leftover `>>>>>>> 5e07d51` line at the end of the 2.5.26 entry from a previous rebase. The opening `<<<<<<<` and middle `=======` were correctly resolved at the time but the closing marker slipped through. One-line deletion.