### PR TITLE
Route codex 0.130+ message types to user-facing UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.5.33
+
+- **Route the codex 0.130+ message types to user-facing UI instead of letting them fall through to "Unknown Codex request".** Followup to 2.5.32 which got the typing in. Each new message type now has a purpose-built dispatch arm:
+  - **Approval requests** wire into the existing `CodexPermissionRequest` event with sensible \`tool_name\`s and trimmed input payloads, so the user gets the existing approve/deny dialog for each:
+    - \`execCommandApproval\` → \`tool_name: "ExecCommand"\` (command + cwd + parsedCmd)
+    - \`applyPatchApproval\` → \`tool_name: "ApplyPatch"\` (file-change map + grant-root + reason)
+    - \`item/permissions/requestApproval\` → \`tool_name: "Permissions"\` (cwd + permissions profile + reason)
+    - \`item/tool/requestUserInput\` → \`tool_name: "AskUserQuestion"\` (reuses the Claude AskUserQuestion renderer — the Codex question shape is structurally compatible)
+    - \`mcpServer/elicitation/request\` → \`tool_name: "McpElicitation"\` (server name)
+  - **Internal/system requests** (no user action to take) emit a portal text message so the user sees what was requested without blocking the agent:
+    - \`item/tool/call\`, \`account/chatgptAuthTokens/refresh\`, \`attestation/generate\`
+  - **Notifications**:
+    - \`deprecationNotice\` / \`guardianWarning\` → portal text (high-visibility)
+    - \`item/plan/delta\`, \`turn/plan/updated\`, \`turn/diff/updated\`, \`item/reasoning/summaryPartAdded\`, \`item/reasoning/textDelta\`, \`item/fileChange/patchUpdated\` → typed structured events the frontend can opt into rendering (currently fall through to the existing raw-codex display but with a stable \`type\` tag for follow-up renderers)
+    - Pure-status notifications (\`mcpServer/oauthLogin/completed\`, \`account/login/completed\`, etc.) stay silent (debug log)
+- **Frontend**: extended \`format_permission_input\` in \`frontend/src/pages/dashboard/types.rs\` so the new tool_names (\`ExecCommand\`, \`ApplyPatch\`, \`Permissions\`, \`McpElicitation\`) get readable one-line summaries in the permission card instead of dumping a JSON blob.
+
 ## 2.5.32
 
 - **Bump `codex-codes` 0.128.0 → 0.129.1.** Upstream added eight new `ServerRequest` variants and roughly ten new `Notification` variants modeling codex CLI 0.130+ protocol additions (tool-input prompts, MCP elicitations, generic permission requests, dynamic tool calls, ChatGPT auth-token refresh, attestation, apply-patch approval, exec-command approval, plus plan/diff/reasoning delta notifications). Extended the proxy's `ServerRequest` match in `claude-session-lib/src/session.rs` to cover all of them — each new variant serializes its typed param struct back to `Value` so the downstream string-dispatch keeps working. New approval-type methods (`ApplyPatchApproval`, `ExecCommandApproval`, `PermissionsRequestApproval`, etc.) currently fall through to the existing `_ => warn!("Unknown Codex request: {}", method)` arm, which surfaces them as raw codex frames in the transcript — purpose-built UIs for each new approval type are a follow-up. New notifications flow through `notif.into_envelope()` and hit the existing string-dispatch's `_ => debug!` arm without code changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@
 ## 2.5.26
 
 - **Fix #703 — codex sessions no longer wedge after a typed-decode failure.** The 2.5.22 patch for #695 kept the session alive after `codex-codes` failed to deserialize a frame, but silently dropped the frame. When the lost frame was a server→client approval request (the `callId`-missing variant in codex 0.130.0's `item/{commandExecution,fileChange}/requestApproval`), codex blocked the turn waiting for a reply it would never get; the proxy stayed in `turn_active = true` and rejected every subsequent user prompt with `Received input while Codex turn is active`. From the user's POV the session looked alive but ignored them. Now, on `codex_codes::Error::Json` during an active turn, `claude-session-lib` (a) emits a `turn.failed` event to the frontend so the hang is visible, and (b) sends `turn/interrupt` so codex unblocks and emits `turn/completed` (Interrupted), which clears the flag through the normal path. If `turn_interrupt` itself errors, the flag is force-cleared to avoid a permanent wedge.
->>>>>>> 5e07d51 (Share message-shape dispatch between Claude and Codex renderers)
 
 ## 2.5.25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.31"
+version = "2.5.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.31"
+version = "2.5.32"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.31"
+version = "2.5.32"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.31"
+version = "2.5.32"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.31"
+version = "2.5.32"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2938,7 +2938,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.31"
+version = "2.5.32"
 dependencies = [
  "anyhow",
  "colored",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.31"
+version = "2.5.32"
 dependencies = [
  "anyhow",
  "hex",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.31"
+version = "2.5.32"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.32"
+version = "2.5.33"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -1141,6 +1141,63 @@ impl Session {
                         let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
                         (ok, false)
                     }
+                    // Codex 0.130+ notifications — high-visibility ones surface as portal text
+                    // so the user sees them; streaming-delta ones get a structured event the
+                    // frontend can opt into rendering; status / lifecycle ones stay silent.
+                    "deprecationNotice" => {
+                        let message = params
+                            .get("message")
+                            .and_then(|v| v.as_str())
+                            .or_else(|| params.get("notice").and_then(|v| v.as_str()))
+                            .unwrap_or("(no message)");
+                        let event = shared::PortalMessage::text(format!(
+                            "**Codex deprecation notice**: {}",
+                            message
+                        ))
+                        .to_json();
+                        let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
+                        (ok, false)
+                    }
+                    "guardianWarning" => {
+                        let message = params
+                            .get("message")
+                            .and_then(|v| v.as_str())
+                            .or_else(|| params.get("warning").and_then(|v| v.as_str()))
+                            .unwrap_or("(no message)");
+                        let event = shared::PortalMessage::text(format!(
+                            "**Codex guardian warning**: {}",
+                            message
+                        ))
+                        .to_json();
+                        let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
+                        (ok, false)
+                    }
+                    // Streaming/plan/diff notifications — emit a typed event so the frontend
+                    // can render them as a delta block. Frontend currently falls through to
+                    // raw display for unknown types; that's tolerable until purpose-built
+                    // renderers land.
+                    "item/plan/delta"
+                    | "turn/plan/updated"
+                    | "turn/diff/updated"
+                    | "item/reasoning/summaryPartAdded"
+                    | "item/reasoning/textDelta"
+                    | "item/fileChange/patchUpdated" => {
+                        let event = serde_json::json!({
+                            "type": method,
+                            "params": params,
+                        });
+                        let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
+                        (ok, false)
+                    }
+                    // Pure-status notifications — not user-facing.
+                    "mcpServer/oauthLogin/completed"
+                    | "account/login/completed"
+                    | "account/rateLimits/updated"
+                    | "mcpServer/startupStatus/updated"
+                    | "remoteControl/status/changed" => {
+                        tracing::debug!("Codex status notification: {}", method);
+                        (true, false)
+                    }
                     _ => {
                         // Skip delta notifications — item/completed provides the full item
                         tracing::debug!("Codex notification: {}", method);
@@ -1226,6 +1283,126 @@ impl Session {
                                 input,
                             })
                             .is_ok();
+                        (ok, false)
+                    }
+                    // Codex 0.130+ alternative exec-approval shape — `command` is now an argv vec
+                    // and the params carry `parsedCmd`, `approvalId`, etc.
+                    "execCommandApproval" => {
+                        let command = params
+                            .get("command")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|x| x.as_str())
+                                    .collect::<Vec<_>>()
+                                    .join(" ")
+                            })
+                            .unwrap_or_else(|| "(unknown)".to_string());
+                        let input = serde_json::json!({
+                            "command": command,
+                            "cwd": params.get("cwd").and_then(|v| v.as_str()).unwrap_or(""),
+                            "parsedCmd": params.get("parsedCmd").cloned().unwrap_or_default(),
+                        });
+                        let ok = event_tx
+                            .send(IoEvent::CodexPermissionRequest {
+                                request_id: request_id_str,
+                                tool_name: "ExecCommand".to_string(),
+                                input,
+                            })
+                            .is_ok();
+                        (ok, false)
+                    }
+                    // Codex 0.130+ apply-patch flow — `fileChanges` is a BTreeMap keyed by path
+                    "applyPatchApproval" => {
+                        let input = serde_json::json!({
+                            "fileChanges": params.get("fileChanges").cloned().unwrap_or_default(),
+                            "grantRoot": params.get("grantRoot").cloned().unwrap_or(serde_json::Value::Null),
+                            "reason": params.get("reason").cloned().unwrap_or(serde_json::Value::Null),
+                        });
+                        let ok = event_tx
+                            .send(IoEvent::CodexPermissionRequest {
+                                request_id: request_id_str,
+                                tool_name: "ApplyPatch".to_string(),
+                                input,
+                            })
+                            .is_ok();
+                        (ok, false)
+                    }
+                    "item/permissions/requestApproval" => {
+                        let input = serde_json::json!({
+                            "cwd": params.get("cwd").cloned().unwrap_or(serde_json::Value::Null),
+                            "permissions": params.get("permissions").cloned().unwrap_or_default(),
+                            "reason": params.get("reason").cloned().unwrap_or(serde_json::Value::Null),
+                        });
+                        let ok = event_tx
+                            .send(IoEvent::CodexPermissionRequest {
+                                request_id: request_id_str,
+                                tool_name: "Permissions".to_string(),
+                                input,
+                            })
+                            .is_ok();
+                        (ok, false)
+                    }
+                    "item/tool/requestUserInput" => {
+                        let input = serde_json::json!({
+                            "questions": params.get("questions").cloned().unwrap_or_default(),
+                        });
+                        let ok = event_tx
+                            .send(IoEvent::CodexPermissionRequest {
+                                request_id: request_id_str,
+                                tool_name: "AskUserQuestion".to_string(),
+                                input,
+                            })
+                            .is_ok();
+                        (ok, false)
+                    }
+                    "mcpServer/elicitation/request" => {
+                        let server = params
+                            .get("serverName")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("(unknown)")
+                            .to_string();
+                        let input = serde_json::json!({
+                            "serverName": server,
+                        });
+                        let ok = event_tx
+                            .send(IoEvent::CodexPermissionRequest {
+                                request_id: request_id_str,
+                                tool_name: "McpElicitation".to_string(),
+                                input,
+                            })
+                            .is_ok();
+                        (ok, false)
+                    }
+                    // Internal / system requests (codex 0.130+) — surface a portal message so
+                    // the user sees what was requested, but don't block on user approval. We
+                    // can't auto-respond meaningfully (we have no auth token, no attestation
+                    // signer); codex will retry or move on.
+                    "item/tool/call" => {
+                        let tool = params
+                            .get("tool")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("(unknown)");
+                        let msg = format!("**Codex tool call**: `{}`", tool);
+                        let event = shared::PortalMessage::text(msg).to_json();
+                        let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
+                        (ok, false)
+                    }
+                    "account/chatgptAuthTokens/refresh" => {
+                        let event = shared::PortalMessage::text(
+                            "**Codex requested ChatGPT auth token refresh** (not handled — the agent may pause)."
+                                .to_string(),
+                        )
+                        .to_json();
+                        let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
+                        (ok, false)
+                    }
+                    "attestation/generate" => {
+                        let event = shared::PortalMessage::text(
+                            "**Codex requested attestation generation** (not handled).".to_string(),
+                        )
+                        .to_json();
+                        let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
                         (ok, false)
                     }
                     _ => {

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -231,6 +231,37 @@ pub fn format_permission_input(tool_name: &str, input: &serde_json::Value) -> St
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
             .unwrap_or_else(|| serde_json::to_string_pretty(input).unwrap_or_default()),
+        // Codex 0.130+ approval types — single-line summaries so the permission
+        // card doesn't drop a full JSON blob into the dialog.
+        "ExecCommand" => input
+            .get("command")
+            .and_then(|v| v.as_str())
+            .map(|s| format!("$ {}", s))
+            .unwrap_or_else(|| serde_json::to_string_pretty(input).unwrap_or_default()),
+        "ApplyPatch" => {
+            // `fileChanges` is a JSON object keyed by file path — list the paths.
+            let paths: Vec<String> = input
+                .get("fileChanges")
+                .and_then(|v| v.as_object())
+                .map(|m| m.keys().cloned().collect())
+                .unwrap_or_default();
+            if paths.is_empty() {
+                serde_json::to_string_pretty(input).unwrap_or_default()
+            } else {
+                format!("Patch {} file(s):\n  {}", paths.len(), paths.join("\n  "))
+            }
+        }
+        "Permissions" => input
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| serde_json::to_string_pretty(input).unwrap_or_default()),
+        "McpElicitation" => input
+            .get("serverName")
+            .and_then(|v| v.as_str())
+            .map(|s| format!("MCP server `{}` is asking for input", s))
+            .unwrap_or_else(|| serde_json::to_string_pretty(input).unwrap_or_default()),
         _ => serde_json::to_string_pretty(input).unwrap_or_else(|_| format!("{:?}", input)),
     }
 }


### PR DESCRIPTION
Follow-up to PR #712 (2.5.32 bumped codex-codes to 0.129.1 and got the types in). All eight new \`ServerRequest\` variants and the new \`Notification\` variants were routed through the existing \`_ => warn!("Unknown Codex request")\` / \`_ => debug!\` arms — visible to the user only as raw codex frames. This PR replaces those with purpose-built dispatch.

## What changes

### Approval requests → existing permission UI

Each new approval method gets its own \`tool_name\` + trimmed input payload, wired into the existing \`CodexPermissionRequest\` event. The user gets the same approve/deny dialog they already know:

| Codex method | \`tool_name\` | Surfaces |
|---|---|---|
| \`execCommandApproval\` | \`ExecCommand\` | command (joined argv) + cwd + parsedCmd |
| \`applyPatchApproval\` | \`ApplyPatch\` | file-change map + grant-root + reason |
| \`item/permissions/requestApproval\` | \`Permissions\` | cwd + permissions profile + reason |
| \`item/tool/requestUserInput\` | \`AskUserQuestion\` | reuses the Claude AskUserQuestion renderer — the Codex question shape (header / question / options of \`{label, description}\`) is structurally compatible |
| \`mcpServer/elicitation/request\` | \`McpElicitation\` | server name |

### Internal / system requests → portal-message stub

\`item/tool/call\`, \`account/chatgptAuthTokens/refresh\`, \`attestation/generate\` — no user action to take. Emit a portal text message so the user sees what was requested; don't block the agent.

### Notifications

- \`deprecationNotice\` / \`guardianWarning\` → portal text (high-visibility, user-bound).
- \`item/plan/delta\`, \`turn/plan/updated\`, \`turn/diff/updated\`, \`item/reasoning/summaryPartAdded\`, \`item/reasoning/textDelta\`, \`item/fileChange/patchUpdated\` → typed structured events with a stable \`type\` field; frontend currently falls through to the existing raw-codex display but the structured tag makes adding purpose-built renderers a one-line extension.
- Pure-status notifications (\`mcpServer/oauthLogin/completed\`, \`account/login/completed\`, etc.) stay silent at \`debug!\` level.

### Frontend

\`format_permission_input\` in \`frontend/src/pages/dashboard/types.rs\` got branches for the four new approval tool_names so the permission card shows a readable one-line summary instead of a JSON blob:

- \`ExecCommand\` → \`$ <command>\`
- \`ApplyPatch\` → \`Patch N file(s):\\n  <paths>\`
- \`Permissions\` → \`reason\` (with JSON fallback)
- \`McpElicitation\` → \`MCP server \`<name>\` is asking for input\`

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings\`
- [x] \`cargo test --workspace --exclude backend\` (149 tests)
- [ ] Exercise each approval flow on a real codex 0.130+ session