### PR TITLE
Bump codex-codes 0.129.1 to 0.129.2 + wire extra_args through to codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.34
+
+- **Bump `codex-codes` 0.129.1 → 0.129.2.** Picks up [SDK #135](https://github.com/meawoppl/rust-code-agent-sdks/issues/135), which added `AppServerBuilder::config_override(key, value)` and `extra_args(IntoIterator)` so the spawned codex command line can carry `-c key=value` global overrides and arbitrary subcommand flags. No call-site changes yet — wiring `sandbox_mode=workspace-write` etc. through `claude-session-lib`'s codex_io_task is a follow-up; this PR is just the dep bump so the API is available.
+
 ## 2.5.33
 
 - **Route the codex 0.130+ message types to user-facing UI instead of letting them fall through to "Unknown Codex request".** Followup to 2.5.32 which got the typing in. Each new message type now has a purpose-built dispatch arm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 2.5.34
 
-- **Bump `codex-codes` 0.129.1 → 0.129.2.** Picks up [SDK #135](https://github.com/meawoppl/rust-code-agent-sdks/issues/135), which added `AppServerBuilder::config_override(key, value)` and `extra_args(IntoIterator)` so the spawned codex command line can carry `-c key=value` global overrides and arbitrary subcommand flags. No call-site changes yet — wiring `sandbox_mode=workspace-write` etc. through `claude-session-lib`'s codex_io_task is a follow-up; this PR is just the dep bump so the API is available.
+- **Bump `codex-codes` 0.129.1 → 0.129.2** and wire it through `codex_io_task`. The dep bump picks up [SDK #135](https://github.com/meawoppl/rust-code-agent-sdks/issues/135) (`AppServerBuilder::config_override` + `extra_args`). The call-site change parses each codex session's `SessionConfig::extra_args` (the existing "Extra args" launch-dialog text input — already wired through to the launcher) into two buckets:
+  - tokens of the form `-c key=value` / `--config key=value` become `builder.config_override(k, v)` (rendered as `-c k=v` **before** the `app-server` subcommand, since `-c` is a global codex flag);
+  - everything else becomes `builder.extra_args(...)` (appended **after** `--listen stdio://`).
+  - Lets a user type e.g. `-c sandbox_mode=workspace-write -c approval_policy=on-request --strict-config` in the launch dialog and have each token land in the right slot on the spawned codex command line. No structured UI for sandbox/approval pickers yet — that's a follow-up.
 
 ## 2.5.33
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.32"
+version = "2.5.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.32"
+version = "2.5.34"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.32"
+version = "2.5.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.32"
+version = "2.5.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -632,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.129.1"
+version = "0.129.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f2807b5ab62e25b9f1c5be1c054ff824413ed4c3d991e2c106673e6124dd3"
+checksum = "82fa3783cc1e8aa7f03ea911b8294f315f1c9c835909764c175a6c7bdfe0987c"
 dependencies = [
  "log",
  "serde",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.32"
+version = "2.5.34"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2938,7 +2938,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.32"
+version = "2.5.34"
 dependencies = [
  "anyhow",
  "colored",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.32"
+version = "2.5.34"
 dependencies = [
  "anyhow",
  "hex",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.32"
+version = "2.5.34"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.33"
+version = "2.5.34"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -42,7 +42,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = { version = "2.1.140", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.129.1", default-features = false, features = ["types"] }
+codex-codes = { version = "0.129.2", default-features = false, features = ["types"] }
 
 # Frontend (Yew)
 yew = { version = "0.21", features = ["csr"] }

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -833,12 +833,53 @@ impl Session {
 
         let codex_path = config.claude_path.as_deref().unwrap_or(Path::new("codex"));
 
-        let mut builder = AppServerBuilder::new().command(codex_path);
-        builder = builder.working_directory(&config.working_directory);
+        // Parse the user-supplied extra_args into (a) global `-c key=value`
+        // codex config overrides and (b) plain trailing args, because the two
+        // need to land in different positions on the spawned command line:
+        //
+        //   codex  -c k=v  app-server --listen stdio://  <trailing args>
+        //          ^^^^^^^                               ^^^^^^^^^^^^^^^
+        //          global  subcommand + builder-managed  per-subcommand
+        //
+        // (codex-codes 0.129.2 added `config_override` / `extra_args` on
+        // AppServerBuilder; see SDK #135.)
+        let mut overrides: Vec<(String, String)> = Vec::new();
+        let mut trailing: Vec<String> = Vec::new();
+        let mut iter = config.extra_args.iter();
+        while let Some(tok) = iter.next() {
+            if tok == "-c" || tok == "--config" {
+                if let Some(pair) = iter.next() {
+                    if let Some((k, v)) = pair.split_once('=') {
+                        overrides.push((k.to_string(), v.to_string()));
+                        continue;
+                    } else {
+                        // `-c key` with no `=value` — pass through unchanged
+                        // so codex's own error surfaces if it's malformed.
+                        trailing.push(tok.clone());
+                        trailing.push(pair.clone());
+                        continue;
+                    }
+                }
+            }
+            trailing.push(tok.clone());
+        }
+
+        let mut builder = AppServerBuilder::new()
+            .command(codex_path)
+            .working_directory(&config.working_directory);
+        for (k, v) in &overrides {
+            builder = builder.config_override(k, v);
+        }
+        if !trailing.is_empty() {
+            builder = builder.extra_args(trailing.iter().cloned());
+        }
 
         tracing::info!(
-            "Starting Codex app-server: {} app-server --listen stdio://",
-            codex_path.display()
+            "Starting Codex app-server: {} app-server --listen stdio:// \
+             ({} config override(s), {} extra arg(s))",
+            codex_path.display(),
+            overrides.len(),
+            trailing.len(),
         );
 
         let mut client = match CodexAsyncClient::start_with(builder).await {


### PR DESCRIPTION
Two commits:

1. **Bump `codex-codes` 0.129.1 → 0.129.2** to pick up [rust-code-agent-sdks#135](https://github.com/meawoppl/rust-code-agent-sdks/issues/135) — `AppServerBuilder::config_override(key, value)` + `extra_args(IntoIterator)`.
2. **Wire `SessionConfig::extra_args` through to `codex_io_task`.** Splits each token in the existing launch-dialog "Extra args" input into:
   - `-c key=value` / `--config key=value` → `builder.config_override(k, v)` (rendered **before** `app-server` since `-c` is a global codex flag);
   - everything else → `builder.extra_args(...)` (appended **after** `--listen stdio://`).

   Lets a user type e.g. `-c sandbox_mode=workspace-write -c approval_policy=on-request --strict-config` in the launch dialog and have each token land in the right slot on the spawned codex command line.

## What it does NOT do

- No structured UI for sandbox mode / approval policy. Those still have to be typed by hand into the existing free-form Extra args input. Worth a follow-up — `sandbox_mode` and `approval_policy` are the two most common ones to set per session.
- No defaults baked in. Codex still defaults to `sandbox: read-only`. The launch dialog or per-launcher config is responsible for opting in to `workspace-write` if that's the desired behavior.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p claude-session-lib`
- [ ] Live: launch a codex session with `-c sandbox_mode=workspace-write` in Extra args, ask it to write a file, confirm it lands instead of silently aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
