### PR TITLE
Rate-limit retry: 30 attempts, 60s backoff cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.35
+
+- **Rate-limit retry: bump cap from 4 attempts/30s to 30 attempts/60s.** The original 2.5.29 settings gave up after ~1 minute of sustained throttling, which was too short for the rate-limit windows Anthropic actually applies (multi-minute holds are common). With 30 attempts at full-jitter exponential backoff capped at 60s, the upper bound on retry wall time is ~30 minutes of patience before we surface the "send your message again" portal note — and any earlier success short-circuits, so well-behaved limits unblock as soon as the window opens. Counter still resets on every fresh user input and every successful turn.
+
 ## 2.5.34
 
 - **Bump `codex-codes` 0.129.1 → 0.129.2** and wire it through `codex_io_task`. The dep bump picks up [SDK #135](https://github.com/meawoppl/rust-code-agent-sdks/issues/135) (`AppServerBuilder::config_override` + `extra_args`). The call-site change parses each codex session's `SessionConfig::extra_args` (the existing "Extra args" launch-dialog text input — already wired through to the launcher) into two buckets:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.34"
+version = "2.5.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.34"
+version = "2.5.35"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.34"
+version = "2.5.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.34"
+version = "2.5.35"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.34"
+version = "2.5.35"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2938,7 +2938,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.34"
+version = "2.5.35"
 dependencies = [
  "anyhow",
  "colored",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.34"
+version = "2.5.35"
 dependencies = [
  "anyhow",
  "hex",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.34"
+version = "2.5.35"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.34"
+version = "2.5.35"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -248,8 +248,8 @@ impl Session {
         // then emits a Result with is_error=true. We retry that turn for the
         // user with full-jitter exponential backoff.
         const RATE_LIMIT_TEXT_PREFIX: &str = "API Error: Server is temporarily limiting requests";
-        const MAX_RATE_LIMIT_RETRIES: u32 = 4;
-        const RATE_LIMIT_BACKOFF_CAP_SECS: u64 = 30;
+        const MAX_RATE_LIMIT_RETRIES: u32 = 30;
+        const RATE_LIMIT_BACKOFF_CAP_SECS: u64 = 60;
 
         // Take stderr so we can read it if Claude exits unexpectedly
         let mut stderr_reader = client.take_stderr();


### PR DESCRIPTION
Bump the upstream-429 retry constants in `claude_io_task`:

| | Was (2.5.29) | Now |
|---|---|---|
| `MAX_RATE_LIMIT_RETRIES` | 4 | **30** |
| `RATE_LIMIT_BACKOFF_CAP_SECS` | 30 | **60** |

The original numbers gave up after ~1 minute of sustained throttling. Anthropic's actual rate-limit windows commonly hold for multiple minutes — the user would see the auto-retry surrender just as the limit was about to open. New upper bound is ~30 minutes of patience before we surface the "send your message again" portal note; any earlier success short-circuits.

Behavior otherwise unchanged: full-jitter exponential backoff, counter resets on every fresh user input + every successful turn, new user input during backoff still cancels the retry and runs normally.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p claude-session-lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)