### PR TITLE
Shrink pill watermark 10%, keep center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.36
+
+- Session pill agent-type watermark (Anthropic asterisk / OpenAI knot) is now 10% smaller — 88×88 → 80×80 — with the left offset adjusted from −28px to −24px so the icon's horizontal center stays at the same x=16 in pill coords. Vertical center is unchanged.
+
 ## 2.5.35
 
 - **Rate-limit retry: bump cap from 4 attempts/30s to 30 attempts/60s.** The original 2.5.29 settings gave up after ~1 minute of sustained throttling, which was too short for the rate-limit windows Anthropic actually applies (multi-minute holds are common). With 30 attempts at full-jitter exponential backoff capped at 60s, the upper bound on retry wall time is ~30 minutes of patience before we surface the "send your message again" portal note — and any earlier success short-circuits, so well-behaved limits unblock as soon as the window opens. Counter still resets on every fresh user input and every successful turn.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.35"
+version = "2.5.36"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -162,15 +162,19 @@
     box-sizing: border-box;
 }
 
-/* Agent-type watermark — large logo anchored to the pill's left edge, clipped
-   by the pill's overflow:hidden, behind all foreground content. */
+/* Agent-type watermark — large logo anchored to the pill's left edge,
+   clipped by the pill's overflow:hidden, behind all foreground content.
+   Sized 10% under the 2.5.27 launch dimensions (88×88, left:-28px); the
+   new offset keeps the icon's horizontal center at x=16 in pill coords so
+   the visual centering doesn't drift. Vertical center is held by top:50%
+   + translateY(-50%). */
 .pill-watermark {
     position: absolute;
-    left: -28px;
+    left: -24px;
     top: 50%;
     transform: translateY(-50%);
-    width: 88px;
-    height: 88px;
+    width: 80px;
+    height: 80px;
     pointer-events: none;
     background-repeat: no-repeat;
     background-position: center;


### PR DESCRIPTION
Quick aesthetic tweak per user request. Watermark drops from 88×88 to 80×80; the left offset changes from −28px to −24px so the icon's horizontal center stays at x=16 in pill coords. Vertical center unchanged (still anchored via `top:50% + translateY(-50%)`).