### PR TITLE
Fix FileChange permission dialog showing {"changes": null}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.38
+
+- **Fix `FileChange` permission dialog showing `{"changes": null}`.** codex-codes 0.129.3 regenerated `FileChangeRequestApprovalParams` from the schema: the fields are now `itemId` / `reason` / `grantRoot` / `threadId` / `turnId` / `startedAtMs` — no `changes` field. Codex doesn't inline the patch on the approval request; the diff was streamed earlier as the `item/started` for the matching `itemId`. agent-portal's dispatch arm for `item/fileChange/requestApproval` was still extracting `params.get("changes")` (returning `null`) and the frontend was rendering the resulting `{"changes": null}` as a raw JSON dump in the permission card.
+  - **Backend (`claude-session-lib/src/session.rs`)**: surface the actual wire fields (`itemId`, `reason`, `grantRoot`) on the `CodexPermissionRequest` event.
+  - **Frontend (`frontend/src/pages/dashboard/types.rs`)**: new `FileChange` arm in `format_permission_input` — shows `File change for item \`<id>\`` plus reason/grant-root when present, with a `(diff streamed above under this item id)` pointer so the user knows the patch is in the transcript. Inlining the diff into the dialog would require correlating `itemId` back to the prior `item/started` payload — left as a follow-up.
+
 ## 2.5.37
 
 - **Bump `codex-codes` 0.129.2 → 0.129.3 and absorb the SDK rewrite.** Upstream 0.129.3 (PR #138) regenerated every wire type from the schema and shipped [SDK #134](https://github.com/meawoppl/rust-code-agent-sdks/issues/134)'s structured `ParseError`. Three concrete consequences for agent-portal:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2937,7 +2937,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "colored",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "hex",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.37"
+version = "2.5.38"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/session.rs
+++ b/claude-session-lib/src/session.rs
@@ -1367,8 +1367,18 @@ impl Session {
                         (ok, false)
                     }
                     "item/fileChange/requestApproval" => {
+                        // codex-codes 0.129.3 reshaped this approval params:
+                        // codex no longer inlines the patch. The wire now
+                        // carries `itemId` (reference to the matching
+                        // `item/started` for the fileChange that was streamed
+                        // earlier in this turn), `reason` (why approval is
+                        // needed), and `grantRoot` (what scope of permission
+                        // codex wants). The actual diff is upstream in the
+                        // transcript under the matching item id.
                         let input = serde_json::json!({
-                            "changes": params.get("changes").cloned().unwrap_or_default()
+                            "itemId": params.get("itemId").cloned().unwrap_or(serde_json::Value::Null),
+                            "reason": params.get("reason").cloned().unwrap_or(serde_json::Value::Null),
+                            "grantRoot": params.get("grantRoot").cloned().unwrap_or(serde_json::Value::Null),
                         });
                         let ok = event_tx
                             .send(IoEvent::CodexPermissionRequest {

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -251,6 +251,29 @@ pub fn format_permission_input(tool_name: &str, input: &serde_json::Value) -> St
                 format!("Patch {} file(s):\n  {}", paths.len(), paths.join("\n  "))
             }
         }
+        "FileChange" => {
+            // codex 0.130 doesn't inline the diff on the approval request —
+            // the patch was streamed earlier as an `item/started` for the
+            // matching item id. Show the id (so the user can find the diff
+            // in the transcript above) plus reason/grantRoot when present.
+            let item_id = input
+                .get("itemId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(unknown)");
+            let mut lines = vec![format!("File change for item `{}`", item_id)];
+            if let Some(reason) = input.get("reason").and_then(|v| v.as_str()) {
+                if !reason.is_empty() {
+                    lines.push(format!("Reason: {}", reason));
+                }
+            }
+            if let Some(root) = input.get("grantRoot").and_then(|v| v.as_str()) {
+                if !root.is_empty() {
+                    lines.push(format!("Grant root: {}", root));
+                }
+            }
+            lines.push(String::from("(diff streamed above under this item id)"));
+            lines.join("\n")
+        }
         "Permissions" => input
             .get("reason")
             .and_then(|v| v.as_str())


### PR DESCRIPTION
## What you saw

```
⚠️ Permission Required
Tool: FileChange
{
  "changes": null
}
```

## Why

codex-codes 0.129.3 regenerated `FileChangeRequestApprovalParams` from the schema. The new fields are `itemId` / `reason` / `grantRoot` / `threadId` / `turnId` / `startedAtMs` — **no `changes` field**. Codex 0.130+ doesn't inline the patch on the approval request anymore; the actual diff was streamed earlier as the `item/started` event for the matching `itemId`.

agent-portal's dispatch arm for `item/fileChange/requestApproval` in `claude-session-lib/src/session.rs` was still extracting `params.get("changes")`, which returns `null` against the new wire shape. The frontend's `format_permission_input` has no `FileChange` arm so it fell through to a raw `serde_json::to_string_pretty(input)` of `{"changes": null}`.

Confirmed against live wire frames seen on this device:

```
{"method":"item/fileChange/requestApproval",
 "id":3,
 "params":{"threadId":"...","turnId":"...",
           "itemId":"call_HKaP84kozIUwWE1Ynd5hPpCN",
           "startedAtMs":1779060084995,
           "reason":null,
           "grantRoot":null}}
```

## Fix

- **Backend**: extract `itemId` / `reason` / `grantRoot` from `params` and emit them on the `CodexPermissionRequest` input.
- **Frontend**: new `FileChange` arm in `format_permission_input` (`frontend/src/pages/dashboard/types.rs`) — renders as:

  ```
  File change for item `call_HKaP84kozIUwWE1Ynd5hPpCN`
  Reason: …                      (omitted if absent/empty)
  Grant root: /some/path         (omitted if absent/empty)
  (diff streamed above under this item id)
  ```

## Out of scope (follow-up)

Inlining the diff itself into the permission dialog would need the proxy to correlate `itemId` ↔ the prior `item/started` fileChange payload (small in-memory map keyed by itemId, drained on `item/completed`). Worth it but a separate change.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p claude-session-lib`
- [ ] Live: trigger a file-write codex request, confirm the dialog now shows the item id + pointer note instead of `{"changes": null}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
