### PR TITLE
CLAUDE.md: prefer typed interfaces; push schema gaps upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.38
+
+- CLAUDE.md: codify typed-interface preference + upstream-first rule, lifted from the codex `item/fileChange/requestApproval` regression in 2.5.38 / PR #721.
+
 ## 2.5.37
 
 - **Bump `codex-codes` 0.129.2 → 0.129.3 and absorb the SDK rewrite.** Upstream 0.129.3 (PR #138) regenerated every wire type from the schema and shipped [SDK #134](https://github.com/meawoppl/rust-code-agent-sdks/issues/134)'s structured `ParseError`. Three concrete consequences for agent-portal:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,6 +575,28 @@ let body = AddMemberRequest { email, role };
 Request::post(&url).json(&body)
 ```
 
+### Prefer typed interfaces; push schema gaps upstream
+
+**Match on typed enum variants from `claude-codes` / `codex-codes` — don't poke at JSON field names.** Both SDKs expose typed enums (`ClaudeOutput`, `ServerRequest`, `Notification`, …) with strongly-typed param structs. The typed shape is a compile-time contract: when the SDK regenerates fields, the compiler tells you what to update. JSON-poking silently misses fields and ships broken UI.
+
+```rust
+// ❌ BAD - reads a field that doesn't exist in codex 0.130+; silently null
+let changes = params.get("changes").cloned();
+emit_permission_card(changes);
+
+// ✅ GOOD - dispatch on the typed variant, read typed fields directly
+match server_request {
+    ServerRequest::FileChangeApproval(p) => {
+        emit_permission_card(&p.item_id, &p.reason, p.grant_root);
+    }
+    // …
+}
+```
+
+**When the typed model is missing or wrong, push upstream.** If you reach for `params: serde_json::Value` because the typed enum lacks a variant, has the wrong field name, or doesn't expose what you need: file an issue (or open a PR) against [`meawoppl/rust-code-agent-sdks`](https://github.com/meawoppl/rust-code-agent-sdks) instead of weaving a local workaround. The library is small, the maintainer is responsive, and a typed fix benefits every consumer.
+
+**When a local workaround is OK:** only when (a) you're shipping a hotfix on a clock the SDK turnaround can't meet, **and** (b) you've filed the upstream issue. Tag it with `// TODO(SDK #NNN)` so it's easy to find and rip out when upstream lands.
+
 ### Error Handling
 
 **Backend handlers**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2937,7 +2937,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "colored",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "anyhow",
  "hex",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.37"
+version = "2.5.38"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shared", "backend", "frontend", "proxy", "claude-session-lib", "laun
 resolver = "2"
 
 [workspace.package]
-version = "2.5.37"
+version = "2.5.38"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## Summary

Adds a new subsection to `CLAUDE.md` under **Code Conventions** titled "Prefer typed interfaces; push schema gaps upstream." The rule:

1. Match on typed enum variants from `claude-codes` / `codex-codes` (e.g. `ServerRequest::FileChangeApproval(p)` -> `p.item_id`); don't poke at JSON field names like `params.get("itemId")`. The typed shape is a compile-time contract.
2. When the typed model is missing or wrong, file an issue / PR against [`meawoppl/rust-code-agent-sdks`](https://github.com/meawoppl/rust-code-agent-sdks) instead of weaving a local workaround.
3. Local workarounds only when shipping a hotfix the SDK turnaround can't meet, and only after the upstream issue is filed. Tag with `// TODO(SDK #NNN)`.

## Motivation

PR #721 fixed a concrete instance of this anti-pattern: codex 0.130 reshaped `item/fileChange/requestApproval` (dropped inline `changes`, added `itemId` / `reason` / `grantRoot`), but `claude-session-lib/src/session.rs` was reading `params.get("changes")` instead of matching on the typed `codex_codes::ServerRequest::FileChangeApproval(p)` enum. Result: the permission card silently shipped `{"changes": null}`. Had we been matching on the typed variant, the SDK regen would have caused a compile error pointing straight at the fields to update.

This PR is the **rule** that would have caught it at write time.

## Changes

- `CLAUDE.md` — new subsection (~225 words) with bad/good code example, slotted next to the analogous "No `serde_json::json!`" rule.
- `Cargo.toml` — workspace version `2.5.37` -> `2.5.38` (per the every-PR-needs-a-bump convention).
- `CHANGELOG.md` — one-line entry under `## 2.5.38`.

## Test plan

- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo check --workspace --exclude backend` (clean at v2.5.38; the backend's `memory-serve` build script needs `frontend/dist` which is unrelated to this change)
- [x] No code changes, only docs + version bump