### PR TITLE
Bump claude-codes 2.1.140 to 2.1.141

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.43
+
+- **Bump `claude-codes` 2.1.140 → 2.1.141.** Pure addition upstream — adds `ToolPermissionRequest::answer_questions(answers, request_id)`, a typed helper for replying to `AskUserQuestion` approvals that preserves the original `questions` array in the `updatedInput` payload (manual `{answers: {...}}` responses drop it, which crashes downstream viewers that call `tool_use_result.questions.map(...)`). Not yet used by agent-portal — existing AskUserQuestion approval path can switch to the helper in a follow-up.
+
 ## 2.5.42
 
 - **Tag `agent_type` per-message at the proxy emission boundary instead of capturing it from registration.** The 2.5.40/2.5.41 design captured `agent_type` from the proxy's `Register` and threaded it through `proxy_socket.rs` into every insert site. That was functionally correct today (one connection = one io_task = one agent) but wrong shape for any future multi-agent / sub-agent session: every insert site would silently mis-attribute the day a single `/ws/session` connection started ferrying messages from more than one agent. Now `ProxyToServer::SequencedOutput` and `ProxyToServer::ClaudeOutput` carry `agent_type: AgentType` on each message, the proxy reads `config.agent_type` at every emission site (output forwarder, wiggum portal messages, replay loop, codex raw output, connection-portal banner, shim mode), and `proxy_socket.rs` trusts the per-message tag — the `session_agent_type` capture is gone, as is the error-and-drop guard for pre-Register output. The live broadcast `ServerToClient::ClaudeOutput` also grew an `agent_type` field so the frontend's in-flight messages can be tagged the same way as the historical-read path. **Wire compat caveat:** pre-2.5.42 proxies don't send `agent_type` on output messages; `#[serde(default)]` makes them parse as `AgentType::Claude`, which is a presumed misattribution for any in-flight codex session running an older proxy until the proxy upgrades.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.42"
+version = "2.5.43"
 dependencies = [
  "anyhow",
  "chrono",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.42"
+version = "2.5.43"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -564,9 +564,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.140"
+version = "2.1.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46aa3a5f22bb526e7d1aba0bea447ece47a023093cd3c353b3c04381eaadb16b"
+checksum = "fc4430abb2bef291e8e1084287aa85d53ebe441ffc6567ad7a6a72e21410f744"
 dependencies = [
  "anyhow",
  "chrono",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.42"
+version = "2.5.43"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.42"
+version = "2.5.43"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.5.42"
+version = "2.5.43"
 dependencies = [
  "claude-codes",
  "codex-codes",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.42"
+version = "2.5.43"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2954,7 +2954,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.42"
+version = "2.5.43"
 dependencies = [
  "anyhow",
  "colored",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.42"
+version = "2.5.43"
 dependencies = [
  "anyhow",
  "hex",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.5.42"
+version = "2.5.43"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.42"
+version = "2.5.43"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.5.42"
+version = "2.5.43"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -50,7 +50,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.140", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.141", default-features = false, features = ["types"] }
 
 # Codex CLI integration
 codex-codes = { version = "0.129.3", default-features = false, features = ["types"] }


### PR DESCRIPTION
Pure addition upstream — adds `ToolPermissionRequest::answer_questions(answers, request_id)`, a typed helper for replying to AskUserQuestion approvals that preserves the original `questions` array in the `updatedInput` payload. Hand-built responses drop it, which crashes downstream viewers calling `tool_use_result.questions.map(...)`.

Not yet used by agent-portal — existing AskUserQuestion approval path can switch to the helper in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)