### PR TITLE
Banned page: typed query-param parse (closes #732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.47
+
+- **Typed query-param parse on the banned page (closes #732).** `frontend/src/pages/banned.rs` no longer pokes `web_sys::UrlSearchParams::get("reason")` against the URL; it uses `yew_router::use_location().query::<BannedQuery>()` with a `#[derive(Deserialize)] struct BannedQuery { reason: Option<String> }`, and `serde_urlencoded` handles URL decoding so the manual `js_sys::decode_uri_component` block is gone.
+
 ## 2.5.46
 
 - **Typed frontend renderers for codex streaming-delta events.** `turn/diff/updated`, `item/fileChange/patchUpdated`, and `turn/plan/updated` previously fell through `CodexEvent`'s `#[serde(other)] Unknown` arm and got dumped as raw pretty-printed JSON in the transcript. Now `CodexEvent` carries typed variants for all six slash-named delta methods the proxy forwards (the three above plus `item/plan/delta`, `item/reasoning/summaryPartAdded`, `item/reasoning/textDelta`); the first three render as real cards (cumulative unified diff, per-file patches, numbered plan with status icons) and the latter three are typed no-op stubs that suppress the raw-JSON dump without aggregating delta state. The per-line HTML emission was extracted out of `render_diff_lines` into a private `render_diff_html` helper, and a new public `render_unified_diff(diff: &str)` parses unified-diff strings (skipping `--- `, `+++ `, `@@ ` headers and the `\\ No newline at end of file` marker, classifying body lines by leading char with a context fallback) and feeds the same helper. Both the claude `Edit` tool renderer and the new codex diff renderers go through `render_diff_html`, so styling stays in lockstep. Tests cover `parse_unified_diff` (single hunk, multi-hunk, blank context, no-newline marker, missing file headers, unprefixed lines) and round-trip each new `CodexEvent` variant through `serde_json::from_str`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.46"
+version = "2.5.47"
 dependencies = [
  "anyhow",
  "chrono",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.46"
+version = "2.5.47"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.46"
+version = "2.5.47"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.46"
+version = "2.5.47"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.5.46"
+version = "2.5.47"
 dependencies = [
  "claude-codes",
  "codex-codes",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.46"
+version = "2.5.47"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2954,7 +2954,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.46"
+version = "2.5.47"
 dependencies = [
  "anyhow",
  "colored",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.46"
+version = "2.5.47"
 dependencies = [
  "anyhow",
  "hex",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.5.46"
+version = "2.5.47"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.46"
+version = "2.5.47"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.5.46"
+version = "2.5.47"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/banned.rs
+++ b/frontend/src/pages/banned.rs
@@ -1,24 +1,18 @@
-use gloo::utils::window;
+use serde::{Deserialize, Serialize};
 use yew::prelude::*;
+use yew_router::prelude::*;
+
+#[derive(Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+struct BannedQuery {
+    #[serde(default)]
+    reason: Option<String>,
+}
 
 #[function_component(BannedPage)]
 pub fn banned_page() -> Html {
-    // Extract reason from URL query params
-    let reason = window()
-        .location()
-        .search()
-        .ok()
-        .and_then(|search| {
-            let params = web_sys::UrlSearchParams::new_with_str(&search).ok()?;
-            params.get("reason")
-        })
-        .map(|r| {
-            // URL decode the reason
-            js_sys::decode_uri_component(&r)
-                .ok()
-                .map(|s| s.as_string().unwrap_or_default())
-                .unwrap_or(r)
-        })
+    let reason = use_location()
+        .and_then(|loc| loc.query::<BannedQuery>().ok())
+        .and_then(|q| q.reason)
         .unwrap_or_else(|| "No reason provided".to_string());
 
     html! {


### PR DESCRIPTION
## Summary

- Replaces `frontend/src/pages/banned.rs`'s raw `web_sys::UrlSearchParams::get("reason")` (plus `js_sys::decode_uri_component`) with `yew_router::use_location().query::<BannedQuery>()` against a typed `BannedQuery { reason: Option<String> }`. URL decoding now flows through `serde_urlencoded` (already on the dep tree via `gloo-history`'s default `query` feature).
- Bumps workspace `2.5.44` -> `2.5.45` and adds the CHANGELOG entry.
- Closes #732.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo build --target wasm32-unknown-unknown -p frontend`
- [ ] Manual: visit `/banned?reason=Test%20reason` and confirm the rendered reason still URL-decodes to "Test reason"