### PR TITLE
ExitPlanMode: typed ToolInput access for permission dialog (closes #736)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.49
+
+- **Typed `ToolInput::ExitPlanMode` access in `frontend/src/pages/dashboard/permission_dialog.rs` (closes #736).** The ExitPlanMode permission card was reading `perm.input.get("allowedPrompts").and_then(|v| v.as_array())` and then per-entry `.get("tool").as_str()` / `.get("prompt").as_str()` on the inner objects — silent regression bait if the wire renames a field. Replaced with `serde_json::from_value::<ToolInput>(perm.input.clone())` matching `ToolInput::ExitPlanMode(epm)` and reading `epm.allowed_prompts: Option<Vec<AllowedPrompt>>` typed; iteration uses typed `p.tool` / `p.prompt` directly. `ToolInput`, `ExitPlanModeInput`, and `AllowedPrompt` are now re-exported from `shared` so the frontend doesn't need a direct `claude-codes` dep. The `perm.input: serde_json::Value` envelope stays — per-tool inputs have different shapes; typed decoding happens at the dispatch site. Render layout, CSS classes, and other permission-tool branches (Bash, Edit, Write) are unchanged — they remain separate issues.
+
 ## 2.5.48
 
 - **`render_todowrite_tool` uses typed `ToolInput::TodoWrite` instead of JSON-poking (closes #735).** The frontend renderer now deserializes its `serde_json::Value` input into `claude_codes::tool_inputs::ToolInput`, matches the `TodoWrite(TodoWriteInput)` variant, and reads each `TodoItem`'s typed `content: String` and `status: TodoStatus` enum (`Completed` / `InProgress` / `Pending` / `Unknown(_)`). Same icons, same CSS classes, same empty-list fallback when deserialization fails — just no more `.get("todos").as_array()` / `.get("status").as_str()`. `shared` now re-exports `TodoItem`, `TodoStatus`, `TodoWriteInput`, and `ToolInput` so the frontend can use them without taking a direct `claude-codes` dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.48"
+version = "2.5.49"
 dependencies = [
  "anyhow",
  "chrono",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.48"
+version = "2.5.49"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.48"
+version = "2.5.49"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.48"
+version = "2.5.49"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.5.48"
+version = "2.5.49"
 dependencies = [
  "claude-codes",
  "codex-codes",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.48"
+version = "2.5.49"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2954,7 +2954,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.48"
+version = "2.5.49"
 dependencies = [
  "anyhow",
  "colored",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.48"
+version = "2.5.49"
 dependencies = [
  "anyhow",
  "hex",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.5.48"
+version = "2.5.49"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.48"
+version = "2.5.49"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.5.48"
+version = "2.5.49"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/permission_dialog.rs
+++ b/frontend/src/pages/dashboard/permission_dialog.rs
@@ -4,6 +4,8 @@ use std::collections::{HashMap, HashSet};
 use web_sys::KeyboardEvent;
 use yew::prelude::*;
 
+use shared::{AllowedPrompt, ToolInput};
+
 use super::types::{
     format_permission_input, parse_ask_user_question, AskUserQuestionInput, PendingPermission,
     QuestionAnswers,
@@ -377,12 +379,18 @@ fn render_exitplanmode_permission(props: &PermissionDialogProps) -> Html {
         _ => {}
     });
 
-    let allowed_prompts = perm
-        .input
-        .get("allowedPrompts")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
+    // Decode the per-tool input typed instead of JSON-poking field names.
+    // `perm.input` stays a `serde_json::Value` envelope (it carries different shapes per tool);
+    // we parse to the typed `ToolInput` enum at this dispatch site and pull the
+    // `ExitPlanMode` variant's `allowed_prompts` directly.
+    let allowed_prompts: Vec<AllowedPrompt> =
+        serde_json::from_value::<ToolInput>(perm.input.clone())
+            .ok()
+            .and_then(|t| match t {
+                ToolInput::ExitPlanMode(epm) => epm.allowed_prompts,
+                _ => None,
+            })
+            .unwrap_or_default();
 
     let options: Vec<(&str, &str)> = vec![("allow", "Allow"), ("deny", "Deny")];
 
@@ -404,16 +412,12 @@ fn render_exitplanmode_permission(props: &PermissionDialogProps) -> Html {
                             <div class="exitplan-permissions">
                                 <div class="exitplan-permissions-header">{ "Requested permissions:" }</div>
                                 {
-                                    allowed_prompts.iter().map(|p| {
-                                        let tool = p.get("tool").and_then(|t| t.as_str()).unwrap_or("Unknown");
-                                        let prompt = p.get("prompt").and_then(|p| p.as_str()).unwrap_or("");
-                                        html! {
-                                            <div class="exitplan-permission-item">
-                                                <span class="permission-tool-name">{ tool }</span>
-                                                <span class="permission-separator">{ ": " }</span>
-                                                <span class="permission-description">{ prompt }</span>
-                                            </div>
-                                        }
+                                    allowed_prompts.iter().map(|p| html! {
+                                        <div class="exitplan-permission-item">
+                                            <span class="permission-tool-name">{ &p.tool }</span>
+                                            <span class="permission-separator">{ ": " }</span>
+                                            <span class="permission-description">{ &p.prompt }</span>
+                                        </div>
                                     }).collect::<Html>()
                                 }
                             </div>

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -48,6 +48,7 @@ pub use claude_codes::ClaudeOutput;
 // Re-export typed tool-input types so frontend renderers can match on enum
 // variants instead of poking at JSON field names.
 pub use claude_codes::tool_inputs::{TodoItem, TodoStatus, TodoWriteInput, ToolInput};
+pub use claude_codes::{AllowedPrompt, ExitPlanModeInput};
 
 /// Returns true when a system message marks the END of a context compaction.
 ///


### PR DESCRIPTION
## Summary

- Replace the `perm.input.get("allowedPrompts").as_array()` + per-entry `.get("tool").as_str()` / `.get("prompt").as_str()` JSON-poking in `frontend/src/pages/dashboard/permission_dialog.rs` with typed `claude_codes::tool_inputs::ToolInput::ExitPlanMode(ExitPlanModeInput)` decoding via `serde_json::from_value::<ToolInput>(perm.input.clone())`; iterate typed `Vec<AllowedPrompt>` with `p.tool` / `p.prompt`.
- Re-export `ToolInput`, `ExitPlanModeInput`, and `AllowedPrompt` from `shared/src/lib.rs` so the frontend doesn't need its own `claude-codes` dependency.
- The `perm.input: serde_json::Value` envelope is unchanged — per-tool inputs have different shapes, so typed decoding happens at the dispatch site (same pattern `claude_io_task` uses on the proxy side). A broader refactor to `perm.input: Option<ToolInput>` is out of scope.
- Render layout (`<div class="exitplan-permission-item">`, `<span class="permission-tool-name">`, etc.) and CSS classes are unchanged.
- Other permission-tool branches in `permission_dialog.rs` (Bash, Edit, Write) also JSON-poke, but each is an independent follow-up — out of scope here.
- Verified SDK shape against `claude-codes 2.1.141`: `ExitPlanModeInput.allowed_prompts: Option<Vec<AllowedPrompt>>` (the `Option` was missed in the issue body — handled by chaining and `.unwrap_or_default()`); `AllowedPrompt { tool: String, prompt: String }` matches.
- Bump 2.5.44 → 2.5.45.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` all green
- [x] `cargo build --target wasm32-unknown-unknown -p frontend` succeeds
- [x] `trunk build` (frontend) succeeds — required for backend's `memory-serve` embed step
- [ ] Manual smoke: trigger an ExitPlanMode permission and confirm tool/prompt rows render the same as before (`<span class="permission-tool-name">` text + `: ` separator + `<span class="permission-description">` text)

Closes #736.

Generated with [Claude Code](https://claude.com/claude-code)