### PR TITLE
Task tool renderer: typed ToolInput::Task dispatch (closes #749)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.58
+
+- **`render_task_tool` uses typed `ToolInput::Task` instead of JSON-poking (closes #749).** Follow-up to 2.5.48 (#735) / 2.5.49 (#736): the Task subagent renderer in `frontend/src/components/tool_renderers/task.rs` was the third claude-side renderer still reading `input.get("description") / input.get("subagent_type") / input.get("run_in_background")` against `serde_json::Value`. It now deserializes its `serde_json::Value` input into `claude_codes::tool_inputs::ToolInput`, matches `ToolInput::Task(TaskInput)`, and reads the typed `description: String`, `subagent_type: SubagentType` (via `.as_str()`, which handles `Unknown(_)` for forward-compat), and `run_in_background: Option<bool>` fields directly. Same icon, same CSS classes, same `"?"` / `"agent"` / `false` fallbacks when deserialization fails — just no more silent-null bait the next time the SDK renames a field. `shared` now re-exports `TaskInput` alongside the existing `TodoItem` / `TodoStatus` / `TodoWriteInput` / `ToolInput` re-exports.
+
 ## 2.5.57
 
 - **`render_webfetch_tool` / `render_websearch_tool` use typed `ToolInput::WebFetch` / `ToolInput::WebSearch` instead of JSON-poking (closes #748).** Both renderers in `frontend/src/components/tool_renderers/search.rs` now deserialize their `serde_json::Value` input into `claude_codes::tool_inputs::ToolInput`, match the relevant variant, and read typed `WebFetchInput { url: String, prompt: String }` / `WebSearchInput { query: String, … }` fields directly — no more `input.get("url")` / `input.get("prompt")` / `input.get("query")`. Same icons, same CSS classes, same `?` fallback when deserialization fails. `shared` now re-exports `WebFetchInput` and `WebSearchInput` so the frontend can use them without a direct `claude-codes` dep. The Glob/Grep portions of the same file remain JSON-poked under #747.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.57"
+version = "2.5.58"
 dependencies = [
  "anyhow",
  "chrono",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.57"
+version = "2.5.58"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.57"
+version = "2.5.58"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.57"
+version = "2.5.58"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.5.57"
+version = "2.5.58"
 dependencies = [
  "claude-codes",
  "codex-codes",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.57"
+version = "2.5.58"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2954,7 +2954,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.57"
+version = "2.5.58"
 dependencies = [
  "anyhow",
  "colored",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.57"
+version = "2.5.58"
 dependencies = [
  "anyhow",
  "hex",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.5.57"
+version = "2.5.58"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.57"
+version = "2.5.58"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.5.57"
+version = "2.5.58"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/tool_renderers/task.rs
+++ b/frontend/src/components/tool_renderers/task.rs
@@ -1,18 +1,23 @@
 use serde_json::Value;
+use shared::{TaskInput, ToolInput};
 use yew::prelude::*;
 
 pub fn render_task_tool(input: &Value) -> Html {
-    let description = input
-        .get("description")
-        .and_then(|v| v.as_str())
-        .unwrap_or("?");
-    let agent_type = input
-        .get("subagent_type")
-        .and_then(|v| v.as_str())
+    let task: Option<TaskInput> = serde_json::from_value::<ToolInput>(input.clone())
+        .ok()
+        .and_then(|t| match t {
+            ToolInput::Task(task) => Some(task),
+            _ => None,
+        });
+
+    let description: &str = task.as_ref().map(|t| t.description.as_str()).unwrap_or("?");
+    let agent_type: &str = task
+        .as_ref()
+        .map(|t| t.subagent_type.as_str())
         .unwrap_or("agent");
-    let background = input
-        .get("run_in_background")
-        .and_then(|v| v.as_bool())
+    let background: bool = task
+        .as_ref()
+        .and_then(|t| t.run_in_background)
         .unwrap_or(false);
 
     html! {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -48,8 +48,8 @@ pub use claude_codes::ClaudeOutput;
 // Re-export typed tool-input types so frontend renderers can match on enum
 // variants instead of poking at JSON field names.
 pub use claude_codes::tool_inputs::{
-    BashInput, EditInput, GlobInput, GrepInput, ReadInput, TodoItem, TodoStatus, TodoWriteInput,
-    ToolInput, WebFetchInput, WebSearchInput, WriteInput,
+    BashInput, EditInput, GlobInput, GrepInput, ReadInput, TaskInput, TodoItem, TodoStatus,
+    TodoWriteInput, ToolInput, WebFetchInput, WebSearchInput, WriteInput,
 };
 pub use claude_codes::{AllowedPrompt, ExitPlanModeInput};
 


### PR DESCRIPTION
## Summary

Closes #749. Follow-up to #735 (TodoWrite) and #736 (ExitPlanMode): the Task subagent renderer in `frontend/src/components/tool_renderers/task.rs` was the third claude-side renderer still reading `input.get("description")` / `input.get("subagent_type")` / `input.get("run_in_background")` against `serde_json::Value`. Per the [typed-interfaces rule in CLAUDE.md](../blob/main/CLAUDE.md#prefer-typed-interfaces-push-schema-gaps-upstream), it now deserializes into `claude_codes::tool_inputs::ToolInput`, matches `ToolInput::Task(TaskInput)`, and reads the typed fields directly.

- `description: String` (was `as_str().unwrap_or("?")`)
- `subagent_type: SubagentType` rendered via `.as_str()` — `SubagentType::Unknown(_)` keeps forward-compat with new SDK variants
- `run_in_background: Option<bool>` (was `as_bool().unwrap_or(false)`)

Same icon, same CSS classes, same `"?"` / `"agent"` / `false` fallbacks when deserialization fails — just no silent-null bait when the SDK renames a field.

`shared::lib.rs` now re-exports `TaskInput` alongside the existing `TodoItem` / `TodoStatus` / `TodoWriteInput` / `ToolInput` re-exports added in 2.5.48 / 2.5.49.

Workspace bumped to **2.5.58** with CHANGELOG entry.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo check --workspace --exclude backend`
- [x] `cargo clippy --workspace --exclude backend -- -D warnings`
- [ ] Visual: live render of a Task tool call still shows agent type, description, and the background pill when set

DO NOT MERGE — awaiting human review.