### PR TITLE
Citations: typed Citation struct (closes #754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.64
+
+- **Typed `Citation` struct for content-block citations (closes #754).** `frontend/src/components/message_renderer/renderers.rs::render_citations` was iterating a `Vec<serde_json::Value>` and per-entry JSON-poking `cite.get("url")`, `cite.get("title")`, and `cite.get("cited_text")` — the last typed-interface gap left on the assistant text-block render path. The `citations` field on `ContentBlock::Text` in `frontend/src/components/message_renderer/types.rs` is now `Vec<shared::Citation>`, a new `#[derive(Serialize, Deserialize)] struct Citation { url, title, cited_text }` in `shared::api` with all-optional `#[serde(default)]` fields. `claude-codes` 2.1.141 also stores citations as `Vec<serde_json::Value>` on `TextBlock` (`src/io/content_blocks.rs:168`), so the local definition stays for now and SDK issue [meawoppl/rust-code-agent-sdks#142](https://github.com/meawoppl/rust-code-agent-sdks/issues/142) has been filed proposing the typed shape upstream — once it lands we can drop `shared::Citation` and re-export from `claude-codes` per the typed-interfaces rule. Wire shape is unchanged: unknown fields like `type: "web_search_result_location"` are silently dropped (regression-tested), older messages that omit `citations` entirely keep parsing via `#[serde(default)]`, and empty citations still serialize to nothing via `skip_serializing_if = "Option::is_none"`. The renderer's URL/title fallback logic (`title → cited_text → "source"`, `url → "#"`) is preserved exactly. Unit tests cover the full round-trip, the unknown-field-ignored path, and the empty-frame default.
+
 ## 2.5.63
 
 - **Fix #758 (PR 1/4): Categorized `MessageGroup` + Assistant grouping bug fix.** Two things landed together:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.62"
+version = "2.5.64"
 dependencies = [
  "anyhow",
  "chrono",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.62"
+version = "2.5.64"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.62"
+version = "2.5.64"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.62"
+version = "2.5.64"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.5.62"
+version = "2.5.64"
 dependencies = [
  "claude-codes",
  "codex-codes",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.62"
+version = "2.5.64"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2954,7 +2954,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.62"
+version = "2.5.64"
 dependencies = [
  "anyhow",
  "colored",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.62"
+version = "2.5.64"
 dependencies = [
  "anyhow",
  "hex",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.5.62"
+version = "2.5.64"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.62"
+version = "2.5.64"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.5.63"
+version = "2.5.64"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -9,7 +9,7 @@ use crate::components::time_ago::TimeAgo;
 use crate::components::tool_renderers::render_tool_use;
 use serde::Deserialize;
 use serde_json::Value;
-use shared::ToolResultContent;
+use shared::{Citation, ToolResultContent};
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
@@ -1087,16 +1087,16 @@ fn image_viewer(props: &ImageViewerProps) -> Html {
     }
 }
 
-fn render_citations(citations: &[Value]) -> Html {
+fn render_citations(citations: &[Citation]) -> Html {
     if citations.is_empty() {
         return html! {};
     }
     html! {
         <div class="citation-list">
             { for citations.iter().enumerate().map(|(i, cite)| {
-                let url = cite.get("url").and_then(|v| v.as_str()).unwrap_or("#");
-                let title = cite.get("title").and_then(|v| v.as_str())
-                    .or_else(|| cite.get("cited_text").and_then(|v| v.as_str()))
+                let url = cite.url.as_deref().unwrap_or("#");
+                let title = cite.title.as_deref()
+                    .or(cite.cited_text.as_deref())
                     .unwrap_or("source");
                 html! {
                     <a class="citation-link"

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use shared::{CacheCreationDetails, ToolResultContent};
+use shared::{CacheCreationDetails, Citation, ToolResultContent};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -152,7 +152,7 @@ pub enum ContentBlock {
     Text {
         text: String,
         #[serde(default)]
-        citations: Vec<Value>,
+        citations: Vec<Citation>,
     },
     #[serde(rename = "image")]
     Image { source: ImageSource },

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -5,6 +5,41 @@ use uuid::Uuid;
 
 use crate::SessionInfo;
 
+/// Typed citation entry attached to an Anthropic text content block.
+///
+/// The Anthropic wire shape carries one of several citation variants
+/// (`char_location`, `page_location`, `content_block_location`,
+/// `web_search_result_location`, …); only a small subset of fields is
+/// shown in the agent-portal UI today (`url`, `title`, and `cited_text`),
+/// so we model just those as a single flat struct with optional fields
+/// rather than re-deriving the full upstream enum here. Unknown fields on
+/// the wire are silently ignored — the UI only needs enough to render a
+/// `[1]`/`[2]`/… link list.
+///
+/// Closes #754: replaces a previous `Vec<serde_json::Value>` field on
+/// `ContentBlock::Text` that the frontend JSON-poked with
+/// `cite.get("url")` / `cite.get("title")` / `cite.get("cited_text")`.
+///
+/// `claude-codes` 2.1.141 also stores citations as `Vec<serde_json::Value>`
+/// on `TextBlock`; upstream issue
+/// <https://github.com/meawoppl/rust-code-agent-sdks/issues/142> proposes
+/// this typed shape so we can eventually drop the local definition and
+/// just re-export from the SDK.
+// TODO(SDK #142): replace with `claude_codes::Citation` once upstream
+// adds a typed model — see agent-portal #754.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct Citation {
+    /// URL of the cited source (e.g. a web search result link).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Human-readable title of the cited source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Exact text quoted from the cited source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cited_text: Option<String>,
+}
+
 /// Typed envelope for a Codex permission request's `input` payload.
 ///
 /// Replaces the prior `serde_json::Value` envelope shared between the proxy
@@ -679,6 +714,47 @@ mod tests {
         let parsed: CodexPermissionInput = serde_json::from_value(json).unwrap();
         assert_eq!(parsed, input);
         assert_eq!(parsed.tool_name(), "AskUserQuestion");
+    }
+
+    #[test]
+    fn citation_full_roundtrip() {
+        let cite = Citation {
+            url: Some("https://example.com".to_string()),
+            title: Some("Example".to_string()),
+            cited_text: Some("hello world".to_string()),
+        };
+        let json = serde_json::to_value(&cite).unwrap();
+        assert_eq!(json["url"], "https://example.com");
+        assert_eq!(json["title"], "Example");
+        assert_eq!(json["cited_text"], "hello world");
+        let parsed: Citation = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, cite);
+    }
+
+    /// Wire frame as actually produced by the Anthropic API for a
+    /// `web_search_result_location` citation (per claude-codes
+    /// `test_text_block_with_citations`). Extra fields like `type` must
+    /// be silently ignored.
+    #[test]
+    fn citation_ignores_unknown_fields() {
+        let json = serde_json::json!({
+            "type": "web_search_result_location",
+            "url": "https://example.com",
+            "title": "Example"
+        });
+        let parsed: Citation = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.url.as_deref(), Some("https://example.com"));
+        assert_eq!(parsed.title.as_deref(), Some("Example"));
+        assert!(parsed.cited_text.is_none());
+    }
+
+    /// Empty wire frame must parse to all-`None` so historical content
+    /// blocks that omitted citations stay readable.
+    #[test]
+    fn citation_empty_roundtrip() {
+        let json = serde_json::json!({});
+        let parsed: Citation = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, Citation::default());
     }
 
     /// Regression guard for the pattern that motivated #725/#731: optional

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -19,7 +19,7 @@ pub mod protocol;
 // API client types and trait
 pub mod api;
 pub use api::{
-    ApiError, CodexPermissionInput, CompactionExtra, InitExtra, SoundSettingsResponse,
+    ApiError, Citation, CodexPermissionInput, CompactionExtra, InitExtra, SoundSettingsResponse,
     TaskNotificationExtra,
 };
 


### PR DESCRIPTION
## Summary

- Replaces `Vec<serde_json::Value>` citation poking in `frontend/src/components/message_renderer/renderers.rs::render_citations` with a typed `shared::Citation { url, title, cited_text }` (all optional, `#[serde(default)]`) so the last JSON-poke on the content-block render path is gone.
- `ContentBlock::Text.citations` in `frontend/src/components/message_renderer/types.rs` is now `Vec<shared::Citation>`; older messages parse cleanly via `#[serde(default)]`, the renderer fallback chain (`title → cited_text → "source"`, `url → "#"`) is preserved exactly, and unknown wire fields (e.g. `type: "web_search_result_location"`) are silently dropped.
- `claude-codes` 2.1.141 also stores citations as `Vec<Value>` on `TextBlock` (`src/io/content_blocks.rs:168`); upstream issue [meawoppl/rust-code-agent-sdks#142](https://github.com/meawoppl/rust-code-agent-sdks/issues/142) filed proposing the typed shape — once it lands we drop `shared::Citation` and re-export from `claude-codes` (`TODO(SDK #142)` left in `shared/src/api.rs`).
- Workspace bumped to 2.5.63 with CHANGELOG entry.

## Test plan

- [x] `cargo check --workspace --exclude backend`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --exclude backend -- -D warnings`
- [x] `cargo test -p shared` (3 new `citation_*` tests pass: full round-trip, unknown-field-ignored, empty default)
- [ ] Smoke: render an assistant message with `web_search_result_location` citations and verify the `[1]`/`[2]`/… link list still renders with hover-title and target=_blank.