### PR TITLE
PR 4/4 of #758: group-level time-ago footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.70
+
+- **PR 4/4 of #758: group-level time-ago footer.** Closes the message-grouping roadmap. The three group renderers added by PR 2 (`render_portal_group`) and PR 3 (`render_user_group`, `render_codex_group`) now mirror the assistant-group treatment from PR 1: pull the **last** message's `_created_at` ISO via `extract_raw_iso(messages.last())` and render a `.message-footer` containing a live-updating `<TimeAgo iso={iso} />`. The existing `.claude-message .message-footer { justify-content: flex-end; }` puts the chip in the bottom-right corner exactly as the roadmap spec called for. Mechanical three-line change per renderer, gated on `if let Some(iso)` so pre-`_created_at` messages still render cleanly. All 19 `message_renderer` unit tests continue to pass — no new tests because the change is presence-only and the underlying `TimeAgo` component already has its own coverage.
+
 ## 2.5.69
 
 - **PR 3/4 of #758: User + Codex grouping with explicit predicate ordering.** Extends the categorized `MessageGroup` from PR 1 and the Portal grouping from PR 2 with two new `GroupCategory` variants:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.5.69"
+version = "2.5.70"
 dependencies = [
  "anyhow",
  "chrono",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.5.69"
+version = "2.5.70"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.5.69"
+version = "2.5.70"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.5.69"
+version = "2.5.70"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.5.69"
+version = "2.5.70"
 dependencies = [
  "claude-codes",
  "codex-codes",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.5.69"
+version = "2.5.70"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -2954,7 +2954,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.5.69"
+version = "2.5.70"
 dependencies = [
  "anyhow",
  "colored",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.5.69"
+version = "2.5.70"
 dependencies = [
  "anyhow",
  "hex",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.5.69"
+version = "2.5.70"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.5.69"
+version = "2.5.70"
 dependencies = [
  "claude-codes",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.5.69"
+version = "2.5.70"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -344,6 +344,7 @@ pub fn render_user_group(
 ) -> Html {
     let count = messages.len();
     let header_title = timestamp.unwrap_or_default().to_string();
+    let last_iso = messages.last().and_then(|json| extract_raw_iso(json));
     html! {
         <div class="claude-message message-group user-group">
             <div class="message-header" title={header_title}>
@@ -360,6 +361,11 @@ pub fn render_user_group(
                     }
                 }) }
             </div>
+            if let Some(iso) = last_iso {
+                <div class="message-footer">
+                    <TimeAgo iso={iso} />
+                </div>
+            }
         </div>
     }
 }
@@ -371,6 +377,7 @@ pub fn render_user_group(
 pub fn render_codex_group(messages: &[String], timestamp: Option<&str>) -> Html {
     let count = messages.len();
     let header_title = timestamp.unwrap_or_default().to_string();
+    let last_iso = messages.last().and_then(|json| extract_raw_iso(json));
     html! {
         <div class="claude-message message-group codex-group">
             <div class="message-header" title={header_title}>
@@ -384,6 +391,11 @@ pub fn render_codex_group(messages: &[String], timestamp: Option<&str>) -> Html 
                     html! { <crate::components::codex_renderer::CodexMessageRenderer json={json.clone()} /> }
                 }) }
             </div>
+            if let Some(iso) = last_iso {
+                <div class="message-footer">
+                    <TimeAgo iso={iso} />
+                </div>
+            }
         </div>
     }
 }
@@ -397,6 +409,7 @@ pub fn render_codex_group(messages: &[String], timestamp: Option<&str>) -> Html 
 pub fn render_portal_group(messages: &[String], timestamp: Option<&str>) -> Html {
     let count = messages.len();
     let header_title = timestamp.unwrap_or_default().to_string();
+    let last_iso = messages.last().and_then(|json| extract_raw_iso(json));
     html! {
         <div class="claude-message message-group portal-group">
             <div class="message-header" title={header_title}>
@@ -413,6 +426,11 @@ pub fn render_portal_group(messages: &[String], timestamp: Option<&str>) -> Html
                     }
                 }) }
             </div>
+            if let Some(iso) = last_iso {
+                <div class="message-footer">
+                    <TimeAgo iso={iso} />
+                </div>
+            }
         </div>
     }
 }


### PR DESCRIPTION
## Summary

Closes the #758 message-grouping roadmap. The three group renderers added by PR 2 (\`render_portal_group\`) and PR 3 (\`render_user_group\`, \`render_codex_group\`) now mirror the assistant-group treatment from PR 1: pull the **last** message's \`_created_at\` ISO via \`extract_raw_iso(messages.last())\` and render a \`.message-footer\` containing a live-updating \`<TimeAgo iso={iso} />\`.

The existing \`.claude-message .message-footer { justify-content: flex-end; }\` puts the chip in the bottom-right corner exactly as the roadmap spec called for.

Mechanical three-line change per renderer, gated on \`if let Some(iso)\` so pre-\`_created_at\` messages still render cleanly.

## Tests

All 19 \`message_renderer\` unit tests continue to pass. No new tests — the change is presence-only and the underlying \`TimeAgo\` component already has its own coverage.

## Test plan

- [x] \`cargo test --workspace\` passes
- [x] \`cargo clippy --workspace --all-targets\` clean
- [x] \`cargo fmt --all\` applied
- [ ] Local browser check that each group shows a live time-ago in its bottom-right corner