### PR TITLE
Render Codex compaction events

### DIFF
--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -871,6 +871,7 @@ async fn run_main_loop<A: Agent>(
                 // Handle raw output directly (Codex JSONL) — bypasses the
                 // ClaudeOutput-typed output forwarder
                 if let Some(SessionEvent::RawOutput(ref value)) = event {
+                    let is_codex_compaction = is_codex_compaction_event(value);
                     let seq = {
                         let mut buf = state.output_buffer.lock().await;
                         buf.push(value.clone())
@@ -884,6 +885,9 @@ async fn run_main_loop<A: Agent>(
                     if ws.send(msg).await.is_err() {
                         error!("Failed to send raw output");
                         return ConnectionResult::Disconnected(state.connection_start.elapsed());
+                    }
+                    if is_codex_compaction {
+                        inject_portal_reminder(claude_session).await;
                     }
                     continue;
                 }
@@ -904,6 +908,13 @@ async fn run_main_loop<A: Agent>(
             }
         }
     }
+}
+
+fn is_codex_compaction_event(value: &serde_json::Value) -> bool {
+    value
+        .get("type")
+        .and_then(|t| t.as_str())
+        .is_some_and(|t| t == "thread/compacted")
 }
 
 /// Handle a file upload event (start or chunk)

--- a/codex-session-lib/src/handler.rs
+++ b/codex-session-lib/src/handler.rs
@@ -138,6 +138,7 @@ fn handle_notification(
         Notification::FileChangePatchUpdated(p) => {
             emit_passthrough(event_tx, "item/fileChange/patchUpdated", &p)
         }
+        Notification::ContextCompacted(p) => emit_passthrough(event_tx, "thread/compacted", &p),
 
         // Pure-status notifications — not user-facing. Logged via the typed
         // `Notification::method()` accessor so the debug message stays accurate
@@ -184,7 +185,6 @@ fn handle_notification(
         | Notification::ProcessExited(_)
         | Notification::ProcessOutputDelta(_)
         | Notification::ServerRequestResolved(_)
-        | Notification::ContextCompacted(_)
         | Notification::ThreadGoalUpdated(_)
         | Notification::ThreadRealtimeClosed(_)
         | Notification::ThreadRealtimeError(_)
@@ -393,6 +393,29 @@ mod tests {
         let (sent, ended) = handle_codex_server_message(msg, &tx);
         drop(tx);
         (drain(&mut rx), sent, ended)
+    }
+
+    #[test]
+    fn context_compacted_emits_renderable_event() {
+        let notif: codex_codes::ContextCompactedNotification = serde_json::from_value(json!({
+            "threadId": "thread-1",
+            "turnId": "turn-1"
+        }))
+        .unwrap();
+        let msg = ServerMessage::Notification(Notification::ContextCompacted(notif));
+        let (events, sent, ended) = handle(msg);
+
+        assert!(sent);
+        assert!(!ended);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            IoEvent::RawOutput(value) => {
+                assert_eq!(value["type"], "thread/compacted");
+                assert_eq!(value["params"]["threadId"], "thread-1");
+                assert_eq!(value["params"]["turnId"], "turn-1");
+            }
+            _ => panic!("expected RawOutput"),
+        }
     }
 
     /// `FileChangeApproval` should now expose the typed `itemId`/`reason`/`grantRoot`

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -67,6 +67,10 @@ pub enum CodexEvent {
     ReasoningTextDelta {
         params: Option<serde_json::Value>,
     },
+    #[serde(rename = "thread/compacted")]
+    ThreadCompacted {
+        params: Option<ContextCompactedParams>,
+    },
     #[serde(other)]
     Unknown,
 }
@@ -129,6 +133,14 @@ pub struct PlanDeltaParams {
     pub delta: Option<String>,
     #[serde(default, rename = "itemId", alias = "item_id")]
     pub item_id: Option<String>,
+    #[serde(default, rename = "threadId", alias = "thread_id")]
+    pub thread_id: Option<String>,
+    #[serde(default, rename = "turnId", alias = "turn_id")]
+    pub turn_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ContextCompactedParams {
     #[serde(default, rename = "threadId", alias = "thread_id")]
     pub thread_id: Option<String>,
     #[serde(default, rename = "turnId", alias = "turn_id")]
@@ -283,6 +295,7 @@ pub fn codex_message_renderer(props: &CodexMessageRendererProps) -> Html {
             params.as_ref().and_then(|p| p.plan.as_deref()),
             params.as_ref().and_then(|p| p.explanation.as_deref()),
         ),
+        Ok(CodexEvent::ThreadCompacted { params }) => render_context_compacted(params.as_ref()),
         // Per-chunk deltas — the consolidated content lands in `turn/plan/updated`
         // (for plans) or `item.completed` (for reasoning). Emit nothing for the
         // streaming chunks to avoid visual noise without losing information.
@@ -405,6 +418,7 @@ pub fn render_codex_message_content(json: &str) -> Html {
             params.as_ref().and_then(|p| p.plan.as_deref()),
             params.as_ref().and_then(|p| p.explanation.as_deref()),
         ),
+        Ok(CodexEvent::ThreadCompacted { params }) => render_context_compacted(params.as_ref()),
         _ => html! {},
     }
 }
@@ -760,6 +774,29 @@ fn render_turn_plan(plan: Option<&[TurnPlanStep]>, explanation: Option<&str>) ->
     }
 }
 
+fn render_context_compacted(params: Option<&ContextCompactedParams>) -> Html {
+    let title = params
+        .and_then(|p| p.turn_id.as_deref())
+        .map(|turn_id| format!("Codex compacted context for turn {}", turn_id))
+        .unwrap_or_else(|| "Codex compacted the conversation context".to_string());
+
+    html! {
+        <div class="claude-message compaction-message">
+            <div class="message-header">
+                <span class="message-type-badge compaction">{ "Context Compacted" }</span>
+            </div>
+            <div class="message-body">
+                <div class="compaction-content">
+                    <div class="compaction-icon">{ "\u{1f4e6}" }</div>
+                    <div class="compaction-text">
+                        <div class="compaction-description">{ title }</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
 fn render_raw_codex(json: &str) -> Html {
     let display = serde_json::from_str::<Value>(json)
         .ok()
@@ -792,6 +829,7 @@ pub fn is_codex_terminal_event(json: &str) -> Option<bool> {
         | CodexEvent::TurnDiffUpdated { .. }
         | CodexEvent::FileChangePatchUpdated { .. }
         | CodexEvent::TurnPlanUpdated { .. }
+        | CodexEvent::ThreadCompacted { .. }
         | CodexEvent::PlanDelta { .. }
         | CodexEvent::ReasoningSummaryPartAdded { .. }
         | CodexEvent::ReasoningTextDelta { .. }
@@ -1114,6 +1152,19 @@ mod tests {
                 assert_eq!(p.explanation.as_deref(), Some("so far"));
             }
             other => panic!("expected TurnPlanUpdated, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn event_thread_compacted() {
+        let json = r#"{"type":"thread/compacted","params":{"threadId":"t","turnId":"u"}}"#;
+        let event: CodexEvent = serde_json::from_str(json).unwrap();
+        match event {
+            CodexEvent::ThreadCompacted { params: Some(p) } => {
+                assert_eq!(p.thread_id.as_deref(), Some("t"));
+                assert_eq!(p.turn_id.as_deref(), Some("u"));
+            }
+            other => panic!("expected ThreadCompacted, got {:?}", other),
         }
     }
 


### PR DESCRIPTION
## Summary
- emit Codex context compaction notifications as renderable `thread/compacted` transcript events
- reinject the portal rendering-hints reminder after forwarding a Codex compaction event
- render Codex compaction events with the existing compaction message styling

## Tests
- `cargo test -p codex-session-lib context_compacted_emits_renderable_event`
- `cargo test -p frontend event_thread_compacted`
- `cargo test -p claude-session-lib`