### PR TITLE
Enrich Codex completion stats

### DIFF
--- a/codex-session-lib/src/handler.rs
+++ b/codex-session-lib/src/handler.rs
@@ -21,9 +21,12 @@ use crate::helpers::format_request_id;
 pub(crate) fn handle_codex_server_message(
     msg: ServerMessage,
     event_tx: &mpsc::UnboundedSender<IoEvent>,
+    latest_token_usage: Option<&serde_json::Value>,
 ) -> (bool, bool) {
     match msg {
-        ServerMessage::Notification(notif) => handle_notification(notif, event_tx),
+        ServerMessage::Notification(notif) => {
+            handle_notification(notif, event_tx, latest_token_usage)
+        }
         ServerMessage::Request { id, request } => {
             handle_request(format_request_id(&id), request, event_tx)
         }
@@ -33,6 +36,7 @@ pub(crate) fn handle_codex_server_message(
 fn handle_notification(
     notif: Notification,
     event_tx: &mpsc::UnboundedSender<IoEvent>,
+    latest_token_usage: Option<&serde_json::Value>,
 ) -> (bool, bool) {
     match notif {
         // Lifecycle — already handled elsewhere or intentionally silent.
@@ -41,16 +45,16 @@ fn handle_notification(
         | Notification::TurnStarted(_)
         | Notification::ThreadTokenUsageUpdated(_) => (true, false),
 
-        Notification::TurnCompleted(_p) => {
-            // `Turn` has no `usage` field in the typed schema (the pre-refactor
-            // code's `params.get("turn").get("usage")` lookup already returned
-            // null in practice). Preserve that — emit usage: null — and let
-            // `thread/tokenUsage/updated` carry the real usage when codex emits
-            // it. If upstream adds `Turn.usage`, fail-to-compile will surface
-            // here.
+        Notification::TurnCompleted(p) => {
+            let status = serde_json::to_value(&p.turn.status)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_string));
             let event = serde_json::json!({
                 "type": "turn.completed",
-                "usage": serde_json::Value::Null,
+                "turn_id": p.turn.id,
+                "status": status,
+                "duration_ms": p.turn.duration_ms,
+                "usage": latest_token_usage.cloned(),
             });
             let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
             (ok, true)
@@ -388,11 +392,18 @@ mod tests {
         out
     }
 
-    fn handle(msg: ServerMessage) -> (Vec<IoEvent>, bool, bool) {
+    fn handle_with_usage(
+        msg: ServerMessage,
+        latest_token_usage: Option<&serde_json::Value>,
+    ) -> (Vec<IoEvent>, bool, bool) {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let (sent, ended) = handle_codex_server_message(msg, &tx);
+        let (sent, ended) = handle_codex_server_message(msg, &tx, latest_token_usage);
         drop(tx);
         (drain(&mut rx), sent, ended)
+    }
+
+    fn handle(msg: ServerMessage) -> (Vec<IoEvent>, bool, bool) {
+        handle_with_usage(msg, None)
     }
 
     #[test]
@@ -413,6 +424,54 @@ mod tests {
                 assert_eq!(value["type"], "thread/compacted");
                 assert_eq!(value["params"]["threadId"], "thread-1");
                 assert_eq!(value["params"]["turnId"], "turn-1");
+            }
+            _ => panic!("expected RawOutput"),
+        }
+    }
+
+    #[test]
+    fn turn_completed_emits_duration_status_and_latest_usage() {
+        let notif: codex_codes::TurnCompletedNotification = serde_json::from_value(json!({
+            "threadId": "thread-1",
+            "turn": {
+                "id": "turn-1",
+                "status": "completed",
+                "durationMs": 4200,
+                "items": []
+            }
+        }))
+        .unwrap();
+        let usage = json!({
+            "last": {
+                "inputTokens": 100,
+                "cachedInputTokens": 25,
+                "outputTokens": 40,
+                "reasoningOutputTokens": 7,
+                "totalTokens": 147
+            },
+            "total": {
+                "inputTokens": 300,
+                "cachedInputTokens": 75,
+                "outputTokens": 90,
+                "reasoningOutputTokens": 17,
+                "totalTokens": 407
+            },
+            "model_context_window": 200000
+        });
+        let msg = ServerMessage::Notification(Notification::TurnCompleted(notif));
+        let (events, sent, ended) = handle_with_usage(msg, Some(&usage));
+
+        assert!(sent);
+        assert!(ended);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            IoEvent::RawOutput(value) => {
+                assert_eq!(value["type"], "turn.completed");
+                assert_eq!(value["turn_id"], "turn-1");
+                assert_eq!(value["status"], "completed");
+                assert_eq!(value["duration_ms"], 4200);
+                assert_eq!(value["usage"]["last"]["inputTokens"], 100);
+                assert_eq!(value["usage"]["model_context_window"], 200000);
             }
             _ => panic!("expected RawOutput"),
         }

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -120,6 +120,7 @@ pub(crate) async fn codex_io_task(
     // Set when a `turn/started` notification arrives; cleared when
     // `turn/completed` arrives.
     let mut current_turn_id: Option<String> = None;
+    let mut latest_token_usage: Option<(String, serde_json::Value)> = None;
 
     loop {
         if turn_active {
@@ -133,6 +134,18 @@ pub(crate) async fn codex_io_task(
                             // can't observe these via the typed handler
                             // below because it consumes the message.
                             if let codex_codes::ServerMessage::Notification(notif) = &msg {
+                                if let codex_codes::Notification::ThreadTokenUsageUpdated(p) =
+                                    notif
+                                {
+                                    latest_token_usage = Some((
+                                        p.turn_id.clone(),
+                                        serde_json::json!({
+                                            "last": &p.token_usage.last,
+                                            "total": &p.token_usage.total,
+                                            "model_context_window": p.token_usage.model_context_window,
+                                        }),
+                                    ));
+                                }
                                 if let Ok((method, params_opt)) =
                                     notif.clone().into_envelope()
                                 {
@@ -154,8 +167,24 @@ pub(crate) async fn codex_io_task(
                                     }
                                 }
                             }
+                            let latest_usage_for_msg =
+                                if let codex_codes::ServerMessage::Notification(
+                                    codex_codes::Notification::TurnCompleted(p),
+                                ) = &msg
+                                {
+                                    latest_token_usage
+                                        .as_ref()
+                                        .filter(|(turn_id, _)| turn_id == &p.turn.id)
+                                        .map(|(_, usage)| usage)
+                                } else {
+                                    None
+                                };
                             let (ok, turn_ended) =
-                                handle_codex_server_message(msg, &event_tx);
+                                handle_codex_server_message(
+                                    msg,
+                                    &event_tx,
+                                    latest_usage_for_msg,
+                                );
                             if turn_ended {
                                 turn_active = false;
                                 if let Some(prompt) = queued_prompts.pop_front() {

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -1,4 +1,5 @@
 use super::markdown::render_markdown;
+use super::message_renderer::format_duration;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use yew::prelude::*;
@@ -18,6 +19,12 @@ pub enum CodexEvent {
     #[serde(rename = "turn.completed")]
     TurnCompleted {
         usage: Option<CodexUsage>,
+        #[serde(default, rename = "duration_ms", alias = "durationMs")]
+        duration_ms: Option<u64>,
+        #[serde(default, rename = "turn_id", alias = "turnId")]
+        turn_id: Option<String>,
+        #[serde(default)]
+        status: Option<String>,
     },
     #[serde(rename = "turn.failed")]
     TurnFailed {
@@ -149,9 +156,86 @@ pub struct ContextCompactedParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CodexUsage {
+    #[serde(default)]
+    pub last: Option<CodexTokenUsage>,
+    #[serde(default)]
+    pub total: Option<CodexTokenUsage>,
+    #[serde(default, rename = "model_context_window", alias = "modelContextWindow")]
+    pub model_context_window: Option<u64>,
+    // Legacy flat shape from older portal proxies.
+    #[serde(default)]
     pub input_tokens: Option<u64>,
+    #[serde(default)]
     pub cached_input_tokens: Option<u64>,
+    #[serde(default)]
     pub output_tokens: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CodexTokenUsage {
+    #[serde(default, rename = "inputTokens", alias = "input_tokens")]
+    pub input_tokens: Option<u64>,
+    #[serde(default, rename = "cachedInputTokens", alias = "cached_input_tokens")]
+    pub cached_input_tokens: Option<u64>,
+    #[serde(default, rename = "outputTokens", alias = "output_tokens")]
+    pub output_tokens: Option<u64>,
+    #[serde(
+        default,
+        rename = "reasoningOutputTokens",
+        alias = "reasoning_output_tokens"
+    )]
+    pub reasoning_output_tokens: Option<u64>,
+    #[serde(default, rename = "totalTokens", alias = "total_tokens")]
+    pub total_tokens: Option<u64>,
+}
+
+impl CodexUsage {
+    fn input_tokens(&self) -> u64 {
+        self.last
+            .as_ref()
+            .and_then(|u| u.input_tokens)
+            .or(self.input_tokens)
+            .unwrap_or(0)
+    }
+
+    fn cached_input_tokens(&self) -> u64 {
+        self.last
+            .as_ref()
+            .and_then(|u| u.cached_input_tokens)
+            .or(self.cached_input_tokens)
+            .unwrap_or(0)
+    }
+
+    fn output_tokens(&self) -> u64 {
+        self.last
+            .as_ref()
+            .and_then(|u| u.output_tokens)
+            .or(self.output_tokens)
+            .unwrap_or(0)
+    }
+
+    fn reasoning_output_tokens(&self) -> u64 {
+        self.last
+            .as_ref()
+            .and_then(|u| u.reasoning_output_tokens)
+            .unwrap_or(0)
+    }
+
+    fn total_tokens(&self) -> u64 {
+        self.last
+            .as_ref()
+            .and_then(|u| u.total_tokens)
+            .unwrap_or_else(|| {
+                self.input_tokens()
+                    + self.cached_input_tokens()
+                    + self.output_tokens()
+                    + self.reasoning_output_tokens()
+            })
+    }
+
+    fn thread_total_tokens(&self) -> Option<u64> {
+        self.total.as_ref().and_then(|u| u.total_tokens)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -278,7 +362,17 @@ pub fn codex_message_renderer(props: &CodexMessageRendererProps) -> Html {
     match parsed {
         Ok(CodexEvent::ThreadStarted { .. }) => html! {},
         Ok(CodexEvent::TurnStarted {}) => html! {},
-        Ok(CodexEvent::TurnCompleted { usage }) => render_turn_completed(usage.as_ref()),
+        Ok(CodexEvent::TurnCompleted {
+            usage,
+            duration_ms,
+            turn_id,
+            status,
+        }) => render_turn_completed(
+            usage.as_ref(),
+            duration_ms,
+            turn_id.as_deref(),
+            status.as_deref(),
+        ),
         Ok(CodexEvent::TurnFailed { error }) => render_turn_failed(error.as_ref()),
         Ok(CodexEvent::ItemStarted { item }) | Ok(CodexEvent::ItemUpdated { item }) => {
             render_item(item.as_ref(), false)
@@ -405,7 +499,17 @@ pub fn render_codex_message_content(json: &str) -> Html {
             render_item(item.as_ref(), false)
         }
         Ok(CodexEvent::ItemCompleted { item }) => render_item(item.as_ref(), true),
-        Ok(CodexEvent::TurnCompleted { usage }) => render_turn_completed(usage.as_ref()),
+        Ok(CodexEvent::TurnCompleted {
+            usage,
+            duration_ms,
+            turn_id,
+            status,
+        }) => render_turn_completed(
+            usage.as_ref(),
+            duration_ms,
+            turn_id.as_deref(),
+            status.as_deref(),
+        ),
         Ok(CodexEvent::TurnFailed { error }) => render_turn_failed(error.as_ref()),
         Ok(CodexEvent::Error { message }) => render_error_block(message.as_deref()),
         Ok(CodexEvent::TurnDiffUpdated { params }) => {
@@ -607,25 +711,87 @@ fn render_todo_list(items: Option<&[TodoEntry]>, completed: bool) -> Html {
     tool_card("\u{2611}", "Todo List".into(), None, body, completed)
 }
 
-fn render_turn_completed(usage: Option<&CodexUsage>) -> Html {
-    let input = usage.and_then(|u| u.input_tokens).unwrap_or(0);
-    let output = usage.and_then(|u| u.output_tokens).unwrap_or(0);
-    let cached = usage.and_then(|u| u.cached_input_tokens).unwrap_or(0);
+fn render_turn_completed(
+    usage: Option<&CodexUsage>,
+    duration_ms: Option<u64>,
+    turn_id: Option<&str>,
+    status: Option<&str>,
+) -> Html {
+    let input = usage.map(CodexUsage::input_tokens).unwrap_or(0);
+    let output = usage.map(CodexUsage::output_tokens).unwrap_or(0);
+    let cached = usage.map(CodexUsage::cached_input_tokens).unwrap_or(0);
+    let reasoning = usage.map(CodexUsage::reasoning_output_tokens).unwrap_or(0);
+    let total = usage.map(CodexUsage::total_tokens).unwrap_or(0);
+    let thread_total = usage.and_then(CodexUsage::thread_total_tokens);
+    let context_window = usage.and_then(|u| u.model_context_window);
 
-    let tooltip = format!("Input: {} | Output: {} | Cached: {}", input, output, cached);
+    let mut tooltip = format!(
+        "Input: {} | Output: {} | Cached: {} | Reasoning: {} | Total: {}",
+        input, output, cached, reasoning, total
+    );
+    if let Some(thread_total) = thread_total {
+        tooltip.push_str(&format!(" | Thread total: {}", thread_total));
+    }
+    if let Some(context_window) = context_window {
+        tooltip.push_str(&format!(" | Context window: {}", context_window));
+    }
+    let status_title = turn_id.unwrap_or("Codex turn").to_string();
 
     html! {
         <div class="claude-message result-message success">
             <div class="result-stats-bar">
                 <span class="result-status success">{ "\u{2713}" }</span>
                 {
-                    if input > 0 || output > 0 {
+                    if let Some(ms) = duration_ms {
+                        html! {
+                            <span class="stat-item duration" title="Turn duration">
+                                { format_duration(ms) }
+                            </span>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
+                    if input > 0 || output > 0 || cached > 0 || reasoning > 0 {
                         html! {
                             <>
                                 <span class="stat-item tokens" title={tooltip}>
                                     { format!("{}\u{2193} {}\u{2191}", input, output) }
                                 </span>
+                                if cached > 0 {
+                                    <span class="stat-item tokens" title="Cached input tokens">
+                                        { format!("{} cached", cached) }
+                                    </span>
+                                }
+                                if reasoning > 0 {
+                                    <span class="stat-item tokens" title="Reasoning output tokens">
+                                        { format!("{} reasoning", reasoning) }
+                                    </span>
+                                }
                             </>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
+                    if let (Some(thread_total), Some(context_window)) = (thread_total, context_window) {
+                        html! {
+                            <span class="stat-item turns" title="Thread tokens / model context window">
+                                { format!("{} / {} ctx", thread_total, context_window) }
+                            </span>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
+                    if let Some(status) = status {
+                        html! {
+                            <span class="stat-item stop-reason" title={status_title.clone()}>
+                                { status }
+                            </span>
                         }
                     } else {
                         html! {}
@@ -1072,12 +1238,16 @@ mod tests {
                 input_tokens: Some(100),
                 cached_input_tokens: Some(50),
                 output_tokens: Some(200),
+                ..Default::default()
             }),
+            duration_ms: Some(4200),
+            turn_id: Some("turn-1".into()),
+            status: Some("completed".into()),
         };
         let json = serde_json::to_string(&event).unwrap();
         let back: CodexEvent = serde_json::from_str(&json).unwrap();
         assert!(
-            matches!(back, CodexEvent::TurnCompleted { usage: Some(ref u) } if u.output_tokens == Some(200))
+            matches!(back, CodexEvent::TurnCompleted { usage: Some(ref u), duration_ms: Some(4200), .. } if u.output_tokens() == 200)
         );
     }
 


### PR DESCRIPTION
## Summary
- attach Codex turn duration, status, id, and latest matching token usage to `turn.completed` events
- cache token usage by turn id so stale usage is not shown on later completions
- render Codex completion lines with duration, input/output, cached, reasoning, and context-window stats

## Tests
- `cargo test -p codex-session-lib`
- `cargo test -p frontend codex_renderer`