### PR TITLE
Fix launcher session-mutation auth bypass (#782)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.1
+
+- **Fix #782: launcher session-mutation authorization bypass.** `LauncherToServer::InjectInput` and `LauncherToServer::ScheduledRunCompleted` in `backend/src/handlers/websocket/launcher_socket.rs` previously accepted any `session_id` and acted on it (inject input / delete the session) without checking that the session belonged to the launcher's authenticated user or that this launcher had even spawned the session. A compromised, malicious, or buggy launcher could mutate or delete sessions owned by other users by passing arbitrary UUIDs. Added `authorize_launcher_session(...)` which loads the target `Session`, verifies `session.user_id == launcher_user_id` AND `session.launcher_id == this_launcher_id`, and logs a forensic `warn!` (with all four IDs) on failure. Both handlers now precheck through that helper and return early on denial. `ScheduledRunCompleted` additionally verifies `session.scheduled_task_id == reported_task_id` so a launcher can't report completion of *its* task for someone else's session. The only other launcher message that mutates server state, `ScheduledRunStarted`, already filtered `scheduled_tasks` by `user_id` and is unchanged.
+
 ## 2.6.0
 
 - **Replace Google Cloud Speech-to-Text with the browser's Web Speech API.** Voice transcription now runs entirely in the user's browser via `webkitSpeechRecognition` — no server-side STT, no GCP service-account credentials, no `GOOGLE_APPLICATION_CREDENTIALS` env var. The backend no longer ships the `google-cognitive-apis` gRPC client, the `/ws/voice/{session_id}` route, the `pcm-processor.js` AudioWorklet, or the streaming PCM upload path; ~600 LOC of voice plumbing is gone.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.0"
+version = "2.6.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -294,6 +294,51 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
     app_state.session_manager.unregister_launcher(&launcher_id);
 }
 
+/// Verify that this launcher is authorized to mutate `session_id`. A
+/// session is mutable by a launcher iff (a) the session's owner matches
+/// the launcher's authenticated user, AND (b) the session was spawned
+/// by this very launcher (matching `launcher_id`).
+///
+/// Without this check, a compromised or buggy launcher could pass any
+/// session UUID and the backend would happily inject input into it or
+/// delete it (see #782). Returns `Ok(Session)` if authorized, else logs
+/// a warn with all the IDs for forensics and returns `Err(())`.
+fn authorize_launcher_session(
+    db_conn: &mut diesel::PgConnection,
+    launcher_id: Uuid,
+    user_id: Uuid,
+    session_id: Uuid,
+) -> Result<crate::models::Session, ()> {
+    use crate::schema::sessions;
+    let session = sessions::table
+        .find(session_id)
+        .first::<crate::models::Session>(db_conn)
+        .map_err(|e| {
+            warn!(
+                "Launcher {} (user {}) referenced unknown session {}: {}",
+                launcher_id, user_id, session_id, e
+            );
+        })?;
+
+    if session.user_id != user_id {
+        warn!(
+            "Launcher {} (user {}) attempted to act on session {} owned by user {} — denied",
+            launcher_id, user_id, session_id, session.user_id
+        );
+        return Err(());
+    }
+
+    if session.launcher_id != Some(launcher_id) {
+        warn!(
+            "Launcher {} (user {}) attempted to act on session {} spawned by launcher {:?} — denied",
+            launcher_id, user_id, session_id, session.launcher_id
+        );
+        return Err(());
+    }
+
+    Ok(session)
+}
+
 fn handle_launcher_message(
     msg: LauncherToServer,
     launcher_id: Uuid,
@@ -437,6 +482,17 @@ fn handle_launcher_message(
                 "InjectInput for session {} from launcher {}",
                 session_id, launcher_id
             );
+
+            let Ok(mut db_conn) = app_state.db_pool.get() else {
+                return;
+            };
+
+            // Ownership precheck: only this launcher (for its own user) may
+            // inject input into a session it itself spawned. See #782.
+            if authorize_launcher_session(&mut db_conn, launcher_id, user_id, session_id).is_err() {
+                return;
+            }
+
             let session_key = session_id.to_string();
             let content_value = serde_json::Value::String(content);
 
@@ -447,35 +503,33 @@ fn handle_launcher_message(
                 .insert(session_id, (user_id, "Scheduler".to_string()));
 
             // Sequence and send (same pipeline as web client input)
-            if let Ok(mut db_conn) = app_state.db_pool.get() {
-                use crate::schema::{pending_inputs, sessions};
+            use crate::schema::{pending_inputs, sessions};
 
-                let next_seq: i64 = diesel::update(sessions::table.find(session_id))
-                    .set(sessions::input_seq.eq(sessions::input_seq + 1))
-                    .returning(sessions::input_seq)
-                    .get_result(&mut db_conn)
-                    .unwrap_or(0);
+            let next_seq: i64 = diesel::update(sessions::table.find(session_id))
+                .set(sessions::input_seq.eq(sessions::input_seq + 1))
+                .returning(sessions::input_seq)
+                .get_result(&mut db_conn)
+                .unwrap_or(0);
 
-                if next_seq > 0 {
-                    let new_input = crate::models::NewPendingInput {
+            if next_seq > 0 {
+                let new_input = crate::models::NewPendingInput {
+                    session_id,
+                    seq_num: next_seq,
+                    content: serde_json::to_string(&content_value).unwrap_or_default(),
+                };
+                let _ = diesel::insert_into(pending_inputs::table)
+                    .values(&new_input)
+                    .execute(&mut db_conn);
+
+                app_state.session_manager.send_to_session(
+                    &session_key,
+                    ServerToProxy::SequencedInput {
                         session_id,
-                        seq_num: next_seq,
-                        content: serde_json::to_string(&content_value).unwrap_or_default(),
-                    };
-                    let _ = diesel::insert_into(pending_inputs::table)
-                        .values(&new_input)
-                        .execute(&mut db_conn);
-
-                    app_state.session_manager.send_to_session(
-                        &session_key,
-                        ServerToProxy::SequencedInput {
-                            session_id,
-                            seq: next_seq,
-                            content: content_value,
-                            send_mode: None,
-                        },
-                    );
-                }
+                        seq: next_seq,
+                        content: content_value,
+                        send_mode: None,
+                    },
+                );
             }
         }
         LauncherToServer::ScheduledRunStarted {
@@ -514,33 +568,38 @@ fn handle_launcher_message(
 
             // Auto-delete completed scheduled sessions to avoid cluttering the UI.
             // Costs are preserved in deleted_session_costs.
-            if let Ok(mut db_conn) = app_state.db_pool.get() {
-                use crate::schema::sessions;
-                match sessions::table
-                    .find(session_id)
-                    .first::<crate::models::Session>(&mut db_conn)
-                {
-                    Ok(session) => {
-                        if let Err(e) = super::super::helpers::delete_session_with_data(
-                            &mut db_conn,
-                            &session,
-                            true,
-                        ) {
-                            error!(
-                                "Failed to auto-delete scheduled session {}: {:?}",
-                                session_id, e
-                            );
-                        } else {
-                            info!("Auto-deleted completed scheduled session {}", session_id);
-                        }
-                    }
-                    Err(e) => {
-                        warn!(
-                            "Could not find scheduled session {} for cleanup: {}",
-                            session_id, e
-                        );
-                    }
-                }
+            let Ok(mut db_conn) = app_state.db_pool.get() else {
+                return;
+            };
+
+            // Ownership precheck: only this launcher (for its own user) may
+            // mark its own scheduled run complete. The session must also have
+            // been spawned for this exact task — otherwise a launcher could
+            // pass a sibling user's session UUID with its own task_id. See #782.
+            let session =
+                match authorize_launcher_session(&mut db_conn, launcher_id, user_id, session_id) {
+                    Ok(s) => s,
+                    Err(_) => return,
+                };
+
+            if session.scheduled_task_id != Some(task_id) {
+                warn!(
+                    "Launcher {} (user {}) reported ScheduledRunCompleted with task {} \
+                     for session {} (its scheduled_task_id is {:?}) — denied",
+                    launcher_id, user_id, task_id, session_id, session.scheduled_task_id
+                );
+                return;
+            }
+
+            if let Err(e) =
+                super::super::helpers::delete_session_with_data(&mut db_conn, &session, true)
+            {
+                error!(
+                    "Failed to auto-delete scheduled session {}: {:?}",
+                    session_id, e
+                );
+            } else {
+                info!("Auto-deleted completed scheduled session {}", session_id);
             }
         }
         LauncherToServer::LauncherRegister { .. } => {}


### PR DESCRIPTION
Closes #782.

## Summary

\`LauncherToServer::InjectInput\` and \`LauncherToServer::ScheduledRunCompleted\` in \`backend/src/handlers/websocket/launcher_socket.rs\` accepted any \`session_id\` from a launcher and acted on it (inject input / auto-delete the session) **without checking** that the session belonged to the launcher's authenticated user or that this launcher had even spawned the session.

A compromised, malicious, or buggy launcher could mutate or delete sessions owned by other users by passing arbitrary UUIDs.

## Fix

New helper \`authorize_launcher_session(...)\`:

\`\`\`rust
fn authorize_launcher_session(
    db_conn: &mut diesel::PgConnection,
    launcher_id: Uuid,
    user_id: Uuid,
    session_id: Uuid,
) -> Result<crate::models::Session, ()>
\`\`\`

Loads the target \`Session\`, then requires:
1. \`session.user_id == user_id\` (the launcher's authenticated user owns the session), AND
2. \`session.launcher_id == Some(launcher_id)\` (this exact launcher spawned the session).

On failure, logs a \`warn!\` with all four IDs (launcher_id, claimed user_id, session_id, true session.user_id / true session.launcher_id) for forensic review, and returns \`Err(())\`.

Both \`InjectInput\` and \`ScheduledRunCompleted\` precheck through the helper and return early on denial.

\`ScheduledRunCompleted\` additionally verifies \`session.scheduled_task_id == reported_task_id\` so a launcher can't claim completion of *its* task on someone else's session.

\`ScheduledRunStarted\` already filtered \`scheduled_tasks\` by \`user_id\`; left unchanged. Other \`LauncherToServer\` variants either don't mutate server state or only broadcast within the launcher's own user scope, so no further hardening is needed in this PR.

Version bump 2.6.0 → 2.6.1.

## Test plan

- [ ] CI: workspace build, clippy, tests, WASM frontend build
- [ ] Manual: launcher A spawns session, launcher B (different user) sends \`InjectInput { session_id: <A's session UUID> }\` → backend logs a \`denied\` warn, no input lands, no side effects
- [ ] Manual: launcher A sends \`ScheduledRunCompleted { task_id: <its task>, session_id: <a session it didn't spawn> }\` → denied + warn
- [ ] Manual: legitimate scheduled completion (same launcher, same task, same session) still auto-deletes the session as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)