### PR TITLE
iOS voice: prevent stuck-recording state (#840 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.6.3
+
+- **iOS voice follow-up to #840: prevent stuck-recording state.** After 2.6.2 shipped, iOS testing surfaced that the recognizer never naturally terminated — the recording icon stayed lit, and a subsequent tap-to-stop sometimes didn't deliver `onend` either, leaving `pending_stop` set forever (so the next tap showed the busy hint indefinitely). Three changes in `frontend/src/components/voice_input.rs`:
+  - **`continuous = false`** universally. iOS Safari does not reliably honor `continuous = true` (the recognizer doesn't auto-end on silence), and our `SessionView::VoiceTranscription` handler already auto-sends on every Final transcript anyway — so a one-tap-one-utterance UX matches the existing send model. Desktop users get a Siri-style "tap, speak one thing, transcript appears" flow.
+  - **Stop watchdog**: when the user taps to stop, a 1500 ms `Timeout` is scheduled alongside the session drop. If `onend` arrives within the window (the normal path), `Ended` cancels the watchdog. If `onend` is late or never fires (the iOS hang case), the watchdog force-clears `pending_stop` so the user can tap again. A `warn!` logs the fallback for forensics.
+  - **Max-duration safety stop**: a 60 s `Timeout` is armed when a session is established. If it fires while a session is still alive, we drop the session, flip back to idle, and arm the same stop watchdog. Prevents a leaked recognizer from holding the mic indicator indefinitely.
+- Two new message variants (`StopWatchdog`, `MaxDurationReached`) handle the fallback paths; both are idempotent with `Ended`.
+
 ## 2.6.2
 
 - **Fix #840: voice transcription on iOS Safari / iOS Chrome.** iOS WebKit allows only one `SpeechRecognition` per page and races the permission prompt against `recognition.start()` — a captured probe on iOS 18.7 showed the recognizer reaching `start` and `audiostart` and then being killed by `{error: "aborted", message: "Another request is started"}`. The previous implementation matched `aborted` as benign and silently flipped the mic icon back to idle, so the user saw "nothing happened." Three fixes in `frontend/src/components/voice_input.rs`:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.2"
+version = "2.6.3"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/voice_input.rs
+++ b/frontend/src/components/voice_input.rs
@@ -148,8 +148,25 @@ pub enum VoiceInputMsg {
     /// started"` from a plain user-initiated abort.
     RecognitionError(String, String),
     Ended,
+    /// Fallback fired by the stop-watchdog when iOS doesn't deliver `onend`
+    /// within a reasonable window after `stop()`. Idempotent with `Ended`.
+    StopWatchdog,
+    /// Max-duration safety stop. Fires once after `MAX_SESSION_MS` even if
+    /// the recognizer is still alive — prevents a leaked session from holding
+    /// the mic forever.
+    MaxDurationReached,
     HideHint,
 }
+
+/// How long after `recognition.stop()` we wait for iOS's `onend` before
+/// force-clearing `pending_stop` ourselves. 1.5s comfortably covers a normal
+/// teardown (~tens of ms on desktop) but unblocks the user when iOS hangs.
+const STOP_WATCHDOG_MS: u32 = 1500;
+
+/// Hard ceiling on a single recording session. After this elapsed, we trigger
+/// a stop even if the user hasn't tapped — defense against a stuck recognizer
+/// holding the mic indicator on iOS.
+const MAX_SESSION_MS: u32 = 60_000;
 
 /// Reasons the async start path can bail before a session is established.
 pub enum StartFailure {
@@ -208,6 +225,12 @@ pub struct VoiceInput {
     session: Option<ActiveSession>,
     hint_message: Option<&'static str>,
     hint_timer: Option<Timeout>,
+    /// Watchdog set when we call `stop()`; clears `pending_stop` if `onend`
+    /// is late. Cleared on `Ended`.
+    stop_watchdog: Option<Timeout>,
+    /// Max-duration timer set when a session is established. Triggers
+    /// `MaxDurationReached` after `MAX_SESSION_MS`. Cleared on `Ended`.
+    max_duration_timer: Option<Timeout>,
 }
 
 impl Component for VoiceInput {
@@ -223,6 +246,8 @@ impl Component for VoiceInput {
             session: None,
             hint_message: None,
             hint_timer: None,
+            stop_watchdog: None,
+            max_duration_timer: None,
         }
     }
 
@@ -245,6 +270,13 @@ impl Component for VoiceInput {
                     self.is_recording = false;
                     self.pending_stop = true;
                     ctx.props().on_recording_change.emit(false);
+                    // Watchdog: iOS sometimes never fires onend after stop().
+                    // If Ended hasn't arrived in STOP_WATCHDOG_MS, force-clear.
+                    let link = ctx.link().clone();
+                    self.stop_watchdog =
+                        Some(Timeout::new(STOP_WATCHDOG_MS, move || {
+                            link.send_message(VoiceInputMsg::StopWatchdog);
+                        }));
                     return true;
                 }
 
@@ -277,6 +309,11 @@ impl Component for VoiceInput {
                     return true;
                 }
                 self.session = Some(session);
+                // Arm the max-duration safety stop.
+                let link = ctx.link().clone();
+                self.max_duration_timer = Some(Timeout::new(MAX_SESSION_MS, move || {
+                    link.send_message(VoiceInputMsg::MaxDurationReached);
+                }));
                 true
             }
             VoiceInputMsg::StartFailed(failure) => {
@@ -333,11 +370,51 @@ impl Component for VoiceInput {
             VoiceInputMsg::Ended => {
                 self.session = None;
                 self.pending_stop = false;
+                self.stop_watchdog = None;
+                self.max_duration_timer = None;
                 if self.is_recording {
                     self.is_recording = false;
                     ctx.props().on_recording_change.emit(false);
                 }
                 true
+            }
+            VoiceInputMsg::StopWatchdog => {
+                self.stop_watchdog = None;
+                if self.pending_stop {
+                    log::warn!(
+                        "SpeechRecognition.stop() didn't deliver onend within \
+                         {}ms — force-clearing pending_stop",
+                        STOP_WATCHDOG_MS
+                    );
+                    self.pending_stop = false;
+                    self.session = None;
+                    self.max_duration_timer = None;
+                    true
+                } else {
+                    false
+                }
+            }
+            VoiceInputMsg::MaxDurationReached => {
+                self.max_duration_timer = None;
+                if self.session.is_some() {
+                    log::warn!(
+                        "Voice session exceeded {}ms — auto-stopping",
+                        MAX_SESSION_MS
+                    );
+                    // Drop the session; its onend (if it fires) clears the
+                    // rest, but install a watchdog regardless.
+                    self.session = None;
+                    self.is_recording = false;
+                    self.pending_stop = true;
+                    ctx.props().on_recording_change.emit(false);
+                    let link = ctx.link().clone();
+                    self.stop_watchdog = Some(Timeout::new(STOP_WATCHDOG_MS, move || {
+                        link.send_message(VoiceInputMsg::StopWatchdog);
+                    }));
+                    true
+                } else {
+                    false
+                }
             }
             VoiceInputMsg::HideHint => {
                 self.hint_timer = None;
@@ -403,6 +480,8 @@ impl Component for VoiceInput {
     fn destroy(&mut self, _ctx: &Context<Self>) {
         self.session = None;
         self.hint_timer = None;
+        self.stop_watchdog = None;
+        self.max_duration_timer = None;
     }
 }
 
@@ -450,7 +529,10 @@ async fn start_session_async(
             &JsValue::from_bool(val),
         );
     };
-    set_bool("continuous", true);
+    // continuous=false: single-utterance per tap. With true, iOS Safari
+    // never auto-ends and our SessionView's "auto-send on Final" already
+    // implies a one-tap-one-utterance UX anyway. See #840 follow-up.
+    set_bool("continuous", false);
     set_bool("interimResults", true);
 
     let lang = web_sys::window()

--- a/frontend/src/components/voice_input.rs
+++ b/frontend/src/components/voice_input.rs
@@ -273,10 +273,9 @@ impl Component for VoiceInput {
                     // Watchdog: iOS sometimes never fires onend after stop().
                     // If Ended hasn't arrived in STOP_WATCHDOG_MS, force-clear.
                     let link = ctx.link().clone();
-                    self.stop_watchdog =
-                        Some(Timeout::new(STOP_WATCHDOG_MS, move || {
-                            link.send_message(VoiceInputMsg::StopWatchdog);
-                        }));
+                    self.stop_watchdog = Some(Timeout::new(STOP_WATCHDOG_MS, move || {
+                        link.send_message(VoiceInputMsg::StopWatchdog);
+                    }));
                     return true;
                 }
 


### PR DESCRIPTION
Follow-up to #841 (#840). Reported in main testing: \"iOS seems to get stuck in recording mode, never terminating.\"

## Hypotheses

1. **iOS doesn't auto-end with \`continuous = true\`**. iOS Safari's WebKit doesn't reliably honor the continuous flag — the recognizer never auto-ends on silence, so the recording icon stays lit until the user explicitly taps stop. (Desktop honors continuous=true correctly; iOS doesn't.)
2. **\`stop()\` doesn't always deliver \`onend\` on iOS**. Even when the user taps stop, the \`onend\` event may not arrive — \`pending_stop\` stays \`true\` forever, and subsequent taps see the busy hint indefinitely.

## Fix

Three changes in \`frontend/src/components/voice_input.rs\`:

### 1. \`continuous = false\` universally

The recognizer auto-ends after a single utterance (~0.5s of silence). Matches the existing \`SessionView::VoiceTranscription\` handler which already auto-sends on every Final transcript — so the natural UX is one-tap-one-utterance anyway, like Siri.

### 2. Stop watchdog

When the user taps to stop, a 1500ms \`Timeout\` is scheduled alongside the session drop:

- **Normal path**: \`onend\` fires within the window → \`Ended\` clears \`pending_stop\` and cancels the watchdog
- **iOS hang case**: \`onend\` never arrives → watchdog fires \`StopWatchdog\` after 1.5s, which force-clears \`pending_stop\` and \`warn!\`-logs the fallback

### 3. Max-duration safety stop

A 60 s \`Timeout\` is armed when a session is established. If a session is still alive when it fires, we drop the session, flip back to idle, and arm the same stop watchdog. Defense against a leaked recognizer holding the mic indicator indefinitely.

Two new message variants (\`StopWatchdog\`, \`MaxDurationReached\`) handle the fallback paths. Both idempotent with \`Ended\`.

Version 2.6.2 → 2.6.3.

## Test plan

- [ ] CI
- [ ] iPhone: tap mic → speak \"hello world\" → stop speaking → recognizer auto-ends within ~1s → transcript drops into input bar → mic icon reverts to idle (no manual stop tap needed)
- [ ] iPhone: tap mic → speak → tap stop mid-utterance → transcript captured up to that point → mic reverts to idle within 1.5s even if iOS hangs onend
- [ ] iPhone: tap mic, speak nothing for 60s → safety stop fires, mic reverts to idle, no leaked indicator
- [ ] Desktop Chrome regression: tap → single utterance → auto-end → transcript appears. Multi-sentence dictation now requires multiple taps (intentional — matches send model)
- [ ] Firefox regression: greyed unsupported state unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)