### PR TITLE
Reject disabled users in cookie auth

### DIFF
--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -3,22 +3,39 @@ use tower_cookies::Cookies;
 use uuid::Uuid;
 
 use crate::errors::AppError;
+use crate::models::User;
 use crate::AppState;
 
-/// Extract the authenticated user's ID from the session cookie.
-///
-/// In dev mode, returns the test user's ID without checking cookies.
-/// In production, reads the signed session cookie and parses the user ID.
-pub fn extract_user_id(app_state: &AppState, cookies: &Cookies) -> Result<Uuid, AppError> {
-    if app_state.dev_mode {
-        let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+/// Return `Forbidden` for disabled accounts.
+fn reject_disabled_user(user: User) -> Result<User, AppError> {
+    if user.disabled {
+        tracing::warn!(
+            "Disabled user {} attempted authenticated access",
+            user.email
+        );
+        Err(AppError::Forbidden)
+    } else {
+        Ok(user)
+    }
+}
 
-        use crate::schema::users;
-        return users::table
+/// Extract and load the authenticated user from the session cookie.
+///
+/// In dev mode, returns the test user without checking cookies. In production,
+/// reads the signed session cookie, parses the user ID, and loads the user row.
+/// Disabled users are rejected in both modes so a ban takes effect for existing
+/// browser sessions immediately.
+pub fn extract_user(app_state: &AppState, cookies: &Cookies) -> Result<User, AppError> {
+    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+
+    use crate::schema::users;
+
+    if app_state.dev_mode {
+        let user = users::table
             .filter(users::email.eq("testing@testing.local"))
-            .select(users::id)
-            .first::<Uuid>(&mut conn)
-            .map_err(|e| AppError::DbQuery(e.to_string()));
+            .first::<User>(&mut conn)
+            .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        return reject_disabled_user(user);
     }
 
     let cookie = cookies
@@ -26,5 +43,55 @@ pub fn extract_user_id(app_state: &AppState, cookies: &Cookies) -> Result<Uuid, 
         .get(shared::protocol::SESSION_COOKIE_NAME)
         .ok_or(AppError::Unauthorized)?;
 
-    cookie.value().parse().map_err(|_| AppError::Unauthorized)
+    let user_id: Uuid = cookie.value().parse().map_err(|_| AppError::Unauthorized)?;
+    let user = users::table
+        .find(user_id)
+        .first::<User>(&mut conn)
+        .map_err(|_| AppError::Unauthorized)?;
+
+    reject_disabled_user(user)
+}
+
+/// Extract the authenticated user's ID from the session cookie.
+///
+/// In dev mode, returns the test user's ID without checking cookies.
+/// In production, reads the signed session cookie and parses the user ID.
+/// Disabled users are rejected in both modes.
+pub fn extract_user_id(app_state: &AppState, cookies: &Cookies) -> Result<Uuid, AppError> {
+    extract_user(app_state, cookies).map(|user| user.id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user(disabled: bool) -> User {
+        User {
+            id: Uuid::new_v4(),
+            google_id: "google-id".to_string(),
+            email: "user@example.com".to_string(),
+            name: Some("User".to_string()),
+            avatar_url: None,
+            created_at: chrono::Utc::now().naive_utc(),
+            updated_at: chrono::Utc::now().naive_utc(),
+            is_admin: false,
+            disabled,
+            ban_reason: None,
+            sound_config: None,
+        }
+    }
+
+    #[test]
+    fn enabled_user_is_allowed() {
+        let user = user(false);
+        assert_eq!(reject_disabled_user(user.clone()).unwrap().id, user.id);
+    }
+
+    #[test]
+    fn disabled_user_is_forbidden() {
+        assert!(matches!(
+            reject_disabled_user(user(true)),
+            Err(AppError::Forbidden)
+        ));
+    }
 }

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -11,7 +11,6 @@ use shared::api::MeResponse;
 use std::sync::Arc;
 use tower_cookies::{cookie::SameSite, Cookie, Cookies};
 use tracing::{error, info};
-use uuid::Uuid;
 
 use crate::{
     models::{NewUser, User},
@@ -301,28 +300,13 @@ pub async fn me(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
 ) -> Result<Json<MeResponse>, StatusCode> {
-    // Extract user ID from signed session cookie
-    let cookie = cookies
-        .signed(&app_state.cookie_key)
-        .get(SESSION_COOKIE_NAME)
-        .ok_or(StatusCode::UNAUTHORIZED)?;
-
-    let user_id: Uuid = cookie
-        .value()
-        .parse()
-        .map_err(|_| StatusCode::UNAUTHORIZED)?;
-
-    // Fetch user from database
-    use crate::schema::users::dsl::*;
-    let mut conn = app_state
-        .db_pool
-        .get()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let user = users
-        .find(user_id)
-        .first::<User>(&mut conn)
-        .map_err(|_| StatusCode::NOT_FOUND)?;
+    let user = crate::auth::extract_user(&app_state, &cookies).map_err(|e| match e {
+        crate::errors::AppError::Forbidden => StatusCode::FORBIDDEN,
+        crate::errors::AppError::DbPool | crate::errors::AppError::DbQuery(_) => {
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+        _ => StatusCode::UNAUTHORIZED,
+    })?;
 
     Ok(Json(MeResponse {
         id: user.id,

--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -16,6 +16,8 @@ use tracing::{error, info};
 use uuid::Uuid;
 
 use crate::{
+    auth,
+    errors::AppError,
     jwt::{create_proxy_token, hash_token},
     models::NewProxyAuthToken,
     schema::proxy_auth_tokens,
@@ -74,6 +76,24 @@ impl IntoResponse for DeviceFlowApiError {
             }),
         )
             .into_response()
+    }
+}
+
+fn auth_error_to_device_flow(error: AppError, action: &str) -> DeviceFlowApiError {
+    match error {
+        AppError::Forbidden => DeviceFlowApiError {
+            status: StatusCode::FORBIDDEN,
+            error: "forbidden".to_string(),
+            message: format!("You are not allowed to {} device authorization", action),
+        },
+        AppError::DbPool | AppError::DbQuery(_) => {
+            DeviceFlowApiError::internal_error("Database connection failed")
+        }
+        _ => DeviceFlowApiError {
+            status: StatusCode::UNAUTHORIZED,
+            error: "unauthorized".to_string(),
+            message: format!("You must be logged in to {} device authorization", action),
+        },
     }
 }
 
@@ -323,21 +343,8 @@ pub async fn device_approve(
     cookies: Cookies,
     Json(req): Json<ApproveRequest>,
 ) -> Result<Json<DeviceFlowActionResponse>, DeviceFlowApiError> {
-    // Verify user is logged in
-    let cookie = cookies
-        .signed(&app_state.cookie_key)
-        .get(SESSION_COOKIE_NAME)
-        .ok_or_else(|| DeviceFlowApiError {
-            status: StatusCode::UNAUTHORIZED,
-            error: "unauthorized".to_string(),
-            message: "You must be logged in to approve device authorization".to_string(),
-        })?;
-
-    let user_id: Uuid = cookie.value().parse().map_err(|_| DeviceFlowApiError {
-        status: StatusCode::UNAUTHORIZED,
-        error: "unauthorized".to_string(),
-        message: "Invalid session".to_string(),
-    })?;
+    let user_id = auth::extract_user_id(&app_state, &cookies)
+        .map_err(|e| auth_error_to_device_flow(e, "approve"))?;
 
     let store = app_state
         .device_flow_store
@@ -366,21 +373,8 @@ pub async fn device_deny(
     cookies: Cookies,
     Json(req): Json<ApproveRequest>,
 ) -> Result<Json<DeviceFlowActionResponse>, DeviceFlowApiError> {
-    // Verify user is logged in
-    let cookie = cookies
-        .signed(&app_state.cookie_key)
-        .get(SESSION_COOKIE_NAME)
-        .ok_or_else(|| DeviceFlowApiError {
-            status: StatusCode::UNAUTHORIZED,
-            error: "unauthorized".to_string(),
-            message: "You must be logged in to deny device authorization".to_string(),
-        })?;
-
-    let _user_id: Uuid = cookie.value().parse().map_err(|_| DeviceFlowApiError {
-        status: StatusCode::UNAUTHORIZED,
-        error: "unauthorized".to_string(),
-        message: "Invalid session".to_string(),
-    })?;
+    auth::extract_user_id(&app_state, &cookies)
+        .map_err(|e| auth_error_to_device_flow(e, "deny"))?;
 
     let store = app_state
         .device_flow_store


### PR DESCRIPTION
## Summary
- add shared `extract_user` auth helper that loads the session-cookie user row and rejects disabled accounts
- make `extract_user_id` delegate through the disabled-user check so existing cookie-authenticated APIs inherit it
- move `/api/auth/me` and device approve/deny off manual cookie parsing and onto the shared auth path

Closes #848.

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p backend`

Note: `cargo test -p backend auth::tests --locked` fails before running tests because `Cargo.lock` on current `main` is already out of sync with the manifests and Cargo wants to update it; I restored the generated lockfile changes and left this PR source-only.