### PR TITLE
Centralize auth cookie helpers

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -22,12 +22,18 @@ use shared::protocol::SESSION_COOKIE_NAME;
 const OAUTH_CSRF_COOKIE: &str = "oauth_csrf";
 const OAUTH_DEVICE_CSRF_COOKIE: &str = "oauth_device_csrf";
 const OAUTH_CALLBACK_PATH: &str = "/api/auth/google/callback";
+const ROOT_PATH: &str = "/";
+const DASHBOARD_PATH: &str = "/dashboard";
+const BANNED_PATH: &str = "/banned";
+const ACCESS_DENIED_PATH: &str = "/access-denied";
+const DEV_LOGIN_PATH: &str = "/api/auth/dev-login";
+const DEVICE_APPROVAL_PATH: &str = "/api/auth/device";
 
 /// Regular web login - redirects to Google OAuth
 pub async fn login(State(app_state): State<Arc<AppState>>, cookies: Cookies) -> impl IntoResponse {
     let client = match &app_state.oauth_basic_client {
         Some(c) => c,
-        None => return Redirect::temporary("/api/auth/dev-login").into_response(),
+        None => return Redirect::temporary(DEV_LOGIN_PATH).into_response(),
     };
 
     let auth_request = client
@@ -76,23 +82,14 @@ pub async fn device_login(
 
         if user.disabled {
             info!("Banned user {} attempted dev device login", user.email);
-            return Ok(Redirect::temporary("/banned").into_response());
+            return Ok(Redirect::temporary(BANNED_PATH).into_response());
         }
 
         info!("Dev mode: auto-logged in for device flow");
 
-        let mut cookie = Cookie::new(SESSION_COOKIE_NAME, user.id.to_string());
-        cookie.set_path("/");
-        cookie.set_http_only(true);
-        cookie.set_secure(false);
-        cookie.set_same_site(SameSite::Lax);
-        cookies.signed(&app_state.cookie_key).add(cookie);
+        add_session_cookie(&cookies, &app_state, &user);
 
-        return Ok(Redirect::temporary(&format!(
-            "/api/auth/device?user_code={}",
-            query.device_user_code
-        ))
-        .into_response());
+        return Ok(device_approval_redirect(&query.device_user_code).into_response());
     }
 
     let client = app_state.oauth_basic_client.as_ref().unwrap();
@@ -275,55 +272,24 @@ pub async fn callback(
     // Check if user is banned
     if user.disabled {
         let reason = user.ban_reason.as_deref().unwrap_or("No reason provided");
-        // URL encode the reason for the query parameter
-        let encoded_reason: String = reason
-            .chars()
-            .map(|c| {
-                if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '~' {
-                    c.to_string()
-                } else if c == ' ' {
-                    "+".to_string()
-                } else {
-                    format!("%{:02X}", c as u8)
-                }
-            })
-            .collect();
         info!("Banned user {} attempted login", user.email);
-        return Ok(Redirect::temporary(&format!(
-            "/banned?reason={}",
-            encoded_reason
-        )));
+        return Ok(banned_redirect(reason));
     }
 
     if let Some(device_state) = device_state {
-        // Set session cookie first so user is logged in
-        let mut cookie = Cookie::new(SESSION_COOKIE_NAME, user.id.to_string());
-        cookie.set_path("/");
-        cookie.set_http_only(true);
-        cookie.set_secure(!app_state.dev_mode);
-        cookie.set_same_site(SameSite::Lax);
-        cookies.signed(&app_state.cookie_key).add(cookie);
+        add_session_cookie(&cookies, &app_state, &user);
 
         // Redirect back to device verify page to show approval UI
         info!(
             "OAuth complete for device flow, redirecting to approval page for user: {}",
             user.email
         );
-        return Ok(Redirect::temporary(&format!(
-            "/api/auth/device?user_code={}",
-            device_state.user_code
-        )));
+        return Ok(device_approval_redirect(&device_state.user_code));
     }
 
-    // Set session cookie with user ID
-    let mut cookie = Cookie::new(SESSION_COOKIE_NAME, user.id.to_string());
-    cookie.set_path("/");
-    cookie.set_http_only(true);
-    cookie.set_secure(!app_state.dev_mode); // Don't require HTTPS in dev mode
-    cookie.set_same_site(SameSite::Lax);
-    cookies.signed(&app_state.cookie_key).add(cookie);
+    add_session_cookie(&cookies, &app_state, &user);
 
-    Ok(Redirect::temporary("/dashboard"))
+    Ok(Redirect::temporary(DASHBOARD_PATH))
 }
 
 pub async fn me(
@@ -348,17 +314,12 @@ pub async fn me(
 }
 
 pub async fn logout(State(app_state): State<Arc<AppState>>, cookies: Cookies) -> impl IntoResponse {
-    // Remove session cookie by setting it with empty value and immediate expiry
-    let mut cookie = Cookie::new(SESSION_COOKIE_NAME, "");
-    cookie.set_path("/");
-    cookie.set_http_only(true);
-    cookie.set_secure(true);
-    cookie.set_same_site(SameSite::Lax);
-    cookie.set_max_age(tower_cookies::cookie::time::Duration::ZERO);
-    cookies.signed(&app_state.cookie_key).add(cookie);
+    cookies
+        .signed(&app_state.cookie_key)
+        .add(remove_session_cookie());
 
     info!("User logged out");
-    Redirect::temporary("/")
+    Redirect::temporary(ROOT_PATH)
 }
 
 // Development mode handlers (bypass OAuth)
@@ -381,37 +342,16 @@ pub async fn dev_login(
     // Check if user is banned
     if user.disabled {
         let reason = user.ban_reason.as_deref().unwrap_or("No reason provided");
-        let encoded_reason: String = reason
-            .chars()
-            .map(|c| {
-                if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '~' {
-                    c.to_string()
-                } else if c == ' ' {
-                    "+".to_string()
-                } else {
-                    format!("%{:02X}", c as u8)
-                }
-            })
-            .collect();
         info!("Banned user {} attempted dev login", user.email);
-        return Ok(Redirect::temporary(&format!(
-            "/banned?reason={}",
-            encoded_reason
-        )));
+        return Ok(banned_redirect(reason));
     }
 
     info!("Dev mode: auto-logged in as testing@testing.local");
 
-    // Set session cookie with user ID
-    let mut cookie = Cookie::new(SESSION_COOKIE_NAME, user.id.to_string());
-    cookie.set_path("/");
-    cookie.set_http_only(true);
-    cookie.set_secure(!app_state.dev_mode); // Don't require HTTPS in dev mode
-    cookie.set_same_site(SameSite::Lax);
-    cookies.signed(&app_state.cookie_key).add(cookie);
+    add_session_cookie(&cookies, &app_state, &user);
 
     // Redirect to dashboard
-    Ok(Redirect::temporary("/dashboard"))
+    Ok(Redirect::temporary(DASHBOARD_PATH))
 }
 
 /// Check if an email is allowed based on ALLOWED_EMAIL_DOMAIN and ALLOWED_EMAILS
@@ -442,7 +382,63 @@ fn check_email_allowed(app_state: &AppState, email: &str) -> Result<(), Redirect
 
     // Access denied
     info!("Access denied for email: {} (not in allowlist)", email);
-    Err(Redirect::temporary("/access-denied"))
+    Err(Redirect::temporary(ACCESS_DENIED_PATH))
+}
+
+fn add_session_cookie(cookies: &Cookies, app_state: &AppState, user: &User) {
+    cookies
+        .signed(&app_state.cookie_key)
+        .add(session_cookie(user, !app_state.dev_mode));
+}
+
+fn session_cookie(user: &User, secure: bool) -> Cookie<'static> {
+    let mut cookie = Cookie::new(SESSION_COOKIE_NAME, user.id.to_string());
+    cookie.set_path(ROOT_PATH);
+    cookie.set_http_only(true);
+    cookie.set_secure(secure);
+    cookie.set_same_site(SameSite::Lax);
+    cookie
+}
+
+fn remove_session_cookie() -> Cookie<'static> {
+    let mut cookie = Cookie::new(SESSION_COOKIE_NAME, "");
+    cookie.set_path(ROOT_PATH);
+    cookie.set_http_only(true);
+    cookie.set_secure(true);
+    cookie.set_same_site(SameSite::Lax);
+    cookie.set_max_age(tower_cookies::cookie::time::Duration::ZERO);
+    cookie
+}
+
+fn banned_redirect(reason: &str) -> Redirect {
+    Redirect::temporary(&format!(
+        "{}?reason={}",
+        BANNED_PATH,
+        encode_query_value(reason)
+    ))
+}
+
+fn device_approval_redirect(user_code: &str) -> Redirect {
+    Redirect::temporary(&format!(
+        "{}?user_code={}",
+        DEVICE_APPROVAL_PATH,
+        encode_query_value(user_code)
+    ))
+}
+
+fn encode_query_value(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '~' {
+                c.to_string()
+            } else if c == ' ' {
+                "+".to_string()
+            } else {
+                format!("%{:02X}", c as u8)
+            }
+        })
+        .collect()
 }
 
 fn oauth_csrf_cookie(name: &'static str, value: &str, secure: bool) -> Cookie<'static> {
@@ -508,5 +504,13 @@ mod tests {
         assert_eq!(parse_device_oauth_state("device::nonce"), None);
         assert_eq!(parse_device_oauth_state("device:ABC-123:"), None);
         assert_eq!(parse_device_oauth_state("regular-state"), None);
+    }
+
+    #[test]
+    fn encode_query_value_keeps_unreserved_and_encodes_reserved_chars() {
+        assert_eq!(
+            encode_query_value("ABC-123 reason?/"),
+            "ABC-123+reason%3F%2F"
+        );
     }
 }


### PR DESCRIPTION
Closes #862

## Summary
- add route constants for auth redirects used in the handler
- centralize session cookie creation/removal
- centralize banned and device approval redirect construction
- add a small query-value encoding regression test

## Tests
- cargo fmt --check
- cargo test -p backend handlers::auth::tests
- cargo check -p backend
- git diff --check