### PR TITLE
Split portal message rendering

### DIFF
--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -1,5 +1,7 @@
 //! Rendering functions for each message type.
 
+mod portal;
+
 use super::types::*;
 use super::{format_duration, shorten_model_name};
 use crate::components::copy_button::CopyButton;
@@ -12,6 +14,8 @@ use serde_json::Value;
 use shared::{Citation, ToolResultContent};
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
+
+pub use portal::{render_portal_message, render_portal_message_content};
 
 /// Convert single newlines to markdown hard breaks (trailing two spaces)
 /// so that user-typed line breaks are preserved when rendered as markdown.
@@ -220,130 +224,6 @@ pub fn render_error_message(msg: &ErrorMessage, timestamp: Option<&str>) -> Html
                 <div class="error-text">{ crate::components::markdown::linkify_urls(message) }</div>
             </div>
         </div>
-    }
-}
-
-pub fn render_portal_message(msg: &PortalMessage, timestamp: Option<&str>) -> Html {
-    let copy_text: String = msg
-        .content
-        .iter()
-        .filter_map(|c| match c {
-            shared::PortalContent::Text { text } => Some(text.clone()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("\n\n");
-    html! {
-        <div class="claude-message portal-message">
-            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
-                <span class="message-type-badge portal">{ "Portal" }</span>
-                if !copy_text.is_empty() {
-                    <CopyButton text={copy_text} title="Copy portal text" />
-                }
-            </div>
-            <div class="message-body">{ render_portal_message_content(msg) }</div>
-        </div>
-    }
-}
-
-pub fn render_portal_message_content(msg: &PortalMessage) -> Html {
-    html! { <>{ for msg.content.iter().map(render_portal_content) }</> }
-}
-
-fn render_portal_content(content: &shared::PortalContent) -> Html {
-    match content {
-        shared::PortalContent::Text { text } => render_markdown(text),
-        shared::PortalContent::Image {
-            media_type,
-            data,
-            file_path,
-            file_size,
-            source_type,
-        } => {
-            let source = ImageSource {
-                source_type: source_type.clone().unwrap_or_else(|| "base64".to_string()),
-                media_type: media_type.clone(),
-                data: data.clone(),
-            };
-            let filename = file_path
-                .as_deref()
-                .and_then(|p| p.rsplit('/').next())
-                .map(|s| s.to_string());
-            html! {
-                <>
-                    { render_portal_image_header(file_path.as_deref(), *file_size) }
-                    { render_image_source(&source, filename) }
-                </>
-            }
-        }
-        shared::PortalContent::Reminder { title, body } => {
-            html! { <PortalReminder title={title.clone()} body={body.clone()} /> }
-        }
-    }
-}
-
-#[derive(Properties, PartialEq)]
-struct PortalReminderProps {
-    title: AttrValue,
-    body: AttrValue,
-}
-
-/// Collapsed-by-default "Portal features reminder" block. Header is always
-/// visible; clicking it toggles the markdown body open/closed.
-#[function_component(PortalReminder)]
-fn portal_reminder(props: &PortalReminderProps) -> Html {
-    let expanded = use_state(|| false);
-    let on_toggle = {
-        let expanded = expanded.clone();
-        Callback::from(move |_: MouseEvent| expanded.set(!*expanded))
-    };
-    let header_class = if *expanded {
-        "portal-reminder-header expanded"
-    } else {
-        "portal-reminder-header"
-    };
-    html! {
-        <div class="portal-reminder">
-            <button type="button" class={header_class} onclick={on_toggle}>
-                <span class="portal-reminder-icon">{ "ⓘ" }</span>
-                <span class="portal-reminder-title">{ &*props.title }</span>
-                <span class="portal-reminder-toggle">{ if *expanded { "▾" } else { "▸" } }</span>
-            </button>
-            if *expanded {
-                <div class="portal-reminder-body">
-                    { render_markdown(&props.body) }
-                </div>
-            }
-        </div>
-    }
-}
-
-fn render_portal_image_header(file_path: Option<&str>, file_size: Option<u64>) -> Html {
-    let Some(path) = file_path else {
-        return html! {};
-    };
-    html! {
-        <div class="tool-use-header">
-            <span class="tool-icon">{ "\u{1f5bc}\u{fe0f}" }</span>
-            <span class="read-file-path">{ path }</span>
-            {
-                if let Some(size) = file_size {
-                    html! { <span class="tool-meta">{ format_file_size(size) }</span> }
-                } else {
-                    html! {}
-                }
-            }
-        </div>
-    }
-}
-
-fn format_file_size(bytes: u64) -> String {
-    if bytes < 1024 {
-        format!("{} B", bytes)
-    } else if bytes < 1024 * 1024 {
-        format!("{:.1} KB", bytes as f64 / 1024.0)
-    } else {
-        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
     }
 }
 
@@ -881,7 +761,7 @@ const ALLOWED_IMAGE_MEDIA_TYPES: &[&str] = &[
     "image/svg+xml",
 ];
 
-fn render_image_source(source: &ImageSource, filename: Option<String>) -> Html {
+pub(super) fn render_image_source(source: &ImageSource, filename: Option<String>) -> Html {
     if !ALLOWED_IMAGE_MEDIA_TYPES.contains(&source.media_type.as_str()) {
         return html! {
             <pre class="tool-result-content">

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -1,0 +1,129 @@
+use super::super::types::{ImageSource, PortalMessage};
+use super::render_image_source;
+use crate::components::copy_button::CopyButton;
+use crate::components::markdown::render_markdown;
+use yew::prelude::*;
+
+pub fn render_portal_message(msg: &PortalMessage, timestamp: Option<&str>) -> Html {
+    let copy_text: String = msg
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            shared::PortalContent::Text { text } => Some(text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    html! {
+        <div class="claude-message portal-message">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
+                <span class="message-type-badge portal">{ "Portal" }</span>
+                if !copy_text.is_empty() {
+                    <CopyButton text={copy_text} title="Copy portal text" />
+                }
+            </div>
+            <div class="message-body">{ render_portal_message_content(msg) }</div>
+        </div>
+    }
+}
+
+pub fn render_portal_message_content(msg: &PortalMessage) -> Html {
+    html! { <>{ for msg.content.iter().map(render_portal_content) }</> }
+}
+
+fn render_portal_content(content: &shared::PortalContent) -> Html {
+    match content {
+        shared::PortalContent::Text { text } => render_markdown(text),
+        shared::PortalContent::Image {
+            media_type,
+            data,
+            file_path,
+            file_size,
+            source_type,
+        } => {
+            let source = ImageSource {
+                source_type: source_type.clone().unwrap_or_else(|| "base64".to_string()),
+                media_type: media_type.clone(),
+                data: data.clone(),
+            };
+            let filename = file_path
+                .as_deref()
+                .and_then(|p| p.rsplit('/').next())
+                .map(|s| s.to_string());
+            html! {
+                <>
+                    { render_portal_image_header(file_path.as_deref(), *file_size) }
+                    { render_image_source(&source, filename) }
+                </>
+            }
+        }
+        shared::PortalContent::Reminder { title, body } => {
+            html! { <PortalReminder title={title.clone()} body={body.clone()} /> }
+        }
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct PortalReminderProps {
+    title: AttrValue,
+    body: AttrValue,
+}
+
+/// Collapsed-by-default "Portal features reminder" block. Header is always
+/// visible; clicking it toggles the markdown body open/closed.
+#[function_component(PortalReminder)]
+fn portal_reminder(props: &PortalReminderProps) -> Html {
+    let expanded = use_state(|| false);
+    let on_toggle = {
+        let expanded = expanded.clone();
+        Callback::from(move |_: MouseEvent| expanded.set(!*expanded))
+    };
+    let header_class = if *expanded {
+        "portal-reminder-header expanded"
+    } else {
+        "portal-reminder-header"
+    };
+    html! {
+        <div class="portal-reminder">
+            <button type="button" class={header_class} onclick={on_toggle}>
+                <span class="portal-reminder-icon">{ "ⓘ" }</span>
+                <span class="portal-reminder-title">{ &*props.title }</span>
+                <span class="portal-reminder-toggle">{ if *expanded { "▾" } else { "▸" } }</span>
+            </button>
+            if *expanded {
+                <div class="portal-reminder-body">
+                    { render_markdown(&props.body) }
+                </div>
+            }
+        </div>
+    }
+}
+
+fn render_portal_image_header(file_path: Option<&str>, file_size: Option<u64>) -> Html {
+    let Some(path) = file_path else {
+        return html! {};
+    };
+    html! {
+        <div class="tool-use-header">
+            <span class="tool-icon">{ "\u{1f5bc}\u{fe0f}" }</span>
+            <span class="read-file-path">{ path }</span>
+            {
+                if let Some(size) = file_size {
+                    html! { <span class="tool-meta">{ format_file_size(size) }</span> }
+                } else {
+                    html! {}
+                }
+            }
+        </div>
+    }
+}
+
+fn format_file_size(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{} B", bytes)
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}


### PR DESCRIPTION
Part of #859

## Summary
- move portal message rendering into a focused renderer submodule
- re-export portal renderer entry points from the existing renderers module
- keep image rendering shared so behavior stays unchanged

## Tests
- cargo fmt --check
- cargo check -p frontend
- git diff --check