### PR TITLE
Centralize backend route paths

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -14,26 +14,18 @@ use tracing::{error, info};
 
 use crate::{
     models::{NewUser, User},
-    AppState,
+    routes, AppState,
 };
 
 use shared::protocol::SESSION_COOKIE_NAME;
 
 const OAUTH_CSRF_COOKIE: &str = "oauth_csrf";
 const OAUTH_DEVICE_CSRF_COOKIE: &str = "oauth_device_csrf";
-const OAUTH_CALLBACK_PATH: &str = "/api/auth/google/callback";
-const ROOT_PATH: &str = "/";
-const DASHBOARD_PATH: &str = "/dashboard";
-const BANNED_PATH: &str = "/banned";
-const ACCESS_DENIED_PATH: &str = "/access-denied";
-const DEV_LOGIN_PATH: &str = "/api/auth/dev-login";
-const DEVICE_APPROVAL_PATH: &str = "/api/auth/device";
-
 /// Regular web login - redirects to Google OAuth
 pub async fn login(State(app_state): State<Arc<AppState>>, cookies: Cookies) -> impl IntoResponse {
     let client = match &app_state.oauth_basic_client {
         Some(c) => c,
-        None => return Redirect::temporary(DEV_LOGIN_PATH).into_response(),
+        None => return Redirect::temporary(routes::AUTH_DEV_LOGIN).into_response(),
     };
 
     let auth_request = client
@@ -82,7 +74,7 @@ pub async fn device_login(
 
         if user.disabled {
             info!("Banned user {} attempted dev device login", user.email);
-            return Ok(Redirect::temporary(BANNED_PATH).into_response());
+            return Ok(Redirect::temporary(routes::BANNED).into_response());
         }
 
         info!("Dev mode: auto-logged in for device flow");
@@ -289,7 +281,7 @@ pub async fn callback(
 
     add_session_cookie(&cookies, &app_state, &user);
 
-    Ok(Redirect::temporary(DASHBOARD_PATH))
+    Ok(Redirect::temporary(routes::DASHBOARD))
 }
 
 pub async fn me(
@@ -319,7 +311,7 @@ pub async fn logout(State(app_state): State<Arc<AppState>>, cookies: Cookies) ->
         .add(remove_session_cookie());
 
     info!("User logged out");
-    Redirect::temporary(ROOT_PATH)
+    Redirect::temporary(routes::ROOT)
 }
 
 // Development mode handlers (bypass OAuth)
@@ -351,7 +343,7 @@ pub async fn dev_login(
     add_session_cookie(&cookies, &app_state, &user);
 
     // Redirect to dashboard
-    Ok(Redirect::temporary(DASHBOARD_PATH))
+    Ok(Redirect::temporary(routes::DASHBOARD))
 }
 
 /// Check if an email is allowed based on ALLOWED_EMAIL_DOMAIN and ALLOWED_EMAILS
@@ -382,7 +374,7 @@ fn check_email_allowed(app_state: &AppState, email: &str) -> Result<(), Redirect
 
     // Access denied
     info!("Access denied for email: {} (not in allowlist)", email);
-    Err(Redirect::temporary(ACCESS_DENIED_PATH))
+    Err(Redirect::temporary(routes::ACCESS_DENIED))
 }
 
 fn add_session_cookie(cookies: &Cookies, app_state: &AppState, user: &User) {
@@ -393,7 +385,7 @@ fn add_session_cookie(cookies: &Cookies, app_state: &AppState, user: &User) {
 
 fn session_cookie(user: &User, secure: bool) -> Cookie<'static> {
     let mut cookie = Cookie::new(SESSION_COOKIE_NAME, user.id.to_string());
-    cookie.set_path(ROOT_PATH);
+    cookie.set_path(routes::ROOT);
     cookie.set_http_only(true);
     cookie.set_secure(secure);
     cookie.set_same_site(SameSite::Lax);
@@ -402,7 +394,7 @@ fn session_cookie(user: &User, secure: bool) -> Cookie<'static> {
 
 fn remove_session_cookie() -> Cookie<'static> {
     let mut cookie = Cookie::new(SESSION_COOKIE_NAME, "");
-    cookie.set_path(ROOT_PATH);
+    cookie.set_path(routes::ROOT);
     cookie.set_http_only(true);
     cookie.set_secure(true);
     cookie.set_same_site(SameSite::Lax);
@@ -413,7 +405,7 @@ fn remove_session_cookie() -> Cookie<'static> {
 fn banned_redirect(reason: &str) -> Redirect {
     Redirect::temporary(&format!(
         "{}?reason={}",
-        BANNED_PATH,
+        routes::BANNED,
         encode_query_value(reason)
     ))
 }
@@ -421,7 +413,7 @@ fn banned_redirect(reason: &str) -> Redirect {
 fn device_approval_redirect(user_code: &str) -> Redirect {
     Redirect::temporary(&format!(
         "{}?user_code={}",
-        DEVICE_APPROVAL_PATH,
+        routes::AUTH_DEVICE,
         encode_query_value(user_code)
     ))
 }
@@ -443,7 +435,7 @@ fn encode_query_value(value: &str) -> String {
 
 fn oauth_csrf_cookie(name: &'static str, value: &str, secure: bool) -> Cookie<'static> {
     let mut cookie = Cookie::new(name, value.to_owned());
-    cookie.set_path(OAUTH_CALLBACK_PATH);
+    cookie.set_path(routes::AUTH_GOOGLE_CALLBACK);
     cookie.set_http_only(true);
     cookie.set_secure(secure);
     cookie.set_same_site(SameSite::Lax);
@@ -453,7 +445,7 @@ fn oauth_csrf_cookie(name: &'static str, value: &str, secure: bool) -> Cookie<'s
 
 fn remove_oauth_csrf_cookie(name: &'static str) -> Cookie<'static> {
     let mut cookie = Cookie::new(name, "");
-    cookie.set_path(OAUTH_CALLBACK_PATH);
+    cookie.set_path(routes::AUTH_GOOGLE_CALLBACK);
     cookie.set_max_age(tower_cookies::cookie::time::Duration::ZERO);
     cookie
 }

--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -20,6 +20,7 @@ use crate::{
     errors::AppError,
     jwt::{create_proxy_token, hash_token},
     models::NewProxyAuthToken,
+    routes,
     schema::proxy_auth_tokens,
     AppState,
 };
@@ -293,7 +294,7 @@ pub async fn device_verify_page(
     // Check if user code exists and get device info
     let store = match &app_state.device_flow_store {
         Some(s) => s,
-        None => return Redirect::temporary("/").into_response(),
+        None => return Redirect::temporary(routes::ROOT).into_response(),
     };
     let store_lock = store.read().await;
     let device_info = store_lock
@@ -304,8 +305,11 @@ pub async fn device_verify_page(
         Some(state) => (state.hostname.clone(), state.working_directory.clone()),
         None => {
             drop(store_lock);
-            return Redirect::temporary("/api/auth/device/error?message=Invalid+or+expired+code")
-                .into_response();
+            return Redirect::temporary(&format!(
+                "{}?message=Invalid+or+expired+code",
+                routes::AUTH_DEVICE_ERROR
+            ))
+            .into_response();
         }
     };
     drop(store_lock);
@@ -329,7 +333,8 @@ pub async fn device_verify_page(
     // User not logged in - redirect to device-specific login endpoint
     // This endpoint will handle OAuth and redirect back to the approval page
     Redirect::temporary(&format!(
-        "/api/auth/device-login?device_user_code={}",
+        "{}?device_user_code={}",
+        routes::AUTH_DEVICE_LOGIN,
         user_code
     ))
     .into_response()

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,6 +4,7 @@ mod errors;
 mod handlers;
 mod jwt;
 mod models;
+mod routes;
 mod schema;
 
 use crate::db::DbPool;
@@ -401,11 +402,11 @@ async fn main() -> anyhow::Result<()> {
     // Rate-limited device flow auth routes
     let auth_device_routes = Router::new()
         .route(
-            "/api/auth/device/code",
+            routes::AUTH_DEVICE_CODE,
             post(handlers::device_flow::device_code),
         )
         .route(
-            "/api/auth/device/poll",
+            routes::AUTH_DEVICE_POLL,
             post(handlers::device_flow::device_poll),
         )
         .layer(GovernorLayer::new(auth_rate_limit))
@@ -508,24 +509,24 @@ async fn main() -> anyhow::Result<()> {
                 .put(handlers::sound_settings::save_sound_settings),
         )
         // Auth routes (under /api/auth)
-        .route("/api/auth/google", get(handlers::auth::login))
-        .route("/api/auth/google/callback", get(handlers::auth::callback))
-        .route("/api/auth/me", get(handlers::auth::me))
-        .route("/api/auth/logout", get(handlers::auth::logout))
-        .route("/api/auth/dev-login", get(handlers::auth::dev_login))
+        .route(routes::AUTH_GOOGLE, get(handlers::auth::login))
+        .route(routes::AUTH_GOOGLE_CALLBACK, get(handlers::auth::callback))
+        .route(routes::AUTH_ME, get(handlers::auth::me))
+        .route(routes::AUTH_LOGOUT, get(handlers::auth::logout))
+        .route(routes::AUTH_DEV_LOGIN, get(handlers::auth::dev_login))
         // Device-specific login endpoint (separate from regular web login)
-        .route("/api/auth/device-login", get(handlers::auth::device_login))
+        .route(routes::AUTH_DEVICE_LOGIN, get(handlers::auth::device_login))
         // Non-rate-limited device flow endpoints (verify page, approve, deny are user-facing)
         .route(
-            "/api/auth/device",
+            routes::AUTH_DEVICE,
             get(handlers::device_flow::device_verify_page),
         )
         .route(
-            "/api/auth/device/approve",
+            routes::AUTH_DEVICE_APPROVE,
             post(handlers::device_flow::device_approve),
         )
         .route(
-            "/api/auth/device/deny",
+            routes::AUTH_DEVICE_DENY,
             post(handlers::device_flow::device_deny),
         )
         // WebSocket routes (paths from ws-bridge endpoint definitions)

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,0 +1,18 @@
+pub const ROOT: &str = "/";
+pub const DASHBOARD: &str = "/dashboard";
+pub const BANNED: &str = "/banned";
+pub const ACCESS_DENIED: &str = "/access-denied";
+
+pub const AUTH_GOOGLE: &str = "/api/auth/google";
+pub const AUTH_GOOGLE_CALLBACK: &str = "/api/auth/google/callback";
+pub const AUTH_ME: &str = "/api/auth/me";
+pub const AUTH_LOGOUT: &str = "/api/auth/logout";
+pub const AUTH_DEV_LOGIN: &str = "/api/auth/dev-login";
+pub const AUTH_DEVICE_LOGIN: &str = "/api/auth/device-login";
+
+pub const AUTH_DEVICE: &str = "/api/auth/device";
+pub const AUTH_DEVICE_CODE: &str = "/api/auth/device/code";
+pub const AUTH_DEVICE_POLL: &str = "/api/auth/device/poll";
+pub const AUTH_DEVICE_APPROVE: &str = "/api/auth/device/approve";
+pub const AUTH_DEVICE_DENY: &str = "/api/auth/device/deny";
+pub const AUTH_DEVICE_ERROR: &str = "/api/auth/device/error";


### PR DESCRIPTION
Closes #863.\n\n## Summary\n- add a backend routes module for auth and device-flow paths\n- reuse route constants in router registration, redirects, and cookie paths\n- keep behavior unchanged while reducing stringly path drift\n\n## Verification\n- cargo fmt --check\n- cargo check -p backend\n- cargo test -p backend handlers::auth::tests\n- cargo test -p backend handlers::device_flow::tests\n- git diff --check