### PR TITLE
Add architecture vocabulary doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The **portal** refers to the complete system: backend server, web frontend, and 
 | [Usage Guide](docs/USAGE.md) | Web interface, CLI options, voice input, session sharing |
 | [Local Development](docs/LOCAL_DEVELOPMENT.md) | Quick setup with `dev.sh`, available commands |
 | [Development Guide](docs/DEVELOPING.md) | Full dev workflow, building, testing, contributing |
+| [Architecture Vocabulary](docs/ARCHITECTURE_VOCABULARY.md) | Runtime components, core concepts, and message flow terminology |
 | [Deployment Guide](docs/DEPLOYING.md) | Production deployment, Google OAuth setup, configuration |
 | [Docker Guide](docs/DOCKER.md) | Docker and Kubernetes deployment with 1Password |
 | [VS Code Setup](docs/VSCODE_SETUP.md) | Use Claude Code in VS Code with portal integration |

--- a/docs/ARCHITECTURE_VOCABULARY.md
+++ b/docs/ARCHITECTURE_VOCABULARY.md
@@ -1,0 +1,45 @@
+# Architecture Vocabulary
+
+This document names the major runtime pieces in agent-portal and how messages move between them. Use these terms when discussing code changes so issues, PRs, and code comments describe the same boundaries.
+
+## Runtime Components
+
+| Term | Location | Responsibility |
+|------|----------|----------------|
+| Backend | `backend/` | Axum HTTP server, PostgreSQL persistence, authentication, WebSocket coordination, static frontend serving |
+| Frontend | `frontend/` | Yew WebAssembly UI for dashboards, sessions, messages, settings, and interactive browser workflows |
+| Shared | `shared/` | Protocol, API, and data-transfer types used by backend, frontend, proxy, and launcher crates |
+| Proxy | `proxy/` | Local CLI wrapper that runs an agent process and streams session traffic to the backend |
+| Launcher | `launcher/` | Long-lived local daemon that registers a machine with the backend and starts agent sessions on request |
+| Portal auth | `portal-auth/` | Reusable OAuth device-flow client logic for local binaries |
+| Portal update | `portal-update/` | Shared release and update logic for local binaries |
+
+## Core Concepts
+
+| Term | Meaning |
+|------|---------|
+| Portal | The complete system: backend, frontend, shared protocol, and local binaries working together |
+| Session | A persisted conversation/workflow record owned by a user and optionally shared with collaborators |
+| Web client | A browser frontend connected to the backend over HTTP and WebSocket |
+| Agent process | The local AI coding process managed by the proxy or launcher |
+| Device flow | The browser-assisted login flow that grants a local binary a proxy token |
+| Proxy token | A JWT-backed credential used by local binaries to authenticate back to the backend |
+| Launcher token | A backend-issued token used to authorize launcher-specific machine/session operations |
+| Shared protocol | The typed message and endpoint contracts that keep Rust backend, WASM frontend, and local binaries aligned |
+
+## Message Flow
+
+1. A user opens the frontend and authenticates with the backend.
+2. The frontend lists sessions over HTTP and subscribes to live session updates over WebSocket.
+3. A local proxy or launcher authenticates to the backend with device-flow credentials.
+4. The backend coordinates session ownership, membership, replay, and fanout.
+5. Agent output, tool activity, permissions, uploads, and status updates flow through shared protocol types.
+6. The frontend renders persisted history plus live updates from the backend.
+
+## Ownership Boundaries
+
+- Keep authentication and route behavior in the backend; local binaries should not infer backend access rules.
+- Keep transport contracts in `shared/` when more than one crate needs the same shape.
+- Keep browser-only rendering state in `frontend/`; avoid leaking UI-only concepts into protocol types.
+- Keep local process lifecycle concerns in `proxy/` or `launcher/`; the backend should coordinate, not manage local OS process details directly.
+- Prefer small handler modules when a backend flow mixes persistence, authentication, protocol mapping, and response rendering.


### PR DESCRIPTION
Closes #866.\n\n## Summary\n- add a concise architecture vocabulary doc for runtime components and shared concepts\n- describe high-level message flow and ownership boundaries\n- link the doc from the README documentation table\n\n## Verification\n- git diff --check