### PR TITLE
Split assistant message renderers

### DIFF
--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -1,5 +1,6 @@
 //! Rendering functions for each message type.
 
+mod assistant;
 mod portal;
 mod system;
 mod tools;
@@ -7,99 +8,21 @@ mod tools;
 use super::types::*;
 use super::{format_duration, shorten_model_name};
 use crate::components::copy_button::CopyButton;
-use crate::components::expandable::ExpandableText;
 use crate::components::markdown::render_markdown;
-use crate::components::time_ago::TimeAgo;
-use crate::components::tool_renderers::render_tool_use;
 use serde::Deserialize;
-use shared::{Citation, ToolResultContent};
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
+pub use assistant::{
+    render_assistant_message, render_assistant_message_content, render_content_blocks,
+};
 pub use portal::{render_portal_message, render_portal_message_content};
 pub use system::render_system_message;
-use tools::{
-    render_code_execution_result, render_container_upload, render_mcp_tool_result,
-    render_mcp_tool_use, render_server_tool_use, render_structured_block, render_unknown_block,
-    render_web_search_result,
-};
 
 /// Convert single newlines to markdown hard breaks (trailing two spaces)
 /// so that user-typed line breaks are preserved when rendered as markdown.
 fn preserve_user_newlines(text: &str) -> String {
     text.replace('\n', "  \n")
-}
-
-fn extract_ephemeral_cache(usage: &UsageInfo) -> (u64, u64) {
-    usage
-        .cache_creation
-        .as_ref()
-        .map(|cc| {
-            (
-                u64::from(cc.ephemeral_1h_input_tokens),
-                u64::from(cc.ephemeral_5m_input_tokens),
-            )
-        })
-        .unwrap_or((0, 0))
-}
-
-fn build_model_tooltip(model: &str, usage: Option<&UsageInfo>) -> String {
-    let mut parts = vec![model.to_string()];
-    if let Some(u) = usage {
-        if let Some(tier) = &u.service_tier {
-            parts.push(tier.clone());
-        }
-        if let Some(geo) = &u.inference_geo {
-            parts.push(geo.clone());
-        }
-    }
-    parts.join(" | ")
-}
-
-fn build_usage_tooltip(usage: Option<&UsageInfo>) -> String {
-    usage
-        .map(|u| {
-            let mut tooltip = format!(
-                "Input: {} | Output: {} | Cache read: {} | Cache created: {}",
-                u.input_tokens.unwrap_or(0),
-                u.output_tokens.unwrap_or(0),
-                u.cache_read_input_tokens.unwrap_or(0),
-                u.cache_creation_input_tokens.unwrap_or(0)
-            );
-            let (e1h, e5m) = extract_ephemeral_cache(u);
-            if e1h > 0 || e5m > 0 {
-                tooltip.push_str(&format!(" | Ephemeral 1h: {} | Ephemeral 5m: {}", e1h, e5m));
-            }
-            tooltip
-        })
-        .unwrap_or_default()
-}
-
-/// Extract concatenated raw text from a list of content blocks.
-/// Used for the message header copy button — pulls out text and thinking
-/// blocks as markdown, ignoring tool_use/tool_result internals.
-fn content_blocks_to_text(blocks: &[ContentBlock]) -> String {
-    let mut out = String::new();
-    for block in blocks {
-        match block {
-            ContentBlock::Text { text, .. } => {
-                if !out.is_empty() {
-                    out.push_str("\n\n");
-                }
-                out.push_str(text);
-            }
-            ContentBlock::Thinking { thinking } => {
-                if !out.is_empty() {
-                    out.push_str("\n\n");
-                }
-                out.push_str("<thinking>\n");
-                out.push_str(thinking);
-                out.push_str("\n</thinking>");
-            }
-            _ => {}
-        }
-    }
-    out
 }
 
 // --- Message renderers ---
@@ -331,169 +254,6 @@ pub fn render_rate_limit_event(msg: &RateLimitEventMessage, timestamp: Option<&s
     }
 }
 
-pub fn render_assistant_message(
-    msg: &AssistantMessage,
-    timestamp: Option<&str>,
-    raw_iso: Option<&str>,
-) -> Html {
-    let blocks = msg
-        .message
-        .as_ref()
-        .and_then(|m| m.content.as_ref())
-        .cloned()
-        .unwrap_or_default();
-
-    let usage = msg.message.as_ref().and_then(|m| m.usage.as_ref());
-    let model = msg
-        .message
-        .as_ref()
-        .and_then(|m| m.model.as_ref())
-        .map(|s| s.as_str())
-        .unwrap_or("");
-    let stop_reason = msg.message.as_ref().and_then(|m| m.stop_reason.as_deref());
-    let is_truncated = stop_reason == Some("max_tokens");
-
-    let model_tooltip = build_model_tooltip(model, usage);
-    let usage_tooltip = build_usage_tooltip(usage);
-    let copy_text = content_blocks_to_text(&blocks);
-
-    html! {
-        <div class="claude-message assistant-message">
-            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
-                <span class="message-type-badge assistant">{ "Assistant" }</span>
-                {
-                    if let Some(short_name) = shorten_model_name(model) {
-                        html! { <span class="model-name" title={model_tooltip}>{ short_name }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
-                if !copy_text.is_empty() {
-                    <CopyButton text={copy_text} title="Copy assistant text" />
-                }
-                {
-                    if is_truncated {
-                        html! { <span class="truncated-badge" title="Response was cut off (max_tokens)">{ "truncated" }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
-                {
-                    if let Some(u) = usage {
-                        html! {
-                            <span class="usage-badge" title={usage_tooltip}>
-                                <span class="token-count">{ format!("{}↓ {}↑", u.input_tokens.unwrap_or(0), u.output_tokens.unwrap_or(0)) }</span>
-                            </span>
-                        }
-                    } else {
-                        html! {}
-                    }
-                }
-            </div>
-            <div class="message-body">{ render_assistant_message_content(msg) }</div>
-            if let Some(iso) = raw_iso {
-                <div class="message-footer">
-                    <TimeAgo iso={iso.to_string()} />
-                </div>
-            }
-        </div>
-    }
-}
-
-pub fn render_assistant_message_content(msg: &AssistantMessage) -> Html {
-    let blocks = msg
-        .message
-        .as_ref()
-        .and_then(|m| m.content.as_ref())
-        .cloned()
-        .unwrap_or_default();
-    render_content_blocks(&blocks)
-}
-
-pub fn render_content_blocks(blocks: &[ContentBlock]) -> Html {
-    html! {
-        <>
-            {
-                blocks.iter().map(|block| {
-                    match block {
-                        ContentBlock::Text { text, citations } => {
-                            html! {
-                                <div class="assistant-text">
-                                    { render_markdown(text) }
-                                    { render_citations(citations) }
-                                </div>
-                            }
-                        }
-                        ContentBlock::ToolUse { id: _, name, input } => {
-                            render_tool_use(name, input)
-                        }
-                        ContentBlock::ToolResult { tool_use_id: _, content, is_error } => {
-                            let class = if *is_error { "tool-result error" } else { "tool-result" };
-                            match content {
-                                Some(ToolResultContent::Text(s)) => {
-                                    html! {
-                                        <div class={class}>
-                                            <ExpandableText full_text={s.clone()} max_len={500} class="tool-result-content" />
-                                        </div>
-                                    }
-                                }
-                                Some(ToolResultContent::Structured(blocks)) => {
-                                    html! {
-                                        <div class={class}>
-                                            { for blocks.iter().map(|v| {
-                                                match serde_json::from_value::<shared::ContentBlock>(v.clone()) {
-                                                    Ok(typed) => render_structured_block(&typed),
-                                                    Err(_) => {
-                                                        let json = serde_json::to_string_pretty(v).unwrap_or_default();
-                                                        html! { <pre class="tool-result-content">{ json }</pre> }
-                                                    }
-                                                }
-                                            }) }
-                                        </div>
-                                    }
-                                }
-                                None => html! { <div class={class}></div> },
-                            }
-                        }
-                        ContentBlock::Image { source } => {
-                            render_image_source(source, None)
-                        }
-                        ContentBlock::Thinking { thinking } => {
-                            html! {
-                                <div class="thinking-block">
-                                    <span class="thinking-label">{ "thinking" }</span>
-                                    <div class="thinking-content">{ crate::components::markdown::linkify_urls(thinking) }</div>
-                                </div>
-                            }
-                        }
-                        ContentBlock::ServerToolUse { id: _, name, input } => {
-                            render_server_tool_use(name, input)
-                        }
-                        ContentBlock::WebSearchToolResult { tool_use_id: _, content } => {
-                            render_web_search_result(content)
-                        }
-                        ContentBlock::CodeExecutionToolResult { tool_use_id: _, content } => {
-                            render_code_execution_result(content)
-                        }
-                        ContentBlock::McpToolUse { id: _, name, server_name, input } => {
-                            render_mcp_tool_use(name, server_name.as_deref(), input)
-                        }
-                        ContentBlock::McpToolResult { tool_use_id: _, content, is_error } => {
-                            render_mcp_tool_result(content, is_error.unwrap_or(false))
-                        }
-                        ContentBlock::ContainerUpload { data } => {
-                            render_container_upload(data)
-                        }
-                        ContentBlock::Unknown(value) => {
-                            render_unknown_block(value)
-                        }
-                    }
-                }).collect::<Html>()
-            }
-        </>
-    }
-}
-
 const ALLOWED_IMAGE_MEDIA_TYPES: &[&str] = &[
     "image/png",
     "image/jpeg",
@@ -613,31 +373,6 @@ fn image_viewer(props: &ImageViewerProps) -> Html {
                 </div>
             }
         </>
-    }
-}
-
-fn render_citations(citations: &[Citation]) -> Html {
-    if citations.is_empty() {
-        return html! {};
-    }
-    html! {
-        <div class="citation-list">
-            { for citations.iter().enumerate().map(|(i, cite)| {
-                let url = cite.url.as_deref().unwrap_or("#");
-                let title = cite.title.as_deref()
-                    .or(cite.cited_text.as_deref())
-                    .unwrap_or("source");
-                html! {
-                    <a class="citation-link"
-                       href={url.to_string()}
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       title={title.to_string()}>
-                        { format!("[{}]", i + 1) }
-                    </a>
-                }
-            })}
-        </div>
     }
 }
 

--- a/frontend/src/components/message_renderer/renderers/assistant.rs
+++ b/frontend/src/components/message_renderer/renderers/assistant.rs
@@ -1,0 +1,275 @@
+use super::super::shorten_model_name;
+use super::super::types::{AssistantMessage, ContentBlock, UsageInfo};
+use super::render_image_source;
+use super::tools::{
+    render_code_execution_result, render_container_upload, render_mcp_tool_result,
+    render_mcp_tool_use, render_server_tool_use, render_structured_block, render_unknown_block,
+    render_web_search_result,
+};
+use crate::components::copy_button::CopyButton;
+use crate::components::expandable::ExpandableText;
+use crate::components::markdown::render_markdown;
+use crate::components::time_ago::TimeAgo;
+use crate::components::tool_renderers::render_tool_use;
+use shared::{Citation, ToolResultContent};
+use yew::prelude::*;
+
+fn extract_ephemeral_cache(usage: &UsageInfo) -> (u64, u64) {
+    usage
+        .cache_creation
+        .as_ref()
+        .map(|cc| {
+            (
+                u64::from(cc.ephemeral_1h_input_tokens),
+                u64::from(cc.ephemeral_5m_input_tokens),
+            )
+        })
+        .unwrap_or((0, 0))
+}
+
+fn build_model_tooltip(model: &str, usage: Option<&UsageInfo>) -> String {
+    let mut parts = vec![model.to_string()];
+    if let Some(u) = usage {
+        if let Some(tier) = &u.service_tier {
+            parts.push(tier.clone());
+        }
+        if let Some(geo) = &u.inference_geo {
+            parts.push(geo.clone());
+        }
+    }
+    parts.join(" | ")
+}
+
+fn build_usage_tooltip(usage: Option<&UsageInfo>) -> String {
+    usage
+        .map(|u| {
+            let mut tooltip = format!(
+                "Input: {} | Output: {} | Cache read: {} | Cache created: {}",
+                u.input_tokens.unwrap_or(0),
+                u.output_tokens.unwrap_or(0),
+                u.cache_read_input_tokens.unwrap_or(0),
+                u.cache_creation_input_tokens.unwrap_or(0)
+            );
+            let (e1h, e5m) = extract_ephemeral_cache(u);
+            if e1h > 0 || e5m > 0 {
+                tooltip.push_str(&format!(" | Ephemeral 1h: {} | Ephemeral 5m: {}", e1h, e5m));
+            }
+            tooltip
+        })
+        .unwrap_or_default()
+}
+
+/// Extract concatenated raw text from a list of content blocks.
+/// Used for the message header copy button: pulls out text and thinking
+/// blocks as markdown, ignoring tool_use/tool_result internals.
+fn content_blocks_to_text(blocks: &[ContentBlock]) -> String {
+    let mut out = String::new();
+    for block in blocks {
+        match block {
+            ContentBlock::Text { text, .. } => {
+                if !out.is_empty() {
+                    out.push_str("\n\n");
+                }
+                out.push_str(text);
+            }
+            ContentBlock::Thinking { thinking } => {
+                if !out.is_empty() {
+                    out.push_str("\n\n");
+                }
+                out.push_str("<thinking>\n");
+                out.push_str(thinking);
+                out.push_str("\n</thinking>");
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+pub fn render_assistant_message(
+    msg: &AssistantMessage,
+    timestamp: Option<&str>,
+    raw_iso: Option<&str>,
+) -> Html {
+    let blocks = msg
+        .message
+        .as_ref()
+        .and_then(|m| m.content.as_ref())
+        .cloned()
+        .unwrap_or_default();
+
+    let usage = msg.message.as_ref().and_then(|m| m.usage.as_ref());
+    let model = msg
+        .message
+        .as_ref()
+        .and_then(|m| m.model.as_ref())
+        .map(|s| s.as_str())
+        .unwrap_or("");
+    let stop_reason = msg.message.as_ref().and_then(|m| m.stop_reason.as_deref());
+    let is_truncated = stop_reason == Some("max_tokens");
+
+    let model_tooltip = build_model_tooltip(model, usage);
+    let usage_tooltip = build_usage_tooltip(usage);
+    let copy_text = content_blocks_to_text(&blocks);
+
+    html! {
+        <div class="claude-message assistant-message">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
+                <span class="message-type-badge assistant">{ "Assistant" }</span>
+                {
+                    if let Some(short_name) = shorten_model_name(model) {
+                        html! { <span class="model-name" title={model_tooltip}>{ short_name }</span> }
+                    } else {
+                        html! {}
+                    }
+                }
+                if !copy_text.is_empty() {
+                    <CopyButton text={copy_text} title="Copy assistant text" />
+                }
+                {
+                    if is_truncated {
+                        html! { <span class="truncated-badge" title="Response was cut off (max_tokens)">{ "truncated" }</span> }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
+                    if let Some(u) = usage {
+                        html! {
+                            <span class="usage-badge" title={usage_tooltip}>
+                                <span class="token-count">{ format!("{}↓ {}↑", u.input_tokens.unwrap_or(0), u.output_tokens.unwrap_or(0)) }</span>
+                            </span>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
+            </div>
+            <div class="message-body">{ render_assistant_message_content(msg) }</div>
+            if let Some(iso) = raw_iso {
+                <div class="message-footer">
+                    <TimeAgo iso={iso.to_string()} />
+                </div>
+            }
+        </div>
+    }
+}
+
+pub fn render_assistant_message_content(msg: &AssistantMessage) -> Html {
+    let blocks = msg
+        .message
+        .as_ref()
+        .and_then(|m| m.content.as_ref())
+        .cloned()
+        .unwrap_or_default();
+    render_content_blocks(&blocks)
+}
+
+pub fn render_content_blocks(blocks: &[ContentBlock]) -> Html {
+    html! {
+        <>
+            {
+                blocks.iter().map(|block| {
+                    match block {
+                        ContentBlock::Text { text, citations } => {
+                            html! {
+                                <div class="assistant-text">
+                                    { render_markdown(text) }
+                                    { render_citations(citations) }
+                                </div>
+                            }
+                        }
+                        ContentBlock::ToolUse { id: _, name, input } => {
+                            render_tool_use(name, input)
+                        }
+                        ContentBlock::ToolResult { tool_use_id: _, content, is_error } => {
+                            let class = if *is_error { "tool-result error" } else { "tool-result" };
+                            match content {
+                                Some(ToolResultContent::Text(s)) => {
+                                    html! {
+                                        <div class={class}>
+                                            <ExpandableText full_text={s.clone()} max_len={500} class="tool-result-content" />
+                                        </div>
+                                    }
+                                }
+                                Some(ToolResultContent::Structured(blocks)) => {
+                                    html! {
+                                        <div class={class}>
+                                            { for blocks.iter().map(|v| {
+                                                match serde_json::from_value::<shared::ContentBlock>(v.clone()) {
+                                                    Ok(typed) => render_structured_block(&typed),
+                                                    Err(_) => {
+                                                        let json = serde_json::to_string_pretty(v).unwrap_or_default();
+                                                        html! { <pre class="tool-result-content">{ json }</pre> }
+                                                    }
+                                                }
+                                            }) }
+                                        </div>
+                                    }
+                                }
+                                None => html! { <div class={class}></div> },
+                            }
+                        }
+                        ContentBlock::Image { source } => {
+                            render_image_source(source, None)
+                        }
+                        ContentBlock::Thinking { thinking } => {
+                            html! {
+                                <div class="thinking-block">
+                                    <span class="thinking-label">{ "thinking" }</span>
+                                    <div class="thinking-content">{ crate::components::markdown::linkify_urls(thinking) }</div>
+                                </div>
+                            }
+                        }
+                        ContentBlock::ServerToolUse { id: _, name, input } => {
+                            render_server_tool_use(name, input)
+                        }
+                        ContentBlock::WebSearchToolResult { tool_use_id: _, content } => {
+                            render_web_search_result(content)
+                        }
+                        ContentBlock::CodeExecutionToolResult { tool_use_id: _, content } => {
+                            render_code_execution_result(content)
+                        }
+                        ContentBlock::McpToolUse { id: _, name, server_name, input } => {
+                            render_mcp_tool_use(name, server_name.as_deref(), input)
+                        }
+                        ContentBlock::McpToolResult { tool_use_id: _, content, is_error } => {
+                            render_mcp_tool_result(content, is_error.unwrap_or(false))
+                        }
+                        ContentBlock::ContainerUpload { data } => {
+                            render_container_upload(data)
+                        }
+                        ContentBlock::Unknown(value) => {
+                            render_unknown_block(value)
+                        }
+                    }
+                }).collect::<Html>()
+            }
+        </>
+    }
+}
+
+fn render_citations(citations: &[Citation]) -> Html {
+    if citations.is_empty() {
+        return html! {};
+    }
+    html! {
+        <div class="citation-list">
+            { for citations.iter().enumerate().map(|(i, cite)| {
+                let url = cite.url.as_deref().unwrap_or("#");
+                let title = cite.title.as_deref()
+                    .or(cite.cited_text.as_deref())
+                    .unwrap_or("source");
+                html! {
+                    <a class="citation-link"
+                       href={url.to_string()}
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       title={title.to_string()}>
+                        { format!("[{}]", i + 1) }
+                    </a>
+                }
+            })}
+        </div>
+    }
+}


### PR DESCRIPTION
Part of #859.\n\n## Summary\n- move assistant message and content-block rendering into a dedicated renderer module\n- re-export the assistant renderer and shared content-block dispatcher for existing callers\n- reduce the main message renderer file from roughly 923 LOC to 658 LOC\n\n## Verification\n- cargo fmt --check\n- cargo check -p frontend\n- git diff --check