### PR TITLE
Test auth error semantics

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -39,3 +39,32 @@ impl IntoResponse for AppError {
         (status, msg.to_string()).into_response()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_unavailable_maps_to_503() {
+        let response = AppError::ServiceUnavailable("OAuth client not configured").into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn auth_failures_map_to_expected_statuses() {
+        let cases = [
+            (AppError::Unauthorized, StatusCode::UNAUTHORIZED),
+            (AppError::Forbidden, StatusCode::FORBIDDEN),
+            (AppError::DbPool, StatusCode::INTERNAL_SERVER_ERROR),
+            (
+                AppError::DbQuery("lookup failed".to_string()),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        ];
+
+        for (error, expected_status) in cases {
+            assert_eq!(error.into_response().status(), expected_status);
+        }
+    }
+}

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -342,6 +342,42 @@ mod tests {
     use super::*;
 
     #[test]
+    fn auth_user_error_preserves_forbidden_and_database_errors() {
+        assert!(matches!(
+            auth_user_error(AppError::Forbidden),
+            AppError::Forbidden
+        ));
+        assert!(matches!(
+            auth_user_error(AppError::DbPool),
+            AppError::DbPool
+        ));
+        assert!(matches!(
+            auth_user_error(AppError::DbQuery("session lookup failed".to_string())),
+            AppError::DbQuery(message) if message == "session lookup failed"
+        ));
+    }
+
+    #[test]
+    fn auth_user_error_collapses_other_failures_to_unauthorized() {
+        assert!(matches!(
+            auth_user_error(AppError::BadRequest("bad cookie")),
+            AppError::Unauthorized
+        ));
+        assert!(matches!(
+            auth_user_error(AppError::NotFound("user")),
+            AppError::Unauthorized
+        ));
+        assert!(matches!(
+            auth_user_error(AppError::Internal("decode failed".to_string())),
+            AppError::Unauthorized
+        ));
+        assert!(matches!(
+            auth_user_error(AppError::ServiceUnavailable("auth unavailable")),
+            AppError::Unauthorized
+        ));
+    }
+
+    #[test]
     fn encode_query_value_keeps_unreserved_and_encodes_reserved_chars() {
         assert_eq!(
             encode_query_value("ABC-123 reason?/"),


### PR DESCRIPTION
## Summary
- add coverage for auth_user_error preserving forbidden and database failures
- add coverage for auth_user_error collapsing other extraction failures to unauthorized
- pin AppError service-unavailable and auth failure HTTP statuses

## Verification
- cargo fmt --check
- cargo test -p backend auth_user_error
- cargo test -p backend service_unavailable_maps_to_503
- cargo check -p backend
- git diff --check