### PR TITLE
Link architecture vocabulary from development guide

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -1,6 +1,7 @@
 # Development Guide
 
 This guide covers setting up a development environment and contributing to agent-portal.
+For runtime component names and ownership boundaries, see [Architecture Vocabulary](ARCHITECTURE_VOCABULARY.md).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- link the architecture vocabulary doc from the development guide intro
- make component naming and ownership boundaries easier to find during onboarding

## Verification
- git diff --check