### PR TITLE
Split Codex tool renderers

### DIFF
--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -2,13 +2,16 @@ use super::copy_button::CopyButton;
 use super::expandable::ExpandableText;
 use super::markdown::render_markdown;
 use super::message_renderer::format_duration;
-use codex_codes::io::items::{
-    CommandExecutionItem, CommandExecutionStatus, FileChangeItem, FileUpdateChange,
-    McpToolCallItem, McpToolCallStatus, PatchApplyStatus, PatchChangeKind, ThreadItem, TodoItem,
-};
+use codex_codes::io::items::{FileUpdateChange, ThreadItem};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use yew::prelude::*;
+
+mod tools;
+use tools::{
+    render_command_execution, render_diff_card, render_file_change, render_mcp_tool_call,
+    render_todo_list, render_web_search,
+};
 
 // Local outer-`CodexEvent` enum is the project-specific wire shape: a hybrid
 // of the codex exec JSONL format (`thread.started`, `item.started`, …) and
@@ -363,38 +366,6 @@ fn item_card_classes(completed: bool) -> &'static str {
     }
 }
 
-/// Wraps a per-variant body in the standard tool-style card chrome:
-/// card wrapper (with in-progress styling), message-body, tool-use-section,
-/// and a tool-use-header with icon + name + optional `status` meta line.
-/// Returns `html! {}` when `body` is empty so callers can short-circuit
-/// empty-data cases by handing in a no-op body.
-fn tool_card(
-    icon: &str,
-    name: String,
-    status: Option<String>,
-    body: Html,
-    completed: bool,
-) -> Html {
-    html! {
-        <div class={item_card_classes(completed)}>
-            <div class="message-body">
-                <div class="tool-use-section">
-                    <div class="tool-use-header">
-                        <span class="tool-icon">{ icon }</span>
-                        <span class="tool-name">{ name }</span>
-                        { if let Some(s) = status {
-                            html! { <span class="tool-meta">{ s }</span> }
-                        } else {
-                            html! {}
-                        } }
-                    </div>
-                    { body }
-                </div>
-            </div>
-        </div>
-    }
-}
-
 fn render_item(item: Option<&ThreadItem>, completed: bool) -> Html {
     let Some(item) = item else {
         return html! {};
@@ -502,196 +473,6 @@ fn render_reasoning(text: &str, completed: bool) -> Html {
             </div>
         </div>
     }
-}
-
-fn render_command_execution(it: &CommandExecutionItem, completed: bool) -> Html {
-    let cmd = if it.command.is_empty() {
-        "(unknown command)"
-    } else {
-        it.command.as_str()
-    };
-    let out = it.aggregated_output.as_deref().unwrap_or("");
-
-    let status_text = if completed {
-        match it.exit_code {
-            Some(0) => "completed".to_string(),
-            Some(code) => format!("exit {}", code),
-            None => command_status_label(&it.status).to_string(),
-        }
-    } else {
-        "running...".to_string()
-    };
-
-    let is_error = it.exit_code.is_some_and(|c| c != 0);
-
-    let body = html! {
-        <>
-            <ExpandableText
-                full_text={cmd.to_string()}
-                max_len=500
-                tag="pre"
-                class={classes!("tool-input-content")}
-            />
-            {
-                if !out.is_empty() {
-                    let class = if is_error { "tool-result error" } else { "tool-result" };
-                    html! {
-                        <div class={class}>
-                            <ExpandableText
-                                full_text={out.to_string()}
-                                max_len=500
-                                tag="pre"
-                                class={classes!("tool-result-content")}
-                            />
-                        </div>
-                    }
-                } else {
-                    html! {}
-                }
-            }
-        </>
-    };
-
-    tool_card("$", "Bash".into(), Some(status_text), body, completed)
-}
-
-fn command_status_label(status: &CommandExecutionStatus) -> &'static str {
-    match status {
-        CommandExecutionStatus::InProgress => "in_progress",
-        CommandExecutionStatus::Completed => "completed",
-        CommandExecutionStatus::Failed => "failed",
-        CommandExecutionStatus::Declined => "declined",
-    }
-}
-
-fn patch_status_label(status: &PatchApplyStatus) -> &'static str {
-    match status {
-        PatchApplyStatus::InProgress => "in progress",
-        PatchApplyStatus::Completed => "completed",
-        PatchApplyStatus::Failed => "failed",
-        PatchApplyStatus::Declined => "declined",
-    }
-}
-
-/// Tagged-enum `PatchChangeKind` to a CSS suffix that pairs with the existing
-/// `.diff-card-kind.{add,update,delete}` styles from #823's unified DiffCard.
-fn patch_kind_css(kind: &PatchChangeKind) -> &'static str {
-    match kind {
-        PatchChangeKind::Add => "add",
-        PatchChangeKind::Delete => "delete",
-        PatchChangeKind::Update { .. } => "update",
-    }
-}
-
-fn render_file_change(it: &FileChangeItem, completed: bool) -> Html {
-    if it.changes.is_empty() {
-        return html! {};
-    }
-    let status_label = patch_status_label(&it.status).to_string();
-    // Closes #827 part 2 — render the actual diff bodies through the unified
-    // `<DiffCard>` from #823 instead of just chip + path. Each per-file
-    // change becomes its own framed card with kind chip + path + diff body,
-    // matching the layout of `render_file_change_patch`.
-    let body = html! {
-        <>
-            { for it.changes.iter().map(render_diff_card) }
-        </>
-    };
-    tool_card(
-        "\u{1f4dd}",
-        "File Changes".into(),
-        Some(status_label),
-        body,
-        completed,
-    )
-}
-
-/// Render one `FileUpdateChange` through the shared `<DiffCard>`. Returns
-/// the bare path + kind chip (without a diff body) for empty-diff entries
-/// — `item.started{file_change}` events typically carry the diff text
-/// already, but a defensive empty-diff path still shows the file path.
-fn render_diff_card(c: &FileUpdateChange) -> Html {
-    let kind_css = AttrValue::from(patch_kind_css(&c.kind));
-    let path = AttrValue::from(c.path.clone());
-    if c.diff.trim().is_empty() {
-        return html! {
-            <div class="diff-card">
-                <div class="diff-card-header">
-                    <span class="tool-icon">{ "\u{1f4dd}" }</span>
-                    <span class={classes!("diff-card-kind", kind_css.to_string())}>{ kind_css.clone() }</span>
-                    <span class="diff-card-path">{ path }</span>
-                </div>
-            </div>
-        };
-    }
-    let source = super::diff::DiffSource::Unified {
-        text: c.diff.clone(),
-    };
-    html! {
-        <super::diff::DiffCard {source} file_path={path} kind={kind_css} />
-    }
-}
-
-fn render_mcp_tool_call(it: &McpToolCallItem, completed: bool) -> Html {
-    let server = if it.server.is_empty() {
-        "(unknown)"
-    } else {
-        it.server.as_str()
-    };
-    let tool = if it.tool.is_empty() {
-        "(unknown)"
-    } else {
-        it.tool.as_str()
-    };
-    let status = mcp_status_label(&it.status).to_string();
-    tool_card(
-        "\u{1f50c}",
-        format!("{} / {}", server, tool),
-        Some(status),
-        html! {},
-        completed,
-    )
-}
-
-fn mcp_status_label(status: &McpToolCallStatus) -> &'static str {
-    match status {
-        McpToolCallStatus::InProgress => "in_progress",
-        McpToolCallStatus::Completed => "completed",
-        McpToolCallStatus::Failed => "failed",
-    }
-}
-
-fn render_web_search(query: &str, completed: bool) -> Html {
-    let query = if query.is_empty() {
-        "(no query)"
-    } else {
-        query
-    };
-    let body = html! { <pre class="tool-input-content">{ query }</pre> };
-    tool_card("\u{1f50d}", "Web Search".into(), None, body, completed)
-}
-
-fn render_todo_list(items: &[TodoItem], completed: bool) -> Html {
-    if items.is_empty() {
-        return html! {};
-    }
-    let body = html! {
-        <div class="codex-todo-list">
-            { for items.iter().map(|item| {
-                let text = item.text.as_str();
-                let done = item.completed;
-                let marker = if done { "\u{2611}" } else { "\u{2610}" };
-                let class = if done { "codex-todo done" } else { "codex-todo" };
-                html! {
-                    <div class={class}>
-                        <span class="codex-todo-marker">{ marker }</span>
-                        <span class="codex-todo-text">{ text }</span>
-                    </div>
-                }
-            })}
-        </div>
-    };
-    tool_card("\u{2611}", "Todo List".into(), None, body, completed)
 }
 
 fn render_turn_completed(
@@ -1011,6 +792,7 @@ pub fn is_codex_terminal_event(json: &str) -> Option<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codex_codes::io::items::PatchChangeKind;
 
     // --- ThreadItem deserialization (replaces the pre-#827 local CodexItem) ---
     //

--- a/frontend/src/components/codex_renderer/tools.rs
+++ b/frontend/src/components/codex_renderer/tools.rs
@@ -1,0 +1,230 @@
+use super::item_card_classes;
+use crate::components::diff::{DiffCard, DiffSource};
+use crate::components::expandable::ExpandableText;
+use codex_codes::io::items::{
+    CommandExecutionItem, CommandExecutionStatus, FileChangeItem, FileUpdateChange,
+    McpToolCallItem, McpToolCallStatus, PatchApplyStatus, PatchChangeKind, TodoItem,
+};
+use yew::prelude::*;
+
+/// Wraps a per-variant body in the standard tool-style card chrome:
+/// card wrapper (with in-progress styling), message-body, tool-use-section,
+/// and a tool-use-header with icon + name + optional `status` meta line.
+/// Returns `html! {}` when `body` is empty so callers can short-circuit
+/// empty-data cases by handing in a no-op body.
+fn tool_card(
+    icon: &str,
+    name: String,
+    status: Option<String>,
+    body: Html,
+    completed: bool,
+) -> Html {
+    html! {
+        <div class={item_card_classes(completed)}>
+            <div class="message-body">
+                <div class="tool-use-section">
+                    <div class="tool-use-header">
+                        <span class="tool-icon">{ icon }</span>
+                        <span class="tool-name">{ name }</span>
+                        { if let Some(s) = status {
+                            html! { <span class="tool-meta">{ s }</span> }
+                        } else {
+                            html! {}
+                        } }
+                    </div>
+                    { body }
+                </div>
+            </div>
+        </div>
+    }
+}
+
+pub(super) fn render_command_execution(it: &CommandExecutionItem, completed: bool) -> Html {
+    let cmd = if it.command.is_empty() {
+        "(unknown command)"
+    } else {
+        it.command.as_str()
+    };
+    let out = it.aggregated_output.as_deref().unwrap_or("");
+
+    let status_text = if completed {
+        match it.exit_code {
+            Some(0) => "completed".to_string(),
+            Some(code) => format!("exit {}", code),
+            None => command_status_label(&it.status).to_string(),
+        }
+    } else {
+        "running...".to_string()
+    };
+
+    let is_error = it.exit_code.is_some_and(|c| c != 0);
+
+    let body = html! {
+        <>
+            <ExpandableText
+                full_text={cmd.to_string()}
+                max_len=500
+                tag="pre"
+                class={classes!("tool-input-content")}
+            />
+            {
+                if !out.is_empty() {
+                    let class = if is_error { "tool-result error" } else { "tool-result" };
+                    html! {
+                        <div class={class}>
+                            <ExpandableText
+                                full_text={out.to_string()}
+                                max_len=500
+                                tag="pre"
+                                class={classes!("tool-result-content")}
+                            />
+                        </div>
+                    }
+                } else {
+                    html! {}
+                }
+            }
+        </>
+    };
+
+    tool_card("$", "Bash".into(), Some(status_text), body, completed)
+}
+
+fn command_status_label(status: &CommandExecutionStatus) -> &'static str {
+    match status {
+        CommandExecutionStatus::InProgress => "in_progress",
+        CommandExecutionStatus::Completed => "completed",
+        CommandExecutionStatus::Failed => "failed",
+        CommandExecutionStatus::Declined => "declined",
+    }
+}
+
+fn patch_status_label(status: &PatchApplyStatus) -> &'static str {
+    match status {
+        PatchApplyStatus::InProgress => "in progress",
+        PatchApplyStatus::Completed => "completed",
+        PatchApplyStatus::Failed => "failed",
+        PatchApplyStatus::Declined => "declined",
+    }
+}
+
+/// Tagged-enum `PatchChangeKind` to a CSS suffix that pairs with the existing
+/// `.diff-card-kind.{add,update,delete}` styles from #823's unified DiffCard.
+fn patch_kind_css(kind: &PatchChangeKind) -> &'static str {
+    match kind {
+        PatchChangeKind::Add => "add",
+        PatchChangeKind::Delete => "delete",
+        PatchChangeKind::Update { .. } => "update",
+    }
+}
+
+pub(super) fn render_file_change(it: &FileChangeItem, completed: bool) -> Html {
+    if it.changes.is_empty() {
+        return html! {};
+    }
+    let status_label = patch_status_label(&it.status).to_string();
+    // Closes #827 part 2 — render the actual diff bodies through the unified
+    // `<DiffCard>` from #823 instead of just chip + path. Each per-file
+    // change becomes its own framed card with kind chip + path + diff body,
+    // matching the layout of `render_file_change_patch`.
+    let body = html! {
+        <>
+            { for it.changes.iter().map(render_diff_card) }
+        </>
+    };
+    tool_card(
+        "\u{1f4dd}",
+        "File Changes".into(),
+        Some(status_label),
+        body,
+        completed,
+    )
+}
+
+/// Render one `FileUpdateChange` through the shared `<DiffCard>`. Returns
+/// the bare path + kind chip (without a diff body) for empty-diff entries
+/// — `item.started{file_change}` events typically carry the diff text
+/// already, but a defensive empty-diff path still shows the file path.
+pub(super) fn render_diff_card(c: &FileUpdateChange) -> Html {
+    let kind_css = AttrValue::from(patch_kind_css(&c.kind));
+    let path = AttrValue::from(c.path.clone());
+    if c.diff.trim().is_empty() {
+        return html! {
+            <div class="diff-card">
+                <div class="diff-card-header">
+                    <span class="tool-icon">{ "\u{1f4dd}" }</span>
+                    <span class={classes!("diff-card-kind", kind_css.to_string())}>{ kind_css.clone() }</span>
+                    <span class="diff-card-path">{ path }</span>
+                </div>
+            </div>
+        };
+    }
+    let source = DiffSource::Unified {
+        text: c.diff.clone(),
+    };
+    html! {
+        <DiffCard {source} file_path={path} kind={kind_css} />
+    }
+}
+
+pub(super) fn render_mcp_tool_call(it: &McpToolCallItem, completed: bool) -> Html {
+    let server = if it.server.is_empty() {
+        "(unknown)"
+    } else {
+        it.server.as_str()
+    };
+    let tool = if it.tool.is_empty() {
+        "(unknown)"
+    } else {
+        it.tool.as_str()
+    };
+    let status = mcp_status_label(&it.status).to_string();
+    tool_card(
+        "\u{1f50c}",
+        format!("{} / {}", server, tool),
+        Some(status),
+        html! {},
+        completed,
+    )
+}
+
+fn mcp_status_label(status: &McpToolCallStatus) -> &'static str {
+    match status {
+        McpToolCallStatus::InProgress => "in_progress",
+        McpToolCallStatus::Completed => "completed",
+        McpToolCallStatus::Failed => "failed",
+    }
+}
+
+pub(super) fn render_web_search(query: &str, completed: bool) -> Html {
+    let query = if query.is_empty() {
+        "(no query)"
+    } else {
+        query
+    };
+    let body = html! { <pre class="tool-input-content">{ query }</pre> };
+    tool_card("\u{1f50d}", "Web Search".into(), None, body, completed)
+}
+
+pub(super) fn render_todo_list(items: &[TodoItem], completed: bool) -> Html {
+    if items.is_empty() {
+        return html! {};
+    }
+    let body = html! {
+        <div class="codex-todo-list">
+            { for items.iter().map(|item| {
+                let text = item.text.as_str();
+                let done = item.completed;
+                let marker = if done { "\u{2611}" } else { "\u{2610}" };
+                let class = if done { "codex-todo done" } else { "codex-todo" };
+                html! {
+                    <div class={class}>
+                        <span class="codex-todo-marker">{ marker }</span>
+                        <span class="codex-todo-text">{ text }</span>
+                    </div>
+                }
+            })}
+        </div>
+    };
+    tool_card("\u{2611}", "Todo List".into(), None, body, completed)
+}


### PR DESCRIPTION
## Summary
- move Codex bash/file-change/MCP/web-search/todo rendering into a dedicated tools submodule
- keep event parsing and turn-level rendering in codex_renderer.rs
- preserve existing renderer behavior and tests

Part of #859.

## Verification
- cargo fmt --check
- cargo check -p frontend
- cargo test -p frontend codex_renderer
- git diff --check