### PR TITLE
Add launcher error semantics tests

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -71,4 +71,25 @@ mod tests {
             assert_eq!(error.into_response().status(), expected_status);
         }
     }
+
+    #[test]
+    fn handler_failures_map_to_expected_statuses() {
+        let cases = [
+            (AppError::BadRequest("bad input"), StatusCode::BAD_REQUEST),
+            (AppError::NotFound("missing"), StatusCode::NOT_FOUND),
+            (AppError::BadGateway("send failed"), StatusCode::BAD_GATEWAY),
+            (
+                AppError::GatewayTimeout("timed out"),
+                StatusCode::GATEWAY_TIMEOUT,
+            ),
+            (
+                AppError::Internal("disk failed".to_string()),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        ];
+
+        for (error, expected_status) in cases {
+            assert_eq!(error.into_response().status(), expected_status);
+        }
+    }
 }

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -414,4 +414,14 @@ mod tests {
             Err(AppError::NotFound("Launcher not found"))
         ));
     }
+
+    #[test]
+    fn default_launcher_requires_connected_launcher() {
+        let manager = SessionManager::new();
+
+        assert!(matches!(
+            resolve_launch_target(&manager, None, Uuid::new_v4()),
+            Err(AppError::NotFound("No connected launchers"))
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
- pin AppError status mappings for handler failure variants
- add coverage for default launcher selection when no launcher is connected

Part of #864.

## Tests
- cargo fmt --check
- cargo test -p backend errors::tests
- cargo test -p backend handlers::launchers
- cargo check -p backend
- git diff --check