### PR TITLE
Normalize backend empty responses

### DIFF
--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -4,7 +4,6 @@
 
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
     Json,
 };
 use diesel::prelude::*;
@@ -16,7 +15,10 @@ use tower_cookies::Cookies;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::{db::get_user_usage, errors::AppError, models::User, schema, AppState};
+use crate::{
+    db::get_user_usage, errors::AppError, handlers::responses::EmptyResponse, models::User, schema,
+    AppState,
+};
 
 use shared::protocol::SESSION_COOKIE_NAME;
 
@@ -265,7 +267,7 @@ pub async fn update_user(
     cookies: Cookies,
     Path(user_id): Path<Uuid>,
     Json(update): Json<UpdateUserRequest>,
-) -> Result<StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let admin = require_admin(&app_state, &cookies).await?;
 
     // Prevent admin from demoting themselves
@@ -365,7 +367,7 @@ pub async fn update_user(
         );
     }
 
-    Ok(StatusCode::NO_CONTENT)
+    Ok(EmptyResponse::NO_CONTENT)
 }
 
 // ============================================================================
@@ -444,7 +446,7 @@ pub async fn delete_session(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
     Path(session_id): Path<Uuid>,
-) -> Result<StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let admin = require_admin(&app_state, &cookies).await?;
 
     let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
@@ -470,7 +472,7 @@ pub async fn delete_session(
         admin.email, session_id, session.session_name, session.total_cost_usd
     );
 
-    Ok(StatusCode::NO_CONTENT)
+    Ok(EmptyResponse::NO_CONTENT)
 }
 
 fn admin_db_query(context: &str, error: diesel::result::Error) -> AppError {

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -1,6 +1,5 @@
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
     Json,
 };
 use serde::Deserialize;
@@ -13,6 +12,7 @@ use uuid::Uuid;
 
 use crate::auth::extract_user_id;
 use crate::errors::AppError;
+use crate::handlers::responses::EmptyResponse;
 use crate::handlers::websocket::SessionManager;
 use crate::AppState;
 
@@ -231,7 +231,7 @@ pub async fn renew_launcher_token(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
     Path(launcher_id): Path<Uuid>,
-) -> Result<StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let user_id = extract_user_id(&app_state, &cookies)?;
 
     // Verify the launcher belongs to this user and get its current token info
@@ -257,7 +257,7 @@ pub async fn renew_launcher_token(
     .map_err(|e| AppError::Internal(format!("{:?}", e)))?;
 
     info!("Manually renewed token for launcher {}", launcher_id);
-    Ok(StatusCode::OK)
+    Ok(EmptyResponse::OK)
 }
 
 /// POST /api/launchers/:launcher_id/update - Tell the launcher to fetch the
@@ -266,7 +266,7 @@ pub async fn update_launcher(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
     Path(launcher_id): Path<Uuid>,
-) -> Result<StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let user_id = extract_user_id(&app_state, &cookies)?;
 
     let sender = {
@@ -287,7 +287,7 @@ pub async fn update_launcher(
     }
 
     info!("Sent UpdateAndRestart to launcher {}", launcher_id);
-    Ok(StatusCode::OK)
+    Ok(EmptyResponse::OK)
 }
 
 #[derive(serde::Serialize)]

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod images;
 pub mod launchers;
 pub mod messages;
 pub mod proxy_tokens;
+pub mod responses;
 pub mod retention;
 pub mod scheduled_tasks;
 pub mod session_access;

--- a/backend/src/handlers/proxy_tokens.rs
+++ b/backend/src/handlers/proxy_tokens.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 
 use crate::{
     errors::AppError,
+    handlers::responses::EmptyResponse,
     jwt::{create_proxy_token, hash_token},
     models::{NewProxyAuthToken, ProxyAuthToken, User},
     schema::proxy_auth_tokens,
@@ -133,7 +134,7 @@ pub async fn revoke_token_handler(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
     Path(token_id): Path<Uuid>,
-) -> Result<StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
 
     let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
@@ -153,7 +154,7 @@ pub async fn revoke_token_handler(
     }
 
     info!("Revoked proxy token {}", token_id);
-    Ok(StatusCode::NO_CONTENT)
+    Ok(EmptyResponse::NO_CONTENT)
 }
 
 /// POST /api/proxy-tokens/:id/renew - Renew a token with a new expiration

--- a/backend/src/handlers/responses.rs
+++ b/backend/src/handlers/responses.rs
@@ -1,0 +1,20 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct EmptyResponse(StatusCode);
+
+impl EmptyResponse {
+    pub const OK: Self = Self(StatusCode::OK);
+    pub const CREATED: Self = Self(StatusCode::CREATED);
+    pub const ACCEPTED: Self = Self(StatusCode::ACCEPTED);
+    pub const NO_CONTENT: Self = Self(StatusCode::NO_CONTENT);
+}
+
+impl IntoResponse for EmptyResponse {
+    fn into_response(self) -> Response {
+        self.0.into_response()
+    }
+}

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -4,7 +4,6 @@
 
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
     Json,
 };
 use diesel::prelude::*;
@@ -20,6 +19,7 @@ use uuid::Uuid;
 
 use crate::{
     errors::AppError,
+    handlers::responses::EmptyResponse,
     models::{NewScheduledTask, ScheduledTask},
     schema::scheduled_tasks,
     AppState,
@@ -248,7 +248,7 @@ pub async fn delete_task_handler(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
     Path(task_id): Path<Uuid>,
-) -> Result<StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
 
     let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
@@ -275,7 +275,7 @@ pub async fn delete_task_handler(
     // Notify connected launchers
     send_schedule_sync(&app_state, user_id);
 
-    Ok(StatusCode::NO_CONTENT)
+    Ok(EmptyResponse::NO_CONTENT)
 }
 
 /// GET /api/scheduled-tasks/:id/runs

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 use crate::{
     auth::extract_user_id,
     errors::AppError,
+    handlers::responses::EmptyResponse,
     models::{Message, NewSessionMember, Session, SessionMember},
     AppState,
 };
@@ -114,7 +115,7 @@ pub async fn delete_session(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
     Path(session_id): Path<Uuid>,
-) -> Result<axum::http::StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
     let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
@@ -150,14 +151,14 @@ pub async fn delete_session(
     super::helpers::delete_session_with_data(&mut conn, &session, true)
         .map_err(|e| AppError::Internal(format!("{:?}", e)))?;
 
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    Ok(EmptyResponse::NO_CONTENT)
 }
 
 pub async fn stop_session(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
     Path(session_id): Path<Uuid>,
-) -> Result<axum::http::StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
     let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
@@ -178,7 +179,7 @@ pub async fn stop_session(
         .stop_session_on_launcher(session_id);
 
     if stopped {
-        Ok(axum::http::StatusCode::ACCEPTED)
+        Ok(EmptyResponse::ACCEPTED)
     } else {
         Err(AppError::NotFound("Session not connected"))
     }
@@ -262,7 +263,7 @@ pub async fn add_session_member(
     cookies: Cookies,
     Path(session_id): Path<Uuid>,
     Json(req): Json<AddMemberRequest>,
-) -> Result<axum::http::StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
     if req.role != "editor" && req.role != "viewer" {
@@ -312,7 +313,7 @@ pub async fn add_session_member(
         .execute(&mut conn)
         .map_err(|e| AppError::DbQuery(e.to_string()))?;
 
-    Ok(axum::http::StatusCode::CREATED)
+    Ok(EmptyResponse::CREATED)
 }
 
 /// Remove a member from a session
@@ -321,7 +322,7 @@ pub async fn remove_session_member(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
     Path((session_id, target_user_id)): Path<(Uuid, Uuid)>,
-) -> Result<axum::http::StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
     let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
@@ -360,7 +361,7 @@ pub async fn remove_session_member(
         return Err(AppError::NotFound("Member not found"));
     }
 
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    Ok(EmptyResponse::NO_CONTENT)
 }
 
 /// Update a member's role (owner only)
@@ -369,7 +370,7 @@ pub async fn update_session_member_role(
     cookies: Cookies,
     Path((session_id, target_user_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<UpdateMemberRoleRequest>,
-) -> Result<axum::http::StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
     if req.role != "editor" && req.role != "viewer" {
@@ -406,5 +407,5 @@ pub async fn update_session_member_role(
         return Err(AppError::NotFound("Member not found"));
     }
 
-    Ok(axum::http::StatusCode::OK)
+    Ok(EmptyResponse::OK)
 }

--- a/backend/src/handlers/sound_settings.rs
+++ b/backend/src/handlers/sound_settings.rs
@@ -1,4 +1,4 @@
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{extract::State, Json};
 use diesel::prelude::*;
 use shared::api::SoundSettingsResponse;
 use std::sync::Arc;
@@ -6,6 +6,7 @@ use tower_cookies::Cookies;
 
 use crate::auth::extract_user_id;
 use crate::errors::AppError;
+use crate::handlers::responses::EmptyResponse;
 use crate::AppState;
 
 pub async fn get_sound_settings(
@@ -30,7 +31,7 @@ pub async fn save_sound_settings(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
     Json(config): Json<serde_json::Value>,
-) -> Result<StatusCode, AppError> {
+) -> Result<EmptyResponse, AppError> {
     let user_id = extract_user_id(&app_state, &cookies)?;
 
     let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
@@ -41,5 +42,5 @@ pub async fn save_sound_settings(
         .execute(&mut conn)
         .map_err(|e| AppError::DbQuery(e.to_string()))?;
 
-    Ok(StatusCode::OK)
+    Ok(EmptyResponse::OK)
 }


### PR DESCRIPTION
## Summary
- add a shared EmptyResponse wrapper for handlers that return only a status
- convert backend success-only handlers to use named empty responses instead of raw StatusCode returns

## Tests
- cargo fmt --check
- cargo check -p backend
- cargo test -p backend handlers::sessions
- cargo test -p backend handlers::launchers
- cargo test -p backend handlers::proxy_tokens
- git diff --check