### PR TITLE
Add server-side paused sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.15"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.15"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.15"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.15"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.15"
+version = "2.6.17"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.15"
+version = "2.6.17"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.15"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.15"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.15"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.15"
+version = "2.6.17"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.15"
+version = "2.6.17"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/2026-05-28-153000_add_paused_sessions/down.sql
+++ b/backend/migrations/2026-05-28-153000_add_paused_sessions/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_sessions_paused;
+
+ALTER TABLE sessions
+    DROP COLUMN claude_args,
+    DROP COLUMN paused;

--- a/backend/migrations/2026-05-28-153000_add_paused_sessions/up.sql
+++ b/backend/migrations/2026-05-28-153000_add_paused_sessions/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sessions
+    ADD COLUMN paused BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN claude_args JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE INDEX idx_sessions_paused ON sessions(paused);

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -54,6 +54,7 @@ pub async fn launch_session(
         claude_args: req.claude_args,
         agent_type: req.agent_type,
         scheduled_task_id: None,
+        resume_session_id: None,
     };
 
     if !app_state

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -432,6 +432,8 @@ mod db_tests {
             agent_type: "claude".to_string(),
             repo_url: None,
             scheduled_task_id: None,
+            paused: false,
+            claude_args: serde_json::Value::Array(Vec::new()),
         };
         diesel::insert_into(sessions::table)
             .values(&new_session)

--- a/backend/src/handlers/session_access.rs
+++ b/backend/src/handlers/session_access.rs
@@ -239,6 +239,8 @@ mod db_tests {
             agent_type: "claude".to_string(),
             repo_url: None,
             scheduled_task_id: None,
+            paused: false,
+            claude_args: serde_json::Value::Array(Vec::new()),
         };
         diesel::insert_into(sessions::table)
             .values(&new_session)

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -185,6 +185,122 @@ pub async fn stop_session(
     }
 }
 
+pub async fn pause_session(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path(session_id): Path<Uuid>,
+) -> Result<EmptyResponse, AppError> {
+    let current_user_id = extract_user_id(&app_state, &cookies)?;
+
+    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    crate::handlers::session_access::verify_session_mutator(
+        &mut conn,
+        session_id,
+        current_user_id,
+    )?;
+
+    use crate::schema::sessions;
+    diesel::update(sessions::table.find(session_id))
+        .set((
+            sessions::paused.eq(true),
+            sessions::status.eq("disconnected"),
+            sessions::updated_at.eq(diesel::dsl::now),
+        ))
+        .execute(&mut conn)
+        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+
+    app_state.session_manager.disconnect_session(session_id);
+    app_state
+        .session_manager
+        .pause_session_on_launcher(session_id);
+
+    Ok(EmptyResponse::ACCEPTED)
+}
+
+pub async fn resume_session(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Path(session_id): Path<Uuid>,
+) -> Result<EmptyResponse, AppError> {
+    let current_user_id = extract_user_id(&app_state, &cookies)?;
+
+    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let session = crate::handlers::session_access::verify_session_mutator(
+        &mut conn,
+        session_id,
+        current_user_id,
+    )?;
+
+    let launcher_id = resolve_resume_launcher(&app_state, &session)
+        .ok_or(AppError::NotFound("Launcher not connected"))?;
+
+    let auth_token = crate::handlers::launchers::mint_launch_token(&app_state, session.user_id)?;
+    let request_id = Uuid::new_v4();
+    let claude_args =
+        serde_json::from_value::<Vec<String>>(session.claude_args.clone()).unwrap_or_default();
+    let agent_type = session
+        .agent_type
+        .parse()
+        .unwrap_or(shared::AgentType::Claude);
+
+    use crate::schema::sessions;
+    diesel::update(sessions::table.find(session_id))
+        .set((
+            sessions::paused.eq(false),
+            sessions::updated_at.eq(diesel::dsl::now),
+        ))
+        .execute(&mut conn)
+        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+
+    let launch_msg = shared::ServerToLauncher::LaunchSession {
+        request_id,
+        user_id: session.user_id,
+        auth_token,
+        working_directory: session.working_directory.clone(),
+        session_name: Some(session.session_name.clone()),
+        claude_args,
+        agent_type,
+        scheduled_task_id: session.scheduled_task_id,
+        resume_session_id: Some(session.id),
+    };
+
+    if !app_state
+        .session_manager
+        .send_to_launcher(&launcher_id, launch_msg)
+    {
+        let _ = diesel::update(sessions::table.find(session_id))
+            .set(sessions::paused.eq(true))
+            .execute(&mut conn);
+        return Err(AppError::Internal(
+            "Failed to send resume request to launcher".to_string(),
+        ));
+    }
+
+    Ok(EmptyResponse::ACCEPTED)
+}
+
+fn resolve_resume_launcher(app_state: &AppState, session: &Session) -> Option<Uuid> {
+    if let Some(launcher_id) = session.launcher_id {
+        if app_state
+            .session_manager
+            .launchers
+            .get(&launcher_id)
+            .is_some_and(|l| l.user_id == session.user_id)
+        {
+            return Some(launcher_id);
+        }
+    }
+
+    app_state
+        .session_manager
+        .launchers
+        .iter()
+        .find(|entry| {
+            entry.value().user_id == session.user_id && entry.value().hostname == session.hostname
+        })
+        .map(|entry| *entry.key())
+}
+
 // ============================================================================
 // Session Member Management
 // ============================================================================

--- a/backend/src/handlers/websocket/launcher_registry.rs
+++ b/backend/src/handlers/websocket/launcher_registry.rs
@@ -120,4 +120,19 @@ impl SessionManager {
         }
         false
     }
+
+    /// Stop a running process on its launcher without removing the launcher's
+    /// persisted expected-session metadata.
+    pub fn pause_session_on_launcher(&self, session_id: Uuid) -> bool {
+        for entry in self.launchers.iter() {
+            if entry.value().running_sessions.contains(&session_id) {
+                return entry
+                    .value()
+                    .sender
+                    .send(ServerToLauncher::PauseSession { session_id })
+                    .is_ok();
+            }
+        }
+        false
+    }
 }

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -439,11 +439,33 @@ fn handle_launcher_message(
             claude_args,
             agent_type,
             scheduled_task_id,
+            last_session_id,
         } => {
             info!(
                 "Launcher requested launch: dir={}, name={:?}",
                 working_directory, session_name
             );
+
+            if scheduled_task_id.is_none() {
+                if let Some(session_id) = last_session_id {
+                    match is_session_paused(app_state, session_id, user_id) {
+                        Ok(true) => {
+                            info!(
+                                "Skipping launcher auto-resume for paused session {}",
+                                session_id
+                            );
+                            return;
+                        }
+                        Ok(false) => {}
+                        Err(e) => {
+                            warn!(
+                                "Failed to check pause state for session {} before launch: {}",
+                                session_id, e
+                            );
+                        }
+                    }
+                }
+            }
             match crate::handlers::launchers::mint_launch_token(app_state, user_id) {
                 Ok(auth_token) => {
                     let launch_msg = ServerToLauncher::LaunchSession {
@@ -455,6 +477,7 @@ fn handle_launcher_message(
                         claude_args,
                         agent_type,
                         scheduled_task_id,
+                        resume_session_id: last_session_id,
                     };
                     if !app_state
                         .session_manager
@@ -604,6 +627,24 @@ fn handle_launcher_message(
         }
         LauncherToServer::LauncherRegister { .. } => {}
     }
+}
+
+fn is_session_paused(
+    app_state: &AppState,
+    session_id: Uuid,
+    user_id: Uuid,
+) -> Result<bool, String> {
+    use crate::schema::sessions;
+
+    let mut conn = app_state.db_pool.get().map_err(|e| e.to_string())?;
+    sessions::table
+        .find(session_id)
+        .filter(sessions::user_id.eq(user_id))
+        .select(sessions::paused)
+        .first::<bool>(&mut conn)
+        .optional()
+        .map(|value| value.unwrap_or(false))
+        .map_err(|e| e.to_string())
 }
 
 /// Mint a new 30-day token for a launcher, revoke the old one, and push it over WS.

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -127,6 +127,7 @@ fn handle_proxy_message(
             agent_type,
             repo_url,
             scheduled_task_id,
+            claude_args,
         }) => {
             let key = claude_session_id.to_string();
 
@@ -154,6 +155,7 @@ fn handle_proxy_message(
                 agent_type,
                 repo_url: &repo_url,
                 scheduled_task_id,
+                claude_args: &claude_args,
             };
             let result = register_or_update_session(app_state, &params);
 

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -35,6 +35,7 @@ pub struct RegistrationParams<'a> {
     pub agent_type: AgentType,
     pub repo_url: &'a Option<String>,
     pub scheduled_task_id: Option<Uuid>,
+    pub claude_args: &'a Vec<String>,
 }
 
 /// Register or update a session in the database.
@@ -133,12 +134,16 @@ pub fn register_or_update_session(
         match diesel::update(sessions::table.find(existing_session.id))
             .set((
                 sessions::status.eq("active"),
+                sessions::paused.eq(false),
                 sessions::last_activity.eq(diesel::dsl::now),
                 sessions::working_directory.eq(params.working_directory),
                 sessions::git_branch.eq(params.git_branch),
                 sessions::client_version.eq(params.client_version),
                 sessions::hostname.eq(params.hostname),
                 sessions::repo_url.eq(params.repo_url),
+                sessions::launcher_id.eq(params.launcher_id),
+                sessions::claude_args.eq(serde_json::to_value(params.claude_args)
+                    .unwrap_or_else(|_| serde_json::Value::Array(Vec::new()))),
             ))
             .execute(&mut conn)
         {
@@ -229,6 +234,9 @@ fn create_new_session(
         agent_type: params.agent_type.as_str().to_string(),
         repo_url: params.repo_url.clone(),
         scheduled_task_id: params.scheduled_task_id,
+        paused: false,
+        claude_args: serde_json::to_value(params.claude_args)
+            .unwrap_or_else(|_| serde_json::Value::Array(Vec::new())),
     };
 
     match diesel::insert_into(sessions::table)

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -210,6 +210,8 @@ mod replay_tests {
             agent_type: "claude".to_string(),
             repo_url: None,
             scheduled_task_id: None,
+            paused: false,
+            claude_args: serde_json::Value::Array(Vec::new()),
         };
         diesel::insert_into(sessions::table)
             .values(&new_session)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -442,6 +442,14 @@ async fn main() -> anyhow::Result<()> {
             "/api/sessions/{id}/stop",
             post(handlers::sessions::stop_session),
         )
+        .route(
+            "/api/sessions/{id}/pause",
+            post(handlers::sessions::pause_session),
+        )
+        .route(
+            "/api/sessions/{id}/resume",
+            post(handlers::sessions::resume_session),
+        )
         // Session member management routes
         .route(
             "/api/sessions/{id}/members",

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -56,6 +56,8 @@ pub struct Session {
     pub agent_type: String,
     pub repo_url: Option<String>,
     pub scheduled_task_id: Option<Uuid>,
+    pub paused: bool,
+    pub claude_args: serde_json::Value,
 }
 
 #[derive(Debug, Insertable)]
@@ -86,6 +88,8 @@ pub struct NewSessionWithId {
     pub agent_type: String,
     pub repo_url: Option<String>,
     pub scheduled_task_id: Option<Uuid>,
+    pub paused: bool,
+    pub claude_args: serde_json::Value,
 }
 
 #[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -139,6 +139,8 @@ diesel::table! {
         #[max_length = 512]
         repo_url -> Nullable<Varchar>,
         scheduled_task_id -> Nullable<Uuid>,
+        paused -> Bool,
+        claude_args -> Jsonb,
     }
 }
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -572,6 +572,7 @@ async fn register_session(
         agent_type: config.agent_type,
         repo_url: get_repo_url(&config.working_directory),
         scheduled_task_id: config.scheduled_task_id,
+        claude_args: config.claude_args.clone(),
     });
 
     if conn.send(register_msg).await.is_err() {

--- a/docs/SERVER_PAUSED_SESSIONS_WORKPLAN.md
+++ b/docs/SERVER_PAUSED_SESSIONS_WORKPLAN.md
@@ -1,0 +1,55 @@
+# Server-Side Paused Sessions Workplan
+
+## Goal
+
+Prevent launcher/backend restarts from automatically resuming Claude sessions that the user has paused in the dashboard. Paused sessions must remain resumable on demand, but should not spawn `claude --resume <session_id>` during reconnect/startup because that reloads the full conversation and burns many tokens.
+
+## Current State
+
+- Launcher persists restartable sessions locally in `launcher.json` as `ExpectedSession`.
+- On reconnect/startup, launcher asks the backend to relaunch every expected session.
+- If an expected session has a `session_id`, the proxy starts Claude in resume mode.
+- Dashboard "hidden" state is browser-local only, stored in `claude-portal-hidden-sessions`.
+- Backend and launcher do not know a session is hidden/paused.
+- Existing "Stop Session" terminates the process and removes the launcher expected-session entry, so it is not a resumable pause.
+
+## Target Design
+
+- Add a durable `sessions.paused` boolean owned by the backend.
+- Existing sessions are backfilled as paused by default so the first rollout
+  cannot accidentally auto-resume every historical session before the browser
+  has a chance to migrate its local state.
+- Add `sessions.claude_args` so the backend can relaunch a paused session without depending only on launcher-local metadata.
+- Add pause/resume APIs:
+  - `POST /api/sessions/:id/pause`
+  - `POST /api/sessions/:id/resume`
+- Pause:
+  - verifies mutator access;
+  - sets `paused = true`;
+  - stops the running process without removing the launcher's expected-session record.
+- Resume:
+  - verifies mutator access;
+  - sets `paused = false`;
+  - requests the owning launcher to launch the session in resume mode.
+- Launcher startup/reconnect:
+  - before relaunching an expected session, asks backend with `RequestLaunch { last_session_id }`;
+  - backend refuses paused sessions by returning a launch failure without sending `LaunchSession`.
+- Frontend:
+  - surfaces Pause/Resume in the session menu;
+  - includes paused sessions in the rail;
+  - migrates old browser state by resuming only sessions that were not in the
+    local hidden set, leaving hidden sessions paused.
+
+## Implementation Steps
+
+1. Add migration and model/shared fields for `paused` and `claude_args`.
+2. Extend launcher protocol with non-destructive pause and explicit resume launch metadata.
+3. Add backend endpoints and launcher gating.
+4. Update frontend session rail/dashboard behavior.
+5. Run `cargo fmt`, targeted backend/frontend checks, and protocol tests where practical.
+
+## Risk Notes
+
+- `launcher_id` is currently generated on launcher startup, so resuming after a launcher restart must target a currently connected launcher by hostname/user if the stored `launcher_id` is stale.
+- Existing launcher-local `ExpectedSession` remains the compatibility path; backend-owned resume metadata is additive.
+- Hidden and paused are related but not identical. The migration treats current hidden sessions as paused once to address the immediate token burn problem.

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -20,6 +20,8 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::MouseEvent;
 use yew::prelude::*;
 
+const PAUSED_DEFAULT_UNPAUSE_MIGRATION_KEY: &str = "claude-portal-paused-default-unpause-migrated";
+
 // =============================================================================
 // Dashboard Page - Main Orchestrating Component
 // =============================================================================
@@ -188,12 +190,12 @@ pub fn dashboard_page() -> Html {
         });
     }
 
-    // Get active sessions sorted by repo name, then hostname
-    // Disconnected sessions are completely hidden from the UI
+    // Get live or paused sessions sorted by repo name, then hostname.
+    // Disconnected unpaused sessions are hidden from the active dashboard.
     let active_sessions: Vec<SessionInfo> = {
         let mut sorted: Vec<SessionInfo> = sessions
             .iter()
-            .filter(|s| s.status.as_str() == "active")
+            .filter(|s| s.status.as_str() == "active" || s.paused)
             .cloned()
             .collect();
         sorted.sort_by(|a, b| {
@@ -244,6 +246,61 @@ pub fn dashboard_page() -> Html {
                 || ()
             },
         );
+    }
+
+    // One-time migration: the DB migration defaults existing sessions to
+    // paused. Restore the old browser-local visible set by resuming sessions
+    // that are not in the old hidden set.
+    {
+        let sessions = sessions.clone();
+        let hidden_sessions = (*hidden_sessions).clone();
+        let refresh = sessions_hook.refresh.clone();
+        use_effect_with((sessions.len(), hidden_sessions.len()), move |_| {
+            if !sessions.is_empty() {
+                if let Some(storage) =
+                    web_sys::window().and_then(|w| w.local_storage().ok().flatten())
+                {
+                    let already_migrated = storage
+                        .get_item(PAUSED_DEFAULT_UNPAUSE_MIGRATION_KEY)
+                        .ok()
+                        .flatten()
+                        .as_deref()
+                        == Some("true");
+                    if !already_migrated {
+                        let ids: Vec<Uuid> = sessions
+                            .iter()
+                            .filter(|s| !hidden_sessions.contains(&s.id) && s.paused)
+                            .map(|s| s.id)
+                            .collect();
+                        if ids.is_empty() {
+                            let _ = storage.set_item(PAUSED_DEFAULT_UNPAUSE_MIGRATION_KEY, "true");
+                        } else {
+                            spawn_local(async move {
+                                let mut all_ok = true;
+                                for id in ids {
+                                    let url =
+                                        utils::api_url(&format!("/api/sessions/{}/resume", id));
+                                    match Request::post(&url).send().await {
+                                        Ok(resp) if resp.status() == 202 => {}
+                                        _ => all_ok = false,
+                                    }
+                                }
+                                if all_ok {
+                                    if let Some(storage) = web_sys::window()
+                                        .and_then(|w| w.local_storage().ok().flatten())
+                                    {
+                                        let _ = storage
+                                            .set_item(PAUSED_DEFAULT_UNPAUSE_MIGRATION_KEY, "true");
+                                    }
+                                }
+                                refresh.emit(());
+                            });
+                        }
+                    }
+                }
+            }
+            || ()
+        });
     }
 
     // Auto-focus newly launched session when it appears in the session list
@@ -490,6 +547,43 @@ pub fn dashboard_page() -> Html {
                     }
                     Err(e) => {
                         log::error!("Failed to stop session: {:?}", e);
+                    }
+                }
+            });
+        })
+    };
+
+    let on_toggle_pause = {
+        let refresh = sessions_hook.refresh.clone();
+        let hidden_sessions = hidden_sessions.clone();
+        Callback::from(move |(session_id, pause): (Uuid, bool)| {
+            let refresh = refresh.clone();
+            let hidden_sessions = hidden_sessions.clone();
+            spawn_local(async move {
+                let action = if pause { "pause" } else { "resume" };
+                let url = utils::api_url(&format!("/api/sessions/{}/{}", session_id, action));
+                match Request::post(&url).send().await {
+                    Ok(resp) if resp.status() == 202 => {
+                        let mut set = (*hidden_sessions).clone();
+                        if pause {
+                            set.insert(session_id);
+                        } else {
+                            set.remove(&session_id);
+                        }
+                        save_hidden_sessions(&set);
+                        hidden_sessions.set(set);
+                        refresh.emit(());
+                    }
+                    Ok(resp) => {
+                        log::error!(
+                            "Failed to {} session {}: status {}",
+                            action,
+                            session_id,
+                            resp.status()
+                        );
+                    }
+                    Err(e) => {
+                        log::error!("Failed to {} session {}: {:?}", action, session_id, e);
                     }
                 }
             });
@@ -770,6 +864,7 @@ pub fn dashboard_page() -> Html {
                         on_toggle_hidden={on_toggle_hidden.clone()}
                         on_toggle_inactive_hidden={on_toggle_inactive_hidden.clone()}
                         on_stop={on_stop.clone()}
+                        on_toggle_pause={on_toggle_pause.clone()}
                     />
 
                     // Session views

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -221,6 +221,7 @@ pub struct SessionRailProps {
     pub on_toggle_hidden: Callback<Uuid>,
     pub on_toggle_inactive_hidden: Callback<MouseEvent>,
     pub on_stop: Callback<Uuid>,
+    pub on_toggle_pause: Callback<(Uuid, bool)>,
 }
 
 /// SessionRail - Horizontal carousel of session pills
@@ -379,6 +380,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     let dropdown_content = if let Some(session) = open_session {
         let is_hidden = props.hidden_sessions.contains(&session.id);
         let is_connected = props.connected_sessions.contains(&session.id);
+        let is_paused = session.paused;
 
         let on_stop = {
             let on_stop = props.on_stop.clone();
@@ -407,6 +409,16 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             })
         };
 
+        let on_toggle_pause = {
+            let on_toggle_pause = props.on_toggle_pause.clone();
+            let session_id = session.id;
+            let menu_session = menu_session.clone();
+            Callback::from(move |_: MouseEvent| {
+                on_toggle_pause.emit((session_id, !is_paused));
+                menu_session.set(None);
+            })
+        };
+
         let on_leave = {
             let on_leave = props.on_leave.clone();
             let session_id = session.id;
@@ -428,7 +440,29 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             "Hide from rotation"
         };
 
-        let stop_option = if is_connected && session.status == shared::SessionStatus::Active {
+        let pause_option = if session.my_role != "viewer" {
+            let (pause_label, pause_hint) = if is_paused {
+                ("Resume Session", "Restart from saved session")
+            } else {
+                ("Pause Session", "Stop and suppress auto-resume")
+            };
+            html! {
+                <button type="button"
+                    class={classes!("pill-menu-option", "pause", is_paused.then_some("active"))}
+                    onclick={on_toggle_pause}
+                >
+                    { pause_label }
+                    <span class="option-hint">{ pause_hint }</span>
+                </button>
+            }
+        } else {
+            html! {}
+        };
+
+        let stop_option = if !is_paused
+            && is_connected
+            && session.status == shared::SessionStatus::Active
+        {
             if *stop_has_tasks {
                 // Block stop — open schedule dialog so user can delete tasks first
                 let schedule_session = schedule_session.clone();
@@ -579,6 +613,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 { share_option }
                 { schedule_option }
                 { repo_option }
+                { pause_option }
                 <button
                     type="button"
                     class={classes!("pill-menu-option", "hide", is_hidden.then_some("active"))}
@@ -779,6 +814,8 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 {
                     if session.scheduled_task_id.is_some() {
                         html! { <span class="pill-agent-badge cron">{ "Cron" }</span> }
+                    } else if session.paused {
+                        html! { <span class="pill-agent-badge paused">{ "Paused" }</span> }
                     } else {
                         html! {}
                     }

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -62,6 +62,7 @@ pub fn connect_websocket(
                     agent_type: Default::default(),
                     repo_url: None,
                     scheduled_task_id: None,
+                    claude_args: Vec::new(),
                 });
 
                 if sender.send(register_msg).await.is_err() {

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -34,6 +34,7 @@ struct LauncherRowProps {
     launcher: LauncherInfo,
     on_renew: Callback<Uuid>,
     on_update: Callback<Uuid>,
+    update_in_progress: bool,
 }
 
 #[function_component(LauncherRow)]
@@ -42,8 +43,6 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
     let on_renew = props.on_renew.clone();
     let on_update = props.on_update.clone();
     let launcher_id = l.launcher_id;
-    // Triple-click confirmation. 0=idle, 1=first prod, 2=last warning, 3=firing.
-    let update_step = use_state(|| 0u8);
 
     let (status_class, status_text) = if let Some(ref exp) = l.token_expires_at {
         let days = days_until_expiration(exp);
@@ -73,24 +72,25 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
         on_renew.emit(launcher_id);
     });
 
-    let (update_label, update_class) = match *update_step {
-        0 => ("Update & Restart", "update-button stage-0"),
-        1 => ("Wait, really?", "update-button stage-1"),
-        2 => (
-            "Are you absolutely positively sure?",
-            "update-button stage-2",
-        ),
-        _ => ("Restarting…", "update-button stage-3"),
+    let (update_label, update_class) = if props.update_in_progress {
+        ("Restarting...", "update-button stage-3")
+    } else {
+        ("Update & Restart", "update-button stage-0")
     };
-    let update_disabled = *update_step >= 3;
 
     let on_update_click = {
-        let update_step = update_step.clone();
         let on_update = on_update.clone();
         Callback::from(move |_| {
-            let next = (*update_step).saturating_add(1);
-            update_step.set(next);
-            if next >= 3 {
+            let confirmed = web_sys::window()
+                .and_then(|window| {
+                    window
+                        .confirm_with_message(
+                            "Update this launcher to the latest release and restart it?",
+                        )
+                        .ok()
+                })
+                .unwrap_or(false);
+            if confirmed {
                 on_update.emit(launcher_id);
             }
         })
@@ -115,7 +115,7 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
                 <button
                     class={update_class}
                     onclick={on_update_click}
-                    disabled={update_disabled}
+                    disabled={props.update_in_progress}
                     title="Pull the latest agent-portal release and restart this launcher"
                 >
                     { update_label }
@@ -135,6 +135,7 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
     let launchers = use_state(Vec::<LauncherInfo>::new);
     let loading = use_state(|| true);
     let renew_result = use_state(|| None::<(bool, String)>);
+    let update_in_progress = use_state(|| None::<Uuid>);
 
     let fetch_launchers = {
         let launchers = launchers.clone();
@@ -203,9 +204,12 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
 
     let on_update = {
         let renew_result = renew_result.clone();
+        let update_in_progress = update_in_progress.clone();
         Callback::from(move |launcher_id: Uuid| {
             let renew_result = renew_result.clone();
+            let update_in_progress = update_in_progress.clone();
             spawn_local(async move {
+                update_in_progress.set(Some(launcher_id));
                 let url = utils::api_url(&format!("/api/launchers/{}/update", launcher_id));
                 match Request::post(&url).send().await {
                     Ok(resp) => {
@@ -226,6 +230,7 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
                         renew_result.set(Some((false, format!("Update request failed: {:?}", e))));
                     }
                 }
+                update_in_progress.set(None);
             });
         })
     };
@@ -277,6 +282,7 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
                                         launcher={l.clone()}
                                         on_renew={on_renew.clone()}
                                         on_update={on_update.clone()}
+                                        update_in_progress={*update_in_progress == Some(l.launcher_id)}
                                     />
                                 }
                             }) }

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -413,6 +413,11 @@
     background: rgba(125, 207, 255, 0.15);
 }
 
+.pill-agent-badge.paused {
+    color: #e0af68;
+    background: rgba(224, 175, 104, 0.15);
+}
+
 /* Version staleness badge */
 .pill-version-badge {
     font-size: 0.6rem;
@@ -660,4 +665,3 @@ a.pill-menu-option.pr-link:hover {
 .pill-share:active {
     background: rgba(122, 162, 247, 0.3);
 }
-

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -379,7 +379,7 @@
     background: var(--accent-hover);
 }
 
-/* Three-stage update-and-restart button — colors escalate to signal "are you sure?" */
+/* Update-and-restart button */
 .update-button {
     border: none;
     color: white;
@@ -396,13 +396,6 @@
 }
 .update-button.stage-0:hover {
     background: #565f89;
-}
-.update-button.stage-1 {
-    background: #e0af68;
-    color: #1a1b26;
-}
-.update-button.stage-2 {
-    background: var(--error);
 }
 .update-button.stage-3 {
     background: #565f89;
@@ -851,4 +844,3 @@
         rgba(255, 255, 255, 0.04) 8px
     );
 }
-

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -122,6 +122,7 @@ pub async fn run_launcher_loop(
                             claude_args: expected.claude_args.clone(),
                             agent_type: expected.agent_type,
                             scheduled_task_id: None,
+                            last_session_id: expected.session_id,
                         };
                         if ws_sender.send(request).await.is_err() {
                             warn!("Failed to send expected session launch request");
@@ -266,6 +267,7 @@ pub async fn run_launcher_loop(
                                 claude_args: session.claude_args,
                                 agent_type: session.agent_type,
                                 scheduled_task_id: None,
+                                last_session_id: session.session_id,
                             };
                             if ws_sender.send(request).await.is_err() {
                                 warn!("Failed to send session restart request");
@@ -287,6 +289,7 @@ pub async fn run_launcher_loop(
                                     claude_args: task_to_fire.config.claude_args.clone(),
                                     agent_type: task_to_fire.config.agent_type,
                                     scheduled_task_id: Some(task_to_fire.config.id),
+                                    last_session_id: task_to_fire.config.last_session_id,
                                 };
                                 if ws_sender.send(msg).await.is_err() {
                                     warn!("Failed to send RequestLaunch for scheduled task");
@@ -445,6 +448,7 @@ async fn handle_message(
             session_name,
             claude_args,
             agent_type,
+            resume_session_id,
             ..
         } => {
             // Check if this is a scheduled launch or a relaunch of an expected session
@@ -456,10 +460,12 @@ async fn handle_message(
             {
                 (resume_id, Some(task_id), true)
             } else {
-                let resume_id = expected_sessions
-                    .iter()
-                    .find(|s| s.working_directory == working_directory)
-                    .and_then(|s| s.session_id);
+                let resume_id = resume_session_id.or_else(|| {
+                    expected_sessions
+                        .iter()
+                        .find(|s| s.working_directory == working_directory)
+                        .and_then(|s| s.session_id)
+                });
                 (resume_id, None, false)
             };
 
@@ -544,6 +550,10 @@ async fn handle_message(
                     warn!("Failed to remove session from config: {}", e);
                 }
             }
+        }
+        ServerToLauncher::PauseSession { session_id } => {
+            info!("Pause request for session {}", session_id);
+            process_manager.stop(&session_id).await;
         }
         ServerToLauncher::ListDirectories { request_id, path } => {
             let response = list_directory(&path, request_id);

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -100,6 +100,7 @@ pub async fn register_with_backend(
         agent_type: config.agent_type,
         repo_url: get_repo_url(&config.working_directory),
         scheduled_task_id: config.scheduled_task_id,
+        claude_args: config.claude_args.clone(),
     });
 
     if let Err(e) = conn.send(&register_msg).await {

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -38,6 +38,8 @@ pub struct RegisterFields {
     pub repo_url: Option<String>,
     #[serde(default)]
     pub scheduled_task_id: Option<Uuid>,
+    #[serde(default)]
+    pub claude_args: Vec<String>,
 }
 
 /// Configuration for a scheduled task, sent from backend to launcher via ScheduleSync.
@@ -503,6 +505,11 @@ pub enum LauncherToServer {
         agent_type: AgentType,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         scheduled_task_id: Option<Uuid>,
+        /// Existing session this launch would resume, if this is a restart of
+        /// a launcher-persisted session. The backend uses this to suppress
+        /// auto-resume when the session is paused server-side.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        last_session_id: Option<Uuid>,
     },
 
     /// Inject input into a session on behalf of the scheduler
@@ -549,10 +556,18 @@ pub enum ServerToLauncher {
         agent_type: AgentType,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         scheduled_task_id: Option<Uuid>,
+        /// Specific existing session to resume. When omitted, the launcher may
+        /// use its local expected-session mapping for backwards compatibility.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        resume_session_id: Option<Uuid>,
     },
 
     /// Request to stop a running session
     StopSession { session_id: Uuid },
+
+    /// Pause a running session without deleting the launcher's persisted
+    /// expected-session metadata.
+    PauseSession { session_id: Uuid },
 
     /// Request directory listing
     ListDirectories { request_id: Uuid, path: String },
@@ -614,6 +629,7 @@ mod tests {
             agent_type: AgentType::Claude,
             repo_url: None,
             scheduled_task_id: None,
+            claude_args: Vec::new(),
         });
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"Register""#));
@@ -811,6 +827,7 @@ mod tests {
             claude_args: vec!["--verbose".into()],
             agent_type: AgentType::Claude,
             scheduled_task_id: None,
+            resume_session_id: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"LaunchSession""#));
@@ -853,6 +870,7 @@ mod tests {
             claude_args: vec!["--verbose".into()],
             agent_type: AgentType::Claude,
             scheduled_task_id: None,
+            last_session_id: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"RequestLaunch""#));

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -231,6 +231,13 @@ pub struct SessionInfo {
     /// Scheduled task ID if this session was spawned by a scheduled task
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scheduled_task_id: Option<Uuid>,
+    /// Server-side pause flag. Paused sessions are resumable on demand but
+    /// launchers must not auto-restart them during reconnect/startup.
+    #[serde(default)]
+    pub paused: bool,
+    /// Arguments used when launching the agent CLI.
+    #[serde(default)]
+    pub claude_args: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- add durable server-side paused session state and stored launch args
- suppress launcher auto-resume for paused sessions during reconnect/startup
- add dashboard Pause/Resume actions and migrate old local hidden state by resuming visible sessions
- fix launcher update button flow to use explicit confirmation and recover on request failures

## Verification
- cargo fmt --check
- ./scripts/check-migration-names.sh
- cargo check -p shared -p backend -p agent-portal -p claude-portal
- cargo check -p frontend --target wasm32-unknown-unknown
- cargo test -p shared --lib
- cargo clippy -p shared -p backend -p agent-portal -p claude-portal --all-targets -- -D warnings