### PR TITLE
Restore paused session rail behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.17"
+version = "2.6.18"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -167,19 +167,32 @@ pub async fn stop_session(
     // able to terminate sessions they only have read access to. The helper
     // also accepts the session's `sessions.user_id` owner row, so owners
     // without a `session_members` row still work.
-    crate::handlers::session_access::verify_session_mutator(
+    let session = crate::handlers::session_access::verify_session_mutator(
         &mut conn,
         session_id,
         current_user_id,
     )?;
 
     let stopped = app_state.session_manager.disconnect_session(session_id);
-    app_state
-        .session_manager
-        .stop_session_on_launcher(session_id);
+    let launcher_stopped = app_state.session_manager.stop_session_on_launcher(
+        session_id,
+        session.launcher_id,
+        Some(session.working_directory.clone()),
+    );
 
-    if stopped {
+    if stopped || launcher_stopped {
+        use crate::schema::sessions;
+        diesel::update(sessions::table.find(session_id))
+            .set((
+                sessions::paused.eq(false),
+                sessions::status.eq("disconnected"),
+                sessions::updated_at.eq(diesel::dsl::now),
+            ))
+            .execute(&mut conn)
+            .map_err(|e| AppError::DbQuery(e.to_string()))?;
         Ok(EmptyResponse::ACCEPTED)
+    } else if session.paused {
+        Err(AppError::NotFound("Launcher not connected"))
     } else {
         Err(AppError::NotFound("Session not connected"))
     }

--- a/backend/src/handlers/websocket/launcher_registry.rs
+++ b/backend/src/handlers/websocket/launcher_registry.rs
@@ -107,16 +107,26 @@ impl SessionManager {
     }
 
     /// Find the launcher running a given session and send StopSession to it.
+    /// If the session is paused, fall back to the persisted launcher id so
+    /// the launcher can remove its expected-session metadata by directory.
     /// Returns true if the message was sent successfully.
-    pub fn stop_session_on_launcher(&self, session_id: Uuid) -> bool {
+    pub fn stop_session_on_launcher(
+        &self,
+        session_id: Uuid,
+        launcher_id: Option<Uuid>,
+        working_directory: Option<String>,
+    ) -> bool {
+        let msg = || ServerToLauncher::StopSession {
+            session_id,
+            working_directory: working_directory.clone(),
+        };
         for entry in self.launchers.iter() {
             if entry.value().running_sessions.contains(&session_id) {
-                return entry
-                    .value()
-                    .sender
-                    .send(ServerToLauncher::StopSession { session_id })
-                    .is_ok();
+                return entry.value().sender.send(msg()).is_ok();
             }
+        }
+        if let Some(launcher_id) = launcher_id {
+            return self.send_to_launcher(&launcher_id, msg());
         }
         false
     }

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -20,8 +20,6 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::MouseEvent;
 use yew::prelude::*;
 
-const PAUSED_DEFAULT_UNPAUSE_MIGRATION_KEY: &str = "claude-portal-paused-default-unpause-migrated";
-
 // =============================================================================
 // Dashboard Page - Main Orchestrating Component
 // =============================================================================
@@ -213,10 +211,19 @@ pub fn dashboard_page() -> Html {
         sorted
     };
 
+    // Paused sessions follow the same frontend convention as manually hidden
+    // sessions: they remain available in the hidden rail section but do not
+    // participate in focus, activation, waiting counts, or keyboard rotation.
+    let effective_hidden_sessions: HashSet<Uuid> = {
+        let mut hidden = (*hidden_sessions).clone();
+        hidden.extend(active_sessions.iter().filter(|s| s.paused).map(|s| s.id));
+        hidden
+    };
+
     // On initial load, focus first non-hidden session and activate all non-hidden sessions
     {
         let active_sessions = active_sessions.clone();
-        let hidden_sessions = hidden_sessions.clone();
+        let effective_hidden_sessions = effective_hidden_sessions.clone();
         let focused_index = focused_index.clone();
         let initial_focus_set = initial_focus_set.clone();
         let activated_sessions = activated_sessions.clone();
@@ -227,7 +234,7 @@ pub fn dashboard_page() -> Html {
                 if !*initial_focus_set && !*is_loading && *session_count > 0 {
                     let first_non_hidden_idx = active_sessions
                         .iter()
-                        .position(|s| !hidden_sessions.contains(&s.id))
+                        .position(|s| !effective_hidden_sessions.contains(&s.id))
                         .unwrap_or(0);
 
                     focused_index.set(first_non_hidden_idx);
@@ -235,7 +242,7 @@ pub fn dashboard_page() -> Html {
                     // Activate all non-hidden sessions so they load in background
                     let mut activated = (*activated_sessions).clone();
                     for s in &active_sessions {
-                        if !hidden_sessions.contains(&s.id) {
+                        if !effective_hidden_sessions.contains(&s.id) {
                             activated.insert(s.id);
                         }
                     }
@@ -246,61 +253,6 @@ pub fn dashboard_page() -> Html {
                 || ()
             },
         );
-    }
-
-    // One-time migration: the DB migration defaults existing sessions to
-    // paused. Restore the old browser-local visible set by resuming sessions
-    // that are not in the old hidden set.
-    {
-        let sessions = sessions.clone();
-        let hidden_sessions = (*hidden_sessions).clone();
-        let refresh = sessions_hook.refresh.clone();
-        use_effect_with((sessions.len(), hidden_sessions.len()), move |_| {
-            if !sessions.is_empty() {
-                if let Some(storage) =
-                    web_sys::window().and_then(|w| w.local_storage().ok().flatten())
-                {
-                    let already_migrated = storage
-                        .get_item(PAUSED_DEFAULT_UNPAUSE_MIGRATION_KEY)
-                        .ok()
-                        .flatten()
-                        .as_deref()
-                        == Some("true");
-                    if !already_migrated {
-                        let ids: Vec<Uuid> = sessions
-                            .iter()
-                            .filter(|s| !hidden_sessions.contains(&s.id) && s.paused)
-                            .map(|s| s.id)
-                            .collect();
-                        if ids.is_empty() {
-                            let _ = storage.set_item(PAUSED_DEFAULT_UNPAUSE_MIGRATION_KEY, "true");
-                        } else {
-                            spawn_local(async move {
-                                let mut all_ok = true;
-                                for id in ids {
-                                    let url =
-                                        utils::api_url(&format!("/api/sessions/{}/resume", id));
-                                    match Request::post(&url).send().await {
-                                        Ok(resp) if resp.status() == 202 => {}
-                                        _ => all_ok = false,
-                                    }
-                                }
-                                if all_ok {
-                                    if let Some(storage) = web_sys::window()
-                                        .and_then(|w| w.local_storage().ok().flatten())
-                                    {
-                                        let _ = storage
-                                            .set_item(PAUSED_DEFAULT_UNPAUSE_MIGRATION_KEY, "true");
-                                    }
-                                }
-                                refresh.emit(());
-                            });
-                        }
-                    }
-                }
-            }
-            || ()
-        });
     }
 
     // Auto-focus newly launched session when it appears in the session list
@@ -369,7 +321,7 @@ pub fn dashboard_page() -> Html {
     let keyboard_nav = use_keyboard_nav(KeyboardNavConfig {
         sessions: active_sessions.clone(),
         focused_index: *focused_index,
-        hidden_sessions: (*hidden_sessions).clone(),
+        hidden_sessions: effective_hidden_sessions.clone(),
         connected_sessions: (*connected_sessions).clone(),
         inactive_hidden: *inactive_hidden,
         on_select: on_select_session.clone(),
@@ -668,7 +620,7 @@ pub fn dashboard_page() -> Html {
     // Computed values
     let waiting_count = awaiting_sessions
         .iter()
-        .filter(|id| !hidden_sessions.contains(id))
+        .filter(|id| !effective_hidden_sessions.contains(id))
         .count();
 
     // Update browser tab title
@@ -852,7 +804,7 @@ pub fn dashboard_page() -> Html {
                         sessions={active_sessions.clone()}
                         focused_index={*focused_index}
                         awaiting_sessions={(*awaiting_sessions).clone()}
-                        hidden_sessions={(*hidden_sessions).clone()}
+                        hidden_sessions={effective_hidden_sessions.clone()}
                         inactive_hidden={*inactive_hidden}
                         connected_sessions={(*connected_sessions).clone()}
                         nav_mode={keyboard_nav.nav_mode}

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -440,6 +440,26 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             "Hide from rotation"
         };
 
+        let hide_option = if is_paused {
+            html! {
+                <span class="pill-menu-option disabled">
+                    { "Hidden While Paused" }
+                    <span class="option-hint">{ "Resume to show in rotation" }</span>
+                </span>
+            }
+        } else {
+            html! {
+                <button
+                    type="button"
+                    class={classes!("pill-menu-option", "hide", is_hidden.then_some("active"))}
+                    onclick={on_hide}
+                >
+                    { hide_label }
+                    <span class="option-hint">{ hide_hint }</span>
+                </button>
+            }
+        };
+
         let pause_option = if session.my_role != "viewer" {
             let (pause_label, pause_hint) = if is_paused {
                 ("Resume Session", "Restart from saved session")
@@ -459,9 +479,8 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             html! {}
         };
 
-        let stop_option = if !is_paused
-            && is_connected
-            && session.status == shared::SessionStatus::Active
+        let stop_option = if is_paused
+            || (is_connected && session.status == shared::SessionStatus::Active)
         {
             if *stop_has_tasks {
                 // Block stop — open schedule dialog so user can delete tasks first
@@ -480,7 +499,14 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 }
             } else {
                 let (stop_label, stop_hint) = if confirming_stop {
-                    ("Click again to confirm", "This will terminate the process")
+                    let hint = if is_paused {
+                        "This will remove the saved launcher entry"
+                    } else {
+                        "This will terminate the process"
+                    };
+                    ("Click again to confirm", hint)
+                } else if is_paused {
+                    ("Stop Session", "Remove saved launcher entry")
                 } else {
                     ("Stop Session", "Terminate process")
                 };
@@ -614,14 +640,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 { schedule_option }
                 { repo_option }
                 { pause_option }
-                <button
-                    type="button"
-                    class={classes!("pill-menu-option", "hide", is_hidden.then_some("active"))}
-                    onclick={on_hide}
-                >
-                    { hide_label }
-                    <span class="option-hint">{ hide_hint }</span>
-                </button>
+                { hide_option }
                 { leave_option }
                 { stop_option }
             </>

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -540,9 +540,14 @@ async fn handle_message(
                 warn!("Failed to send launch session result");
             }
         }
-        ServerToLauncher::StopSession { session_id } => {
+        ServerToLauncher::StopSession {
+            session_id,
+            working_directory,
+        } => {
             info!("Stop request for session {}", session_id);
-            let working_dir = process_manager.session_working_directory(&session_id);
+            let working_dir = process_manager
+                .session_working_directory(&session_id)
+                .or(working_directory);
             process_manager.stop(&session_id).await;
             if let Some(dir) = working_dir {
                 expected_sessions.retain(|s| s.working_directory != dir);

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -562,8 +562,13 @@ pub enum ServerToLauncher {
         resume_session_id: Option<Uuid>,
     },
 
-    /// Request to stop a running session
-    StopSession { session_id: Uuid },
+    /// Request to stop a session and remove the launcher's persisted
+    /// expected-session metadata.
+    StopSession {
+        session_id: Uuid,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        working_directory: Option<String>,
+    },
 
     /// Pause a running session without deleting the launcher's persisted
     /// expected-session metadata.


### PR DESCRIPTION
## Summary
- treat paused sessions as hidden in the dashboard rail without auto-resuming them
- keep paused sessions available in the hidden rail section with clearer menu copy
- allow stopping paused sessions by removing the launcher expected-session entry
- bump workspace version to 2.6.18

## Verification
- cargo fmt --check
- cargo check -p shared -p backend -p agent-portal --all-targets
- cargo check -p frontend --target wasm32-unknown-unknown