### PR TITLE
Fix Codex branch refresh and read ticks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.18"
+version = "2.6.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.18"
+version = "2.6.19"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.18"
+version = "2.6.19"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.18"
+version = "2.6.19"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.18"
+version = "2.6.19"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.18"
+version = "2.6.19"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.18"
+version = "2.6.19"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.18"
+version = "2.6.19"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.18"
+version = "2.6.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.18"
+version = "2.6.19"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.18"
+version = "2.6.19"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/git_metadata.rs
+++ b/claude-session-lib/src/proxy_session/git_metadata.rs
@@ -1,0 +1,304 @@
+//! Git branch / PR metadata detection and session update emission.
+
+use std::sync::Arc;
+
+use claude_codes::io::ContentBlock;
+use claude_codes::ClaudeOutput;
+use shared::ProxyToServer;
+use tokio::sync::Mutex;
+use tracing::{debug, error};
+use uuid::Uuid;
+
+use super::SharedWsWrite;
+
+#[derive(Clone)]
+pub(super) struct GitMetadataState {
+    pub current_branch: Arc<Mutex<Option<String>>>,
+    pub current_pr_url: Arc<Mutex<Option<String>>>,
+    pub current_repo_url: Arc<Mutex<Option<String>>>,
+}
+
+impl GitMetadataState {
+    pub fn new(git_branch: Option<String>) -> Self {
+        Self {
+            current_branch: Arc::new(Mutex::new(git_branch)),
+            current_pr_url: Arc::new(Mutex::new(None)),
+            current_repo_url: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct GitRefreshTrigger {
+    message_count: u64,
+    pending_git_check: bool,
+}
+
+impl GitRefreshTrigger {
+    pub fn should_check_before_message(&mut self) -> bool {
+        self.message_count += 1;
+        let should_check = self.pending_git_check || self.message_count.is_multiple_of(100);
+        self.pending_git_check = false;
+        should_check
+    }
+
+    pub fn mark_git_signal(&mut self) {
+        self.pending_git_check = true;
+    }
+}
+
+/// Get the current git branch name, if in a git repository.
+pub(super) fn get_git_branch(cwd: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let branch = String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
+
+    if branch == "HEAD" {
+        std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .current_dir(cwd)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| format!("detached:{}", s.trim()))
+    } else {
+        Some(branch)
+    }
+}
+
+/// Look up the GitHub repository URL using the `gh` CLI.
+pub(super) fn get_repo_url(cwd: &str) -> Option<String> {
+    let output = std::process::Command::new("gh")
+        .args(["repo", "view", "--json", "url", "-q", ".url"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Look up the GitHub PR URL for a branch using the `gh` CLI.
+pub(super) fn get_pr_url(cwd: &str, branch: &str) -> Option<String> {
+    if branch == "main" || branch == "master" || branch.starts_with("detached:") {
+        return None;
+    }
+    let output = std::process::Command::new("gh")
+        .args(["pr", "view", branch, "--json", "url", "-q", ".url"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+pub(super) fn claude_output_has_git_signal(output: &ClaudeOutput) -> bool {
+    if let ClaudeOutput::User(user) = output {
+        for block in &user.message.content {
+            if let ContentBlock::ToolResult(tr) = block {
+                if tr
+                    .content
+                    .as_ref()
+                    .is_some_and(|content| text_has_git_signal(&format!("{:?}", content)))
+                {
+                    return true;
+                }
+            }
+        }
+    }
+
+    if let Some(bash) = output.as_tool_use("Bash") {
+        if let Some(claude_codes::tool_inputs::ToolInput::Bash(input)) = bash.typed_input() {
+            return text_has_git_signal(&input.command);
+        }
+    }
+    false
+}
+
+pub(super) fn codex_output_has_git_signal(value: &serde_json::Value) -> bool {
+    let Some(event_type) = value.get("type").and_then(|t| t.as_str()) else {
+        return false;
+    };
+    if !matches!(
+        event_type,
+        "item.started" | "item.updated" | "item.completed"
+    ) {
+        return false;
+    }
+
+    let Some(item) = value.get("item") else {
+        return false;
+    };
+    let Some(item_type) = item.get("type").and_then(|t| t.as_str()) else {
+        return false;
+    };
+    if item_type != "commandExecution" && item_type != "command_execution" {
+        return false;
+    }
+
+    item.get("command")
+        .and_then(|command| command.as_str())
+        .is_some_and(text_has_git_signal)
+        || item
+            .get("aggregatedOutput")
+            .or_else(|| item.get("aggregated_output"))
+            .and_then(|output| output.as_str())
+            .is_some_and(text_has_git_signal)
+}
+
+fn text_has_git_signal(text: &str) -> bool {
+    text.contains("git ")
+        || text.contains("gh ")
+        || text.contains("branch")
+        || text.contains("checkout")
+        || text.contains("merge")
+        || text.contains("rebase")
+        || text.contains("commit")
+}
+
+/// Check and send git branch, PR URL, or repo URL update if changed.
+pub(super) async fn check_and_send_branch_update(
+    ws_write: &SharedWsWrite,
+    session_id: Uuid,
+    working_directory: &str,
+    state: &GitMetadataState,
+) {
+    let new_branch = get_git_branch(working_directory);
+    let new_pr_url = new_branch
+        .as_deref()
+        .and_then(|b| get_pr_url(working_directory, b));
+    let new_repo_url = get_repo_url(working_directory);
+
+    let mut branch_guard = state.current_branch.lock().await;
+    let mut pr_guard = state.current_pr_url.lock().await;
+    let mut repo_guard = state.current_repo_url.lock().await;
+
+    let branch_changed = *branch_guard != new_branch;
+    let pr_changed = *pr_guard != new_pr_url;
+    let repo_changed = *repo_guard != new_repo_url;
+
+    if branch_changed || pr_changed || repo_changed {
+        if branch_changed {
+            debug!(
+                "Git branch changed: {:?} -> {:?}",
+                *branch_guard, new_branch
+            );
+        }
+        if pr_changed {
+            debug!("PR URL changed: {:?} -> {:?}", *pr_guard, new_pr_url);
+        }
+        *branch_guard = new_branch.clone();
+        *pr_guard = new_pr_url.clone();
+        *repo_guard = new_repo_url.clone();
+
+        drop(branch_guard);
+        drop(pr_guard);
+        drop(repo_guard);
+
+        let update_msg = ProxyToServer::SessionUpdate {
+            session_id,
+            git_branch: new_branch,
+            pr_url: new_pr_url,
+            repo_url: new_repo_url,
+        };
+
+        let mut ws = ws_write.lock().await;
+        if let Err(e) = ws.send(update_msg).await {
+            error!("Failed to send branch update: {}", e);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn codex_git_signal_detects_command_events() {
+        let value = json!({
+            "type": "item.completed",
+            "item": {
+                "type": "commandExecution",
+                "id": "cmd-1",
+                "command": "git checkout -b feature/codex-branch",
+                "aggregatedOutput": "",
+                "status": "completed"
+            }
+        });
+
+        assert!(codex_output_has_git_signal(&value));
+    }
+
+    #[test]
+    fn codex_git_signal_detects_snake_case_command_events() {
+        let value = json!({
+            "type": "item.updated",
+            "item": {
+                "type": "command_execution",
+                "id": "cmd-1",
+                "command": "printf done",
+                "aggregated_output": "switched to branch feature/test",
+                "status": "completed"
+            }
+        });
+
+        assert!(codex_output_has_git_signal(&value));
+    }
+
+    #[test]
+    fn codex_git_signal_ignores_non_command_events() {
+        let value = json!({
+            "type": "item.completed",
+            "item": {
+                "type": "agentMessage",
+                "id": "msg-1",
+                "text": "run git status next"
+            }
+        });
+
+        assert!(!codex_output_has_git_signal(&value));
+    }
+
+    #[test]
+    fn git_refresh_trigger_defers_after_git_signal() {
+        let mut trigger = GitRefreshTrigger::default();
+
+        assert!(!trigger.should_check_before_message());
+        trigger.mark_git_signal();
+        assert!(trigger.should_check_before_message());
+        assert!(!trigger.should_check_before_message());
+    }
+
+    #[test]
+    fn git_refresh_trigger_checks_every_hundred_messages() {
+        let mut trigger = GitRefreshTrigger::default();
+
+        for _ in 0..99 {
+            assert!(!trigger.should_check_before_message());
+        }
+        assert!(trigger.should_check_before_message());
+    }
+}

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -1,5 +1,6 @@
 //! Proxy session management and WebSocket connection handling.
 
+mod git_metadata;
 mod image_uploader;
 mod output_forwarder;
 mod portal_reminder;
@@ -22,7 +23,11 @@ use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use output_forwarder::{get_git_branch, get_pr_url, get_repo_url, spawn_output_forwarder};
+use git_metadata::{
+    check_and_send_branch_update, codex_output_has_git_signal, get_git_branch, get_pr_url,
+    get_repo_url, GitMetadataState, GitRefreshTrigger,
+};
+use output_forwarder::spawn_output_forwarder;
 use wiggum::{handle_session_event_with_wiggum, WiggumState};
 use ws_reader::{spawn_ws_reader, FileReceiveState, FileUploadEvent};
 
@@ -243,6 +248,8 @@ impl<'a, A: Agent> SessionState<'a, A> {
 /// Contains channels and state that are specific to a single connection attempt.
 /// Note: input_rx is passed separately as it persists across reconnections.
 struct ConnectionState {
+    /// Session id for metadata updates.
+    session_id: Uuid,
     /// Receiver for permission responses from frontend
     perm_rx: mpsc::UnboundedReceiver<PermissionResponseData>,
     /// Receiver for output acknowledgments from backend
@@ -275,6 +282,10 @@ struct ConnectionState {
     active_uploads: std::collections::HashMap<String, FileReceiveState>,
     /// Agent type for tagging per-message wire output (proxy emission side)
     agent_type: shared::AgentType,
+    /// Shared git metadata state for branch / PR / repo refreshes.
+    git_metadata: GitMetadataState,
+    /// Refresh cadence for Codex raw-output messages.
+    git_refresh: GitRefreshTrigger,
 }
 
 /// Run the WebSocket connection loop with auto-reconnect
@@ -669,9 +680,7 @@ async fn run_message_loop<A: Agent>(
     let (disconnect_tx, disconnect_rx) = tokio::sync::oneshot::channel::<()>();
 
     // Shared state for tracking git branch, PR URL, and repo URL updates
-    let current_branch = Arc::new(Mutex::new(config.git_branch.clone()));
-    let current_pr_url = Arc::new(Mutex::new(None::<String>));
-    let current_repo_url = Arc::new(Mutex::new(None::<String>));
+    let git_metadata = GitMetadataState::new(config.git_branch.clone());
 
     // Spawn output forwarder task with buffer
     let output_task = spawn_output_forwarder(
@@ -681,9 +690,7 @@ async fn run_message_loop<A: Agent>(
         config.backend_url.clone(),
         config.auth_token.clone(),
         config.working_directory.clone(),
-        current_branch,
-        current_pr_url,
-        current_repo_url,
+        git_metadata.clone(),
         session.output_buffer.clone(),
         max_image_mb,
         config.agent_type,
@@ -706,6 +713,7 @@ async fn run_message_loop<A: Agent>(
 
     // Create connection state (per-connection channels and timing)
     let mut conn_state = ConnectionState {
+        session_id,
         perm_rx,
         ack_rx,
         output_tx,
@@ -722,6 +730,8 @@ async fn run_message_loop<A: Agent>(
         working_directory: config.working_directory.clone(),
         active_uploads: std::collections::HashMap::new(),
         agent_type: config.agent_type,
+        git_metadata,
+        git_refresh: GitRefreshTrigger::default(),
     };
 
     // On the very first connection of this session, inject the portal
@@ -872,6 +882,19 @@ async fn run_main_loop<A: Agent>(
                 // Handle raw output directly (Codex JSONL) — bypasses the
                 // ClaudeOutput-typed output forwarder
                 if let Some(SessionEvent::RawOutput(ref value)) = event {
+                    if state.git_refresh.should_check_before_message() {
+                        check_and_send_branch_update(
+                            &state.ws_write,
+                            state.session_id,
+                            &state.working_directory,
+                            &state.git_metadata,
+                        )
+                        .await;
+                    }
+                    if codex_output_has_git_signal(value) {
+                        state.git_refresh.mark_git_signal();
+                    }
+
                     let is_codex_compaction = is_codex_compaction_event(value);
                     let seq = {
                         let mut buf = state.output_buffer.lock().await;

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -1,20 +1,22 @@
 //! Output forwarder task: forwards Claude outputs to WebSocket with sequencing.
 //!
-//! Also handles git branch detection, PR URL lookup, and image extraction.
+//! Also handles metadata refresh triggering and image extraction.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use base64::Engine;
 use claude_codes::io::{ContentBlock, ControlRequestPayload, ToolUseBlock};
 use claude_codes::ClaudeOutput;
 use shared::{AgentType, ProxyToServer};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use session_lib::output_buffer::PendingOutputBuffer;
 
+use super::git_metadata::{
+    check_and_send_branch_update, claude_output_has_git_signal, GitMetadataState, GitRefreshTrigger,
+};
 use super::image_uploader::upload_image;
 use super::{format_duration, truncate, SharedWsWrite};
 
@@ -35,45 +37,36 @@ pub fn spawn_output_forwarder(
     backend_url: String,
     auth_token: Option<String>,
     working_directory: String,
-    current_branch: Arc<Mutex<Option<String>>>,
-    current_pr_url: Arc<Mutex<Option<String>>>,
-    current_repo_url: Arc<Mutex<Option<String>>>,
-    output_buffer: Arc<Mutex<PendingOutputBuffer>>,
+    git_metadata: GitMetadataState,
+    output_buffer: std::sync::Arc<tokio::sync::Mutex<PendingOutputBuffer>>,
     max_image_mb: u32,
     agent_type: AgentType,
 ) -> tokio::task::JoinHandle<()> {
     let max_bytes = max_image_mb as usize * 1024 * 1024;
     tokio::spawn(async move {
-        let mut message_count: u64 = 0;
-        let mut pending_git_check = false;
+        let mut git_refresh = GitRefreshTrigger::default();
         // Track Read tool calls on image files: tool_use_id → file_path
         let mut image_read_map: HashMap<String, String> = HashMap::new();
 
         while let Some(output) = output_rx.recv().await {
-            message_count += 1;
-
             // Log detailed info about the message
             log_claude_output(&output);
 
             // Check for branch/PR update from PREVIOUS git command (deferred so
             // the command has finished executing before we query git/gh state)
-            let should_check_branch = pending_git_check || message_count.is_multiple_of(100);
-            if should_check_branch {
-                pending_git_check = false;
+            if git_refresh.should_check_before_message() {
                 check_and_send_branch_update(
                     &ws_write,
                     session_id,
                     &working_directory,
-                    &current_branch,
-                    &current_pr_url,
-                    &current_repo_url,
+                    &git_metadata,
                 )
                 .await;
             }
 
             // Check if THIS message is a git-related bash command (for next iteration)
-            if is_git_bash_command(&output) {
-                pending_git_check = true;
+            if claude_output_has_git_signal(&output) {
+                git_refresh.mark_git_signal();
             }
 
             // Track Read tool calls on image files from assistant messages
@@ -193,161 +186,6 @@ enum ImageWorkItem {
     },
     /// Image exceeded the hard cap; this is a textual rejection notice.
     TooLarge(shared::PortalMessage),
-}
-
-/// Get the current git branch name, if in a git repository
-pub(super) fn get_git_branch(cwd: &str) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(cwd)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let branch = String::from_utf8(output.stdout)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())?;
-
-    // If we're in detached HEAD state, get the short commit hash instead
-    if branch == "HEAD" {
-        std::process::Command::new("git")
-            .args(["rev-parse", "--short", "HEAD"])
-            .current_dir(cwd)
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| format!("detached:{}", s.trim()))
-    } else {
-        Some(branch)
-    }
-}
-
-/// Look up the GitHub repository URL using the `gh` CLI
-pub(super) fn get_repo_url(cwd: &str) -> Option<String> {
-    let output = std::process::Command::new("gh")
-        .args(["repo", "view", "--json", "url", "-q", ".url"])
-        .current_dir(cwd)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    String::from_utf8(output.stdout)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-}
-
-/// Look up the GitHub PR URL for a branch using the `gh` CLI
-pub(super) fn get_pr_url(cwd: &str, branch: &str) -> Option<String> {
-    if branch == "main" || branch == "master" || branch.starts_with("detached:") {
-        return None;
-    }
-    let output = std::process::Command::new("gh")
-        .args(["pr", "view", branch, "--json", "url", "-q", ".url"])
-        .current_dir(cwd)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    String::from_utf8(output.stdout)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-}
-
-/// Check if a tool use is a Bash command containing "git"
-fn is_git_bash_command(output: &ClaudeOutput) -> bool {
-    if let ClaudeOutput::User(user) = output {
-        for block in &user.message.content {
-            if let ContentBlock::ToolResult(tr) = block {
-                if let Some(ref content) = tr.content {
-                    let content_str = format!("{:?}", content);
-                    if content_str.contains("git ")
-                        || content_str.contains("gh ")
-                        || content_str.contains("branch")
-                        || content_str.contains("checkout")
-                        || content_str.contains("merge")
-                        || content_str.contains("rebase")
-                        || content_str.contains("commit")
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-    // Also check if an assistant message contains a Bash tool_use with git
-    if let Some(bash) = output.as_tool_use("Bash") {
-        if let Some(claude_codes::tool_inputs::ToolInput::Bash(input)) = bash.typed_input() {
-            if input.command.contains("git ") || input.command.contains("gh ") {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// Check and send git branch or PR URL update if changed
-async fn check_and_send_branch_update(
-    ws_write: &SharedWsWrite,
-    session_id: Uuid,
-    working_directory: &str,
-    current_branch: &Arc<Mutex<Option<String>>>,
-    current_pr_url: &Arc<Mutex<Option<String>>>,
-    current_repo_url: &Arc<Mutex<Option<String>>>,
-) {
-    let new_branch = get_git_branch(working_directory);
-    let new_pr_url = new_branch
-        .as_deref()
-        .and_then(|b| get_pr_url(working_directory, b));
-    let new_repo_url = get_repo_url(working_directory);
-
-    let mut branch_guard = current_branch.lock().await;
-    let mut pr_guard = current_pr_url.lock().await;
-    let mut repo_guard = current_repo_url.lock().await;
-
-    let branch_changed = *branch_guard != new_branch;
-    let pr_changed = *pr_guard != new_pr_url;
-    let repo_changed = *repo_guard != new_repo_url;
-
-    if branch_changed || pr_changed || repo_changed {
-        if branch_changed {
-            debug!(
-                "Git branch changed: {:?} -> {:?}",
-                *branch_guard, new_branch
-            );
-        }
-        if pr_changed {
-            debug!("PR URL changed: {:?} -> {:?}", *pr_guard, new_pr_url);
-        }
-        *branch_guard = new_branch.clone();
-        *pr_guard = new_pr_url.clone();
-        *repo_guard = new_repo_url.clone();
-
-        // Drop locks before acquiring ws lock
-        drop(branch_guard);
-        drop(pr_guard);
-        drop(repo_guard);
-
-        let update_msg = ProxyToServer::SessionUpdate {
-            session_id,
-            git_branch: new_branch,
-            pr_url: new_pr_url,
-            repo_url: new_repo_url,
-        };
-
-        let mut ws = ws_write.lock().await;
-        if let Err(e) = ws.send(update_msg).await {
-            error!("Failed to send branch update: {}", e);
-        }
-    }
 }
 
 /// Return the MIME type for a supported image extension, or None.

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -23,6 +23,10 @@ pub(crate) enum ActivityTag {
     Assistant,
     /// User input echo (Claude `user`).
     User,
+    /// File-read style tool output. Uses the same green tick as Claude's
+    /// user-shaped read tool-result envelope without participating in
+    /// pending-send reconciliation as a real user echo.
+    Read,
     /// End-of-turn result/summary (Claude `result`, Codex `turn.completed`).
     Result,
     /// Portal frame (connect/disconnect/reconnect notices, raw frame
@@ -55,7 +59,7 @@ impl ActivityTag {
     pub fn tick_css(self) -> Option<&'static str> {
         match self {
             Self::Assistant => Some("assistant"),
-            Self::User => Some("user"),
+            Self::User | Self::Read => Some("user"),
             Self::Result => Some("result"),
             Self::Portal => Some("portal"),
             Self::Error => Some("error"),
@@ -227,6 +231,9 @@ fn classify_codex_event(output: &str) -> Option<ActivityTag> {
         | CodexEvent::ItemUpdated { item: Some(item) }
         | CodexEvent::ItemCompleted { item: Some(item) } => match item {
             ThreadItem::Error(_) => Some(ActivityTag::Error),
+            ThreadItem::CommandExecution(ref it) if command_execution_reads_file(&it.command) => {
+                Some(ActivityTag::Read)
+            }
             ThreadItem::AgentMessage(_)
             | ThreadItem::Reasoning(_)
             | ThreadItem::CommandExecution(_)
@@ -247,6 +254,28 @@ fn classify_codex_event(output: &str) -> Option<ActivityTag> {
         // so emit no sparkline tick.
         _ => None,
     }
+}
+
+fn command_execution_reads_file(command: &str) -> bool {
+    let command = command.trim();
+    if command.is_empty() {
+        return false;
+    }
+
+    let normalized = command.replace("\\\"", "\"");
+    is_numbered_line_read(&normalized) || is_sed_print_read(&normalized)
+}
+
+fn is_numbered_line_read(command: &str) -> bool {
+    command.contains("nl -ba ") && command.contains("| sed -n ")
+}
+
+fn is_sed_print_read(command: &str) -> bool {
+    if command.contains("sed -i") || !command.contains("sed -n ") {
+        return false;
+    }
+
+    command.contains('p')
 }
 
 /// Inject `_created_at` (and optionally `_sender`) metadata into a wire-JSON
@@ -367,6 +396,7 @@ mod tests {
         // test pins both sides.
         assert_eq!(ActivityTag::Assistant.tick_css(), Some("assistant"));
         assert_eq!(ActivityTag::User.tick_css(), Some("user"));
+        assert_eq!(ActivityTag::Read.tick_css(), Some("user"));
         assert_eq!(ActivityTag::Result.tick_css(), Some("result"));
         assert_eq!(ActivityTag::Portal.tick_css(), Some("portal"));
         assert_eq!(ActivityTag::Error.tick_css(), Some("error"));
@@ -386,6 +416,7 @@ mod tests {
         assert!(ActivityTag::TaskStart.is_range_marker());
         assert!(ActivityTag::TaskEnd.is_range_marker());
         assert!(!ActivityTag::Assistant.is_range_marker());
+        assert!(!ActivityTag::Read.is_range_marker());
         assert!(!ActivityTag::Unknown.is_range_marker());
 
         assert!(ActivityTag::CompactionStart.is_compaction_start());
@@ -443,6 +474,25 @@ mod tests {
         // Tool-use lifecycle events count as "agent working" for sparkline
         // purposes — same color as the agent's text reply.
         let json = r#"{"type":"item.started","item":{"type":"command_execution","id":"c1","command":"echo hi","status":"in_progress"}}"#;
+        assert_eq!(classify_output_msg_type(json), ActivityTag::Assistant);
+    }
+
+    #[test]
+    fn classify_codex_numbered_file_read_command_is_read() {
+        let json = r#"{"type":"item.completed","item":{"type":"command_execution","id":"c1","command":"/bin/bash -lc \"nl -ba claude-session-lib/src/proxy_session/output_forwarder.rs | sed -n '45,82p'\"","aggregated_output":"45\tlet max_bytes = max_image_mb;","exit_code":0,"status":"completed"}}"#;
+        assert_eq!(classify_output_msg_type(json), ActivityTag::Read);
+        assert_eq!(classify_output_msg_type(json).tick_css(), Some("user"));
+    }
+
+    #[test]
+    fn classify_codex_sed_print_file_read_command_is_read() {
+        let json = r#"{"type":"item.completed","item":{"type":"command_execution","id":"c1","command":"sed -n '1,40p' frontend/src/pages/dashboard/session_view/helpers.rs","aggregated_output":"//! Pure helpers","exit_code":0,"status":"completed"}}"#;
+        assert_eq!(classify_output_msg_type(json), ActivityTag::Read);
+    }
+
+    #[test]
+    fn classify_codex_non_read_command_execution_stays_assistant() {
+        let json = r#"{"type":"item.completed","item":{"type":"command_execution","id":"c1","command":"cargo test -p frontend","aggregated_output":"ok","exit_code":0,"status":"completed"}}"#;
         assert_eq!(classify_output_msg_type(json), ActivityTag::Assistant);
     }
 


### PR DESCRIPTION
## Summary
- Extract git branch / PR / repo metadata refresh into shared proxy-session helper code
- Wire Codex raw output through the same branch refresh cadence and git-command detection as Claude
- Classify Codex shell file-read commands as green read ticks in the session rail
- Bump workspace version to 2.6.19

## Tests
- cargo fmt --check
- cargo test -p claude-session-lib
- cargo test -p frontend session_view::helpers
- cargo clippy -p claude-session-lib --all-targets -- -D warnings
- cargo clippy -p frontend --all-targets -- -D warnings