### PR TITLE
Fix Codex session resume: actually re-attach to prior app-server thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ frontend/dist/
 *.db
 *.db-shm
 *.db-wal
+
+# Per-session worktrees created by the agent harness
+.claude/worktrees/
+
+# Stray files
+First Article*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.9
+
+- **Codex session resume re-attaches to the prior app-server thread.** Codex launches now persist the app-server `thread_id` and pass it back through `thread/resume` when a session is resumed. Standalone proxy sessions store the id in their directory-session config, launcher sessions store it in a sidecar `codex_threads.json`, and resume falls back to a fresh `thread_start` if the prior thread cannot be reopened.
+
 ## 2.8.7
 
 - **Strip a trailing `` (deleted)`` from `current_exe()` before baking it into the service unit.** On Linux `current_exe()` reads `/proc/self/exe`; per `proc(5)`, once the running binary's inode is unlinked (which `agent-portal update` does by replacing it in place) the kernel appends a literal `` (deleted)``. `service::sync()` then wrote `ExecStart=.../agent-portal (deleted) --no-update`, so the next restart handed `(deleted)` to clap as a subcommand (`unrecognized subcommand`) — a fast restart loop and an offline launcher. `launcher/src/service.rs` now routes its four `current_exe()` consumers through one helper that strips the suffix.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.8"
+version = "2.8.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.8"
+version = "2.8.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.8"
+version = "2.8.9"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.8"
+version = "2.8.9"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.8"
+version = "2.8.9"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.8"
+version = "2.8.9"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.8"
+version = "2.8.9"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.8"
+version = "2.8.9"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.8"
+version = "2.8.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.8"
+version = "2.8.9"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.8"
+version = "2.8.9"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -41,6 +41,14 @@ type SharedWsWrite = Arc<tokio::sync::Mutex<ws_bridge::WsSender<ProxyToServer>>>
 /// Type alias for the WebSocket read half
 type WsRead = ws_bridge::WsReceiver<ServerToProxy>;
 
+/// Sink for codex thread-id persistence. The proxy crate owns the
+/// `ProxyConfig` JSON file; this callback lets the session loop hand the
+/// learned thread id back without claude-session-lib having to depend on
+/// proxy internals. Called at most once per spawn, from the
+/// `SessionEvent::CodexThreadId` arm. `None` is a no-op (the codex
+/// io-task still emits the event, the loop just doesn't persist it).
+pub type CodexThreadIdSink = Arc<dyn Fn(String) + Send + Sync>;
+
 /// Configuration for a proxy session
 #[derive(Clone)]
 pub struct ProxySessionConfig {
@@ -61,6 +69,9 @@ pub struct ProxySessionConfig {
     pub agent_type: shared::AgentType,
     /// If this session was started by a scheduled task
     pub scheduled_task_id: Option<Uuid>,
+    /// Persist-back closure for the codex app-server thread id; see
+    /// [`CodexThreadIdSink`] doc.
+    pub codex_thread_id_sink: Option<CodexThreadIdSink>,
 }
 
 /// Exponential backoff helper
@@ -300,6 +311,10 @@ struct ConnectionState {
     git_metadata: GitMetadataState,
     /// Refresh cadence for Codex raw-output messages.
     git_refresh: GitRefreshTrigger,
+    /// Persist-back closure for the codex app-server thread id; see
+    /// [`CodexThreadIdSink`] doc. Cloned out of `ProxySessionConfig` so
+    /// the per-connection state doesn't need to carry a config reference.
+    codex_thread_id_sink: Option<CodexThreadIdSink>,
 }
 
 /// Run the WebSocket connection loop with auto-reconnect
@@ -748,6 +763,7 @@ async fn run_message_loop<A: Agent>(
         agent_type: config.agent_type,
         git_metadata,
         git_refresh: GitRefreshTrigger::default(),
+        codex_thread_id_sink: config.codex_thread_id_sink.clone(),
     };
 
     // On the very first connection of this session, inject the portal
@@ -984,6 +1000,18 @@ async fn run_main_loop<A: Agent>(
                     if ws.send(msg).await.is_err() {
                         error!("Failed to send turn metrics report");
                         return ConnectionResult::Disconnected(state.connection_start.elapsed());
+                    }
+                    continue;
+                }
+
+                // Codex app-server thread id: hand it to the persistence
+                // sink (the proxy's ProxyConfig writer) so the next resume
+                // of this session can call `thread/resume` with it.
+                // Emitted once per spawn by codex-session-lib. No-op for
+                // claude sessions (claude doesn't emit it).
+                if let Some(SessionEvent::CodexThreadId(thread_id)) = event {
+                    if let Some(sink) = state.codex_thread_id_sink.as_ref() {
+                        sink(thread_id);
                     }
                     continue;
                 }

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -236,6 +236,12 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
                 "TurnMetricsReady should be handled before calling handle_session_event_with_wiggum"
             );
         }
+        Some(SessionEvent::CodexThreadId(_)) => {
+            // Handled in run_main_loop before calling this function
+            unreachable!(
+                "CodexThreadId should be handled before calling handle_session_event_with_wiggum"
+            );
+        }
         Some(SessionEvent::Error(e)) => {
             let err_msg = e.to_string();
             error!("Session error: {}", err_msg);

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -9,8 +9,8 @@ use std::path::Path;
 use std::time::Instant;
 
 use codex_codes::{
-    AppServerBuilder, AsyncClient as CodexAsyncClient, ThreadStartParams, TurnInterruptParams,
-    TurnStartParams, UserInput,
+    methods, AppServerBuilder, AsyncClient as CodexAsyncClient, ThreadResumeParams,
+    ThreadResumeResponse, ThreadStartParams, TurnInterruptParams, TurnStartParams, UserInput,
 };
 use session_lib::error::SessionError;
 use session_lib::io::{IoCommand, IoEvent};
@@ -97,33 +97,102 @@ pub(crate) async fn codex_io_task(
         }
     };
 
-    // Start a thread (conversation session). codex-codes 0.129.3 removed
-    // the `Default` impl on `ThreadStartParams` (15 Option<...> fields,
-    // all skip_serializing_if Some); the SDK's idiom for an "empty"
-    // params is round-tripping through `{}` JSON. See codex-codes
-    // 0.129.3 src/lib.rs:18-30 example.
-    let thread_params = empty_thread_start_params();
-    let (thread_id, thread_model) = match client.thread_start(&thread_params).await {
-        Ok(resp) => {
-            let model = non_empty_string(resp.model).or_else(|| configured_model_fallback.clone());
-            if model.is_none() {
-                tracing::warn!(
-                    "Codex thread {} started without a detectable model; turn metrics will warn until model metadata is available",
-                    resp.thread.id
-                );
+    // Re-attach to a prior codex thread when this is a resume launch
+    // (`config.resume == true`) and the proxy persisted a thread id from
+    // the previous incarnation. codex-codes 0.129.3 doesn't expose a
+    // typed `thread_resume` helper on AsyncClient yet — only
+    // `thread_start` / `turn_*` / `thread_archive` — so we drive the
+    // JSON-RPC call directly via the low-level `request<P, R>` primitive
+    // using `methods::THREAD_RESUME`. Upstream issue filed against
+    // meawoppl/rust-code-agent-sdks for the missing helper.
+    let mut resumed_thread: Option<(String, Option<String>)> = None;
+    if config.resume {
+        if let Some(prior) = config.codex_thread_id.as_ref() {
+            let resume_params = ThreadResumeParams {
+                thread_id: prior.clone(),
+                approval_policy: None,
+                approvals_reviewer: None,
+                base_instructions: None,
+                config: None,
+                // Leave cwd as None on resume — the app-server stored the
+                // thread's working directory at first launch and we don't
+                // want to override it from the launcher's POV.
+                cwd: None,
+                developer_instructions: None,
+                model: None,
+                model_provider: None,
+                personality: None,
+                sandbox: None,
+                service_tier: None,
+            };
+            match client
+                .request::<_, ThreadResumeResponse>(methods::THREAD_RESUME, &resume_params)
+                .await
+            {
+                Ok(resp) => {
+                    tracing::info!("Codex thread resumed: {}", prior);
+                    let model =
+                        non_empty_string(resp.model).or_else(|| configured_model_fallback.clone());
+                    resumed_thread = Some((prior.clone(), model));
+                }
+                Err(e) => {
+                    // Fall through to `thread_start`. Common failure
+                    // modes: the codex binary upgraded across a thread
+                    // storage breaking change, or the thread was archived
+                    // out of band. Don't lose the session — just strip
+                    // server-side context. The transcript is rehydrated
+                    // by the backend's message-replay path independently.
+                    tracing::warn!(
+                        "Codex thread/resume of {} failed: {} — falling back to fresh thread_start",
+                        prior,
+                        e
+                    );
+                }
             }
-            (resp.thread.id.clone(), model)
+        } else {
+            tracing::info!(
+                "Codex resume requested but no prior thread_id is known — starting fresh thread"
+            );
         }
-        Err(e) => {
-            let _ = event_tx.send(IoEvent::Error(SessionError::CommunicationError(format!(
-                "Failed to start Codex thread: {}",
-                e
-            ))));
-            return;
+    }
+
+    let (thread_id, thread_model) = match resumed_thread {
+        Some(thread) => thread,
+        None => {
+            // codex-codes 0.129.3 removed the `Default` impl on
+            // `ThreadStartParams` (15 Option<...> fields, all
+            // skip_serializing_if Some); the SDK's idiom for an "empty"
+            // params is round-tripping through `{}` JSON. See codex-codes
+            // 0.129.3 src/lib.rs:18-30 example.
+            let thread_params = empty_thread_start_params();
+            match client.thread_start(&thread_params).await {
+                Ok(resp) => {
+                    let model =
+                        non_empty_string(resp.model).or_else(|| configured_model_fallback.clone());
+                    if model.is_none() {
+                        tracing::warn!(
+                            "Codex thread {} started without a detectable model; turn metrics will warn until model metadata is available",
+                            resp.thread.id
+                        );
+                    }
+                    (resp.thread.id.clone(), model)
+                }
+                Err(e) => {
+                    let _ = event_tx.send(IoEvent::Error(SessionError::CommunicationError(
+                        format!("Failed to start Codex thread: {}", e),
+                    )));
+                    return;
+                }
+            }
         }
     };
 
-    tracing::info!("Codex thread started: {}", thread_id);
+    tracing::info!("Codex thread ready: {}", thread_id);
+
+    // Surface the thread id to the proxy so it can persist it for the
+    // next resume of this session. Emitted once per spawn after either
+    // thread_start or thread/resume returns.
+    let _ = event_tx.send(IoEvent::CodexThreadId(thread_id.clone()));
 
     let _ = event_tx.send(IoEvent::RawOutput(to_raw_output(&ThreadStartedEvent::new(
         &thread_id,

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -5,11 +5,56 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
+use claude_session_lib::proxy_session::CodexThreadIdSink;
 use claude_session_lib::{
     run_connection_loop, ClaudeAgent, LoopResult, PortalInput, ProxySessionConfig,
 };
 use codex_session_lib::CodexAgent;
 use session_lib::{Session, SessionConfig};
+
+/// Path to the launcher's sidecar codex-thread map: `session_id -> thread_id`.
+/// Lives next to `launcher.json` in `ProjectDirs` so it ships with the same
+/// install/uninstall surface and survives across restarts.
+fn codex_threads_path() -> PathBuf {
+    directories::ProjectDirs::from("com", "anthropic", "agent-portal")
+        .map(|p| p.config_dir().to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("/tmp/agent-portal"))
+        .join("codex_threads.json")
+}
+
+fn load_codex_threads() -> HashMap<Uuid, String> {
+    std::fs::read_to_string(codex_threads_path())
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_codex_threads(map: &HashMap<Uuid, String>) -> std::io::Result<()> {
+    let path = codex_threads_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let body = serde_json::to_string_pretty(map)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(path, body)
+}
+
+fn load_codex_thread_id(session_id: Uuid) -> Option<String> {
+    load_codex_threads().get(&session_id).cloned()
+}
+
+fn make_codex_thread_id_sink(session_id: Uuid) -> CodexThreadIdSink {
+    std::sync::Arc::new(move |thread_id: String| {
+        let mut map = load_codex_threads();
+        map.insert(session_id, thread_id);
+        if let Err(e) = save_codex_threads(&map) {
+            warn!(
+                "Failed to persist codex thread id for session {}: {}",
+                session_id, e
+            );
+        }
+    })
+}
 
 /// Notification that a session task has finished.
 pub struct SessionExited {
@@ -128,6 +173,11 @@ impl ProcessManager {
             launcher_id: self.launcher_id,
             agent_type: params.agent_type,
             scheduled_task_id: params.scheduled_task_id,
+            // Persist the codex app-server thread id under the launcher's
+            // session_id key so the next resume of this session can call
+            // thread/resume. No-op for claude sessions (the codex io-task
+            // is the only emitter).
+            codex_thread_id_sink: Some(make_codex_thread_id_sink(session_id)),
         };
 
         let exit_tx = self.exit_tx.clone();
@@ -217,6 +267,15 @@ async fn run_session_task(
     cancel: CancellationToken,
 ) -> Option<i32> {
     loop {
+        // On resume, look up the codex app-server thread id we persisted
+        // on the previous launch. Missing entry / claude sessions yield
+        // `None` and the codex io-task falls back to `thread_start`.
+        let codex_thread_id = if config.resume {
+            load_codex_thread_id(config.session_id)
+        } else {
+            None
+        };
+
         let session_config = SessionConfig {
             session_id: config.session_id,
             working_directory: PathBuf::from(&config.working_directory),
@@ -225,6 +284,7 @@ async fn run_session_task(
             claude_path: None,
             extra_args: config.claude_args.clone(),
             agent_type: config.agent_type,
+            codex_thread_id,
         };
 
         let mut session = match AnySession::new(session_config).await {

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -31,6 +31,14 @@ pub struct DirectorySession {
     pub created_at: String,
     /// Last time this session was used
     pub last_used: String,
+    /// Codex app-server thread id, learned from `thread.started` on the
+    /// first launch of a codex session and written back here so the next
+    /// resume can call `thread/resume` with it. Ignored / absent for
+    /// claude sessions (claude resumes via `--resume <session_id>` which
+    /// doesn't need a separate identifier). `#[serde(default)]` keeps
+    /// existing config files on disk readable without manual migration.
+    #[serde(default)]
+    pub codex_thread_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -286,6 +294,7 @@ impl ProxyConfig {
             session_name,
             created_at: now.clone(),
             last_used: now,
+            codex_thread_id: None,
         }
     }
 }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -18,7 +18,7 @@ use shared::api::{ResolveProxySessionRequest, ResolveProxySessionResponse};
 /// Type alias — the proxy binary only ever drives Claude sessions; the
 /// launcher is where heterogeneous (Claude + Codex) dispatch lives.
 type ClaudeSession = Session<ClaudeAgent>;
-use config::{ProxyConfig, SessionAuth};
+use config::{DirectorySession, ProxyConfig, SessionAuth};
 use session::ProxySessionConfig;
 use tracing::{info, warn};
 use tracing_subscriber::prelude::*;
@@ -395,6 +395,45 @@ async fn main() -> Result<()> {
         info!("Detected git branch: {}", branch);
     }
 
+    // Persist-back sink for the codex thread id learned from
+    // `thread.started` / `thread/resume`. The closure captures the
+    // working directory so it can stamp the right DirectorySession row;
+    // load+update+save is atomic via `ProxyConfig::load_locked`. No-op
+    // path for claude sessions (the codex io-task is the only emitter).
+    let codex_thread_id_sink: claude_session_lib::proxy_session::CodexThreadIdSink = {
+        let cwd_for_sink = cwd.clone();
+        std::sync::Arc::new(move |thread_id: String| {
+            let (mut cfg, lock) = match ProxyConfig::load_locked() {
+                Ok(pair) => pair,
+                Err(e) => {
+                    warn!("codex_thread_id_sink: load_locked failed: {}", e);
+                    return;
+                }
+            };
+            let updated = match cfg.get_directory_session(&cwd_for_sink) {
+                Some(existing) => DirectorySession {
+                    codex_thread_id: Some(thread_id),
+                    ..existing.clone()
+                },
+                None => {
+                    // Directory record vanished between launch and the
+                    // codex thread.started event — unusual but recoverable.
+                    // Skip rather than fabricate a session_id row that
+                    // doesn't match the in-memory session.
+                    warn!(
+                        "codex_thread_id_sink: no DirectorySession for {:?}, skipping persist",
+                        cwd_for_sink
+                    );
+                    return;
+                }
+            };
+            cfg.set_directory_session(cwd_for_sink.clone(), updated);
+            if let Err(e) = cfg.save_with_lock(&lock) {
+                warn!("codex_thread_id_sink: save_with_lock failed: {}", e);
+            }
+        })
+    };
+
     // Build session config
     let session_config = ProxySessionConfig {
         backend_url,
@@ -409,6 +448,7 @@ async fn main() -> Result<()> {
         launcher_id: None,
         agent_type,
         scheduled_task_id: None,
+        codex_thread_id_sink: Some(codex_thread_id_sink),
     };
 
     // Branch: shim mode or normal proxy mode
@@ -760,6 +800,16 @@ async fn run_proxy_session(mut config: ProxySessionConfig) -> Result<()> {
 
 /// Create a Claude session using claude-session-lib
 async fn create_claude_session(config: &ProxySessionConfig) -> Result<ClaudeSession> {
+    // For codex resumes we need to hand the io-task the app-server
+    // thread id from the prior incarnation. Load it from the per-directory
+    // record the proxy persisted on the previous launch. Missing on a
+    // fresh launch, missing for claude sessions — both fine, the codex
+    // io-task gates resume on `Some` + `config.resume`.
+    let codex_thread_id = ProxyConfig::load().ok().and_then(|cfg| {
+        cfg.get_directory_session(&config.working_directory)
+            .and_then(|s| s.codex_thread_id.clone())
+    });
+
     let claude_config = SessionConfig {
         session_id: config.session_id,
         working_directory: PathBuf::from(&config.working_directory),
@@ -768,6 +818,7 @@ async fn create_claude_session(config: &ProxySessionConfig) -> Result<ClaudeSess
         claude_path: None,
         extra_args: config.claude_args.clone(),
         agent_type: config.agent_type,
+        codex_thread_id,
     };
 
     if config.resume {

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -59,6 +59,13 @@ pub enum IoEvent {
     /// ship to the backend as `ProxyToServer::TurnMetricsReport`. Emitted
     /// once per finalize by the agent-specific I/O task.
     TurnMetricsReady(Box<TurnMetrics>),
+    /// The codex io-task learned (or re-confirmed) the app-server thread
+    /// id for this session — emitted exactly once per spawn after
+    /// `thread_start` / `thread/resume` returns. The proxy persists the
+    /// value into `ProxyConfig.directory_sessions[wd].codex_thread_id` so
+    /// the next launch of the same session can pass it back through
+    /// `SessionConfig.codex_thread_id` to drive `thread/resume`.
+    CodexThreadId(String),
     Error(SessionError),
     Exited {
         code: i32,
@@ -100,6 +107,10 @@ pub enum SessionEvent {
     /// to the backend as `ProxyToServer::TurnMetricsReport`. See PR-1
     /// design doc / `shared::TurnMetrics` for field semantics.
     TurnMetricsReady(Box<TurnMetrics>),
+
+    /// Codex app-server thread id, surfaced by the codex io-task so the
+    /// proxy can persist it. See `IoEvent::CodexThreadId`.
+    CodexThreadId(String),
 }
 
 /// Response to a permission request.

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -236,6 +236,9 @@ impl<A: Agent> Session<A> {
                 Some(IoEvent::TurnMetricsReady(metrics)) => {
                     return Some(SessionEvent::TurnMetricsReady(metrics));
                 }
+                Some(IoEvent::CodexThreadId(thread_id)) => {
+                    return Some(SessionEvent::CodexThreadId(thread_id));
+                }
                 Some(IoEvent::Exited { code }) => {
                     self.state = SessionState::Exited { code };
                     self.command_tx = None;

--- a/session-lib/src/snapshot.rs
+++ b/session-lib/src/snapshot.rs
@@ -26,6 +26,15 @@ pub struct SessionConfig {
     /// Which agent CLI to use
     #[serde(default)]
     pub agent_type: shared::AgentType,
+    /// Codex thread id from a prior incarnation of this session, learned
+    /// from `thread.started` on first launch and persisted by the proxy.
+    /// Consumed by the codex io-task: when `resume == true` and this is
+    /// `Some`, call `thread/resume` to re-attach to the app-server's
+    /// existing thread context rather than starting a fresh one.
+    /// Ignored by the claude path (claude's resume keys off `session_id`
+    /// directly via `--resume`).
+    #[serde(default)]
+    pub codex_thread_id: Option<String>,
 }
 
 /// A pending permission request that hasn't been responded to
@@ -104,6 +113,7 @@ mod tests {
             claude_path: None,
             extra_args: vec![],
             agent_type: Default::default(),
+            codex_thread_id: None,
         }
     }
 


### PR DESCRIPTION
## Summary

`SessionConfig.resume: bool` was plumbed end-to-end from launcher → process manager → `codex_io_task`, but **`codex-session-lib/src/io_task.rs:98-100` unconditionally called `client.thread_start(&ThreadStartParams::from(json!({})))` on every spawn** — no branch on `config.resume`, no use of `config.session_id`. Net effect: a "resume" on a Codex session was indistinguishable from a fresh launch — new thread, no prior server-side context.

Compare claude-session-lib/src/spawn.rs:34 which does it right:
```rust
if config.resume { cmd.arg("--resume").arg(config.session_id.to_string()); }
```

## Three-layer fix

**1. Plumb `codex_thread_id: Option<String>` through `SessionConfig`** (`session-lib/src/snapshot.rs`) — input to the io-task indicating which thread to resume. `#[serde(default)]` for forward-compat with existing snapshots.

**2. `codex_io_task` branches** — when `config.resume && config.codex_thread_id.is_some()`, call the JSON-RPC `thread/resume` method via the low-level `AsyncClient::request<P, R>` primitive:
```rust
client.request::<_, ThreadResumeResponse>(methods::THREAD_RESUME, &ThreadResumeParams { thread_id, .. })
```
codex-codes 0.129.3 exposes `ThreadResumeParams` / `ThreadResumeResponse` and `methods::THREAD_RESUME = "thread/resume"` but **no typed `thread_resume(...)` helper on `AsyncClient`** — only `thread_start` / `turn_*` / `thread_archive` / `initialize`. Upstream issue filed against `meawoppl/rust-code-agent-sdks` for the missing helper; this PR uses the low-level primitive in the meantime.

On resume failure (codex binary upgraded across a thread-storage breaking change, thread archived out of band, etc.): `tracing::warn!` and fall through to `thread_start` so the session is never lost — just stripped of server-side context. The transcript is still rehydrated by the backend's message-replay path.

**3. Persist the learned thread id back** — new `IoEvent::CodexThreadId(String)` → `SessionEvent::CodexThreadId(String)` variants surface the thread id to the proxy on every spawn (after either `thread_start` *or* `thread/resume`). New `CodexThreadIdSink = Arc<dyn Fn(String) + Send + Sync>` callback field on `ProxySessionConfig` lets each consumer wire its own persistence:

| Consumer | Where the thread id lives |
|---|---|
| Standalone proxy binary (`claude-portal`) | New `codex_thread_id: Option<String>` field on `ProxyConfig::DirectorySession` — sits alongside the existing per-directory session metadata in `~/.config/agent-portal/config.json`. |
| Launcher daemon (`agent-portal`) | Sidecar `codex_threads.json` keyed by `session_id`, in the launcher's `ProjectDirs` config dir alongside `launcher.json`. |

On next resume: standalone proxy's `create_claude_session` reads `ProxyConfig::DirectorySession.codex_thread_id` for the working directory; launcher's `run_session_task` reads the json sidecar for the session_id. Either way, the io-task sees `config.codex_thread_id = Some(...)` and `config.resume = true`, takes the `thread/resume` branch, and the user gets their conversation context back.

`wiggum.rs` gains a `SessionEvent::CodexThreadId(_)` → `unreachable!(...)` arm matching the existing pattern for `RawOutput` / `TurnMetricsReady` (mod.rs main loop handles these before delegating to wiggum).

## Follow-ups (deliberately out of scope)

- **Multi-machine resume** needs backend-authoritative storage — a `codex_thread_id` column on `sessions` and a `codex_thread_id` field on `ServerToLauncher::LaunchSession`. The current per-installation-local store works for the common case but doesn't survive launcher swaps.
- Once upstream `meawoppl/rust-code-agent-sdks` lands the typed `AsyncClient::thread_resume(...)` helper, switch from the low-level `request<_, _>` to the typed call.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --workspace` — 17 test groups, 532 individual tests pass
- [ ] Manual: start a codex session, send a turn, kill the proxy, restart via launcher resume, verify the agent remembers the prior turn's context (and `tracing::info!("Codex thread resumed: ...")` shows in launcher logs).
- [ ] Manual: forge a stale `codex_thread_id` in `codex_threads.json` (e.g. random `th_xxx`), resume — verify the `tracing::warn!` fallback to `thread_start` fires and the session still starts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)