### PR TITLE
Clean expired proxy tokens independently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.19"
+version = "2.6.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.19"
+version = "2.6.20"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.19"
+version = "2.6.20"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.19"
+version = "2.6.20"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.19"
+version = "2.6.20"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.19"
+version = "2.6.20"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.19"
+version = "2.6.20"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.19"
+version = "2.6.20"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.19"
+version = "2.6.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.19"
+version = "2.6.20"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.19"
+version = "2.6.20"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -669,6 +669,19 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
+    // Spawn background task for expired proxy token cleanup (runs every hour)
+    {
+        let app_state = app_state.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600));
+            loop {
+                interval.tick().await;
+                run_expired_token_cleanup(&app_state).await;
+            }
+        });
+        tracing::info!("Started expired proxy token cleanup task (every hour)");
+    }
+
     // Run the server with graceful shutdown
     let addr = format!("{}:{}", host, port);
 
@@ -897,8 +910,24 @@ async fn run_session_age_cleanup(app_state: &Arc<AppState>) {
         deleted,
         max_days
     );
+}
 
-    // Also clean up tokens expired more than 7 days ago
+/// Delete proxy auth tokens whose expiration is more than 7 days in the past.
+async fn run_expired_token_cleanup(app_state: &Arc<AppState>) {
+    use diesel::prelude::*;
+
+    let Ok(mut conn) = app_state.db_pool.get() else {
+        tracing::error!("Failed to get DB connection for expired token cleanup");
+        return;
+    };
+
+    if let Err(e) = diesel::sql_query("SET LOCAL statement_timeout = '5000'").execute(&mut conn) {
+        tracing::warn!(
+            "Failed to set statement_timeout for expired token cleanup: {}",
+            e
+        );
+    }
+
     let token_cutoff = chrono::Utc::now().naive_utc() - chrono::Duration::days(7);
     match diesel::delete(
         schema::proxy_auth_tokens::table


### PR DESCRIPTION
## Summary
- Run expired proxy-token cleanup as its own hourly backend task instead of only after session-age cleanup finds old sessions.
- Keep the existing 7-day grace period for expired credentials.
- Bump workspace version to 2.6.20.

## Why
The Settings page says credentials expired for more than 7 days are automatically deleted, but that cleanup was placed after an early return in `run_session_age_cleanup`. If there were no old sessions, expired credentials were never removed, so one-day `launcher-spawned` tokens accumulated.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo check -p backend`