### PR TITLE
Make session database authoritative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.20"
+version = "2.6.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.20"
+version = "2.6.21"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.20"
+version = "2.6.21"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.20"
+version = "2.6.21"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.20"
+version = "2.6.21"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.20"
+version = "2.6.21"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.20"
+version = "2.6.21"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.20"
+version = "2.6.21"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.20"
+version = "2.6.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.20"
+version = "2.6.21"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.20"
+version = "2.6.21"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/2026-05-28-170000_reset_sessions_for_db_authority/down.sql
+++ b/backend/migrations/2026-05-28-170000_reset_sessions_for_db_authority/down.sql
@@ -1,0 +1,2 @@
+-- Irreversible data reset. Session rows deleted by the up migration cannot be
+-- reconstructed from the remaining schema.

--- a/backend/migrations/2026-05-28-170000_reset_sessions_for_db_authority/up.sql
+++ b/backend/migrations/2026-05-28-170000_reset_sessions_for_db_authority/up.sql
@@ -1,0 +1,7 @@
+-- Reset legacy split-brain session state.
+--
+-- After this migration the backend database is the authority for which
+-- launcher-backed sessions should run. Existing sessions were created under
+-- the old launcher-local expected-session model, so keep users/credentials/
+-- scheduled task definitions but clear session rows and their dependent data.
+DELETE FROM sessions;

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -2,6 +2,7 @@ use axum::{
     extract::{Path, Query, State},
     Json,
 };
+use diesel::prelude::*;
 use serde::Deserialize;
 use shared::api::LaunchRequest;
 use shared::{DirectoryEntry, LauncherInfo, LauncherToServer, ServerToLauncher};
@@ -14,6 +15,7 @@ use crate::auth::extract_user_id;
 use crate::errors::AppError;
 use crate::handlers::responses::EmptyResponse;
 use crate::handlers::websocket::SessionManager;
+use crate::models::{NewSessionMember, NewSessionWithId};
 use crate::AppState;
 
 /// GET /api/launchers - List connected launchers for the current user
@@ -40,27 +42,61 @@ pub async fn launch_session(
     let user_id = extract_user_id(&app_state, &cookies)?;
 
     let launcher_id = resolve_launch_target(&app_state.session_manager, req.launcher_id, user_id)?;
+    let (hostname, version) = {
+        let launcher = app_state
+            .session_manager
+            .launchers
+            .get(&launcher_id)
+            .ok_or(AppError::NotFound("Launcher not found"))?;
+        (launcher.hostname.clone(), launcher.version.clone())
+    };
 
     // Create a fresh short-lived proxy token for the child process
     let auth_token = mint_launch_token(&app_state, user_id)?;
 
     let request_id = Uuid::new_v4();
+    let session_id = Uuid::new_v4();
+    create_desired_session(
+        &app_state,
+        DesiredSessionDraft {
+            session_id,
+            user_id,
+            working_directory: req.working_directory.clone(),
+            hostname,
+            launcher_id: Some(launcher_id),
+            client_version: Some(version),
+            agent_type: req.agent_type,
+            claude_args: req.claude_args.clone(),
+        },
+    )?;
+    app_state
+        .session_manager
+        .pending_launch_sessions
+        .insert(request_id, session_id);
+
     let launch_msg = ServerToLauncher::LaunchSession {
         request_id,
         user_id,
         auth_token,
         working_directory: req.working_directory.clone(),
-        session_name: None,
+        session_name: Some(default_session_name(&req.working_directory)),
         claude_args: req.claude_args,
         agent_type: req.agent_type,
         scheduled_task_id: None,
-        resume_session_id: None,
+        resume_session_id: Some(session_id),
     };
 
     if !app_state
         .session_manager
         .send_to_launcher(&launcher_id, launch_msg)
     {
+        app_state
+            .session_manager
+            .pending_launch_sessions
+            .remove(&request_id);
+        let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+        use crate::schema::sessions;
+        let _ = diesel::delete(sessions::table.find(session_id)).execute(&mut conn);
         error!("Failed to send launch request to launcher {}", launcher_id);
         return Err(AppError::Internal(
             "Failed to send launch request".to_string(),
@@ -73,6 +109,72 @@ pub async fn launch_session(
     );
 
     Ok(Json(LaunchResponse { request_id }))
+}
+
+fn default_session_name(working_directory: &str) -> String {
+    std::path::Path::new(working_directory)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or(working_directory)
+        .to_string()
+}
+
+pub(crate) struct DesiredSessionDraft {
+    session_id: Uuid,
+    user_id: Uuid,
+    working_directory: String,
+    hostname: String,
+    launcher_id: Option<Uuid>,
+    client_version: Option<String>,
+    agent_type: shared::AgentType,
+    claude_args: Vec<String>,
+}
+
+pub(crate) fn create_desired_session(
+    app_state: &AppState,
+    draft: DesiredSessionDraft,
+) -> Result<(), AppError> {
+    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+
+    use crate::schema::{session_members, sessions};
+    use diesel::prelude::*;
+
+    let session_name = default_session_name(&draft.working_directory);
+    let new_session = NewSessionWithId {
+        id: draft.session_id,
+        user_id: draft.user_id,
+        session_name,
+        session_key: draft.session_id.to_string(),
+        working_directory: draft.working_directory,
+        status: "disconnected".to_string(),
+        git_branch: None,
+        client_version: draft.client_version,
+        hostname: draft.hostname,
+        launcher_id: draft.launcher_id,
+        agent_type: draft.agent_type.as_str().to_string(),
+        repo_url: None,
+        scheduled_task_id: None,
+        paused: false,
+        claude_args: serde_json::to_value(&draft.claude_args)
+            .unwrap_or_else(|_| serde_json::Value::Array(Vec::new())),
+    };
+
+    diesel::insert_into(sessions::table)
+        .values(&new_session)
+        .execute(&mut conn)
+        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+
+    diesel::insert_into(session_members::table)
+        .values(NewSessionMember {
+            session_id: draft.session_id,
+            user_id: draft.user_id,
+            role: "owner".to_string(),
+        })
+        .execute(&mut conn)
+        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+
+    Ok(())
 }
 
 fn resolve_launch_target(

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -148,6 +148,13 @@ pub async fn delete_session(
             .ok_or(AppError::NotFound("Session not found"))?,
     };
 
+    app_state.session_manager.disconnect_session(session_id);
+    app_state.session_manager.stop_session_on_launcher(
+        session_id,
+        session.launcher_id,
+        Some(session.working_directory.clone()),
+    );
+
     super::helpers::delete_session_with_data(&mut conn, &session, true)
         .map_err(|e| AppError::Internal(format!("{:?}", e)))?;
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -353,6 +353,11 @@ fn handle_launcher_message(
             pid,
             ref error,
         } => {
+            let desired_session_id = app_state
+                .session_manager
+                .pending_launch_sessions
+                .remove(&request_id)
+                .map(|(_, id)| id);
             if success {
                 info!(
                     "Launch succeeded: request={}, session={:?}, pid={:?}",
@@ -360,6 +365,22 @@ fn handle_launcher_message(
                 );
             } else {
                 warn!("Launch failed: request={}, error={:?}", request_id, error);
+                if let Some(session_id) = desired_session_id {
+                    if let Ok(mut conn) = app_state.db_pool.get() {
+                        use crate::schema::sessions;
+                        use diesel::prelude::*;
+                        if let Err(e) = diesel::update(sessions::table.find(session_id))
+                            .set((
+                                sessions::paused.eq(true),
+                                sessions::status.eq("disconnected"),
+                                sessions::updated_at.eq(diesel::dsl::now),
+                            ))
+                            .execute(&mut conn)
+                        {
+                            warn!("Failed to mark failed launch {} paused: {}", session_id, e);
+                        }
+                    }
+                }
             }
             // Forward to web clients as ServerToClient
             app_state.session_manager.broadcast_to_user(
@@ -397,6 +418,7 @@ fn handle_launcher_message(
                     }
                 }
             }
+            reconcile_desired_sessions(app_state, launcher_id, user_id);
         }
         LauncherToServer::ProxyLog {
             session_id,
@@ -448,15 +470,22 @@ fn handle_launcher_message(
 
             if scheduled_task_id.is_none() {
                 if let Some(session_id) = last_session_id {
-                    match is_session_paused(app_state, session_id, user_id) {
-                        Ok(true) => {
+                    match get_session_paused(app_state, session_id, user_id) {
+                        Ok(Some(true)) => {
                             info!(
                                 "Skipping launcher auto-resume for paused session {}",
                                 session_id
                             );
                             return;
                         }
-                        Ok(false) => {}
+                        Ok(Some(false)) => {}
+                        Ok(None) => {
+                            info!(
+                                "Skipping launcher auto-resume for deleted session {}",
+                                session_id
+                            );
+                            return;
+                        }
                         Err(e) => {
                             warn!(
                                 "Failed to check pause state for session {} before launch: {}",
@@ -629,11 +658,11 @@ fn handle_launcher_message(
     }
 }
 
-fn is_session_paused(
+fn get_session_paused(
     app_state: &AppState,
     session_id: Uuid,
     user_id: Uuid,
-) -> Result<bool, String> {
+) -> Result<Option<bool>, String> {
     use crate::schema::sessions;
 
     let mut conn = app_state.db_pool.get().map_err(|e| e.to_string())?;
@@ -643,8 +672,101 @@ fn is_session_paused(
         .select(sessions::paused)
         .first::<bool>(&mut conn)
         .optional()
-        .map(|value| value.unwrap_or(false))
         .map_err(|e| e.to_string())
+}
+
+fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: Uuid) {
+    use crate::models::Session;
+    use crate::schema::sessions;
+    use diesel::prelude::*;
+
+    let running_sessions = app_state
+        .session_manager
+        .launchers
+        .get(&launcher_id)
+        .map(|launcher| launcher.running_sessions.clone())
+        .unwrap_or_default();
+
+    let Ok(mut conn) = app_state.db_pool.get() else {
+        warn!("Failed to get DB connection for desired-session reconciliation");
+        return;
+    };
+
+    let desired: Vec<Session> = match sessions::table
+        .filter(sessions::user_id.eq(user_id))
+        .filter(sessions::launcher_id.eq(launcher_id))
+        .filter(sessions::paused.eq(false))
+        .filter(sessions::scheduled_task_id.is_null())
+        .filter(sessions::status.ne("replaced"))
+        .select(Session::as_select())
+        .load(&mut conn)
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            warn!(
+                "Failed to load desired sessions for launcher {}: {}",
+                launcher_id, e
+            );
+            return;
+        }
+    };
+
+    for session in desired {
+        if running_sessions.contains(&session.id)
+            || app_state
+                .session_manager
+                .pending_launch_sessions
+                .iter()
+                .any(|entry| *entry.value() == session.id)
+        {
+            continue;
+        }
+
+        let Ok(auth_token) = crate::handlers::launchers::mint_launch_token(app_state, user_id)
+        else {
+            warn!("Failed to mint token for desired session {}", session.id);
+            continue;
+        };
+
+        let request_id = Uuid::new_v4();
+        app_state
+            .session_manager
+            .pending_launch_sessions
+            .insert(request_id, session.id);
+
+        let claude_args =
+            serde_json::from_value::<Vec<String>>(session.claude_args.clone()).unwrap_or_default();
+        let agent_type = session
+            .agent_type
+            .parse()
+            .unwrap_or(shared::AgentType::Claude);
+
+        let launch_msg = ServerToLauncher::LaunchSession {
+            request_id,
+            user_id,
+            auth_token,
+            working_directory: session.working_directory.clone(),
+            session_name: Some(session.session_name.clone()),
+            claude_args,
+            agent_type,
+            scheduled_task_id: None,
+            resume_session_id: Some(session.id),
+        };
+
+        if !app_state
+            .session_manager
+            .send_to_launcher(&launcher_id, launch_msg)
+        {
+            app_state
+                .session_manager
+                .pending_launch_sessions
+                .remove(&request_id);
+            warn!(
+                "Failed to send desired session {} to launcher {}",
+                session.id, launcher_id
+            );
+        }
+    }
 }
 
 /// Mint a new 30-day token for a launcher, revoke the old one, and push it over WS.

--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -44,6 +44,7 @@ pub struct SessionManager {
     launcher_dedup: Arc<DashMap<(Uuid, String), Uuid>>,
     pub pending_dir_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
     pub pending_probe_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
+    pub pending_launch_sessions: Arc<DashMap<Uuid, Uuid>>,
     /// Tracks who sent the last input for each session (session_id → (user_id, display_name))
     pub last_input_sender: Arc<DashMap<Uuid, (Uuid, String)>>,
     /// Monotonic counter for connection generations (prevents stale cleanup)
@@ -65,6 +66,7 @@ impl Default for SessionManager {
             launcher_dedup: Arc::new(DashMap::new()),
             pending_dir_requests: Arc::new(DashMap::new()),
             pending_probe_requests: Arc::new(DashMap::new()),
+            pending_launch_sessions: Arc::new(DashMap::new()),
             last_input_sender: Arc::new(DashMap::new()),
             gen_counter: Arc::new(AtomicU64::new(1)),
             connection_gen: Arc::new(DashMap::new()),

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -73,6 +73,7 @@ pub fn dashboard_page() -> Html {
     let rail_position = use_state(load_rail_position);
     let connected_sessions = use_state(HashSet::<Uuid>::new);
     let pending_leave = use_state(|| None::<Uuid>);
+    let pending_delete = use_state(|| None::<Uuid>);
     let is_admin = use_state(|| false);
     let current_user_id = use_state(|| None::<String>);
     let app_title = use_state(|| "Agent Portal".to_string());
@@ -188,14 +189,11 @@ pub fn dashboard_page() -> Html {
         });
     }
 
-    // Get live or paused sessions sorted by repo name, then hostname.
-    // Disconnected unpaused sessions are hidden from the active dashboard.
+    // Get DB-authoritative sessions sorted by repo name, then hostname. A
+    // disconnected, unpaused session is desired-running and should stay visible
+    // while the launcher reconciles it.
     let active_sessions: Vec<SessionInfo> = {
-        let mut sorted: Vec<SessionInfo> = sessions
-            .iter()
-            .filter(|s| s.status.as_str() == "active" || s.paused)
-            .cloned()
-            .collect();
+        let mut sorted: Vec<SessionInfo> = sessions.iter().cloned().collect();
         sorted.sort_by(|a, b| {
             let folder_a = utils::extract_folder(&a.working_directory);
             let folder_b = utils::extract_folder(&b.working_directory);
@@ -419,6 +417,46 @@ pub fn dashboard_page() -> Html {
                         log::error!("Failed to get current user ID for leave");
                     }
                     pending_leave.set(None);
+                });
+            }
+        })
+    };
+
+    let on_delete = {
+        let pending_delete = pending_delete.clone();
+        Callback::from(move |session_id: Uuid| {
+            pending_delete.set(Some(session_id));
+        })
+    };
+
+    let on_cancel_delete = {
+        let pending_delete = pending_delete.clone();
+        Callback::from(move |_| {
+            pending_delete.set(None);
+        })
+    };
+
+    let on_confirm_delete = {
+        let pending_delete = pending_delete.clone();
+        let refresh = sessions_hook.refresh.clone();
+        Callback::from(move |_| {
+            if let Some(session_id) = *pending_delete {
+                let refresh = refresh.clone();
+                let pending_delete = pending_delete.clone();
+                spawn_local(async move {
+                    let api_endpoint = utils::api_url(&format!("/api/sessions/{}", session_id));
+                    match Request::delete(&api_endpoint).send().await {
+                        Ok(response) if response.status() == 204 => {
+                            refresh.emit(());
+                        }
+                        Ok(response) => {
+                            log::error!("Failed to delete session: status {}", response.status());
+                        }
+                        Err(e) => {
+                            log::error!("Failed to delete session: {:?}", e);
+                        }
+                    }
+                    pending_delete.set(None);
                 });
             }
         })
@@ -813,6 +851,7 @@ pub fn dashboard_page() -> Html {
                         launcher_token_expiry={(*expiring_launchers).clone()}
                         on_select={on_select_session.clone()}
                         on_leave={on_leave.clone()}
+                        on_delete={on_delete.clone()}
                         on_toggle_hidden={on_toggle_hidden.clone()}
                         on_toggle_inactive_hidden={on_toggle_inactive_hidden.clone()}
                         on_stop={on_stop.clone()}
@@ -899,6 +938,32 @@ pub fn dashboard_page() -> Html {
                         </div>
                     </div>
                 </>
+            }
+
+            // Delete confirmation modal
+            {
+                if let Some(session_id) = *pending_delete {
+                    let session_name = sessions.iter()
+                        .find(|s| s.id == session_id)
+                        .map(|s| utils::extract_folder(&s.working_directory))
+                        .unwrap_or("this session");
+
+                    html! {
+                        <div class="modal-overlay" onclick={on_cancel_delete.clone()}>
+                            <div class="modal-content delete-confirm" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                                <h2>{ "Delete Session?" }</h2>
+                                <p>{ format!("Are you sure you want to delete \"{}\"?", session_name) }</p>
+                                <p class="modal-warning">{ "All message history and session metadata will be permanently removed." }</p>
+                                <div class="modal-actions">
+                                    <button class="modal-cancel" onclick={on_cancel_delete.clone()}>{ "Cancel" }</button>
+                                    <button class="modal-confirm" onclick={on_confirm_delete.clone()}>{ "Delete" }</button>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                } else {
+                    html! {}
+                }
             }
 
             // Admin modal — full-page overlay preserves dashboard state

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -193,7 +193,7 @@ pub fn dashboard_page() -> Html {
     // disconnected, unpaused session is desired-running and should stay visible
     // while the launcher reconciles it.
     let active_sessions: Vec<SessionInfo> = {
-        let mut sorted: Vec<SessionInfo> = sessions.iter().cloned().collect();
+        let mut sorted: Vec<SessionInfo> = sessions.to_vec();
         sorted.sort_by(|a, b| {
             let folder_a = utils::extract_folder(&a.working_directory);
             let folder_b = utils::extract_folder(&b.working_directory);

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -218,6 +218,7 @@ pub struct SessionRailProps {
     pub launcher_token_expiry: HashMap<Uuid, String>,
     pub on_select: Callback<usize>,
     pub on_leave: Callback<Uuid>,
+    pub on_delete: Callback<Uuid>,
     pub on_toggle_hidden: Callback<Uuid>,
     pub on_toggle_inactive_hidden: Callback<MouseEvent>,
     pub on_stop: Callback<Uuid>,
@@ -429,6 +430,16 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             })
         };
 
+        let on_delete = {
+            let on_delete = props.on_delete.clone();
+            let session_id = session.id;
+            let menu_session = menu_session.clone();
+            Callback::from(move |_: MouseEvent| {
+                on_delete.emit(session_id);
+                menu_session.set(None);
+            })
+        };
+
         let hide_label = if is_hidden {
             "Show Session"
         } else {
@@ -608,6 +619,17 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             html! {}
         };
 
+        let delete_option = if session.my_role == "owner" {
+            html! {
+                <button type="button" class="pill-menu-option stop" onclick={on_delete}>
+                    { "Delete Session" }
+                    <span class="option-hint">{ "Remove history and metadata" }</span>
+                </button>
+            }
+        } else {
+            html! {}
+        };
+
         let schedule_option = if session.my_role == "owner" {
             let schedule_session = schedule_session.clone();
             let session_clone = session.clone();
@@ -643,6 +665,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 { hide_option }
                 { leave_option }
                 { stop_option }
+                { delete_option }
             </>
         }
     } else {

--- a/launcher/src/config.rs
+++ b/launcher/src/config.rs
@@ -132,38 +132,6 @@ pub fn save_auth_token(token: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn add_session(session: &ExpectedSession) -> anyhow::Result<()> {
-    let mut config = load_config();
-    if config
-        .sessions
-        .iter()
-        .any(|s| s.working_directory == session.working_directory)
-    {
-        tracing::debug!("Session already in config: {}", session.working_directory);
-        return Ok(());
-    }
-    config.sessions.push(session.clone());
-    save_config(&config)
-}
-
-pub fn update_session_id(working_directory: &str, session_id: Uuid) -> anyhow::Result<()> {
-    let mut config = load_config();
-    if let Some(session) = config
-        .sessions
-        .iter_mut()
-        .find(|s| s.working_directory == working_directory)
-    {
-        session.session_id = Some(session_id);
-        save_config(&config)?;
-        tracing::debug!(
-            "Updated session_id for {}: {}",
-            working_directory,
-            session_id
-        );
-    }
-    Ok(())
-}
-
 pub fn remove_session(working_directory: &str) -> anyhow::Result<()> {
     let mut config = load_config();
     let before = config.sessions.len();
@@ -173,6 +141,16 @@ pub fn remove_session(working_directory: &str) -> anyhow::Result<()> {
     if config.sessions.len() < before {
         save_config(&config)?;
         tracing::debug!("Removed session from config: {}", working_directory);
+    }
+    Ok(())
+}
+
+pub fn clear_sessions() -> anyhow::Result<()> {
+    let mut config = load_config();
+    if !config.sessions.is_empty() {
+        config.sessions.clear();
+        save_config(&config)?;
+        tracing::info!("Cleared launcher-local expected sessions from config");
     }
     Ok(())
 }

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -23,6 +23,16 @@ pub async fn run_launcher_loop(
     mut expected_sessions: Vec<ExpectedSession>,
 ) -> anyhow::Result<()> {
     process_manager.set_launcher_id(launcher_id);
+    if !expected_sessions.is_empty() {
+        info!(
+            "Discarding {} launcher-local expected session(s); backend DB is authoritative",
+            expected_sessions.len()
+        );
+        expected_sessions.clear();
+        if let Err(e) = config::clear_sessions() {
+            warn!("Failed to clear launcher-local expected sessions: {}", e);
+        }
+    }
     let mut backoff = Duration::from_secs(1);
     let mut scheduler = Scheduler::new();
 
@@ -102,34 +112,8 @@ pub async fn run_launcher_loop(
                     Some(true) => {} // fall through to main loop
                 }
 
-                // Reconcile expected sessions: launch any that aren't running
+                // Expected sessions are reconciled by the backend from the DB.
                 let mut restart_counts: HashMap<String, u32> = HashMap::new();
-                if !expected_sessions.is_empty() {
-                    let running_dirs = process_manager.running_directories();
-                    for expected in &expected_sessions {
-                        if running_dirs.contains(&expected.working_directory) {
-                            info!(
-                                "Expected session already running: {}",
-                                expected.working_directory
-                            );
-                            continue;
-                        }
-                        info!("Launching expected session: {}", expected.working_directory);
-                        let request = LauncherToServer::RequestLaunch {
-                            request_id: Uuid::new_v4(),
-                            working_directory: expected.working_directory.clone(),
-                            session_name: expected.session_name.clone(),
-                            claude_args: expected.claude_args.clone(),
-                            agent_type: expected.agent_type,
-                            scheduled_task_id: None,
-                            last_session_id: expected.session_id,
-                        };
-                        if ws_sender.send(request).await.is_err() {
-                            warn!("Failed to send expected session launch request");
-                            break;
-                        }
-                    }
-                }
 
                 // Channel for delayed restart requests
                 let (restart_tx, mut restart_rx) = mpsc::unbounded_channel::<ExpectedSession>();
@@ -490,28 +474,6 @@ async fn handle_message(
                 Ok(session_id) => {
                     if is_scheduled {
                         scheduler.on_session_spawned(request_id, session_id);
-                    } else if let Some(existing) = expected_sessions
-                        .iter_mut()
-                        .find(|s| s.working_directory == working_directory)
-                    {
-                        // Update stored session_id so future restarts resume this session
-                        existing.session_id = Some(session_id);
-                        if let Err(e) = config::update_session_id(&working_directory, session_id) {
-                            warn!("Failed to update session_id in config: {}", e);
-                        }
-                    } else {
-                        // New session — persist so it survives launcher restarts
-                        let expected = ExpectedSession {
-                            working_directory: working_directory.clone(),
-                            session_name: session_name.clone(),
-                            agent_type,
-                            claude_args: claude_args.clone(),
-                            session_id: Some(session_id),
-                        };
-                        if let Err(e) = config::add_session(&expected) {
-                            warn!("Failed to persist session to config: {}", e);
-                        }
-                        expected_sessions.push(expected);
                     }
                     LauncherToServer::LaunchSessionResult {
                         request_id,

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -65,14 +65,6 @@ impl ProcessManager {
         self.tasks.keys().copied().collect()
     }
 
-    /// Returns the set of working directories that currently have running sessions.
-    pub fn running_directories(&self) -> Vec<String> {
-        self.tasks
-            .values()
-            .map(|t| t.working_directory.clone())
-            .collect()
-    }
-
     /// Returns the working directory for a given session, if it exists.
     pub fn session_working_directory(&self, session_id: &Uuid) -> Option<String> {
         self.tasks


### PR DESCRIPTION
## Summary
- make new launcher sessions durable desired-state rows before process spawn
- reconcile unpaused DB sessions from launcher heartbeats instead of launcher-local expected session config
- clear legacy launcher expected-session state on upgraded launchers
- make dashboard Delete stop first, then remove session metadata even when the launcher is offline
- reset legacy session rows with a one-time migration so the new desired-state model starts clean
- bump workspace version to 2.6.21

## Notes
- This keeps the existing session columns for compatibility and treats `sessions.paused = false` as desired-running, `paused = true` as desired-stopped.
- Scheduled-task sessions are excluded from durable desired-state reconciliation.

## Test plan
- [x] cargo fmt --check
- [x] cargo check -p backend
- [x] cargo check -p frontend --target wasm32-unknown-unknown
- [x] cargo test -p backend
- [x] cargo test -p agent-portal
- [x] cargo clippy -p backend -p agent-portal --all-targets -- -D warnings
- [x] ./scripts/check-migration-names.sh