### PR TITLE
Label Claude responses with model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.21"
+version = "2.6.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.21"
+version = "2.6.22"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.21"
+version = "2.6.22"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.21"
+version = "2.6.22"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.21"
+version = "2.6.22"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.21"
+version = "2.6.22"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.21"
+version = "2.6.22"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.21"
+version = "2.6.22"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.21"
+version = "2.6.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.21"
+version = "2.6.22"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.21"
+version = "2.6.22"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 
+use super::renderers::assistant_label;
 use super::types::{self, ClaudeMessage, ContentBlock};
 
 /// Extract the raw `_created_at` ISO string from a message JSON, for use with
@@ -177,17 +178,17 @@ pub(super) fn classify(
     agent_type: shared::AgentType,
     current_user_id: Option<&str>,
 ) -> Option<MessageIdentity> {
-    let assistant_label = if agent_type == shared::AgentType::Codex {
+    let assistant_identity_label = if agent_type == shared::AgentType::Codex {
         "Codex"
     } else {
-        "Assistant"
+        "Claude"
     };
 
     match serde_json::from_str::<ClaudeMessage>(json) {
         Ok(ClaudeMessage::Assistant(_)) => {
             return Some(MessageIdentity {
                 category: GroupCategory::Assistant,
-                label: assistant_label.to_string(),
+                label: assistant_identity_label.to_string(),
                 badge_class: "assistant".to_string(),
             });
         }
@@ -195,7 +196,7 @@ pub(super) fn classify(
             if user_is_tool_result_envelope(&msg) {
                 return Some(MessageIdentity {
                     category: GroupCategory::Assistant,
-                    label: assistant_label.to_string(),
+                    label: assistant_identity_label.to_string(),
                     badge_class: "assistant".to_string(),
                 });
             }
@@ -238,6 +239,25 @@ pub(super) fn classify(
     }
 
     None
+}
+
+fn group_label(identity: &MessageIdentity, messages: &[String]) -> String {
+    if identity.category != GroupCategory::Assistant || identity.label == "Codex" {
+        return identity.label.clone();
+    }
+
+    messages
+        .iter()
+        .filter_map(|json| serde_json::from_str::<ClaudeMessage>(json).ok())
+        .find_map(|msg| match msg {
+            ClaudeMessage::Assistant(msg) => msg
+                .message
+                .as_ref()
+                .and_then(|m| m.model.as_deref())
+                .map(assistant_label),
+            _ => None,
+        })
+        .unwrap_or_else(|| identity.label.clone())
 }
 
 /// True iff `json` parses as a per-turn terminator: Claude's
@@ -292,9 +312,10 @@ pub fn group_messages(
 
     fn flush(out: &mut Vec<MessageGroup>, slot: &mut Option<(MessageIdentity, Vec<String>)>) {
         if let Some((identity, messages)) = slot.take() {
+            let label = group_label(&identity, &messages);
             out.push(MessageGroup::IdentityGroup {
                 category: identity.category,
-                label: identity.label,
+                label,
                 badge_class: identity.badge_class,
                 messages,
             });

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -228,7 +228,14 @@ pub(crate) fn shorten_model_name(model: &str) -> Option<String> {
     let extract_version = |model: &str| -> Option<String> {
         let parts: Vec<&str> = model.split('-').collect();
         for i in 0..parts.len().saturating_sub(1) {
-            if let (Ok(major), Ok(minor)) = (parts[i].parse::<u32>(), parts[i + 1].parse::<u32>()) {
+            let minor_digits: String = parts[i + 1]
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
+            if minor_digits.len() >= 8 {
+                continue;
+            }
+            if let (Ok(major), Ok(minor)) = (parts[i].parse::<u32>(), minor_digits.parse::<u32>()) {
                 if parts[i + 1].len() >= 8 {
                     continue;
                 }
@@ -856,6 +863,28 @@ mod tests {
     }
 
     #[test]
+    fn assistant_group_label_uses_claude_model() {
+        let messages = vec![serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-7-20260501",
+                "content": [{"type": "text", "text": "hello"}],
+            },
+            "_created_at": "2026-05-17T10:00:00.000Z",
+        })
+        .to_string()];
+
+        let groups = group_for_tests(&messages);
+        match &groups[0] {
+            MessageGroup::IdentityGroup { label, .. } => {
+                assert_eq!(label, "Claude - Opus 4.7");
+            }
+            other => panic!("expected assistant identity group, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn test_shorten_model_name() {
         assert_eq!(
             shorten_model_name("claude-opus-4-5-20251101"),
@@ -876,6 +905,10 @@ mod tests {
         assert_eq!(
             shorten_model_name("claude-opus-4-6"),
             Some("Opus 4.6".to_string())
+        );
+        assert_eq!(
+            shorten_model_name("claude-opus-4-7[1m]"),
+            Some("Opus 4.7".to_string())
         );
         assert_eq!(
             shorten_model_name("claude-sonnet-4-5"),

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
+pub(crate) use assistant::assistant_label;
 pub use assistant::{
     render_assistant_message, render_assistant_message_content, render_content_blocks,
 };

--- a/frontend/src/components/message_renderer/renderers/assistant.rs
+++ b/frontend/src/components/message_renderer/renderers/assistant.rs
@@ -59,6 +59,13 @@ fn build_usage_tooltip(usage: Option<&UsageInfo>) -> String {
         .unwrap_or_default()
 }
 
+pub(crate) fn assistant_label(model: &str) -> String {
+    match shorten_model_name(model) {
+        Some(short_name) => format!("Claude - {short_name}"),
+        None => "Claude".to_string(),
+    }
+}
+
 /// Extract concatenated raw text from a list of content blocks.
 /// Used for the message header copy button: pulls out text and thinking
 /// blocks as markdown, ignoring tool_use/tool_result internals.
@@ -110,19 +117,13 @@ pub fn render_assistant_message(
 
     let model_tooltip = build_model_tooltip(model, usage);
     let usage_tooltip = build_usage_tooltip(usage);
+    let label = assistant_label(model);
     let copy_text = content_blocks_to_text(&blocks);
 
     html! {
         <div class="claude-message assistant-message">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
-                <span class="message-type-badge assistant">{ "Assistant" }</span>
-                {
-                    if let Some(short_name) = shorten_model_name(model) {
-                        html! { <span class="model-name" title={model_tooltip}>{ short_name }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
+                <span class="message-type-badge assistant" title={model_tooltip}>{ label }</span>
                 if !copy_text.is_empty() {
                     <CopyButton text={copy_text} title="Copy assistant text" />
                 }


### PR DESCRIPTION
## Summary
- change Claude assistant response badges from `Assistant` to `Claude - <model>` when model metadata is available
- apply the same label to grouped assistant/tool-result runs
- keep Codex labels unchanged
- harden model shortening for decorated Claude model strings like `claude-opus-4-7[1m]`
- bump workspace version to 2.6.22

## Test plan
- [x] cargo test -p frontend assistant_group_label_uses_claude_model
- [x] cargo test -p frontend test_shorten_model_name
- [x] cargo check -p frontend --target wasm32-unknown-unknown
- [x] cargo clippy -p frontend --all-targets -- -D warnings