### PR TITLE
Improve performance chart granularity and axis layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.22"
+version = "2.6.23"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/turn_metrics.rs
+++ b/backend/src/handlers/turn_metrics.rs
@@ -11,8 +11,8 @@
 //!   pill only summarizes the dashboard user's own sessions; multi-tenant
 //!   member-shared views can land in a later PR alongside multi-pill UI).
 //! - `GET /api/metrics/turns?bucket=…&window=…` (PR 4): aggregated rollups for
-//!   the Settings → Performance drill-in page. Bucketed by `date_trunc` (hour
-//!   or day), grouped by `(agent_type, model, service_tier)`, with p50/p95
+//!   the Settings → Performance drill-in page. Bucketed by `date_bin` over a
+//!   small allowlist of minute/hour/day intervals, grouped by `(agent_type, model, service_tier)`, with p50/p95
 //!   latency + throughput computed via `percentile_cont` server-side. Same
 //!   owner-only gate as `/api/metrics/recent`.
 
@@ -162,7 +162,7 @@ pub async fn list_recent_user_turn_metrics(
 
 // =============================================================================
 // `GET /api/metrics/turns` — aggregated bucketed rollups for the Settings →
-// Performance drill-in page (PR 4). Bucketed by `date_trunc('hour' | 'day',
+// Performance drill-in page (PR 4). Bucketed by `date_bin(<allowed interval>,
 // started_at)` and grouped by `(agent_type, model, service_tier)`; p50/p95
 // latency and throughput are computed server-side via Postgres
 // `percentile_cont(...)`. Stop-reason histogram is built in Rust from a
@@ -171,22 +171,28 @@ pub async fn list_recent_user_turn_metrics(
 // =============================================================================
 
 /// Bucketing granularity for the aggregated endpoint. The wire form is a tiny
-/// allowlist (`"hour" | "day"`) so an attacker can't smuggle arbitrary SQL into
-/// the `date_trunc` argument — only these two values reach the query.
+/// allowlist so an attacker can't smuggle arbitrary SQL into the `date_bin`
+/// interval argument — only these constants reach the query.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BucketKind {
+    Minute1,
+    Minute5,
+    Minute15,
     Hour,
     Day,
 }
 
 impl BucketKind {
-    /// String that flows into the `date_trunc($1, ...)` bind parameter. Safe
-    /// because the value is one of two constants — there is no path from
+    /// String that flows into the `date_bin($1::interval, ...)` bind parameter.
+    /// Safe because the value is one of a few constants — there is no path from
     /// untrusted input to this `&'static str`.
-    fn as_pg(self) -> &'static str {
+    fn as_interval(self) -> &'static str {
         match self {
-            BucketKind::Hour => "hour",
-            BucketKind::Day => "day",
+            BucketKind::Minute1 => "1 minute",
+            BucketKind::Minute5 => "5 minutes",
+            BucketKind::Minute15 => "15 minutes",
+            BucketKind::Hour => "1 hour",
+            BucketKind::Day => "1 day",
         }
     }
 }
@@ -202,16 +208,21 @@ pub struct TurnMetricsAggregateQuery {
     pub window: Option<String>,
 }
 
-/// Parse `bucket=hour|day`. Empty / missing → `Day`. Unknown → `Err`.
+/// Parse `bucket=1m|5m|15m|hour|day`. Empty / missing → `Day`. Unknown → `Err`.
 fn parse_bucket(raw: Option<&str>) -> Result<BucketKind, AppError> {
     let trimmed = raw.unwrap_or("").trim();
     if trimmed.is_empty() {
         return Ok(BucketKind::Day);
     }
     match trimmed.to_ascii_lowercase().as_str() {
+        "minute" | "1m" | "m" => Ok(BucketKind::Minute1),
+        "5m" | "5min" | "5minute" | "5minutes" => Ok(BucketKind::Minute5),
+        "15m" | "15min" | "15minute" | "15minutes" => Ok(BucketKind::Minute15),
         "hour" | "h" => Ok(BucketKind::Hour),
         "day" | "d" => Ok(BucketKind::Day),
-        _ => Err(AppError::BadRequest("bucket must be 'hour' or 'day'")),
+        _ => Err(AppError::BadRequest(
+            "bucket must be one of '1m', '5m', '15m', 'hour', or 'day'",
+        )),
     }
 }
 
@@ -305,7 +316,7 @@ struct StopReasonRow {
 /// Owner-only gate (same as `/api/metrics/recent`): joins `turn_metrics` to
 /// `sessions` and filters `sessions.user_id = current_user_id`. Bucket and
 /// window are validated against a small allowlist before any SQL runs; only
-/// the validated constants (`"hour" | "day"`, `"N days" | "N hours"` strings)
+/// the validated constants (`"N minutes" | "N hours" | "N days"` strings)
 /// reach the query.
 pub async fn list_aggregated_turn_metrics(
     State(app_state): State<Arc<AppState>>,
@@ -325,7 +336,7 @@ pub async fn list_aggregated_turn_metrics(
     // explicitly so Diesel can decode them per CLAUDE.md's raw-SQL guidance.
     let aggregate_sql = "\
         SELECT \
-            date_trunc($1, tm.started_at) AS bucket_start, \
+            date_bin($1::interval, tm.started_at, TIMESTAMPTZ '1970-01-01 00:00:00+00') AS bucket_start, \
             tm.agent_type AS agent_type, \
             tm.model AS model, \
             tm.service_tier AS service_tier, \
@@ -360,7 +371,7 @@ pub async fn list_aggregated_turn_metrics(
         ORDER BY bucket_start ASC, tm.agent_type ASC, tm.model ASC, tm.service_tier ASC";
 
     let aggregate_rows: Vec<AggregateRow> = diesel::sql_query(aggregate_sql)
-        .bind::<Text, _>(bucket.as_pg())
+        .bind::<Text, _>(bucket.as_interval())
         .bind::<diesel::sql_types::Uuid, _>(current_user_id)
         .bind::<Text, _>(&interval)
         .load(&mut conn)
@@ -372,7 +383,7 @@ pub async fn list_aggregated_turn_metrics(
     // histogram.
     let stop_reason_sql = "\
         SELECT \
-            date_trunc($1, tm.started_at) AS bucket_start, \
+            date_bin($1::interval, tm.started_at, TIMESTAMPTZ '1970-01-01 00:00:00+00') AS bucket_start, \
             tm.agent_type AS agent_type, \
             tm.model AS model, \
             tm.service_tier AS service_tier, \
@@ -389,7 +400,7 @@ pub async fn list_aggregated_turn_metrics(
         GROUP BY bucket_start, tm.agent_type, tm.model, tm.service_tier, reason_key";
 
     let reason_rows: Vec<StopReasonRow> = diesel::sql_query(stop_reason_sql)
-        .bind::<Text, _>(bucket.as_pg())
+        .bind::<Text, _>(bucket.as_interval())
         .bind::<diesel::sql_types::Uuid, _>(current_user_id)
         .bind::<Text, _>(&interval)
         .load(&mut conn)
@@ -463,11 +474,15 @@ mod tests {
     }
 
     #[test]
-    fn parse_bucket_accepts_hour_and_day_case_insensitive() {
+    fn parse_bucket_accepts_granular_intervals_case_insensitive() {
+        assert_eq!(parse_bucket(Some("1m")).unwrap(), BucketKind::Minute1);
+        assert_eq!(parse_bucket(Some("minute")).unwrap(), BucketKind::Minute1);
+        assert_eq!(parse_bucket(Some("5m")).unwrap(), BucketKind::Minute5);
+        assert_eq!(parse_bucket(Some("15M")).unwrap(), BucketKind::Minute15);
         assert_eq!(parse_bucket(Some("hour")).unwrap(), BucketKind::Hour);
         assert_eq!(parse_bucket(Some("HOUR")).unwrap(), BucketKind::Hour);
         assert_eq!(parse_bucket(Some("day")).unwrap(), BucketKind::Day);
-        // Single-letter aliases for brevity (`?bucket=h`).
+        // Single-letter aliases for brevity (`?bucket=h`, `?bucket=d`).
         assert_eq!(parse_bucket(Some("h")).unwrap(), BucketKind::Hour);
         assert_eq!(parse_bucket(Some("d")).unwrap(), BucketKind::Day);
     }
@@ -479,7 +494,7 @@ mod tests {
             AppError::BadRequest(_) => {}
             other => panic!("expected BadRequest, got {other:?}"),
         }
-        assert!(parse_bucket(Some("minute")).is_err());
+        assert!(parse_bucket(Some("month")).is_err());
         assert!(parse_bucket(Some("'; DROP TABLE turn_metrics; --")).is_err());
     }
 

--- a/frontend/src/components/charts/line_plot.rs
+++ b/frontend/src/components/charts/line_plot.rs
@@ -52,7 +52,7 @@ pub struct LinePlotProps {
 const VIEW_W: f32 = 800.0;
 const VIEW_H: f32 = 260.0;
 /// Padding on each side of the plot area to leave room for axis labels.
-const PAD_L: f32 = 48.0;
+const PAD_L: f32 = 66.0;
 const PAD_R: f32 = 12.0;
 const PAD_T: f32 = 12.0;
 const PAD_B: f32 = 36.0;
@@ -201,9 +201,11 @@ pub fn line_plot(props: &LinePlotProps) -> Html {
                 preserveAspectRatio="xMidYMid meet"
             >
                 <text
-                    x="4"
-                    y={format!("{:.2}", PAD_T + 4.0)}
+                    x={format!("{:.2}", 14.0)}
+                    y={format!("{:.2}", PAD_T + plot_h / 2.0)}
                     class="chart-y-axis-title"
+                    text-anchor="middle"
+                    transform={format!("rotate(-90 14 {:.2})", PAD_T + plot_h / 2.0)}
                 >
                     { &props.y_label }
                 </text>

--- a/frontend/src/components/charts/scale.rs
+++ b/frontend/src/components/charts/scale.rs
@@ -12,23 +12,22 @@
 use chrono::{DateTime, Datelike, Timelike, Utc};
 
 /// Bucket granularity, used to pick a date / time format for axis tick labels.
-/// Same enum the backend exposes through the `?bucket=hour|day` query.
-/// `Hour` is currently unused by the frontend (the Performance page only
-/// requests daily buckets), but the helper supports it so a follow-up
-/// hourly-zoom toggle doesn't have to retouch the math.
+/// Same enum shape the backend exposes through the `?bucket=…` query.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BucketKind {
+    Minute,
     Hour,
     Day,
 }
 
 impl BucketKind {
-    /// Parse the wire form (`"hour" | "day"`) into a `BucketKind`. Returns
+    /// Parse the wire form into a `BucketKind`. Returns
     /// `None` for any other value; consumers use this to round-trip a server-
     /// chosen bucket from a query-string back into the typed enum. Defensive
     /// fallback to `Day` lives at the call sites.
     pub fn from_wire(s: &str) -> Option<Self> {
         match s.trim().to_ascii_lowercase().as_str() {
+            "minute" | "m" | "1m" | "5m" | "15m" => Some(Self::Minute),
             "hour" | "h" => Some(Self::Hour),
             "day" | "d" => Some(Self::Day),
             _ => None,
@@ -108,7 +107,7 @@ fn nice_step(raw: f64) -> f64 {
 ///
 /// Labels:
 /// - `BucketKind::Day` → `"May 5"` (month abbreviation + day-of-month)
-/// - `BucketKind::Hour` → `"14:00"` (24-hour HH:MM)
+/// - `BucketKind::Minute` / `Hour` → `"14:05"` / `"14:00"` (24-hour HH:MM)
 pub fn time_axis_ticks(
     buckets: &[DateTime<Utc>],
     bucket: BucketKind,
@@ -147,6 +146,7 @@ pub fn time_axis_ticks(
 
 fn format_tick_label(ts: DateTime<Utc>, bucket: BucketKind) -> String {
     match bucket {
+        BucketKind::Minute => format!("{:02}:{:02}", ts.hour(), ts.minute()),
         BucketKind::Hour => format!("{:02}:00", ts.hour()),
         BucketKind::Day => {
             let month = match ts.month() {
@@ -331,6 +331,18 @@ mod tests {
         assert_eq!(ticks.len(), 4);
         assert_eq!(ticks[0].label, "00:00");
         assert_eq!(ticks[3].label, "23:00");
+    }
+
+    #[test]
+    fn time_axis_ticks_minute_labels_include_minutes() {
+        let mut buckets = Vec::new();
+        for minute in 0..60 {
+            buckets.push(Utc.with_ymd_and_hms(2026, 5, 5, 14, minute, 0).unwrap());
+        }
+        let ticks = time_axis_ticks(&buckets, BucketKind::Minute, 5);
+        assert_eq!(ticks.len(), 5);
+        assert_eq!(ticks[0].label, "14:00");
+        assert_eq!(ticks[4].label, "14:59");
     }
 
     #[test]

--- a/frontend/src/components/charts/stacked_area.rs
+++ b/frontend/src/components/charts/stacked_area.rs
@@ -32,7 +32,7 @@ pub struct StackedAreaProps {
 
 const VIEW_W: f32 = 800.0;
 const VIEW_H: f32 = 260.0;
-const PAD_L: f32 = 48.0;
+const PAD_L: f32 = 66.0;
 const PAD_R: f32 = 12.0;
 const PAD_T: f32 = 12.0;
 const PAD_B: f32 = 36.0;
@@ -195,9 +195,11 @@ pub fn stacked_area(props: &StackedAreaProps) -> Html {
                 preserveAspectRatio="xMidYMid meet"
             >
                 <text
-                    x="4"
-                    y={format!("{:.2}", PAD_T + 4.0)}
+                    x={format!("{:.2}", 14.0)}
+                    y={format!("{:.2}", PAD_T + plot_h / 2.0)}
                     class="chart-y-axis-title"
+                    text-anchor="middle"
+                    transform={format!("rotate(-90 14 {:.2})", PAD_T + plot_h / 2.0)}
                 >
                     { &props.y_label }
                 </text>

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -94,12 +94,14 @@ fn window_param(window: TimeWindow) -> &'static str {
 }
 
 /// Build the bucket-granularity query string for the selected window.
-/// Short windows (≤ 1 day) get hourly buckets so a 1h view doesn't collapse
-/// into a single data point; week-plus windows stay daily so 30 / 90 day
-/// runs don't overwhelm the x-axis with hundreds of ticks.
+/// Pick enough buckets to show shape without turning sparse per-turn metrics
+/// into comb noise: roughly 60 buckets for 1h, 72 for 6h, 96 for 1d, and
+/// daily for week-plus windows.
 fn bucket_param(window: TimeWindow) -> &'static str {
     match window {
-        TimeWindow::Hours1 | TimeWindow::Hours6 | TimeWindow::Days1 => "hour",
+        TimeWindow::Hours1 => "1m",
+        TimeWindow::Hours6 => "5m",
+        TimeWindow::Days1 => "15m",
         TimeWindow::Days7 | TimeWindow::Days30 | TimeWindow::Days90 => "day",
     }
 }
@@ -849,14 +851,13 @@ mod tests {
         assert_eq!(window_param(TimeWindow::Days90), "90d");
     }
 
-    /// Short windows must request hourly buckets so a 1-hour view doesn't
-    /// collapse into a single daily data point. Week-plus windows stay
-    /// daily so the x-axis tick count stays reasonable.
+    /// Short windows should stay granular enough to show shape; week-plus
+    /// windows stay daily so the query and x-axis remain readable.
     #[test]
     fn bucket_param_dispatches_on_window_length() {
-        assert_eq!(bucket_param(TimeWindow::Hours1), "hour");
-        assert_eq!(bucket_param(TimeWindow::Hours6), "hour");
-        assert_eq!(bucket_param(TimeWindow::Days1), "hour");
+        assert_eq!(bucket_param(TimeWindow::Hours1), "1m");
+        assert_eq!(bucket_param(TimeWindow::Hours6), "5m");
+        assert_eq!(bucket_param(TimeWindow::Days1), "15m");
         assert_eq!(bucket_param(TimeWindow::Days7), "day");
         assert_eq!(bucket_param(TimeWindow::Days30), "day");
         assert_eq!(bucket_param(TimeWindow::Days90), "day");


### PR DESCRIPTION
## Summary
- switch performance aggregation from `date_trunc(hour|day)` to allowlisted `date_bin` intervals
- use visually denser buckets for short windows: 1h→1m, 6h→5m, 1d→15m, week-plus→day
- add minute-aware x-axis labels (`HH:MM`)
- rotate y-axis unit labels vertically and widen the left chart gutter so units no longer collide with numeric ticks
- bump workspace version to 2.6.23

## Visual rationale
Short windows need enough samples to show shape: about 60-100 buckets is the useful range before sparse per-turn data starts looking like comb noise. Daily buckets remain better for 7d/30d/90d because they keep the chart readable and the query result bounded.

## Test plan
- [x] cargo fmt --check
- [x] cargo test -p backend parse_bucket
- [x] cargo test -p frontend bucket_param_dispatches_on_window_length
- [x] cargo test -p frontend time_axis_ticks_minute_labels_include_minutes
- [x] cargo check -p backend
- [x] cargo check -p frontend --target wasm32-unknown-unknown
- [x] cargo clippy -p backend -p frontend --all-targets -- -D warnings