### PR TITLE
Session-pill watermark: shrink agent logos to 80%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.6.24
+
+- **Pill watermark: shrink to 80% (80×80 → 64×64), keep horizontal center at x=16.** Continues the gradual size taper started by #719 (which had taken the original 88×88 launch dimensions down to 80×80). New size is exactly 80% of the current main-tree value, with `left: -24px` → `left: -16px` recomputed so the watermark's horizontal center stays at x=16 in pill coordinates — the visual centering doesn't drift across the resize. Vertical center is held by the existing `top: 50%; translateY(-50%)` which is size-agnostic. CSS-only change; no Rust touched.
+
+
+
+- **Session-pill agent-logo watermark: shrink to 80%.** `.pill-watermark` in `frontend/styles/session-rail.css` drops from 80×80 to 64×64 and `left` shifts from `-24px` to `-16px` so the icon's horizontal center stays anchored at `x = 16` in pill coords. Vertical centering uses `top: 50%` + `translateY(-50%)`, which is size-agnostic — no change there. Net visual: same position, same crop, same opacity, just a smaller mark.
+
 ## 2.6.15
 
 - **Performance page: add `1h` / `6h` / `1d` window buttons.** The radio group previously offered only `7d` / `30d` / `90d`; the three new short-window buttons sit before them in chronological order so the most-recent view is on the left. Adds three `TimeWindow` variants (`Hours1` / `Hours6` / `Days1`) and a new `bucket_param(window) -> &'static str` dispatch helper: short windows (≤ 1 day) request `bucket=hour` so a 1-hour view doesn't collapse into a single daily data point; week-plus windows stay `bucket=day` so 30 / 90 day runs don't overwhelm the x-axis. `render_charts` now takes the active `window` and threads it into `BucketKind::from_wire(bucket_param(window))` so the time-axis label format (HH:MM for hourly, "May 5" for daily) stays in lockstep with the requested data. The hardcoded `BUCKET_PARAM: &str = "day"` constant deletes. Backend already accepts `Nh` window suffixes and `bucket=hour` (verified by `parse_window_accepts_d_and_h_suffix` + the existing `BucketKind::from_wire` arms) — no backend changes. Three new tests: `bucket_param_dispatches_on_window_length` pins the short-window → hourly / long-window → daily mapping, `window_param_strings` extends to cover all six variants, `time_window_all_lists_every_variant_in_chronological_order` pins the radio button ordering (Hours1 first, Days90 last). 16 performance-panel tests pass; workspace clippy clean.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.23"
+version = "2.6.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.23"
+version = "2.6.24"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.23"
+version = "2.6.24"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.23"
+version = "2.6.24"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.23"
+version = "2.6.24"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.23"
+version = "2.6.24"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.23"
+version = "2.6.24"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.23"
+version = "2.6.24"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.23"
+version = "2.6.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.23"
+version = "2.6.24"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.23"
+version = "2.6.24"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -164,17 +164,17 @@
 
 /* Agent-type watermark — large logo anchored to the pill's left edge,
    clipped by the pill's overflow:hidden, behind all foreground content.
-   Sized 10% under the 2.5.27 launch dimensions (88×88, left:-28px); the
-   new offset keeps the icon's horizontal center at x=16 in pill coords so
-   the visual centering doesn't drift. Vertical center is held by top:50%
-   + translateY(-50%). */
+   Sized at 80% of the previous 80×80 (so 64×64); the new `left: -16px`
+   keeps the icon's horizontal center at x=16 in pill coords so the visual
+   centering doesn't drift across the resize. Vertical center is held by
+   `top: 50%` + `translateY(-50%)`, which is size-agnostic. */
 .pill-watermark {
     position: absolute;
-    left: -24px;
+    left: -16px;
     top: 50%;
     transform: translateY(-50%);
-    width: 80px;
-    height: 80px;
+    width: 64px;
+    height: 64px;
     pointer-events: none;
     background-repeat: no-repeat;
     background-position: center;


### PR DESCRIPTION
## Summary

Per request: \"make the logos in the background of the pills maybe 80% their current size, the location is perfect, but maintain the centering as it is.\"

\`.pill-watermark\` in \`frontend/styles/session-rail.css\`:

| | before | after |
|---|---|---|
| width / height | \`80px\` | \`64px\` (= 80% × 80) |
| left | \`-24px\` | \`-16px\` |
| x-center in pill coords | \`-24 + 80/2 = 16\` | \`-16 + 64/2 = 16\` ✓ |
| top + translateY | \`50%\` + \`-50%\` | unchanged (size-agnostic) |

So the icon stays anchored at \`x = 16\` and vertically centered, just smaller.

## Test plan

- [x] \`cargo build --workspace\` passes
- [x] CSS stylelint clean
- [ ] Browser: open the dashboard, verify Claude / Codex watermarks render at 80% with the same crop-position