### PR TITLE
Use claude-codes types in frontend renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.25"
+version = "2.6.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.25"
+version = "2.6.26"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.25"
+version = "2.6.26"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.25"
+version = "2.6.26"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.25"
+version = "2.6.26"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.25"
+version = "2.6.26"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.25"
+version = "2.6.26"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.25"
+version = "2.6.26"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.25"
+version = "2.6.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.25"
+version = "2.6.26"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.25"
+version = "2.6.26"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use super::renderers::assistant_label;
-use super::types::{self, ClaudeMessage, ContentBlock};
+use super::types::{user_meta_from_json, ClaudeMessage};
 
 /// Extract the raw `_created_at` ISO string from a message JSON, for use with
 /// the live-updating TimeAgo component (which parses it itself).
@@ -106,21 +106,16 @@ pub(super) struct MessageIdentity {
 /// `content` field, because that field is the optimistic-send envelope shape
 /// and can leak onto real echoes through the cross-process wire wrapping.
 /// Gating on it broke serial Read tool-use grouping in the wild (#758).
-fn user_is_tool_result_envelope(msg: &types::UserMessage) -> bool {
-    let Some(message) = &msg.message else {
-        return false;
-    };
-    let Some(blocks) = &message.content else {
-        return false;
-    };
+fn user_is_tool_result_envelope(msg: &shared::UserMessage) -> bool {
+    let blocks = &msg.message.content;
     !blocks.is_empty()
         && blocks.iter().all(|b| {
             matches!(
                 b,
-                ContentBlock::ToolResult { .. }
-                    | ContentBlock::WebSearchToolResult { .. }
-                    | ContentBlock::McpToolResult { .. }
-                    | ContentBlock::CodeExecutionToolResult { .. }
+                shared::ContentBlock::ToolResult(_)
+                    | shared::ContentBlock::WebSearchToolResult(_)
+                    | shared::ContentBlock::McpToolResult(_)
+                    | shared::ContentBlock::CodeExecutionToolResult(_)
             )
         })
 }
@@ -132,20 +127,12 @@ fn user_is_tool_result_envelope(msg: &types::UserMessage) -> bool {
 /// We deliberately require *all* nested blocks to be `Text` so we don't
 /// silently roll a tool-result envelope into User — those belong with
 /// Assistant and are caught by `user_is_tool_result_envelope`.
-fn user_is_plain_text(msg: &types::UserMessage) -> bool {
-    if msg.content.is_some() {
-        return true;
-    }
-    let Some(message) = &msg.message else {
-        return false;
-    };
-    let Some(blocks) = &message.content else {
-        return false;
-    };
+fn user_is_plain_text(msg: &shared::UserMessage) -> bool {
+    let blocks = &msg.message.content;
     !blocks.is_empty()
         && blocks
             .iter()
-            .all(|b| matches!(b, ContentBlock::Text { .. }))
+            .all(|b| matches!(b, shared::ContentBlock::Text(_)))
 }
 
 /// Classify a single wire message into the display identity it belongs to,
@@ -184,7 +171,7 @@ pub(super) fn classify(
         "Claude"
     };
 
-    match serde_json::from_str::<ClaudeMessage>(json) {
+    match ClaudeMessage::parse(json) {
         Ok(ClaudeMessage::Assistant(_)) => {
             return Some(MessageIdentity {
                 category: GroupCategory::Assistant,
@@ -201,7 +188,8 @@ pub(super) fn classify(
                 });
             }
             if user_is_plain_text(&msg) {
-                let label = match &msg.sender {
+                let meta = user_meta_from_json(json);
+                let label = match &meta.sender {
                     Some(sender) if current_user_id != Some(sender.user_id.as_str()) => {
                         sender.name.clone()
                     }
@@ -213,6 +201,19 @@ pub(super) fn classify(
                     badge_class: "user".to_string(),
                 });
             }
+        }
+        Ok(ClaudeMessage::OptimisticUser(msg)) => {
+            let label = match &msg.sender {
+                Some(sender) if current_user_id != Some(sender.user_id.as_str()) => {
+                    sender.name.clone()
+                }
+                _ => "You".to_string(),
+            };
+            return Some(MessageIdentity {
+                category: GroupCategory::User,
+                label,
+                badge_class: "user".to_string(),
+            });
         }
         Ok(ClaudeMessage::Portal(_)) => {
             return Some(MessageIdentity {
@@ -248,13 +249,9 @@ fn group_label(identity: &MessageIdentity, messages: &[String]) -> String {
 
     messages
         .iter()
-        .filter_map(|json| serde_json::from_str::<ClaudeMessage>(json).ok())
+        .filter_map(|json| ClaudeMessage::parse(json).ok())
         .find_map(|msg| match msg {
-            ClaudeMessage::Assistant(msg) => msg
-                .message
-                .as_ref()
-                .and_then(|m| m.model.as_deref())
-                .map(assistant_label),
+            ClaudeMessage::Assistant(msg) => Some(assistant_label(&msg.message.model)),
             _ => None,
         })
         .unwrap_or_else(|| identity.label.clone())
@@ -274,7 +271,7 @@ pub fn is_turn_terminator(json: &str) -> bool {
     // The `User`/`Portal`/`Error`/etc. variants are not terminators (and
     // there's no Codex `Result` shape — Codex terminators parse through
     // `CodexEvent` instead).
-    if let Ok(ClaudeMessage::Result(_)) = serde_json::from_str::<ClaudeMessage>(json) {
+    if let Ok(ClaudeMessage::Result(_)) = ClaudeMessage::parse(json) {
         return true;
     }
     // Codex side: terminators are `TurnCompleted` and `TurnFailed`. The

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -11,7 +11,7 @@ use yew::prelude::*;
 use grouping::classify;
 use grouping::{extract_raw_iso, visible_group_indices, GroupCategory};
 pub use grouping::{group_is_turn_terminator, group_messages, MessageGroup};
-use types::ClaudeMessage;
+use types::{user_meta_from_json, ClaudeMessage};
 
 /// Extract `_created_at` from a raw JSON message string and format it as local time.
 fn extract_local_timestamp(json: &str) -> Option<String> {
@@ -53,7 +53,7 @@ pub struct MessageRendererProps {
 pub fn message_renderer(props: &MessageRendererProps) -> Html {
     let ts = extract_local_timestamp(&props.json);
     let raw_iso = extract_raw_iso(&props.json);
-    let parsed: Result<ClaudeMessage, _> = serde_json::from_str(&props.json);
+    let parsed = ClaudeMessage::parse(&props.json);
 
     // Dispatch on the message shape, not the agent. `User` (the proxy's
     // synthetic echo) and `Portal` (the backend's portal-content envelope)
@@ -73,7 +73,16 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
             return renderers::render_result_message(&msg, props.turn_metrics.as_ref());
         }
         Ok(ClaudeMessage::User(msg)) => {
+            let meta = user_meta_from_json(&props.json);
             return renderers::render_user_message(
+                &msg,
+                &meta,
+                props.current_user_id.as_deref(),
+                ts.as_deref(),
+            );
+        }
+        Ok(ClaudeMessage::OptimisticUser(msg)) => {
+            return renderers::render_optimistic_user_message(
                 &msg,
                 props.current_user_id.as_deref(),
                 ts.as_deref(),
@@ -170,8 +179,11 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
 }
 
 fn render_identity_group_part(json: &str, agent_type: shared::AgentType) -> Html {
-    match serde_json::from_str::<ClaudeMessage>(json) {
+    match ClaudeMessage::parse(json) {
         Ok(ClaudeMessage::User(msg)) => renderers::render_user_message_content(&msg),
+        Ok(ClaudeMessage::OptimisticUser(msg)) => {
+            renderers::render_optimistic_user_message_content(&msg)
+        }
         Ok(ClaudeMessage::Assistant(msg)) => renderers::render_assistant_message_content(&msg),
         Ok(ClaudeMessage::Portal(msg)) => renderers::render_portal_message_content(&msg),
         _ if agent_type == shared::AgentType::Codex => {
@@ -326,7 +338,9 @@ mod tests {
         serde_json::json!({
             "type": "assistant",
             "message": {
+                "id": format!("msg_{tool_use_id}"),
                 "role": "assistant",
+                "model": "claude-sonnet-4-5-20250929",
                 "content": [{
                     "type": "tool_use",
                     "id": tool_use_id,
@@ -714,7 +728,12 @@ mod tests {
                 serde_json::json!({
                     "type": "result",
                     "subtype": "success",
+                    "is_error": false,
+                    "duration_ms": 100,
+                    "duration_api_ms": 80,
+                    "num_turns": 1,
                     "session_id": "01890000-0000-7000-8000-000000000001",
+                    "total_cost_usd": 0.0,
                     "_created_at": "2026-05-17T10:00:00.000Z",
                 })
                 .to_string(),
@@ -867,10 +886,12 @@ mod tests {
         let messages = vec![serde_json::json!({
             "type": "assistant",
             "message": {
+                "id": "msg_1",
                 "role": "assistant",
                 "model": "claude-opus-4-7-20260501",
                 "content": [{"type": "text", "text": "hello"}],
             },
+            "session_id": "01890000-0000-7000-8000-000000000001",
             "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string()];

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -5,7 +5,7 @@ mod portal;
 mod system;
 mod tools;
 
-use super::types::*;
+use super::types::{OptimisticUserMessage, UserMessageMeta};
 use super::{format_duration, shorten_model_name};
 use crate::components::copy_button::CopyButton;
 use crate::components::markdown::render_markdown;
@@ -28,8 +28,8 @@ fn preserve_user_newlines(text: &str) -> String {
 
 // --- Message renderers ---
 
-pub fn render_user_message(
-    msg: &UserMessage,
+pub fn render_optimistic_user_message(
+    msg: &OptimisticUserMessage,
     current_user_id: Option<&str>,
     timestamp: Option<&str>,
 ) -> Html {
@@ -39,75 +39,81 @@ pub fn render_user_message(
     };
     let pending_class = if msg.pending { " pending" } else { "" };
 
-    if let Some(text) = &msg.content {
+    html! {
+        <div class={format!("claude-message user-message{}", pending_class)}>
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
+                <span class="message-type-badge user">{ &label }</span>
+                if msg.pending {
+                    <span class="pending-indicator" title="Sending...">{ "\u{2022}" }</span>
+                }
+                <CopyButton text={msg.content.clone()} title="Copy message" />
+            </div>
+            <div class="message-body">{ render_optimistic_user_message_content(msg) }</div>
+        </div>
+    }
+}
+
+pub fn render_user_message(
+    msg: &shared::UserMessage,
+    meta: &UserMessageMeta,
+    current_user_id: Option<&str>,
+    timestamp: Option<&str>,
+) -> Html {
+    let label = match &meta.sender {
+        Some(sender) if current_user_id != Some(sender.user_id.as_str()) => sender.name.clone(),
+        _ => "You".to_string(),
+    };
+    let pending_class = if meta.pending { " pending" } else { "" };
+    let blocks = msg.message.content.clone();
+
+    let text_content: String = blocks
+        .iter()
+        .filter_map(|block| match block {
+            shared::ContentBlock::Text(t) => Some(t.text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let has_tool_results = blocks
+        .iter()
+        .any(|b| matches!(b, shared::ContentBlock::ToolResult(_)));
+
+    if has_tool_results {
+        html! {
+            <div class="claude-message user-message tool-result-message">
+                <div class="message-body">{ render_user_message_content(msg) }</div>
+            </div>
+        }
+    } else if !text_content.is_empty() {
         html! {
             <div class={format!("claude-message user-message{}", pending_class)}>
                 <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                     <span class="message-type-badge user">{ &label }</span>
-                    if msg.pending {
+                    if meta.pending {
                         <span class="pending-indicator" title="Sending...">{ "\u{2022}" }</span>
                     }
-                    <CopyButton text={text.clone()} title="Copy message" />
+                    <CopyButton text={text_content.clone()} title="Copy message" />
                 </div>
                 <div class="message-body">{ render_user_message_content(msg) }</div>
             </div>
-        }
-    } else if let Some(message) = &msg.message {
-        let blocks = message.content.as_ref().cloned().unwrap_or_default();
-
-        let text_content: String = blocks
-            .iter()
-            .filter_map(|block| match block {
-                ContentBlock::Text { text, .. } => Some(text.clone()),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        let has_tool_results = blocks
-            .iter()
-            .any(|b| matches!(b, ContentBlock::ToolResult { .. }));
-
-        if has_tool_results {
-            html! {
-                <div class="claude-message user-message tool-result-message">
-                    <div class="message-body">{ render_user_message_content(msg) }</div>
-                </div>
-            }
-        } else if !text_content.is_empty() {
-            html! {
-                <div class="claude-message user-message">
-                    <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
-                        <span class="message-type-badge user">{ &label }</span>
-                        <CopyButton text={text_content.clone()} title="Copy message" />
-                    </div>
-                    <div class="message-body">{ render_user_message_content(msg) }</div>
-                </div>
-            }
-        } else {
-            html! {}
         }
     } else {
         html! {}
     }
 }
 
-pub fn render_user_message_content(msg: &UserMessage) -> Html {
-    if let Some(text) = &msg.content {
-        return html! {
-            <div class="user-text">{ render_markdown(&preserve_user_newlines(text)) }</div>
-        };
+pub fn render_optimistic_user_message_content(msg: &OptimisticUserMessage) -> Html {
+    html! {
+        <div class="user-text">{ render_markdown(&preserve_user_newlines(&msg.content)) }</div>
     }
+}
 
-    let blocks = msg
-        .message
-        .as_ref()
-        .and_then(|m| m.content.as_ref())
-        .cloned()
-        .unwrap_or_default();
+pub fn render_user_message_content(msg: &shared::UserMessage) -> Html {
+    let blocks = msg.message.content.clone();
     let has_tool_results = blocks
         .iter()
-        .any(|b| matches!(b, ContentBlock::ToolResult { .. }));
+        .any(|b| matches!(b, shared::ContentBlock::ToolResult(_)));
 
     if has_tool_results {
         render_content_blocks(&blocks)
@@ -115,7 +121,7 @@ pub fn render_user_message_content(msg: &UserMessage) -> Html {
         let text_content = blocks
             .iter()
             .filter_map(|block| match block {
-                ContentBlock::Text { text, .. } => Some(text.clone()),
+                shared::ContentBlock::Text(t) => Some(t.text.clone()),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -131,24 +137,20 @@ pub fn render_user_message_content(msg: &UserMessage) -> Html {
     }
 }
 
-pub fn render_error_message(msg: &ErrorMessage, timestamp: Option<&str>) -> Html {
-    if msg.is_overload() {
+pub fn render_error_message(msg: &shared::AnthropicError, timestamp: Option<&str>) -> Html {
+    if msg.is_overloaded() {
         return render_overload_error(msg, timestamp);
     }
 
-    let message = msg.display_message();
-    let error_type = msg.error_type();
+    let message = msg.error.message.as_str();
+    let error_type = msg.error.error_type.as_str();
 
     html! {
         <div class="claude-message error-message-display">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge result error">{ "Error" }</span>
                 {
-                    if let Some(err_type) = error_type {
-                        html! { <span class="error-type">{ err_type }</span> }
-                    } else {
-                        html! {}
-                    }
+                    html! { <span class="error-type">{ error_type }</span> }
                 }
             </div>
             <div class="message-body">
@@ -158,7 +160,7 @@ pub fn render_error_message(msg: &ErrorMessage, timestamp: Option<&str>) -> Html
     }
 }
 
-fn render_overload_error(msg: &ErrorMessage, timestamp: Option<&str>) -> Html {
+fn render_overload_error(msg: &shared::AnthropicError, timestamp: Option<&str>) -> Html {
     let request_id = msg.request_id.as_deref().unwrap_or("unknown");
 
     html! {
@@ -184,15 +186,17 @@ fn render_overload_error(msg: &ErrorMessage, timestamp: Option<&str>) -> Html {
     }
 }
 
-pub fn render_rate_limit_event(msg: &RateLimitEventMessage, timestamp: Option<&str>) -> Html {
-    let info = msg.rate_limit_info.as_ref();
-    let status = info.and_then(|i| i.status.as_deref()).unwrap_or("unknown");
+pub fn render_rate_limit_event(msg: &shared::RateLimitEvent, timestamp: Option<&str>) -> Html {
+    let info = &msg.rate_limit_info;
+    let status = info.status.as_str();
     let rate_type = info
-        .and_then(|i| i.rate_limit_type.as_deref())
+        .rate_limit_type
+        .as_ref()
+        .map(|t| t.as_str())
         .unwrap_or("unknown");
-    let resets_at = info.and_then(|i| i.resets_at).unwrap_or(0);
-    let using_overage = info.and_then(|i| i.is_using_overage).unwrap_or(false);
-    let utilization = info.and_then(|i| i.utilization);
+    let resets_at = info.resets_at.unwrap_or(0);
+    let using_overage = info.is_using_overage;
+    let utilization = info.utilization;
 
     let reset_text = if resets_at > 0 {
         let now = (js_sys::Date::now() / 1000.0) as u64;
@@ -263,7 +267,7 @@ const ALLOWED_IMAGE_MEDIA_TYPES: &[&str] = &[
     "image/svg+xml",
 ];
 
-pub(super) fn render_image_source(source: &ImageSource, filename: Option<String>) -> Html {
+pub(super) fn render_image_source(source: &shared::ImageSource, filename: Option<String>) -> Html {
     if !ALLOWED_IMAGE_MEDIA_TYPES.contains(&source.media_type.as_str()) {
         return html! {
             <pre class="tool-result-content">
@@ -272,13 +276,13 @@ pub(super) fn render_image_source(source: &ImageSource, filename: Option<String>
         };
     }
     // Support both URL sources (from backend image store) and base64 data URIs
-    let src = if source.source_type == "url" {
+    let src = if source.source_type.as_str() == "url" {
         source.data.clone()
     } else {
         format!("data:{};base64,{}", source.media_type, source.data)
     };
     html! {
-        <ImageViewer src={src} media_type={source.media_type.clone()} {filename} />
+        <ImageViewer src={src} media_type={source.media_type.as_str().to_string()} {filename} />
     }
 }
 
@@ -378,26 +382,30 @@ fn image_viewer(props: &ImageViewerProps) -> Html {
 }
 
 pub fn render_result_message(
-    msg: &ResultMessage,
+    msg: &shared::ResultMessage,
     turn_metrics: Option<&shared::TurnMetrics>,
 ) -> Html {
-    let is_error = msg.is_error.unwrap_or(false);
+    let is_error = msg.is_error;
     let status_class = if is_error { "error" } else { "success" };
 
-    let duration_ms = msg.duration_ms.unwrap_or(0);
-    let api_ms = msg.duration_api_ms.unwrap_or(0);
-    let turns = msg.num_turns.unwrap_or(0);
+    let duration_ms = msg.duration_ms;
+    let api_ms = msg.duration_api_ms;
+    let turns = msg.num_turns;
 
     let mut timing_tooltip = format!(
         "Total: {}ms | API: {}ms | Turns: {}",
         duration_ms, api_ms, turns
     );
 
-    if let Some(model_usage) = &msg.model_usage {
+    if let Some(model_usage) = msg
+        .model_usage
+        .as_ref()
+        .and_then(|v| serde_json::from_value::<shared::ModelUsage>(v.clone()).ok())
+    {
         for (model, entry) in model_usage {
             timing_tooltip.push_str(&format!(
                 " | {}: ${:.4}",
-                shorten_model_name(model).unwrap_or_else(|| model.clone()),
+                shorten_model_name(&model).unwrap_or_else(|| model.clone()),
                 entry.cost_usd
             ));
         }
@@ -412,12 +420,7 @@ pub fn render_result_message(
     let denials_tooltip = if !msg.permission_denials.is_empty() {
         msg.permission_denials
             .iter()
-            .filter_map(|v| {
-                v.get("tool_name")
-                    .and_then(|t| t.as_str())
-                    .or_else(|| v.as_str())
-                    .map(|s| s.to_string())
-            })
+            .map(|v| v.tool_name.clone())
             .collect::<Vec<_>>()
             .join(", ")
     } else {
@@ -427,10 +430,10 @@ pub fn render_result_message(
     let extra_badges = html! {
         <>
             {
-                if let Some(cost) = msg.total_cost_usd {
+                    if msg.total_cost_usd > 0.0 {
                     html! {
                         <span class="stat-item cost" title="Total cost">
-                            { format!("${:.2}", cost) }
+                            { format!("${:.2}", msg.total_cost_usd) }
                         </span>
                     }
                 } else {
@@ -530,10 +533,10 @@ pub fn render_result_message(
                         html! {
                             <>
                                 <span class="stat-item tokens" title="Input tokens">
-                                    { format!("{}↓", usage.input_tokens.unwrap_or(0)) }
+                                    { format!("{}↓", usage.input_tokens) }
                                 </span>
                                 <span class="stat-item tokens" title="Output tokens">
-                                    { format!("{}↑", usage.output_tokens.unwrap_or(0)) }
+                                    { format!("{}↑", usage.output_tokens) }
                                 </span>
                             </>
                         }

--- a/frontend/src/components/message_renderer/renderers/assistant.rs
+++ b/frontend/src/components/message_renderer/renderers/assistant.rs
@@ -1,5 +1,4 @@
 use super::super::shorten_model_name;
-use super::super::types::{AssistantMessage, ContentBlock, UsageInfo};
 use super::render_image_source;
 use super::tools::{
     render_code_execution_result, render_container_upload, render_mcp_tool_result,
@@ -11,7 +10,8 @@ use crate::components::expandable::ExpandableText;
 use crate::components::markdown::render_markdown;
 use crate::components::time_ago::TimeAgo;
 use crate::components::tool_renderers::render_tool_use;
-use shared::{Citation, ToolResultContent};
+use shared::{AssistantMessage, AssistantUsage as UsageInfo};
+use shared::{Citation, ContentBlock, ToolResultContent};
 use yew::prelude::*;
 
 fn extract_ephemeral_cache(usage: &UsageInfo) -> (u64, u64) {
@@ -45,10 +45,10 @@ fn build_usage_tooltip(usage: Option<&UsageInfo>) -> String {
         .map(|u| {
             let mut tooltip = format!(
                 "Input: {} | Output: {} | Cache read: {} | Cache created: {}",
-                u.input_tokens.unwrap_or(0),
-                u.output_tokens.unwrap_or(0),
-                u.cache_read_input_tokens.unwrap_or(0),
-                u.cache_creation_input_tokens.unwrap_or(0)
+                u.input_tokens,
+                u.output_tokens,
+                u.cache_read_input_tokens,
+                u.cache_creation_input_tokens
             );
             let (e1h, e5m) = extract_ephemeral_cache(u);
             if e1h > 0 || e5m > 0 {
@@ -73,18 +73,18 @@ fn content_blocks_to_text(blocks: &[ContentBlock]) -> String {
     let mut out = String::new();
     for block in blocks {
         match block {
-            ContentBlock::Text { text, .. } => {
+            ContentBlock::Text(t) => {
                 if !out.is_empty() {
                     out.push_str("\n\n");
                 }
-                out.push_str(text);
+                out.push_str(&t.text);
             }
-            ContentBlock::Thinking { thinking } => {
+            ContentBlock::Thinking(th) => {
                 if !out.is_empty() {
                     out.push_str("\n\n");
                 }
                 out.push_str("<thinking>\n");
-                out.push_str(thinking);
+                out.push_str(&th.thinking);
                 out.push_str("\n</thinking>");
             }
             _ => {}
@@ -98,22 +98,11 @@ pub fn render_assistant_message(
     timestamp: Option<&str>,
     raw_iso: Option<&str>,
 ) -> Html {
-    let blocks = msg
-        .message
-        .as_ref()
-        .and_then(|m| m.content.as_ref())
-        .cloned()
-        .unwrap_or_default();
+    let blocks = msg.message.content.clone();
 
-    let usage = msg.message.as_ref().and_then(|m| m.usage.as_ref());
-    let model = msg
-        .message
-        .as_ref()
-        .and_then(|m| m.model.as_ref())
-        .map(|s| s.as_str())
-        .unwrap_or("");
-    let stop_reason = msg.message.as_ref().and_then(|m| m.stop_reason.as_deref());
-    let is_truncated = stop_reason == Some("max_tokens");
+    let usage = msg.message.usage.as_ref();
+    let model = msg.message.model.as_str();
+    let is_truncated = msg.message.stop_reason.as_ref().map(|r| r.as_str()) == Some("max_tokens");
 
     let model_tooltip = build_model_tooltip(model, usage);
     let usage_tooltip = build_usage_tooltip(usage);
@@ -138,7 +127,7 @@ pub fn render_assistant_message(
                     if let Some(u) = usage {
                         html! {
                             <span class="usage-badge" title={usage_tooltip}>
-                                <span class="token-count">{ format!("{}↓ {}↑", u.input_tokens.unwrap_or(0), u.output_tokens.unwrap_or(0)) }</span>
+                                <span class="token-count">{ format!("{}↓ {}↑", u.input_tokens, u.output_tokens) }</span>
                             </span>
                         }
                     } else {
@@ -157,12 +146,7 @@ pub fn render_assistant_message(
 }
 
 pub fn render_assistant_message_content(msg: &AssistantMessage) -> Html {
-    let blocks = msg
-        .message
-        .as_ref()
-        .and_then(|m| m.content.as_ref())
-        .cloned()
-        .unwrap_or_default();
+    let blocks = msg.message.content.clone();
     render_content_blocks(&blocks)
 }
 
@@ -172,20 +156,20 @@ pub fn render_content_blocks(blocks: &[ContentBlock]) -> Html {
             {
                 blocks.iter().map(|block| {
                     match block {
-                        ContentBlock::Text { text, citations } => {
+                        ContentBlock::Text(t) => {
                             html! {
                                 <div class="assistant-text">
-                                    { render_markdown(text) }
-                                    { render_citations(citations) }
+                                    { render_markdown(&t.text) }
+                                    { render_citations(&t.citations) }
                                 </div>
                             }
                         }
-                        ContentBlock::ToolUse { id: _, name, input } => {
-                            render_tool_use(name, input)
+                        ContentBlock::ToolUse(tu) => {
+                            render_tool_use(&tu.name, &tu.input)
                         }
-                        ContentBlock::ToolResult { tool_use_id: _, content, is_error } => {
-                            let class = if *is_error { "tool-result error" } else { "tool-result" };
-                            match content {
+                        ContentBlock::ToolResult(tr) => {
+                            let class = if tr.is_error.unwrap_or(false) { "tool-result error" } else { "tool-result" };
+                            match &tr.content {
                                 Some(ToolResultContent::Text(s)) => {
                                     html! {
                                         <div class={class}>
@@ -211,34 +195,40 @@ pub fn render_content_blocks(blocks: &[ContentBlock]) -> Html {
                                 None => html! { <div class={class}></div> },
                             }
                         }
-                        ContentBlock::Image { source } => {
-                            render_image_source(source, None)
+                        ContentBlock::Image(img) => {
+                            render_image_source(&img.source, None)
                         }
-                        ContentBlock::Thinking { thinking } => {
+                        ContentBlock::Thinking(th) => {
                             html! {
                                 <div class="thinking-block">
                                     <span class="thinking-label">{ "thinking" }</span>
-                                    <div class="thinking-content">{ crate::components::markdown::linkify_urls(thinking) }</div>
+                                    if th.thinking.trim().is_empty() {
+                                        <div class="thinking-content muted" title="Thinking text was omitted by the model; the encrypted signature is preserved in the raw message.">
+                                            { "thinking omitted" }
+                                        </div>
+                                    } else {
+                                        <div class="thinking-content">{ crate::components::markdown::linkify_urls(&th.thinking) }</div>
+                                    }
                                 </div>
                             }
                         }
-                        ContentBlock::ServerToolUse { id: _, name, input } => {
-                            render_server_tool_use(name, input)
+                        ContentBlock::ServerToolUse(stu) => {
+                            render_server_tool_use(&stu.name, &stu.input)
                         }
-                        ContentBlock::WebSearchToolResult { tool_use_id: _, content } => {
-                            render_web_search_result(content)
+                        ContentBlock::WebSearchToolResult(r) => {
+                            render_web_search_result(&r.content)
                         }
-                        ContentBlock::CodeExecutionToolResult { tool_use_id: _, content } => {
-                            render_code_execution_result(content)
+                        ContentBlock::CodeExecutionToolResult(r) => {
+                            render_code_execution_result(&r.content)
                         }
-                        ContentBlock::McpToolUse { id: _, name, server_name, input } => {
-                            render_mcp_tool_use(name, server_name.as_deref(), input)
+                        ContentBlock::McpToolUse(mtu) => {
+                            render_mcp_tool_use(&mtu.name, mtu.server_name.as_deref(), &mtu.input)
                         }
-                        ContentBlock::McpToolResult { tool_use_id: _, content, is_error } => {
-                            render_mcp_tool_result(content, is_error.unwrap_or(false))
+                        ContentBlock::McpToolResult(r) => {
+                            render_mcp_tool_result(&r.content, r.is_error.unwrap_or(false))
                         }
-                        ContentBlock::ContainerUpload { data } => {
-                            render_container_upload(data)
+                        ContentBlock::ContainerUpload(upload) => {
+                            render_container_upload(&upload.data)
                         }
                         ContentBlock::Unknown(value) => {
                             render_unknown_block(value)
@@ -250,16 +240,17 @@ pub fn render_content_blocks(blocks: &[ContentBlock]) -> Html {
     }
 }
 
-fn render_citations(citations: &[Citation]) -> Html {
+fn render_citations(citations: &[serde_json::Value]) -> Html {
     if citations.is_empty() {
         return html! {};
     }
     html! {
         <div class="citation-list">
             { for citations.iter().enumerate().map(|(i, cite)| {
-                let url = cite.url.as_deref().unwrap_or("#");
-                let title = cite.title.as_deref()
-                    .or(cite.cited_text.as_deref())
+                let cite = serde_json::from_value::<Citation>(cite.clone()).ok();
+                let url = cite.as_ref().and_then(|c| c.url.as_deref()).unwrap_or("#");
+                let title = cite.as_ref().and_then(|c| c.title.as_deref()
+                    .or(c.cited_text.as_deref()))
                     .unwrap_or("source");
                 html! {
                     <a class="citation-link"

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -1,4 +1,4 @@
-use super::super::types::{ImageSource, PortalMessage};
+use super::super::types::PortalMessage;
 use super::render_image_source;
 use crate::components::copy_button::CopyButton;
 use crate::components::markdown::render_markdown;
@@ -41,9 +41,11 @@ fn render_portal_content(content: &shared::PortalContent) -> Html {
             file_size,
             source_type,
         } => {
-            let source = ImageSource {
-                source_type: source_type.clone().unwrap_or_else(|| "base64".to_string()),
-                media_type: media_type.clone(),
+            let source = shared::ImageSource {
+                source_type: shared::ImageSourceType::from(
+                    source_type.as_deref().unwrap_or("base64"),
+                ),
+                media_type: shared::MediaType::from(media_type.as_str()),
                 data: data.clone(),
             };
             let filename = file_path

--- a/frontend/src/components/message_renderer/renderers/system.rs
+++ b/frontend/src/components/message_renderer/renderers/system.rs
@@ -1,16 +1,14 @@
-use super::super::types::SystemMessage;
 use super::super::{format_duration, shorten_model_name};
 use crate::components::markdown::render_markdown;
 use yew::prelude::*;
 
-pub fn render_system_message(msg: &SystemMessage, timestamp: Option<&str>) -> Html {
-    let subtype = msg.subtype.as_deref().unwrap_or("system");
+pub fn render_system_message(msg: &shared::SystemMessage, timestamp: Option<&str>) -> Html {
+    let subtype = msg.subtype.as_str();
 
     // Check if this is a compaction-related message via subtype or status field
     let status_value = msg
-        .extra
-        .as_ref()
-        .and_then(|v| v.get("status"))
+        .data
+        .get("status")
         .and_then(|s| s.as_str())
         .unwrap_or("");
 
@@ -53,26 +51,23 @@ pub fn render_system_message(msg: &SystemMessage, timestamp: Option<&str>) -> Ht
     }
 }
 
-fn render_init_bar(msg: &SystemMessage, timestamp: Option<&str>) -> Html {
-    let model_short = msg
-        .model
-        .as_deref()
+fn render_init_bar(msg: &shared::SystemMessage, timestamp: Option<&str>) -> Html {
+    let init = msg.as_init();
+    let model_short = init
+        .as_ref()
+        .and_then(|m| m.model.as_deref())
         .and_then(shorten_model_name)
         .unwrap_or_default();
-    let version = msg.claude_code_version.as_deref().unwrap_or("");
-    let tool_count = msg.tools.as_ref().map(|t| t.len()).unwrap_or(0);
-    let mcp_count = msg.mcp_servers.as_ref().map(|s| s.len()).unwrap_or(0);
-    // Typed dispatch over `extra` (closes #752). `InitExtra::fast_mode_state`
-    // mirrors `claude_codes::InitMessage::fast_mode_state` (already typed
-    // upstream); we use a narrow local mirror because the SDK's full
-    // `InitMessage` has many required fields and a partial frame here would
-    // otherwise fail to deserialize.
-    let init_extra: shared::InitExtra = msg
-        .extra
+    let version = init
         .as_ref()
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
-        .unwrap_or_default();
-    let fast_mode = init_extra.fast_mode_state.as_deref().unwrap_or("off");
+        .and_then(|m| m.claude_code_version.as_deref())
+        .unwrap_or("");
+    let tool_count = init.as_ref().map(|m| m.tools.len()).unwrap_or(0);
+    let mcp_count = init.as_ref().map(|m| m.mcp_servers.len()).unwrap_or(0);
+    let fast_mode = init
+        .as_ref()
+        .and_then(|m| m.fast_mode_state.as_deref())
+        .unwrap_or("off");
 
     html! {
         <div class="claude-message system-message compact" title={timestamp.unwrap_or_default().to_string()}>
@@ -106,28 +101,36 @@ fn render_compaction_beginning() -> Html {
     }
 }
 
-fn render_compaction_completed(msg: &SystemMessage) -> Html {
+fn render_compaction_completed(msg: &shared::SystemMessage) -> Html {
     // Typed dispatch over `extra` (closes #752). The SDK's
     // `CompactBoundaryMessage` currently only exposes
     // `compact_metadata { pre_tokens, trigger }` - not the `summary` /
     // `leaf_message_count` / `duration_ms` fields the renderer needs.
     // TODO(SDK rust-code-agent-sdks#141): drop the local `CompactionExtra`
     // mirror once upstream adds these fields to `CompactBoundaryMessage`,
-    // and switch to `CCSystemMessage::as_compact_boundary()` here.
+    // and switch to `SystemMessage::as_compact_boundary()` here.
     let compact_extra: shared::CompactionExtra = msg
-        .extra
-        .as_ref()
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .data
+        .as_object()
+        .and_then(|_| serde_json::from_value(msg.data.clone()).ok())
         .unwrap_or_default();
 
     let summary_text = msg
-        .summary
-        .as_deref()
+        .data
+        .get("summary")
+        .and_then(|v| v.as_str())
         .or_else(|| compact_extra.summary_text());
     let leaf_count = msg
-        .leaf_message_count
+        .data
+        .get("leaf_message_count")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
         .or_else(|| compact_extra.message_count());
-    let duration = msg.duration_ms.or(compact_extra.duration_ms);
+    let duration = msg
+        .data
+        .get("duration_ms")
+        .and_then(|v| v.as_u64())
+        .or(compact_extra.duration_ms);
 
     html! {
         <div class="claude-message compaction-message">
@@ -183,21 +186,20 @@ fn render_compaction_completed(msg: &SystemMessage) -> Html {
     }
 }
 
-fn render_task_started(msg: &SystemMessage, timestamp: Option<&str>) -> Html {
-    let extra = msg.extra.as_ref();
-    let description = extra
-        .and_then(|v| v.get("description").and_then(|d| d.as_str()))
+fn render_task_started(msg: &shared::SystemMessage, timestamp: Option<&str>) -> Html {
+    let task = msg.as_task_started();
+    let description = task
+        .as_ref()
+        .map(|t| t.description.as_str())
         .unwrap_or("Background task");
-    let task_id = extra
-        .and_then(|v| v.get("task_id").and_then(|t| t.as_str()))
-        .unwrap_or("");
+    let task_id = task.as_ref().map(|t| t.task_id.as_str()).unwrap_or("");
 
-    let type_label = extra
-        .and_then(|v| v.get("task_type"))
-        .and_then(|v| serde_json::from_value::<shared::CCTaskType>(v.clone()).ok())
+    let type_label = task
+        .as_ref()
+        .map(|t| t.task_type.clone())
         .map(|tt| match tt {
-            shared::CCTaskType::LocalAgent => "Sub-agent",
-            shared::CCTaskType::LocalBash => "Background Bash",
+            shared::TaskType::LocalAgent => "Sub-agent",
+            shared::TaskType::LocalBash => "Background Bash",
         })
         .unwrap_or("Task");
 
@@ -212,25 +214,28 @@ fn render_task_started(msg: &SystemMessage, timestamp: Option<&str>) -> Html {
     }
 }
 
-fn render_task_notification(msg: &SystemMessage, timestamp: Option<&str>) -> Html {
-    // Typed dispatch over `extra` (closes #752). `TaskNotificationExtra`
-    // mirrors the renderable subset of `claude_codes::TaskNotificationMessage`
-    // (the SDK type's required `session_id` / `summary` are already consumed
-    // by the outer lenient `SystemMessage`'s typed top-level fields and would
-    // not appear in the flattened `extra` Value).
-    let notif: shared::TaskNotificationExtra = msg
-        .extra
+fn render_task_notification(msg: &shared::SystemMessage, timestamp: Option<&str>) -> Html {
+    let notif = msg.as_task_notification();
+
+    let summary_text = notif.as_ref().map(|n| n.summary.as_str());
+    let task_id = notif.as_ref().map(|n| n.task_id.as_str()).unwrap_or("");
+    let duration = notif
         .as_ref()
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
-        .unwrap_or_default();
+        .and_then(|n| n.usage.as_ref())
+        .map(|u| u.duration_ms);
+    let tool_uses = notif
+        .as_ref()
+        .and_then(|n| n.usage.as_ref())
+        .map(|u| u.tool_uses);
+    let total_tokens = notif
+        .as_ref()
+        .and_then(|n| n.usage.as_ref())
+        .map(|u| u.total_tokens);
 
-    let summary_text = msg.summary.as_deref();
-    let task_id = notif.task_id.as_deref().unwrap_or("");
-    let duration = notif.usage.as_ref().map(|u| u.duration_ms);
-    let tool_uses = notif.usage.as_ref().map(|u| u.tool_uses);
-    let total_tokens = notif.usage.as_ref().map(|u| u.total_tokens);
-
-    let is_failed = matches!(notif.status, Some(shared::CCTaskStatus::Failed));
+    let is_failed = matches!(
+        notif.as_ref().map(|n| &n.status),
+        Some(shared::TaskStatus::Failed)
+    );
     let status_class = if is_failed { "failed" } else { "completed" };
 
     html! {

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -1,27 +1,22 @@
-//! Message type definitions for parsing Claude Code JSON output.
+//! Thin frontend-only wrappers around the shared Claude Code wire types.
+//!
+//! Claude messages should parse through `shared::ClaudeOutput`, which re-exports
+//! `claude-codes` types. The local shapes below exist only for Portal's
+//! frontend-specific envelope and optimistic user messages synthesized before
+//! the proxy echoes a typed Claude user frame.
 
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use shared::{CacheCreationDetails, Citation, ModelUsage, ToolResultContent};
+use serde::{Deserialize, Deserializer, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
+#[derive(Debug, Clone, Serialize)]
 pub enum ClaudeMessage {
-    #[serde(rename = "system")]
-    System(SystemMessage),
-    #[serde(rename = "assistant")]
-    Assistant(AssistantMessage),
-    #[serde(rename = "result")]
-    Result(ResultMessage),
-    #[serde(rename = "user")]
-    User(UserMessage),
-    #[serde(rename = "error")]
-    Error(ErrorMessage),
-    #[serde(rename = "portal")]
+    System(shared::SystemMessage),
+    Assistant(shared::AssistantMessage),
+    Result(shared::ResultMessage),
+    User(shared::UserMessage),
+    Error(shared::AnthropicError),
     Portal(PortalMessage),
-    #[serde(rename = "rate_limit_event")]
-    RateLimitEvent(RateLimitEventMessage),
-    #[serde(other)]
+    RateLimitEvent(shared::RateLimitEvent),
+    OptimisticUser(OptimisticUserMessage),
     Unknown,
 }
 
@@ -38,9 +33,8 @@ pub struct MessageSender {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct UserMessage {
-    pub content: Option<String>,
-    pub message: Option<UserMessageContent>,
+pub struct OptimisticUserMessage {
+    pub content: String,
     #[serde(default, rename = "_sender")]
     pub sender: Option<MessageSender>,
     #[serde(default, rename = "_pending")]
@@ -48,273 +42,77 @@ pub struct UserMessage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct UserMessageContent {
-    pub content: Option<Vec<ContentBlock>>,
+pub struct UserMessageMeta {
+    #[serde(default, rename = "_sender")]
+    pub sender: Option<MessageSender>,
+    #[serde(default, rename = "_pending")]
+    pub pending: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct ErrorDetails {
-    #[serde(rename = "type")]
-    pub error_type: Option<String>,
-    pub message: Option<String>,
+pub fn user_meta_from_json(json: &str) -> UserMessageMeta {
+    serde_json::from_str(json).unwrap_or_default()
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct ErrorMessage {
-    pub message: Option<String>,
-    pub error: Option<ErrorDetails>,
-    pub request_id: Option<String>,
-}
+impl ClaudeMessage {
+    pub fn parse(json: &str) -> Result<Self, serde_json::Error> {
+        if let Ok(output) = serde_json::from_str::<shared::ClaudeOutput>(json) {
+            return Ok(match output {
+                shared::ClaudeOutput::System(msg) => Self::System(msg),
+                shared::ClaudeOutput::User(msg) => Self::User(msg),
+                shared::ClaudeOutput::Assistant(msg) => Self::Assistant(msg),
+                shared::ClaudeOutput::Result(msg) => Self::Result(msg),
+                shared::ClaudeOutput::Error(msg) => Self::Error(msg),
+                shared::ClaudeOutput::RateLimitEvent(msg) => Self::RateLimitEvent(msg),
+                shared::ClaudeOutput::ControlRequest(_)
+                | shared::ClaudeOutput::ControlResponse(_) => Self::Unknown,
+            });
+        }
 
-impl ErrorMessage {
-    pub fn is_overload(&self) -> bool {
-        self.error
-            .as_ref()
-            .and_then(|e| e.error_type.as_deref())
-            .map(|t| t == "overloaded_error")
-            .unwrap_or(false)
-    }
-
-    pub fn display_message(&self) -> &str {
-        self.error
-            .as_ref()
-            .and_then(|e| e.message.as_deref())
-            .or(self.message.as_deref())
-            .unwrap_or("Unknown error")
-    }
-
-    pub fn error_type(&self) -> Option<&str> {
-        self.error.as_ref().and_then(|e| e.error_type.as_deref())
+        serde_json::from_str::<LocalMessage>(json).map(Into::into)
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct RateLimitEventMessage {
-    pub rate_limit_info: Option<RateLimitInfo>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct RateLimitInfo {
-    pub status: Option<String>,
-    #[serde(rename = "resetsAt")]
-    pub resets_at: Option<u64>,
-    #[serde(rename = "rateLimitType")]
-    pub rate_limit_type: Option<String>,
-    pub utilization: Option<f64>,
-    #[serde(rename = "overageStatus")]
-    pub overage_status: Option<String>,
-    #[serde(rename = "overageDisabledReason")]
-    pub overage_disabled_reason: Option<String>,
-    #[serde(rename = "isUsingOverage")]
-    pub is_using_overage: Option<bool>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct SystemMessage {
-    pub subtype: Option<String>,
-    pub session_id: Option<String>,
-    pub model: Option<String>,
-    pub cwd: Option<String>,
-    pub claude_code_version: Option<String>,
-    pub tools: Option<Vec<String>>,
-    pub agents: Option<Vec<String>>,
-    pub skills: Option<Vec<String>>,
-    pub slash_commands: Option<Vec<String>>,
-    pub mcp_servers: Option<Vec<Value>>,
-    pub plugins: Option<Vec<Value>>,
-    pub summary: Option<String>,
-    pub leaf_message_count: Option<u32>,
-    pub duration_ms: Option<u64>,
-    #[serde(flatten)]
-    pub extra: Option<Value>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct AssistantMessage {
-    pub message: Option<MessageContent>,
-    pub session_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct MessageContent {
-    pub id: Option<String>,
-    pub model: Option<String>,
-    pub role: Option<String>,
-    pub stop_reason: Option<String>,
-    pub content: Option<Vec<ContentBlock>>,
-    pub usage: Option<UsageInfo>,
+impl<'de> Deserialize<'de> for ClaudeMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if let Ok(output) = serde_json::from_value::<shared::ClaudeOutput>(value.clone()) {
+            return Ok(match output {
+                shared::ClaudeOutput::System(msg) => Self::System(msg),
+                shared::ClaudeOutput::User(msg) => Self::User(msg),
+                shared::ClaudeOutput::Assistant(msg) => Self::Assistant(msg),
+                shared::ClaudeOutput::Result(msg) => Self::Result(msg),
+                shared::ClaudeOutput::Error(msg) => Self::Error(msg),
+                shared::ClaudeOutput::RateLimitEvent(msg) => Self::RateLimitEvent(msg),
+                shared::ClaudeOutput::ControlRequest(_)
+                | shared::ClaudeOutput::ControlResponse(_) => Self::Unknown,
+            });
+        }
+        serde_json::from_value::<LocalMessage>(value)
+            .map(Into::into)
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
-pub enum ContentBlock {
-    #[serde(rename = "text")]
-    Text {
-        text: String,
-        #[serde(default)]
-        citations: Vec<Citation>,
-    },
-    #[serde(rename = "image")]
-    Image { source: ImageSource },
-    #[serde(rename = "tool_use")]
-    ToolUse {
-        id: String,
-        name: String,
-        input: Value,
-    },
-    #[serde(rename = "tool_result")]
-    ToolResult {
-        tool_use_id: String,
-        content: Option<ToolResultContent>,
-        #[serde(default)]
-        is_error: bool,
-    },
-    #[serde(rename = "thinking")]
-    Thinking { thinking: String },
-    #[serde(rename = "server_tool_use")]
-    ServerToolUse {
-        id: String,
-        name: String,
-        #[serde(default)]
-        input: Value,
-    },
-    #[serde(rename = "web_search_tool_result")]
-    WebSearchToolResult {
-        tool_use_id: String,
-        #[serde(default)]
-        content: Value,
-    },
-    #[serde(rename = "code_execution_tool_result")]
-    CodeExecutionToolResult {
-        tool_use_id: String,
-        #[serde(default)]
-        content: Value,
-    },
-    #[serde(rename = "mcp_tool_use")]
-    McpToolUse {
-        id: String,
-        name: String,
-        #[serde(default)]
-        server_name: Option<String>,
-        #[serde(default)]
-        input: Value,
-    },
-    #[serde(rename = "mcp_tool_result")]
-    McpToolResult {
-        tool_use_id: String,
-        #[serde(default)]
-        content: Value,
-        #[serde(default)]
-        is_error: Option<bool>,
-    },
-    #[serde(rename = "container_upload")]
-    ContainerUpload {
-        #[serde(flatten)]
-        data: Value,
-    },
-    #[serde(untagged)]
-    Unknown(Value),
+enum LocalMessage {
+    #[serde(rename = "portal")]
+    Portal(PortalMessage),
+    #[serde(rename = "user")]
+    OptimisticUser(OptimisticUserMessage),
+    #[serde(other)]
+    Unknown,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ImageSource {
-    #[serde(rename = "type")]
-    pub source_type: String,
-    pub media_type: String,
-    pub data: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct UsageInfo {
-    pub input_tokens: Option<u64>,
-    pub output_tokens: Option<u64>,
-    pub cache_read_input_tokens: Option<u64>,
-    pub cache_creation_input_tokens: Option<u64>,
-    pub service_tier: Option<String>,
-    pub inference_geo: Option<String>,
-    pub cache_creation: Option<CacheCreationDetails>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct ResultMessage {
-    pub subtype: Option<String>,
-    pub session_id: Option<String>,
-    pub result: Option<String>,
-    pub is_error: Option<bool>,
-    pub duration_ms: Option<u64>,
-    pub duration_api_ms: Option<u64>,
-    pub total_cost_usd: Option<f64>,
-    pub num_turns: Option<u64>,
-    pub usage: Option<UsageInfo>,
-    pub stop_reason: Option<String>,
-    pub terminal_reason: Option<String>,
-    pub fast_mode_state: Option<String>,
-    #[serde(default)]
-    pub errors: Vec<String>,
-    /// Per-model token/cost breakdown keyed by model name. The wire field is
-    /// `modelUsage` (camelCase) — matches the upstream
-    /// `claude-codes::ResultMessage` rename. TODO(SDK #140): upstream is still
-    /// typed as `Option<serde_json::Value>`; once the SDK adopts a typed map
-    /// the local `shared::ModelUsage` alias can be swapped for the SDK's
-    /// directly.
-    #[serde(rename = "modelUsage")]
-    pub model_usage: Option<ModelUsage>,
-    pub api_error_status: Option<u16>,
-    #[serde(default)]
-    pub permission_denials: Vec<Value>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_error_message_overload_detection() {
-        let msg = ErrorMessage {
-            message: None,
-            error: Some(ErrorDetails {
-                error_type: Some("overloaded_error".to_string()),
-                message: Some("Overloaded".to_string()),
-            }),
-            request_id: Some("req_123".to_string()),
-        };
-        assert!(msg.is_overload());
-        assert_eq!(msg.display_message(), "Overloaded");
-        assert_eq!(msg.error_type(), Some("overloaded_error"));
-    }
-
-    #[test]
-    fn test_error_message_regular_error() {
-        let msg = ErrorMessage {
-            message: Some("Something went wrong".to_string()),
-            error: None,
-            request_id: None,
-        };
-        assert!(!msg.is_overload());
-        assert_eq!(msg.display_message(), "Something went wrong");
-        assert_eq!(msg.error_type(), None);
-    }
-
-    #[test]
-    fn test_error_message_api_error() {
-        let msg = ErrorMessage {
-            message: None,
-            error: Some(ErrorDetails {
-                error_type: Some("invalid_request_error".to_string()),
-                message: Some("Invalid API key".to_string()),
-            }),
-            request_id: Some("req_456".to_string()),
-        };
-        assert!(!msg.is_overload());
-        assert_eq!(msg.display_message(), "Invalid API key");
-        assert_eq!(msg.error_type(), Some("invalid_request_error"));
-    }
-
-    #[test]
-    fn test_error_message_empty() {
-        let msg = ErrorMessage::default();
-        assert!(!msg.is_overload());
-        assert_eq!(msg.display_message(), "Unknown error");
-        assert_eq!(msg.error_type(), None);
+impl From<LocalMessage> for ClaudeMessage {
+    fn from(value: LocalMessage) -> Self {
+        match value {
+            LocalMessage::Portal(msg) => Self::Portal(msg),
+            LocalMessage::OptimisticUser(msg) => Self::OptimisticUser(msg),
+            LocalMessage::Unknown => Self::Unknown,
+        }
     }
 }

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -8,7 +8,7 @@
 //! See the per-function docstrings for which `SessionViewMsg` arm each helper
 //! was extracted from.
 
-use crate::components::message_renderer::types::{ClaudeMessage, ContentBlock};
+use crate::components::message_renderer::types::ClaudeMessage;
 
 /// Cross-agent activity classification used by the session-rail sparkline and
 /// the pending-send reconciler. The same enum bridges Claude wire shapes
@@ -99,7 +99,7 @@ pub(super) fn message_type_tag(m: &ClaudeMessage) -> ActivityTag {
         ClaudeMessage::System(_) => ActivityTag::System,
         ClaudeMessage::Assistant(_) => ActivityTag::Assistant,
         ClaudeMessage::Result(_) => ActivityTag::Result,
-        ClaudeMessage::User(_) => ActivityTag::User,
+        ClaudeMessage::User(_) | ClaudeMessage::OptimisticUser(_) => ActivityTag::User,
         ClaudeMessage::Error(_) => ActivityTag::Error,
         ClaudeMessage::Portal(_) => ActivityTag::Portal,
         ClaudeMessage::RateLimitEvent(_) => ActivityTag::RateLimit,
@@ -114,16 +114,16 @@ pub(super) fn message_type_tag(m: &ClaudeMessage) -> ActivityTag {
 /// `message.content` (the shape Claude's `--replay-user-messages` emits).
 pub(super) fn extract_user_text(m: &ClaudeMessage) -> Option<String> {
     let ClaudeMessage::User(u) = m else {
+        if let ClaudeMessage::OptimisticUser(u) = m {
+            return Some(u.content.clone());
+        }
         return None;
     };
-    if let Some(text) = u.content.as_ref() {
-        return Some(text.clone());
-    }
-    let blocks = u.message.as_ref().and_then(|m| m.content.as_ref())?;
+    let blocks = &u.message.content;
     let texts: Vec<&str> = blocks
         .iter()
         .filter_map(|b| match b {
-            ContentBlock::Text { text, .. } => Some(text.as_str()),
+            shared::ContentBlock::Text(t) => Some(t.text.as_str()),
             _ => None,
         })
         .collect();
@@ -156,7 +156,7 @@ pub(super) fn is_claude_awaiting(
     messages
         .rev()
         .find_map(|msg| {
-            serde_json::from_str::<ClaudeMessage>(msg.as_ref())
+            ClaudeMessage::parse(msg.as_ref())
                 .ok()
                 .filter(|m| {
                     matches!(
@@ -164,6 +164,7 @@ pub(super) fn is_claude_awaiting(
                         ClaudeMessage::Result(_)
                             | ClaudeMessage::Assistant(_)
                             | ClaudeMessage::User(_)
+                            | ClaudeMessage::OptimisticUser(_)
                     )
                 })
                 .map(|m| message_type_tag(&m))
@@ -209,7 +210,7 @@ pub(super) fn classify_output_msg_type(output: &str) -> ActivityTag {
         }
         return tag;
     }
-    if let Ok(parsed) = serde_json::from_str::<ClaudeMessage>(output) {
+    if let Ok(parsed) = ClaudeMessage::parse(output) {
         let tag = message_type_tag(&parsed);
         if tag != ActivityTag::Unknown {
             return tag;
@@ -337,13 +338,13 @@ pub(super) fn reconcile_pending_sends(
     }
     match tag {
         ActivityTag::User => {
-            let echo_text = serde_json::from_str::<ClaudeMessage>(output)
+            let echo_text = ClaudeMessage::parse(output)
                 .ok()
                 .as_ref()
                 .and_then(extract_user_text);
             if let Some(ref echo) = echo_text {
                 if let Some(pos) = pending_sends.iter().position(|pending| {
-                    serde_json::from_str::<ClaudeMessage>(pending)
+                    ClaudeMessage::parse(pending)
                         .ok()
                         .as_ref()
                         .and_then(extract_user_text)
@@ -435,7 +436,7 @@ mod tests {
 
     #[test]
     fn classify_output_msg_type_recognizes_assistant_envelope() {
-        let json = r#"{"type":"assistant","message":{"content":[]}}"#;
+        let json = r#"{"type":"assistant","message":{"id":"msg_1","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[]},"session_id":"01890000-0000-7000-8000-000000000001"}"#;
         assert_eq!(classify_output_msg_type(json), ActivityTag::Assistant);
     }
 
@@ -456,7 +457,7 @@ mod tests {
 
     #[test]
     fn classify_output_msg_type_recognizes_error_envelope() {
-        let json = r#"{"type":"error","content":"boom"}"#;
+        let json = r#"{"type":"error","error":{"type":"api_error","message":"boom"}}"#;
         assert_eq!(classify_output_msg_type(json), ActivityTag::Error);
     }
 
@@ -697,8 +698,8 @@ mod tests {
     fn is_claude_awaiting_true_when_last_signal_is_result() {
         let msgs = [
             r#"{"type":"user","content":"q"}"#.to_string(),
-            r#"{"type":"assistant","message":{"content":[]}}"#.to_string(),
-            r#"{"type":"result","total_cost_usd":0.0}"#.to_string(),
+            r#"{"type":"assistant","message":{"id":"msg_1","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[]},"session_id":"01890000-0000-7000-8000-000000000001"}"#.to_string(),
+            r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":1,"duration_api_ms":1,"num_turns":1,"session_id":"01890000-0000-7000-8000-000000000001","total_cost_usd":0.0}"#.to_string(),
         ];
         assert!(is_claude_awaiting(msgs.iter()));
     }
@@ -707,7 +708,7 @@ mod tests {
     fn is_claude_awaiting_false_when_last_signal_is_assistant() {
         let msgs = [
             r#"{"type":"user","content":"q"}"#.to_string(),
-            r#"{"type":"assistant","message":{"content":[]}}"#.to_string(),
+            r#"{"type":"assistant","message":{"id":"msg_1","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[]},"session_id":"01890000-0000-7000-8000-000000000001"}"#.to_string(),
         ];
         assert!(!is_claude_awaiting(msgs.iter()));
     }
@@ -717,9 +718,9 @@ mod tests {
         // Portal / error / system messages don't gate awaiting — the last
         // result before any of those still counts.
         let msgs = [
-            r#"{"type":"result","total_cost_usd":0.0}"#.to_string(),
+            r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":1,"duration_api_ms":1,"num_turns":1,"session_id":"01890000-0000-7000-8000-000000000001","total_cost_usd":0.0}"#.to_string(),
             r#"{"type":"portal","content":[{"type":"text","text":"x"}]}"#.to_string(),
-            r#"{"type":"error","content":"y"}"#.to_string(),
+            r#"{"type":"error","error":{"type":"api_error","message":"y"}}"#.to_string(),
         ];
         assert!(is_claude_awaiting(msgs.iter()));
     }
@@ -742,7 +743,7 @@ mod tests {
     #[test]
     fn extract_user_text_falls_back_to_concatenated_text_blocks() {
         let m: ClaudeMessage = serde_json::from_str(
-            r#"{"type":"user","message":{"content":[{"type":"text","text":"foo"},{"type":"text","text":"bar"}]}}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"foo"},{"type":"text","text":"bar"}]},"session_id":"01890000-0000-7000-8000-000000000001"}"#,
         )
         .unwrap();
         assert_eq!(extract_user_text(&m).as_deref(), Some("foobar"));
@@ -750,14 +751,17 @@ mod tests {
 
     #[test]
     fn extract_user_text_returns_none_for_non_user_variant() {
-        let m: ClaudeMessage = serde_json::from_str(r#"{"type":"system"}"#).unwrap();
+        let m: ClaudeMessage = serde_json::from_str(
+            r#"{"type":"system","subtype":"init","session_id":"01890000-0000-7000-8000-000000000001"}"#,
+        )
+        .unwrap();
         assert_eq!(extract_user_text(&m), None);
     }
 
     #[test]
     fn extract_user_text_returns_none_when_no_text_blocks_and_no_top_level_content() {
         let m: ClaudeMessage =
-            serde_json::from_str(r#"{"type":"user","message":{"content":[]}}"#).unwrap();
+            serde_json::from_str(r#"{"type":"user","message":{"role":"user","content":[]},"session_id":"01890000-0000-7000-8000-000000000001"}"#).unwrap();
         assert_eq!(extract_user_text(&m), None);
     }
 
@@ -767,7 +771,10 @@ mod tests {
     fn message_type_tag_returns_expected_variant_for_each_claude_shape() {
         assert_eq!(
             message_type_tag(
-                &serde_json::from_str::<ClaudeMessage>(r#"{"type":"system"}"#).unwrap()
+                &serde_json::from_str::<ClaudeMessage>(
+                    r#"{"type":"system","subtype":"init","session_id":"01890000-0000-7000-8000-000000000001"}"#
+                )
+                .unwrap()
             ),
             ActivityTag::System
         );
@@ -779,8 +786,10 @@ mod tests {
         );
         assert_eq!(
             message_type_tag(
-                &serde_json::from_str::<ClaudeMessage>(r#"{"type":"error","content":"x"}"#)
-                    .unwrap()
+                &serde_json::from_str::<ClaudeMessage>(
+                    r#"{"type":"error","error":{"type":"api_error","message":"x"}}"#
+                )
+                .unwrap()
             ),
             ActivityTag::Error
         );

--- a/frontend/src/pages/dashboard/session_view/tasks_panel.rs
+++ b/frontend/src/pages/dashboard/session_view/tasks_panel.rs
@@ -549,8 +549,8 @@ pub(super) fn derive_task_events(
         shared::ClaudeOutput::System(sys) => {
             if let Some(task) = sys.as_task_started() {
                 let task_type = match task.task_type {
-                    shared::CCTaskType::LocalAgent => "local_agent",
-                    shared::CCTaskType::LocalBash => "local_bash",
+                    shared::TaskType::LocalAgent => "local_agent",
+                    shared::TaskType::LocalBash => "local_bash",
                 }
                 .to_string();
                 events.push(TaskEvent::Started {
@@ -572,8 +572,8 @@ pub(super) fn derive_task_events(
                 });
             } else if let Some(notif) = sys.as_task_notification() {
                 let status = match notif.status {
-                    shared::CCTaskStatus::Completed => TaskStatus::Completed,
-                    shared::CCTaskStatus::Failed => TaskStatus::Failed,
+                    shared::TaskStatus::Completed => TaskStatus::Completed,
+                    shared::TaskStatus::Failed => TaskStatus::Failed,
                 };
                 let usage = notif
                     .usage

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -327,7 +327,7 @@ pub struct SoundSettingsResponse {
 //   `rust-code-agent-sdks#141`; the SDK's `CompactBoundaryMessage` currently
 //   only exposes `compact_metadata { pre_tokens, trigger }`. Once upstream
 //   lands these, this struct can be deleted and the renderer can switch to
-//   `CCSystemMessage::as_compact_boundary()`.
+//   `SystemMessage::as_compact_boundary()`.
 // - `InitExtra` — `fast_mode_state`. The SDK's `InitMessage::fast_mode_state`
 //   is already typed `Option<String>`; we keep a narrow local mirror because
 //   `InitMessage` has many required fields and a single-field shape is
@@ -343,7 +343,7 @@ pub struct SoundSettingsResponse {
 //
 // TODO(SDK rust-code-agent-sdks#141): drop this struct once
 // `claude_codes::CompactBoundaryMessage` exposes these fields directly and
-// switch `render_compaction_completed` to `CCSystemMessage::as_compact_boundary`.
+// switch `render_compaction_completed` to `SystemMessage::as_compact_boundary`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CompactionExtra {
     #[serde(default)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -36,16 +36,15 @@ pub fn default_backend_url() -> &'static str {
 
 // Re-export claude-codes types for frontend message parsing
 pub use claude_codes::io::{
-    ContentBlock, ImageBlock, ImageSource, PermissionSuggestion, TextBlock, ThinkingBlock,
-    ToolResultBlock, ToolResultContent, ToolUseBlock,
+    ContentBlock, ImageBlock, ImageSource, ImageSourceType, MediaType, PermissionSuggestion,
+    TextBlock, ThinkingBlock, ToolResultBlock, ToolResultContent, ToolUseBlock,
 };
 
-// Re-export claude-codes output types for typed parsing (aliased to avoid conflicts with
-// frontend's local lenient types in message_renderer/types.rs)
+// Re-export claude-codes output types for typed parsing.
 pub use claude_codes::io::{
-    ResultMessage as CCResultMessage, SystemMessage as CCSystemMessage,
-    SystemSubtype as CCSystemSubtype, TaskNotificationMessage, TaskProgressMessage,
-    TaskStartedMessage, TaskStatus as CCTaskStatus, TaskType as CCTaskType, TaskUsage,
+    AnthropicError, AssistantMessage, AssistantUsage, MessageContent, RateLimitEvent,
+    ResultMessage, ServerToolUse, SystemMessage, SystemSubtype, TaskNotificationMessage,
+    TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType, TaskUsage, UserMessage,
 };
 pub use claude_codes::CacheCreationDetails;
 pub use claude_codes::ClaudeOutput;
@@ -64,7 +63,7 @@ pub use claude_codes::{AllowedPrompt, ExitPlanModeInput};
 /// The CLI uses several spellings depending on version and code path, so this
 /// helper centralizes the predicate. Callers should use this instead of
 /// inlining the disjunction.
-pub fn is_compaction_boundary(sys: &CCSystemMessage) -> bool {
+pub fn is_compaction_boundary(sys: &SystemMessage) -> bool {
     sys.is_compact_boundary()
         || matches!(
             sys.subtype.as_str(),


### PR DESCRIPTION
## Summary
- Replace duplicate frontend Claude message/content mirrors with shared claude-codes wire types
- Keep only frontend-specific portal, optimistic user, and metadata wrappers
- Render omitted Opus thinking blocks explicitly and preserve typed thinking signatures
- Remove leftover CC* alias re-exports and use direct shared type names
- Bump workspace version to 2.6.24

## Verification
- cargo check -p frontend
- cargo test -p frontend
- cargo check --target wasm32-unknown-unknown -p shared