### PR TITLE
Require known model for turn metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.26"
+version = "2.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.26"
+version = "2.6.27"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.26"
+version = "2.6.27"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.26"
+version = "2.6.27"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.26"
+version = "2.6.27"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.26"
+version = "2.6.27"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.26"
+version = "2.6.27"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.26"
+version = "2.6.27"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.26"
+version = "2.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.26"
+version = "2.6.27"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.26"
+version = "2.6.27"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/2026-05-29-143758_drop_unknown_model_turn_metrics/down.sql
+++ b/backend/migrations/2026-05-29-143758_drop_unknown_model_turn_metrics/down.sql
@@ -1,0 +1,2 @@
+-- Irreversible data cleanup: unknown-model turn metrics are intentionally
+-- discarded because they cannot be grouped or interpreted correctly.

--- a/backend/migrations/2026-05-29-143758_drop_unknown_model_turn_metrics/up.sql
+++ b/backend/migrations/2026-05-29-143758_drop_unknown_model_turn_metrics/up.sql
@@ -1,0 +1,4 @@
+DELETE FROM turn_metrics
+WHERE model IS NULL
+   OR btrim(model) = ''
+   OR lower(btrim(model)) = 'unknown';

--- a/backend/src/handlers/websocket/turn_metrics.rs
+++ b/backend/src/handlers/websocket/turn_metrics.rs
@@ -9,7 +9,7 @@
 
 use diesel::prelude::*;
 use shared::{ServerToClient, TurnMetrics};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use super::{SessionId, SessionManager};
@@ -35,6 +35,14 @@ pub fn handle_turn_metrics_report(
         return;
     };
     metrics.session_id = session_id;
+
+    if has_unknown_model(metrics.model.as_deref()) {
+        warn!(
+            "Dropping turn metrics for session {} with unknown model (agent={})",
+            session_id, metrics.agent_type
+        );
+        return;
+    }
 
     let mut conn = match db_pool.get() {
         Ok(c) => c,
@@ -150,6 +158,13 @@ pub fn handle_turn_metrics_report(
             ServerToClient::TurnMetrics(Box::new(payload.clone())),
         );
     }
+}
+
+fn has_unknown_model(model: Option<&str>) -> bool {
+    model.is_none_or(|value| {
+        let value = value.trim();
+        value.is_empty() || value.eq_ignore_ascii_case("unknown")
+    })
 }
 
 // No unit tests here — the persist/broadcast round-trip needs a real

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -168,9 +168,10 @@ pub(crate) async fn claude_io_task(
                         // again).
                         if let ClaudeOutput::Result(ref r) = output {
                             let usage = r.usage.as_ref();
+                            let model = current_model.clone();
                             let outcome = TurnOutcome {
                                 agent_type: shared::AgentType::Claude.as_str().to_string(),
-                                model: current_model.clone(),
+                                model,
                                 service_tier: current_service_tier.clone().or_else(|| {
                                     usage
                                         .map(|u| u.service_tier.clone())
@@ -198,8 +199,22 @@ pub(crate) async fn claude_io_task(
                                 chrono::Utc::now(),
                                 outcome,
                             ) {
-                                let _ = event_tx
-                                    .send(IoEvent::TurnMetricsReady(Box::new(metrics)));
+                                if metrics
+                                    .model
+                                    .as_deref()
+                                    .is_some_and(|m| {
+                                        let m = m.trim();
+                                        !m.is_empty() && !m.eq_ignore_ascii_case("unknown")
+                                    })
+                                {
+                                    let _ = event_tx
+                                        .send(IoEvent::TurnMetricsReady(Box::new(metrics)));
+                                } else {
+                                    tracing::warn!(
+                                        "Claude result completed without model metadata for session {}; dropping turn metrics",
+                                        session_id
+                                    );
+                                }
                             }
                         }
 

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -70,6 +70,7 @@ pub(crate) async fn codex_io_task(
     if !trailing.is_empty() {
         builder = builder.extra_args(trailing.iter().cloned());
     }
+    let configured_model_fallback = configured_codex_model(&overrides, &trailing);
 
     tracing::info!(
         "Starting Codex app-server: {} app-server --listen stdio:// \
@@ -97,8 +98,17 @@ pub(crate) async fn codex_io_task(
     // 0.129.3 src/lib.rs:18-30 example.
     let thread_params: ThreadStartParams = serde_json::from_value(serde_json::json!({}))
         .expect("empty JSON object is a valid ThreadStartParams");
-    let thread_id = match client.thread_start(&thread_params).await {
-        Ok(resp) => resp.thread.id.clone(),
+    let (thread_id, thread_model) = match client.thread_start(&thread_params).await {
+        Ok(resp) => {
+            let model = non_empty_string(resp.model).or_else(|| configured_model_fallback.clone());
+            if model.is_none() {
+                tracing::warn!(
+                    "Codex thread {} started without a detectable model; turn metrics will warn until model metadata is available",
+                    resp.thread.id
+                );
+            }
+            (resp.thread.id.clone(), model)
+        }
         Err(e) => {
             let _ = event_tx.send(IoEvent::Error(SessionError::CommunicationError(format!(
                 "Failed to start Codex thread: {}",
@@ -131,6 +141,7 @@ pub(crate) async fn codex_io_task(
     // Latest `ThreadTokenUsageUpdated` capture for the current turn so we
     // can plug it into the finalized `TurnMetrics`.
     let mut current_turn_usage: Option<codex_codes::TokenUsageBreakdown> = None;
+    let mut current_turn_model: Option<String> = None;
 
     loop {
         if turn_active {
@@ -145,6 +156,23 @@ pub(crate) async fn codex_io_task(
                             // observe these via the typed handler below
                             // because it consumes the message.
                             if let codex_codes::ServerMessage::Notification(notif) = &msg {
+                                if let codex_codes::Notification::TurnStarted(p) = notif {
+                                    current_turn_id = Some(p.turn.id.clone());
+                                    current_turn_model = thread_model.clone();
+                                }
+                                if let codex_codes::Notification::ModelRerouted(p) = notif {
+                                    let matches_current_turn = current_turn_id
+                                        .as_deref()
+                                        .is_some_and(|turn_id| turn_id == p.turn_id);
+                                    if p.thread_id == thread_id && matches_current_turn {
+                                        current_turn_model =
+                                            non_empty_string(p.to_model.clone()).or_else(|| {
+                                                current_turn_model.clone().or_else(|| {
+                                                    thread_model.clone()
+                                                })
+                                            });
+                                    }
+                                }
                                 if let codex_codes::Notification::ThreadTokenUsageUpdated(p) =
                                     notif
                                 {
@@ -230,11 +258,15 @@ pub(crate) async fn codex_io_task(
                                     codex_codes::TurnStatus::Completed
                                 );
                                 let usage = current_turn_usage.take();
+                                let model = current_turn_model
+                                    .clone()
+                                    .or_else(|| thread_model.clone())
+                                    .or_else(|| configured_model_fallback.clone());
                                 let outcome = TurnOutcome {
                                     agent_type: shared::AgentType::Codex
                                         .as_str()
                                         .to_string(),
-                                    model: None,
+                                    model,
                                     service_tier: None,
                                     input_tokens: usage
                                         .as_ref()
@@ -262,9 +294,18 @@ pub(crate) async fn codex_io_task(
                                     chrono::Utc::now(),
                                     outcome,
                                 ) {
-                                    let _ = event_tx
-                                        .send(IoEvent::TurnMetricsReady(Box::new(metrics)));
+                                    if metrics.model.is_some() {
+                                        let _ = event_tx
+                                            .send(IoEvent::TurnMetricsReady(Box::new(metrics)));
+                                    } else {
+                                        tracing::warn!(
+                                            "Codex turn {} completed without model metadata for session {}; dropping turn metrics",
+                                            p.turn.id,
+                                            session_id
+                                        );
+                                    }
                                 }
+                                current_turn_model = None;
                             }
                             let latest_usage_for_msg =
                                 if let codex_codes::ServerMessage::Notification(
@@ -493,5 +534,104 @@ async fn start_codex_turn(
             })));
             false
         }
+    }
+}
+
+fn non_empty_string(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn configured_codex_model(overrides: &[(String, String)], trailing: &[String]) -> Option<String> {
+    overrides
+        .iter()
+        .find_map(|(key, value)| {
+            key.eq_ignore_ascii_case("model")
+                .then(|| non_empty_string(value.clone()))
+                .flatten()
+        })
+        .or_else(|| trailing_codex_model(trailing))
+}
+
+fn trailing_codex_model(args: &[String]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--model" || arg == "-m" {
+            if let Some(value) = iter.next() {
+                if let Some(model) = non_empty_string(value.clone()) {
+                    return Some(model);
+                }
+            }
+            continue;
+        }
+
+        if let Some(value) = arg.strip_prefix("--model=") {
+            if let Some(model) = non_empty_string(value.to_string()) {
+                return Some(model);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn configured_codex_model_prefers_config_override() {
+        let overrides = vec![("model".to_string(), "gpt-5.4".to_string())];
+        let trailing = strings(&["--model", "gpt-5.3"]);
+
+        assert_eq!(
+            configured_codex_model(&overrides, &trailing).as_deref(),
+            Some("gpt-5.4")
+        );
+    }
+
+    #[test]
+    fn configured_codex_model_reads_long_flag() {
+        let overrides = Vec::new();
+        let trailing = strings(&["--model", "gpt-5.3-codex"]);
+
+        assert_eq!(
+            configured_codex_model(&overrides, &trailing).as_deref(),
+            Some("gpt-5.3-codex")
+        );
+    }
+
+    #[test]
+    fn configured_codex_model_reads_equals_flag() {
+        let overrides = Vec::new();
+        let trailing = strings(&["--model=gpt-5.3-codex-spark"]);
+
+        assert_eq!(
+            configured_codex_model(&overrides, &trailing).as_deref(),
+            Some("gpt-5.3-codex-spark")
+        );
+    }
+
+    #[test]
+    fn configured_codex_model_ignores_blank_values() {
+        let overrides = vec![("model".to_string(), " ".to_string())];
+        let trailing = strings(&["--model", ""]);
+
+        assert!(configured_codex_model(&overrides, &trailing).is_none());
+    }
+
+    #[test]
+    fn configured_codex_model_ignores_unknown_values() {
+        let overrides = vec![("model".to_string(), "unknown".to_string())];
+        let trailing = strings(&[]);
+
+        assert!(configured_codex_model(&overrides, &trailing).is_none());
     }
 }

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -7,8 +7,8 @@
 //!
 //! On mount, fetches the default `bucket=day&window=30d` aggregation, then
 //! refetches when the user switches the time-window radio. A group-by
-//! dropdown filters to one `(model, service_tier)` pair, or "All" to render
-//! one line per pair.
+//! dropdown filters to one `(agent_type, model, service_tier)` group, or
+//! "All" to render one line per group.
 
 use std::collections::BTreeMap;
 
@@ -21,30 +21,44 @@ use yew::prelude::*;
 use crate::components::charts::{BucketKind, LinePlot, LineSeries, StackedArea, StackedSeries};
 use crate::utils;
 
-/// (model, service_tier) pair used as the group-by key. `(None, None)` is a
-/// legitimate Codex shape (no model, no tier reported); we render it as
-/// `"all (codex)"` in the dropdown.
-type GroupKey = (Option<String>, Option<String>);
+/// (agent_type, model, service_tier) tuple used as the group-by key. Codex
+/// currently reports no model or tier; keeping the agent in the key lets the
+/// UI label that shape explicitly without colliding with missing Claude
+/// metadata.
+type GroupKey = (String, Option<String>, Option<String>);
 
-/// Pure helper: list the distinct (model, tier) pairs present in the bucket
-/// list, sorted alphabetically with the empty pair last.
+/// Pure helper: list the distinct (agent, model, tier) groups present in the
+/// bucket list.
 fn distinct_pairs(buckets: &[MetricBucket]) -> Vec<GroupKey> {
     let mut seen: std::collections::BTreeSet<GroupKey> = std::collections::BTreeSet::new();
     for b in buckets {
-        seen.insert((b.model.clone(), b.service_tier.clone()));
+        seen.insert(bucket_group_key(b));
     }
     seen.into_iter().collect()
 }
 
-/// Format a (model, tier) pair as a human-readable label for the dropdown
-/// and legend.
+fn bucket_group_key(bucket: &MetricBucket) -> GroupKey {
+    (
+        bucket.agent_type.clone(),
+        bucket.model.clone(),
+        bucket.service_tier.clone(),
+    )
+}
+
+/// Format an (agent, model, tier) group as a human-readable label for the
+/// dropdown and legend.
 fn pair_label(pair: &GroupKey) -> String {
-    let m = pair.0.as_deref().unwrap_or("unknown");
-    match pair.1.as_deref() {
+    let base = match (pair.0.as_str(), pair.1.as_deref()) {
+        ("codex", None) => "Codex".to_string(),
+        (_, Some(model)) => model.to_string(),
+        (agent, None) if !agent.is_empty() => format!("{agent} unknown"),
+        _ => "unknown".to_string(),
+    };
+    match pair.2.as_deref() {
         Some(t) if !t.is_empty() && !t.eq_ignore_ascii_case("standard") => {
-            format!("{m} {t}")
+            format!("{base} {t}")
         }
-        _ => m.to_string(),
+        _ => base,
     }
 }
 
@@ -140,7 +154,7 @@ impl TimeWindow {
     }
 }
 
-/// Group-by selection: either a specific (model, tier) pair or "All".
+/// Group-by selection: either a specific (agent, model, tier) group or "All".
 #[derive(Debug, Clone, PartialEq)]
 enum GroupBy {
     All,
@@ -152,8 +166,9 @@ impl GroupBy {
     fn key(&self) -> String {
         match self {
             Self::All => "__ALL__".to_string(),
-            Self::Pair((m, t)) => format!(
-                "{}|{}",
+            Self::Pair((agent, m, t)) => format!(
+                "{}|{}|{}",
+                agent,
                 m.as_deref().unwrap_or(""),
                 t.as_deref().unwrap_or("")
             ),
@@ -302,7 +317,7 @@ pub fn performance_panel() -> Html {
                             value="__ALL__"
                             selected={matches!(*group_by, GroupBy::All)}
                         >
-                            { "All (model, tier) pairs" }
+                            { "All groups" }
                         </option>
                         { for pairs.iter().map(|pair| {
                             let gb = GroupBy::Pair(pair.clone());
@@ -344,10 +359,7 @@ fn render_charts(
     // Bucketed by (pair, ts) for O(1) lookup.
     let mut indexed: BTreeMap<(GroupKey, DateTime<Utc>), &MetricBucket> = BTreeMap::new();
     for b in buckets {
-        indexed.insert(
-            ((b.model.clone(), b.service_tier.clone()), b.bucket_start),
-            b,
-        );
+        indexed.insert((bucket_group_key(b), b.bucket_start), b);
     }
 
     // ------------ a) Throughput trend: p50 (solid) + p95 (dashed) ------------
@@ -481,7 +493,7 @@ fn build_stop_reason_series(
         by_reason.insert(key, vec![0.0; bucket_axis.len()]);
     }
     for b in buckets {
-        let pair = (b.model.clone(), b.service_tier.clone());
+        let pair = bucket_group_key(b);
         if !active_set.contains(&pair) {
             continue;
         }
@@ -675,6 +687,7 @@ mod tests {
     #[test]
     fn pair_label_appends_non_standard_tier() {
         let label = pair_label(&(
+            "claude".to_string(),
             Some("claude-opus-4-7".to_string()),
             Some("priority".to_string()),
         ));
@@ -684,6 +697,7 @@ mod tests {
     #[test]
     fn pair_label_drops_standard_tier() {
         let label = pair_label(&(
+            "claude".to_string(),
             Some("claude-opus-4-7".to_string()),
             Some("standard".to_string()),
         ));
@@ -691,9 +705,15 @@ mod tests {
     }
 
     #[test]
-    fn pair_label_unknown_when_no_model() {
-        let label = pair_label(&(None, None));
-        assert_eq!(label, "unknown");
+    fn pair_label_codex_when_no_model() {
+        let label = pair_label(&("codex".to_string(), None, None));
+        assert_eq!(label, "Codex");
+    }
+
+    #[test]
+    fn pair_label_unknown_when_no_claude_model() {
+        let label = pair_label(&("claude".to_string(), None, None));
+        assert_eq!(label, "claude unknown");
     }
 
     #[test]
@@ -705,6 +725,7 @@ mod tests {
     #[test]
     fn group_by_key_roundtrips_through_string() {
         let pairs = vec![(
+            "claude".to_string(),
             Some("claude-opus-4-7".to_string()),
             Some("standard".to_string()),
         )];
@@ -789,10 +810,7 @@ mod tests {
         let pairs = distinct_pairs(&buckets);
         let mut indexed: BTreeMap<(GroupKey, DateTime<Utc>), &MetricBucket> = BTreeMap::new();
         for bb in &buckets {
-            indexed.insert(
-                ((bb.model.clone(), bb.service_tier.clone()), bb.bucket_start),
-                bb,
-            );
+            indexed.insert((bucket_group_key(bb), bb.bucket_start), bb);
         }
         let series = build_cache_hit_series(&indexed, &axis, &pairs);
         // Only had a single bucket with denom=0 → no values → no series at all.
@@ -809,10 +827,7 @@ mod tests {
         let pairs = distinct_pairs(&buckets);
         let mut indexed: BTreeMap<(GroupKey, DateTime<Utc>), &MetricBucket> = BTreeMap::new();
         for bb in &buckets {
-            indexed.insert(
-                ((bb.model.clone(), bb.service_tier.clone()), bb.bucket_start),
-                bb,
-            );
+            indexed.insert((bucket_group_key(bb), bb.bucket_start), bb);
         }
         let series = build_cost_per_token_series(&indexed, &axis, &pairs);
         assert!(series.is_empty());
@@ -829,10 +844,7 @@ mod tests {
         let pairs = distinct_pairs(&buckets);
         let mut indexed: BTreeMap<(GroupKey, DateTime<Utc>), &MetricBucket> = BTreeMap::new();
         for bb in &buckets {
-            indexed.insert(
-                ((bb.model.clone(), bb.service_tier.clone()), bb.bucket_start),
-                bb,
-            );
+            indexed.insert((bucket_group_key(bb), bb.bucket_start), bb);
         }
         let series = build_cost_per_token_series(&indexed, &axis, &pairs);
         assert_eq!(series.len(), 1);


### PR DESCRIPTION
## Summary
- resolve Codex turn metric models from thread start, reroute events, and explicit model args
- warn and drop turn metrics when model metadata is missing or unknown at proxy and backend ingest
- clean up existing unknown-model turn metrics and label Codex performance groups by agent/model/tier
- bump workspace version to 2.6.27

## Verification
- cargo fmt --check
- cargo check -p backend
- cargo check -p claude-session-lib
- cargo test -p codex-session-lib
- cargo test -p frontend performance_panel
- ./scripts/check-migration-names.sh