### PR TITLE
Replace production json macro protocol events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Check migration naming convention
         run: ./scripts/check-migration-names.sh
 
+      - name: Check production Rust does not use json! macro
+        run: python3 ./scripts/check-no-json-macro.py
+
   lint-css:
     name: CSS Lint
     runs-on: ubuntu-latest
@@ -365,4 +368,3 @@ jobs:
         with:
           name: launcher-windows-x86_64
           path: target/release/agent-portal.exe
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.27"
+version = "2.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.27"
+version = "2.6.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.27"
+version = "2.6.28"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.27"
+version = "2.6.28"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.27"
+version = "2.6.28"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.27"
+version = "2.6.28"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.27"
+version = "2.6.28"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.27"
+version = "2.6.28"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.27"
+version = "2.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.27"
+version = "2.6.28"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.27"
+version = "2.6.28"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -129,12 +129,18 @@ pub(super) fn replay_history(
                 // Reconstruct _sender for user messages from DB user_id
                 if msg.role == "user" {
                     if let Some(name) = user_names.get(&msg.user_id) {
+                        #[derive(serde::Serialize)]
+                        struct SenderMeta<'a> {
+                            user_id: String,
+                            name: &'a str,
+                        }
                         obj.insert(
                             "_sender".to_string(),
-                            serde_json::json!({
-                                "user_id": msg.user_id.to_string(),
-                                "name": name,
-                            }),
+                            serde_json::to_value(SenderMeta {
+                                user_id: msg.user_id.to_string(),
+                                name,
+                            })
+                            .unwrap_or(serde_json::Value::Null),
                         );
                     }
                 }

--- a/codex-session-lib/src/events.rs
+++ b/codex-session-lib/src/events.rs
@@ -1,0 +1,170 @@
+use codex_codes::TokenUsageBreakdown;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ThreadStartedEvent<'a> {
+    #[serde(rename = "type")]
+    pub event_type: &'static str,
+    pub thread_id: &'a str,
+}
+
+impl<'a> ThreadStartedEvent<'a> {
+    pub fn new(thread_id: &'a str) -> Self {
+        Self {
+            event_type: "thread.started",
+            thread_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct TurnCompletedEvent {
+    #[serde(rename = "type")]
+    pub event_type: &'static str,
+    pub turn_id: String,
+    pub status: String,
+    pub duration_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<CodexUsageEvent>,
+}
+
+impl TurnCompletedEvent {
+    pub fn new(
+        turn_id: String,
+        status: String,
+        duration_ms: Option<i64>,
+        usage: Option<CodexUsageEvent>,
+    ) -> Self {
+        Self {
+            event_type: "turn.completed",
+            turn_id,
+            status,
+            duration_ms,
+            usage,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct TurnFailedEvent {
+    #[serde(rename = "type")]
+    pub event_type: &'static str,
+    pub error: CodexErrorEvent,
+}
+
+impl TurnFailedEvent {
+    pub fn new(message: String) -> Self {
+        Self {
+            event_type: "turn.failed",
+            error: CodexErrorEvent { message },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CodexErrorEvent {
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ItemEvent {
+    #[serde(rename = "type")]
+    pub event_type: &'static str,
+    pub item: serde_json::Value,
+}
+
+impl ItemEvent {
+    pub fn started(item: serde_json::Value) -> Self {
+        Self {
+            event_type: "item.started",
+            item,
+        }
+    }
+
+    pub fn completed(item: serde_json::Value) -> Self {
+        Self {
+            event_type: "item.completed",
+            item,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ErrorEvent {
+    #[serde(rename = "type")]
+    pub event_type: &'static str,
+    pub message: String,
+}
+
+impl ErrorEvent {
+    pub fn new(message: String) -> Self {
+        Self {
+            event_type: "error",
+            message,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct PassthroughEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub params: serde_json::Value,
+}
+
+impl PassthroughEvent {
+    pub fn new(event_type: impl Into<String>, params: serde_json::Value) -> Self {
+        Self {
+            event_type: event_type.into(),
+            params,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CodexUsageEvent {
+    pub last: TokenUsageBreakdown,
+    pub total: TokenUsageBreakdown,
+    pub model_context_window: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct UserEchoEvent {
+    #[serde(rename = "type")]
+    pub event_type: &'static str,
+    pub message: UserEchoMessage,
+    pub content: String,
+}
+
+impl UserEchoEvent {
+    pub fn new(prompt: String) -> Self {
+        Self {
+            event_type: "user",
+            message: UserEchoMessage {
+                role: "user",
+                content: vec![TextContentBlock {
+                    block_type: "text",
+                    text: prompt.clone(),
+                }],
+            },
+            content: prompt,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct UserEchoMessage {
+    pub role: &'static str,
+    pub content: Vec<TextContentBlock>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct TextContentBlock {
+    #[serde(rename = "type")]
+    pub block_type: &'static str,
+    pub text: String,
+}
+
+pub(crate) fn to_raw_output<T: Serialize>(event: &T) -> serde_json::Value {
+    serde_json::to_value(event).unwrap_or(serde_json::Value::Null)
+}

--- a/codex-session-lib/src/handler.rs
+++ b/codex-session-lib/src/handler.rs
@@ -14,6 +14,9 @@ use session_lib::io::IoEvent;
 use shared::CodexPermissionInput;
 use tokio::sync::mpsc;
 
+use crate::events::{
+    to_raw_output, CodexUsageEvent, ErrorEvent, ItemEvent, PassthroughEvent, TurnCompletedEvent,
+};
 use crate::helpers::format_request_id;
 
 /// Convert a Codex app-server ServerMessage into exec-format JSONL events.
@@ -21,7 +24,7 @@ use crate::helpers::format_request_id;
 pub(crate) fn handle_codex_server_message(
     msg: ServerMessage,
     event_tx: &mpsc::UnboundedSender<IoEvent>,
-    latest_token_usage: Option<&serde_json::Value>,
+    latest_token_usage: Option<&CodexUsageEvent>,
 ) -> (bool, bool) {
     match msg {
         ServerMessage::Notification(notif) => {
@@ -36,7 +39,7 @@ pub(crate) fn handle_codex_server_message(
 fn handle_notification(
     notif: Notification,
     event_tx: &mpsc::UnboundedSender<IoEvent>,
-    latest_token_usage: Option<&serde_json::Value>,
+    latest_token_usage: Option<&CodexUsageEvent>,
 ) -> (bool, bool) {
     match notif {
         // Lifecycle — already handled elsewhere or intentionally silent.
@@ -46,37 +49,33 @@ fn handle_notification(
         | Notification::ThreadTokenUsageUpdated(_) => (true, false),
 
         Notification::TurnCompleted(p) => {
-            let status = serde_json::to_value(&p.turn.status)
-                .ok()
-                .and_then(|v| v.as_str().map(str::to_string));
-            let event = serde_json::json!({
-                "type": "turn.completed",
-                "turn_id": p.turn.id,
-                "status": status,
-                "duration_ms": p.turn.duration_ms,
-                "usage": latest_token_usage.cloned(),
-            });
-            let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
+            let event = TurnCompletedEvent::new(
+                p.turn.id,
+                turn_status_label(&p.turn.status).to_string(),
+                p.turn.duration_ms,
+                latest_token_usage.cloned(),
+            );
+            let ok = event_tx
+                .send(IoEvent::RawOutput(to_raw_output(&event)))
+                .is_ok();
             (ok, true)
         }
 
         Notification::ItemStarted(p) => {
             let item = serde_json::to_value(&p.item).unwrap_or(serde_json::Value::Null);
-            let event = serde_json::json!({
-                "type": "item.started",
-                "item": item,
-            });
-            let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
+            let event = ItemEvent::started(item);
+            let ok = event_tx
+                .send(IoEvent::RawOutput(to_raw_output(&event)))
+                .is_ok();
             (ok, false)
         }
 
         Notification::ItemCompleted(p) => {
             let item = serde_json::to_value(&p.item).unwrap_or(serde_json::Value::Null);
-            let event = serde_json::json!({
-                "type": "item.completed",
-                "item": item,
-            });
-            let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
+            let event = ItemEvent::completed(item);
+            let ok = event_tx
+                .send(IoEvent::RawOutput(to_raw_output(&event)))
+                .is_ok();
             (ok, false)
         }
 
@@ -88,11 +87,10 @@ fn handle_notification(
             } else {
                 p.error.message.clone()
             };
-            let event = serde_json::json!({
-                "type": "error",
-                "message": message,
-            });
-            let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
+            let event = ErrorEvent::new(message);
+            let ok = event_tx
+                .send(IoEvent::RawOutput(to_raw_output(&event)))
+                .is_ok();
             (ok, false)
         }
 
@@ -220,12 +218,20 @@ fn emit_passthrough<P: serde::Serialize>(
     p: &P,
 ) -> (bool, bool) {
     let params = serde_json::to_value(p).unwrap_or(serde_json::Value::Null);
-    let event = serde_json::json!({
-        "type": method,
-        "params": params,
-    });
-    let ok = event_tx.send(IoEvent::RawOutput(event)).is_ok();
+    let event = PassthroughEvent::new(method, params);
+    let ok = event_tx
+        .send(IoEvent::RawOutput(to_raw_output(&event)))
+        .is_ok();
     (ok, false)
+}
+
+fn turn_status_label(status: &codex_codes::TurnStatus) -> &'static str {
+    match status {
+        codex_codes::TurnStatus::Completed => "completed",
+        codex_codes::TurnStatus::Interrupted => "interrupted",
+        codex_codes::TurnStatus::Failed => "failed",
+        codex_codes::TurnStatus::InProgress => "in_progress",
+    }
 }
 
 fn handle_request(
@@ -394,7 +400,7 @@ mod tests {
 
     fn handle_with_usage(
         msg: ServerMessage,
-        latest_token_usage: Option<&serde_json::Value>,
+        latest_token_usage: Option<&CodexUsageEvent>,
     ) -> (Vec<IoEvent>, bool, bool) {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let (sent, ended) = handle_codex_server_message(msg, &tx, latest_token_usage);
@@ -441,23 +447,23 @@ mod tests {
             }
         }))
         .unwrap();
-        let usage = json!({
-            "last": {
-                "inputTokens": 100,
-                "cachedInputTokens": 25,
-                "outputTokens": 40,
-                "reasoningOutputTokens": 7,
-                "totalTokens": 147
+        let usage = CodexUsageEvent {
+            last: codex_codes::TokenUsageBreakdown {
+                input_tokens: 100,
+                cached_input_tokens: 25,
+                output_tokens: 40,
+                reasoning_output_tokens: 7,
+                total_tokens: 147,
             },
-            "total": {
-                "inputTokens": 300,
-                "cachedInputTokens": 75,
-                "outputTokens": 90,
-                "reasoningOutputTokens": 17,
-                "totalTokens": 407
+            total: codex_codes::TokenUsageBreakdown {
+                input_tokens: 300,
+                cached_input_tokens: 75,
+                output_tokens: 90,
+                reasoning_output_tokens: 17,
+                total_tokens: 407,
             },
-            "model_context_window": 200000
-        });
+            model_context_window: Some(200000),
+        };
         let msg = ServerMessage::Notification(Notification::TurnCompleted(notif));
         let (events, sent, ended) = handle_with_usage(msg, Some(&usage));
 

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -18,6 +18,9 @@ use session_lib::snapshot::SessionConfig;
 use session_lib::{TurnOutcome, TurnTracker};
 use tokio::sync::mpsc;
 
+use crate::events::{
+    to_raw_output, CodexUsageEvent, ThreadStartedEvent, TurnFailedEvent, UserEchoEvent,
+};
 use crate::handler::handle_codex_server_message;
 use crate::helpers::{extract_prompt_text, parse_request_id};
 
@@ -96,8 +99,7 @@ pub(crate) async fn codex_io_task(
     // all skip_serializing_if Some); the SDK's idiom for an "empty"
     // params is round-tripping through `{}` JSON. See codex-codes
     // 0.129.3 src/lib.rs:18-30 example.
-    let thread_params: ThreadStartParams = serde_json::from_value(serde_json::json!({}))
-        .expect("empty JSON object is a valid ThreadStartParams");
+    let thread_params = empty_thread_start_params();
     let (thread_id, thread_model) = match client.thread_start(&thread_params).await {
         Ok(resp) => {
             let model = non_empty_string(resp.model).or_else(|| configured_model_fallback.clone());
@@ -120,10 +122,9 @@ pub(crate) async fn codex_io_task(
 
     tracing::info!("Codex thread started: {}", thread_id);
 
-    let _ = event_tx.send(IoEvent::RawOutput(serde_json::json!({
-        "type": "thread.started",
-        "thread_id": &thread_id
-    })));
+    let _ = event_tx.send(IoEvent::RawOutput(to_raw_output(&ThreadStartedEvent::new(
+        &thread_id,
+    ))));
 
     let mut turn_active = false;
     let mut queued_prompts: VecDeque<String> = VecDeque::new();
@@ -133,7 +134,7 @@ pub(crate) async fn codex_io_task(
     // Set when a `turn/started` notification arrives; cleared when
     // `turn/completed` arrives.
     let mut current_turn_id: Option<String> = None;
-    let mut latest_token_usage: Option<(String, serde_json::Value)> = None;
+    let mut latest_token_usage: Option<(String, CodexUsageEvent)> = None;
     // Per-turn metrics tracker. `start`ed inside `start_codex_turn`,
     // updated as `ItemStarted` / `ItemCompleted` notifications come in,
     // finalized on `TurnCompleted`.
@@ -178,11 +179,11 @@ pub(crate) async fn codex_io_task(
                                 {
                                     latest_token_usage = Some((
                                         p.turn_id.clone(),
-                                        serde_json::json!({
-                                            "last": &p.token_usage.last,
-                                            "total": &p.token_usage.total,
-                                            "model_context_window": p.token_usage.model_context_window,
-                                        }),
+                                        CodexUsageEvent {
+                                            last: p.token_usage.last.clone(),
+                                            total: p.token_usage.total.clone(),
+                                            model_context_window: p.token_usage.model_context_window,
+                                        },
                                     ));
                                     // Latch the per-turn breakdown so the
                                     // finalized `TurnMetrics` can carry
@@ -383,16 +384,12 @@ pub(crate) async fn codex_io_task(
                                 error_message,
                                 method
                             );
-                            let _ = event_tx.send(IoEvent::RawOutput(serde_json::json!({
-                                "type": "turn.failed",
-                                "error": {
-                                    "message": format!(
-                                        "Codex emitted a frame this client could not parse ({}). \
-                                         Interrupting the turn to recover — please retry.",
-                                        error_message
-                                    )
-                                }
-                            })));
+                            let event = TurnFailedEvent::new(format!(
+                                "Codex emitted a frame this client could not parse ({}). \
+                                 Interrupting the turn to recover \u{2014} please retry.",
+                                error_message
+                            ));
+                            let _ = event_tx.send(IoEvent::RawOutput(to_raw_output(&event)));
 
                             let rendered = raw_json
                                 .as_ref()
@@ -407,13 +404,9 @@ pub(crate) async fn codex_io_task(
                                 method.as_deref().map(|m| format!(" (`{}`)", m)).unwrap_or_default(),
                                 rendered
                             );
-                            let _ = event_tx.send(IoEvent::RawOutput(serde_json::json!({
-                                "type": "portal",
-                                "content": [{
-                                    "type": "text",
-                                    "text": portal_text
-                                }]
-                            })));
+                            let _ = event_tx.send(IoEvent::RawOutput(
+                                shared::PortalMessage::text(portal_text).to_json(),
+                            ));
 
                             let interrupt_params = TurnInterruptParams {
                                 thread_id: thread_id.clone(),
@@ -496,44 +489,75 @@ async fn start_codex_turn(
     // frontend's content-based pending-match. Skip <system-reminder> wrappers
     // (portal reminder injection) because those shouldn't appear in transcript.
     if !prompt.starts_with("<system-reminder>") {
-        let echo = serde_json::json!({
-            "type": "user",
-            "message": {
-                "role": "user",
-                "content": [{"type": "text", "text": prompt}]
-            },
-            "content": prompt,
-        });
-        let _ = event_tx.send(IoEvent::RawOutput(echo));
+        let echo = UserEchoEvent::new(prompt);
+        let _ = event_tx.send(IoEvent::RawOutput(to_raw_output(&echo)));
+        return start_codex_turn_request(client, thread_id, echo.content, event_tx).await;
     }
 
+    start_codex_turn_request(client, thread_id, prompt, event_tx).await
+}
+
+async fn start_codex_turn_request(
+    client: &mut CodexAsyncClient,
+    thread_id: &str,
+    prompt: String,
+    event_tx: &mpsc::UnboundedSender<IoEvent>,
+) -> bool {
     tracing::info!("Starting Codex turn with {} chars", prompt.len());
 
     // codex-codes 0.129.3 generated TurnStartParams from its schema:
     // `reasoning_effort` is now `effort`, a new required `text_elements` field
     // landed on `UserInput::Text`, and the struct has many more Option fields
-    // with no Default impl. We construct the explicit fields and `..` from an
-    // empty JSON baseline to inherit Nones for the rest.
-    let turn_params_base: TurnStartParams =
-        serde_json::from_value(serde_json::json!({"threadId": thread_id, "input": []}))
-            .expect("threadId + empty input is a valid TurnStartParams base");
-    let turn_params = TurnStartParams {
-        thread_id: thread_id.to_string(),
+    // with no Default impl. Keep this construction explicit so SDK schema
+    // changes become compile errors.
+    let turn_params = turn_start_params(thread_id, prompt);
+    match client.turn_start(&turn_params).await {
+        Ok(_) => true,
+        Err(e) => {
+            let event = TurnFailedEvent::new(e.to_string());
+            let _ = event_tx.send(IoEvent::RawOutput(to_raw_output(&event)));
+            false
+        }
+    }
+}
+
+fn empty_thread_start_params() -> ThreadStartParams {
+    ThreadStartParams {
+        approval_policy: None,
+        approvals_reviewer: None,
+        base_instructions: None,
+        config: None,
+        cwd: None,
+        developer_instructions: None,
+        ephemeral: None,
+        model: None,
+        model_provider: None,
+        personality: None,
+        sandbox: None,
+        service_name: None,
+        service_tier: None,
+        session_start_source: None,
+        thread_source: None,
+    }
+}
+
+fn turn_start_params(thread_id: &str, prompt: String) -> TurnStartParams {
+    TurnStartParams {
+        approval_policy: None,
+        approvals_reviewer: None,
+        cwd: None,
+        effort: None,
         input: vec![UserInput::Text {
             text: prompt,
             text_elements: None,
         }],
-        ..turn_params_base
-    };
-    match client.turn_start(&turn_params).await {
-        Ok(_) => true,
-        Err(e) => {
-            let _ = event_tx.send(IoEvent::RawOutput(serde_json::json!({
-                "type": "turn.failed",
-                "error": { "message": e.to_string() }
-            })));
-            false
-        }
+        model: None,
+        output_schema: None,
+        personality: None,
+        sandbox_policy: None,
+        service_tier: None,
+        summary: None,
+        thread_id: thread_id.to_string(),
     }
 }
 

--- a/codex-session-lib/src/lib.rs
+++ b/codex-session-lib/src/lib.rs
@@ -6,6 +6,7 @@
 //! backed session.
 
 pub mod agent;
+mod events;
 mod handler;
 mod helpers;
 mod io_task;

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -303,12 +303,18 @@ pub(super) fn inject_message_metadata(
         return content.to_string();
     };
     if role_user && (user_id.is_some() || sender_name.is_some()) {
+        #[derive(serde::Serialize)]
+        struct SenderMeta<'a> {
+            user_id: &'a str,
+            name: &'a str,
+        }
         obj.insert(
             "_sender".to_string(),
-            serde_json::json!({
-                "user_id": user_id.unwrap_or_default(),
-                "name": sender_name.unwrap_or_default(),
-            }),
+            serde_json::to_value(SenderMeta {
+                user_id: user_id.unwrap_or_default(),
+                name: sender_name.unwrap_or_default(),
+            })
+            .unwrap_or(serde_json::Value::Null),
         );
     }
     obj.insert(

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -139,12 +139,18 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
             if needs_sender || created_at.is_some() {
                 if let Some(obj) = content_val.as_object_mut() {
                     if needs_sender {
+                        #[derive(serde::Serialize)]
+                        struct SenderMeta<'a> {
+                            user_id: &'a str,
+                            name: &'a str,
+                        }
                         obj.insert(
                             "_sender".to_string(),
-                            serde_json::json!({
-                                "user_id": sender_user_id.unwrap_or_default(),
-                                "name": sender_name.unwrap_or_default(),
-                            }),
+                            serde_json::to_value(SenderMeta {
+                                user_id: sender_user_id.as_deref().unwrap_or_default(),
+                                name: sender_name.as_deref().unwrap_or_default(),
+                            })
+                            .unwrap_or(serde_json::Value::Null),
                         );
                     }
                     if let Some(ref ts) = created_at {

--- a/scripts/check-no-json-macro.py
+++ b/scripts/check-no-json-macro.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Reject serde_json::json!/json! in production Rust code.
+
+Test fixtures may still use json! while production protocol paths are migrated
+to typed structs. This intentionally allows code inside #[cfg(test)] modules.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".git", "target", "dist"}
+JSON_MACRO = re.compile(r"serde_json::json!\s*\(|(?<![A-Za-z0-9_])json!\s*\(")
+CFG_TEST = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
+MOD_WITH_OPEN_BRACE = re.compile(r"\bmod\s+\w+\s*\{")
+
+
+def rust_files():
+    for path in ROOT.rglob("*.rs"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        yield path
+
+
+def code_before_comment(line: str) -> str:
+    return line.split("//", 1)[0]
+
+
+def brace_delta(line: str) -> int:
+    # Good enough for this lint: it only needs to keep us inside ordinary
+    # #[cfg(test)] modules, not parse arbitrary Rust.
+    code = code_before_comment(line)
+    return code.count("{") - code.count("}")
+
+
+def violations_in(path: Path):
+    violations = []
+    cfg_test_pending = False
+    test_depth = None
+    depth = 0
+
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        code = code_before_comment(line)
+        stripped = code.strip()
+        in_test_module = test_depth is not None
+
+        if not in_test_module and JSON_MACRO.search(code):
+            violations.append((lineno, line.strip()))
+
+        starts_test_module = False
+        if CFG_TEST.search(stripped):
+            cfg_test_pending = True
+        elif cfg_test_pending and MOD_WITH_OPEN_BRACE.search(stripped):
+            starts_test_module = True
+        elif stripped and not stripped.startswith("#"):
+            cfg_test_pending = False
+
+        depth += brace_delta(line)
+
+        if starts_test_module:
+            test_depth = depth
+            cfg_test_pending = False
+        elif test_depth is not None and depth < test_depth:
+            test_depth = None
+
+    return violations
+
+
+def main() -> int:
+    failures = []
+    for path in rust_files():
+        for lineno, line in violations_in(path):
+            failures.append((path.relative_to(ROOT), lineno, line))
+
+    if failures:
+        print("serde_json::json!/json! is not allowed in production Rust code.")
+        print("Use typed structs plus serde_json::to_value instead.\n")
+        for path, lineno, line in failures:
+            print(f"{path}:{lineno}: {line}")
+        return 1
+
+    print("PASSED: no production Rust serde_json::json!/json! usages found")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add typed Codex projected event structs and use them for app-server RawOutput events
- replace production json! macro usage in Codex event projection, backend replay sender metadata, and frontend live metadata injection
- add a CI lint that rejects json!/serde_json::json! in production Rust code while allowing test fixtures
- bump workspace version to 2.6.28

Closes #918.

## Verification
- python3 ./scripts/check-no-json-macro.py
- cargo test -p codex-session-lib
- cargo test -p frontend session_view
- cargo check -p backend
- cargo fmt --check