### PR TITLE
Close turn metrics dropdown on outside click

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.28"
+version = "2.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.28"
+version = "2.6.29"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.28"
+version = "2.6.29"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.28"
+version = "2.6.29"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.28"
+version = "2.6.29"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.28"
+version = "2.6.29"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.28"
+version = "2.6.29"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.28"
+version = "2.6.29"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.28"
+version = "2.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.28"
+version = "2.6.29"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.28"
+version = "2.6.29"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/turn_metrics_pill.rs
+++ b/frontend/src/components/turn_metrics_pill.rs
@@ -8,6 +8,8 @@
 //! PR — the v1 chrome is one chip, one trend.
 
 use shared::TurnMetrics;
+use wasm_bindgen::JsCast;
+use web_sys::Element;
 use yew::prelude::*;
 
 use super::sparkline::Sparkline;
@@ -175,6 +177,36 @@ pub struct TurnMetricsHeaderPillProps {
 pub fn turn_metrics_header_pill(props: &TurnMetricsHeaderPillProps) -> Html {
     let selected_metric = use_state(|| SparklineMetric::TokPerSec);
     let dropdown_open = use_state(|| false);
+    let pill_ref = use_node_ref();
+
+    {
+        let dropdown_open = dropdown_open.clone();
+        let pill_ref = pill_ref.clone();
+        let is_open = *dropdown_open;
+        use_effect_with(is_open, move |is_open| {
+            let listener = if *is_open {
+                let document = gloo::utils::document();
+                Some(gloo::events::EventListener::new(
+                    &document,
+                    "click",
+                    move |e| {
+                        if let Some(pill_el) = pill_ref.cast::<Element>() {
+                            if let Some(target) =
+                                e.target().and_then(|t| t.dyn_into::<web_sys::Node>().ok())
+                            {
+                                if !pill_el.contains(Some(&target)) {
+                                    dropdown_open.set(false);
+                                }
+                            }
+                        }
+                    },
+                ))
+            } else {
+                None
+            };
+            move || drop(listener)
+        });
+    }
 
     // Pick the (model, tier) pair from the most recent turn. If nothing
     // qualifies (empty buffer, or no model/tier on the newest row), render
@@ -202,7 +234,7 @@ pub fn turn_metrics_header_pill(props: &TurnMetricsHeaderPillProps) -> Html {
     };
 
     html! {
-        <div class="turn-metrics-pill" onclick={on_toggle.clone()}>
+        <div ref={pill_ref} class="turn-metrics-pill" onclick={on_toggle.clone()}>
             <span class="turn-metrics-pill-label">{ label }</span>
             <Sparkline values={values} />
             <span class="turn-metrics-pill-value">


### PR DESCRIPTION
## Summary
- close the dashboard turn metrics dropdown when a document click lands outside the pill
- keep inside menu clicks from closing via the existing selection flow
- bump workspace version to 2.6.29

## Tests
- cargo fmt --check
- cargo check -p frontend --target wasm32-unknown-unknown