### PR TITLE
Fix proxy session resume and Codex compaction rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.29"
+version = "2.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.29"
+version = "2.6.30"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.29"
+version = "2.6.30"
 dependencies = [
  "anyhow",
  "base64",
@@ -519,6 +519,7 @@ dependencies = [
  "libc",
  "portal-auth",
  "portal-update",
+ "reqwest",
  "serde",
  "serde_json",
  "session-lib",
@@ -533,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.29"
+version = "2.6.30"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.29"
+version = "2.6.30"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.29"
+version = "2.6.30"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.29"
+version = "2.6.30"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.29"
+version = "2.6.30"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.29"
+version = "2.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.29"
+version = "2.6.30"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.29"
+version = "2.6.30"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -5,7 +5,10 @@ use axum::{
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use serde::Serialize;
-use shared::api::{AddMemberRequest, UpdateMemberRoleRequest};
+use shared::api::{
+    AddMemberRequest, ResolveProxySessionRequest, ResolveProxySessionResponse,
+    UpdateMemberRoleRequest,
+};
 use std::sync::Arc;
 use tower_cookies::Cookies;
 use uuid::Uuid;
@@ -69,6 +72,79 @@ pub async fn list_sessions(
     Ok(Json(SessionListResponse {
         sessions: sessions_with_role,
     }))
+}
+
+pub async fn resolve_proxy_session(
+    State(app_state): State<Arc<AppState>>,
+    Json(req): Json<ResolveProxySessionRequest>,
+) -> Result<Json<ResolveProxySessionResponse>, AppError> {
+    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let current_user_id = proxy_request_user_id(&app_state, &mut conn, req.auth_token.as_deref())?;
+
+    use crate::schema::{session_members, sessions};
+
+    let mut query = sessions::table
+        .inner_join(session_members::table.on(session_members::session_id.eq(sessions::id)))
+        .filter(session_members::user_id.eq(current_user_id))
+        .filter(sessions::working_directory.eq(req.working_directory))
+        .filter(sessions::agent_type.eq(req.agent_type.as_str()))
+        .filter(sessions::scheduled_task_id.is_null())
+        .filter(sessions::status.ne("replaced"))
+        .filter(sessions::paused.eq(false))
+        .select(Session::as_select())
+        .into_boxed();
+
+    if let Some(hostname) = req.hostname.as_deref().filter(|h| !h.is_empty()) {
+        query = query.filter(sessions::hostname.eq(hostname));
+    }
+
+    let session = query
+        .order((sessions::last_activity.desc(), sessions::created_at.desc()))
+        .first::<Session>(&mut conn)
+        .optional()
+        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+
+    Ok(Json(match session {
+        Some(session) => ResolveProxySessionResponse {
+            session_id: Some(session.id),
+            session_name: Some(session.session_name),
+            created_at: Some(session.created_at.and_utc().to_rfc3339()),
+            last_activity: Some(session.last_activity.and_utc().to_rfc3339()),
+        },
+        None => ResolveProxySessionResponse {
+            session_id: None,
+            session_name: None,
+            created_at: None,
+            last_activity: None,
+        },
+    }))
+}
+
+fn proxy_request_user_id(
+    app_state: &AppState,
+    conn: &mut diesel::pg::PgConnection,
+    auth_token: Option<&str>,
+) -> Result<Uuid, AppError> {
+    use crate::schema::users;
+
+    if let Some(token) = auth_token {
+        return crate::handlers::proxy_tokens::verify_and_get_user(app_state, conn, token)
+            .map(|(user_id, _)| user_id)
+            .map_err(|status| match status {
+                axum::http::StatusCode::FORBIDDEN => AppError::Forbidden,
+                _ => AppError::Unauthorized,
+            });
+    }
+
+    if app_state.dev_mode {
+        return users::table
+            .filter(users::email.eq("testing@testing.local"))
+            .select(users::id)
+            .first::<Uuid>(conn)
+            .map_err(|e| AppError::DbQuery(e.to_string()));
+    }
+
+    Err(AppError::Unauthorized)
 }
 
 #[derive(Debug, Serialize)]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -479,6 +479,10 @@ async fn main() -> anyhow::Result<()> {
         )
         // Proxy token management endpoints
         .route(
+            "/api/proxy/resolve-session",
+            post(handlers::sessions::resolve_proxy_session),
+        )
+        .route(
             "/api/proxy-tokens",
             get(handlers::proxy_tokens::list_tokens_handler)
                 .post(handlers::proxy_tokens::create_token_handler),

--- a/claude-session-lib/src/proxy_session/git_metadata.rs
+++ b/claude-session-lib/src/proxy_session/git_metadata.rs
@@ -230,6 +230,24 @@ pub(super) async fn check_and_send_branch_update(
     }
 }
 
+/// Cheap input-path refresh: only pay for PR/repo lookup when the branch changed.
+pub(super) async fn check_and_send_branch_update_if_branch_changed(
+    ws_write: &SharedWsWrite,
+    session_id: Uuid,
+    working_directory: &str,
+    state: &GitMetadataState,
+) {
+    let new_branch = get_git_branch(working_directory);
+    let branch_changed = {
+        let branch_guard = state.current_branch.lock().await;
+        *branch_guard != new_branch
+    };
+
+    if branch_changed {
+        check_and_send_branch_update(ws_write, session_id, working_directory, state).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -24,8 +24,9 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use git_metadata::{
-    check_and_send_branch_update, codex_output_has_git_signal, get_git_branch, get_pr_url,
-    get_repo_url, GitMetadataState, GitRefreshTrigger,
+    check_and_send_branch_update, check_and_send_branch_update_if_branch_changed,
+    codex_output_has_git_signal, get_git_branch, get_pr_url, get_repo_url, GitMetadataState,
+    GitRefreshTrigger,
 };
 use output_forwarder::spawn_output_forwarder;
 use wiggum::{handle_session_event_with_wiggum, WiggumState};
@@ -392,16 +393,14 @@ async fn run_single_connection<A: Agent>(session: &mut SessionState<'_, A>) -> C
         .git_branch
         .as_deref()
         .and_then(|b| get_pr_url(&session.config.working_directory, b));
-    if pr_url.is_some() || repo_url.is_some() {
-        let update_msg = ProxyToServer::SessionUpdate {
-            session_id: config_with_branch.session_id,
-            git_branch: config_with_branch.git_branch.clone(),
-            pr_url,
-            repo_url,
-        };
-        if conn.send(update_msg).await.is_err() {
-            error!("Failed to send initial session update");
-        }
+    let update_msg = ProxyToServer::SessionUpdate {
+        session_id: config_with_branch.session_id,
+        git_branch: config_with_branch.git_branch.clone(),
+        pr_url,
+        repo_url,
+    };
+    if conn.send(update_msg).await.is_err() {
+        error!("Failed to send initial session update");
     }
 
     // Replay pending messages after successful registration.
@@ -810,6 +809,14 @@ async fn run_main_loop<A: Agent>(
             }
 
             Some(text) = input_rx.recv() => {
+                check_and_send_branch_update_if_branch_changed(
+                    &state.ws_write,
+                    state.session_id,
+                    &state.working_directory,
+                    &state.git_metadata,
+                )
+                .await;
+
                 debug!("sending to claude process: {}", truncate(&text, 100));
 
                 if let Err(e) = claude_session.send_input(serde_json::Value::String(text)).await {
@@ -821,6 +828,13 @@ async fn run_main_loop<A: Agent>(
             // Wiggum mode activation — set state and send prompt atomically
             Some(original_prompt) = state.wiggum_rx.recv() => {
                 info!("Wiggum mode activated with prompt: {}", truncate(&original_prompt, 60));
+                check_and_send_branch_update_if_branch_changed(
+                    &state.ws_write,
+                    state.session_id,
+                    &state.working_directory,
+                    &state.git_metadata,
+                )
+                .await;
                 let wiggum_prompt = format!(
                     "{}\n\nTake action on the directions above until fully complete. If complete, respond only with DONE.",
                     original_prompt

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -10,7 +10,7 @@ mod events;
 mod tools;
 #[cfg(test)]
 use events::thread_item_id;
-pub use events::{codex_event_item_id, is_codex_terminal_event, CodexEvent};
+pub use events::{codex_event_item_id, is_codex_terminal_event, CodexEvent, CodexItem};
 use events::{CodexError, CodexUsage, ContextCompactedParams, TurnPlanStep};
 use tools::{
     render_command_execution, render_diff_card, render_file_change, render_mcp_tool_call,
@@ -88,37 +88,40 @@ fn item_card_classes(completed: bool) -> &'static str {
     }
 }
 
-fn render_item(item: Option<&ThreadItem>, completed: bool) -> Html {
+fn render_item(item: Option<&CodexItem>, completed: bool) -> Html {
     let Some(item) = item else {
         return html! {};
     };
     match item {
-        ThreadItem::AgentMessage(it) => render_agent_message(&it.text, completed),
-        ThreadItem::Reasoning(it) => render_reasoning(&it.text, completed),
-        ThreadItem::CommandExecution(it) => render_command_execution(it, completed),
-        ThreadItem::FileChange(it) => render_file_change(it, completed),
-        ThreadItem::McpToolCall(it) => render_mcp_tool_call(it, completed),
-        ThreadItem::WebSearch(it) => render_web_search(&it.query, completed),
-        ThreadItem::TodoList(it) => render_todo_list(&it.items, completed),
-        ThreadItem::Error(it) => render_error_block(Some(&it.message)),
-        // UserMessage is the user's prompt for the turn — emitted by the
-        // app-server protocol as the first item; the portal renders the
-        // user-typed prompt out-of-band (Claude wire shape), so suppress
-        // here to avoid duplication.
-        ThreadItem::UserMessage(_) => html! {},
+        CodexItem::ContextCompaction(_) => render_context_compaction_item(completed),
+        CodexItem::Thread(item) => match item {
+            ThreadItem::AgentMessage(it) => render_agent_message(&it.text, completed),
+            ThreadItem::Reasoning(it) => render_reasoning(&it.text, completed),
+            ThreadItem::CommandExecution(it) => render_command_execution(it, completed),
+            ThreadItem::FileChange(it) => render_file_change(it, completed),
+            ThreadItem::McpToolCall(it) => render_mcp_tool_call(it, completed),
+            ThreadItem::WebSearch(it) => render_web_search(&it.query, completed),
+            ThreadItem::TodoList(it) => render_todo_list(&it.items, completed),
+            ThreadItem::Error(it) => render_error_block(Some(&it.message)),
+            // UserMessage is the user's prompt for the turn — emitted by the
+            // app-server protocol as the first item; the portal renders the
+            // user-typed prompt out-of-band (Claude wire shape), so suppress
+            // here to avoid duplication.
+            ThreadItem::UserMessage(_) => html! {},
+        },
     }
 }
 
 pub fn render_codex_message_content(json: &str) -> Html {
     match serde_json::from_str::<CodexEvent>(json) {
         Ok(CodexEvent::ItemCompleted {
-            item: Some(ThreadItem::AgentMessage(it)),
+            item: Some(CodexItem::Thread(ThreadItem::AgentMessage(it))),
         })
         | Ok(CodexEvent::ItemStarted {
-            item: Some(ThreadItem::AgentMessage(it)),
+            item: Some(CodexItem::Thread(ThreadItem::AgentMessage(it))),
         })
         | Ok(CodexEvent::ItemUpdated {
-            item: Some(ThreadItem::AgentMessage(it)),
+            item: Some(CodexItem::Thread(ThreadItem::AgentMessage(it))),
         }) => render_agent_message_content(&it.text),
         Ok(CodexEvent::ItemStarted { item }) | Ok(CodexEvent::ItemUpdated { item }) => {
             render_item(item.as_ref(), false)
@@ -463,6 +466,30 @@ fn render_context_compacted(params: Option<&ContextCompactedParams>) -> Html {
     }
 }
 
+fn render_context_compaction_item(completed: bool) -> Html {
+    let title = if completed {
+        "Codex compacted the conversation context"
+    } else {
+        "Codex is compacting the conversation context"
+    };
+
+    html! {
+        <div class="claude-message compaction-message">
+            <div class="message-header">
+                <span class="message-type-badge compaction">{ "Context Compaction" }</span>
+            </div>
+            <div class="message-body">
+                <div class="compaction-content">
+                    <div class="compaction-icon">{ "\u{1f4e6}" }</div>
+                    <div class="compaction-text">
+                        <div class="compaction-description">{ title }</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
 fn render_raw_codex(json: &str) -> Html {
     let display = serde_json::from_str::<Value>(json)
         .ok()
@@ -609,7 +636,7 @@ mod tests {
         assert!(matches!(
             event,
             CodexEvent::ItemCompleted {
-                item: Some(ThreadItem::AgentMessage(_))
+                item: Some(CodexItem::Thread(ThreadItem::AgentMessage(_)))
             }
         ));
     }
@@ -621,7 +648,7 @@ mod tests {
         assert!(matches!(
             event,
             CodexEvent::ItemUpdated {
-                item: Some(ThreadItem::CommandExecution(ref c))
+                item: Some(CodexItem::Thread(ThreadItem::CommandExecution(ref c)))
             } if c.exit_code == Some(1)
         ));
     }
@@ -652,7 +679,7 @@ mod tests {
         }"#;
         let event: CodexEvent = serde_json::from_str(json).unwrap();
         let CodexEvent::ItemStarted {
-            item: Some(ThreadItem::FileChange(fc)),
+            item: Some(CodexItem::Thread(ThreadItem::FileChange(fc))),
         } = event
         else {
             panic!("expected ItemStarted{{FileChange}}, got {:?}", event);
@@ -663,6 +690,35 @@ mod tests {
             "/home/meawoppl/repos/agent-portal-2/frontend/src/components/schedule_dialog.rs"
         );
         assert!(fc.changes[0].diff.contains("session_agent_type"));
+    }
+
+    /// #930 regression target — Codex emits compaction as an item lifecycle
+    /// event whose item type is not in codex-codes yet. It should parse as a
+    /// typed local item and render via the compaction card, not fall through
+    /// to the raw JSON renderer.
+    #[test]
+    fn event_item_started_context_compaction_no_longer_renders_raw() {
+        let json = r#"{
+            "_created_at": "2026-06-01T23:58:42.384Z",
+            "item": {
+                "id": "9edb35c0-6b6b-407f-84e3-d03a03050a2a",
+                "type": "contextCompaction"
+            },
+            "type": "item.started"
+        }"#;
+
+        let event: CodexEvent = serde_json::from_str(json).unwrap();
+        let CodexEvent::ItemStarted {
+            item: Some(CodexItem::ContextCompaction(item)),
+        } = event
+        else {
+            panic!("expected ItemStarted{{ContextCompaction}}, got {:?}", event);
+        };
+        assert_eq!(item.id, "9edb35c0-6b6b-407f-84e3-d03a03050a2a");
+        assert_eq!(
+            codex_event_item_id(json).as_deref(),
+            Some("9edb35c0-6b6b-407f-84e3-d03a03050a2a")
+        );
     }
 
     #[test]

--- a/frontend/src/components/codex_renderer/events.rs
+++ b/frontend/src/components/codex_renderer/events.rs
@@ -40,15 +40,15 @@ pub enum CodexEvent {
     },
     #[serde(rename = "item.started")]
     ItemStarted {
-        item: Option<ThreadItem>,
+        item: Option<CodexItem>,
     },
     #[serde(rename = "item.updated")]
     ItemUpdated {
-        item: Option<ThreadItem>,
+        item: Option<CodexItem>,
     },
     #[serde(rename = "item.completed")]
     ItemCompleted {
-        item: Option<ThreadItem>,
+        item: Option<CodexItem>,
     },
     Error {
         message: Option<String>,
@@ -88,6 +88,28 @@ pub enum CodexEvent {
     },
     #[serde(other)]
     Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CodexItem {
+    // TODO(SDK #930): move this variant to codex-codes once the generated
+    // ThreadItem model includes `contextCompaction`.
+    ContextCompaction(ContextCompactionItem),
+    Thread(ThreadItem),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextCompactionItem {
+    pub id: String,
+    #[serde(rename = "type")]
+    item_type: ContextCompactionItemType,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum ContextCompactionItemType {
+    #[serde(rename = "contextCompaction", alias = "context_compaction")]
+    ContextCompaction,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -267,6 +289,13 @@ pub fn thread_item_id(item: &ThreadItem) -> &str {
     }
 }
 
+pub fn codex_item_id(item: &CodexItem) -> &str {
+    match item {
+        CodexItem::ContextCompaction(it) => &it.id,
+        CodexItem::Thread(it) => thread_item_id(it),
+    }
+}
+
 /// Extract the `item_id` from a Codex event JSON, if it carries one. Returns
 /// `None` for events without items (turn-level events, deltas, errors) or for
 /// unparseable JSON. The group renderer uses this to dedupe progressive
@@ -280,7 +309,7 @@ pub fn codex_event_item_id(json: &str) -> Option<String> {
         | CodexEvent::ItemCompleted { item } => item?,
         _ => return None,
     };
-    Some(thread_item_id(&item).to_string())
+    Some(codex_item_id(&item).to_string())
 }
 
 /// Check if a Codex message indicates "awaiting" (turn complete or turn failed)

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -224,25 +224,30 @@ pub(super) fn classify_output_msg_type(output: &str) -> ActivityTag {
 /// for thread/turn-started signals and streaming deltas (those don't render
 /// visible cards, so the sparkline stays clean) and for unparseable JSON.
 fn classify_codex_event(output: &str) -> Option<ActivityTag> {
-    use crate::components::codex_renderer::CodexEvent;
+    use crate::components::codex_renderer::{CodexEvent, CodexItem};
     use codex_codes::io::items::ThreadItem;
     let event: CodexEvent = serde_json::from_str(output).ok()?;
     match event {
         CodexEvent::ItemStarted { item: Some(item) }
         | CodexEvent::ItemUpdated { item: Some(item) }
         | CodexEvent::ItemCompleted { item: Some(item) } => match item {
-            ThreadItem::Error(_) => Some(ActivityTag::Error),
-            ThreadItem::CommandExecution(ref it) if command_execution_reads_file(&it.command) => {
+            CodexItem::ContextCompaction(_) => Some(ActivityTag::Assistant),
+            CodexItem::Thread(ThreadItem::Error(_)) => Some(ActivityTag::Error),
+            CodexItem::Thread(ThreadItem::CommandExecution(ref it))
+                if command_execution_reads_file(&it.command) =>
+            {
                 Some(ActivityTag::Read)
             }
-            ThreadItem::AgentMessage(_)
-            | ThreadItem::Reasoning(_)
-            | ThreadItem::CommandExecution(_)
-            | ThreadItem::FileChange(_)
-            | ThreadItem::McpToolCall(_)
-            | ThreadItem::WebSearch(_)
-            | ThreadItem::TodoList(_)
-            | ThreadItem::UserMessage(_) => Some(ActivityTag::Assistant),
+            CodexItem::Thread(
+                ThreadItem::AgentMessage(_)
+                | ThreadItem::Reasoning(_)
+                | ThreadItem::CommandExecution(_)
+                | ThreadItem::FileChange(_)
+                | ThreadItem::McpToolCall(_)
+                | ThreadItem::WebSearch(_)
+                | ThreadItem::TodoList(_)
+                | ThreadItem::UserMessage(_),
+            ) => Some(ActivityTag::Assistant),
         },
         CodexEvent::TurnCompleted { .. } | CodexEvent::TurnFailed { .. } => {
             Some(ActivityTag::Result)

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -50,6 +50,9 @@ hostname = "0.4"
 # URL parsing
 url = "2.5"
 
+# HTTP client for pre-spawn backend session resolution
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+
 # Config file management
 directories = "5.0"
 
@@ -69,4 +72,3 @@ base64 = "0.22"
 # Unix system calls (for lock file process checking)
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use claude_session_lib::ClaudeAgent;
 use session_lib::{Session, SessionConfig};
+use shared::api::{ResolveProxySessionRequest, ResolveProxySessionResponse};
 
 /// Type alias — the proxy binary only ever drives Claude sessions; the
 /// launcher is where heterogeneous (Claude + Codex) dispatch lives.
@@ -339,9 +340,6 @@ async fn main() -> Result<()> {
         return commands::handle_init(&mut config, &cwd, init_value, args.backend_url.as_deref());
     }
 
-    // Resolve session (new or resume)
-    let (session_id, session_name, resuming) = resolve_session(&args, &cwd)?;
-
     // Resolve backend URL: CLI arg > per-directory config > global default > compile-time default
     let backend_url = args
         .backend_url
@@ -350,19 +348,9 @@ async fn main() -> Result<()> {
         .or_else(|| config.preferences.default_backend_url.clone())
         .unwrap_or_else(|| shared::default_backend_url().to_string());
 
-    // Print startup info (suppress in shim mode — stdout is reserved for claude I/O)
-    if !args.shim {
-        ui::print_startup_banner();
-        if args.session_id_tag.is_none() {
-            ui::print_deprecation_warning();
-        }
-        ui::print_session_info(
-            &session_name,
-            &session_id.to_string(),
-            &backend_url,
-            resuming,
-        );
-    }
+    // Parse agent type
+    let agent_type: shared::AgentType =
+        args.agent.parse().map_err(|e: String| anyhow::anyhow!(e))?;
 
     // Resolve auth token — in shim mode, auth failure is non-fatal so claude
     // still launches even if the portal backend is unreachable.
@@ -378,15 +366,34 @@ async fn main() -> Result<()> {
         resolve_auth_token(&args, &mut config, &cwd, &backend_url).await?
     };
 
+    // Resolve session (new or resume). Prefer the backend's DB-backed session
+    // identity; fall back to the local directory cache only when the backend
+    // cannot answer (offline, auth unavailable, older server).
+    let resolved_session =
+        resolve_session(&args, &cwd, &backend_url, auth_token.as_deref(), agent_type).await?;
+    let session_id = resolved_session.session_id;
+    let session_name = resolved_session.session_name;
+    let resuming = resolved_session.resuming;
+
+    // Print startup info (suppress in shim mode — stdout is reserved for claude I/O)
+    if !args.shim {
+        ui::print_startup_banner();
+        if args.session_id_tag.is_none() {
+            ui::print_deprecation_warning();
+        }
+        ui::print_session_info(
+            &session_name,
+            &session_id.to_string(),
+            &backend_url,
+            resuming,
+        );
+    }
+
     // Detect git branch
     let git_branch = get_git_branch(&cwd);
     if let Some(ref branch) = git_branch {
         info!("Detected git branch: {}", branch);
     }
-
-    // Parse agent type
-    let agent_type: shared::AgentType =
-        args.agent.parse().map_err(|e: String| anyhow::anyhow!(e))?;
 
     // Build session config
     let session_config = ProxySessionConfig {
@@ -415,48 +422,119 @@ async fn main() -> Result<()> {
     run_proxy_session(session_config).await
 }
 
-/// Resolve which session to use (new or resume existing)
-fn resolve_session(args: &Args, cwd: &str) -> Result<(Uuid, String, bool)> {
+struct ResolvedSession {
+    session_id: Uuid,
+    session_name: String,
+    resuming: bool,
+}
+
+/// Resolve which session to use (new or resume existing).
+async fn resolve_session(
+    args: &Args,
+    cwd: &str,
+    backend_url: &str,
+    auth_token: Option<&str>,
+    agent_type: shared::AgentType,
+) -> Result<ResolvedSession> {
+    if args.new_session {
+        return create_fresh_local_session(args, cwd, true);
+    }
+
+    if let Some(token) = auth_token {
+        match resolve_session_from_backend(args, cwd, backend_url, token, agent_type).await {
+            Ok(Some(resolved)) => return Ok(resolved),
+            Ok(None) => {
+                info!("Backend has no resumable session for {}; creating new", cwd);
+                return create_fresh_local_session(args, cwd, false);
+            }
+            Err(e) => {
+                warn!(
+                    "Backend session resolution failed (falling back to local cache): {}",
+                    e
+                );
+            }
+        }
+    } else {
+        info!("No auth token available; using local session cache");
+    }
+
+    resolve_session_from_local_cache(args, cwd)
+}
+
+async fn resolve_session_from_backend(
+    args: &Args,
+    cwd: &str,
+    backend_url: &str,
+    auth_token: &str,
+    agent_type: shared::AgentType,
+) -> Result<Option<ResolvedSession>> {
+    let http_url = http_api_url(backend_url, "/api/proxy/resolve-session")?;
+    let hostname = hostname::get().ok().and_then(|h| h.into_string().ok());
+    let req = ResolveProxySessionRequest {
+        auth_token: Some(auth_token.to_string()),
+        working_directory: cwd.to_string(),
+        hostname,
+        agent_type,
+    };
+
+    let response = reqwest::Client::new()
+        .post(http_url)
+        .json(&req)
+        .send()
+        .await
+        .context("request failed")?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !response.status().is_success() {
+        anyhow::bail!("server returned {}", response.status());
+    }
+
+    let resolved = response
+        .json::<ResolveProxySessionResponse>()
+        .await
+        .context("invalid resolve-session response")?;
+
+    let Some(session_id) = resolved.session_id else {
+        return Ok(None);
+    };
+    let session_name = args
+        .session_name
+        .clone()
+        .or(resolved.session_name.clone())
+        .unwrap_or_else(default_session_name);
+
+    cache_directory_session(
+        cwd,
+        session_id,
+        session_name.clone(),
+        resolved.created_at.clone(),
+        resolved.last_activity.clone(),
+    )?;
+
+    if !args.shim {
+        let created_at = resolved
+            .created_at
+            .as_deref()
+            .unwrap_or("unknown creation time");
+        ui::print_resuming_session(&session_id.to_string(), created_at);
+    }
+
+    Ok(Some(ResolvedSession {
+        session_id,
+        session_name,
+        resuming: true,
+    }))
+}
+
+fn resolve_session_from_local_cache(args: &Args, cwd: &str) -> Result<ResolvedSession> {
     let (mut config, lock) =
         ProxyConfig::load_locked().context("Failed to load config with lock")?;
 
     let existing_session = config.get_directory_session(cwd).cloned();
 
-    // Force new session or no existing session to resume
-    if args.new_session || existing_session.is_none() {
-        let had_existing = existing_session.is_some();
-
-        // Start a new session
-        let session_id = Uuid::new_v4();
-        let session_name = args
-            .session_name
-            .clone()
-            .unwrap_or_else(default_session_name);
-
-        let dir_session = ProxyConfig::create_directory_session(session_id, session_name.clone());
-        config.set_directory_session(cwd.to_string(), dir_session);
-        config.save_with_lock(&lock)?;
-
-        if args.new_session && had_existing {
-            warn!(
-                "Starting new session (--new-session flag) - previous session will not be resumed"
-            );
-            if !args.shim {
-                ui::print_new_session_forced();
-            }
-        } else if !had_existing {
-            info!(
-                "No existing session for directory {}, creating new session {}",
-                cwd, session_id
-            );
-            if !args.shim {
-                ui::print_no_previous_session();
-            }
-        }
-
-        info!("New session ID: {}", session_id);
-        Ok((session_id, session_name, false))
-    } else if let Some(existing) = existing_session {
+    if let Some(existing) = existing_session {
         // Resume existing session
         let session_name = args
             .session_name
@@ -474,11 +552,86 @@ fn resolve_session(args: &Args, cwd: &str) -> Result<(Uuid, String, bool)> {
             ui::print_resuming_session(&existing.session_id.to_string(), &existing.created_at);
         }
 
-        Ok((existing.session_id, session_name, true))
+        Ok(ResolvedSession {
+            session_id: existing.session_id,
+            session_name,
+            resuming: true,
+        })
     } else {
-        // This branch is unreachable: if first condition is false, existing_session must be Some
-        unreachable!("existing_session cannot be None here")
+        create_fresh_local_session(args, cwd, false)
     }
+}
+
+fn create_fresh_local_session(args: &Args, cwd: &str, forced: bool) -> Result<ResolvedSession> {
+    let (mut config, lock) =
+        ProxyConfig::load_locked().context("Failed to load config with lock")?;
+    let had_existing = config.get_directory_session(cwd).is_some();
+    let session_id = Uuid::new_v4();
+    let session_name = args
+        .session_name
+        .clone()
+        .unwrap_or_else(default_session_name);
+
+    let dir_session = ProxyConfig::create_directory_session(session_id, session_name.clone());
+    config.set_directory_session(cwd.to_string(), dir_session);
+    config.save_with_lock(&lock)?;
+
+    if forced && had_existing {
+        warn!("Starting new session (--new-session flag) - previous session will not be resumed");
+        if !args.shim {
+            ui::print_new_session_forced();
+        }
+    } else if !had_existing {
+        info!(
+            "No existing session for directory {}, creating new session {}",
+            cwd, session_id
+        );
+        if !args.shim {
+            ui::print_no_previous_session();
+        }
+    }
+
+    info!("New session ID: {}", session_id);
+    Ok(ResolvedSession {
+        session_id,
+        session_name,
+        resuming: false,
+    })
+}
+
+fn cache_directory_session(
+    cwd: &str,
+    session_id: Uuid,
+    session_name: String,
+    created_at: Option<String>,
+    last_used: Option<String>,
+) -> Result<()> {
+    let (mut config, lock) =
+        ProxyConfig::load_locked().context("Failed to load config with lock")?;
+    let mut dir_session = ProxyConfig::create_directory_session(session_id, session_name);
+    if let Some(created_at) = created_at {
+        dir_session.created_at = created_at;
+    }
+    if let Some(last_used) = last_used {
+        dir_session.last_used = last_used;
+    }
+    config.set_directory_session(cwd.to_string(), dir_session);
+    config.save_with_lock(&lock)
+}
+
+fn http_api_url(backend_url: &str, path: &str) -> Result<String> {
+    let mut url = url::Url::parse(backend_url).context("Invalid backend URL")?;
+    match url.scheme() {
+        "ws" => url.set_scheme("http").ok(),
+        "wss" => url.set_scheme("https").ok(),
+        "http" | "https" => Some(()),
+        other => anyhow::bail!("Unsupported backend URL scheme: {}", other),
+    }
+    .context("Failed to convert backend URL scheme")?;
+    url.set_path(path);
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url.to_string())
 }
 
 /// Resolve the authentication token
@@ -631,4 +784,33 @@ async fn create_claude_session(config: &ProxySessionConfig) -> Result<ClaudeSess
     ClaudeSession::new(claude_config)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to create Claude session: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::http_api_url;
+
+    #[test]
+    fn http_api_url_converts_ws_backend_url() {
+        assert_eq!(
+            http_api_url("ws://localhost:3000", "/api/proxy/resolve-session").unwrap(),
+            "http://localhost:3000/api/proxy/resolve-session"
+        );
+        assert_eq!(
+            http_api_url("wss://portal.example", "/api/proxy/resolve-session").unwrap(),
+            "https://portal.example/api/proxy/resolve-session"
+        );
+    }
+
+    #[test]
+    fn http_api_url_replaces_existing_path_query_and_fragment() {
+        assert_eq!(
+            http_api_url(
+                "wss://portal.example/base/path?x=1#frag",
+                "/api/proxy/resolve-session"
+            )
+            .unwrap(),
+            "https://portal.example/api/proxy/resolve-session"
+        );
+    }
 }

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -451,6 +451,40 @@ pub struct SessionsResponse {
 }
 
 // =============================================================================
+// Proxy Session Resolution Endpoint (POST /api/proxy/resolve-session)
+// =============================================================================
+
+/// Request from a proxy before it spawns the agent process. The backend uses
+/// this to choose the latest resumable session for the authenticated user and
+/// local machine/path, so clients don't need to persist directory -> session_id
+/// as the source of truth.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolveProxySessionRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_token: Option<String>,
+    pub working_directory: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    #[serde(default)]
+    pub agent_type: crate::AgentType,
+}
+
+/// Response from `POST /api/proxy/resolve-session`. `session_id == None`
+/// means the backend has no matching resumable session and the proxy should
+/// allocate a fresh UUID.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolveProxySessionResponse {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<Uuid>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_activity: Option<String>,
+}
+
+// =============================================================================
 // Admin Users Endpoint (GET /api/admin/users)
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- resolve proxy session IDs from backend DB state before falling back to local directory cache
- refresh and broadcast git metadata more reliably on reconnect and user input
- render Codex `contextCompaction` item lifecycle events as formatted compaction cards instead of raw JSON
- bump workspace version to 2.6.30

## Verification
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo build -p shared --target wasm32-unknown-unknown`
- `cargo check -p frontend --target wasm32-unknown-unknown`

Fixes #930
