### PR TITLE
Make session/launcher tokens non-expiring; revoke on terminate (#932)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.6.30"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.6.30"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.6.30"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.6.30"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.6.30"
+version = "2.7.0"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.6.30"
+version = "2.7.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.6.30"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.6.30"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.6.30"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.6.30"
+version = "2.7.0"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.30"
+version = "2.7.0"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/2026-06-02-181500_proxy_tokens_no_expiry/down.sql
+++ b/backend/migrations/2026-06-02-181500_proxy_tokens_no_expiry/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE proxy_auth_tokens DROP COLUMN session_id;
+
+-- Backfill any NULL expiries before restoring the NOT NULL constraint.
+UPDATE proxy_auth_tokens SET expires_at = now() WHERE expires_at IS NULL;
+ALTER TABLE proxy_auth_tokens ALTER COLUMN expires_at SET NOT NULL;

--- a/backend/migrations/2026-06-02-181500_proxy_tokens_no_expiry/up.sql
+++ b/backend/migrations/2026-06-02-181500_proxy_tokens_no_expiry/up.sql
@@ -1,0 +1,11 @@
+-- Per-session and launcher proxy tokens no longer carry a fixed TTL. Their
+-- lifetime is tracked by revocation (revoke-on-terminate) plus the always-live
+-- DB checks in verify_and_get_user, not by `expires_at`. See #932.
+--
+-- expires_at becomes nullable: NULL means "never expires". User-created
+-- dashboard CLI tokens still set an explicit expiry.
+ALTER TABLE proxy_auth_tokens ALTER COLUMN expires_at DROP NOT NULL;
+
+-- session_id links a launch token to the session whose proxy holds it, so the
+-- token can be revoked when that session terminates.
+ALTER TABLE proxy_auth_tokens ADD COLUMN session_id UUID;

--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -396,19 +396,19 @@ pub async fn complete_device_flow(
         error!("Failed to find user: {}", e);
     })?;
 
-    // Generate token ID and create JWT
+    // Generate token ID and create JWT. Device-flow tokens (used by launchers
+    // and CLI proxies) never expire; revocation governs their lifetime. See
+    // #932.
     let token_id = Uuid::new_v4();
-    let expires_in_days: u32 = 30; // Device flow tokens valid for 30 days
     let jwt_secret = app_state.jwt_secret.as_bytes();
 
-    let token = create_proxy_token(jwt_secret, token_id, user_id, &user.email, expires_in_days)
-        .map_err(|e| {
+    let token =
+        create_proxy_token(jwt_secret, token_id, user_id, &user.email, None).map_err(|e| {
             error!("Failed to create JWT: {}", e);
         })?;
 
     // Store token hash in database
     let token_hash = hash_token(&token);
-    let expires_at = chrono::Utc::now() + chrono::Duration::days(expires_in_days as i64);
 
     let new_token = NewProxyAuthToken {
         user_id,
@@ -417,7 +417,7 @@ pub async fn complete_device_flow(
             chrono::Utc::now().format("%Y-%m-%d %H:%M")
         ),
         token_hash,
-        expires_at: expires_at.naive_utc(),
+        expires_at: None,
     };
 
     diesel::insert_into(proxy_auth_tokens::table)

--- a/backend/src/handlers/helpers.rs
+++ b/backend/src/handlers/helpers.rs
@@ -105,6 +105,10 @@ pub fn delete_session_with_data(
     )
     .execute(conn);
 
+    // Revoke any (non-expiring) launch tokens bound to this session so they
+    // don't outlive the session row. See #932.
+    crate::handlers::proxy_tokens::revoke_tokens_for_session(conn, session_id);
+
     // Delete the session
     diesel::delete(sessions::table.filter(sessions::id.eq(session_id)))
         .execute(conn)

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -302,12 +302,15 @@ pub(crate) fn mint_launch_token(app_state: &AppState, user_id: Uuid) -> Result<S
         .map_err(|e| AppError::DbQuery(e.to_string()))?;
 
     let token_id = Uuid::new_v4();
+    // Launch tokens never expire. The token is bound to its session at proxy
+    // registration and revoked when the session terminates, so its lifetime
+    // tracks the session rather than a fixed TTL. See #932.
     let token = crate::jwt::create_proxy_token(
         app_state.jwt_secret.as_bytes(),
         token_id,
         user_id,
         &user.email,
-        1, // 1 day expiration for launched sessions
+        None,
     )
     .map_err(|e| AppError::Internal(format!("Failed to create launch token: {}", e)))?;
 
@@ -315,9 +318,9 @@ pub(crate) fn mint_launch_token(app_state: &AppState, user_id: Uuid) -> Result<S
     let token_hash = crate::jwt::hash_token(&token);
     let new_token = crate::models::NewProxyAuthToken {
         user_id,
-        name: "launcher-spawned".to_string(),
+        name: crate::handlers::proxy_tokens::LAUNCH_TOKEN_NAME.to_string(),
         token_hash,
-        expires_at: (chrono::Utc::now() + chrono::Duration::days(1)).naive_utc(),
+        expires_at: None,
     };
 
     use crate::schema::proxy_auth_tokens;
@@ -327,40 +330,6 @@ pub(crate) fn mint_launch_token(app_state: &AppState, user_id: Uuid) -> Result<S
         .map_err(|e| AppError::DbQuery(e.to_string()))?;
 
     Ok(token)
-}
-
-/// POST /api/launchers/:launcher_id/renew-token - Manually renew a launcher's auth token
-pub async fn renew_launcher_token(
-    State(app_state): State<Arc<AppState>>,
-    cookies: Cookies,
-    Path(launcher_id): Path<Uuid>,
-) -> Result<EmptyResponse, AppError> {
-    let user_id = extract_user_id(&app_state, &cookies)?;
-
-    // Verify the launcher belongs to this user and get its current token info
-    let (old_token_hash, sender) = {
-        let launcher = app_state
-            .session_manager
-            .launchers
-            .get(&launcher_id)
-            .ok_or(AppError::NotFound("Launcher not found"))?;
-        if launcher.user_id != user_id {
-            return Err(AppError::Forbidden);
-        }
-        (launcher.token_hash.clone(), launcher.sender.clone())
-    };
-
-    crate::handlers::websocket::launcher_socket::renew_launcher_token_for(
-        &app_state,
-        launcher_id,
-        user_id,
-        old_token_hash,
-        sender,
-    )
-    .map_err(|e| AppError::Internal(format!("{:?}", e)))?;
-
-    info!("Manually renewed token for launcher {}", launcher_id);
-    Ok(EmptyResponse::OK)
 }
 
 /// POST /api/launchers/:launcher_id/update - Tell the launcher to fetch the
@@ -472,8 +441,6 @@ mod tests {
             running_sessions: Vec::new(),
             working_directory: None,
             version: "test".to_string(),
-            token_hash: None,
-            token_expires_at: None,
         }
     }
 

--- a/backend/src/handlers/proxy_tokens.rs
+++ b/backend/src/handlers/proxy_tokens.rs
@@ -57,7 +57,7 @@ pub async fn create_token_handler(
         token_id,
         user_id,
         &user.email,
-        req.expires_in_days,
+        Some(req.expires_in_days),
     )
     .map_err(|e| AppError::Internal(e.to_string()))?;
 
@@ -69,7 +69,7 @@ pub async fn create_token_handler(
         user_id,
         name: req.name.clone(),
         token_hash,
-        expires_at: expires_at.naive_utc(),
+        expires_at: Some(expires_at.naive_utc()),
     };
 
     let saved_token: ProxyAuthToken = diesel::insert_into(proxy_auth_tokens::table)
@@ -119,7 +119,7 @@ pub async fn list_tokens_handler(
             name: t.name,
             created_at: t.created_at.and_utc().to_rfc3339(),
             last_used_at: t.last_used_at.map(|dt| dt.and_utc().to_rfc3339()),
-            expires_at: t.expires_at.and_utc().to_rfc3339(),
+            expires_at: t.expires_at.map(|dt| dt.and_utc().to_rfc3339()),
             revoked: t.revoked,
         })
         .collect();
@@ -193,7 +193,7 @@ pub async fn renew_token_handler(
         new_token_id,
         user_id,
         &user.email,
-        req.expires_in_days,
+        Some(req.expires_in_days),
     )
     .map_err(|e| AppError::Internal(e.to_string()))?;
 
@@ -206,7 +206,7 @@ pub async fn renew_token_handler(
     )
     .set((
         proxy_auth_tokens::token_hash.eq(&token_hash),
-        proxy_auth_tokens::expires_at.eq(expires_at.naive_utc()),
+        proxy_auth_tokens::expires_at.eq(Some(expires_at.naive_utc())),
     ))
     .execute(&mut conn)
     .map_err(|e| AppError::DbQuery(e.to_string()))?;
@@ -263,11 +263,15 @@ pub fn verify_and_get_user(
         return Err(StatusCode::UNAUTHORIZED);
     }
 
-    // Check if expired (belt and suspenders - JWT already checked this)
-    let now = chrono::Utc::now().naive_utc();
-    if db_token.expires_at < now {
-        error!("Token has expired");
-        return Err(StatusCode::UNAUTHORIZED);
+    // Check if expired (belt and suspenders - JWT already checked this).
+    // A NULL `expires_at` means the token never expires (launch/launcher
+    // tokens); its lifetime is governed by revocation instead. See #932.
+    if let Some(expires_at) = db_token.expires_at {
+        let now = chrono::Utc::now().naive_utc();
+        if expires_at < now {
+            error!("Token has expired");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
     }
 
     // Check if user is banned
@@ -288,4 +292,71 @@ pub fn verify_and_get_user(
         .execute(conn);
 
     Ok((claims.sub, claims.email))
+}
+
+/// Name stamped on tokens minted per launched session (`mint_launch_token`).
+///
+/// Only tokens with this name are bound to a session and revoked when the
+/// session ends. Durable credentials — user dashboard tokens and device-flow
+/// tokens (which a direct `claude-portal` CLI may reuse across sessions) — must
+/// never be revoked just because one session they registered terminated.
+pub const LAUNCH_TOKEN_NAME: &str = "launcher-spawned";
+
+/// Bind a launch token to the session whose proxy registered with it, and
+/// revoke any older tokens previously bound to the same session.
+///
+/// Launch tokens never expire (see #932); instead their lifetime tracks the
+/// session. The proxy currently attached to a session is whichever one
+/// registered most recently, so binding the active token and revoking the
+/// rest keeps exactly one live token per session. A reconnect re-binds the
+/// *same* token (no-op); a relaunch binds a fresh token and revokes the dead
+/// proxy's old one.
+///
+/// Only `LAUNCH_TOKEN_NAME` tokens are bound — the filter makes binding a no-op
+/// for durable credentials, so they are never revoked on session termination.
+pub fn link_token_to_session(conn: &mut diesel::pg::PgConnection, token: &str, session: Uuid) {
+    let token_hash = hash_token(token);
+
+    let bound = match diesel::update(
+        proxy_auth_tokens::table
+            .filter(proxy_auth_tokens::token_hash.eq(&token_hash))
+            .filter(proxy_auth_tokens::name.eq(LAUNCH_TOKEN_NAME)),
+    )
+    .set(proxy_auth_tokens::session_id.eq(Some(session)))
+    .execute(conn)
+    {
+        Ok(n) => n,
+        Err(e) => {
+            error!("Failed to bind token to session {}: {}", session, e);
+            return;
+        }
+    };
+
+    // Not a launch token (durable credential): leave it and every other token
+    // for this session alone.
+    if bound == 0 {
+        return;
+    }
+
+    // Revoke superseded tokens for this session (any token bound to it that
+    // isn't the one that just registered).
+    let _ = diesel::update(
+        proxy_auth_tokens::table
+            .filter(proxy_auth_tokens::session_id.eq(session))
+            .filter(proxy_auth_tokens::token_hash.ne(&token_hash)),
+    )
+    .set(proxy_auth_tokens::revoked.eq(true))
+    .execute(conn);
+}
+
+/// Revoke every token bound to a session. Called when the session terminates
+/// (proxy exit) or is deleted, so a session's tokens never outlive it.
+pub fn revoke_tokens_for_session(conn: &mut diesel::pg::PgConnection, session: Uuid) {
+    if let Err(e) =
+        diesel::update(proxy_auth_tokens::table.filter(proxy_auth_tokens::session_id.eq(session)))
+            .set(proxy_auth_tokens::revoked.eq(true))
+            .execute(conn)
+    {
+        error!("Failed to revoke tokens for session {}: {}", session, e);
+    }
 }

--- a/backend/src/handlers/websocket/launcher_registry.rs
+++ b/backend/src/handlers/websocket/launcher_registry.rs
@@ -16,10 +16,6 @@ pub struct LauncherConnection {
     pub running_sessions: Vec<Uuid>,
     pub working_directory: Option<String>,
     pub version: String,
-    /// SHA256 hash of the launcher's current auth token (for revocation on renewal)
-    pub token_hash: Option<String>,
-    /// When the launcher's auth token expires
-    pub token_expires_at: Option<chrono::NaiveDateTime>,
 }
 
 impl SessionManager {
@@ -90,10 +86,6 @@ impl SessionManager {
                 running_sessions: entry.value().running_sessions.len() as u32,
                 working_directory: entry.value().working_directory.clone(),
                 version: entry.value().version.clone(),
-                token_expires_at: entry
-                    .value()
-                    .token_expires_at
-                    .map(|dt| dt.and_utc().to_rfc3339()),
             })
             .collect()
     }

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -17,16 +17,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
     let (mut ws_sender, mut ws_receiver) = conn.split();
 
     // Wait for LauncherRegister message
-    let (
-        launcher_id,
-        launcher_name,
-        hostname,
-        user_id,
-        working_directory,
-        version,
-        reg_token_hash,
-        reg_token_expires_at,
-    ) = loop {
+    let (launcher_id, launcher_name, hostname, user_id, working_directory, version) = loop {
         match ws_receiver.recv().await {
             Some(Ok(LauncherToServer::LauncherRegister {
                 launcher_id,
@@ -36,10 +27,9 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                 working_directory,
                 version,
             })) => {
-                // Authenticate and look up token metadata
-                let (user_id, reg_token_hash, reg_token_expires_at) = if let Some(ref token) =
-                    auth_token
-                {
+                // Authenticate. Launcher tokens never expire (see #932), so
+                // there is no expiry to track here.
+                let user_id = if let Some(ref token) = auth_token {
                     match app_state.db_pool.get() {
                         Ok(mut conn) => {
                             match crate::handlers::proxy_tokens::verify_and_get_user(
@@ -47,22 +37,11 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                             ) {
                                 Ok((uid, email)) => {
                                     info!("Launcher authenticated as {} ({})", email, uid);
-                                    // Look up token expiry from DB
-                                    let token_hash = crate::jwt::hash_token(token);
-                                    let expires_at = {
-                                        use crate::schema::proxy_auth_tokens;
-                                        use diesel::prelude::*;
-                                        proxy_auth_tokens::table
-                                            .filter(proxy_auth_tokens::token_hash.eq(&token_hash))
-                                            .select(proxy_auth_tokens::expires_at)
-                                            .first::<chrono::NaiveDateTime>(&mut conn)
-                                            .ok()
-                                    };
-                                    (uid, Some(token_hash), expires_at)
+                                    uid
                                 }
                                 Err(_) => {
                                     if app_state.dev_mode {
-                                        (get_dev_user_id(&app_state), None, None)
+                                        get_dev_user_id(&app_state)
                                     } else {
                                         let _ = ws_sender
                                             .send(ServerToLauncher::LauncherRegisterAck {
@@ -90,7 +69,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                         }
                     }
                 } else if app_state.dev_mode {
-                    (get_dev_user_id(&app_state), None, None)
+                    get_dev_user_id(&app_state)
                 } else {
                     let _ = ws_sender
                         .send(ServerToLauncher::LauncherRegisterAck {
@@ -110,8 +89,6 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                     user_id,
                     working_directory,
                     version,
-                    reg_token_hash,
-                    reg_token_expires_at,
                 );
             }
             Some(Ok(_)) => continue,
@@ -171,8 +148,6 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
             running_sessions: Vec::new(),
             working_directory,
             version: version.unwrap_or_default(),
-            token_hash: reg_token_hash,
-            token_expires_at: reg_token_expires_at,
         },
     );
 
@@ -399,24 +374,6 @@ fn handle_launcher_message(
         } => {
             if let Some(mut launcher) = app_state.session_manager.launchers.get_mut(&launcher_id) {
                 launcher.running_sessions = running_sessions;
-
-                // Check if token needs renewal (within 7 days of expiry)
-                if let Some(expires_at) = launcher.token_expires_at {
-                    let now = chrono::Utc::now().naive_utc();
-                    let days_until_expiry = (expires_at - now).num_days();
-                    if days_until_expiry <= 7 {
-                        let old_hash = launcher.token_hash.clone();
-                        let sender = launcher.sender.clone();
-                        drop(launcher); // release DashMap lock before DB work
-                        let _ = renew_launcher_token_for(
-                            app_state,
-                            launcher_id,
-                            user_id,
-                            old_hash,
-                            sender,
-                        );
-                    }
-                }
             }
             reconcile_desired_sessions(app_state, launcher_id, user_id);
         }
@@ -436,6 +393,11 @@ fn handle_launcher_message(
             exit_code,
         } => {
             info!("Proxy exited: session={}, code={:?}", session_id, exit_code);
+            // The proxy holding this session's token has exited; revoke the
+            // token so it can't be reused. A resume mints a fresh one. See #932.
+            if let Ok(mut conn) = app_state.db_pool.get() {
+                crate::handlers::proxy_tokens::revoke_tokens_for_session(&mut conn, session_id);
+            }
             app_state.session_manager.broadcast_to_user(
                 &user_id,
                 ServerToClient::SessionExited {
@@ -767,91 +729,6 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
             );
         }
     }
-}
-
-/// Mint a new 30-day token for a launcher, revoke the old one, and push it over WS.
-/// Used by both the heartbeat auto-renewal and the manual renew API endpoint.
-pub fn renew_launcher_token_for(
-    app_state: &AppState,
-    launcher_id: Uuid,
-    user_id: Uuid,
-    old_token_hash: Option<String>,
-    sender: mpsc::UnboundedSender<ServerToLauncher>,
-) -> Result<(), ()> {
-    let mut conn = app_state.db_pool.get().map_err(|e| {
-        error!("Failed to get DB connection for token renewal: {}", e);
-    })?;
-
-    use crate::schema::{proxy_auth_tokens, users};
-    use diesel::prelude::*;
-
-    let user: crate::models::User = users::table.find(user_id).first(&mut conn).map_err(|e| {
-        error!("Failed to find user for token renewal: {}", e);
-    })?;
-
-    let token_id = Uuid::new_v4();
-    let expires_in_days: u32 = 30;
-    let token = crate::jwt::create_proxy_token(
-        app_state.jwt_secret.as_bytes(),
-        token_id,
-        user_id,
-        &user.email,
-        expires_in_days,
-    )
-    .map_err(|e| {
-        error!("Failed to create renewal token: {}", e);
-    })?;
-
-    let new_hash = crate::jwt::hash_token(&token);
-    let new_expires_at =
-        (chrono::Utc::now() + chrono::Duration::days(expires_in_days as i64)).naive_utc();
-
-    let new_token = crate::models::NewProxyAuthToken {
-        user_id,
-        name: format!(
-            "Launcher renewal {}",
-            chrono::Utc::now().format("%Y-%m-%d %H:%M")
-        ),
-        token_hash: new_hash.clone(),
-        expires_at: new_expires_at,
-    };
-
-    diesel::insert_into(proxy_auth_tokens::table)
-        .values(&new_token)
-        .execute(&mut conn)
-        .map_err(|e| {
-            error!("Failed to store renewed token: {}", e);
-        })?;
-
-    // Revoke old token
-    if let Some(ref old_hash) = old_token_hash {
-        let _ = diesel::update(
-            proxy_auth_tokens::table.filter(proxy_auth_tokens::token_hash.eq(old_hash)),
-        )
-        .set(proxy_auth_tokens::revoked.eq(true))
-        .execute(&mut conn);
-    }
-
-    // Update launcher connection with new token info
-    if let Some(mut launcher) = app_state.session_manager.launchers.get_mut(&launcher_id) {
-        launcher.token_hash = Some(new_hash);
-        launcher.token_expires_at = Some(new_expires_at);
-    }
-
-    // Push the new token to the launcher
-    if sender
-        .send(ServerToLauncher::TokenRenewed { token })
-        .is_ok()
-    {
-        info!(
-            "Renewed launcher token for '{}' (user {}), new expiry: {}",
-            launcher_id, user.email, new_expires_at
-        );
-    } else {
-        warn!("Failed to send renewed token to launcher {}", launcher_id);
-    }
-
-    Ok(())
 }
 
 fn get_dev_user_id(app_state: &AppState) -> Uuid {

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -115,7 +115,7 @@ pub fn register_or_update_session(
         .optional()
         .unwrap_or(None);
 
-    if let Some(existing_session) = existing {
+    let result = if let Some(existing_session) = existing {
         // Authorization gate for reattach: the resolved user_id must be the
         // session's owner or a `session_members` row. Same error shape as
         // "session not found" so a probe can't distinguish the two cases.
@@ -176,7 +176,18 @@ pub fn register_or_update_session(
         }
 
         create_new_session(&mut conn, requesting_user_id, params)
+    };
+
+    // Bind the auth token to the session it just registered, and revoke any
+    // token previously bound to that session. Launch tokens never expire, so
+    // this binding is what ties a token's lifetime to its session. See #932.
+    if result.success {
+        if let (Some(session_id), Some(token)) = (result.session_id, params.auth_token) {
+            super::super::proxy_tokens::link_token_to_session(&mut conn, token, session_id);
+        }
     }
+
+    result
 }
 
 /// Returns true if `user_id` owns the session or has a `session_members` row for it.

--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -634,8 +634,6 @@ mod tests {
             running_sessions: Vec::new(),
             working_directory: None,
             version: "test".to_string(),
-            token_hash: None,
-            token_expires_at: None,
         }
     }
 
@@ -723,8 +721,6 @@ mod tests {
                         running_sessions: Vec::new(),
                         working_directory: None,
                         version: "test".to_string(),
-                        token_hash: None,
-                        token_expires_at: None,
                     }
                 };
                 mgr_clone

--- a/backend/src/jwt.rs
+++ b/backend/src/jwt.rs
@@ -22,23 +22,27 @@ pub enum JwtError {
     Expired,
 }
 
-/// Create a new JWT token for proxy authentication
+/// Create a new JWT token for proxy authentication.
+///
+/// `expires_in_days` is `Some(n)` for tokens with a fixed TTL (user dashboard
+/// tokens) or `None` for non-expiring tokens (launch/launcher tokens), whose
+/// validity is governed by the live DB checks instead. See #932.
 pub fn create_proxy_token(
     secret: &[u8],
     token_id: Uuid,
     user_id: Uuid,
     email: &str,
-    expires_in_days: u32,
+    expires_in_days: Option<u32>,
 ) -> Result<String, JwtError> {
     let now = Utc::now();
-    let exp = now + Duration::days(expires_in_days as i64);
+    let exp = expires_in_days.map(|days| (now + Duration::days(days as i64)).timestamp());
 
     let claims = ProxyTokenClaims {
         jti: token_id,
         sub: user_id,
         email: email.to_string(),
         iat: now.timestamp(),
-        exp: exp.timestamp(),
+        exp,
         token_type: "proxy".to_string(),
     };
 
@@ -54,7 +58,12 @@ pub fn create_proxy_token(
 /// Verify and decode a JWT token
 pub fn verify_proxy_token(secret: &[u8], token: &str) -> Result<ProxyTokenClaims, JwtError> {
     let mut validation = Validation::default();
+    // `exp` is optional: non-expiring tokens omit it. When present it is still
+    // validated; when absent the token simply never expires. Clearing the
+    // required-claims set lets a token without `exp` decode rather than being
+    // rejected for a missing claim.
     validation.validate_exp = true;
+    validation.required_spec_claims.clear();
 
     let token_data =
         decode::<ProxyTokenClaims>(token, &DecodingKey::from_secret(secret), &validation).map_err(
@@ -85,7 +94,7 @@ mod tests {
         let user_id = Uuid::new_v4();
         let email = "test@example.com";
 
-        let token = create_proxy_token(secret, token_id, user_id, email, 30).unwrap();
+        let token = create_proxy_token(secret, token_id, user_id, email, Some(30)).unwrap();
         let claims = verify_proxy_token(secret, &token).unwrap();
 
         assert_eq!(claims.jti, token_id);
@@ -107,7 +116,8 @@ mod tests {
         let token_id = Uuid::new_v4();
         let user_id = Uuid::new_v4();
 
-        let token = create_proxy_token(secret1, token_id, user_id, "test@example.com", 30).unwrap();
+        let token =
+            create_proxy_token(secret1, token_id, user_id, "test@example.com", Some(30)).unwrap();
         let result = verify_proxy_token(secret2, &token);
         assert!(result.is_err());
     }
@@ -147,7 +157,7 @@ mod tests {
         let email = "test@example.com";
 
         // Create token with 30 day expiration
-        let token = create_proxy_token(secret, token_id, user_id, email, 30).unwrap();
+        let token = create_proxy_token(secret, token_id, user_id, email, Some(30)).unwrap();
         let claims = verify_proxy_token(secret, &token).unwrap();
 
         // Verify expiration is roughly 30 days from now
@@ -155,8 +165,9 @@ mod tests {
         let expected_exp = now + (30 * 24 * 60 * 60); // 30 days in seconds
 
         // Allow 60 seconds tolerance for test execution time
+        let exp = claims.exp.expect("token created with a TTL must carry exp");
         assert!(
-            (claims.exp - expected_exp).abs() < 60,
+            (exp - expected_exp).abs() < 60,
             "Expiration should be approximately 30 days from now"
         );
 
@@ -165,6 +176,17 @@ mod tests {
             (claims.iat - now).abs() < 60,
             "Issued-at should be close to now"
         );
+    }
+
+    #[test]
+    fn test_non_expiring_token_verifies() {
+        // Launch/launcher tokens are minted with `None` (no expiry). They must
+        // omit `exp` and still verify successfully. See #932.
+        let secret = b"test-secret-key-at-least-32-bytes";
+        let token = create_proxy_token(secret, Uuid::new_v4(), Uuid::new_v4(), "x@y.z", None)
+            .expect("non-expiring token should be creatable");
+        let claims = verify_proxy_token(secret, &token).expect("should verify without exp");
+        assert!(claims.exp.is_none(), "non-expiring token must omit exp");
     }
 
     #[test]
@@ -182,8 +204,9 @@ mod tests {
         let expires_in_days = 30u32; // Device tokens valid for 30 days
 
         // Step 1: Create the JWT token
-        let token = create_proxy_token(secret, token_id, user_id, user_email, expires_in_days)
-            .expect("Token creation should succeed");
+        let token =
+            create_proxy_token(secret, token_id, user_id, user_email, Some(expires_in_days))
+                .expect("Token creation should succeed");
 
         // Step 2: Hash for database storage
         let token_hash = hash_token(&token);
@@ -218,7 +241,8 @@ mod tests {
         // Test wrong secret (also Invalid)
         let token_id = Uuid::new_v4();
         let user_id = Uuid::new_v4();
-        let token = create_proxy_token(secret, token_id, user_id, "test@test.com", 30).unwrap();
+        let token =
+            create_proxy_token(secret, token_id, user_id, "test@test.com", Some(30)).unwrap();
         let wrong_secret = b"wrong-secret-key-at-least-32-bytes";
         let result = verify_proxy_token(wrong_secret, &token);
         assert!(matches!(result, Err(JwtError::Invalid(_))));
@@ -237,7 +261,7 @@ mod tests {
 
         for _ in 0..5 {
             let token_id = Uuid::new_v4();
-            let token = create_proxy_token(secret, token_id, user_id, email, 30).unwrap();
+            let token = create_proxy_token(secret, token_id, user_id, email, Some(30)).unwrap();
             let hash = hash_token(&token);
 
             // Verify token

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -566,10 +566,6 @@ async fn main() -> anyhow::Result<()> {
         )
         .route("/api/launch", post(handlers::launchers::launch_session))
         .route(
-            "/api/launchers/{launcher_id}/renew-token",
-            post(handlers::launchers::renew_launcher_token),
-        )
-        .route(
             "/api/launchers/{launcher_id}/update",
             post(handlers::launchers::update_launcher),
         )

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -129,8 +129,13 @@ pub struct ProxyAuthToken {
     pub token_hash: String,
     pub created_at: NaiveDateTime,
     pub last_used_at: Option<NaiveDateTime>,
-    pub expires_at: NaiveDateTime,
+    /// `None` means the token never expires (launch/launcher tokens). User
+    /// dashboard tokens still carry an explicit expiry. See #932.
+    pub expires_at: Option<NaiveDateTime>,
     pub revoked: bool,
+    /// Session whose proxy holds this token, if it is a launch token. Used to
+    /// revoke the token when that session terminates.
+    pub session_id: Option<Uuid>,
 }
 
 #[derive(Debug, Insertable)]
@@ -139,7 +144,8 @@ pub struct NewProxyAuthToken {
     pub user_id: Uuid,
     pub name: String,
     pub token_hash: String,
-    pub expires_at: NaiveDateTime,
+    /// `None` mints a non-expiring token.
+    pub expires_at: Option<NaiveDateTime>,
 }
 
 // ============================================================================

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -63,8 +63,9 @@ diesel::table! {
         token_hash -> Varchar,
         created_at -> Timestamp,
         last_used_at -> Nullable<Timestamp>,
-        expires_at -> Timestamp,
+        expires_at -> Nullable<Timestamp>,
         revoked -> Bool,
+        session_id -> Nullable<Uuid>,
     }
 }
 

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -85,28 +85,6 @@ pub fn dashboard_page() -> Html {
     let initial_focus_set = use_state(|| false);
     let sessions_at_launch = use_state(|| None::<HashSet<Uuid>>);
 
-    // Map of launcher_id → token_expires_at (ISO string) for launchers with expiring tokens.
-    // Passed to SessionRail so it can show warning icons on sessions from those launchers.
-    let expiring_launchers = use_state(std::collections::HashMap::<Uuid, String>::new);
-    {
-        let expiring_launchers = expiring_launchers.clone();
-        use_effect_with((), move |_| {
-            spawn_local(async move {
-                let url = utils::api_url("/api/launchers");
-                if let Ok(resp) = Request::get(&url).send().await {
-                    if let Ok(launchers) = resp.json::<Vec<shared::LauncherInfo>>().await {
-                        let map: std::collections::HashMap<Uuid, String> = launchers
-                            .into_iter()
-                            .filter_map(|l| l.token_expires_at.map(|exp| (l.launcher_id, exp)))
-                            .collect();
-                        expiring_launchers.set(map);
-                    }
-                }
-            });
-            || ()
-        });
-    }
-
     // Detect spend tier changes and trigger timed animation
     {
         let spend_animating = spend_animating.clone();
@@ -848,7 +826,6 @@ pub fn dashboard_page() -> Html {
                         nav_mode={keyboard_nav.nav_mode}
                         activity_timestamps={(*activity_timestamps).clone()}
                         server_version={(*server_version).clone()}
-                        launcher_token_expiry={(*expiring_launchers).clone()}
                         on_select={on_select_session.clone()}
                         on_leave={on_leave.clone()}
                         on_delete={on_delete.clone()}

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -213,9 +213,6 @@ pub struct SessionRailProps {
     /// Server version string for comparing against client versions
     #[prop_or_default]
     pub server_version: String,
-    /// Map of launcher_id → token_expires_at (ISO string) for all launchers
-    #[prop_or_default]
-    pub launcher_token_expiry: HashMap<Uuid, String>,
     pub on_select: Callback<usize>,
     pub on_leave: Callback<Uuid>,
     pub on_delete: Callback<Uuid>,
@@ -858,48 +855,6 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                         html! { <span class="pill-agent-badge cron">{ "Cron" }</span> }
                     } else if session.paused {
                         html! { <span class="pill-agent-badge paused">{ "Paused" }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
-                {
-                    // Show warning icon when this session's launcher token is expiring
-                    if let Some(expires_at) = session.launcher_id
-                        .and_then(|lid| props.launcher_token_expiry.get(&lid))
-                    {
-                        let now = js_sys::Date::now();
-                        let exp = js_sys::Date::parse(expires_at);
-                        let days_left = if !exp.is_nan() {
-                            ((exp - now) / (1000.0 * 60.0 * 60.0 * 24.0)).floor() as i64
-                        } else {
-                            999
-                        };
-                        if days_left <= 7 {
-                            let tooltip = if days_left <= 0 {
-                                "Launcher token expired! Go to Settings > Launchers to renew.".to_string()
-                            } else if days_left == 1 {
-                                "Launcher token expires tomorrow. Go to Settings > Launchers to renew.".to_string()
-                            } else {
-                                format!(
-                                    "Launcher token expires in {} days. Go to Settings > Launchers to renew.",
-                                    days_left
-                                )
-                            };
-                            let badge_class = if days_left <= 0 {
-                                "pill-token-warning expired"
-                            } else if days_left <= 3 {
-                                "pill-token-warning critical"
-                            } else {
-                                "pill-token-warning"
-                            };
-                            html! {
-                                <span class={badge_class} title={tooltip}>
-                                    { "⚠" }
-                                </span>
-                            }
-                        } else {
-                            html! {}
-                        }
                     } else {
                         html! {}
                     }

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -5,34 +5,9 @@ use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
-fn days_until_expiration(expires_at: &str) -> Option<i64> {
-    let now = js_sys::Date::now();
-    let expires = js_sys::Date::parse(expires_at);
-    if expires.is_nan() {
-        return None;
-    }
-    let diff_ms = expires - now;
-    let diff_days = (diff_ms / (1000.0 * 60.0 * 60.0 * 24.0)).floor() as i64;
-    Some(diff_days)
-}
-
-pub fn count_expiring_launchers(launchers: &[LauncherInfo]) -> usize {
-    launchers
-        .iter()
-        .filter(|l| {
-            l.token_expires_at
-                .as_ref()
-                .and_then(|exp| days_until_expiration(exp))
-                .map(|d| d <= 7)
-                .unwrap_or(false)
-        })
-        .count()
-}
-
 #[derive(Properties, PartialEq)]
 struct LauncherRowProps {
     launcher: LauncherInfo,
-    on_renew: Callback<Uuid>,
     on_update: Callback<Uuid>,
     update_in_progress: bool,
 }
@@ -40,37 +15,8 @@ struct LauncherRowProps {
 #[function_component(LauncherRow)]
 fn launcher_row(props: &LauncherRowProps) -> Html {
     let l = &props.launcher;
-    let on_renew = props.on_renew.clone();
     let on_update = props.on_update.clone();
     let launcher_id = l.launcher_id;
-
-    let (status_class, status_text) = if let Some(ref exp) = l.token_expires_at {
-        let days = days_until_expiration(exp);
-        match days {
-            Some(d) if d < 0 => ("token-status expired", "Expired".to_string()),
-            Some(0) => ("token-status expiring-soon", "Expires today".to_string()),
-            Some(1) => ("token-status expiring-soon", "Expires tomorrow".to_string()),
-            Some(d) if d <= 7 => (
-                "token-status expiring-soon",
-                format!("Expires in {} days", d),
-            ),
-            Some(_) => ("token-status active", "Active".to_string()),
-            None => ("token-status active", "Active".to_string()),
-        }
-    } else {
-        ("token-status active", "Dev mode".to_string())
-    };
-
-    let needs_renewal = l
-        .token_expires_at
-        .as_ref()
-        .and_then(|exp| days_until_expiration(exp))
-        .map(|d| d <= 7)
-        .unwrap_or(false);
-
-    let on_renew_click = Callback::from(move |_| {
-        on_renew.emit(launcher_id);
-    });
 
     let (update_label, update_class) = if props.update_in_progress {
         ("Restarting...", "update-button stage-3")
@@ -102,16 +48,7 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
             <td>{ &l.hostname }</td>
             <td>{ format!("v{}", &l.version) }</td>
             <td>{ l.running_sessions }</td>
-            <td class="token-expires">
-                { l.token_expires_at.as_ref().map(|t| utils::format_timestamp(t)).unwrap_or_else(|| "N/A".to_string()) }
-            </td>
-            <td class={status_class}>{ status_text }</td>
             <td class="token-actions">
-                if needs_renewal {
-                    <button class="submit-button" onclick={on_renew_click}>
-                        { "Renew Token" }
-                    </button>
-                }
                 <button
                     class={update_class}
                     onclick={on_update_click}
@@ -125,33 +62,25 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
     }
 }
 
-#[derive(Properties, PartialEq)]
-pub struct LaunchersPanelProps {
-    pub on_launchers_loaded: Callback<Vec<LauncherInfo>>,
-}
-
 #[function_component(LaunchersPanel)]
-pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
+pub fn launchers_panel() -> Html {
     let launchers = use_state(Vec::<LauncherInfo>::new);
     let loading = use_state(|| true);
-    let renew_result = use_state(|| None::<(bool, String)>);
+    let action_result = use_state(|| None::<(bool, String)>);
     let update_in_progress = use_state(|| None::<Uuid>);
 
     let fetch_launchers = {
         let launchers = launchers.clone();
         let loading = loading.clone();
-        let on_loaded = props.on_launchers_loaded.clone();
 
         Callback::from(move |_| {
             let launchers = launchers.clone();
             let loading = loading.clone();
-            let on_loaded = on_loaded.clone();
 
             spawn_local(async move {
                 let url = utils::api_url("/api/launchers");
                 if let Ok(resp) = Request::get(&url).send().await {
                     if let Ok(data) = resp.json::<Vec<LauncherInfo>>().await {
-                        on_loaded.emit(data.clone());
                         launchers.set(data);
                     }
                 }
@@ -168,45 +97,11 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
         });
     }
 
-    let on_renew = {
-        let renew_result = renew_result.clone();
-        let fetch_launchers = fetch_launchers.clone();
-
-        Callback::from(move |launcher_id: Uuid| {
-            let renew_result = renew_result.clone();
-            let fetch_launchers = fetch_launchers.clone();
-
-            spawn_local(async move {
-                let url = utils::api_url(&format!("/api/launchers/{}/renew-token", launcher_id));
-                match Request::post(&url).send().await {
-                    Ok(resp) => {
-                        if resp.status() == 200 {
-                            renew_result.set(Some((
-                                true,
-                                "Token renewed successfully. The launcher will use it on next heartbeat.".to_string(),
-                            )));
-                            fetch_launchers.emit(());
-                        } else {
-                            let text = resp.text().await.unwrap_or_default();
-                            renew_result.set(Some((
-                                false,
-                                format!("Failed to renew: {} {}", resp.status(), text),
-                            )));
-                        }
-                    }
-                    Err(e) => {
-                        renew_result.set(Some((false, format!("Request failed: {:?}", e))));
-                    }
-                }
-            });
-        })
-    };
-
     let on_update = {
-        let renew_result = renew_result.clone();
+        let action_result = action_result.clone();
         let update_in_progress = update_in_progress.clone();
         Callback::from(move |launcher_id: Uuid| {
-            let renew_result = renew_result.clone();
+            let action_result = action_result.clone();
             let update_in_progress = update_in_progress.clone();
             spawn_local(async move {
                 update_in_progress.set(Some(launcher_id));
@@ -214,20 +109,20 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
                 match Request::post(&url).send().await {
                     Ok(resp) => {
                         if resp.status() == 200 {
-                            renew_result.set(Some((
+                            action_result.set(Some((
                                 true,
                                 "Update requested. The launcher will fetch the latest release and restart.".to_string(),
                             )));
                         } else {
                             let text = resp.text().await.unwrap_or_default();
-                            renew_result.set(Some((
+                            action_result.set(Some((
                                 false,
                                 format!("Update failed: {} {}", resp.status(), text),
                             )));
                         }
                     }
                     Err(e) => {
-                        renew_result.set(Some((false, format!("Update request failed: {:?}", e))));
+                        action_result.set(Some((false, format!("Update request failed: {:?}", e))));
                     }
                 }
                 update_in_progress.set(None);
@@ -240,12 +135,12 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
             <div class="section-header">
                 <h2>{ "Launchers" }</h2>
                 <p class="section-description">
-                    { "Connected launcher daemons and their authentication token status. " }
-                    { "Tokens auto-renew when within 7 days of expiry. Use the Renew button for immediate renewal." }
+                    { "Connected launcher daemons. Authentication tokens do not expire and are \
+                       managed automatically." }
                 </p>
             </div>
 
-            if let Some((success, message)) = &*renew_result {
+            if let Some((success, message)) = &*action_result {
                 <div class={if *success { "token-created-success" } else { "error-message" }}>
                     <p>{ message }</p>
                 </div>
@@ -269,8 +164,6 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
                                 <th>{ "Host" }</th>
                                 <th>{ "Version" }</th>
                                 <th>{ "Sessions" }</th>
-                                <th>{ "Token Expires" }</th>
-                                <th>{ "Status" }</th>
                                 <th>{ "Actions" }</th>
                             </tr>
                         </thead>
@@ -280,7 +173,6 @@ pub fn launchers_panel(props: &LaunchersPanelProps) -> Html {
                                     <LauncherRow
                                         key={l.launcher_id.to_string()}
                                         launcher={l.clone()}
-                                        on_renew={on_renew.clone()}
                                         on_update={on_update.clone()}
                                         update_in_progress={*update_in_progress == Some(l.launcher_id)}
                                     />

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -6,10 +6,10 @@ mod sounds_panel;
 mod tokens_panel;
 
 use appearance_panel::AppearancePanel;
-use launchers_panel::{count_expiring_launchers, LaunchersPanel};
+use launchers_panel::LaunchersPanel;
 use performance_panel::PerformancePanel;
 use sessions_panel::SessionsPanel;
-use shared::{LauncherInfo, ProxyTokenInfo, SessionInfo};
+use shared::{ProxyTokenInfo, SessionInfo};
 use sounds_panel::SoundsPanel;
 use tokens_panel::{count_expiring_tokens, TokensPanel};
 use yew::prelude::*;
@@ -36,7 +36,6 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
     // Counts for tab badges (updated when panels load their data)
     let session_count = use_state(|| 0usize);
     let expiring_token_count = use_state(|| 0usize);
-    let expiring_launcher_count = use_state(|| 0usize);
 
     let on_sessions_loaded = {
         let session_count = session_count.clone();
@@ -49,13 +48,6 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
         let expiring_token_count = expiring_token_count.clone();
         Callback::from(move |tokens: Vec<ProxyTokenInfo>| {
             expiring_token_count.set(count_expiring_tokens(&tokens));
-        })
-    };
-
-    let on_launchers_loaded = {
-        let expiring_launcher_count = expiring_launcher_count.clone();
-        Callback::from(move |launchers: Vec<LauncherInfo>| {
-            expiring_launcher_count.set(count_expiring_launchers(&launchers));
         })
     };
 
@@ -132,9 +124,6 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                     onclick={on_launchers_tab}
                 >
                     { "Launchers" }
-                    if *expiring_launcher_count > 0 {
-                        <span class="expiring-badge">{ *expiring_launcher_count }</span>
-                    }
                 </button>
                 <button
                     class={classes!("tab-button", (*active_tab == SettingsTab::Sounds).then_some("active"))}
@@ -161,7 +150,7 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                     <TokensPanel on_tokens_loaded={on_tokens_loaded} />
                 }
                 if *active_tab == SettingsTab::Launchers {
-                    <LaunchersPanel on_launchers_loaded={on_launchers_loaded} />
+                    <LaunchersPanel />
                 }
                 if *active_tab == SettingsTab::Sounds {
                     <SoundsPanel />

--- a/frontend/src/pages/settings/tokens_panel.rs
+++ b/frontend/src/pages/settings/tokens_panel.rs
@@ -26,7 +26,9 @@ pub fn count_expiring_tokens(tokens: &[ProxyTokenInfo]) -> usize {
         .iter()
         .filter(|t| !t.revoked)
         .filter(|t| {
-            days_until_expiration(&t.expires_at)
+            t.expires_at
+                .as_deref()
+                .and_then(days_until_expiration)
                 .map(|d| (0..=7).contains(&d))
                 .unwrap_or(false)
         })
@@ -71,7 +73,7 @@ fn token_row(props: &TokenRowProps) -> Html {
     let on_renew = props.on_renew.clone();
     let token_id = token.id;
 
-    let days_left = days_until_expiration(&token.expires_at);
+    let days_left = token.expires_at.as_deref().and_then(days_until_expiration);
     let is_expired = days_left.map(|d| d < 0).unwrap_or(false);
     let is_expiring_soon = days_left.map(|d| (0..=7).contains(&d)).unwrap_or(false);
 
@@ -121,7 +123,9 @@ fn token_row(props: &TokenRowProps) -> Html {
             <td class="token-last-used">
                 { token.last_used_at.as_ref().map(|t| utils::format_timestamp(t)).unwrap_or_else(|| "Never".to_string()) }
             </td>
-            <td class="token-expires">{ utils::format_timestamp(&token.expires_at) }</td>
+            <td class="token-expires">
+                { token.expires_at.as_ref().map(|t| utils::format_timestamp(t)).unwrap_or_else(|| "Never".to_string()) }
+            </td>
             <td class={status_class}>{ status_text }</td>
             <td class="token-actions">
                 if !token.revoked {

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -543,14 +543,6 @@ async fn handle_message(
             info!("Received ScheduleSync with {} task(s)", tasks.len());
             scheduler.update_tasks(tasks);
         }
-        ServerToLauncher::TokenRenewed { token } => {
-            info!("Received renewed auth token from server");
-            if let Err(e) = config::save_auth_token(&token) {
-                error!("Failed to save renewed token: {}", e);
-            } else {
-                info!("Renewed token saved to config");
-            }
-        }
         ServerToLauncher::ServerShutdown { reason, .. } => {
             info!("Server shutting down: {}", reason);
         }

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -590,9 +590,6 @@ pub enum ServerToLauncher {
     /// Sync scheduled task definitions to the launcher
     ScheduleSync { tasks: Vec<ScheduledTaskConfig> },
 
-    /// Push a renewed auth token to the launcher (auto-renewal or manual)
-    TokenRenewed { token: String },
-
     /// Tell the launcher to pull the latest release, install it, and restart
     /// the agent-portal service. Triggered from the dashboard Launchers panel.
     UpdateAndRestart,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -188,9 +188,6 @@ pub struct LauncherInfo {
     /// Launcher binary version
     #[serde(default)]
     pub version: String,
-    /// ISO 8601 timestamp when the launcher's auth token expires
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub token_expires_at: Option<String>,
 }
 
 /// API types for HTTP endpoints

--- a/shared/src/proxy_tokens.rs
+++ b/shared/src/proxy_tokens.rs
@@ -18,8 +18,11 @@ pub struct ProxyTokenClaims {
     pub email: String,
     /// Issued at (Unix timestamp)
     pub iat: i64,
-    /// Expires at (Unix timestamp)
-    pub exp: i64,
+    /// Expires at (Unix timestamp). `None` means the token never expires; the
+    /// backend's live DB checks (revocation, user disabled) govern validity
+    /// instead of a fixed TTL. See #932.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exp: Option<i64>,
     /// Token type: "proxy" or "launcher"
     #[serde(default = "default_token_type")]
     pub token_type: String,
@@ -97,7 +100,8 @@ pub struct ProxyTokenInfo {
     pub name: String,
     pub created_at: String,
     pub last_used_at: Option<String>,
-    pub expires_at: String,
+    /// `None` for non-expiring tokens (launch/launcher tokens). See #932.
+    pub expires_at: Option<String>,
     pub revoked: bool,
 }
 


### PR DESCRIPTION
Fixes #932.

## Problem
Per-session proxy tokens were minted with a **1-day TTL and never renewed**. Any session that re-registered after the token lapsed (portal restart, network blip, resume of an older session) was rejected with `JWT verification failed: Token expired`, sat `disconnected`, and the proxy retried the *same dead token* on a backoff loop forever — a silent failure that took down a whole bench after a routine Watchtower restart.

## Approach (B from the issue, + remove renewal)
A session token should live exactly as long as its session. Since the DB revocation/disabled checks are already live on every verify, a fixed TTL is redundant — so tokens no longer expire, and lifetime is tracked by revocation instead.

### Token lifecycle
- **No expiry.** `create_proxy_token` now takes `Option<u32>`; launch + device-flow/launcher tokens are minted with `None` (JWT `exp` omitted). `proxy_auth_tokens.expires_at` is now nullable (`NULL` = never). User dashboard CLI tokens keep their explicit TTL.
- **Revoke-on-terminate.** Launch tokens carry a `session_id`. The token is bound to its session when the proxy registers (superseding/revoking any prior token for that session), and revoked when the session **exits** (`SessionExited`) or is **deleted**. Binding is scoped to launcher-spawned tokens by name, so durable user/device credentials reused by a direct `claude-portal` CLI are never revoked out from under a session that just ended.

### Removed launcher renewal machinery (now dead once tokens don't expire)
- Heartbeat sliding renewal, `renew_launcher_token_for`, the `/renew-token` endpoint + route, `ServerToLauncher::TokenRenewed` + the launcher-side handler.
- `token_hash` / `token_expires_at` on `LauncherConnection`; `LauncherInfo.token_expires_at`.
- The expiry/renew UI: launchers panel renew button + status/expiry columns, settings tab badge, dashboard expiring-launcher map, and the session-rail token-expiry warning.

## Migration
`2026-06-02-181500_proxy_tokens_no_expiry`: `expires_at` → nullable; add `session_id UUID`.

## Versioning
Minor bump 2.6.30 → **2.7.0** (protocol change: dropped `TokenRenewed` variant and `LauncherInfo.token_expires_at`).

## Testing
- `cargo build` (backend, proxy, launcher, shared) ✅
- `cargo build -p frontend --target wasm32-unknown-unknown` ✅
- `cargo test -p backend` (106) ✅, `cargo test -p shared` (46) ✅ — incl. new `test_non_expiring_token_verifies`
- `cargo clippy` (native + wasm) clean, `cargo fmt --check` ✅
- migration name check ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)