### PR TITLE
Prefix launch-dialog arg placeholders with "ex:"; refresh Codex example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.7.0"
+version = "2.7.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -67,12 +67,12 @@ struct AgentConfig {
 fn agent_config(agent_type: shared::AgentType) -> AgentConfig {
     match agent_type {
         shared::AgentType::Claude => AgentConfig {
-            args_placeholder: "--model sonnet --allowedTools \"Bash Edit\"",
+            args_placeholder: "ex: --model sonnet --allowedTools \"Bash Edit\"",
             skip_permissions_args: &["--dangerously-skip-permissions"],
             skip_permissions_label: Some("--dangerously-skip-permissions"),
         },
         shared::AgentType::Codex => AgentConfig {
-            args_placeholder: "-c model=o3 -c model_reasoning_effort=high",
+            args_placeholder: "ex: -c model=gpt-5.5 -c model_reasoning_effort=high",
             skip_permissions_args: &[
                 "-c",
                 "approval_policy=never",


### PR DESCRIPTION
## Summary
The Codex and Claude extra-args fields in the launch dialog showed example args (`-c model=o3 …`, `--model sonnet …`) as bare placeholders, which read like applied defaults. This prefixes both with `ex:` so they're unambiguously examples, and refreshes the stale Codex example to a current model (`gpt-5.5`).

## Changes
- `frontend/src/components/launch_dialog.rs`: prefix both placeholders with `ex:`; update Codex example `o3` → `gpt-5.5`
- Version bump 2.7.0 → 2.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)