### PR TITLE
Render markdown HTML literals as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.10
+
+- **Render literal angle-bracket text in markdown instead of dropping it as raw HTML.** `pulldown-cmark` classifies text like `<Download sensor-report.csv>` as inline HTML; the frontend markdown renderer now emits those events as escaped text, preserving portal messages without allowing raw HTML injection.
+
 ## 2.8.9
 
 - **Codex session resume re-attaches to the prior app-server thread.** Codex launches now persist the app-server `thread_id` and pass it back through `thread/resume` when a session is resumed. Standalone proxy sessions store the id in their directory-session config, launcher sessions store it in a sidecar `codex_threads.json`, and resume falls back to a fresh `thread_start` if the prior thread cannot be reopened.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.9"
+version = "2.8.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.9"
+version = "2.8.10"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.9"
+version = "2.8.10"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.9"
+version = "2.8.10"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.9"
+version = "2.8.10"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.9"
+version = "2.8.10"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.9"
+version = "2.8.10"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.9"
+version = "2.8.10"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.9"
+version = "2.8.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.9"
+version = "2.8.10"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.9"
+version = "2.8.10"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -259,6 +259,9 @@ fn render_event(events: &[Event], session_id: Option<uuid::Uuid>) -> (Html, usiz
         Event::HardBreak => (html! { <br /> }, 1),
         Event::Rule => (html! { <hr class="md-rule" /> }, 1),
         Event::End(_) => (html! {}, 1),
+        Event::Html(html_text) | Event::InlineHtml(html_text) => {
+            (html! { <>{ html_text.to_string() }</> }, 1)
+        }
         _ => (html! {}, 1),
     }
 }
@@ -1003,7 +1006,7 @@ mod tests {
     /// fenced ```latex``` code block (no `$` inside), then real `$$…$$`
     /// display math, then inline `$…$` math in a list. We verify the math
     /// placeholders survive the pulldown-cmark round-trip and end up as
-    /// plain `Event::Text` (not `Event::Html`, which we drop). My initial
+    /// plain `Event::Text` (not `Event::Html`). My initial
     /// hypothesis for #684 was that the `<thinking>` block was swallowing
     /// the math into raw HTML events — this test disproves that.
     #[test]
@@ -1038,7 +1041,7 @@ Where:\n\
 
         // The math content (`\rho`) must land in plain Text events so KaTeX
         // auto-render can find the delimiters. If it ends up in `Event::Html`
-        // or `Event::InlineHtml`, our catch-all renderer drops it silently.
+        // or `Event::InlineHtml`, KaTeX cannot find the math reliably.
         let math_in_text = restored.iter().any(|e| match e {
             Event::Text(t) => t.contains("\\rho"),
             _ => false,
@@ -1049,5 +1052,24 @@ Where:\n\
         });
         assert!(math_in_text, "math should reach Event::Text");
         assert!(!math_in_html, "math should not leak into Event::Html");
+    }
+
+    #[test]
+    fn angle_bracket_text_is_html_not_plain_text() {
+        let input = "<Download sensor-report.csv>";
+
+        let mut options = Options::empty();
+        options.insert(Options::ENABLE_TABLES);
+        options.insert(Options::ENABLE_STRIKETHROUGH);
+        let parser = Parser::new_ext(input, options);
+        let events: Vec<Event> = parser.collect();
+
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                Event::Html(t) | Event::InlineHtml(t) if t.as_ref() == input
+            )),
+            "pulldown-cmark classifies angle-bracket labels as raw HTML: {events:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- preserve raw HTML markdown events as escaped text instead of dropping them
- fixes portal text like `<Download sensor-report.csv>` disappearing because pulldown-cmark classifies it as raw HTML
- bump workspace version to 2.8.10

## Verification
- cargo test -p frontend --lib markdown::tests
- cargo test -p frontend --lib
- cargo check -p frontend --target wasm32-unknown-unknown
- cargo fmt --check