### PR TITLE
Fix portal links in grouped assistant markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.12
+
+- **Keep portal file downloads active in grouped assistant messages.** Consecutive assistant messages render through the identity-group path, which previously passed `None` for `session_id` into assistant markdown. That made `[label](portal://file/path)` hit the generic invalid-link fallback and display as literal angle-bracket text. Grouped assistant markdown now receives the active session id, matching standalone assistant and portal-message rendering.
+
 ## 2.8.11
 
 - **Keep portal file downloads active in portal reminders and grouped portal messages.** The markdown renderer already rewrites `[label](portal://file/path)` into an authenticated session download URL, but two portal-message paths discarded `session_id` before rendering markdown. Reminder bodies and collapsed portal groups now pass the active session id through, so documented download links are formatted consistently.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.11"
+version = "2.8.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.11"
+version = "2.8.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.11"
+version = "2.8.12"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.11"
+version = "2.8.12"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.11"
+version = "2.8.12"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.11"
+version = "2.8.12"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.11"
+version = "2.8.12"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.11"
+version = "2.8.12"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.11"
+version = "2.8.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.11"
+version = "2.8.12"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.11"
+version = "2.8.12"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -218,7 +218,7 @@ fn render_identity_group_part(
             renderers::render_optimistic_user_message_content(&msg)
         }
         Ok(ClaudeMessage::Assistant(msg)) => {
-            renderers::render_assistant_message_content(&msg, None)
+            renderers::render_assistant_message_content(&msg, session_id)
         }
         Ok(ClaudeMessage::Portal(msg)) => {
             renderers::render_portal_message_content(&msg, session_id)


### PR DESCRIPTION
## Summary
- pass the active session id into grouped assistant markdown rendering
- prevents portal file markdown links from falling back to literal angle-bracket text in assistant identity groups
- bump workspace version to 2.8.12

## Verification
- cargo fmt --check
- cargo test -p frontend --lib components::message_renderer::tests
- cargo test -p frontend --lib markdown::tests
- cargo check -p frontend --target wasm32-unknown-unknown