### PR TITLE
Require session id for portal file links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.13
+
+- **Add a direct regression test for portal file link rewriting.** Markdown link destinations are now classified through a small testable helper, and `[description](portal://file/path)` is pinned to render as an authenticated portal download target. `portal://file/...` now requires a session id and panics in tests/dev if called without one, because session file downloads cannot work outside a session context. Codex assistant markdown now receives the active session id too.
+
 ## 2.8.12
 
 - **Keep portal file downloads active in grouped assistant messages.** Consecutive assistant messages render through the identity-group path, which previously passed `None` for `session_id` into assistant markdown. That made `[label](portal://file/path)` hit the generic invalid-link fallback and display as literal angle-bracket text. Grouped assistant markdown now receives the active session id, matching standalone assistant and portal-message rendering.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.12"
+version = "2.8.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.12"
+version = "2.8.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.12"
+version = "2.8.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.12"
+version = "2.8.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.12"
+version = "2.8.13"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.12"
+version = "2.8.13"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.12"
+version = "2.8.13"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.12"
+version = "2.8.13"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.12"
+version = "2.8.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.12"
+version = "2.8.13"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.12"
+version = "2.8.13"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -1,9 +1,10 @@
 use super::copy_button::CopyButton;
 use super::expandable::ExpandableText;
-use super::markdown::render_markdown;
+use super::markdown::render_markdown_for_session;
 use super::message_renderer::format_duration;
 use codex_codes::io::items::{FileUpdateChange, ThreadItem};
 use serde_json::Value;
+use uuid::Uuid;
 use yew::prelude::*;
 
 mod events;
@@ -22,6 +23,7 @@ use tools::{
 #[derive(Properties, PartialEq)]
 pub struct CodexMessageRendererProps {
     pub json: String,
+    pub session_id: Uuid,
     /// Per-turn metrics for the terminator card, if any. Forwarded down
     /// into `render_turn_completed` / `render_turn_failed` so the chip-strip
     /// footer renders beneath the existing result card. PR 2 of N.
@@ -52,9 +54,11 @@ pub fn codex_message_renderer(props: &CodexMessageRendererProps) -> Html {
             render_turn_failed(error.as_ref(), props.turn_metrics.as_ref())
         }
         Ok(CodexEvent::ItemStarted { item }) | Ok(CodexEvent::ItemUpdated { item }) => {
-            render_item(item.as_ref(), false)
+            render_item(item.as_ref(), false, props.session_id)
         }
-        Ok(CodexEvent::ItemCompleted { item }) => render_item(item.as_ref(), true),
+        Ok(CodexEvent::ItemCompleted { item }) => {
+            render_item(item.as_ref(), true, props.session_id)
+        }
         Ok(CodexEvent::Error { message }) => render_error_block(message.as_deref()),
         Ok(CodexEvent::TurnDiffUpdated { params }) => {
             render_turn_diff(params.as_ref().and_then(|p| p.diff.as_deref()))
@@ -88,14 +92,14 @@ fn item_card_classes(completed: bool) -> &'static str {
     }
 }
 
-fn render_item(item: Option<&CodexItem>, completed: bool) -> Html {
+fn render_item(item: Option<&CodexItem>, completed: bool, session_id: Uuid) -> Html {
     let Some(item) = item else {
         return html! {};
     };
     match item {
         CodexItem::ContextCompaction(_) => render_context_compaction_item(completed),
         CodexItem::Thread(item) => match item {
-            ThreadItem::AgentMessage(it) => render_agent_message(&it.text, completed),
+            ThreadItem::AgentMessage(it) => render_agent_message(&it.text, completed, session_id),
             ThreadItem::Reasoning(it) => render_reasoning(&it.text, completed),
             ThreadItem::CommandExecution(it) => render_command_execution(it, completed),
             ThreadItem::FileChange(it) => render_file_change(it, completed),
@@ -112,7 +116,7 @@ fn render_item(item: Option<&CodexItem>, completed: bool) -> Html {
     }
 }
 
-pub fn render_codex_message_content(json: &str) -> Html {
+pub fn render_codex_message_content(json: &str, session_id: Uuid) -> Html {
     match serde_json::from_str::<CodexEvent>(json) {
         Ok(CodexEvent::ItemCompleted {
             item: Some(CodexItem::Thread(ThreadItem::AgentMessage(it))),
@@ -122,11 +126,11 @@ pub fn render_codex_message_content(json: &str) -> Html {
         })
         | Ok(CodexEvent::ItemUpdated {
             item: Some(CodexItem::Thread(ThreadItem::AgentMessage(it))),
-        }) => render_agent_message_content(&it.text),
+        }) => render_agent_message_content(&it.text, session_id),
         Ok(CodexEvent::ItemStarted { item }) | Ok(CodexEvent::ItemUpdated { item }) => {
-            render_item(item.as_ref(), false)
+            render_item(item.as_ref(), false, session_id)
         }
-        Ok(CodexEvent::ItemCompleted { item }) => render_item(item.as_ref(), true),
+        Ok(CodexEvent::ItemCompleted { item }) => render_item(item.as_ref(), true, session_id),
         Ok(CodexEvent::TurnCompleted {
             usage,
             duration_ms,
@@ -160,7 +164,7 @@ pub fn render_codex_message_content(json: &str) -> Html {
     }
 }
 
-fn render_agent_message(text: &str, completed: bool) -> Html {
+fn render_agent_message(text: &str, completed: bool, session_id: Uuid) -> Html {
     if text.is_empty() {
         return html! {};
     }
@@ -170,16 +174,16 @@ fn render_agent_message(text: &str, completed: bool) -> Html {
             <div class="message-header">
                 <span class="message-type-badge assistant">{ "Codex" }</span>
             </div>
-            <div class="message-body">{ render_agent_message_content(text) }</div>
+            <div class="message-body">{ render_agent_message_content(text, session_id) }</div>
         </div>
     }
 }
 
-fn render_agent_message_content(text: &str) -> Html {
+fn render_agent_message_content(text: &str, session_id: Uuid) -> Html {
     if text.is_empty() {
         html! {}
     } else {
-        html! { <div class="assistant-text">{ render_markdown(text) }</div> }
+        html! { <div class="assistant-text">{ render_markdown_for_session(text, session_id) }</div> }
     }
 }
 

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -6,6 +6,7 @@
 
 use gloo::timers::callback::Timeout;
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+use uuid::Uuid;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::window;
@@ -14,12 +15,14 @@ use yew::prelude::*;
 /// Render markdown text as HTML, with a post-render hook that triggers KaTeX
 /// to render any LaTeX math expressions (`$...$`, `$$...$$`).
 pub fn render_markdown(text: &str) -> Html {
-    render_markdown_for_session(text, None)
+    html! {
+        <MarkdownView text={text.to_string()} />
+    }
 }
 
-pub fn render_markdown_for_session(text: &str, session_id: Option<uuid::Uuid>) -> Html {
+pub fn render_markdown_for_session(text: &str, session_id: Uuid) -> Html {
     html! {
-        <MarkdownView text={text.to_string()} {session_id} />
+        <MarkdownView text={text.to_string()} session_id={Some(session_id)} />
     }
 }
 
@@ -27,7 +30,7 @@ pub fn render_markdown_for_session(text: &str, session_id: Option<uuid::Uuid>) -
 struct MarkdownViewProps {
     text: String,
     #[prop_or_default]
-    session_id: Option<uuid::Uuid>,
+    session_id: Option<Uuid>,
 }
 
 #[function_component(MarkdownView)]
@@ -228,7 +231,7 @@ fn restore_math(text: &str, math_blocks: &[String]) -> String {
 }
 
 /// Convert pulldown-cmark events to Yew Html
-fn render_events(events: &[Event], session_id: Option<uuid::Uuid>) -> Html {
+fn render_events(events: &[Event], session_id: Option<Uuid>) -> Html {
     let mut html_parts: Vec<Html> = Vec::new();
     let mut i = 0;
 
@@ -243,7 +246,7 @@ fn render_events(events: &[Event], session_id: Option<uuid::Uuid>) -> Html {
 
 /// Render a single event or a group of related events
 /// Returns (Html, number of events consumed)
-fn render_event(events: &[Event], session_id: Option<uuid::Uuid>) -> (Html, usize) {
+fn render_event(events: &[Event], session_id: Option<Uuid>) -> (Html, usize) {
     if events.is_empty() {
         return (html! {}, 0);
     }
@@ -267,7 +270,7 @@ fn render_event(events: &[Event], session_id: Option<uuid::Uuid>) -> (Html, usiz
 }
 
 /// Render a tag and its contents
-fn render_tag(tag: &Tag, events: &[Event], session_id: Option<uuid::Uuid>) -> (Html, usize) {
+fn render_tag(tag: &Tag, events: &[Event], session_id: Option<Uuid>) -> (Html, usize) {
     let end_tag = get_end_tag(tag);
     let (inner_events, total_consumed) = collect_until_end(events, &end_tag);
     let inner_html = render_events(&inner_events, session_id);
@@ -288,32 +291,36 @@ fn render_tag(tag: &Tag, events: &[Event], session_id: Option<uuid::Uuid>) -> (H
             dest_url, title, ..
         } => {
             let href = dest_url.to_string();
-            if let Some(download_href) = portal_file_download_href(&href, session_id) {
-                let title_attr = if title.is_empty() {
-                    Some("Download file from session workspace".to_string())
-                } else {
-                    Some(title.to_string())
-                };
-                html! {
-                    <a href={download_href} title={title_attr} class="md-link portal-file-link">
-                        { inner_html }
-                    </a>
+            match classify_link_destination(&href, session_id) {
+                LinkDestination::PortalDownload(download_href) => {
+                    let title_attr = if title.is_empty() {
+                        Some("Download file from session workspace".to_string())
+                    } else {
+                        Some(title.to_string())
+                    };
+                    html! {
+                        <a href={download_href} title={title_attr} class="md-link portal-file-link">
+                            { inner_html }
+                        </a>
+                    }
                 }
-            } else if !is_valid_url(&href) && !href.starts_with('#') && !href.starts_with('/') {
-                // Guard against false autolinks from angle-bracket syntax like
-                // <crate::path::Type> which pulldown-cmark interprets as URLs.
-                // Not a real URL — render as plain text with angle brackets
-                html! { <><>{"<"}</>{ inner_html }<>{">"}</></> }
-            } else {
-                let title_attr = if title.is_empty() {
-                    None
-                } else {
-                    Some(title.to_string())
-                };
-                html! {
-                    <a href={href} title={title_attr} target="_blank" rel="noopener noreferrer" class="md-link">
-                        { inner_html }
-                    </a>
+                LinkDestination::LiteralAngleText => {
+                    // Guard against false autolinks from angle-bracket syntax like
+                    // <crate::path::Type> which pulldown-cmark interprets as URLs.
+                    // Not a real URL — render as plain text with angle brackets.
+                    html! { <><>{"<"}</>{ inner_html }<>{">"}</></> }
+                }
+                LinkDestination::ExternalOrRelative(href) => {
+                    let title_attr = if title.is_empty() {
+                        None
+                    } else {
+                        Some(title.to_string())
+                    };
+                    html! {
+                        <a href={href} title={title_attr} target="_blank" rel="noopener noreferrer" class="md-link">
+                            { inner_html }
+                        </a>
+                    }
                 }
             }
         }
@@ -339,19 +346,64 @@ fn render_tag(tag: &Tag, events: &[Event], session_id: Option<uuid::Uuid>) -> (H
     (html, total_consumed)
 }
 
-fn portal_file_download_href(href: &str, session_id: Option<uuid::Uuid>) -> Option<String> {
+#[derive(Debug, PartialEq, Eq)]
+enum LinkDestination {
+    PortalDownload(String),
+    LiteralAngleText,
+    ExternalOrRelative(String),
+}
+
+fn classify_link_destination(href: &str, session_id: Option<Uuid>) -> LinkDestination {
+    if href.starts_with("portal://file/") {
+        let session_id =
+            session_id.expect("portal://file markdown links require a session_id to render");
+        if let Some(download_href) = portal_file_download_href(href, session_id) {
+            LinkDestination::PortalDownload(download_href)
+        } else {
+            LinkDestination::LiteralAngleText
+        }
+    } else if !is_valid_url(href) && !href.starts_with('#') && !href.starts_with('/') {
+        LinkDestination::LiteralAngleText
+    } else {
+        LinkDestination::ExternalOrRelative(href.to_string())
+    }
+}
+
+fn portal_file_download_href(href: &str, session_id: Uuid) -> Option<String> {
     let path = href.strip_prefix("portal://file/")?;
     if path.is_empty() {
         return None;
     }
-    let session_id = session_id?;
-    let encoded = js_sys::encode_uri_component(path)
-        .as_string()
-        .unwrap_or_else(|| path.to_string());
+    let encoded = encode_uri_component(path);
     Some(format!(
         "/api/sessions/{}/files/pull?path={}",
         session_id, encoded
     ))
+}
+
+fn encode_uri_component(input: &str) -> String {
+    let mut encoded = String::with_capacity(input.len());
+    for &byte in input.as_bytes() {
+        match byte {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'_'
+            | b'.'
+            | b'!'
+            | b'~'
+            | b'*'
+            | b'\''
+            | b'('
+            | b')' => encoded.push(byte as char),
+            _ => {
+                encoded.push('%');
+                encoded.push_str(&format!("{:02X}", byte));
+            }
+        }
+    }
+    encoded
 }
 
 /// Get the corresponding end tag for a start tag
@@ -507,7 +559,7 @@ fn render_list(start: Option<u64>, inner: Html) -> Html {
 fn render_table(
     events: &[Event],
     alignments: &[pulldown_cmark::Alignment],
-    session_id: Option<uuid::Uuid>,
+    session_id: Option<Uuid>,
 ) -> Html {
     // Tables have: TableHead (with TableRow and TableCells), then TableRows with TableCells
     // We need to process the events to build proper thead/tbody structure
@@ -559,7 +611,7 @@ fn render_table(
 fn render_table_head(
     events: &[Event],
     alignments: &[pulldown_cmark::Alignment],
-    session_id: Option<uuid::Uuid>,
+    session_id: Option<Uuid>,
 ) -> Html {
     let mut cells: Vec<Html> = Vec::new();
     let mut i = 0;
@@ -592,7 +644,7 @@ fn render_table_head(
 fn render_table_row(
     events: &[Event],
     alignments: &[pulldown_cmark::Alignment],
-    session_id: Option<uuid::Uuid>,
+    session_id: Option<Uuid>,
 ) -> Html {
     let mut cells: Vec<Html> = Vec::new();
     let mut i = 0;
@@ -1071,5 +1123,44 @@ Where:\n\
             )),
             "pulldown-cmark classifies angle-bracket labels as raw HTML: {events:?}"
         );
+    }
+
+    #[test]
+    fn bare_angle_bracket_description_is_html_not_a_link() {
+        let input = "<description>";
+
+        let mut options = Options::empty();
+        options.insert(Options::ENABLE_TABLES);
+        options.insert(Options::ENABLE_STRIKETHROUGH);
+        let parser = Parser::new_ext(input, options);
+        let events: Vec<Event> = parser.collect();
+
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                Event::Html(t) | Event::InlineHtml(t) if t.as_ref() == input
+            )),
+            "pulldown-cmark classifies bare <description> as raw HTML text, not a markdown link: {events:?}"
+        );
+    }
+
+    #[test]
+    fn portal_file_markdown_link_rewrites_description_to_download_href() {
+        let session_id = Uuid::parse_str("11111111-2222-3333-4444-555555555555")
+            .expect("static uuid should parse");
+
+        assert_eq!(
+            classify_link_destination("portal://file/docs/portal link.svg", Some(session_id)),
+            LinkDestination::PortalDownload(
+                "/api/sessions/11111111-2222-3333-4444-555555555555/files/pull?path=docs%2Fportal%20link.svg"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "portal://file markdown links require a session_id to render")]
+    fn portal_file_markdown_link_without_session_panics() {
+        let _ = classify_link_destination("portal://file/docs/portal_link_rendering.svg", None);
     }
 }

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -31,8 +31,7 @@ fn extract_local_timestamp(json: &str) -> Option<String> {
 #[derive(Properties, PartialEq)]
 pub struct MessageRendererProps {
     pub json: String,
-    #[prop_or_default]
-    pub session_id: Option<Uuid>,
+    pub session_id: Uuid,
     #[prop_or_default]
     pub agent_type: shared::AgentType,
     #[prop_or_default]
@@ -84,6 +83,7 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
                 &meta,
                 props.current_user_id.as_deref(),
                 ts.as_deref(),
+                props.session_id,
             );
         }
         Ok(ClaudeMessage::OptimisticUser(msg)) => {
@@ -91,6 +91,7 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
                 &msg,
                 props.current_user_id.as_deref(),
                 ts.as_deref(),
+                props.session_id,
             );
         }
         Ok(ClaudeMessage::Error(msg)) => {
@@ -106,7 +107,7 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
     }
 
     if props.agent_type == shared::AgentType::Codex {
-        html! { <super::codex_renderer::CodexMessageRenderer json={props.json.clone()} turn_metrics={props.turn_metrics.clone()} /> }
+        html! { <super::codex_renderer::CodexMessageRenderer json={props.json.clone()} session_id={props.session_id} turn_metrics={props.turn_metrics.clone()} /> }
     } else {
         render_raw_json(&props.json)
     }
@@ -115,8 +116,7 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
 #[derive(Properties, PartialEq)]
 pub struct MessageGroupRendererProps {
     pub group: MessageGroup,
-    #[prop_or_default]
-    pub session_id: Option<Uuid>,
+    pub session_id: Uuid,
     #[prop_or_default]
     pub agent_type: shared::AgentType,
     #[prop_or_default]
@@ -207,15 +207,11 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
     }
 }
 
-fn render_identity_group_part(
-    json: &str,
-    agent_type: shared::AgentType,
-    session_id: Option<Uuid>,
-) -> Html {
+fn render_identity_group_part(json: &str, agent_type: shared::AgentType, session_id: Uuid) -> Html {
     match ClaudeMessage::parse(json) {
-        Ok(ClaudeMessage::User(msg)) => renderers::render_user_message_content(&msg),
+        Ok(ClaudeMessage::User(msg)) => renderers::render_user_message_content(&msg, session_id),
         Ok(ClaudeMessage::OptimisticUser(msg)) => {
-            renderers::render_optimistic_user_message_content(&msg)
+            renderers::render_optimistic_user_message_content(&msg, session_id)
         }
         Ok(ClaudeMessage::Assistant(msg)) => {
             renderers::render_assistant_message_content(&msg, session_id)
@@ -224,7 +220,7 @@ fn render_identity_group_part(
             renderers::render_portal_message_content(&msg, session_id)
         }
         _ if agent_type == shared::AgentType::Codex => {
-            super::codex_renderer::render_codex_message_content(json)
+            super::codex_renderer::render_codex_message_content(json, session_id)
         }
         _ => html! {},
     }

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -8,11 +8,12 @@ mod tools;
 use super::types::{OptimisticUserMessage, UserMessageMeta};
 use super::{format_duration, shorten_model_name};
 use crate::components::copy_button::CopyButton;
-use crate::components::markdown::render_markdown;
+use crate::components::markdown::render_markdown_for_session;
 use crate::components::tool_renderers::{
     has_askuserquestion_answers, render_askuserquestion_result,
 };
 use serde::Deserialize;
+use uuid::Uuid;
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
@@ -35,6 +36,7 @@ pub fn render_optimistic_user_message(
     msg: &OptimisticUserMessage,
     current_user_id: Option<&str>,
     timestamp: Option<&str>,
+    session_id: Uuid,
 ) -> Html {
     let label = match &msg.sender {
         Some(sender) if current_user_id != Some(sender.user_id.as_str()) => sender.name.clone(),
@@ -51,7 +53,7 @@ pub fn render_optimistic_user_message(
                 }
                 <CopyButton text={msg.content.clone()} title="Copy message" />
             </div>
-            <div class="message-body">{ render_optimistic_user_message_content(msg) }</div>
+            <div class="message-body">{ render_optimistic_user_message_content(msg, session_id) }</div>
         </div>
     }
 }
@@ -61,6 +63,7 @@ pub fn render_user_message(
     meta: &UserMessageMeta,
     current_user_id: Option<&str>,
     timestamp: Option<&str>,
+    session_id: Uuid,
 ) -> Html {
     let label = match &meta.sender {
         Some(sender) if current_user_id != Some(sender.user_id.as_str()) => sender.name.clone(),
@@ -85,7 +88,7 @@ pub fn render_user_message(
     if has_tool_results {
         html! {
             <div class="claude-message user-message tool-result-message">
-                <div class="message-body">{ render_user_message_content(msg) }</div>
+                <div class="message-body">{ render_user_message_content(msg, session_id) }</div>
             </div>
         }
     } else if !text_content.is_empty() {
@@ -98,7 +101,7 @@ pub fn render_user_message(
                     }
                     <CopyButton text={text_content.clone()} title="Copy message" />
                 </div>
-                <div class="message-body">{ render_user_message_content(msg) }</div>
+                <div class="message-body">{ render_user_message_content(msg, session_id) }</div>
             </div>
         }
     } else {
@@ -106,13 +109,16 @@ pub fn render_user_message(
     }
 }
 
-pub fn render_optimistic_user_message_content(msg: &OptimisticUserMessage) -> Html {
+pub fn render_optimistic_user_message_content(
+    msg: &OptimisticUserMessage,
+    session_id: Uuid,
+) -> Html {
     html! {
-        <div class="user-text">{ render_markdown(&preserve_user_newlines(&msg.content)) }</div>
+        <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&msg.content), session_id) }</div>
     }
 }
 
-pub fn render_user_message_content(msg: &shared::UserMessage) -> Html {
+pub fn render_user_message_content(msg: &shared::UserMessage, session_id: Uuid) -> Html {
     if let Some(Ok(input)) = msg.tool_use_result_as::<shared::AskUserQuestionInput>() {
         if has_askuserquestion_answers(&input) {
             return render_askuserquestion_result(&input);
@@ -125,7 +131,7 @@ pub fn render_user_message_content(msg: &shared::UserMessage) -> Html {
         .any(|b| matches!(b, shared::ContentBlock::ToolResult(_)));
 
     if has_tool_results {
-        render_content_blocks(&blocks, None)
+        render_content_blocks(&blocks, session_id)
     } else {
         let text_content = blocks
             .iter()
@@ -140,7 +146,7 @@ pub fn render_user_message_content(msg: &shared::UserMessage) -> Html {
             html! {}
         } else {
             html! {
-                <div class="user-text">{ render_markdown(&preserve_user_newlines(&text_content)) }</div>
+                <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&text_content), session_id) }</div>
             }
         }
     }

--- a/frontend/src/components/message_renderer/renderers/assistant.rs
+++ b/frontend/src/components/message_renderer/renderers/assistant.rs
@@ -12,6 +12,7 @@ use crate::components::time_ago::TimeAgo;
 use crate::components::tool_renderers::render_tool_use;
 use shared::{AssistantMessage, AssistantUsage as UsageInfo};
 use shared::{Citation, ContentBlock, ToolResultContent};
+use uuid::Uuid;
 use yew::prelude::*;
 
 fn extract_ephemeral_cache(usage: &UsageInfo) -> (u64, u64) {
@@ -97,7 +98,7 @@ pub fn render_assistant_message(
     msg: &AssistantMessage,
     timestamp: Option<&str>,
     raw_iso: Option<&str>,
-    session_id: Option<uuid::Uuid>,
+    session_id: Uuid,
 ) -> Html {
     let blocks = msg.message.content.clone();
 
@@ -146,15 +147,12 @@ pub fn render_assistant_message(
     }
 }
 
-pub fn render_assistant_message_content(
-    msg: &AssistantMessage,
-    session_id: Option<uuid::Uuid>,
-) -> Html {
+pub fn render_assistant_message_content(msg: &AssistantMessage, session_id: Uuid) -> Html {
     let blocks = msg.message.content.clone();
     render_content_blocks(&blocks, session_id)
 }
 
-pub fn render_content_blocks(blocks: &[ContentBlock], session_id: Option<uuid::Uuid>) -> Html {
+pub fn render_content_blocks(blocks: &[ContentBlock], session_id: Uuid) -> Html {
     html! {
         <>
             {

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -2,12 +2,13 @@ use super::super::types::PortalMessage;
 use super::render_image_source;
 use crate::components::copy_button::CopyButton;
 use crate::components::markdown::render_markdown_for_session;
+use uuid::Uuid;
 use yew::prelude::*;
 
 pub fn render_portal_message(
     msg: &PortalMessage,
     timestamp: Option<&str>,
-    session_id: Option<uuid::Uuid>,
+    session_id: Uuid,
 ) -> Html {
     let copy_text: String = msg
         .content
@@ -31,11 +32,11 @@ pub fn render_portal_message(
     }
 }
 
-pub fn render_portal_message_content(msg: &PortalMessage, session_id: Option<uuid::Uuid>) -> Html {
+pub fn render_portal_message_content(msg: &PortalMessage, session_id: Uuid) -> Html {
     html! { <>{ for msg.content.iter().map(|content| render_portal_content(content, session_id)) }</> }
 }
 
-fn render_portal_content(content: &shared::PortalContent, session_id: Option<uuid::Uuid>) -> Html {
+fn render_portal_content(content: &shared::PortalContent, session_id: Uuid) -> Html {
     match content {
         shared::PortalContent::Text { text } => render_markdown_for_session(text, session_id),
         shared::PortalContent::Image {
@@ -73,8 +74,7 @@ fn render_portal_content(content: &shared::PortalContent, session_id: Option<uui
 struct PortalReminderProps {
     title: AttrValue,
     body: AttrValue,
-    #[prop_or_default]
-    session_id: Option<uuid::Uuid>,
+    session_id: Uuid,
 }
 
 /// Collapsed-by-default "Portal features reminder" block. Header is always

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -465,11 +465,11 @@ impl Component for SessionView {
                             groups.into_iter().enumerate().map(|(i, group)| {
                                 let key = group.key(i);
                                 let metrics = group_metrics.get(i).cloned().flatten();
-                                html! { <MessageGroupRenderer {key} group={group} session_id={Some(ctx.props().session.id)} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} /> }
+                                html! { <MessageGroupRenderer {key} group={group} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} /> }
                             }).collect::<Html>()
                         }
                         { for self.pending_sends.iter().enumerate().map(|(i, json)| {
-                            html! { <MessageRenderer key={format!("p{}", i)} json={json.clone()} session_id={Some(ctx.props().session.id)} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} /> }
+                            html! { <MessageRenderer key={format!("p{}", i)} json={json.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} /> }
                         })}
                     </div>
                     if !is_tailing {


### PR DESCRIPTION
## Summary
- require a concrete session id through transcript message rendering
- pass session id through Codex assistant markdown so portal file links can rewrite correctly
- make portal file link classification testable and assert missing session ids panic in tests/dev
- add regression coverage for [description](portal://file/...) versus bare <description>
- bump workspace version to 2.8.13

## Verification
- cargo fmt --check
- cargo test -p frontend --lib markdown::tests
- cargo test -p frontend --lib components::message_renderer::tests
- cargo check -p frontend --target wasm32-unknown-unknown