### PR TITLE
Compact Claude rate limit messages and update SDK crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.8.14
+
+- **Update code-agent protocol crates.** `claude-codes` is now `2.1.155` and `codex-codes` is now `0.137.3`, with frontend and Codex bridge call sites updated for the newer typed citation, model-usage, turn-start, and notification shapes.
+- **Render Claude rate-limit events as a compact single-line message.** The previous card used the same large visual treatment as API overload messages despite carrying only status, rate-limit window, reset timing, overage, and optional utilization. The renderer now keeps those fields inline in the header row and removes the progress bar/icon block.
+
 ## 2.8.13
 
 - **Add a direct regression test for portal file link rewriting.** Markdown link destinations are now classified through a small testable helper, and `[description](portal://file/path)` is pinned to render as an authenticated portal download target. `portal://file/...` now requires a session id and panics in tests/dev if called without one, because session file downloads cannot work outside a session context. Codex assistant markdown now receives the active session id too.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.13"
+version = "2.8.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.13"
+version = "2.8.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -485,9 +485,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.141"
+version = "2.1.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4430abb2bef291e8e1084287aa85d53ebe441ffc6567ad7a6a72e21410f744"
+checksum = "fae0d0f45f19147bab483423223888c21cd6a7da92c6e395b4f7af6dbcdd54ff"
 dependencies = [
  "anyhow",
  "chrono",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.13"
+version = "2.8.14"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.13"
+version = "2.8.14"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.129.3"
+version = "0.137.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e315ac25585083cfb1c1035a6c6e1b3e9e3457686d9a46b9f99668615873a1"
+checksum = "ee0e7507510e88735234d2ce3fdbb63e7655cb15c63415396b479404dda9e3a4"
 dependencies = [
  "log",
  "serde",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.13"
+version = "2.8.14"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -973,7 +973,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1041,7 +1041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.13"
+version = "2.8.14"
 dependencies = [
  "base64",
  "chrono",
@@ -2455,7 +2455,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.13"
+version = "2.8.14"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.13"
+version = "2.8.14"
 dependencies = [
  "anyhow",
  "hex",
@@ -3142,7 +3142,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.13"
+version = "2.8.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.13"
+version = "2.8.14"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -3644,7 +3644,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4454,7 +4454,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.13"
+version = "2.8.14"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -50,10 +50,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.141", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.155", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.129.3", default-features = false, features = ["types"] }
+codex-codes = { version = "0.137.3", default-features = false, features = ["types"] }
 
 # Frontend (Yew)
 yew = { version = "0.21", features = ["csr"] }

--- a/codex-session-lib/src/handler.rs
+++ b/codex-session-lib/src/handler.rs
@@ -162,6 +162,8 @@ fn handle_notification(
         | Notification::FileChangeOutputDelta(_)
         | Notification::ReasoningDelta(_)
         | Notification::Warning(_)
+        | Notification::ThreadSettingsUpdated(_)
+        | Notification::TurnModerationMetadata(_)
         | Notification::ThreadArchived(_)
         | Notification::ThreadClosed(_)
         | Notification::ThreadUnarchived(_)

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -640,6 +640,7 @@ fn turn_start_params(thread_id: &str, prompt: String) -> TurnStartParams {
     TurnStartParams {
         approval_policy: None,
         approvals_reviewer: None,
+        client_user_message_id: None,
         cwd: None,
         effort: None,
         input: vec![UserInput::Text {

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -218,57 +218,37 @@ pub fn render_rate_limit_event(msg: &shared::RateLimitEvent, timestamp: Option<&
         if resets_at > now {
             let mins = (resets_at - now) / 60;
             if mins > 60 {
-                format!("Resets in {}h {}m", mins / 60, mins % 60)
+                Some(format!("resets in {}h {}m", mins / 60, mins % 60))
             } else {
-                format!("Resets in {}m", mins)
+                Some(format!("resets in {}m", mins))
             }
         } else {
-            "Reset".to_string()
+            Some("reset".to_string())
         }
     } else {
-        String::new()
+        None
     };
 
     let format_type = rate_type.replace('_', " ");
+    let utilization_text = utilization.map(|pct| format!("{}%", (pct * 100.0).round() as u32));
 
     html! {
         <div class="claude-message rate-limit-message">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge rate-limit">{ "Rate Limit" }</span>
-            </div>
-            <div class="message-body">
-                <div class="overload-content">
-                    <div class="overload-icon">{ "\u{23f1}\u{fe0f}" }</div>
-                    <div class="overload-text">
-                        <div class="overload-title">{ format!("Rate limit: {} ({})", status, format_type) }</div>
-                        <div class="overload-description">
-                            { &reset_text }
-                            { if using_overage { " \u{b7} Using overage" } else { "" } }
-                        </div>
-                        {
-                            if let Some(pct) = utilization {
-                                let pct_int = (pct * 100.0).round() as u32;
-                                let bar_class = if pct >= 0.9 {
-                                    "utilization-bar critical"
-                                } else if pct >= 0.7 {
-                                    "utilization-bar warning"
-                                } else {
-                                    "utilization-bar"
-                                };
-                                html! {
-                                    <div class="utilization-row">
-                                        <div class={bar_class}>
-                                            <div class="utilization-fill" style={format!("width: {}%", pct_int)}></div>
-                                        </div>
-                                        <span class="utilization-label">{ format!("{}%", pct_int) }</span>
-                                    </div>
-                                }
-                            } else {
-                                html! {}
-                            }
-                        }
-                    </div>
-                </div>
+                <span class="rate-limit-inline">
+                    <span class="rate-limit-status">{ status }</span>
+                    <span class="rate-limit-detail">{ format_type }</span>
+                    if let Some(text) = reset_text {
+                        <span class="rate-limit-detail">{ text }</span>
+                    }
+                    if using_overage {
+                        <span class="rate-limit-detail">{ "using overage" }</span>
+                    }
+                    if let Some(text) = utilization_text {
+                        <span class="rate-limit-detail">{ text }</span>
+                    }
+                </span>
             </div>
         </div>
     }
@@ -412,11 +392,7 @@ pub fn render_result_message(
         duration_ms, api_ms, turns
     );
 
-    if let Some(model_usage) = msg
-        .model_usage
-        .as_ref()
-        .and_then(|v| serde_json::from_value::<shared::ModelUsage>(v.clone()).ok())
-    {
+    if let Some(model_usage) = msg.model_usage.as_ref() {
         for (model, entry) in model_usage {
             timing_tooltip.push_str(&format!(
                 " | {}: ${:.4}",

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -396,7 +396,7 @@ pub fn render_result_message(
         for (model, entry) in model_usage {
             timing_tooltip.push_str(&format!(
                 " | {}: ${:.4}",
-                shorten_model_name(&model).unwrap_or_else(|| model.clone()),
+                shorten_model_name(model).unwrap_or_else(|| model.clone()),
                 entry.cost_usd
             ));
         }

--- a/frontend/src/components/message_renderer/renderers/assistant.rs
+++ b/frontend/src/components/message_renderer/renderers/assistant.rs
@@ -242,17 +242,17 @@ pub fn render_content_blocks(blocks: &[ContentBlock], session_id: Uuid) -> Html 
     }
 }
 
-fn render_citations(citations: &[serde_json::Value]) -> Html {
+fn render_citations(citations: &[Citation]) -> Html {
     if citations.is_empty() {
         return html! {};
     }
     html! {
         <div class="citation-list">
             { for citations.iter().enumerate().map(|(i, cite)| {
-                let cite = serde_json::from_value::<Citation>(cite.clone()).ok();
-                let url = cite.as_ref().and_then(|c| c.url.as_deref()).unwrap_or("#");
-                let title = cite.as_ref().and_then(|c| c.title.as_deref()
-                    .or(c.cited_text.as_deref()))
+                let url = cite.url.as_deref().unwrap_or("#");
+                let title = cite.title.as_deref()
+                    .or(cite.cited_text.as_deref())
+                    .or(cite.document_title.as_deref())
                     .unwrap_or("source");
                 html! {
                     <a class="citation-link"

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -941,9 +941,35 @@
     background: rgba(224, 175, 104, 0.05);
 }
 
+.rate-limit-message .message-header {
+    align-items: center;
+    gap: 0.5rem;
+}
+
 .message-type-badge.rate-limit {
     background: rgba(224, 175, 104, 0.2);
     color: #e0af68;
+}
+
+.rate-limit-inline {
+    align-items: center;
+    color: var(--text-secondary);
+    display: inline-flex;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+    gap: 0.35rem;
+    min-width: 0;
+}
+
+.rate-limit-status {
+    color: #e0af68;
+    font-weight: 600;
+}
+
+.rate-limit-detail::before {
+    color: var(--text-muted);
+    content: "·";
+    margin-right: 0.35rem;
 }
 
 .utilization-row {

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -7,41 +7,6 @@ use uuid::Uuid;
 
 use crate::SessionInfo;
 
-/// Typed citation entry attached to an Anthropic text content block.
-///
-/// The Anthropic wire shape carries one of several citation variants
-/// (`char_location`, `page_location`, `content_block_location`,
-/// `web_search_result_location`, …); only a small subset of fields is
-/// shown in the agent-portal UI today (`url`, `title`, and `cited_text`),
-/// so we model just those as a single flat struct with optional fields
-/// rather than re-deriving the full upstream enum here. Unknown fields on
-/// the wire are silently ignored — the UI only needs enough to render a
-/// `[1]`/`[2]`/… link list.
-///
-/// Closes #754: replaces a previous `Vec<serde_json::Value>` field on
-/// `ContentBlock::Text` that the frontend JSON-poked with
-/// `cite.get("url")` / `cite.get("title")` / `cite.get("cited_text")`.
-///
-/// `claude-codes` 2.1.141 also stores citations as `Vec<serde_json::Value>`
-/// on `TextBlock`; upstream issue
-/// <https://github.com/meawoppl/rust-code-agent-sdks/issues/142> proposes
-/// this typed shape so we can eventually drop the local definition and
-/// just re-export from the SDK.
-// TODO(SDK #142): replace with `claude_codes::Citation` once upstream
-// adds a typed model — see agent-portal #754.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct Citation {
-    /// URL of the cited source (e.g. a web search result link).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    /// Human-readable title of the cited source.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    /// Exact text quoted from the cited source.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cited_text: Option<String>,
-}
-
 /// Typed envelope for a Codex permission request's `input` payload.
 ///
 /// Replaces the prior `serde_json::Value` envelope shared between the proxy
@@ -952,47 +917,6 @@ mod tests {
         let parsed: CodexPermissionInput = serde_json::from_value(json).unwrap();
         assert_eq!(parsed, input);
         assert_eq!(parsed.tool_name(), "AskUserQuestion");
-    }
-
-    #[test]
-    fn citation_full_roundtrip() {
-        let cite = Citation {
-            url: Some("https://example.com".to_string()),
-            title: Some("Example".to_string()),
-            cited_text: Some("hello world".to_string()),
-        };
-        let json = serde_json::to_value(&cite).unwrap();
-        assert_eq!(json["url"], "https://example.com");
-        assert_eq!(json["title"], "Example");
-        assert_eq!(json["cited_text"], "hello world");
-        let parsed: Citation = serde_json::from_value(json).unwrap();
-        assert_eq!(parsed, cite);
-    }
-
-    /// Wire frame as actually produced by the Anthropic API for a
-    /// `web_search_result_location` citation (per claude-codes
-    /// `test_text_block_with_citations`). Extra fields like `type` must
-    /// be silently ignored.
-    #[test]
-    fn citation_ignores_unknown_fields() {
-        let json = serde_json::json!({
-            "type": "web_search_result_location",
-            "url": "https://example.com",
-            "title": "Example"
-        });
-        let parsed: Citation = serde_json::from_value(json).unwrap();
-        assert_eq!(parsed.url.as_deref(), Some("https://example.com"));
-        assert_eq!(parsed.title.as_deref(), Some("Example"));
-        assert!(parsed.cited_text.is_none());
-    }
-
-    /// Empty wire frame must parse to all-`None` so historical content
-    /// blocks that omitted citations stay readable.
-    #[test]
-    fn citation_empty_roundtrip() {
-        let json = serde_json::json!({});
-        let parsed: Citation = serde_json::from_value(json).unwrap();
-        assert_eq!(parsed, Citation::default());
     }
 
     /// Wire shape lifted verbatim from `claude-codes`'

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -19,9 +19,8 @@ pub mod protocol;
 // API client types and trait
 pub mod api;
 pub use api::{
-    ApiError, Citation, CodexPermissionInput, CompactionExtra, InitExtra, ModelUsage,
-    ModelUsageEntry, SoundSettingsResponse, TaskNotificationExtra, TurnMetrics,
-    TurnMetricsResponse,
+    ApiError, CodexPermissionInput, CompactionExtra, InitExtra, ModelUsage, ModelUsageEntry,
+    SoundSettingsResponse, TaskNotificationExtra, TurnMetrics, TurnMetricsResponse,
 };
 
 /// Default backend URL based on build profile.
@@ -36,8 +35,9 @@ pub fn default_backend_url() -> &'static str {
 
 // Re-export claude-codes types for frontend message parsing
 pub use claude_codes::io::{
-    ContentBlock, ImageBlock, ImageSource, ImageSourceType, MediaType, PermissionSuggestion,
-    TextBlock, ThinkingBlock, ToolResultBlock, ToolResultContent, ToolUseBlock,
+    Citation, ContentBlock, ImageBlock, ImageSource, ImageSourceType, MediaType,
+    PermissionSuggestion, TextBlock, ThinkingBlock, ToolResultBlock, ToolResultContent,
+    ToolUseBlock,
 };
 
 // Re-export claude-codes output types for typed parsing.


### PR DESCRIPTION
## Summary
- render Claude rate-limit events as a compact single-line header row
- update claude-codes to 2.1.155 and codex-codes to 0.137.3
- remove the local Citation shim and adapt frontend/Codex bridge call sites to new typed SDK shapes

## Verification
- cargo fmt --check
- cargo check -p shared --target wasm32-unknown-unknown
- cargo check -p frontend --target wasm32-unknown-unknown
- cargo check -p backend -p claude-portal -p claude-session-lib -p codex-session-lib -p session-lib
- npm run lint:css