### PR TITLE
Keep launch dialog within viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.15
+
+- **Keep the launch-session modal inside the viewport.** The launcher dialog now has bounded height, backdrop padding, and internal scrolling so tall directory listings or install instructions do not extend off the bottom of the screen.
+
 ## 2.8.14
 
 - **Update code-agent protocol crates.** `claude-codes` is now `2.1.155` and `codex-codes` is now `0.137.3`, with frontend and Codex bridge call sites updated for the newer typed citation, model-usage, turn-start, and notification shapes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.14"
+version = "2.8.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.14"
+version = "2.8.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.14"
+version = "2.8.15"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.14"
+version = "2.8.15"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.14"
+version = "2.8.15"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.14"
+version = "2.8.15"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.14"
+version = "2.8.15"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.14"
+version = "2.8.15"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.14"
+version = "2.8.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.14"
+version = "2.8.15"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.14"
+version = "2.8.15"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -334,12 +334,14 @@
     left: 0;
     right: 0;
     bottom: 0;
+    box-sizing: border-box;
     background: rgba(0, 0, 0, 0.6);
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
     display: flex;
     justify-content: center;
     align-items: center;
+    padding: 2rem;
     z-index: 1000;
     animation: fadeIn 0.2s ease-out;
 }
@@ -348,8 +350,13 @@
     background: var(--bg-darker);
     border: 1px solid var(--border);
     border-radius: 8px;
+    box-sizing: border-box;
     padding: 2rem;
     max-width: 540px;
+    max-height: calc(100vh - 4rem);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
     width: 90%;
     animation: scaleIn 0.2s ease-out;
 }
@@ -554,6 +561,16 @@
     overflow-y: auto;
 }
 
+@supports (height: 100dvh) {
+    .launch-dialog {
+        max-height: calc(100dvh - 4rem);
+    }
+
+    .dir-browser {
+        max-height: min(240px, 32dvh);
+    }
+}
+
 .dir-entry {
     display: flex;
     align-items: center;
@@ -628,5 +645,3 @@
     border-color: var(--text-muted);
     color: var(--text-primary);
 }
-
-


### PR DESCRIPTION
## Summary
- constrain the launch-session dialog to the viewport with internal scrolling
- add backdrop padding so the modal cannot run flush off-screen
- cap the directory browser relative to viewport height on dynamic-viewport browsers
- bump version to 2.8.15

## Verification
- cargo fmt --check
- cargo check -p frontend --target wasm32-unknown-unknown
- npm run lint:css