### PR TITLE
Increase performance chart resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.16
+
+- **Increase Performance chart x-axis resolution.** Performance tabs now request minute buckets for 6-hour windows, 5-minute buckets for 1-day windows, and hourly buckets for week-plus windows instead of collapsing long windows to daily data. Multi-day minute/hour tick labels include the date so the denser charts stay readable.
+
 ## 2.8.15
 
 - **Keep the launch-session modal inside the viewport.** The launcher dialog now has bounded height, backdrop padding, and internal scrolling so tall directory listings or install instructions do not extend off the bottom of the screen.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.15"
+version = "2.8.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.15"
+version = "2.8.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.15"
+version = "2.8.16"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.15"
+version = "2.8.16"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.15"
+version = "2.8.16"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.15"
+version = "2.8.16"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.15"
+version = "2.8.16"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.15"
+version = "2.8.16"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.15"
+version = "2.8.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.15"
+version = "2.8.16"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.15"
+version = "2.8.16"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/charts/scale.rs
+++ b/frontend/src/components/charts/scale.rs
@@ -107,7 +107,8 @@ fn nice_step(raw: f64) -> f64 {
 ///
 /// Labels:
 /// - `BucketKind::Day` → `"May 5"` (month abbreviation + day-of-month)
-/// - `BucketKind::Minute` / `Hour` → `"14:05"` / `"14:00"` (24-hour HH:MM)
+/// - single-day `BucketKind::Minute` / `Hour` → `"14:05"` / `"14:00"`
+/// - multi-day `BucketKind::Minute` / `Hour` → `"May 5 14:05"` / `"May 5 14:00"`
 pub fn time_axis_ticks(
     buckets: &[DateTime<Utc>],
     bucket: BucketKind,
@@ -119,10 +120,15 @@ pub fn time_axis_ticks(
     if buckets.len() == 1 {
         return vec![TickLabel {
             frac: 0.5,
-            label: format_tick_label(buckets[0], bucket),
+            label: format_tick_label(buckets[0], bucket, false),
         }];
     }
     let n = buckets.len();
+    let include_date = matches!(bucket, BucketKind::Minute | BucketKind::Hour)
+        && buckets
+            .first()
+            .zip(buckets.last())
+            .is_some_and(|(first, last)| first.date_naive() != last.date_naive());
     let target = max_ticks.clamp(2, n);
     // Step so we land on `target - 1` intervals across the [0..n-1] range.
     let last = (n - 1) as f64;
@@ -138,35 +144,51 @@ pub fn time_axis_ticks(
         };
         out.push(TickLabel {
             frac,
-            label: format_tick_label(buckets[idx], bucket),
+            label: format_tick_label(buckets[idx], bucket, include_date),
         });
     }
     out
 }
 
-fn format_tick_label(ts: DateTime<Utc>, bucket: BucketKind) -> String {
+fn format_tick_label(ts: DateTime<Utc>, bucket: BucketKind, include_date: bool) -> String {
     match bucket {
-        BucketKind::Minute => format!("{:02}:{:02}", ts.hour(), ts.minute()),
-        BucketKind::Hour => format!("{:02}:00", ts.hour()),
-        BucketKind::Day => {
-            let month = match ts.month() {
-                1 => "Jan",
-                2 => "Feb",
-                3 => "Mar",
-                4 => "Apr",
-                5 => "May",
-                6 => "Jun",
-                7 => "Jul",
-                8 => "Aug",
-                9 => "Sep",
-                10 => "Oct",
-                11 => "Nov",
-                12 => "Dec",
-                _ => "?",
-            };
-            format!("{} {}", month, ts.day())
+        BucketKind::Minute => {
+            let time = format!("{:02}:{:02}", ts.hour(), ts.minute());
+            if include_date {
+                format!("{} {time}", format_month_day(ts))
+            } else {
+                time
+            }
         }
+        BucketKind::Hour => {
+            let time = format!("{:02}:00", ts.hour());
+            if include_date {
+                format!("{} {time}", format_month_day(ts))
+            } else {
+                time
+            }
+        }
+        BucketKind::Day => format_month_day(ts),
     }
+}
+
+fn format_month_day(ts: DateTime<Utc>) -> String {
+    let month = match ts.month() {
+        1 => "Jan",
+        2 => "Feb",
+        3 => "Mar",
+        4 => "Apr",
+        5 => "May",
+        6 => "Jun",
+        7 => "Jul",
+        8 => "Aug",
+        9 => "Sep",
+        10 => "Oct",
+        11 => "Nov",
+        12 => "Dec",
+        _ => "?",
+    };
+    format!("{} {}", month, ts.day())
 }
 
 /// Build the y-axis ticks as `(value, normalized_frac)` pairs. `frac == 0.0`
@@ -334,6 +356,20 @@ mod tests {
     }
 
     #[test]
+    fn time_axis_ticks_hourly_labels_include_dates_across_days() {
+        let mut buckets = Vec::new();
+        for day in 5..=7 {
+            for hour in 0..24 {
+                buckets.push(Utc.with_ymd_and_hms(2026, 5, day, hour, 0, 0).unwrap());
+            }
+        }
+        let ticks = time_axis_ticks(&buckets, BucketKind::Hour, 4);
+        assert_eq!(ticks.len(), 4);
+        assert_eq!(ticks[0].label, "May 5 00:00");
+        assert_eq!(ticks[3].label, "May 7 23:00");
+    }
+
+    #[test]
     fn time_axis_ticks_minute_labels_include_minutes() {
         let mut buckets = Vec::new();
         for minute in 0..60 {
@@ -343,6 +379,18 @@ mod tests {
         assert_eq!(ticks.len(), 5);
         assert_eq!(ticks[0].label, "14:00");
         assert_eq!(ticks[4].label, "14:59");
+    }
+
+    #[test]
+    fn time_axis_ticks_minute_labels_include_dates_across_days() {
+        let buckets = vec![
+            Utc.with_ymd_and_hms(2026, 5, 5, 23, 55, 0).unwrap(),
+            Utc.with_ymd_and_hms(2026, 5, 6, 0, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2026, 5, 6, 0, 5, 0).unwrap(),
+        ];
+        let ticks = time_axis_ticks(&buckets, BucketKind::Minute, 3);
+        assert_eq!(ticks[0].label, "May 5 23:55");
+        assert_eq!(ticks[2].label, "May 6 00:05");
     }
 
     #[test]

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -5,10 +5,10 @@
 //! the existing settings nav (alongside Launchers / Tokens / Sounds / Sessions
 //! / Appearance) — same chrome, same back-button pattern.
 //!
-//! On mount, fetches the default `bucket=day&window=30d` aggregation, then
-//! refetches when the user switches the time-window radio. A group-by
-//! dropdown filters to one `(agent_type, model, service_tier)` group, or
-//! "All" to render one line per group.
+//! On mount, fetches the default high-resolution `bucket=hour&window=30d`
+//! aggregation, then refetches when the user switches the time-window radio.
+//! A group-by dropdown filters to one `(agent_type, model, service_tier)`
+//! group, or "All" to render one line per group.
 
 use std::collections::BTreeMap;
 
@@ -108,15 +108,15 @@ fn window_param(window: TimeWindow) -> &'static str {
 }
 
 /// Build the bucket-granularity query string for the selected window.
-/// Pick enough buckets to show shape without turning sparse per-turn metrics
-/// into comb noise: roughly 60 buckets for 1h, 72 for 6h, 96 for 1d, and
-/// daily for week-plus windows.
+/// Pick high-fidelity buckets for the selected window. The charts only render
+/// a handful of x-axis labels, so dense buckets preserve real per-turn shape
+/// without cluttering the axis.
 fn bucket_param(window: TimeWindow) -> &'static str {
     match window {
         TimeWindow::Hours1 => "1m",
-        TimeWindow::Hours6 => "5m",
-        TimeWindow::Days1 => "15m",
-        TimeWindow::Days7 | TimeWindow::Days30 | TimeWindow::Days90 => "day",
+        TimeWindow::Hours6 => "1m",
+        TimeWindow::Days1 => "5m",
+        TimeWindow::Days7 | TimeWindow::Days30 | TimeWindow::Days90 => "hour",
     }
 }
 
@@ -863,16 +863,16 @@ mod tests {
         assert_eq!(window_param(TimeWindow::Days90), "90d");
     }
 
-    /// Short windows should stay granular enough to show shape; week-plus
-    /// windows stay daily so the query and x-axis remain readable.
+    /// Windows should stay granular enough to show shape; the chart axis
+    /// itself is already subsampled to a few readable labels.
     #[test]
     fn bucket_param_dispatches_on_window_length() {
         assert_eq!(bucket_param(TimeWindow::Hours1), "1m");
-        assert_eq!(bucket_param(TimeWindow::Hours6), "5m");
-        assert_eq!(bucket_param(TimeWindow::Days1), "15m");
-        assert_eq!(bucket_param(TimeWindow::Days7), "day");
-        assert_eq!(bucket_param(TimeWindow::Days30), "day");
-        assert_eq!(bucket_param(TimeWindow::Days90), "day");
+        assert_eq!(bucket_param(TimeWindow::Hours6), "1m");
+        assert_eq!(bucket_param(TimeWindow::Days1), "5m");
+        assert_eq!(bucket_param(TimeWindow::Days7), "hour");
+        assert_eq!(bucket_param(TimeWindow::Days30), "hour");
+        assert_eq!(bucket_param(TimeWindow::Days90), "hour");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- request higher-fidelity buckets on Performance tabs: 6h uses 1m, 1d uses 5m, and week-plus windows use hourly buckets
- include dates in multi-day minute/hour x-axis tick labels
- bump workspace version to 2.8.16 and update changelog

## Tests
- cargo fmt --check
- cargo check -p frontend --target wasm32-unknown-unknown
- cargo test -p frontend performance_panel
- cargo test -p frontend time_axis_ticks