### PR TITLE
Add performance chart log scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.17
+
+- **Add log-scale support to Performance plots.** The Performance page now has a `Y scale` control with `Linear` as the default and `Log` as an alternate view across all plots. Log scaling maps positive values by base-10 decades while keeping zero/non-positive buckets on a baseline, and the chart headers show the active scale.
+
 ## 2.8.16
 
 - **Increase Performance chart x-axis resolution.** Performance tabs now request minute buckets for 6-hour windows, 5-minute buckets for 1-day windows, and hourly buckets for week-plus windows instead of collapsing long windows to daily data. Multi-day minute/hour tick labels include the date so the denser charts stay readable.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.16"
+version = "2.8.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.16"
+version = "2.8.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.16"
+version = "2.8.17"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.16"
+version = "2.8.17"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.16"
+version = "2.8.17"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.16"
+version = "2.8.17"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.16"
+version = "2.8.17"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.16"
+version = "2.8.17"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.16"
+version = "2.8.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.16"
+version = "2.8.17"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.16"
+version = "2.8.17"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/charts/line_plot.rs
+++ b/frontend/src/components/charts/line_plot.rs
@@ -13,7 +13,8 @@ use chrono::{DateTime, Utc};
 use yew::prelude::*;
 
 use super::scale::{
-    nice_y_axis, series_points, time_axis_ticks, y_axis_ticks, BucketKind, TickLabel,
+    format_axis_value, series_points_with_axis, time_axis_ticks, y_axis_for_values,
+    y_axis_tick_labels, AxisScale, BucketKind, TickLabel,
 };
 
 /// One labelled line in the chart. `dashed = true` is used for p95 traces
@@ -45,6 +46,8 @@ pub struct LinePlotProps {
     pub bucket_kind: BucketKind,
     /// Lines to draw. Empty list → renders the "no data" placeholder.
     pub series: Vec<LineSeries>,
+    /// Y-axis projection mode. Defaults are owned by the parent page.
+    pub axis_scale: AxisScale,
 }
 
 /// Internal SVG canvas size. We render at 800×260 in the viewBox and let CSS
@@ -85,19 +88,14 @@ pub fn line_plot(props: &LinePlotProps) -> Html {
             </div>
         };
     }
-    let (min_v, max_v) = all_y
-        .iter()
-        .fold((f64::INFINITY, f64::NEG_INFINITY), |a, &b| {
-            (a.0.min(b), a.1.max(b))
-        });
-    let (y_min, y_max, y_step) = nice_y_axis(min_v, max_v);
+    let y_axis = y_axis_for_values(&all_y, props.axis_scale);
 
     let plot_w = VIEW_W - PAD_L - PAD_R;
     let plot_h = VIEW_H - PAD_T - PAD_B;
     let viewbox = format!("0 0 {VIEW_W} {VIEW_H}");
 
     let x_ticks = time_axis_ticks(&props.buckets, props.bucket_kind, 6);
-    let y_ticks = y_axis_ticks(y_min, y_max, y_step);
+    let y_ticks = y_axis_tick_labels(&y_axis);
 
     // For each series, split into contiguous runs (skipping `None` gaps), then
     // turn each run into its own polyline via `series_points` against the same
@@ -110,7 +108,7 @@ pub fn line_plot(props: &LinePlotProps) -> Html {
                 * (plot_w / (props.buckets.len() as f32 - 1.0).max(1.0));
             let offset_x =
                 (start_idx as f32) * (plot_w / (props.buckets.len() as f32 - 1.0).max(1.0));
-            let points = series_points(&run, scaled_w.max(0.0), plot_h, y_min, y_max);
+            let points = series_points_with_axis(&run, scaled_w.max(0.0), plot_h, &y_axis);
             if points.is_empty() {
                 continue;
             }
@@ -193,7 +191,10 @@ pub fn line_plot(props: &LinePlotProps) -> Html {
 
     html! {
         <div class="performance-chart">
-            <h3 class="chart-title">{ &props.title }</h3>
+            <div class="chart-header">
+                <h3 class="chart-title">{ &props.title }</h3>
+                <span class="chart-scale-badge">{ props.axis_scale.label() }</span>
+            </div>
             <div class="chart-legend">{ legend }</div>
             <svg
                 class="performance-chart-svg"
@@ -243,20 +244,6 @@ fn contiguous_runs(values: &[Option<f64>]) -> Vec<(usize, Vec<f64>)> {
         runs.push((current_start, current));
     }
     runs
-}
-
-/// Format a y-axis tick value as compactly as possible. Whole numbers drop the
-/// decimal; small fractions keep 2 decimals; big values use a `k` suffix.
-fn format_axis_value(v: f64) -> String {
-    if v.abs() >= 1000.0 {
-        format!("{:.1}k", v / 1000.0)
-    } else if v.fract().abs() < 1e-9 {
-        format!("{}", v as i64)
-    } else if v.abs() < 1.0 {
-        format!("{:.2}", v)
-    } else {
-        format!("{:.1}", v)
-    }
 }
 
 #[cfg(test)]

--- a/frontend/src/components/charts/mod.rs
+++ b/frontend/src/components/charts/mod.rs
@@ -18,5 +18,5 @@ pub mod scale;
 pub mod stacked_area;
 
 pub use line_plot::{LinePlot, LineSeries};
-pub use scale::BucketKind;
+pub use scale::{AxisScale, BucketKind};
 pub use stacked_area::{StackedArea, StackedSeries};

--- a/frontend/src/components/charts/scale.rs
+++ b/frontend/src/components/charts/scale.rs
@@ -35,6 +35,35 @@ impl BucketKind {
     }
 }
 
+/// Y-axis projection mode for Performance charts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AxisScale {
+    Linear,
+    Log,
+}
+
+impl AxisScale {
+    pub const fn all() -> [Self; 2] {
+        [Self::Linear, Self::Log]
+    }
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Linear => "Linear",
+            Self::Log => "Log",
+        }
+    }
+}
+
+/// Complete y-axis mapping, including displayed tick positions.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum YAxis {
+    Linear { min: f64, max: f64, step: f64 },
+    Log { min_log: f64, max_log: f64 },
+}
+
+const LOG_ZERO_BAND_FRAC: f32 = 0.08;
+
 /// One axis tick — a normalized x position in `[0.0, 1.0]` plus the label
 /// string to render. Consumers multiply by the chart width to get the SVG
 /// `x` coordinate.
@@ -74,6 +103,52 @@ pub fn nice_y_axis(min: f64, max: f64) -> (f64, f64, f64) {
     let nice_min = nice_min.max(0.0); // never below zero for our metrics
     let nice_max = (max / step).ceil() * step;
     (nice_min, nice_max, step)
+}
+
+/// Build a linear or logarithmic y-axis from the finite chart values.
+///
+/// Log scale reserves a small baseline band for zero/non-positive values, then
+/// maps positive values by base-10 decades. That keeps sparse zero buckets
+/// visible without pretending that `log(0)` exists.
+pub fn y_axis_for_values(values: &[f64], scale: AxisScale) -> YAxis {
+    match scale {
+        AxisScale::Linear => {
+            let (min_v, max_v) = finite_min_max(values).unwrap_or((0.0, 1.0));
+            let (min, max, step) = nice_y_axis(min_v, max_v);
+            YAxis::Linear { min, max, step }
+        }
+        AxisScale::Log => {
+            let positives: Vec<f64> = values
+                .iter()
+                .copied()
+                .filter(|v| v.is_finite() && *v > 0.0)
+                .collect();
+            let Some((min_positive, max_positive)) = finite_min_max(&positives) else {
+                let (min, max, step) = nice_y_axis(0.0, 1.0);
+                return YAxis::Linear { min, max, step };
+            };
+            let mut min_log = min_positive.log10().floor();
+            let mut max_log = max_positive.log10().ceil();
+            if (max_log - min_log).abs() < f64::EPSILON {
+                min_log -= 1.0;
+                max_log += 1.0;
+            }
+            YAxis::Log { min_log, max_log }
+        }
+    }
+}
+
+fn finite_min_max(values: &[f64]) -> Option<(f64, f64)> {
+    values
+        .iter()
+        .copied()
+        .filter(|v| v.is_finite())
+        .fold(None, |acc, v| {
+            Some(match acc {
+                Some((min, max)) => (min.min(v), max.max(v)),
+                None => (v, v),
+            })
+        })
 }
 
 /// Round `raw` up to the nearest "nice" value (1, 2, or 5 times a power of ten).
@@ -212,21 +287,38 @@ pub fn y_axis_ticks(min: f64, max: f64, step: f64) -> Vec<(f64, f32)> {
     out
 }
 
-/// Project a series of `(x_index, value)` data points onto an SVG-friendly
-/// "x,y x,y …" string for a `<polyline>`. `width` and `height` are the SVG
-/// viewBox dimensions; `(y_min, y_max)` are the *displayed* y-axis bounds
-/// (typically from [`nice_y_axis`]). Values outside the bounds are clamped.
+/// Build y-axis ticks for an already resolved axis mapping.
+pub fn y_axis_tick_labels(axis: &YAxis) -> Vec<(f64, f32)> {
+    match *axis {
+        YAxis::Linear { min, max, step } => y_axis_ticks(min, max, step),
+        YAxis::Log { min_log, max_log } => {
+            if !min_log.is_finite() || !max_log.is_finite() || max_log <= min_log {
+                return Vec::new();
+            }
+            let mut ticks = vec![(0.0, 0.0)];
+            let min_power = min_log as i32;
+            let max_power = max_log as i32;
+            for power in min_power..=max_power {
+                let value = 10f64.powi(power);
+                ticks.push((value, value_frac(value, axis)));
+            }
+            ticks
+        }
+    }
+}
+
+/// Project a series using a resolved [`YAxis`] mapping.
 ///
 /// Returns an empty string for an empty series; a single-point series renders
 /// as one `x,y` pair at `x = width` (right edge), mirroring the Sparkline
 /// convention so a one-point chart looks consistent across the page.
-pub fn series_points(values: &[f64], width: f32, height: f32, y_min: f64, y_max: f64) -> String {
+pub fn series_points_with_axis(values: &[f64], width: f32, height: f32, axis: &YAxis) -> String {
     if values.is_empty() {
         return String::new();
     }
     if values.len() == 1 {
         let v = values[0];
-        let y = value_to_y(v, y_min, y_max, height);
+        let y = value_to_y(v, axis, height);
         return format!("{:.2},{:.2}", width, y);
     }
     let n = values.len();
@@ -237,21 +329,61 @@ pub fn series_points(values: &[f64], width: f32, height: f32, y_min: f64, y_max:
             out.push(' ');
         }
         let x = step * i as f32;
-        let y = value_to_y(v, y_min, y_max, height);
+        let y = value_to_y(v, axis, height);
         out.push_str(&format!("{:.2},{:.2}", x, y));
     }
     out
 }
 
-fn value_to_y(v: f64, y_min: f64, y_max: f64, height: f32) -> f32 {
-    let span = y_max - y_min;
-    if span.abs() < f64::EPSILON {
-        return height / 2.0;
-    }
-    let clamped = v.clamp(y_min, y_max);
-    let frac = ((clamped - y_min) / span) as f32;
-    // y grows down in SVG, so high values → small y.
+/// Convert a raw value to an SVG y coordinate for `height`.
+pub fn value_to_y(v: f64, axis: &YAxis, height: f32) -> f32 {
+    let frac = value_frac(v, axis);
     height - frac * height
+}
+
+/// Convert a raw value to a normalized y fraction in `[0.0, 1.0]`.
+pub fn value_frac(v: f64, axis: &YAxis) -> f32 {
+    match *axis {
+        YAxis::Linear { min, max, .. } => {
+            let span = max - min;
+            if span.abs() < f64::EPSILON {
+                return 0.5;
+            }
+            let clamped = v.clamp(min, max);
+            ((clamped - min) / span) as f32
+        }
+        YAxis::Log { min_log, max_log } => {
+            if !v.is_finite() || v <= 0.0 {
+                return 0.0;
+            }
+            let span = max_log - min_log;
+            if span.abs() < f64::EPSILON {
+                return 1.0;
+            }
+            let log_frac = ((v.log10() - min_log) / span).clamp(0.0, 1.0) as f32;
+            LOG_ZERO_BAND_FRAC + log_frac * (1.0 - LOG_ZERO_BAND_FRAC)
+        }
+    }
+}
+
+/// Format a y-axis tick value as compactly as possible. Whole numbers drop the
+/// decimal; small fractions keep enough precision to avoid rendering as `0`.
+pub fn format_axis_value(v: f64) -> String {
+    if v == 0.0 {
+        "0".to_string()
+    } else if v.abs() >= 1000.0 {
+        format!("{:.1}k", v / 1000.0)
+    } else if v.fract().abs() < 1e-9 {
+        format!("{}", v as i64)
+    } else if v.abs() >= 1.0 {
+        format!("{:.1}", v)
+    } else if v.abs() >= 0.01 {
+        format!("{:.2}", v)
+    } else if v.abs() >= 0.001 {
+        format!("{:.3}", v)
+    } else {
+        format!("{:.1e}", v)
+    }
 }
 
 #[cfg(test)]
@@ -419,20 +551,51 @@ mod tests {
     }
 
     #[test]
+    fn log_y_axis_reserves_zero_baseline() {
+        let axis = y_axis_for_values(&[0.0, 1.0, 10.0, 100.0], AxisScale::Log);
+        let ticks = y_axis_tick_labels(&axis);
+        assert_eq!(ticks[0], (0.0, 0.0));
+        assert_eq!(value_frac(0.0, &axis), 0.0);
+        assert!(value_frac(1.0, &axis) > 0.0);
+        assert!(value_frac(100.0, &axis) > value_frac(10.0, &axis));
+    }
+
+    #[test]
+    fn log_y_axis_without_positive_values_falls_back_to_linear() {
+        let axis = y_axis_for_values(&[0.0, 0.0], AxisScale::Log);
+        assert!(matches!(axis, YAxis::Linear { .. }));
+    }
+
+    #[test]
     fn series_points_empty_yields_empty_string() {
-        assert_eq!(series_points(&[], 100.0, 50.0, 0.0, 10.0), "");
+        let axis = YAxis::Linear {
+            min: 0.0,
+            max: 10.0,
+            step: 1.0,
+        };
+        assert_eq!(series_points_with_axis(&[], 100.0, 50.0, &axis), "");
     }
 
     #[test]
     fn series_points_single_value_pins_right_edge() {
-        let out = series_points(&[5.0], 100.0, 50.0, 0.0, 10.0);
+        let axis = YAxis::Linear {
+            min: 0.0,
+            max: 10.0,
+            step: 1.0,
+        };
+        let out = series_points_with_axis(&[5.0], 100.0, 50.0, &axis);
         // single point parks at the right edge (mirrors Sparkline)
         assert!(out.starts_with("100.00,"), "got: {out}");
     }
 
     #[test]
     fn series_points_endpoints_anchored() {
-        let out = series_points(&[0.0, 10.0], 100.0, 50.0, 0.0, 10.0);
+        let axis = YAxis::Linear {
+            min: 0.0,
+            max: 10.0,
+            step: 1.0,
+        };
+        let out = series_points_with_axis(&[0.0, 10.0], 100.0, 50.0, &axis);
         let parts: Vec<&str> = out.split_whitespace().collect();
         assert_eq!(parts.len(), 2);
         // First x is 0, last x is 100.
@@ -448,7 +611,12 @@ mod tests {
     #[test]
     fn series_points_clamps_out_of_range() {
         // y_max=10 but value=20 → should clamp to top of chart, not flow off.
-        let out = series_points(&[20.0], 100.0, 50.0, 0.0, 10.0);
+        let axis = YAxis::Linear {
+            min: 0.0,
+            max: 10.0,
+            step: 1.0,
+        };
+        let out = series_points_with_axis(&[20.0], 100.0, 50.0, &axis);
         let parts: Vec<&str> = out.split_whitespace().collect();
         let y: f32 = parts[0].split(',').nth(1).unwrap().parse().unwrap();
         assert!((y - 0.0).abs() < 0.01);

--- a/frontend/src/components/charts/stacked_area.rs
+++ b/frontend/src/components/charts/stacked_area.rs
@@ -8,7 +8,10 @@
 use chrono::{DateTime, Utc};
 use yew::prelude::*;
 
-use super::scale::{nice_y_axis, time_axis_ticks, y_axis_ticks, BucketKind, TickLabel};
+use super::scale::{
+    format_axis_value, time_axis_ticks, value_to_y as scaled_value_to_y, y_axis_for_values,
+    y_axis_tick_labels, AxisScale, BucketKind, TickLabel,
+};
 
 /// One band in the stacked area. Order matters — bands are stacked in vector
 /// order from the bottom upward.
@@ -28,6 +31,7 @@ pub struct StackedAreaProps {
     pub buckets: Vec<DateTime<Utc>>,
     pub bucket_kind: BucketKind,
     pub series: Vec<StackedSeries>,
+    pub axis_scale: AxisScale,
 }
 
 const VIEW_W: f32 = 800.0;
@@ -65,14 +69,14 @@ pub fn stacked_area(props: &StackedAreaProps) -> Html {
             </div>
         };
     }
-    let (y_min, y_max, y_step) = nice_y_axis(0.0, max_total);
+    let y_axis = y_axis_for_values(&totals, props.axis_scale);
 
     let plot_w = VIEW_W - PAD_L - PAD_R;
     let plot_h = VIEW_H - PAD_T - PAD_B;
     let viewbox = format!("0 0 {VIEW_W} {VIEW_H}");
 
     let x_ticks = time_axis_ticks(&props.buckets, props.bucket_kind, 6);
-    let y_ticks = y_axis_ticks(y_min, y_max, y_step);
+    let y_ticks = y_axis_tick_labels(&y_axis);
 
     // Build cumulative bottoms per series. `bottoms[i][b]` is the y-stack
     // floor for series i at bucket b — the previous series' top.
@@ -105,14 +109,14 @@ pub fn stacked_area(props: &StackedAreaProps) -> Html {
                     points.push(' ');
                 }
                 let x = PAD_L + (i as f32 / last_idx) * plot_w;
-                let y = value_to_y(t, y_min, y_max, plot_h);
+                let y = value_to_y(t, &y_axis, plot_h);
                 points.push_str(&format!("{:.2},{:.2}", x, y));
             }
             // bottom, right → left
             for (i, &b) in bottom.iter().enumerate().rev().take(n_buckets) {
                 points.push(' ');
                 let x = PAD_L + (i as f32 / last_idx) * plot_w;
-                let y = value_to_y(b, y_min, y_max, plot_h);
+                let y = value_to_y(b, &y_axis, plot_h);
                 points.push_str(&format!("{:.2},{:.2}", x, y));
             }
             html! {
@@ -145,7 +149,7 @@ pub fn stacked_area(props: &StackedAreaProps) -> Html {
                         class="chart-y-label"
                         text-anchor="end"
                     >
-                        { format_count(*v) }
+                        { format_axis_value(*v) }
                     </text>
                 </>
             }
@@ -187,7 +191,10 @@ pub fn stacked_area(props: &StackedAreaProps) -> Html {
 
     html! {
         <div class="performance-chart">
-            <h3 class="chart-title">{ &props.title }</h3>
+            <div class="chart-header">
+                <h3 class="chart-title">{ &props.title }</h3>
+                <span class="chart-scale-badge">{ props.axis_scale.label() }</span>
+            </div>
             <div class="chart-legend">{ legend }</div>
             <svg
                 class="performance-chart-svg"
@@ -211,24 +218,8 @@ pub fn stacked_area(props: &StackedAreaProps) -> Html {
     }
 }
 
-fn value_to_y(v: f64, y_min: f64, y_max: f64, plot_h: f32) -> f32 {
-    let span = y_max - y_min;
-    if span.abs() < f64::EPSILON {
-        return PAD_T + plot_h;
-    }
-    let clamped = v.clamp(y_min, y_max);
-    let frac = ((clamped - y_min) / span) as f32;
-    PAD_T + plot_h - frac * plot_h
-}
-
-fn format_count(v: f64) -> String {
-    if v.abs() >= 1000.0 {
-        format!("{:.1}k", v / 1000.0)
-    } else if v.fract().abs() < 1e-9 {
-        format!("{}", v as i64)
-    } else {
-        format!("{:.1}", v)
-    }
+fn value_to_y(v: f64, axis: &super::scale::YAxis, plot_h: f32) -> f32 {
+    PAD_T + scaled_value_to_y(v, axis, plot_h)
 }
 
 #[cfg(test)]
@@ -237,9 +228,9 @@ mod tests {
 
     #[test]
     fn format_count_for_axis() {
-        assert_eq!(format_count(0.0), "0");
-        assert_eq!(format_count(5.0), "5");
-        assert_eq!(format_count(2_500.0), "2.5k");
-        assert_eq!(format_count(7.5), "7.5");
+        assert_eq!(format_axis_value(0.0), "0");
+        assert_eq!(format_axis_value(5.0), "5");
+        assert_eq!(format_axis_value(2_500.0), "2.5k");
+        assert_eq!(format_axis_value(7.5), "7.5");
     }
 }

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -18,7 +18,9 @@ use shared::api::{MetricBucket, MetricBucketsResponse};
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
-use crate::components::charts::{BucketKind, LinePlot, LineSeries, StackedArea, StackedSeries};
+use crate::components::charts::{
+    AxisScale, BucketKind, LinePlot, LineSeries, StackedArea, StackedSeries,
+};
 use crate::utils;
 
 /// (agent_type, model, service_tier) tuple used as the group-by key. Codex
@@ -192,6 +194,7 @@ impl GroupBy {
 pub fn performance_panel() -> Html {
     let window = use_state(|| TimeWindow::Days30);
     let group_by = use_state(|| GroupBy::All);
+    let axis_scale = use_state(|| AxisScale::Linear);
     let buckets = use_state(Vec::<MetricBucket>::new);
     let loading = use_state(|| true);
     let error_msg = use_state(|| None::<String>);
@@ -255,6 +258,13 @@ pub fn performance_panel() -> Html {
         })
     };
 
+    let on_axis_scale_change = {
+        let axis_scale = axis_scale.clone();
+        Callback::from(move |scale: AxisScale| {
+            axis_scale.set(scale);
+        })
+    };
+
     let body = if *loading {
         html! {
             <div class="chart-empty">{ "Loading…" }</div>
@@ -270,7 +280,7 @@ pub fn performance_panel() -> Html {
             </div>
         }
     } else {
-        render_charts(&buckets, &group_by, &pairs, *window)
+        render_charts(&buckets, &group_by, &pairs, *window, *axis_scale)
     };
 
     html! {
@@ -330,6 +340,27 @@ pub fn performance_panel() -> Html {
                         }) }
                     </select>
                 </div>
+
+                <div class="performance-scale-group" role="radiogroup">
+                    <span class="performance-control-label">{ "Y scale:" }</span>
+                    { for AxisScale::all().iter().copied().map(|scale| {
+                        let is_active = *axis_scale == scale;
+                        let on_axis_scale_change = on_axis_scale_change.clone();
+                        let on_click = Callback::from(move |_| on_axis_scale_change.emit(scale));
+                        html! {
+                            <button
+                                type="button"
+                                class={classes!(
+                                    "performance-window-button",
+                                    is_active.then_some("active"),
+                                )}
+                                onclick={on_click}
+                            >
+                                { scale.label() }
+                            </button>
+                        }
+                    }) }
+                </div>
             </div>
 
             { body }
@@ -343,6 +374,7 @@ fn render_charts(
     group_by: &GroupBy,
     pairs: &[GroupKey],
     window: TimeWindow,
+    axis_scale: AxisScale,
 ) -> Html {
     let bucket_axis = distinct_bucket_starts(buckets);
     // Resolve the bucket-kind from the same wire param we sent on the request,
@@ -439,6 +471,7 @@ fn render_charts(
                 buckets={bucket_axis.clone()}
                 bucket_kind={bucket_kind}
                 series={throughput_series}
+                axis_scale={axis_scale}
             />
             <LinePlot
                 title="Time to first token"
@@ -446,6 +479,7 @@ fn render_charts(
                 buckets={bucket_axis.clone()}
                 bucket_kind={bucket_kind}
                 series={ttft_series}
+                axis_scale={axis_scale}
             />
             <StackedArea
                 title="Stop-reason mix"
@@ -453,6 +487,7 @@ fn render_charts(
                 buckets={bucket_axis.clone()}
                 bucket_kind={bucket_kind}
                 series={stop_reason_series}
+                axis_scale={axis_scale}
             />
             <LinePlot
                 title="Cache hit rate"
@@ -460,6 +495,7 @@ fn render_charts(
                 buckets={bucket_axis.clone()}
                 bucket_kind={bucket_kind}
                 series={cache_hit_series}
+                axis_scale={axis_scale}
             />
             <LinePlot
                 title="Cost per 1k output tokens"
@@ -467,6 +503,7 @@ fn render_charts(
                 buckets={bucket_axis.clone()}
                 bucket_kind={bucket_kind}
                 series={cost_series}
+                axis_scale={axis_scale}
             />
         </div>
     }

--- a/frontend/styles/performance.css
+++ b/frontend/styles/performance.css
@@ -26,7 +26,8 @@
     margin-right: 0.5rem;
 }
 
-.performance-window-group {
+.performance-window-group,
+.performance-scale-group {
     display: flex;
     align-items: center;
     gap: 0.25rem;
@@ -90,6 +91,23 @@
     color: var(--text-primary);
     font-size: 1rem;
     font-weight: 600;
+}
+
+.chart-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.chart-scale-badge {
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.1rem 0.4rem;
+    font-size: 0.7rem;
+    line-height: 1.2;
+    white-space: nowrap;
 }
 
 .chart-legend {


### PR DESCRIPTION
## Summary
- add a Performance page Y scale control with Linear as the default and Log as the alternate mode
- apply the selected scale to all Performance plots, including line charts and the stop-reason stacked area
- keep zero and non-positive values on a baseline in log mode while scaling positive values by base-10 decades
- bump workspace version to 2.8.17 and update the changelog

## Tests
- cargo fmt --check
- cargo check -p frontend --target wasm32-unknown-unknown
- cargo test -p frontend components::charts::scale
- cargo test -p frontend performance_panel
- npm run lint:css