### PR TITLE
Centralize turn-metrics model validation in shared

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.17"
+version = "2.8.18"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/turn_metrics.rs
+++ b/backend/src/handlers/websocket/turn_metrics.rs
@@ -36,7 +36,7 @@ pub fn handle_turn_metrics_report(
     };
     metrics.session_id = session_id;
 
-    if has_unknown_model(metrics.model.as_deref()) {
+    if !metrics.has_known_model() {
         warn!(
             "Dropping turn metrics for session {} with unknown model (agent={})",
             session_id, metrics.agent_type
@@ -184,13 +184,6 @@ pub fn handle_turn_metrics_report(
             ServerToClient::TurnMetrics(Box::new(payload.clone())),
         );
     }
-}
-
-fn has_unknown_model(model: Option<&str>) -> bool {
-    model.is_none_or(|value| {
-        let value = value.trim();
-        value.is_empty() || value.eq_ignore_ascii_case("unknown")
-    })
 }
 
 // No unit tests here — the persist/broadcast round-trip needs a real

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -202,14 +202,7 @@ pub(crate) async fn claude_io_task(
                                 chrono::Utc::now(),
                                 outcome,
                             ) {
-                                if metrics
-                                    .model
-                                    .as_deref()
-                                    .is_some_and(|m| {
-                                        let m = m.trim();
-                                        !m.is_empty() && !m.eq_ignore_ascii_case("unknown")
-                                    })
-                                {
+                                if metrics.has_known_model() {
                                     let _ = event_tx
                                         .send(IoEvent::TurnMetricsReady(Box::new(metrics)));
                                 } else {

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -367,7 +367,7 @@ pub(crate) async fn codex_io_task(
                                     chrono::Utc::now(),
                                     outcome,
                                 ) {
-                                    if metrics.model.is_some() {
+                                    if metrics.has_known_model() {
                                         let _ = event_tx
                                             .send(IoEvent::TurnMetricsReady(Box::new(metrics)));
                                     } else {

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -712,6 +712,19 @@ pub struct TurnMetrics {
     pub total_cost_usd: Option<f64>,
 }
 
+impl TurnMetrics {
+    /// True when `model` is usable telemetry: present, non-blank, and not the
+    /// literal placeholder `"unknown"`. All three ingest points (Claude
+    /// proxy, Codex proxy, backend persist) warn-and-drop turn metrics that
+    /// fail this check, so the rule must stay identical everywhere.
+    pub fn has_known_model(&self) -> bool {
+        self.model.as_deref().is_some_and(|value| {
+            let value = value.trim();
+            !value.is_empty() && !value.eq_ignore_ascii_case("unknown")
+        })
+    }
+}
+
 // =============================================================================
 // Turn-metrics list endpoint (`GET /api/sessions/{id}/turn-metrics`)
 //
@@ -1030,6 +1043,50 @@ mod tests {
         assert_eq!(json["total_cost_usd"], 0.0145);
         let parsed: TurnMetrics = serde_json::from_value(json).unwrap();
         assert_eq!(parsed, metrics);
+    }
+
+    /// The shared known-model gate: missing, blank, whitespace, and the
+    /// literal `unknown` placeholder (any case) are all rejected; real model
+    /// ids pass.
+    #[test]
+    fn turn_metrics_has_known_model() {
+        let mut metrics = TurnMetrics {
+            id: None,
+            session_id: Uuid::nil(),
+            user_message_id: None,
+            agent_type: "claude".to_string(),
+            model: Some("claude-opus-4-7".to_string()),
+            service_tier: None,
+            started_at: Utc::now(),
+            first_token_at: None,
+            completed_at: None,
+            ttft_ms: None,
+            total_duration_ms: None,
+            generation_duration_ms: None,
+            max_inter_token_gap_ms: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            thinking_tokens: 0,
+            stop_reason: None,
+            is_error: false,
+            tool_call_count: 0,
+            stream_restarts: 0,
+            total_cost_usd: None,
+        };
+        assert!(metrics.has_known_model());
+
+        for bad in [
+            None,
+            Some(""),
+            Some("   "),
+            Some("unknown"),
+            Some("UNKNOWN"),
+        ] {
+            metrics.model = bad.map(str::to_string);
+            assert!(!metrics.has_known_model(), "expected {:?} rejected", bad);
+        }
     }
 
     /// `MetricBucket` round-trip. Claude row with all fields populated; the


### PR DESCRIPTION
Closes #919.

## Summary
- The reject-missing/blank/literal-`unknown` model rule was enforced in three places with three implementations: `claude-session-lib/src/io_task.rs` (inline closure), `codex-session-lib/src/io_task.rs` (only `is_some()` — weaker than the rule), and `backend/.../turn_metrics.rs` (`has_unknown_model`).
- Moved the rule to `TurnMetrics::has_known_model()` in `shared/src/api.rs`, next to the struct, and switched all three ingest points to it. The Codex path now also rejects blank/`unknown` models, matching the stated rule.
- Warn-and-drop behavior preserved at every site.

## Testing
- New `turn_metrics_has_known_model` unit test pins the rule (missing, blank, whitespace, `unknown`, `UNKNOWN` rejected; real ids pass).
- Full workspace test run: 17 suites, 0 failures; clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)