### PR TITLE
Normalize backend handler error mapping via AppError From impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.18"
+version = "2.8.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.18"
+version = "2.8.19"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.18"
+version = "2.8.19"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.18"
+version = "2.8.19"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.18"
+version = "2.8.19"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.18"
+version = "2.8.19"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.18"
+version = "2.8.19"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.18"
+version = "2.8.19"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.18"
+version = "2.8.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.18"
+version = "2.8.19"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.18"
+version = "2.8.19"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -26,15 +26,14 @@ fn reject_disabled_user(user: User) -> Result<User, AppError> {
 /// Disabled users are rejected in both modes so a ban takes effect for existing
 /// browser sessions immediately.
 pub fn extract_user(app_state: &AppState, cookies: &Cookies) -> Result<User, AppError> {
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::users;
 
     if app_state.dev_mode {
         let user = users::table
             .filter(users::email.eq("testing@testing.local"))
-            .first::<User>(&mut conn)
-            .map_err(|e| AppError::DbQuery(e.to_string()))?;
+            .first::<User>(&mut conn)?;
         return reject_disabled_user(user);
     }
 

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -17,6 +17,23 @@ pub enum AppError {
     Internal(String),
 }
 
+/// Blanket Diesel-error conversion so handlers can use `?` directly on
+/// query results. Matches the historical blanket `map_err(|e|
+/// AppError::DbQuery(e.to_string()))` mapping — handlers that want a
+/// different status for `diesel::result::Error::NotFound` keep an explicit
+/// `map_err`/`optional()` at the call site.
+impl From<diesel::result::Error> for AppError {
+    fn from(e: diesel::result::Error) -> Self {
+        AppError::DbQuery(e.to_string())
+    }
+}
+
+impl From<diesel::r2d2::PoolError> for AppError {
+    fn from(_: diesel::r2d2::PoolError) -> Self {
+        AppError::DbPool
+    }
+}
+
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, msg) = match &self {
@@ -47,6 +64,16 @@ impl IntoResponse for AppError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn diesel_errors_convert_to_db_query() {
+        let err: AppError = diesel::result::Error::NotFound.into();
+        assert!(matches!(err, AppError::DbQuery(_)));
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
 
     #[test]
     fn service_unavailable_maps_to_503() {

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -38,7 +38,7 @@ pub async fn require_admin(app_state: &Arc<AppState>, cookies: &Cookies) -> Resu
     let user_id: Uuid = cookie.value().parse().map_err(|_| AppError::Unauthorized)?;
 
     // Fetch user from database
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     let user = schema::users::table
         .find(user_id)
@@ -144,7 +144,7 @@ pub async fn get_stats(
     let admin = require_admin(&app_state, &cookies).await?;
     info!("Admin {} requested system stats", admin.email);
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Query 1: All user counts in one pass
     let user_stats: UserStats = diesel::sql_query(
@@ -221,7 +221,7 @@ pub async fn list_users(
     let admin = require_admin(&app_state, &cookies).await?;
     info!("Admin {} requested user list", admin.email);
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Get all users
     let users: Vec<User> = schema::users::table
@@ -292,7 +292,7 @@ pub async fn update_user(
         ));
     }
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Get target user for logging
     let target_user: User = schema::users::table
@@ -402,7 +402,7 @@ pub async fn list_sessions(
     let admin = require_admin(&app_state, &cookies).await?;
     info!("Admin {} requested sessions list", admin.email);
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Get all sessions with user email
     let results: Vec<(crate::models::Session, String)> = schema::sessions::table
@@ -449,7 +449,7 @@ pub async fn delete_session(
 ) -> Result<EmptyResponse, AppError> {
     let admin = require_admin(&app_state, &cookies).await?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Get session info for logging and cost tracking
     let session: crate::models::Session = schema::sessions::table

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -47,7 +47,7 @@ pub async fn device_login(
     if app_state.oauth_basic_client.is_none() {
         use crate::schema::users::dsl::*;
 
-        let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+        let mut conn = app_state.db_pool.get()?;
 
         let user = users
             .filter(email.eq("testing@testing.local"))
@@ -135,7 +135,7 @@ pub async fn callback(
     }
 
     // Save or update user in database
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::users::dsl::*;
 
@@ -216,7 +216,7 @@ pub async fn dev_login(
 ) -> Result<impl IntoResponse, AppError> {
     use crate::schema::users::dsl::*;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     let user = users
         .filter(email.eq("testing@testing.local"))

--- a/backend/src/handlers/files.rs
+++ b/backend/src/handlers/files.rs
@@ -118,7 +118,7 @@ fn verify_session_read_access(
     session_id: Uuid,
     user_id: Uuid,
 ) -> Result<(), AppError> {
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
     use crate::schema::{session_members, sessions};
 
     let is_owner = sessions::table
@@ -126,8 +126,7 @@ fn verify_session_read_access(
         .filter(sessions::user_id.eq(user_id))
         .select(sessions::id)
         .first::<Uuid>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?
+        .optional()?
         .is_some();
     if is_owner {
         return Ok(());
@@ -138,8 +137,7 @@ fn verify_session_read_access(
         .filter(session_members::user_id.eq(user_id))
         .select(session_members::id)
         .first::<Uuid>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?
+        .optional()?
         .map(|_| ())
         .ok_or(AppError::NotFound("Session not found"))
 }

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -94,7 +94,7 @@ pub async fn launch_session(
             .session_manager
             .pending_launch_sessions
             .remove(&request_id);
-        let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+        let mut conn = app_state.db_pool.get()?;
         use crate::schema::sessions;
         let _ = diesel::delete(sessions::table.find(session_id)).execute(&mut conn);
         error!("Failed to send launch request to launcher {}", launcher_id);
@@ -135,7 +135,7 @@ pub(crate) fn create_desired_session(
     app_state: &AppState,
     draft: DesiredSessionDraft,
 ) -> Result<(), AppError> {
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::{session_members, sessions};
     use diesel::prelude::*;
@@ -162,8 +162,7 @@ pub(crate) fn create_desired_session(
 
     diesel::insert_into(sessions::table)
         .values(&new_session)
-        .execute(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .execute(&mut conn)?;
 
     diesel::insert_into(session_members::table)
         .values(NewSessionMember {
@@ -171,8 +170,7 @@ pub(crate) fn create_desired_session(
             user_id: draft.user_id,
             role: "owner".to_string(),
         })
-        .execute(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .execute(&mut conn)?;
 
     Ok(())
 }
@@ -291,15 +289,12 @@ pub async fn list_directories(
 }
 
 pub(crate) fn mint_launch_token(app_state: &AppState, user_id: Uuid) -> Result<String, AppError> {
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::users;
     use diesel::prelude::*;
 
-    let user: crate::models::User = users::table
-        .find(user_id)
-        .first(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+    let user: crate::models::User = users::table.find(user_id).first(&mut conn)?;
 
     let token_id = Uuid::new_v4();
     // Launch tokens never expire. The token is bound to its session at proxy
@@ -326,8 +321,7 @@ pub(crate) fn mint_launch_token(app_state: &AppState, user_id: Uuid) -> Result<S
     use crate::schema::proxy_auth_tokens;
     diesel::insert_into(proxy_auth_tokens::table)
         .values(&new_token)
-        .execute(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .execute(&mut conn)?;
 
     Ok(token)
 }

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -133,7 +133,7 @@ pub async fn create_message(
 ) -> Result<Json<MessageResponse>, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Creating a message is a mutation — require editor/owner role (or the
     // session-row owner). See `session_access` for the layered rules.
@@ -149,8 +149,7 @@ pub async fn create_message(
 
     let message: Message = diesel::insert_into(messages::table)
         .values(&new_message)
-        .get_result(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .get_result(&mut conn)?;
 
     app_state.session_manager.queue_truncation(session_id);
 
@@ -179,7 +178,7 @@ pub async fn list_messages(
 ) -> Result<Json<MessagesListResponse>, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     let _session = verify_session_access(&mut conn, session_id, current_user_id)?;
 
@@ -230,8 +229,7 @@ pub async fn list_messages(
             .filter(messages::created_at.gt(after))
             .order(messages::created_at.asc())
             .limit(limit)
-            .load(&mut conn)
-            .map_err(|e| AppError::DbQuery(e.to_string()))?
+            .load(&mut conn)?
     } else {
         let mut query = messages::table
             .filter(messages::session_id.eq(session_id))
@@ -242,8 +240,7 @@ pub async fn list_messages(
         let mut newest_first: Vec<Message> = query
             .order(messages::created_at.desc())
             .limit(limit)
-            .load(&mut conn)
-            .map_err(|e| AppError::DbQuery(e.to_string()))?;
+            .load(&mut conn)?;
         newest_first.reverse();
         newest_first
     };

--- a/backend/src/handlers/proxy_tokens.rs
+++ b/backend/src/handlers/proxy_tokens.rs
@@ -5,7 +5,6 @@
 
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
     Json,
 };
 use diesel::prelude::*;
@@ -35,14 +34,11 @@ pub async fn create_token_handler(
 ) -> Result<Json<CreateProxyTokenResponse>, AppError> {
     let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Get user email for JWT claims
     use crate::schema::users;
-    let user: User = users::table
-        .find(user_id)
-        .first(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+    let user: User = users::table.find(user_id).first(&mut conn)?;
 
     // Generate token ID
     let token_id = Uuid::new_v4();
@@ -74,8 +70,7 @@ pub async fn create_token_handler(
 
     let saved_token: ProxyAuthToken = diesel::insert_into(proxy_auth_tokens::table)
         .values(&new_token)
-        .get_result(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .get_result(&mut conn)?;
 
     // Build init URL
     let config = ProxyInitConfig {
@@ -104,13 +99,12 @@ pub async fn list_tokens_handler(
 ) -> Result<Json<ProxyTokenListResponse>, AppError> {
     let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     let tokens: Vec<ProxyAuthToken> = proxy_auth_tokens::table
         .filter(proxy_auth_tokens::user_id.eq(user_id))
         .order(proxy_auth_tokens::created_at.desc())
-        .load(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .load(&mut conn)?;
 
     let token_infos: Vec<ProxyTokenInfo> = tokens
         .into_iter()
@@ -137,7 +131,7 @@ pub async fn revoke_token_handler(
 ) -> Result<EmptyResponse, AppError> {
     let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Update token to revoked (only if owned by user)
     let updated = diesel::update(
@@ -146,8 +140,7 @@ pub async fn revoke_token_handler(
             .filter(proxy_auth_tokens::user_id.eq(user_id)),
     )
     .set(proxy_auth_tokens::revoked.eq(true))
-    .execute(&mut conn)
-    .map_err(|e| AppError::DbQuery(e.to_string()))?;
+    .execute(&mut conn)?;
 
     if updated == 0 {
         return Err(AppError::NotFound("proxy token"));
@@ -166,7 +159,7 @@ pub async fn renew_token_handler(
 ) -> Result<Json<CreateProxyTokenResponse>, AppError> {
     let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     let existing: ProxyAuthToken = proxy_auth_tokens::table
         .filter(proxy_auth_tokens::id.eq(token_id))
@@ -179,10 +172,7 @@ pub async fn renew_token_handler(
     }
 
     use crate::schema::users;
-    let user: User = users::table
-        .find(user_id)
-        .first(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+    let user: User = users::table.find(user_id).first(&mut conn)?;
 
     let new_token_id = Uuid::new_v4();
     let expires_at = chrono::Utc::now() + chrono::Duration::days(req.expires_in_days as i64);
@@ -208,8 +198,7 @@ pub async fn renew_token_handler(
         proxy_auth_tokens::token_hash.eq(&token_hash),
         proxy_auth_tokens::expires_at.eq(Some(expires_at.naive_utc())),
     ))
-    .execute(&mut conn)
-    .map_err(|e| AppError::DbQuery(e.to_string()))?;
+    .execute(&mut conn)?;
 
     let config = ProxyInitConfig {
         token: token.clone(),
@@ -239,12 +228,12 @@ pub fn verify_and_get_user(
     app_state: &AppState,
     conn: &mut diesel::pg::PgConnection,
     token: &str,
-) -> Result<(Uuid, String), StatusCode> {
+) -> Result<(Uuid, String), AppError> {
     // First verify JWT signature and expiration
     let claims =
         crate::jwt::verify_proxy_token(app_state.jwt_secret.as_bytes(), token).map_err(|e| {
             error!("JWT verification failed: {}", e);
-            StatusCode::UNAUTHORIZED
+            AppError::Unauthorized
         })?;
 
     // Then check database for revocation
@@ -254,13 +243,13 @@ pub fn verify_and_get_user(
         .first(conn)
         .map_err(|_| {
             error!("Token not found in database");
-            StatusCode::UNAUTHORIZED
+            AppError::Unauthorized
         })?;
 
     // Check if revoked
     if db_token.revoked {
         error!("Token has been revoked");
-        return Err(StatusCode::UNAUTHORIZED);
+        return Err(AppError::Unauthorized);
     }
 
     // Check if expired (belt and suspenders - JWT already checked this).
@@ -270,7 +259,7 @@ pub fn verify_and_get_user(
         let now = chrono::Utc::now().naive_utc();
         if expires_at < now {
             error!("Token has expired");
-            return Err(StatusCode::UNAUTHORIZED);
+            return Err(AppError::Unauthorized);
         }
     }
 
@@ -278,12 +267,12 @@ pub fn verify_and_get_user(
     use crate::schema::users;
     let user: crate::models::User = users::table.find(claims.sub).first(conn).map_err(|_| {
         error!("User not found for token");
-        StatusCode::UNAUTHORIZED
+        AppError::Unauthorized
     })?;
 
     if user.disabled {
         error!("Token belongs to banned user: {}", user.email);
-        return Err(StatusCode::FORBIDDEN);
+        return Err(AppError::Forbidden);
     }
 
     // Update last_used_at

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -109,13 +109,12 @@ pub async fn list_tasks_handler(
 ) -> Result<Json<ScheduledTaskListResponse>, AppError> {
     let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     let tasks: Vec<ScheduledTask> = scheduled_tasks::table
         .filter(scheduled_tasks::user_id.eq(user_id))
         .order(scheduled_tasks::created_at.desc())
-        .load(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .load(&mut conn)?;
 
     let infos: Vec<ScheduledTaskInfo> = tasks.into_iter().map(task_to_info).collect();
     Ok(Json(ScheduledTaskListResponse { tasks: infos }))
@@ -136,7 +135,7 @@ pub async fn create_task_handler(
         return Err(AppError::Internal("Invalid cron expression".to_string()));
     }
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     let new_task = NewScheduledTask {
         user_id,
@@ -153,8 +152,7 @@ pub async fn create_task_handler(
 
     let saved: ScheduledTask = diesel::insert_into(scheduled_tasks::table)
         .values(&new_task)
-        .get_result(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .get_result(&mut conn)?;
 
     info!("Created scheduled task '{}' ({})", saved.name, saved.id);
 
@@ -173,7 +171,7 @@ pub async fn update_task_handler(
 ) -> Result<Json<ScheduledTaskInfo>, AppError> {
     let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Verify ownership
     let existing: ScheduledTask = scheduled_tasks::table
@@ -232,8 +230,7 @@ pub async fn update_task_handler(
         scheduled_tasks::max_runtime_minutes.eq(max_runtime_minutes),
         scheduled_tasks::updated_at.eq(diesel::dsl::now),
     ))
-    .get_result(&mut conn)
-    .map_err(|e| AppError::DbQuery(e.to_string()))?;
+    .get_result(&mut conn)?;
 
     info!("Updated scheduled task '{}' ({})", updated.name, updated.id);
 
@@ -251,7 +248,7 @@ pub async fn delete_task_handler(
 ) -> Result<EmptyResponse, AppError> {
     let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Verify ownership
     let task: ScheduledTask = scheduled_tasks::table
@@ -267,8 +264,7 @@ pub async fn delete_task_handler(
         .execute(&mut conn);
 
     diesel::delete(scheduled_tasks::table.filter(scheduled_tasks::id.eq(task_id)))
-        .execute(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .execute(&mut conn)?;
 
     info!("Deleted scheduled task '{}' ({})", task.name, task_id);
 
@@ -286,7 +282,7 @@ pub async fn list_runs_handler(
 ) -> Result<Json<serde_json::Value>, AppError> {
     let user_id = crate::auth::extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Verify task ownership
     let _task: ScheduledTask = scheduled_tasks::table
@@ -300,8 +296,7 @@ pub async fn list_runs_handler(
         .filter(sessions::scheduled_task_id.eq(task_id))
         .order(sessions::created_at.desc())
         .limit(50)
-        .load(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .load(&mut conn)?;
 
     Ok(Json(serde_json::to_value(runs).unwrap_or_default()))
 }

--- a/backend/src/handlers/session_access.rs
+++ b/backend/src/handlers/session_access.rs
@@ -47,8 +47,7 @@ pub fn verify_session_mutator(
         .filter(sessions::user_id.eq(user_id))
         .select(crate::models::Session::as_select())
         .first::<crate::models::Session>(conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?
+        .optional()?
     {
         return Ok(session);
     }
@@ -65,8 +64,7 @@ pub fn verify_session_mutator(
         )
         .select(crate::models::Session::as_select())
         .first::<crate::models::Session>(conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?
+        .optional()?
         .ok_or(AppError::NotFound("Session not found"))
 }
 

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -48,7 +48,7 @@ pub async fn list_sessions(
 ) -> Result<Json<SessionListResponse>, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::{session_members, sessions};
 
@@ -58,8 +58,7 @@ pub async fn list_sessions(
         .filter(sessions::status.ne("replaced"))
         .select((Session::as_select(), session_members::role))
         .order(sessions::last_activity.desc())
-        .load(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .load(&mut conn)?;
 
     let sessions_with_role = results
         .into_iter()
@@ -78,7 +77,7 @@ pub async fn resolve_proxy_session(
     State(app_state): State<Arc<AppState>>,
     Json(req): Json<ResolveProxySessionRequest>,
 ) -> Result<Json<ResolveProxySessionResponse>, AppError> {
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
     let current_user_id = proxy_request_user_id(&app_state, &mut conn, req.auth_token.as_deref())?;
 
     use crate::schema::{session_members, sessions};
@@ -101,8 +100,7 @@ pub async fn resolve_proxy_session(
     let session = query
         .order((sessions::last_activity.desc(), sessions::created_at.desc()))
         .first::<Session>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .optional()?;
 
     Ok(Json(match session {
         Some(session) => ResolveProxySessionResponse {
@@ -129,19 +127,14 @@ fn proxy_request_user_id(
 
     if let Some(token) = auth_token {
         return crate::handlers::proxy_tokens::verify_and_get_user(app_state, conn, token)
-            .map(|(user_id, _)| user_id)
-            .map_err(|status| match status {
-                axum::http::StatusCode::FORBIDDEN => AppError::Forbidden,
-                _ => AppError::Unauthorized,
-            });
+            .map(|(user_id, _)| user_id);
     }
 
     if app_state.dev_mode {
-        return users::table
+        return Ok(users::table
             .filter(users::email.eq("testing@testing.local"))
             .select(users::id)
-            .first::<Uuid>(conn)
-            .map_err(|e| AppError::DbQuery(e.to_string()));
+            .first::<Uuid>(conn)?);
     }
 
     Err(AppError::Unauthorized)
@@ -160,7 +153,7 @@ pub async fn get_session(
 ) -> Result<Json<SessionDetailResponse>, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::{messages, session_members, sessions};
 
@@ -170,16 +163,14 @@ pub async fn get_session(
         .filter(session_members::user_id.eq(current_user_id))
         .select(Session::as_select())
         .first::<Session>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?
+        .optional()?
         .ok_or(AppError::NotFound("Session not found"))?;
 
     let recent_messages = messages::table
         .filter(messages::session_id.eq(session_id))
         .order(messages::created_at.desc())
         .limit(50)
-        .load::<Message>(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .load::<Message>(&mut conn)?;
 
     Ok(Json(SessionDetailResponse {
         session,
@@ -194,7 +185,7 @@ pub async fn delete_session(
 ) -> Result<EmptyResponse, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::{session_members, sessions};
 
@@ -207,8 +198,7 @@ pub async fn delete_session(
         .filter(sessions::user_id.eq(current_user_id))
         .select(Session::as_select())
         .first::<Session>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .optional()?;
 
     let session = match owned_by_user {
         Some(s) => s,
@@ -219,8 +209,7 @@ pub async fn delete_session(
             .filter(session_members::role.eq("owner"))
             .select(Session::as_select())
             .first::<Session>(&mut conn)
-            .optional()
-            .map_err(|e| AppError::DbQuery(e.to_string()))?
+            .optional()?
             .ok_or(AppError::NotFound("Session not found"))?,
     };
 
@@ -244,7 +233,7 @@ pub async fn stop_session(
 ) -> Result<EmptyResponse, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     // Stopping a session is a mutation — viewer-role members must not be
     // able to terminate sessions they only have read access to. The helper
@@ -271,8 +260,7 @@ pub async fn stop_session(
                 sessions::status.eq("disconnected"),
                 sessions::updated_at.eq(diesel::dsl::now),
             ))
-            .execute(&mut conn)
-            .map_err(|e| AppError::DbQuery(e.to_string()))?;
+            .execute(&mut conn)?;
         Ok(EmptyResponse::ACCEPTED)
     } else if session.paused {
         Err(AppError::NotFound("Launcher not connected"))
@@ -288,7 +276,7 @@ pub async fn pause_session(
 ) -> Result<EmptyResponse, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
     crate::handlers::session_access::verify_session_mutator(
         &mut conn,
         session_id,
@@ -302,8 +290,7 @@ pub async fn pause_session(
             sessions::status.eq("disconnected"),
             sessions::updated_at.eq(diesel::dsl::now),
         ))
-        .execute(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .execute(&mut conn)?;
 
     app_state.session_manager.disconnect_session(session_id);
     app_state
@@ -320,7 +307,7 @@ pub async fn resume_session(
 ) -> Result<EmptyResponse, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
     let session = crate::handlers::session_access::verify_session_mutator(
         &mut conn,
         session_id,
@@ -345,8 +332,7 @@ pub async fn resume_session(
             sessions::paused.eq(false),
             sessions::updated_at.eq(diesel::dsl::now),
         ))
-        .execute(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .execute(&mut conn)?;
 
     let launch_msg = shared::ServerToLauncher::LaunchSession {
         request_id,
@@ -431,7 +417,7 @@ pub async fn list_session_members(
 ) -> Result<Json<SessionMembersResponse>, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::{session_members, users};
 
@@ -439,8 +425,7 @@ pub async fn list_session_members(
         .filter(session_members::session_id.eq(session_id))
         .filter(session_members::user_id.eq(current_user_id))
         .first::<SessionMember>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?
+        .optional()?
         .ok_or(AppError::NotFound("Session not found"))?;
 
     let members: Vec<(SessionMember, UserBasicInfo)> = session_members::table
@@ -450,8 +435,7 @@ pub async fn list_session_members(
             SessionMember::as_select(),
             (users::id, users::email, users::name),
         ))
-        .load(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .load(&mut conn)?;
 
     let member_infos = members
         .into_iter()
@@ -482,7 +466,7 @@ pub async fn add_session_member(
         return Err(AppError::Internal("Invalid role".to_string()));
     }
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::{session_members, users};
 
@@ -491,24 +475,21 @@ pub async fn add_session_member(
         .filter(session_members::user_id.eq(current_user_id))
         .filter(session_members::role.eq("owner"))
         .first::<SessionMember>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?
+        .optional()?
         .ok_or(AppError::Forbidden)?;
 
     let target_user_id: Uuid = users::table
         .filter(users::email.eq(&req.email))
         .select(users::id)
         .first(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?
+        .optional()?
         .ok_or(AppError::NotFound("User not found"))?;
 
     let existing = session_members::table
         .filter(session_members::session_id.eq(session_id))
         .filter(session_members::user_id.eq(target_user_id))
         .first::<SessionMember>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .optional()?;
 
     if existing.is_some() {
         return Err(AppError::Internal("User is already a member".to_string()));
@@ -522,8 +503,7 @@ pub async fn add_session_member(
 
     diesel::insert_into(session_members::table)
         .values(&new_member)
-        .execute(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .execute(&mut conn)?;
 
     Ok(EmptyResponse::CREATED)
 }
@@ -537,7 +517,7 @@ pub async fn remove_session_member(
 ) -> Result<EmptyResponse, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::session_members;
 
@@ -545,8 +525,7 @@ pub async fn remove_session_member(
         .filter(session_members::session_id.eq(session_id))
         .filter(session_members::user_id.eq(current_user_id))
         .first::<SessionMember>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?
+        .optional()?
         .ok_or(AppError::NotFound("Session not found"))?;
 
     let is_owner = current_membership.role == "owner";
@@ -566,8 +545,7 @@ pub async fn remove_session_member(
             .filter(session_members::session_id.eq(session_id))
             .filter(session_members::user_id.eq(target_user_id)),
     )
-    .execute(&mut conn)
-    .map_err(|e| AppError::DbQuery(e.to_string()))?;
+    .execute(&mut conn)?;
 
     if deleted == 0 {
         return Err(AppError::NotFound("Member not found"));
@@ -589,7 +567,7 @@ pub async fn update_session_member_role(
         return Err(AppError::Internal("Invalid role".to_string()));
     }
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::session_members;
 
@@ -598,8 +576,7 @@ pub async fn update_session_member_role(
         .filter(session_members::user_id.eq(current_user_id))
         .filter(session_members::role.eq("owner"))
         .first::<SessionMember>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?
+        .optional()?
         .ok_or(AppError::Forbidden)?;
 
     if current_user_id == target_user_id {
@@ -612,8 +589,7 @@ pub async fn update_session_member_role(
             .filter(session_members::user_id.eq(target_user_id)),
     )
     .set(session_members::role.eq(&req.role))
-    .execute(&mut conn)
-    .map_err(|e| AppError::DbQuery(e.to_string()))?;
+    .execute(&mut conn)?;
 
     if updated == 0 {
         return Err(AppError::NotFound("Member not found"));

--- a/backend/src/handlers/sound_settings.rs
+++ b/backend/src/handlers/sound_settings.rs
@@ -15,14 +15,13 @@ pub async fn get_sound_settings(
 ) -> Result<Json<SoundSettingsResponse>, AppError> {
     let user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::users;
     let sound_config: Option<serde_json::Value> = users::table
         .find(user_id)
         .select(users::sound_config)
-        .first(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .first(&mut conn)?;
 
     Ok(Json(SoundSettingsResponse { sound_config }))
 }
@@ -34,13 +33,12 @@ pub async fn save_sound_settings(
 ) -> Result<EmptyResponse, AppError> {
     let user_id = extract_user_id(&app_state, &cookies)?;
 
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::users;
     diesel::update(users::table.find(user_id))
         .set(users::sound_config.eq(Some(config)))
-        .execute(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .execute(&mut conn)?;
 
     Ok(EmptyResponse::OK)
 }

--- a/backend/src/handlers/turn_metrics.rs
+++ b/backend/src/handlers/turn_metrics.rs
@@ -49,8 +49,7 @@ fn verify_session_access(
         .filter(session_members::user_id.eq(user_id))
         .select(sessions::id)
         .first::<uuid::Uuid>(conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .optional()?;
     if exists.is_none() {
         return Err(AppError::NotFound("Session not found"));
     }
@@ -104,7 +103,7 @@ pub async fn list_turn_metrics(
     Path(session_id): Path<uuid::Uuid>,
 ) -> Result<Json<TurnMetricsResponse>, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     verify_session_access(&mut conn, session_id, current_user_id)?;
 
@@ -113,8 +112,7 @@ pub async fn list_turn_metrics(
         .filter(turn_metrics::session_id.eq(session_id))
         .order(turn_metrics::started_at.asc())
         .select(TurnMetric::as_select())
-        .load(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .load(&mut conn)?;
 
     let metrics = rows.into_iter().map(row_to_wire).collect();
     Ok(Json(TurnMetricsResponse { metrics }))
@@ -143,7 +141,7 @@ pub async fn list_recent_user_turn_metrics(
     cookies: Cookies,
 ) -> Result<Json<TurnMetricsResponse>, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     use crate::schema::turn_metrics;
     let mut rows: Vec<TurnMetric> = turn_metrics::table
@@ -151,8 +149,7 @@ pub async fn list_recent_user_turn_metrics(
         .order(turn_metrics::started_at.desc())
         .limit(RECENT_TURN_LIMIT)
         .select(TurnMetric::as_select())
-        .load(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .load(&mut conn)?;
 
     // SQL gave us newest-first; flip to oldest-first so the sparkline reads
     // left→right oldest→newest without a second pass on the frontend.
@@ -326,7 +323,7 @@ pub async fn list_aggregated_turn_metrics(
     Query(query): Query<TurnMetricsAggregateQuery>,
 ) -> Result<Json<MetricBucketsResponse>, AppError> {
     let current_user_id = extract_user_id(&app_state, &cookies)?;
-    let mut conn = app_state.db_pool.get().map_err(|_| AppError::DbPool)?;
+    let mut conn = app_state.db_pool.get()?;
 
     let bucket = parse_bucket(query.bucket.as_deref())?;
     let interval = parse_window_to_interval(query.window.as_deref())?;
@@ -375,8 +372,7 @@ pub async fn list_aggregated_turn_metrics(
         .bind::<Text, _>(bucket.as_interval())
         .bind::<diesel::sql_types::Uuid, _>(current_user_id)
         .bind::<Text, _>(&interval)
-        .load(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .load(&mut conn)?;
 
     // Stop-reason mix runs as a separate `GROUP BY` so the main query stays
     // one-row-per-(bucket, group). Folds error rows under the `"error"` key
@@ -403,8 +399,7 @@ pub async fn list_aggregated_turn_metrics(
         .bind::<Text, _>(bucket.as_interval())
         .bind::<diesel::sql_types::Uuid, _>(current_user_id)
         .bind::<Text, _>(&interval)
-        .load(&mut conn)
-        .map_err(|e| AppError::DbQuery(e.to_string()))?;
+        .load(&mut conn)?;
 
     // Fold the stop-reason rows by `(bucket_start, agent_type, model, tier)`
     // into a histogram keyed by `reason_key`.


### PR DESCRIPTION
Closes #864.

## Summary
- Add `From<diesel::result::Error>` and `From<diesel::r2d2::PoolError>` impls for `AppError`, matching the historical blanket mappings (`DbQuery(e.to_string())` / `DbPool`).
- Replace ~90 mechanical `map_err` calls with `?` across 13 backend files. Handlers that special-case `NotFound` (via `.optional()` or explicit `map_err`) are untouched.
- Convert `proxy_tokens::verify_and_get_user` — the last helper returning raw `StatusCode` — to `Result<_, AppError>` (`Unauthorized`/`Forbidden`), and drop the now-redundant status re-mapping in its `sessions.rs` caller. The other three callers only match on `Ok`/`Err` so they're unaffected.
- Net −34 lines; error semantics and response bodies unchanged.

## Testing
- New `diesel_errors_convert_to_db_query` test pins the From conversion → 500.
- Backend: 109 tests pass; workspace clippy clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)