### PR TITLE
Reduce clone traffic on websocket broadcast hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.19"
+version = "2.8.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.19"
+version = "2.8.20"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.19"
+version = "2.8.20"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.19"
+version = "2.8.20"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.19"
+version = "2.8.20"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.19"
+version = "2.8.20"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.19"
+version = "2.8.20"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.19"
+version = "2.8.20"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.19"
+version = "2.8.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.19"
+version = "2.8.20"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.19"
+version = "2.8.20"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -1,6 +1,7 @@
 use super::{ProxySender, SessionManager};
 use crate::db::DbPool;
 use diesel::prelude::*;
+use serde::Deserialize;
 use shared::{AgentType, SendMode, ServerToClient, ServerToProxy};
 use tracing::{error, info, warn};
 use uuid::Uuid;
@@ -139,7 +140,7 @@ pub fn handle_claude_output(
     };
 
     // Validate that content roundtrips through ClaudeOutput parsing (frontend depends on this)
-    match serde_json::from_value::<shared::ClaudeOutput>(content.clone()) {
+    match shared::ClaudeOutput::deserialize(&content) {
         Ok(parsed) => {
             if let shared::ClaudeOutput::System(ref sys) = parsed {
                 if sys.is_task_started() && sys.as_task_started().is_none() {
@@ -291,7 +292,7 @@ pub fn handle_claude_output(
         session_manager.broadcast_to_web_clients(
             key,
             ServerToClient::ClaudeOutput {
-                content: content.clone(),
+                content,
                 sender_user_id: sender_info.as_ref().map(|(id, _)| id.to_string()),
                 sender_name: sender_info.as_ref().map(|(_, name)| name.clone()),
                 agent_type,
@@ -312,7 +313,7 @@ fn store_result_metadata(
     use crate::schema::sessions;
 
     // Try typed deserialization first
-    if let Ok(result) = serde_json::from_value::<claude_codes::io::ResultMessage>(content.clone()) {
+    if let Ok(result) = claude_codes::io::ResultMessage::deserialize(content) {
         if let Err(e) = diesel::update(sessions::table.find(session_id))
             .set(sessions::total_cost_usd.eq(result.total_cost_usd))
             .execute(conn)

--- a/backend/src/handlers/websocket/session_manager.rs
+++ b/backend/src/handlers/websocket/session_manager.rs
@@ -30,6 +30,27 @@ pub type SessionId = String;
 pub type ProxySender = mpsc::UnboundedSender<ServerToProxy>;
 pub type WebClientSender = mpsc::UnboundedSender<ServerToClient>;
 
+/// Fan a message out to every sender in `clients`, pruning senders whose
+/// channel has closed. The message is moved (not cloned) into the final
+/// send, so the common single-client case never deep-copies the payload.
+fn fanout_to_clients(clients: &mut Vec<WebClientSender>, msg: ServerToClient) {
+    let mut msg = Some(msg);
+    let mut idx = 0;
+    while idx < clients.len() {
+        let payload = if idx + 1 == clients.len() {
+            msg.take()
+        } else {
+            msg.clone()
+        };
+        let Some(payload) = payload else { return };
+        if clients[idx].send(payload).is_ok() {
+            idx += 1;
+        } else {
+            clients.remove(idx);
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct SessionManager {
     pub sessions: Arc<DashMap<SessionId, ProxySender>>,
@@ -169,16 +190,20 @@ impl SessionManager {
 
     pub fn broadcast_to_web_clients(&self, session_key: &SessionId, msg: ServerToClient) {
         if let Some(mut clients) = self.web_clients.get_mut(session_key) {
-            clients.retain(|sender| sender.send(msg.clone()).is_ok());
+            fanout_to_clients(clients.value_mut(), msg);
         }
     }
 
     pub fn send_to_session(&self, session_key: &SessionId, msg: ServerToProxy) -> bool {
-        if let Some(sender) = self.sessions.get(session_key) {
-            if sender.send(msg.clone()).is_ok() {
-                return true;
-            }
-        }
+        let msg = match self.sessions.get(session_key) {
+            Some(sender) => match sender.send(msg) {
+                Ok(()) => return true,
+                // A closed channel hands the message back in the error, so
+                // there's no need to clone up front just in case.
+                Err(mpsc::error::SendError(msg)) => msg,
+            },
+            None => msg,
+        };
 
         self.queue_pending_message(session_key, msg)
     }
@@ -226,7 +251,7 @@ impl SessionManager {
 
     pub fn broadcast_to_user(&self, user_id: &Uuid, msg: ServerToClient) {
         if let Some(mut clients) = self.user_clients.get_mut(user_id) {
-            clients.retain(|sender| sender.send(msg.clone()).is_ok());
+            fanout_to_clients(clients.value_mut(), msg);
         }
     }
 
@@ -249,14 +274,10 @@ impl SessionManager {
             reconnect_delay_ms,
         };
         for mut entry in self.web_clients.iter_mut() {
-            entry
-                .value_mut()
-                .retain(|sender| sender.send(client_msg.clone()).is_ok());
+            fanout_to_clients(entry.value_mut(), client_msg.clone());
         }
         for mut entry in self.user_clients.iter_mut() {
-            entry
-                .value_mut()
-                .retain(|sender| sender.send(client_msg.clone()).is_ok());
+            fanout_to_clients(entry.value_mut(), client_msg.clone());
         }
 
         let launcher_msg = ServerToLauncher::ServerShutdown {
@@ -509,6 +530,60 @@ mod tests {
 
         let clients = mgr.web_clients.get("s1").unwrap();
         assert_eq!(clients.len(), 1);
+    }
+
+    #[test]
+    fn broadcast_delivers_when_last_client_closed() {
+        // The fanout moves the payload into the final send; make sure a
+        // closed channel in that last slot still prunes correctly and the
+        // open clients before it were already served.
+        let mgr = SessionManager::new();
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        let (tx3, rx3) = mpsc::unbounded_channel();
+
+        mgr.add_web_client("s1".into(), tx1);
+        mgr.add_web_client("s1".into(), tx2);
+        mgr.add_web_client("s1".into(), tx3);
+
+        drop(rx3);
+
+        mgr.broadcast_to_web_clients(&"s1".into(), make_client_msg());
+
+        assert!(matches!(
+            rx1.try_recv().unwrap(),
+            ServerToClient::ClaudeOutput { .. }
+        ));
+        assert!(matches!(
+            rx2.try_recv().unwrap(),
+            ServerToClient::ClaudeOutput { .. }
+        ));
+        let clients = mgr.web_clients.get("s1").unwrap();
+        assert_eq!(clients.len(), 2);
+    }
+
+    #[test]
+    fn send_to_session_queues_message_returned_by_closed_channel() {
+        let mgr = SessionManager::new();
+        let (tx, rx) = mpsc::unbounded_channel();
+        mgr.register_session("s1".into(), tx);
+        drop(rx);
+
+        let queued = mgr.send_to_session(
+            &"s1".into(),
+            ServerToProxy::OutputAck {
+                session_id: Uuid::nil(),
+                ack_seq: 7,
+            },
+        );
+
+        assert!(queued);
+        let pending = mgr.pending_messages.get("s1").unwrap();
+        assert_eq!(pending.len(), 1);
+        assert!(matches!(
+            pending.front().unwrap().msg,
+            ServerToProxy::OutputAck { ack_seq: 7, .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #923.

## Summary
Audited the `ServerToClient` fanout paths. The `ws-bridge` sink consumes owned messages, so a full `Arc<ServerToClient>` channel would just move the deep clone to the final hop (and add an `Arc` clone on top) — instead this trims the clones that were genuinely avoidable:

- **`fanout_to_clients` helper** (used by `broadcast_to_web_clients`, `broadcast_to_user`, `broadcast_shutdown`): moves the payload into the last send instead of cloning for every client. The common case is exactly one connected client per session, which previously paid one full deep clone per Claude output line.
- **`send_to_session`**: `mpsc::SendError` returns the message on failure, so the unconditional up-front clone of every proxy input is gone.
- **`handle_claude_output`** (hot output path): the round-trip validation parse now uses `ClaudeOutput::deserialize(&content)` instead of `from_value(content.clone())`, the final broadcast moves `content` (it was the last use), and `store_result_metadata` deserializes by reference. Net: three full `serde_json::Value` clones removed per output message.

## Testing
- Two new tests: closed-last-client fanout pruning (the moved-payload slot) and `send_to_session` re-queueing the message handed back by a closed channel.
- Backend: 111 tests pass; clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)