### PR TITLE
Add Claude session limit continuations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.21"
+version = "2.8.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.21"
+version = "2.8.22"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.21"
+version = "2.8.22"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,11 +533,12 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.21"
+version = "2.8.22"
 dependencies = [
  "anyhow",
  "base64",
  "chrono",
+ "chrono-tz",
  "claude-codes",
  "directories",
  "hostname",
@@ -570,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.21"
+version = "2.8.22"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.21"
+version = "2.8.22"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.21"
+version = "2.8.22"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.21"
+version = "2.8.22"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.21"
+version = "2.8.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.21"
+version = "2.8.22"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.21"
+version = "2.8.22"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/2026-06-10-185127_add_session_continuations/down.sql
+++ b/backend/migrations/2026-06-10-185127_add_session_continuations/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE session_continuations;

--- a/backend/migrations/2026-06-10-185127_add_session_continuations/up.sql
+++ b/backend/migrations/2026-06-10-185127_add_session_continuations/up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE session_continuations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    launcher_id UUID NOT NULL,
+    reset_at TIMESTAMPTZ NOT NULL,
+    prompt TEXT NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'pending',
+    source_message TEXT,
+    last_error TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    scheduled_at TIMESTAMP,
+    fired_at TIMESTAMP,
+    dropped_at TIMESTAMP,
+    cancelled_at TIMESTAMP
+);
+
+CREATE INDEX idx_session_continuations_launcher_status_reset
+    ON session_continuations (launcher_id, status, reset_at);
+
+CREATE INDEX idx_session_continuations_session
+    ON session_continuations (session_id);

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -1,0 +1,371 @@
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use shared::{
+    ContinuationConfig, PortalMessage, ServerToClient, ServerToLauncher,
+    SessionLimitContinuationFields,
+};
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use super::{SessionId, SessionManager};
+use crate::db::DbPool;
+use crate::models::{NewMessage, NewSessionContinuation, Session, SessionContinuation};
+use crate::AppState;
+
+const STATUS_PENDING: &str = "pending";
+const STATUS_SCHEDULED: &str = "scheduled";
+const STATUS_FIRED: &str = "fired";
+const STATUS_DROPPED: &str = "dropped";
+
+pub fn handle_session_limit_reached(
+    app_state: &AppState,
+    session_manager: &SessionManager,
+    session_key: &Option<SessionId>,
+    db_session_id: Option<Uuid>,
+    db_pool: &DbPool,
+    fields: SessionLimitContinuationFields,
+) {
+    let Some(current_session_id) = db_session_id else {
+        warn!("Ignoring SessionLimitReached before registration");
+        return;
+    };
+    if current_session_id != fields.session_id {
+        warn!(
+            "SessionLimitReached session_id mismatch: {} != {}",
+            fields.session_id, current_session_id
+        );
+        return;
+    }
+
+    let reset_at = match DateTime::parse_from_rfc3339(&fields.reset_at) {
+        Ok(dt) => dt.with_timezone(&Utc),
+        Err(e) => {
+            warn!(
+                "Ignoring SessionLimitReached with unparsable reset_at '{}': {}",
+                fields.reset_at, e
+            );
+            return;
+        }
+    };
+
+    let Ok(mut conn) = db_pool.get() else {
+        error!("Failed to get DB connection for SessionLimitReached");
+        return;
+    };
+
+    use crate::schema::{session_continuations, sessions};
+    let session = match sessions::table
+        .find(current_session_id)
+        .first::<Session>(&mut conn)
+    {
+        Ok(session) => session,
+        Err(e) => {
+            warn!(
+                "Ignoring SessionLimitReached for unknown session {}: {}",
+                current_session_id, e
+            );
+            return;
+        }
+    };
+
+    let Some(launcher_id) = session.launcher_id else {
+        warn!(
+            "Ignoring SessionLimitReached for session {} without launcher_id",
+            current_session_id
+        );
+        return;
+    };
+
+    let new_continuation = NewSessionContinuation {
+        session_id: current_session_id,
+        user_id: session.user_id,
+        launcher_id,
+        reset_at,
+        prompt: fields.prompt,
+        status: STATUS_PENDING.to_string(),
+        source_message: Some(fields.source_message),
+    };
+
+    let continuation = match diesel::insert_into(session_continuations::table)
+        .values(&new_continuation)
+        .get_result::<SessionContinuation>(&mut conn)
+    {
+        Ok(row) => row,
+        Err(e) => {
+            error!(
+                "Failed to create session continuation for {}: {}",
+                current_session_id, e
+            );
+            return;
+        }
+    };
+
+    let portal = PortalMessage::continuation_prompt(
+        continuation.id,
+        continuation.reset_at.to_rfc3339(),
+        continuation.status.clone(),
+        continuation.source_message.clone().unwrap_or_default(),
+    );
+    let row_created_at = insert_portal_message(&mut conn, &session, &portal);
+
+    if let Some(key) = session_key {
+        session_manager.broadcast_to_web_clients(
+            key,
+            ServerToClient::ClaudeOutput {
+                content: portal.to_json(),
+                sender_user_id: None,
+                sender_name: None,
+                agent_type: session.agent_type.parse().unwrap_or_default(),
+                created_at: row_created_at,
+            },
+        );
+    }
+
+    info!(
+        "Created session continuation {} for session {} at {}",
+        continuation.id, current_session_id, continuation.reset_at
+    );
+
+    sync_continuations_for_launcher(app_state, launcher_id, session.user_id);
+}
+
+pub fn schedule_limit_continuation(
+    app_state: &AppState,
+    session_manager: &SessionManager,
+    user_id: Uuid,
+    session_id: Uuid,
+    continuation_id: Uuid,
+) {
+    let Ok(mut conn) = app_state.db_pool.get() else {
+        return;
+    };
+
+    use crate::schema::session_continuations;
+    let continuation = match diesel::update(
+        session_continuations::table
+            .filter(session_continuations::id.eq(continuation_id))
+            .filter(session_continuations::session_id.eq(session_id))
+            .filter(session_continuations::user_id.eq(user_id))
+            .filter(session_continuations::status.eq(STATUS_PENDING)),
+    )
+    .set((
+        session_continuations::status.eq(STATUS_SCHEDULED),
+        session_continuations::scheduled_at.eq(diesel::dsl::now),
+        session_continuations::updated_at.eq(diesel::dsl::now),
+    ))
+    .get_result::<SessionContinuation>(&mut conn)
+    {
+        Ok(row) => row,
+        Err(e) => {
+            warn!(
+                "Failed to schedule continuation {} for session {}: {}",
+                continuation_id, session_id, e
+            );
+            session_manager.broadcast_to_web_clients(
+                &session_id.to_string(),
+                ServerToClient::ContinuationStatus {
+                    continuation_id,
+                    status: "failed".to_string(),
+                    message: Some("Unable to schedule continuation".to_string()),
+                },
+            );
+            return;
+        }
+    };
+
+    session_manager.broadcast_to_web_clients(
+        &session_id.to_string(),
+        ServerToClient::ContinuationStatus {
+            continuation_id,
+            status: STATUS_SCHEDULED.to_string(),
+            message: Some("Continuation scheduled".to_string()),
+        },
+    );
+    sync_continuations_for_launcher(app_state, continuation.launcher_id, user_id);
+}
+
+pub fn mark_continuation_fired(
+    app_state: &AppState,
+    launcher_id: Uuid,
+    user_id: Uuid,
+    continuation_id: Uuid,
+    session_id: Uuid,
+) {
+    update_terminal_status(
+        app_state,
+        launcher_id,
+        user_id,
+        continuation_id,
+        session_id,
+        STATUS_FIRED,
+        None,
+    );
+}
+
+pub fn mark_continuation_dropped(
+    app_state: &AppState,
+    launcher_id: Uuid,
+    user_id: Uuid,
+    continuation_id: Uuid,
+    session_id: Uuid,
+    reason: String,
+) {
+    update_terminal_status(
+        app_state,
+        launcher_id,
+        user_id,
+        continuation_id,
+        session_id,
+        STATUS_DROPPED,
+        Some(reason),
+    );
+}
+
+fn update_terminal_status(
+    app_state: &AppState,
+    launcher_id: Uuid,
+    user_id: Uuid,
+    continuation_id: Uuid,
+    session_id: Uuid,
+    status: &str,
+    reason: Option<String>,
+) {
+    let Ok(mut conn) = app_state.db_pool.get() else {
+        return;
+    };
+
+    use crate::schema::{session_continuations, sessions};
+    let updated = diesel::update(
+        session_continuations::table
+            .filter(session_continuations::id.eq(continuation_id))
+            .filter(session_continuations::session_id.eq(session_id))
+            .filter(session_continuations::user_id.eq(user_id))
+            .filter(session_continuations::launcher_id.eq(launcher_id)),
+    )
+    .set((
+        session_continuations::status.eq(status),
+        session_continuations::last_error.eq(reason.clone()),
+        session_continuations::updated_at.eq(diesel::dsl::now),
+        session_continuations::fired_at.eq(if status == STATUS_FIRED {
+            Some(chrono::Utc::now().naive_utc())
+        } else {
+            None
+        }),
+        session_continuations::dropped_at.eq(if status == STATUS_DROPPED {
+            Some(chrono::Utc::now().naive_utc())
+        } else {
+            None
+        }),
+    ))
+    .get_result::<SessionContinuation>(&mut conn);
+
+    match updated {
+        Ok(row) => {
+            app_state.session_manager.broadcast_to_web_clients(
+                &session_id.to_string(),
+                ServerToClient::ContinuationStatus {
+                    continuation_id,
+                    status: status.to_string(),
+                    message: reason.clone(),
+                },
+            );
+
+            if status == STATUS_DROPPED {
+                if let Ok(session) = sessions::table.find(session_id).first::<Session>(&mut conn) {
+                    let portal = PortalMessage::text(
+                        "Continuation was not sent because the local Claude process was no longer running when the session limit reset."
+                            .to_string(),
+                    );
+                    let row_created_at = insert_portal_message(&mut conn, &session, &portal);
+                    app_state.session_manager.broadcast_to_web_clients(
+                        &session_id.to_string(),
+                        ServerToClient::ClaudeOutput {
+                            content: portal.to_json(),
+                            sender_user_id: None,
+                            sender_name: None,
+                            agent_type: session.agent_type.parse().unwrap_or_default(),
+                            created_at: row_created_at,
+                        },
+                    );
+                }
+            }
+
+            sync_continuations_for_launcher(app_state, row.launcher_id, user_id);
+        }
+        Err(e) => warn!(
+            "Failed to mark continuation {} {} for session {}: {}",
+            continuation_id, status, session_id, e
+        ),
+    }
+}
+
+pub fn sync_continuations_for_launcher(app_state: &AppState, launcher_id: Uuid, user_id: Uuid) {
+    let continuations = load_scheduled_continuations(app_state, launcher_id, user_id);
+    let msg = ServerToLauncher::ContinuationSync { continuations };
+    if !app_state
+        .session_manager
+        .send_to_launcher(&launcher_id, msg)
+    {
+        warn!(
+            "Failed to sync continuations to launcher {} for user {}",
+            launcher_id, user_id
+        );
+    }
+}
+
+pub fn load_scheduled_continuations(
+    app_state: &AppState,
+    launcher_id: Uuid,
+    user_id: Uuid,
+) -> Vec<ContinuationConfig> {
+    let Ok(mut conn) = app_state.db_pool.get() else {
+        return Vec::new();
+    };
+
+    use crate::schema::session_continuations;
+    session_continuations::table
+        .filter(session_continuations::launcher_id.eq(launcher_id))
+        .filter(session_continuations::user_id.eq(user_id))
+        .filter(session_continuations::status.eq(STATUS_SCHEDULED))
+        .order(session_continuations::reset_at.asc())
+        .load::<SessionContinuation>(&mut conn)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|row| ContinuationConfig {
+            id: row.id,
+            session_id: row.session_id,
+            reset_at: row.reset_at.to_rfc3339(),
+            prompt: row.prompt,
+        })
+        .collect()
+}
+
+fn insert_portal_message(
+    conn: &mut diesel::PgConnection,
+    session: &Session,
+    portal: &PortalMessage,
+) -> Option<String> {
+    use crate::schema::messages;
+    let new_message = NewMessage {
+        session_id: session.id,
+        role: "portal".to_string(),
+        content: serde_json::to_string(&portal.to_json()).unwrap_or_default(),
+        user_id: session.user_id,
+        agent_type: session.agent_type.clone(),
+    };
+    match diesel::insert_into(messages::table)
+        .values(&new_message)
+        .get_result::<crate::models::Message>(conn)
+    {
+        Ok(inserted) => Some(
+            inserted
+                .created_at
+                .format("%Y-%m-%dT%H:%M:%S%.6f")
+                .to_string(),
+        ),
+        Err(e) => {
+            error!("Failed to store continuation portal message: {}", e);
+            None
+        }
+    }
+}

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -232,6 +232,12 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
         }
     }
 
+    let continuation_configs =
+        super::continuations::load_scheduled_continuations(&app_state, launcher_id, user_id);
+    let _ = tx_for_sync.send(ServerToLauncher::ContinuationSync {
+        continuations: continuation_configs,
+    });
+
     // Main message loop
     loop {
         tokio::select! {
@@ -546,6 +552,36 @@ fn handle_launcher_message(
                     },
                 );
             }
+        }
+        LauncherToServer::ContinuationFired {
+            continuation_id,
+            session_id,
+        } => {
+            super::continuations::mark_continuation_fired(
+                app_state,
+                launcher_id,
+                user_id,
+                continuation_id,
+                session_id,
+            );
+        }
+        LauncherToServer::ContinuationDropped {
+            continuation_id,
+            session_id,
+            reason,
+        } => {
+            warn!(
+                "Continuation {} for session {} dropped by launcher {}: {}",
+                continuation_id, session_id, launcher_id, reason
+            );
+            super::continuations::mark_continuation_dropped(
+                app_state,
+                launcher_id,
+                user_id,
+                continuation_id,
+                session_id,
+                reason,
+            );
         }
         LauncherToServer::ScheduledRunStarted {
             task_id,

--- a/backend/src/handlers/websocket/mod.rs
+++ b/backend/src/handlers/websocket/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod continuations;
 mod image_upload_socket;
 pub mod launcher_socket;
 mod message_handlers;

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -1,3 +1,4 @@
+use super::continuations::handle_session_limit_reached;
 use super::message_handlers::{handle_claude_output, replay_pending_inputs_from_db};
 use super::permissions::handle_permission_request;
 use super::registration::{register_or_update_session, RegistrationParams};
@@ -277,6 +278,16 @@ fn handle_proxy_message(
                 *db_session_id,
                 db_pool,
                 *metrics,
+            );
+        }
+        ProxyToServer::SessionLimitReached(fields) => {
+            handle_session_limit_reached(
+                app_state,
+                session_manager,
+                session_key,
+                *db_session_id,
+                db_pool,
+                fields,
             );
         }
         ProxyToServer::FileDownloadResponse(response) => {

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -231,6 +231,27 @@ fn handle_web_client_message(
             }
             false
         }
+        ClientToServer::ScheduleLimitContinuation { continuation_id } => {
+            if let Some(session_id) = *verified_session_id {
+                if !is_session_mutator(app_state, session_id, user_id) {
+                    warn!(
+                        "Viewer-role user {} attempted ScheduleLimitContinuation on session {}",
+                        user_id, session_id
+                    );
+                    return false;
+                }
+                super::continuations::schedule_limit_continuation(
+                    app_state,
+                    session_manager,
+                    user_id,
+                    session_id,
+                    continuation_id,
+                );
+            } else {
+                warn!("Web client tried to schedule continuation without verified session");
+            }
+            false
+        }
     }
 }
 

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -281,6 +281,43 @@ pub struct NewScheduledTask {
 }
 
 // ============================================================================
+// Session Continuation Models
+// ============================================================================
+
+#[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]
+#[diesel(table_name = crate::schema::session_continuations)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct SessionContinuation {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub user_id: Uuid,
+    pub launcher_id: Uuid,
+    pub reset_at: DateTime<Utc>,
+    pub prompt: String,
+    pub status: String,
+    pub source_message: Option<String>,
+    pub last_error: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+    pub scheduled_at: Option<NaiveDateTime>,
+    pub fired_at: Option<NaiveDateTime>,
+    pub dropped_at: Option<NaiveDateTime>,
+    pub cancelled_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = crate::schema::session_continuations)]
+pub struct NewSessionContinuation {
+    pub session_id: Uuid,
+    pub user_id: Uuid,
+    pub launcher_id: Uuid,
+    pub reset_at: DateTime<Utc>,
+    pub prompt: String,
+    pub status: String,
+    pub source_message: Option<String>,
+}
+
+// ============================================================================
 // Turn Metrics Models (per-turn performance metrics; PR 1 of N)
 // ============================================================================
 

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -98,6 +98,27 @@ diesel::table! {
 }
 
 diesel::table! {
+    session_continuations (id) {
+        id -> Uuid,
+        session_id -> Uuid,
+        user_id -> Uuid,
+        launcher_id -> Uuid,
+        reset_at -> Timestamptz,
+        prompt -> Text,
+        #[max_length = 32]
+        status -> Varchar,
+        source_message -> Nullable<Text>,
+        last_error -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+        scheduled_at -> Nullable<Timestamp>,
+        fired_at -> Nullable<Timestamp>,
+        dropped_at -> Nullable<Timestamp>,
+        cancelled_at -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
     session_members (id) {
         id -> Uuid,
         session_id -> Uuid,
@@ -203,6 +224,8 @@ diesel::joinable!(pending_inputs -> sessions (session_id));
 diesel::joinable!(pending_permission_requests -> sessions (session_id));
 diesel::joinable!(proxy_auth_tokens -> users (user_id));
 diesel::joinable!(scheduled_tasks -> users (user_id));
+diesel::joinable!(session_continuations -> sessions (session_id));
+diesel::joinable!(session_continuations -> users (user_id));
 diesel::joinable!(session_members -> sessions (session_id));
 diesel::joinable!(session_members -> users (user_id));
 diesel::joinable!(sessions -> users (user_id));
@@ -217,6 +240,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     pending_permission_requests,
     proxy_auth_tokens,
     scheduled_tasks,
+    session_continuations,
     session_members,
     sessions,
     turn_metrics,

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 thiserror = "1"
 tracing = "0.1"
 anyhow = { workspace = true }

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -8,6 +8,8 @@
 
 use std::time::{Duration, Instant};
 
+use chrono::{NaiveTime, TimeZone, Utc};
+use chrono_tz::Tz;
 use claude_codes::io::ContentBlock;
 use claude_codes::{AsyncClient as ClaudeAsyncClient, ClaudeInput, ClaudeOutput};
 use rand::Rng;
@@ -17,6 +19,10 @@ use session_lib::{TurnOutcome, TurnTracker};
 use shared::PortalMessage;
 use tokio::sync::mpsc;
 use uuid::Uuid;
+
+const SESSION_LIMIT_TEXT: &str = "You've hit your session limit";
+const SESSION_LIMIT_CONTINUE_PROMPT: &str =
+    "Continue from where you stopped before the Claude session limit was reached.";
 
 /// Background task that owns the Claude process and handles all I/O.
 ///
@@ -54,6 +60,7 @@ pub(crate) async fn claude_io_task(
     // rate-limit text prefix. Latched until the turn's Result frame so we
     // can classify the whole turn on its terminator.
     let mut current_turn_was_rate_limited = false;
+    let mut pending_session_limit: Option<(String, String)> = None;
 
     // Per-turn performance metrics tracker. `start`ed on each user input,
     // `record_content_frame`d on assistant/text frames, finalized on
@@ -75,6 +82,7 @@ pub(crate) async fn claude_io_task(
                         // Each fresh user input gets its own retry budget.
                         rate_limit_attempts = 0;
                         current_turn_was_rate_limited = false;
+                        pending_session_limit = None;
                         // Begin per-turn metrics capture. Wall-clock UTC is
                         // chrono::Utc::now(); the monotonic instant is the
                         // anchor for TTFT / total / gap durations.
@@ -154,12 +162,17 @@ pub(crate) async fn claude_io_task(
                                     if text.starts_with(RATE_LIMIT_TEXT_PREFIX) {
                                         current_turn_was_rate_limited = true;
                                     }
+                                    if let Some(reset_at) = parse_session_limit_reset(text) {
+                                        pending_session_limit =
+                                            Some((reset_at, text.to_string()));
+                                    }
                                 }
                             }
                             ClaudeOutput::Result(r) if !r.is_error => {
                                 // Successful turn — clear consecutive-failure state.
                                 rate_limit_attempts = 0;
                                 current_turn_was_rate_limited = false;
+                                pending_session_limit = None;
                             }
                             _ => {}
                         }
@@ -218,10 +231,25 @@ pub(crate) async fn claude_io_task(
                             &output,
                             ClaudeOutput::Result(r) if r.is_error
                         ) && current_turn_was_rate_limited;
+                        let is_session_limit_terminator = matches!(
+                            &output,
+                            ClaudeOutput::Result(r) if r.is_error
+                        ) && pending_session_limit.is_some();
 
                         if event_tx.send(IoEvent::Output(Box::new(output))).is_err() {
                             // Receiver dropped, session ended.
                             break;
+                        }
+
+                        if is_session_limit_terminator {
+                            if let Some((reset_at, source_message)) = pending_session_limit.take() {
+                                let _ = event_tx.send(IoEvent::SessionLimitReached {
+                                    session_id,
+                                    reset_at,
+                                    source_message,
+                                    prompt: SESSION_LIMIT_CONTINUE_PROMPT.to_string(),
+                                });
+                            }
                         }
 
                         if !is_rate_limit_terminator {
@@ -293,6 +321,7 @@ pub(crate) async fn claude_io_task(
                                         // — honor that, abandon the retry, and reset
                                         // the budget for the new prompt.
                                         rate_limit_attempts = 0;
+                                        pending_session_limit = None;
                                         turn_tracker.start(Instant::now(), chrono::Utc::now());
                                         let r = client.send(&new_input).await;
                                         last_input = Some(new_input);
@@ -377,6 +406,60 @@ pub(crate) async fn claude_io_task(
             }
         }
     }
+}
+
+fn parse_session_limit_reset(text: &str) -> Option<String> {
+    if !text.contains(SESSION_LIMIT_TEXT) {
+        return None;
+    }
+
+    let after_resets = text.split("resets ").nth(1)?;
+    let open = after_resets.find('(')?;
+    let close = after_resets[open + 1..].find(')')? + open + 1;
+    let time_text = after_resets[..open].trim();
+    let tz_text = after_resets[open + 1..close].trim();
+
+    let tz: Tz = tz_text.parse().ok()?;
+    let reset_time = parse_limit_time(time_text)?;
+    let now_utc = Utc::now();
+    let now_local = now_utc.with_timezone(&tz);
+    let mut date = now_local.date_naive();
+
+    let local_dt = match tz.from_local_datetime(&date.and_time(reset_time)) {
+        chrono::LocalResult::Single(dt) => dt,
+        chrono::LocalResult::Ambiguous(earlier, _) => earlier,
+        chrono::LocalResult::None => {
+            date = date.succ_opt()?;
+            match tz.from_local_datetime(&date.and_time(reset_time)) {
+                chrono::LocalResult::Single(dt) => dt,
+                chrono::LocalResult::Ambiguous(earlier, _) => earlier,
+                chrono::LocalResult::None => return None,
+            }
+        }
+    };
+
+    let reset_utc = if local_dt.with_timezone(&Utc) <= now_utc {
+        let next_date = date.succ_opt()?;
+        match tz.from_local_datetime(&next_date.and_time(reset_time)) {
+            chrono::LocalResult::Single(dt) => dt,
+            chrono::LocalResult::Ambiguous(earlier, _) => earlier,
+            chrono::LocalResult::None => return None,
+        }
+    } else {
+        local_dt
+    };
+
+    Some(reset_utc.with_timezone(&Utc).to_rfc3339())
+}
+
+fn parse_limit_time(input: &str) -> Option<NaiveTime> {
+    let lower = input.trim().to_ascii_lowercase();
+    for fmt in ["%-I:%M%P", "%-I:%M %P", "%-I%P", "%-I %P"] {
+        if let Ok(time) = NaiveTime::parse_from_str(&lower, fmt) {
+            return Some(time);
+        }
+    }
+    None
 }
 
 /// Read available stderr output from the Claude process.

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -1016,6 +1016,28 @@ async fn run_main_loop<A: Agent>(
                     continue;
                 }
 
+                if let Some(SessionEvent::SessionLimitReached {
+                    session_id,
+                    reset_at,
+                    source_message,
+                    prompt,
+                }) = event
+                {
+                    let msg =
+                        ProxyToServer::SessionLimitReached(shared::SessionLimitContinuationFields {
+                            session_id,
+                            reset_at,
+                            source_message,
+                            prompt,
+                        });
+                    let mut ws = state.ws_write.lock().await;
+                    if ws.send(msg).await.is_err() {
+                        error!("Failed to send session-limit continuation candidate");
+                        return ConnectionResult::Disconnected(state.connection_start.elapsed());
+                    }
+                    continue;
+                }
+
                 match handle_session_event_with_wiggum(
                     event,
                     &state.output_tx,

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -242,6 +242,12 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
                 "CodexThreadId should be handled before calling handle_session_event_with_wiggum"
             );
         }
+        Some(SessionEvent::SessionLimitReached { .. }) => {
+            // Handled in run_main_loop before calling this function
+            unreachable!(
+                "SessionLimitReached should be handled before calling handle_session_event_with_wiggum"
+            );
+        }
         Some(SessionEvent::Error(e)) => {
             let err_msg = e.to_string();
             error!("Session error: {}", err_msg);

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -4,6 +4,7 @@ pub mod turn_metrics_footer;
 pub mod types;
 
 use serde_json::Value;
+use std::collections::HashMap;
 use uuid::Uuid;
 use yew::prelude::*;
 
@@ -46,6 +47,10 @@ pub struct MessageRendererProps {
     /// chip strip below the existing stats bar when present.
     #[prop_or_default]
     pub turn_metrics: Option<shared::TurnMetrics>,
+    #[prop_or_default]
+    pub continuation_statuses: HashMap<Uuid, String>,
+    #[prop_or_default]
+    pub on_schedule_continuation: Callback<Uuid>,
 }
 
 #[function_component(MessageRenderer)]
@@ -98,7 +103,13 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
             return renderers::render_error_message(&msg, ts.as_deref());
         }
         Ok(ClaudeMessage::Portal(msg)) => {
-            return renderers::render_portal_message(&msg, ts.as_deref(), props.session_id);
+            return renderers::render_portal_message(
+                &msg,
+                ts.as_deref(),
+                props.session_id,
+                &props.continuation_statuses,
+                props.on_schedule_continuation.clone(),
+            );
         }
         Ok(ClaudeMessage::RateLimitEvent(msg)) => {
             return renderers::render_rate_limit_event(&msg, ts.as_deref());
@@ -128,13 +139,17 @@ pub struct MessageGroupRendererProps {
     /// shapes (`Result` / `turn.completed` always render as `Single`).
     #[prop_or_default]
     pub turn_metrics: Option<shared::TurnMetrics>,
+    #[prop_or_default]
+    pub continuation_statuses: HashMap<Uuid, String>,
+    #[prop_or_default]
+    pub on_schedule_continuation: Callback<Uuid>,
 }
 
 #[function_component(MessageGroupRenderer)]
 pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
     match &props.group {
         MessageGroup::Single(json) => {
-            html! { <MessageRenderer json={json.clone()} session_id={props.session_id} agent_type={props.agent_type} current_user_id={props.current_user_id.clone()} turn_metrics={props.turn_metrics.clone()} /> }
+            html! { <MessageRenderer json={json.clone()} session_id={props.session_id} agent_type={props.agent_type} current_user_id={props.current_user_id.clone()} turn_metrics={props.turn_metrics.clone()} continuation_statuses={props.continuation_statuses.clone()} on_schedule_continuation={props.on_schedule_continuation.clone()} /> }
         }
         MessageGroup::IdentityGroup {
             category,
@@ -193,7 +208,7 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                             let key = extract_raw_iso(json)
                                 .map(|iso| format!("m-{}", iso))
                                 .unwrap_or_else(|| format!("m{}", i));
-                            html! { <div {key} class="grouped-message-part">{ render_identity_group_part(json, props.agent_type, props.session_id) }</div> }
+                            html! { <div {key} class="grouped-message-part">{ render_identity_group_part(json, props.agent_type, props.session_id, &props.continuation_statuses, props.on_schedule_continuation.clone()) }</div> }
                         })}
                     </div>
                     if let Some(iso) = last_iso {
@@ -207,7 +222,13 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
     }
 }
 
-fn render_identity_group_part(json: &str, agent_type: shared::AgentType, session_id: Uuid) -> Html {
+fn render_identity_group_part(
+    json: &str,
+    agent_type: shared::AgentType,
+    session_id: Uuid,
+    continuation_statuses: &HashMap<Uuid, String>,
+    on_schedule_continuation: Callback<Uuid>,
+) -> Html {
     match ClaudeMessage::parse(json) {
         Ok(ClaudeMessage::User(msg)) => renderers::render_user_message_content(&msg, session_id),
         Ok(ClaudeMessage::OptimisticUser(msg)) => {
@@ -216,9 +237,12 @@ fn render_identity_group_part(json: &str, agent_type: shared::AgentType, session
         Ok(ClaudeMessage::Assistant(msg)) => {
             renderers::render_assistant_message_content(&msg, session_id)
         }
-        Ok(ClaudeMessage::Portal(msg)) => {
-            renderers::render_portal_message_content(&msg, session_id)
-        }
+        Ok(ClaudeMessage::Portal(msg)) => renderers::render_portal_message_content(
+            &msg,
+            session_id,
+            continuation_statuses,
+            on_schedule_continuation,
+        ),
         _ if agent_type == shared::AgentType::Codex => {
             super::codex_renderer::render_codex_message_content(json, session_id)
         }

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -2,6 +2,7 @@ use super::super::types::PortalMessage;
 use super::render_image_source;
 use crate::components::copy_button::CopyButton;
 use crate::components::markdown::render_markdown_for_session;
+use std::collections::HashMap;
 use uuid::Uuid;
 use yew::prelude::*;
 
@@ -9,6 +10,8 @@ pub fn render_portal_message(
     msg: &PortalMessage,
     timestamp: Option<&str>,
     session_id: Uuid,
+    continuation_statuses: &HashMap<Uuid, String>,
+    on_schedule_continuation: Callback<Uuid>,
 ) -> Html {
     let copy_text: String = msg
         .content
@@ -27,16 +30,26 @@ pub fn render_portal_message(
                     <CopyButton text={copy_text} title="Copy portal text" />
                 }
             </div>
-            <div class="message-body">{ render_portal_message_content(msg, session_id) }</div>
+            <div class="message-body">{ render_portal_message_content(msg, session_id, continuation_statuses, on_schedule_continuation) }</div>
         </div>
     }
 }
 
-pub fn render_portal_message_content(msg: &PortalMessage, session_id: Uuid) -> Html {
-    html! { <>{ for msg.content.iter().map(|content| render_portal_content(content, session_id)) }</> }
+pub fn render_portal_message_content(
+    msg: &PortalMessage,
+    session_id: Uuid,
+    continuation_statuses: &HashMap<Uuid, String>,
+    on_schedule_continuation: Callback<Uuid>,
+) -> Html {
+    html! { <>{ for msg.content.iter().map(|content| render_portal_content(content, session_id, continuation_statuses, on_schedule_continuation.clone())) }</> }
 }
 
-fn render_portal_content(content: &shared::PortalContent, session_id: Uuid) -> Html {
+fn render_portal_content(
+    content: &shared::PortalContent,
+    session_id: Uuid,
+    continuation_statuses: &HashMap<Uuid, String>,
+    on_schedule_continuation: Callback<Uuid>,
+) -> Html {
     match content {
         shared::PortalContent::Text { text } => render_markdown_for_session(text, session_id),
         shared::PortalContent::Image {
@@ -67,7 +80,84 @@ fn render_portal_content(content: &shared::PortalContent, session_id: Uuid) -> H
         shared::PortalContent::Reminder { title, body } => {
             html! { <PortalReminder title={title.clone()} body={body.clone()} session_id={session_id} /> }
         }
+        shared::PortalContent::ContinuationPrompt {
+            continuation_id,
+            reset_at,
+            status,
+            source_message,
+        } => render_continuation_prompt(
+            *continuation_id,
+            reset_at,
+            continuation_statuses
+                .get(continuation_id)
+                .map(String::as_str)
+                .unwrap_or(status),
+            source_message,
+            on_schedule_continuation,
+        ),
     }
+}
+
+fn render_continuation_prompt(
+    continuation_id: Uuid,
+    reset_at: &str,
+    status: &str,
+    source_message: &str,
+    on_schedule_continuation: Callback<Uuid>,
+) -> Html {
+    let reset_label = format_reset_label(reset_at);
+    let terminal = matches!(
+        status,
+        "scheduled" | "scheduling" | "fired" | "dropped" | "failed"
+    );
+    let status_class = status.to_string();
+    let button_label = match status {
+        "scheduled" => "Scheduled",
+        "scheduling" => "Scheduling...",
+        "fired" => "Continued",
+        "dropped" => "Dropped",
+        "failed" => "Failed",
+        _ => "Continue when limit lifted",
+    };
+    let onclick = {
+        let on_schedule_continuation = on_schedule_continuation.clone();
+        Callback::from(move |_: MouseEvent| {
+            on_schedule_continuation.emit(continuation_id);
+        })
+    };
+
+    html! {
+        <div class="continuation-card">
+            <div class="continuation-copy">
+                <div class="continuation-title">{ "Claude session limit reached" }</div>
+                <div class="continuation-detail">{ reset_label }</div>
+                if !source_message.is_empty() {
+                    <div class="continuation-source">{ source_message }</div>
+                }
+            </div>
+            <button
+                type="button"
+                class={classes!("continuation-button", status_class)}
+                disabled={terminal}
+                {onclick}
+            >
+                { button_label }
+            </button>
+        </div>
+    }
+}
+
+fn format_reset_label(reset_at: &str) -> String {
+    let ms = js_sys::Date::parse(reset_at);
+    if ms.is_nan() {
+        return format!("Resets at {}", reset_at);
+    }
+    let date = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ms));
+    let local = date
+        .to_locale_string("default", &js_sys::Object::new())
+        .as_string()
+        .unwrap_or_else(|| reset_at.to_string());
+    format!("Resets at {}", local)
 }
 
 #[derive(Properties, PartialEq)]

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -15,6 +15,7 @@ use gloo::timers::callback::Timeout;
 use gloo_net::http::Request;
 use shared::api::{ErrorMessage, TurnMetricsResponse};
 use shared::{ClientToServer, SendMode, SessionInfo, TurnMetrics};
+use std::collections::HashMap;
 use uuid::Uuid;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
@@ -114,6 +115,8 @@ pub enum SessionViewMsg {
     /// into `turn_metrics` in `started_at`-sorted order, deduping by `id`
     /// so a backfill-then-broadcast pair (or a duplicate replay) collapses.
     TurnMetricsReceived(Box<TurnMetrics>),
+    ScheduleLimitContinuation(Uuid),
+    ContinuationStatus(Uuid, String),
 }
 
 /// SessionView - Main terminal view for a single session
@@ -167,6 +170,7 @@ pub struct SessionView {
     /// because the join walk is sequential — a HashMap with a positional
     /// counter would buy nothing.
     turn_metrics: Vec<TurnMetrics>,
+    continuation_statuses: HashMap<Uuid, String>,
 }
 
 impl Component for SessionView {
@@ -237,6 +241,7 @@ impl Component for SessionView {
             input_bar_dispatcher: None,
             pending_sends: Vec::new(),
             turn_metrics: Vec::new(),
+            continuation_statuses: HashMap::new(),
         }
     }
 
@@ -424,6 +429,21 @@ impl Component for SessionView {
                 self.insert_turn_metrics(*metrics);
                 true
             }
+            SessionViewMsg::ScheduleLimitContinuation(continuation_id) => {
+                self.continuation_statuses
+                    .insert(continuation_id, "scheduling".to_string());
+                if let Some(ref sender) = self.ws_sender {
+                    send_message(
+                        sender,
+                        ClientToServer::ScheduleLimitContinuation { continuation_id },
+                    );
+                }
+                true
+            }
+            SessionViewMsg::ContinuationStatus(continuation_id, status) => {
+                self.continuation_statuses.insert(continuation_id, status);
+                true
+            }
         }
     }
 
@@ -434,6 +454,7 @@ impl Component for SessionView {
             e.stop_propagation();
             SessionViewMsg::JumpToLive
         });
+        let on_schedule_continuation = link.callback(SessionViewMsg::ScheduleLimitContinuation);
 
         // Per-turn metrics join (PR 2 of N): walk grouped messages in order
         // and pair the Nth terminator card with `turn_metrics[N]`. The
@@ -465,11 +486,11 @@ impl Component for SessionView {
                             groups.into_iter().enumerate().map(|(i, group)| {
                                 let key = group.key(i);
                                 let metrics = group_metrics.get(i).cloned().flatten();
-                                html! { <MessageGroupRenderer {key} group={group} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} /> }
+                                html! { <MessageGroupRenderer {key} group={group} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
                             }).collect::<Html>()
                         }
                         { for self.pending_sends.iter().enumerate().map(|(i, json)| {
-                            html! { <MessageRenderer key={format!("p{}", i)} json={json.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} /> }
+                            html! { <MessageRenderer key={format!("p{}", i)} json={json.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
                         })}
                     </div>
                     if !is_tailing {
@@ -554,6 +575,14 @@ impl SessionView {
             WsEvent::TurnMetrics(metrics) => {
                 ctx.link()
                     .send_message(SessionViewMsg::TurnMetricsReceived(metrics));
+                false
+            }
+            WsEvent::ContinuationStatus {
+                continuation_id,
+                status,
+            } => {
+                ctx.link()
+                    .send_message(SessionViewMsg::ContinuationStatus(continuation_id, status));
                 false
             }
         }

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -524,6 +524,7 @@ mod tests {
             WsEvent::HistoryBatch(_, _) => "HistoryBatch",
             WsEvent::Permission(_) => "Permission",
             WsEvent::BranchChanged(_, _, _) => "BranchChanged",
+            WsEvent::ContinuationStatus { .. } => "ContinuationStatus",
             WsEvent::TurnMetrics(_) => "TurnMetrics",
         }
     }

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -27,6 +27,10 @@ pub enum WsEvent {
     HistoryBatch(Vec<String>, Option<String>),
     Permission(PendingPermission),
     BranchChanged(Option<String>, Option<String>, Option<String>),
+    ContinuationStatus {
+        continuation_id: Uuid,
+        status: String,
+    },
     /// Live per-turn metrics broadcast for this session (PR 2 of N).
     /// Boxed to keep `WsEvent` compact — `TurnMetrics` is the largest variant
     /// payload by a wide margin (~22 fields).
@@ -205,6 +209,17 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
         // an explicit branch or land in `unhandled` below.
         ServerToClient::TurnMetrics(metrics) => {
             on_event.emit(WsEvent::TurnMetrics(metrics));
+        }
+        ServerToClient::ContinuationStatus {
+            continuation_id,
+            status,
+            message,
+        } => {
+            let _ = message;
+            on_event.emit(WsEvent::ContinuationStatus {
+                continuation_id,
+                status,
+            });
         }
         unhandled => {
             // Variants we haven't wired a UI route for yet (e.g. new

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -128,6 +128,61 @@
     border-left: 3px solid #7dcfff;
 }
 
+.continuation-card {
+    align-items: center;
+    background: rgba(224, 175, 104, 0.08);
+    border: 1px solid rgba(224, 175, 104, 0.28);
+    border-radius: 8px;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: space-between;
+    padding: 0.75rem;
+}
+
+.continuation-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+.continuation-title {
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.continuation-detail,
+.continuation-source {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+}
+
+.continuation-source {
+    overflow-wrap: anywhere;
+}
+
+.continuation-button {
+    background: rgba(224, 175, 104, 0.18);
+    border: 1px solid rgba(224, 175, 104, 0.45);
+    border-radius: 6px;
+    color: #e0af68;
+    cursor: pointer;
+    flex: 0 0 auto;
+    font-size: 0.82rem;
+    font-weight: 600;
+    padding: 0.45rem 0.65rem;
+}
+
+.continuation-button:hover:not(:disabled) {
+    background: rgba(224, 175, 104, 0.26);
+}
+
+.continuation-button:disabled {
+    cursor: default;
+    opacity: 0.68;
+}
+
 /* Group wrapper for consecutive portal messages (PR 2/4 of #758). Mirrors
    the assistant-group treatment: one outer wrapper around N child message
    blocks so a chatty stretch reads as one visual unit. The inner

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -272,6 +272,15 @@
         padding: 0.75rem;
     }
 
+    .continuation-card {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .continuation-button {
+        width: 100%;
+    }
+
     .message-type-badge {
         font-size: 0.65rem;
         padding: 0.2rem 0.5rem;

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -129,10 +129,15 @@ pub async fn run_launcher_loop(
                     let prompt_dur = scheduler
                         .next_prompt_duration()
                         .unwrap_or(Duration::from_secs(3600));
+                    let continuation_dur = scheduler
+                        .next_continuation_duration()
+                        .unwrap_or(Duration::from_secs(3600));
                     let sched_sleep = tokio::time::sleep(sched_dur);
                     let prompt_sleep = tokio::time::sleep(prompt_dur);
+                    let continuation_sleep = tokio::time::sleep(continuation_dur);
                     tokio::pin!(sched_sleep);
                     tokio::pin!(prompt_sleep);
+                    tokio::pin!(continuation_sleep);
 
                     tokio::select! {
                         result = ws_receiver.recv() => {
@@ -306,6 +311,49 @@ pub async fn run_launcher_loop(
                                 if ws_sender.send(inject).await.is_err() {
                                     warn!("Failed to send InjectInput");
                                     break;
+                                }
+                            }
+                        }
+
+                        _ = &mut continuation_sleep => {
+                            let running = process_manager.running_session_ids();
+                            for continuation in scheduler.ready_continuations() {
+                                if running.contains(&continuation.session_id) {
+                                    info!(
+                                        "Injecting continuation {} into still-running session {}",
+                                        continuation.id, continuation.session_id
+                                    );
+                                    let inject = LauncherToServer::InjectInput {
+                                        session_id: continuation.session_id,
+                                        content: continuation.prompt.clone(),
+                                    };
+                                    if ws_sender.send(inject).await.is_err() {
+                                        warn!("Failed to send continuation InjectInput");
+                                        break;
+                                    }
+                                    let fired = LauncherToServer::ContinuationFired {
+                                        continuation_id: continuation.id,
+                                        session_id: continuation.session_id,
+                                    };
+                                    if ws_sender.send(fired).await.is_err() {
+                                        warn!("Failed to send ContinuationFired");
+                                        break;
+                                    }
+                                } else {
+                                    let reason = "local Claude process was no longer running at reset time".to_string();
+                                    warn!(
+                                        "Dropping continuation {} for session {}: {}",
+                                        continuation.id, continuation.session_id, reason
+                                    );
+                                    let dropped = LauncherToServer::ContinuationDropped {
+                                        continuation_id: continuation.id,
+                                        session_id: continuation.session_id,
+                                        reason,
+                                    };
+                                    if ws_sender.send(dropped).await.is_err() {
+                                        warn!("Failed to send ContinuationDropped");
+                                        break;
+                                    }
                                 }
                             }
                         }
@@ -521,6 +569,9 @@ async fn handle_message(
         ServerToLauncher::PauseSession { session_id } => {
             info!("Pause request for session {}", session_id);
             process_manager.stop(&session_id).await;
+        }
+        ServerToLauncher::ContinuationSync { continuations } => {
+            scheduler.update_continuations(continuations);
         }
         ServerToLauncher::ListDirectories { request_id, path } => {
             let response = list_directory(&path, request_id);

--- a/launcher/src/scheduler.rs
+++ b/launcher/src/scheduler.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use shared::ScheduledTaskConfig;
+use shared::{ContinuationConfig, ScheduledTaskConfig};
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -9,6 +9,7 @@ use uuid::Uuid;
 /// Delay before sending the prompt after session spawn.
 /// Gives the proxy time to connect and register the session row.
 const PROMPT_DELAY: Duration = Duration::from_secs(5);
+const CONTINUATION_RESET_SKEW_SECS: i64 = 60;
 
 struct ActiveTask {
     config: ScheduledTaskConfig,
@@ -28,6 +29,13 @@ struct PendingPrompt {
     send_at: Instant,
 }
 
+#[derive(Clone)]
+pub struct ReadyContinuation {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub prompt: String,
+}
+
 pub struct RunningInfo {
     pub task_id: Uuid,
     pub started_at: Instant,
@@ -44,6 +52,7 @@ pub struct Scheduler {
     pending_launches: HashMap<Uuid, PendingLaunch>,
     running: HashMap<Uuid, RunningInfo>,
     pending_prompts: Vec<PendingPrompt>,
+    continuations: Vec<ContinuationConfig>,
 }
 
 impl Scheduler {
@@ -53,6 +62,7 @@ impl Scheduler {
             pending_launches: HashMap::new(),
             running: HashMap::new(),
             pending_prompts: Vec::new(),
+            continuations: Vec::new(),
         }
     }
 
@@ -101,6 +111,58 @@ impl Scheduler {
             .iter()
             .map(|p| p.send_at.saturating_duration_since(now))
             .min()
+    }
+
+    pub fn update_continuations(&mut self, continuations: Vec<ContinuationConfig>) {
+        info!(
+            "Continuation schedule updated: {} one-shot continuation(s)",
+            continuations.len()
+        );
+        self.continuations = continuations;
+    }
+
+    pub fn next_continuation_duration(&self) -> Option<Duration> {
+        let now = Utc::now();
+        self.continuations
+            .iter()
+            .filter_map(|c| {
+                DateTime::parse_from_rfc3339(&c.reset_at).ok().map(|dt| {
+                    dt.with_timezone(&Utc) + chrono::Duration::seconds(CONTINUATION_RESET_SKEW_SECS)
+                })
+            })
+            .map(|next| {
+                if next <= now {
+                    Duration::ZERO
+                } else {
+                    (next - now).to_std().unwrap_or(Duration::ZERO)
+                }
+            })
+            .min()
+    }
+
+    pub fn ready_continuations(&mut self) -> Vec<ReadyContinuation> {
+        let now = Utc::now();
+        let mut ready = Vec::new();
+        self.continuations.retain(|c| {
+            let due = DateTime::parse_from_rfc3339(&c.reset_at)
+                .ok()
+                .map(|dt| {
+                    dt.with_timezone(&Utc) + chrono::Duration::seconds(CONTINUATION_RESET_SKEW_SECS)
+                        <= now
+                })
+                .unwrap_or(false);
+            if due {
+                ready.push(ReadyContinuation {
+                    id: c.id,
+                    session_id: c.session_id,
+                    prompt: c.prompt.clone(),
+                });
+                false
+            } else {
+                true
+            }
+        });
+        ready
     }
 
     /// Find and return tasks that are due to fire. Advances next_fire times.

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -59,6 +59,14 @@ pub enum IoEvent {
     /// ship to the backend as `ProxyToServer::TurnMetricsReport`. Emitted
     /// once per finalize by the agent-specific I/O task.
     TurnMetricsReady(Box<TurnMetrics>),
+    /// Claude reported a hard session limit with a reset time. The proxy
+    /// persists a one-shot continuation candidate via the backend.
+    SessionLimitReached {
+        session_id: uuid::Uuid,
+        reset_at: String,
+        source_message: String,
+        prompt: String,
+    },
     /// The codex io-task learned (or re-confirmed) the app-server thread
     /// id for this session — emitted exactly once per spawn after
     /// `thread_start` / `thread/resume` returns. The proxy persists the
@@ -111,6 +119,14 @@ pub enum SessionEvent {
     /// Codex app-server thread id, surfaced by the codex io-task so the
     /// proxy can persist it. See `IoEvent::CodexThreadId`.
     CodexThreadId(String),
+
+    /// Claude reported a hard session limit with a reset time.
+    SessionLimitReached {
+        session_id: uuid::Uuid,
+        reset_at: String,
+        source_message: String,
+        prompt: String,
+    },
 }
 
 /// Response to a permission request.

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -239,6 +239,19 @@ impl<A: Agent> Session<A> {
                 Some(IoEvent::CodexThreadId(thread_id)) => {
                     return Some(SessionEvent::CodexThreadId(thread_id));
                 }
+                Some(IoEvent::SessionLimitReached {
+                    session_id,
+                    reset_at,
+                    source_message,
+                    prompt,
+                }) => {
+                    return Some(SessionEvent::SessionLimitReached {
+                        session_id,
+                        reset_at,
+                        source_message,
+                        prompt,
+                    });
+                }
                 Some(IoEvent::Exited { code }) => {
                     self.state = SessionState::Exited { code };
                     self.command_tx = None;

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -61,6 +61,22 @@ pub struct ScheduledTaskConfig {
     pub last_session_id: Option<Uuid>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContinuationConfig {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub reset_at: String,
+    pub prompt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionLimitContinuationFields {
+    pub session_id: Uuid,
+    pub reset_at: String,
+    pub source_message: String,
+    pub prompt: String,
+}
+
 /// Fields for a permission response (shared by server-to-proxy and client-to-server).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PermissionResponseFields {
@@ -219,6 +235,11 @@ pub enum ProxyToServer {
     /// hot-path frames that fly orders of magnitude more often.
     TurnMetricsReport(Box<TurnMetrics>),
 
+    /// Claude reported a hard session limit with a reset time. The backend
+    /// persists a one-shot continuation candidate and asks the user whether
+    /// to schedule it.
+    SessionLimitReached(SessionLimitContinuationFields),
+
     /// Response to a backend-requested local file download.
     FileDownloadResponse(FileDownloadResponseFields),
 }
@@ -320,6 +341,10 @@ pub enum ClientToServer {
 
     /// Interrupt the current Claude response
     Interrupt,
+
+    /// Schedule a one-shot continuation that was detected by the proxy after
+    /// Claude reported a hard session limit.
+    ScheduleLimitContinuation { continuation_id: Uuid },
 }
 
 /// Messages the backend sends to the frontend.
@@ -411,6 +436,14 @@ pub enum ServerToClient {
 
     /// Session status changed
     SessionStatus { status: SessionStatus },
+
+    /// Status update for a one-shot hard-limit continuation action card.
+    ContinuationStatus {
+        continuation_id: Uuid,
+        status: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
 
     /// Launch session result (forwarded from launcher)
     LaunchSessionResult {
@@ -544,6 +577,21 @@ pub enum LauncherToServer {
     /// Inject input into a session on behalf of the scheduler
     InjectInput { session_id: Uuid, content: String },
 
+    /// A one-shot hard-limit continuation was injected into the still-running
+    /// local session.
+    ContinuationFired {
+        continuation_id: Uuid,
+        session_id: Uuid,
+    },
+
+    /// A one-shot hard-limit continuation reached its reset time, but the
+    /// original local session process was no longer running.
+    ContinuationDropped {
+        continuation_id: Uuid,
+        session_id: Uuid,
+        reason: String,
+    },
+
     /// Report that a scheduled task run has started
     ScheduledRunStarted { task_id: Uuid, session_id: Uuid },
 
@@ -618,6 +666,11 @@ pub enum ServerToLauncher {
 
     /// Sync scheduled task definitions to the launcher
     ScheduleSync { tasks: Vec<ScheduledTaskConfig> },
+
+    /// Sync one-shot hard-limit continuations to the launcher.
+    ContinuationSync {
+        continuations: Vec<ContinuationConfig>,
+    },
 
     /// Tell the launcher to pull the latest release, install it, and restart
     /// the agent-portal service. Triggered from the dashboard Launchers panel.

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -354,6 +354,23 @@ impl PortalMessage {
         }
     }
 
+    pub fn continuation_prompt(
+        continuation_id: Uuid,
+        reset_at: String,
+        status: String,
+        source_message: String,
+    ) -> Self {
+        Self {
+            message_type: "portal".to_string(),
+            content: vec![PortalContent::ContinuationPrompt {
+                continuation_id,
+                reset_at,
+                status,
+                source_message,
+            }],
+        }
+    }
+
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or_default()
     }
@@ -385,6 +402,15 @@ pub enum PortalContent {
         title: String,
         body: String,
     },
+    /// Action card shown when Claude reports a hard session limit. The
+    /// frontend may schedule a one-shot continuation for `reset_at`; the
+    /// launcher only injects it if the original local process is still alive.
+    ContinuationPrompt {
+        continuation_id: Uuid,
+        reset_at: String,
+        status: String,
+        source_message: String,
+    },
 }
 
 impl std::fmt::Debug for PortalContent {
@@ -409,6 +435,18 @@ impl std::fmt::Debug for PortalContent {
                 .debug_struct("Reminder")
                 .field("title", title)
                 .field("body", &format_args!("<{} bytes>", body.len()))
+                .finish(),
+            Self::ContinuationPrompt {
+                continuation_id,
+                reset_at,
+                status,
+                source_message,
+            } => f
+                .debug_struct("ContinuationPrompt")
+                .field("continuation_id", continuation_id)
+                .field("reset_at", reset_at)
+                .field("status", status)
+                .field("source_message", source_message)
                 .finish(),
         }
     }


### PR DESCRIPTION
## Summary
- detect Claude hard session-limit turns and persist one-shot continuation candidates
- render a Continue when limit lifted action in session history
- sync scheduled continuations to the launcher and inject only if the original local process is still running, otherwise mark dropped with a warning
- bump workspace version to 2.8.18

## Verification
- cargo fmt
- cargo check -p shared -p session-lib -p claude-session-lib -p backend -p agent-portal
- cargo check --target wasm32-unknown-unknown -p shared
- cd frontend && env -u NO_COLOR trunk build
- git diff --check
- ./scripts/check-migration-names.sh