### PR TITLE
Limit launcher paths to user home

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.22"
+version = "2.8.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.22"
+version = "2.8.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.22"
+version = "2.8.23"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.22"
+version = "2.8.23"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.22"
+version = "2.8.23"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.22"
+version = "2.8.23"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.22"
+version = "2.8.23"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.22"
+version = "2.8.23"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.22"
+version = "2.8.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.22"
+version = "2.8.23"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.22"
+version = "2.8.23"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -90,6 +90,7 @@ fn agent_config(agent_type: shared::AgentType) -> AgentConfig {
 #[derive(Clone)]
 struct DirBrowser {
     path: UseStateHandle<String>,
+    home_root: UseStateHandle<Option<String>>,
     entries: UseStateHandle<Vec<DirectoryEntry>>,
     loading: UseStateHandle<bool>,
     error: UseStateHandle<Option<String>>,
@@ -122,6 +123,9 @@ impl DirBrowser {
             match Request::get(&url).send().await {
                 Ok(resp) if resp.ok() => {
                     if let Ok(listing) = resp.json::<DirectoryListingResponse>().await {
+                        if update_path && (path == "~" || path == "~/") {
+                            browser.home_root.set(listing.resolved_path.clone());
+                        }
                         browser.entries.set(listing.entries);
                         if update_path {
                             if let Some(resolved) = listing.resolved_path {
@@ -139,9 +143,9 @@ impl DirBrowser {
                 Ok(resp) => {
                     let status = resp.status();
                     if status == 400 {
-                        browser
-                            .error
-                            .set(Some("Path not found or not readable".to_string()));
+                        browser.error.set(Some(
+                            "Path not found, not readable, or outside home".to_string(),
+                        ));
                     } else if status == 504 {
                         browser
                             .error
@@ -167,6 +171,37 @@ fn parent_path(path: &str) -> String {
     }
 }
 
+fn clamp_to_home(path: String, home_root: Option<&str>) -> String {
+    let Some(home_root) = home_root else {
+        return path;
+    };
+    let root = ensure_trailing_slash(home_root);
+    if path == "/" || !path.starts_with(&root) {
+        root
+    } else {
+        path
+    }
+}
+
+fn ensure_trailing_slash(path: &str) -> String {
+    if path.ends_with('/') {
+        path.to_string()
+    } else {
+        format!("{}/", path)
+    }
+}
+
+fn is_path_home_scoped(path: &str, home_root: Option<&str>) -> bool {
+    if path == "~" || path.starts_with("~/") {
+        return true;
+    }
+
+    let Some(home_root) = home_root else {
+        return !path.starts_with('/');
+    };
+    path.starts_with(&ensure_trailing_slash(home_root)) || path == home_root.trim_end_matches('/')
+}
+
 #[derive(Properties, PartialEq)]
 pub struct LaunchDialogProps {
     pub on_close: Callback<()>,
@@ -182,6 +217,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     let show_install = use_state(|| false);
     let dir = DirBrowser {
         path: use_state(|| "~".to_string()),
+        home_root: use_state(|| None::<String>),
         entries: use_state(Vec::<DirectoryEntry>::new),
         loading: use_state(|| false),
         error: use_state(|| None::<String>),
@@ -282,6 +318,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let selected_launcher = selected_launcher.clone();
         let dir = dir.clone();
         Callback::from(move |path: String| {
+            let path = clamp_to_home(path, (*dir.home_root).as_deref());
             dir.navigate(*selected_launcher, path);
         })
     };
@@ -330,6 +367,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
     let on_launch = {
         let dir_path = dir.path.clone();
+        let home_root = dir.home_root.clone();
         let extra_args = extra_args.clone();
         let agent_type = agent_type.clone();
         let skip_permissions = skip_permissions.clone();
@@ -342,6 +380,12 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
             let working_dir = (*dir_path).clone();
             if working_dir.is_empty() {
                 error_msg.set(Some("Working directory is required".to_string()));
+                return;
+            }
+            if !is_path_home_scoped(&working_dir, (*home_root).as_deref()) {
+                error_msg.set(Some(
+                    "Choose a directory under the launcher's home folder".to_string(),
+                ));
                 return;
             }
 
@@ -423,11 +467,15 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
     // Build breadcrumb segments from current path
     let path_str = (*dir.path).clone();
-    let breadcrumbs: Vec<(String, String)> = {
-        let mut segs = vec![("/".to_string(), "/".to_string())];
-        let trimmed = path_str.trim_start_matches('/');
+    let breadcrumbs: Vec<(String, String)> = if let Some(home_root) = (*dir.home_root).as_deref() {
+        let root = ensure_trailing_slash(home_root);
+        let mut segs = vec![(root.clone(), "~".to_string())];
+        let trimmed = path_str
+            .strip_prefix(&root)
+            .unwrap_or("")
+            .trim_start_matches('/');
         if !trimmed.is_empty() {
-            let mut built = String::from("/");
+            let mut built = root;
             for part in trimmed.split('/') {
                 if part.is_empty() {
                     continue;
@@ -438,6 +486,8 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
             }
         }
         segs
+    } else {
+        vec![("~".to_string(), "~".to_string())]
     };
 
     // Find selected launcher info for subtitle
@@ -470,7 +520,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     } else if dir.entries.is_empty() {
         html! { <div class="dir-empty">{ "Empty directory" }</div> }
     } else {
-        let parent = parent_path(&dir.path);
+        let parent = clamp_to_home(parent_path(&dir.path), (*dir.home_root).as_deref());
         let on_up = {
             let navigate_to = navigate_to.clone();
             Callback::from(move |_: MouseEvent| navigate_to.emit(parent.clone()))
@@ -603,10 +653,11 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
                     // Directory browser
                     <div class="launch-field">
-                        <label>{ "Directory" }</label>
+                        <label>{ "Directory (home folder only)" }</label>
                         <input
                             type="text"
                             class="dir-path-input"
+                            placeholder="~/project"
                             value={(*dir.path).clone()}
                             oninput={on_path_input}
                             onkeydown={on_path_keydown.clone()}
@@ -624,7 +675,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                                 };
                                 html! {
                                     <>
-                                        if i > 1 {
+                                        if i > 0 {
                                             <span class="dir-breadcrumb-sep">{ "/" }</span>
                                         }
                                         <a

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -1,4 +1,5 @@
 use crate::config::{self, ExpectedSession};
+use crate::path_policy;
 use crate::process_manager::{ProcessManager, SessionExited, SpawnParams};
 use crate::scheduler::Scheduler;
 use shared::{LauncherEndpoint, LauncherToServer, ServerToLauncher};
@@ -391,22 +392,23 @@ fn probe_agents_for_response() -> Vec<shared::AgentInstall> {
 fn list_directory(path: &str, request_id: Uuid) -> LauncherToServer {
     // Resolve ~ to home directory (trailing slash ensures the dir itself is listed,
     // not treated as a filter prefix against its parent)
-    let resolved = if path == "~" || path == "~/" {
-        dirs::home_dir()
-            .map(|p| format!("{}/", p.to_string_lossy()))
-            .unwrap_or_else(|| "/".to_string())
-    } else if let Some(rest) = path.strip_prefix("~/") {
-        dirs::home_dir()
-            .map(|p| format!("{}/{}", p.to_string_lossy(), rest))
-            .unwrap_or_else(|| format!("/{}", rest))
-    } else {
-        path.to_string()
+    let resolved_path = match path_policy::expand_home_path(path) {
+        Ok(path) => path,
+        Err(e) => {
+            return LauncherToServer::ListDirectoriesResult {
+                request_id,
+                entries: vec![],
+                error: Some(e.to_string()),
+                resolved_path: None,
+            };
+        }
     };
+    let resolved = resolved_path.to_string_lossy().to_string();
 
     // Split into (dir_to_list, filter_prefix)
     // If the path ends with '/', list the directory with no filter
     // Otherwise, treat the last component as a prefix filter
-    let (dir_path, filter) = if resolved.ends_with('/') || resolved == "/" {
+    let (dir_path, filter) = if path.ends_with('/') || path == "~" || path == "~/" {
         (resolved.as_str(), "")
     } else {
         let p = std::path::Path::new(&resolved);
@@ -419,9 +421,29 @@ fn list_directory(path: &str, request_id: Uuid) -> LauncherToServer {
     };
 
     let dir = std::path::Path::new(dir_path);
+    let canonical_dir = match dir.canonicalize() {
+        Ok(path) => path,
+        Err(e) => {
+            return LauncherToServer::ListDirectoriesResult {
+                request_id,
+                entries: vec![],
+                error: Some(e.to_string()),
+                resolved_path: None,
+            };
+        }
+    };
+    if let Err(e) = path_policy::ensure_canonical_path_under_home(&canonical_dir) {
+        return LauncherToServer::ListDirectoriesResult {
+            request_id,
+            entries: vec![],
+            error: Some(e.to_string()),
+            resolved_path: None,
+        };
+    }
+
     // Uses synchronous std::fs::read_dir (blocking I/O). This is acceptable because
     // list_directory is only called for small local directories (UI path completion).
-    let read_dir = match std::fs::read_dir(dir) {
+    let read_dir = match std::fs::read_dir(&canonical_dir) {
         Ok(rd) => rd,
         Err(e) => {
             return LauncherToServer::ListDirectoriesResult {
@@ -444,6 +466,17 @@ fn list_directory(path: &str, request_id: Uuid) -> LauncherToServer {
             continue;
         }
         let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+        if is_dir {
+            let under_home = entry
+                .path()
+                .canonicalize()
+                .ok()
+                .and_then(|path| path_policy::ensure_canonical_path_under_home(&path).ok())
+                .is_some();
+            if !under_home {
+                continue;
+            }
+        }
         entries.push(shared::DirectoryEntry { name, is_dir });
     }
 
@@ -640,6 +673,12 @@ async fn handle_message(
 mod tests {
     use super::*;
 
+    fn home_test_dir(name: &str) -> std::path::PathBuf {
+        path_policy::home_dir()
+            .unwrap()
+            .join(format!(".agent-portal-{}", name))
+    }
+
     fn extract_result(
         msg: LauncherToServer,
     ) -> (Vec<shared::DirectoryEntry>, Option<String>, Option<String>) {
@@ -656,7 +695,7 @@ mod tests {
 
     #[test]
     fn list_directory_returns_sorted_entries() {
-        let tmp = std::env::temp_dir().join("launcher_test_sorted");
+        let tmp = home_test_dir("launcher-test-sorted");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
         std::fs::create_dir(tmp.join("beta_dir")).unwrap();
@@ -681,7 +720,7 @@ mod tests {
 
     #[test]
     fn list_directory_filters_hidden_files() {
-        let tmp = std::env::temp_dir().join("launcher_test_hidden");
+        let tmp = home_test_dir("launcher-test-hidden");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
         std::fs::write(tmp.join(".hidden"), "").unwrap();
@@ -699,7 +738,7 @@ mod tests {
 
     #[test]
     fn list_directory_prefix_filter() {
-        let tmp = std::env::temp_dir().join("launcher_test_prefix");
+        let tmp = home_test_dir("launcher-test-prefix");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
         std::fs::write(tmp.join("foo.txt"), "").unwrap();
@@ -728,8 +767,25 @@ mod tests {
     }
 
     #[test]
+    fn list_directory_rejects_existing_paths_outside_home() {
+        let temp = std::env::temp_dir().canonicalize().unwrap();
+        let home = path_policy::home_dir().unwrap().canonicalize().unwrap();
+
+        if temp.starts_with(home) {
+            return;
+        }
+
+        let result = list_directory(&format!("{}/", temp.display()), Uuid::nil());
+        let (entries, error, resolved) = extract_result(result);
+
+        assert!(entries.is_empty());
+        assert!(error.unwrap().contains("home directory"));
+        assert!(resolved.is_none());
+    }
+
+    #[test]
     fn list_directory_resolved_path_has_trailing_slash() {
-        let tmp = std::env::temp_dir();
+        let tmp = path_policy::home_dir().unwrap();
         let path = tmp.to_string_lossy().to_string();
         // Even without trailing slash, if it's a valid dir the resolved_path should end with /
         let result = list_directory(&format!("{}/", path), Uuid::nil());

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod connection;
 mod pastebin;
+mod path_policy;
 mod process_manager;
 mod scheduler;
 mod service;

--- a/launcher/src/path_policy.rs
+++ b/launcher/src/path_policy.rs
@@ -1,0 +1,81 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+pub fn home_dir() -> Result<PathBuf> {
+    dirs::home_dir().context("Could not determine launcher user's home directory")
+}
+
+pub fn expand_home_path(path: &str) -> Result<PathBuf> {
+    if path == "~" || path == "~/" {
+        return home_dir();
+    }
+
+    if let Some(rest) = path.strip_prefix("~/") {
+        return Ok(home_dir()?.join(rest));
+    }
+
+    Ok(PathBuf::from(path))
+}
+
+pub fn ensure_existing_dir_under_home(path: &str) -> Result<PathBuf> {
+    let requested = expand_home_path(path)?;
+    let canonical = requested.canonicalize().with_context(|| {
+        format!(
+            "Working directory does not exist or is not readable: {}",
+            requested.display()
+        )
+    })?;
+
+    if !canonical.is_dir() {
+        anyhow::bail!(
+            "Working directory is not a directory: {}",
+            canonical.display()
+        );
+    }
+
+    ensure_canonical_path_under_home(&canonical)?;
+    Ok(canonical)
+}
+
+pub fn ensure_canonical_path_under_home(path: &Path) -> Result<()> {
+    let home = home_dir()?
+        .canonicalize()
+        .context("Could not resolve launcher user's home directory")?;
+
+    if !path.starts_with(&home) {
+        anyhow::bail!(
+            "Launcher can only access paths under the user's home directory: {}",
+            home.display()
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tilde_expands_to_home() {
+        assert_eq!(expand_home_path("~").unwrap(), home_dir().unwrap());
+    }
+
+    #[test]
+    fn home_directory_is_allowed() {
+        let home = home_dir().unwrap();
+        let allowed = ensure_existing_dir_under_home(&home.to_string_lossy()).unwrap();
+        assert!(allowed.starts_with(home.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn temp_directory_is_rejected_when_outside_home() {
+        let temp = std::env::temp_dir().canonicalize().unwrap();
+        let home = home_dir().unwrap().canonicalize().unwrap();
+
+        if !temp.starts_with(home) {
+            let err = ensure_existing_dir_under_home(&temp.to_string_lossy()).unwrap_err();
+            assert!(err.to_string().contains("home directory"));
+        }
+    }
+}

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -12,6 +12,8 @@ use claude_session_lib::{
 use codex_session_lib::CodexAgent;
 use session_lib::{Session, SessionConfig};
 
+use crate::path_policy;
+
 /// Path to the launcher's sidecar codex-thread map: `session_id -> thread_id`.
 /// Lives next to `launcher.json` in `ProjectDirs` so it ships with the same
 /// install/uninstall surface and survives across restarts.
@@ -132,13 +134,10 @@ impl ProcessManager {
             );
         }
 
-        let wd = std::path::Path::new(&params.working_directory);
-        if !wd.is_dir() {
-            anyhow::bail!(
-                "Working directory does not exist: {}",
-                params.working_directory
-            );
-        }
+        let working_directory =
+            path_policy::ensure_existing_dir_under_home(&params.working_directory)?
+                .to_string_lossy()
+                .to_string();
 
         let (session_id, resume) = match params.resume_session_id {
             Some(id) => (id, true),
@@ -158,14 +157,14 @@ impl ProcessManager {
             .unwrap_or(&default_name)
             .to_string();
 
-        let git_branch = get_git_branch(&params.working_directory);
+        let git_branch = get_git_branch(&working_directory);
 
         let proxy_config = ProxySessionConfig {
             backend_url: self.backend_url.clone(),
             session_id,
             session_name: name.clone(),
             auth_token: Some(params.auth_token),
-            working_directory: params.working_directory.clone(),
+            working_directory: working_directory.clone(),
             resume,
             git_branch,
             claude_args: params.claude_args,
@@ -194,7 +193,7 @@ impl ProcessManager {
 
         info!(
             "Spawned session task: session_id={}, session_name={}, dir={}",
-            session_id, name, params.working_directory
+            session_id, name, working_directory
         );
 
         self.tasks.insert(
@@ -202,7 +201,7 @@ impl ProcessManager {
             ManagedTask {
                 handle,
                 cancel,
-                working_directory: params.working_directory,
+                working_directory,
             },
         );
 


### PR DESCRIPTION
## Summary
- restrict launcher session spawn paths to directories under the launcher user home
- keep the launch modal rooted at the launcher home folder and block outside-home launches client-side
- restrict launcher directory listing to home-scoped paths and add regression coverage
- bump workspace version to 2.8.23

## Verification
- cargo test -p agent-portal
- cargo check -p agent-portal -p frontend
- cargo check --target wasm32-unknown-unknown -p shared
- cd frontend && env -u NO_COLOR trunk build
- cargo clippy -p agent-portal -p frontend --all-targets -- -D warnings
- git diff --check