### PR TITLE
Remove launcher dead expected-session restart machinery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.24
+
+- **Remove the launcher's dead expected-session restart machinery.** `expected_sessions` is wiped unconditionally at startup (the backend DB has been authoritative since #908) and nothing repopulates it, so the crash-restart path could never fire. Deleted: `RESTART_DELAY`/`MAX_RESTART_ATTEMPTS`, the `restart_counts` map, the restart channel and its select arm, the post-exit clean/non-clean expected-session block, the resume-id fallback in `LaunchSession`, `config::remove_session`, and the now-orphaned `session_working_directory()` helper + `ManagedTask.working_directory` field. The one-time legacy-config wipe (`clear_sessions`) moved to `main.rs` where the config is loaded; behavior is identical. Net −132 lines and a simpler launcher select loop.
+
 ## 2.8.17
 
 - **Add log-scale support to Performance plots.** The Performance page now has a `Y scale` control with `Linear` as the default and `Log` as an alternate view across all plots. Log scaling maps positive values by base-10 decades while keeping zero/non-positive buckets on a baseline, and the chart headers show the active scale.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.23"
+version = "2.8.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.23"
+version = "2.8.24"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.23"
+version = "2.8.24"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.23"
+version = "2.8.24"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.23"
+version = "2.8.24"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.23"
+version = "2.8.24"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.23"
+version = "2.8.24"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.23"
+version = "2.8.24"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.23"
+version = "2.8.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.23"
+version = "2.8.24"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.23"
+version = "2.8.24"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/launcher/src/config.rs
+++ b/launcher/src/config.rs
@@ -71,19 +71,6 @@ pub fn save_auth_token(token: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn remove_session(working_directory: &str) -> anyhow::Result<()> {
-    let mut config = load_config();
-    let before = config.sessions.len();
-    config
-        .sessions
-        .retain(|s| s.working_directory != working_directory);
-    if config.sessions.len() < before {
-        save_config(&config)?;
-        tracing::debug!("Removed session from config: {}", working_directory);
-    }
-    Ok(())
-}
-
 pub fn clear_sessions() -> anyhow::Result<()> {
     let mut config = load_config();
     if !config.sessions.is_empty() {

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -1,9 +1,7 @@
-use crate::config::{self, ExpectedSession};
 use crate::path_policy;
 use crate::process_manager::{ProcessManager, SessionExited, SpawnParams};
 use crate::scheduler::Scheduler;
 use shared::{LauncherEndpoint, LauncherToServer, ServerToLauncher};
-use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
@@ -11,8 +9,6 @@ use uuid::Uuid;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_BACKOFF: Duration = Duration::from_secs(shared::protocol::MAX_RECONNECT_BACKOFF_SECS);
-const RESTART_DELAY: Duration = Duration::from_secs(5);
-const MAX_RESTART_ATTEMPTS: u32 = 3;
 
 pub async fn run_launcher_loop(
     backend_url: &str,
@@ -21,19 +17,8 @@ pub async fn run_launcher_loop(
     auth_token: Option<&str>,
     mut process_manager: ProcessManager,
     mut exit_rx: mpsc::UnboundedReceiver<SessionExited>,
-    mut expected_sessions: Vec<ExpectedSession>,
 ) -> anyhow::Result<()> {
     process_manager.set_launcher_id(launcher_id);
-    if !expected_sessions.is_empty() {
-        info!(
-            "Discarding {} launcher-local expected session(s); backend DB is authoritative",
-            expected_sessions.len()
-        );
-        expected_sessions.clear();
-        if let Err(e) = config::clear_sessions() {
-            warn!("Failed to clear launcher-local expected sessions: {}", e);
-        }
-    }
     let mut backoff = Duration::from_secs(1);
     let mut scheduler = Scheduler::new();
 
@@ -113,12 +98,6 @@ pub async fn run_launcher_loop(
                     Some(true) => {} // fall through to main loop
                 }
 
-                // Expected sessions are reconciled by the backend from the DB.
-                let mut restart_counts: HashMap<String, u32> = HashMap::new();
-
-                // Channel for delayed restart requests
-                let (restart_tx, mut restart_rx) = mpsc::unbounded_channel::<ExpectedSession>();
-
                 // Main loop
                 let mut heartbeat_timer = tokio::time::interval(HEARTBEAT_INTERVAL);
                 let start = Instant::now();
@@ -148,7 +127,6 @@ pub async fn run_launcher_loop(
                                         msg,
                                         &mut ws_sender,
                                         &mut process_manager,
-                                        &mut expected_sessions,
                                         &mut scheduler,
                                     ).await;
                                 }
@@ -181,7 +159,6 @@ pub async fn run_launcher_loop(
                         }
 
                         Some(exited) = exit_rx.recv() => {
-                            let exited_dir = process_manager.session_working_directory(&exited.session_id);
                             info!(
                                 "Session {} exited with code {:?}",
                                 exited.session_id, exited.exit_code
@@ -208,60 +185,6 @@ pub async fn run_launcher_loop(
                                     warn!("Failed to send ScheduledRunCompleted");
                                     break;
                                 }
-                            }
-
-                            if let Some(dir) = exited_dir {
-                                let is_clean_exit = exited.exit_code == Some(0);
-                                if is_clean_exit {
-                                    // Clean exit: remove from expected sessions
-                                    expected_sessions.retain(|s| s.working_directory != dir);
-                                    if let Err(e) = config::remove_session(&dir) {
-                                        warn!("Failed to remove session from config: {}", e);
-                                    }
-                                    info!("Session exited cleanly, removed from expected: {}", dir);
-                                } else if let Some(expected) = expected_sessions.iter().find(|s| s.working_directory == dir) {
-                                    // Non-clean exit: try to restart
-                                    let count = restart_counts.entry(dir.clone()).or_insert(0);
-                                    *count += 1;
-                                    if *count <= MAX_RESTART_ATTEMPTS {
-                                        info!(
-                                            "Expected session exited, scheduling restart ({}/{}): {}",
-                                            count, MAX_RESTART_ATTEMPTS, dir
-                                        );
-                                        let tx = restart_tx.clone();
-                                        let session = expected.clone();
-                                        tokio::spawn(async move {
-                                            tokio::time::sleep(RESTART_DELAY).await;
-                                            let _ = tx.send(session);
-                                        });
-                                    } else {
-                                        warn!(
-                                            "Expected session exceeded max restarts ({}): {}",
-                                            MAX_RESTART_ATTEMPTS, dir
-                                        );
-                                        expected_sessions.retain(|s| s.working_directory != dir);
-                                        if let Err(e) = config::remove_session(&dir) {
-                                            warn!("Failed to remove session from config: {}", e);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        Some(session) = restart_rx.recv() => {
-                            info!("Restarting expected session: {}", session.working_directory);
-                            let request = LauncherToServer::RequestLaunch {
-                                request_id: Uuid::new_v4(),
-                                working_directory: session.working_directory,
-                                session_name: session.session_name,
-                                claude_args: session.claude_args,
-                                agent_type: session.agent_type,
-                                scheduled_task_id: None,
-                                last_session_id: session.session_id,
-                            };
-                            if ws_sender.send(request).await.is_err() {
-                                warn!("Failed to send session restart request");
-                                break;
                             }
                         }
 
@@ -502,7 +425,6 @@ async fn handle_message(
     msg: ServerToLauncher,
     ws_sender: &mut ws_bridge::WsSender<LauncherToServer>,
     process_manager: &mut ProcessManager,
-    expected_sessions: &mut Vec<ExpectedSession>,
     scheduler: &mut Scheduler,
 ) {
     match msg {
@@ -516,7 +438,7 @@ async fn handle_message(
             resume_session_id,
             ..
         } => {
-            // Check if this is a scheduled launch or a relaunch of an expected session
+            // Check if this is a scheduled launch
             let (resume_session_id, scheduled_task_id, is_scheduled) = if let Some((
                 resume_id,
                 task_id,
@@ -525,13 +447,7 @@ async fn handle_message(
             {
                 (resume_id, Some(task_id), true)
             } else {
-                let resume_id = resume_session_id.or_else(|| {
-                    expected_sessions
-                        .iter()
-                        .find(|s| s.working_directory == working_directory)
-                        .and_then(|s| s.session_id)
-                });
-                (resume_id, None, false)
+                (resume_session_id, None, false)
             };
 
             info!(
@@ -583,21 +499,9 @@ async fn handle_message(
                 warn!("Failed to send launch session result");
             }
         }
-        ServerToLauncher::StopSession {
-            session_id,
-            working_directory,
-        } => {
+        ServerToLauncher::StopSession { session_id, .. } => {
             info!("Stop request for session {}", session_id);
-            let working_dir = process_manager
-                .session_working_directory(&session_id)
-                .or(working_directory);
             process_manager.stop(&session_id).await;
-            if let Some(dir) = working_dir {
-                expected_sessions.retain(|s| s.working_directory != dir);
-                if let Err(e) = config::remove_session(&dir) {
-                    warn!("Failed to remove session from config: {}", e);
-                }
-            }
         }
         ServerToLauncher::PauseSession { session_id } => {
             info!("Pause request for session {}", session_id);

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -196,9 +196,12 @@ async fn main() -> anyhow::Result<()> {
     tracing::debug!("Max sessions: {}", args.max_sessions);
 
     if !config.sessions.is_empty() {
-        tracing::info!("Expected sessions configured: {}", config.sessions.len());
-        for s in &config.sessions {
-            tracing::info!("  - {} ({})", s.working_directory, s.agent_type);
+        tracing::info!(
+            "Discarding {} launcher-local expected session(s); backend DB is authoritative",
+            config.sessions.len()
+        );
+        if let Err(e) = config::clear_sessions() {
+            tracing::warn!("Failed to clear launcher-local expected sessions: {}", e);
         }
     }
 
@@ -212,7 +215,6 @@ async fn main() -> anyhow::Result<()> {
         auth_token.as_deref(),
         process_manager,
         exit_rx,
-        config.sessions,
     )
     .await
 }

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -67,7 +67,6 @@ pub struct SessionExited {
 struct ManagedTask {
     handle: tokio::task::JoinHandle<()>,
     cancel: CancellationToken,
-    working_directory: String,
 }
 
 pub struct SpawnParams {
@@ -112,13 +111,6 @@ impl ProcessManager {
 
     pub fn running_session_ids(&self) -> Vec<Uuid> {
         self.tasks.keys().copied().collect()
-    }
-
-    /// Returns the working directory for a given session, if it exists.
-    pub fn session_working_directory(&self, session_id: &Uuid) -> Option<String> {
-        self.tasks
-            .get(session_id)
-            .map(|t| t.working_directory.clone())
     }
 
     pub async fn spawn(&mut self, params: SpawnParams) -> anyhow::Result<Uuid> {
@@ -196,14 +188,8 @@ impl ProcessManager {
             session_id, name, working_directory
         );
 
-        self.tasks.insert(
-            session_id,
-            ManagedTask {
-                handle,
-                cancel,
-                working_directory,
-            },
-        );
+        self.tasks
+            .insert(session_id, ManagedTask { handle, cancel });
 
         Ok(session_id)
     }


### PR DESCRIPTION
Fixes #964.

`expected_sessions` is cleared unconditionally at startup (backend DB is authoritative since #908) and nothing ever repopulates it, so the entire crash-restart path was unreachable. This deletes it:

- `RESTART_DELAY`/`MAX_RESTART_ATTEMPTS`, `restart_counts`, the restart channel + select arm
- the post-exit clean/non-clean expected-session handling block
- the resume-id fallback in `LaunchSession`; `StopSession` now just calls `process_manager.stop`
- `config::remove_session`
- now-orphaned `session_working_directory()` + `ManagedTask.working_directory`

Kept: `clear_sessions` + the `ExpectedSession` config shape (needed to parse old config files and perform the one-time wipe, which moved to `main.rs` where the config is loaded — identical behavior).

Validation: `cargo fmt --check` clean, `cargo clippy -p agent-portal --all-targets -- -D warnings` clean, `cargo test -p agent-portal` 31/31, workspace check clean. Net +11/−132.