### PR TITLE
Dedupe git metadata helpers into claude-session-lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.25
+
+- **Dedupe `get_git_branch` (4 copies) and `get_repo_url` (2 copies) into `claude-session-lib`.** The canonical implementations in `proxy_session/git_metadata.rs` are now `pub` and re-exported from `claude_session_lib::proxy_session`; the verbatim copies in `proxy/src/main.rs`, `proxy/src/session.rs`, and `launcher/src/process_manager.rs` are deleted and their call sites pointed at the shared versions. All copies were byte-identical modulo comments — no behavior change. Net −109 lines.
+
 ## 2.8.17
 
 - **Add log-scale support to Performance plots.** The Performance page now has a `Y scale` control with `Linear` as the default and `Log` as an alternate view across all plots. Log scaling maps positive values by base-10 decades while keeping zero/non-positive buckets on a baseline, and the chart headers show the active scale.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.23"
+version = "2.8.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.23"
+version = "2.8.25"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.23"
+version = "2.8.25"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.23"
+version = "2.8.25"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.23"
+version = "2.8.25"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.23"
+version = "2.8.25"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.23"
+version = "2.8.25"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.23"
+version = "2.8.25"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.23"
+version = "2.8.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.23"
+version = "2.8.25"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.23"
+version = "2.8.25"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/git_metadata.rs
+++ b/claude-session-lib/src/proxy_session/git_metadata.rs
@@ -48,7 +48,7 @@ impl GitRefreshTrigger {
 }
 
 /// Get the current git branch name, if in a git repository.
-pub(super) fn get_git_branch(cwd: &str) -> Option<String> {
+pub fn get_git_branch(cwd: &str) -> Option<String> {
     let output = std::process::Command::new("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(cwd)
@@ -79,7 +79,7 @@ pub(super) fn get_git_branch(cwd: &str) -> Option<String> {
 }
 
 /// Look up the GitHub repository URL using the `gh` CLI.
-pub(super) fn get_repo_url(cwd: &str) -> Option<String> {
+pub fn get_repo_url(cwd: &str) -> Option<String> {
     let output = std::process::Command::new("gh")
         .args(["repo", "view", "--json", "url", "-q", ".url"])
         .current_dir(cwd)

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -23,10 +23,11 @@ use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
+pub use git_metadata::{get_git_branch, get_repo_url};
+
 use git_metadata::{
     check_and_send_branch_update, check_and_send_branch_update_if_branch_changed,
-    codex_output_has_git_signal, get_git_branch, get_pr_url, get_repo_url, GitMetadataState,
-    GitRefreshTrigger,
+    codex_output_has_git_signal, get_pr_url, GitMetadataState, GitRefreshTrigger,
 };
 use output_forwarder::spawn_output_forwarder;
 use wiggum::{handle_session_event_with_wiggum, WiggumState};

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -5,7 +5,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use claude_session_lib::proxy_session::CodexThreadIdSink;
+use claude_session_lib::proxy_session::{get_git_branch, CodexThreadIdSink};
 use claude_session_lib::{
     run_connection_loop, ClaudeAgent, LoopResult, PortalInput, ProxySessionConfig,
 };
@@ -345,36 +345,5 @@ async fn run_session_task(
                 return Some(1);
             }
         }
-    }
-}
-
-fn get_git_branch(cwd: &str) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(cwd)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let branch = String::from_utf8(output.stdout)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())?;
-
-    if branch == "HEAD" {
-        // Detached HEAD — return short commit hash
-        std::process::Command::new("git")
-            .args(["rev-parse", "--short", "HEAD"])
-            .current_dir(cwd)
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| format!("detached:{}", s.trim()))
-    } else {
-        Some(branch)
     }
 }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -19,7 +19,7 @@ use shared::api::{ResolveProxySessionRequest, ResolveProxySessionResponse};
 /// launcher is where heterogeneous (Claude + Codex) dispatch lives.
 type ClaudeSession = Session<ClaudeAgent>;
 use config::{DirectorySession, ProxyConfig, SessionAuth};
-use session::ProxySessionConfig;
+use session::{get_git_branch, ProxySessionConfig};
 use tracing::{info, warn};
 use tracing_subscriber::prelude::*;
 use uuid::Uuid;
@@ -192,38 +192,6 @@ fn default_session_name() -> String {
         .unwrap_or_else(|| "unknown".to_string());
     let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
     format!("{}-{}", hostname, timestamp)
-}
-
-/// Get the current git branch name, if in a git repository
-fn get_git_branch(cwd: &str) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(cwd)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let branch = String::from_utf8(output.stdout)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())?;
-
-    // If we're in detached HEAD state, get the short commit hash instead
-    if branch == "HEAD" {
-        std::process::Command::new("git")
-            .args(["rev-parse", "--short", "HEAD"])
-            .current_dir(cwd)
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| format!("detached:{}", s.trim()))
-    } else {
-        Some(branch)
-    }
 }
 
 /// Handle --check-update: check for updates without installing

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -155,53 +155,6 @@ pub async fn register_with_backend(
     }
 }
 
-/// Get the current git branch name, if in a git repository.
-pub fn get_git_branch(cwd: &str) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(cwd)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let branch = String::from_utf8(output.stdout)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())?;
-
-    if branch == "HEAD" {
-        std::process::Command::new("git")
-            .args(["rev-parse", "--short", "HEAD"])
-            .current_dir(cwd)
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| format!("detached:{}", s.trim()))
-    } else {
-        Some(branch)
-    }
-}
-
-/// Get the GitHub repository URL using the `gh` CLI.
-pub fn get_repo_url(cwd: &str) -> Option<String> {
-    let output = std::process::Command::new("gh")
-        .args(["repo", "view", "--json", "url", "-q", ".url"])
-        .current_dir(cwd)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    String::from_utf8(output.stdout)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-}
-
 /// Events produced by the WebSocket reader for the shim's select loop.
 pub enum WsEvent {
     /// Text input from the portal web UI


### PR DESCRIPTION
Fixes #965.

`get_git_branch` existed in four byte-identical copies (`claude-session-lib/proxy_session/git_metadata.rs`, `proxy/src/main.rs`, `proxy/src/session.rs`, `launcher/src/process_manager.rs`) and `get_repo_url` in two. The `git_metadata.rs` versions are now `pub` and re-exported via `claude_session_lib::proxy_session`; the three copies are deleted.

- `proxy/src/session.rs` already glob-re-exports `proxy_session::*`, so `shim.rs` and existing call sites compile unchanged
- launcher already depended on `claude-session-lib`; its import now points at the shared helper

No functional divergence found between the copies (comments only). Net −109 lines.

Validation: fmt clean, `cargo clippy -p claude-portal -p claude-session-lib -p agent-portal --all-targets -- -D warnings` clean, tests 31+2+5 pass, workspace check clean.

Note: expect a trivial `Cargo.toml`/`CHANGELOG.md` conflict with #1001 — whichever merges second gets a version-line touch-up before merge.