### PR TITLE
Drop cumulative codex turn diffs, dedupe file patch updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.34
+
+- **Codex: drop cumulative `turn/diff/updated` cards and dedupe per-file patch updates.** Codex re-sends the entire turn diff on every edit tick, so transcripts accumulated O(ticks) redundant cards — each the size of the whole turn — on top of the per-file `item.completed{file_change}` diffs that already render the same edits. The events are now dropped in `group_messages` (before grouping, so Codex runs don't fragment around each dropped diff) with a no-op dispatcher arm kept for exhaustiveness. `item/fileChange/patchUpdated` events (also cumulative per file) now surface their `item_id` in `codex_event_item_id`, letting the existing group dedup keep only the final patch and collapse it against the matching lifecycle events. The `DiffCard` `cumulative` chip and `render_turn_diff` are deleted with their only producer.
+
 ## 2.8.33
 
 - **CI dedup: one composite `setup-rust` action, one frontend build, matrix release.** `ci.yml` previously built the frontend in four jobs and pasted Install Rust/cache/trunk/protoc steps across eight; now `build-frontend` builds once and uploads `frontend/dist` as an artifact consumed by clippy/build-backend/test, the eight per-platform proxy/launcher jobs are one `build-binaries` matrix, and setup lives in `.github/actions/setup-rust` (which also carries the macOS clean-rustup workaround once instead of twice). `release.yml`'s five copy-pasted platform jobs are one matrix — uploaded artifact and release-asset filenames verified byte-identical against what `portal-update` expects. `container.yml` keeps its independent build (cross-workflow artifact handoff would couple it to CI's run lifecycle) but uses the composite action. Job display names, cache keys, runners, and codesign steps unchanged. actionlint-clean.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.33"
+version = "2.8.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.33"
+version = "2.8.34"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.33"
+version = "2.8.34"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.33"
+version = "2.8.34"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.33"
+version = "2.8.34"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.33"
+version = "2.8.34"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.33"
+version = "2.8.34"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.33"
+version = "2.8.34"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.33"
+version = "2.8.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.33"
+version = "2.8.34"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.33"
+version = "2.8.34"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -95,9 +95,6 @@ fn render_codex_event(
             item => render_item(item, true, session_id),
         },
         Ok(CodexEvent::Error { message }) => render_error_block(message.as_deref()),
-        Ok(CodexEvent::TurnDiffUpdated { params }) => {
-            render_turn_diff(params.as_ref().and_then(|p| p.diff.as_deref()))
-        }
         Ok(CodexEvent::FileChangePatchUpdated { params }) => {
             render_file_change_patch(params.as_ref().and_then(|p| p.changes.as_deref()))
         }
@@ -106,10 +103,18 @@ fn render_codex_event(
             params.as_ref().and_then(|p| p.explanation.as_deref()),
         ),
         Ok(CodexEvent::ThreadCompacted { params }) => render_context_compacted(params.as_ref()),
+        // Cumulative whole-turn diffs (`turn/diff/updated`) are dropped: Codex
+        // re-sends the entire turn diff on every edit tick, so they pile up
+        // O(ticks) redundant cards (each the size of the whole turn) on top of
+        // the per-file `item.completed{file_change}` diffs that already render
+        // the same edits. Dropped before grouping — see
+        // `grouping::group_messages` — so they never reach this renderer in
+        // practice; the no-op arm is kept for match exhaustiveness.
+        Ok(CodexEvent::TurnDiffUpdated { .. })
         // Per-chunk deltas — the consolidated content lands in `turn/plan/updated`
         // (for plans) or `item.completed` (for reasoning). Emit nothing for the
         // streaming chunks to avoid visual noise without losing information.
-        Ok(CodexEvent::PlanDelta { .. })
+        | Ok(CodexEvent::PlanDelta { .. })
         | Ok(CodexEvent::ReasoningSummaryPartAdded { .. })
         | Ok(CodexEvent::ReasoningTextDelta { .. }) => html! {},
         Ok(CodexEvent::Unknown) | Err(_) => {
@@ -344,24 +349,6 @@ fn render_error_block(message: Option<&str>) -> Html {
             </div>
             <div class="message-body">
                 <div class="error-text">{ message }</div>
-            </div>
-        </div>
-    }
-}
-
-fn render_turn_diff(diff: Option<&str>) -> Html {
-    let diff = diff.unwrap_or("");
-    if diff.trim().is_empty() {
-        // Empty deltas — don't render an empty block.
-        return html! {};
-    }
-    let source = super::diff::DiffSource::Unified {
-        text: diff.to_string(),
-    };
-    html! {
-        <div class="claude-message assistant-message">
-            <div class="message-body">
-                <super::diff::DiffCard {source} cumulative=true />
             </div>
         </div>
     }

--- a/frontend/src/components/codex_renderer/events.rs
+++ b/frontend/src/components/codex_renderer/events.rs
@@ -303,13 +303,18 @@ pub fn codex_item_id(item: &CodexItem) -> &str {
 /// into a single rendered card (#776).
 pub fn codex_event_item_id(json: &str) -> Option<String> {
     let event: CodexEvent = serde_json::from_str(json).ok()?;
-    let item = match event {
+    match event {
         CodexEvent::ItemStarted { item }
         | CodexEvent::ItemUpdated { item }
-        | CodexEvent::ItemCompleted { item } => item?,
-        _ => return None,
-    };
-    Some(codex_item_id(&item).to_string())
+        | CodexEvent::ItemCompleted { item } => Some(codex_item_id(&item?).to_string()),
+        // Per-file patch updates (`item/fileChange/patchUpdated`) are cumulative
+        // too — Codex re-sends the full file patch on every tick. Surfacing
+        // their `item_id` here lets the group dedup keep only the final patch,
+        // and collapses them against the matching `item.*{file_change}`
+        // lifecycle events that carry the same id.
+        CodexEvent::FileChangePatchUpdated { params } => params.and_then(|p| p.item_id),
+        _ => None,
+    }
 }
 
 /// Check if a Codex message indicates "awaiting" (turn complete or turn failed)

--- a/frontend/src/components/diff.rs
+++ b/frontend/src/components/diff.rs
@@ -9,22 +9,22 @@ pub enum DiffLine<'a> {
 
 /// Source for a `DiffCard` body: either two snapshots (Claude `Edit` /
 /// `Write`-style: compute the diff via LCS) or a pre-formatted unified-diff
-/// string (Codex `turn/diff/updated` / `item/fileChange/patchUpdated`: parse
-/// the existing patch text). Both paths funnel through `render_diff_html`,
-/// so the per-line styling and parser tests stay shared.
+/// string (Codex per-file `item/fileChange/patchUpdated`: parse the existing
+/// patch text). Both paths funnel through `render_diff_html`, so the per-line
+/// styling and parser tests stay shared.
 #[derive(Debug, Clone, PartialEq)]
 pub enum DiffSource {
     OldNew { old: String, new: String },
     Unified { text: String },
 }
 
-/// One shared diff card for both Claude (`Edit` tool) and Codex
-/// (`turn/diff/updated`, per-file `item/fileChange/patchUpdated`) — see #823.
+/// One shared diff card for both Claude (`Edit` tool) and Codex per-file
+/// (`item/fileChange/patchUpdated`) diffs — see #823.
 ///
 /// The card is the only place that gets the `.diff-card` framed treatment
 /// (background, rounded corners, scrollable body). Header fields are all
 /// optional so the card collapses to just a framed body when called without
-/// labels (e.g. a Codex cumulative turn diff with no file path).
+/// labels.
 #[derive(Properties, PartialEq)]
 pub struct DiffCardProps {
     pub source: DiffSource,
@@ -39,11 +39,6 @@ pub struct DiffCardProps {
     /// Claude `Edit { replace_all: true }` chip. Renders only when set.
     #[prop_or_default]
     pub replace_all: bool,
-    /// Codex turn-level cumulative diff label. Renders a `(cumulative)`
-    /// chip next to the title so the wire semantics aren't lost when the
-    /// card is visually identical to a per-file diff.
-    #[prop_or_default]
-    pub cumulative: bool,
 }
 
 #[function_component(DiffCard)]
@@ -72,11 +67,6 @@ pub fn diff_card(props: &DiffCardProps) -> Html {
                     <span class="diff-card-path">{ path }</span>
                 } else {
                     <span class="diff-card-title">{ "Diff" }</span>
-                }
-                if props.cumulative {
-                    <span class="diff-card-cumulative" title="Codex turn-level cumulative diff">
-                        { "(cumulative)" }
-                    </span>
                 }
                 if props.replace_all {
                     <span class="diff-card-replace-all">{ "(replace all)" }</span>

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -358,6 +358,21 @@ pub fn group_messages(
     }
 
     for json in messages {
+        // Cumulative `turn/diff/updated` events are dropped entirely — Codex
+        // re-sends the whole-turn diff on every edit tick, so they pile up
+        // O(ticks) redundant cards (each the size of the full turn) on top of
+        // the per-file diffs that already show the same edits. Skipping here
+        // rather than in `classify` keeps the surrounding Codex events in one
+        // run instead of fragmenting the group around each dropped diff.
+        if agent_type == shared::AgentType::Codex {
+            use crate::components::codex_renderer::CodexEvent;
+            if matches!(
+                serde_json::from_str::<CodexEvent>(json),
+                Ok(CodexEvent::TurnDiffUpdated { .. })
+            ) {
+                continue;
+            }
+        }
         match classify(json, agent_type, current_user_id) {
             Some(identity) => match current.as_mut() {
                 Some((cur_identity, msgs)) if *cur_identity == identity => msgs.push(json.clone()),


### PR DESCRIPTION
Codex re-sends the whole-turn diff on every edit tick (`turn/diff/updated`), piling up O(ticks) redundant cards on top of the per-file diffs that already show the same edits.

- Drop them in `group_messages` before grouping (keeps Codex event runs contiguous); no-op dispatcher arm kept for match exhaustiveness
- `item/fileChange/patchUpdated` (cumulative per file) now exposes `item_id` via `codex_event_item_id`, so group dedup keeps only the final patch and collapses it against matching `item.*{file_change}` lifecycle events
- Delete the now-orphaned `render_turn_diff` and the `DiffCard` `cumulative` chip

Rebased over #1005's unified dispatcher; intent re-applied on the new structure.

Validation: fmt clean, clippy `-D warnings` clean, `cargo test -p frontend` 310/310, wasm check clean.