### PR TITLE
Delete dead UserInfo, ApiError, DevicePollRequest from shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.35
+
+- **Delete dead `shared` types: `UserInfo`, `ApiError` (+ manual `Display`/`Error` impls), `DevicePollRequest`.** All three were grep-verified unreferenced across every consumer crate (`UserInfo` was a strict subset of `MeResponse`; `DevicePollRequest` an exact field duplicate of the live `DeviceFlowPollRequest`). `DevicePollResponse` stays — #1006 made it the canonical wire type. Pure deletions, −46 lines.
+
 ## 2.8.34
 
 - **Codex: drop cumulative `turn/diff/updated` cards and dedupe per-file patch updates.** Codex re-sends the entire turn diff on every edit tick, so transcripts accumulated O(ticks) redundant cards — each the size of the whole turn — on top of the per-file `item.completed{file_change}` diffs that already render the same edits. The events are now dropped in `group_messages` (before grouping, so Codex runs don't fragment around each dropped diff) with a no-op dispatcher arm kept for exhaustiveness. `item/fileChange/patchUpdated` events (also cumulative per file) now surface their `item_id` in `codex_event_item_id`, letting the existing group dedup keep only the final patch and collapse it against the matching lifecycle events. The `DiffCard` `cumulative` chip and `render_turn_diff` are deleted with their only producer.

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -123,37 +123,6 @@ impl CodexPermissionInput {
     }
 }
 
-/// API error types
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ApiError {
-    /// Network or connection error
-    Network(String),
-    /// Server returned an error status
-    Server { status: u16, message: String },
-    /// Failed to parse response
-    Parse(String),
-    /// Authentication required or failed
-    Auth(String),
-    /// Resource not found
-    NotFound(String),
-}
-
-impl std::fmt::Display for ApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ApiError::Network(msg) => write!(f, "Network error: {}", msg),
-            ApiError::Server { status, message } => {
-                write!(f, "Server error ({}): {}", status, message)
-            }
-            ApiError::Parse(msg) => write!(f, "Parse error: {}", msg),
-            ApiError::Auth(msg) => write!(f, "Auth error: {}", msg),
-            ApiError::NotFound(msg) => write!(f, "Not found: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for ApiError {}
-
 /// Device flow code request response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceCodeResponse {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -19,7 +19,7 @@ pub mod protocol;
 // API client types and trait
 pub mod api;
 pub use api::{
-    ApiError, CodexPermissionInput, CompactionExtra, InitExtra, ModelUsage, ModelUsageEntry,
+    CodexPermissionInput, CompactionExtra, InitExtra, ModelUsage, ModelUsageEntry,
     SoundSettingsResponse, TaskNotificationExtra, TurnMetrics, TurnMetricsResponse,
 };
 
@@ -247,14 +247,6 @@ pub struct SessionInfo {
     pub claude_args: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct UserInfo {
-    pub id: Uuid,
-    pub email: String,
-    pub name: Option<String>,
-    pub avatar_url: Option<String>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MessageRole {
@@ -457,12 +449,6 @@ impl std::fmt::Debug for PortalContent {
 // ============================================================================
 // Device Flow Types (shared between backend and proxy)
 // ============================================================================
-
-/// Request to poll for device flow completion
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DevicePollRequest {
-    pub device_code: String,
-}
 
 /// Response from device flow polling
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Fixes #994.

Pure deletions, all grep-verified unreferenced against current main: `UserInfo` (strict subset of `MeResponse`), `ApiError` + manual impls (re-export removed from lib.rs), `DevicePollRequest` (exact duplicate of live `DeviceFlowPollRequest`). `DevicePollResponse` kept — canonical since #1006. −46 lines.

Validation: fmt clean, workspace clippy `-D warnings` clean, wasm checks clean, workspace check clean.