### PR TITLE
Remove dead cost-flash machinery from session view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.36
+
+- **Remove the dashboard's dead cost-flash machinery.** `total_cost`/`cost_flash` were written on every Result message (with a 600ms flash-clear timeout) but never read by any `view()`, and the `on_cost_change` prop terminated in an explicit no-op callback "kept for API compatibility". Deleted end-to-end: the props, the `ClearCostFlash` msg arm, the struct fields, the whole Result-block cost computation in `handle_received_output`, and the no-op callback at the `<SessionView>` call site. −34 lines, one less fake data path.
+
 ## 2.8.34
 
 - **Codex: drop cumulative `turn/diff/updated` cards and dedupe per-file patch updates.** Codex re-sends the entire turn diff on every edit tick, so transcripts accumulated O(ticks) redundant cards — each the size of the whole turn — on top of the per-file `item.completed{file_change}` diffs that already render the same edits. The events are now dropped in `group_messages` (before grouping, so Codex runs don't fragment around each dropped diff) with a no-op dispatcher arm kept for exhaustiveness. `item/fileChange/patchUpdated` events (also cumulative per file) now surface their `item_id` in `codex_event_item_id`, letting the existing group dedup keep only the final patch and collapse it against the matching lifecycle events. The `DiffCard` `cumulative` chip and `render_turn_diff` are deleted with their only producer.

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -470,13 +470,6 @@ pub fn dashboard_page() -> Html {
         })
     };
 
-    let on_cost_change = {
-        Callback::from(move |(_session_id, _cost): (Uuid, f64)| {
-            // Costs now come from the websocket hook, so this is a no-op
-            // but we keep it for API compatibility with SessionView
-        })
-    };
-
     let on_connected_change = {
         let connected_sessions = connected_sessions.clone();
         Callback::from(move |(session_id, connected): (Uuid, bool)| {
@@ -839,7 +832,6 @@ pub fn dashboard_page() -> Html {
                                                 session={session.clone()}
                                                 focused={is_focused}
                                                 on_awaiting_change={on_awaiting_change.clone()}
-                                                on_cost_change={on_cost_change.clone()}
                                                 on_connected_change={on_connected_change.clone()}
                                                 on_message_sent={on_message_sent.clone()}
                                                 on_branch_change={on_branch_change.clone()}

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -41,7 +41,6 @@ pub struct SessionViewProps {
     pub session: SessionInfo,
     pub focused: bool,
     pub on_awaiting_change: Callback<(Uuid, bool)>,
-    pub on_cost_change: Callback<(Uuid, f64)>,
     pub on_connected_change: Callback<(Uuid, bool)>,
     pub on_message_sent: Callback<Uuid>,
     #[allow(clippy::type_complexity)]
@@ -62,7 +61,6 @@ pub enum SessionViewMsg {
     WebSocketError(String),
     AttemptReconnect,
     CheckAwaiting,
-    ClearCostFlash,
     BranchChanged(Option<String>, Option<String>, Option<String>),
     /// PermissionHandler is mounted and handed us its inbound-request
     /// dispatcher. We store it so live `WsEvent::Permission` frames can be
@@ -127,8 +125,6 @@ pub struct SessionView {
     should_autoscroll: bool,
     #[allow(dead_code)]
     scroll_listener: Option<Closure<dyn Fn()>>,
-    total_cost: f64,
-    cost_flash: bool,
     /// Dispatcher into the mounted `PermissionHandler`. Stored once at child
     /// `create` time via `PermissionDispatcherRegistered`; live permission
     /// frames off the wire are forwarded through it so this component holds
@@ -231,8 +227,6 @@ impl Component for SessionView {
             messages_ref: NodeRef::default(),
             should_autoscroll: true,
             scroll_listener: None,
-            total_cost: 0.0,
-            cost_flash: false,
             permission_dispatcher: None,
             has_pending_permission: false,
             last_permission_request: None,
@@ -297,10 +291,6 @@ impl Component for SessionView {
                 true
             }
             SessionViewMsg::ReceivedOutput(output) => self.handle_received_output(ctx, output),
-            SessionViewMsg::ClearCostFlash => {
-                self.cost_flash = false;
-                true
-            }
             SessionViewMsg::PermissionDispatcherRegistered(dispatcher) => {
                 self.permission_dispatcher = Some(dispatcher);
                 false
@@ -711,22 +701,6 @@ impl SessionView {
     fn handle_received_output(&mut self, ctx: &Context<Self>, output: String) -> bool {
         let tag = classify_output_msg_type(&output);
         if let Ok(claude_msg) = serde_json::from_str::<shared::ClaudeOutput>(&output) {
-            if let shared::ClaudeOutput::Result(res) = &claude_msg {
-                let cost = res.total_cost_usd;
-                if cost != self.total_cost {
-                    self.total_cost = cost;
-                    self.cost_flash = true;
-
-                    let session_id = ctx.props().session.id;
-                    ctx.props().on_cost_change.emit((session_id, cost));
-
-                    let link = ctx.link().clone();
-                    spawn_local(async move {
-                        gloo::timers::future::TimeoutFuture::new(600).await;
-                        link.send_message(SessionViewMsg::ClearCostFlash);
-                    });
-                }
-            }
             // Live task events: the `created_at` field isn't part of the
             // live wire envelope, so the panel falls back to `Date.now()`
             // — see `derive_task_events` for the two paths.


### PR DESCRIPTION
Fixes #980.

`total_cost`/`cost_flash`/`ClearCostFlash`/600ms timeout written but never read; `on_cost_change` ended in an explicit no-op. Deleted the entire chain: props, msg arm, fields, the Result-block cost computation (its only contents), and the no-op callback. Adjacent live code (`derive_task_events`) untouched.

Validation: fmt clean, frontend clippy `-D warnings` clean, 310/310 tests, wasm check clean. −34 lines.