### PR TITLE
Remove backend dead code and dangling device-error route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.37
+
+- **Backend dead code: `NewSession`, `ImageStore::count()`, dangling device-error route.** `NewSession` was never inserted (all five insert sites use `NewSessionWithId`); `ImageStore::count()` had no callers and `with_defaults()` is now `#[cfg(test)]` (its only callers are tests); `routes::AUTH_DEVICE_ERROR` pointed at a route registered nowhere — invalid/expired device codes redirected to the SPA fallback with a `?message=` param nothing rendered. They now redirect to the device-code entry form so users can retry.
+
 ## 2.8.34
 
 - **Codex: drop cumulative `turn/diff/updated` cards and dedupe per-file patch updates.** Codex re-sends the entire turn diff on every edit tick, so transcripts accumulated O(ticks) redundant cards — each the size of the whole turn — on top of the per-file `item.completed{file_change}` diffs that already render the same edits. The events are now dropped in `group_messages` (before grouping, so Codex runs don't fragment around each dropped diff) with a no-op dispatcher arm kept for exhaustiveness. `item/fileChange/patchUpdated` events (also cumulative per file) now surface their `item_id` in `codex_event_item_id`, letting the existing group dedup keep only the final patch and collapse it against the matching lifecycle events. The `DiffCard` `cumulative` chip and `render_turn_diff` are deleted with their only producer.

--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -157,11 +157,9 @@ pub async fn device_verify_page(
         Some(state) => (state.hostname.clone(), state.working_directory.clone()),
         None => {
             drop(store_lock);
-            return Redirect::temporary(&format!(
-                "{}?message=Invalid+or+expired+code",
-                routes::AUTH_DEVICE_ERROR
-            ))
-            .into_response();
+            // Unknown or expired code: send the user back to the code-entry
+            // form so they can try again.
+            return Redirect::temporary(routes::AUTH_DEVICE).into_response();
         }
     };
     drop(store_lock);

--- a/backend/src/handlers/images.rs
+++ b/backend/src/handlers/images.rs
@@ -124,8 +124,8 @@ impl ImageStore {
         }
     }
 
-    /// Build a store with the project defaults — for tests and as a fallback
-    /// when env vars aren't set.
+    /// Build a store with the project defaults.
+    #[cfg(test)]
     pub fn with_defaults() -> Self {
         Self::new(DEFAULT_IMAGE_STORE_MAX_BYTES, DEFAULT_IMAGE_STORE_TTL)
     }
@@ -272,13 +272,6 @@ impl ImageStore {
     /// expired past its TTL, or has been evicted to stay under the byte cap.
     pub fn get(&self, id: &Uuid) -> Option<Arc<StoredImage>> {
         self.images.get(id)
-    }
-
-    /// Approximate number of live entries — exposed for telemetry/tests.
-    /// Note: mini-moka's `entry_count` is best-effort and may briefly include
-    /// entries that have just been scheduled for eviction.
-    pub fn count(&self) -> u64 {
-        self.images.entry_count()
     }
 }
 

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -60,18 +60,7 @@ pub struct Session {
     pub claude_args: serde_json::Value,
 }
 
-#[derive(Debug, Insertable)]
-#[diesel(table_name = crate::schema::sessions)]
-pub struct NewSession {
-    pub user_id: Uuid,
-    pub session_name: String,
-    pub session_key: String,
-    pub working_directory: String,
-    pub status: String,
-    pub git_branch: Option<String>,
-}
-
-/// NewSession variant that allows specifying the ID (for when we want to use Claude's session ID)
+/// Insertable session that specifies the ID (so we can use Claude's session ID)
 #[derive(Debug, Insertable)]
 #[diesel(table_name = crate::schema::sessions)]
 pub struct NewSessionWithId {

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -15,4 +15,3 @@ pub const AUTH_DEVICE_CODE: &str = "/api/auth/device/code";
 pub const AUTH_DEVICE_POLL: &str = "/api/auth/device/poll";
 pub const AUTH_DEVICE_APPROVE: &str = "/api/auth/device/approve";
 pub const AUTH_DEVICE_DENY: &str = "/api/auth/device/deny";
-pub const AUTH_DEVICE_ERROR: &str = "/api/auth/device/error";


### PR DESCRIPTION
Fixes #979.

- `models::NewSession` deleted (all inserts use `NewSessionWithId`)
- `ImageStore::count()` deleted; `with_defaults()` gated `#[cfg(test)]` (test-only callers); `DEFAULT_IMAGE_STORE_*` consts stay pub (main.rs env fallbacks)
- `AUTH_DEVICE_ERROR` removed: the route was never registered, so the redirect landed on the SPA fallback and `?message=` was never rendered. Invalid/expired codes now land on the device-code entry form (retry-able)

All claims re-verified against current main. Validation: fmt clean, backend clippy `-D warnings` clean, 111/111 tests, workspace check clean.