### PR TITLE
Consolidate dev test-user lookup into single helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.38
+
+- **One `dev_user` helper + `DEV_USER_EMAIL` const replace nine `testing@testing.local` literals.** The dev test-user lookup was re-implemented across `auth.rs`, `main.rs` (seeding keeps its create logic but uses the const), `handlers/auth.rs` (dev_login + device dev path), `sessions.rs`, `launcher_socket.rs`, and `registration.rs`. `QueryResult<User>` return fits every site's error style (`?`, `.optional()`, `.expect()`, `.ok()`). Three id-only sites now select the full row — same filter, same error paths, identical semantics.
+
 ## 2.8.34
 
 - **Codex: drop cumulative `turn/diff/updated` cards and dedupe per-file patch updates.** Codex re-sends the entire turn diff on every edit tick, so transcripts accumulated O(ticks) redundant cards — each the size of the whole turn — on top of the per-file `item.completed{file_change}` diffs that already render the same edits. The events are now dropped in `group_messages` (before grouping, so Codex runs don't fragment around each dropped diff) with a no-op dispatcher arm kept for exhaustiveness. `item/fileChange/patchUpdated` events (also cumulative per file) now surface their `item_id` in `codex_event_item_id`, letting the existing group dedup keep only the final patch and collapse it against the matching lifecycle events. The `DiffCard` `cumulative` chip and `render_turn_diff` are deleted with their only producer.

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -10,6 +10,18 @@ use crate::errors::AppError;
 use crate::models::User;
 use crate::AppState;
 
+/// Email of the test user that dev mode auto-creates and logs in as.
+pub const DEV_USER_EMAIL: &str = "testing@testing.local";
+
+/// Look up the dev-mode test user by email.
+pub fn dev_user(conn: &mut PgConnection) -> QueryResult<User> {
+    use crate::schema::users;
+
+    users::table
+        .filter(users::email.eq(DEV_USER_EMAIL))
+        .first::<User>(conn)
+}
+
 /// Return `Forbidden` for disabled accounts.
 fn reject_disabled_user(user: User) -> Result<User, AppError> {
     if user.disabled {
@@ -35,9 +47,7 @@ pub fn extract_user(app_state: &AppState, cookies: &Cookies) -> Result<User, App
     use crate::schema::users;
 
     if app_state.dev_mode {
-        let user = users::table
-            .filter(users::email.eq("testing@testing.local"))
-            .first::<User>(&mut conn)?;
+        let user = dev_user(&mut conn)?;
         return reject_disabled_user(user);
     }
 

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -45,14 +45,9 @@ pub async fn device_login(
 ) -> Result<impl IntoResponse, AppError> {
     // In dev mode, auto-login and redirect to device approval page
     if app_state.oauth_basic_client.is_none() {
-        use crate::schema::users::dsl::*;
-
         let mut conn = app_state.conn()?;
 
-        let user = users
-            .filter(email.eq("testing@testing.local"))
-            .first::<User>(&mut conn)
-            .map_err(dev_user_lookup_error)?;
+        let user = crate::auth::dev_user(&mut conn).map_err(dev_user_lookup_error)?;
 
         if user.disabled {
             info!("Banned user {} attempted dev device login", user.email);
@@ -214,14 +209,9 @@ pub async fn dev_login(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
 ) -> Result<impl IntoResponse, AppError> {
-    use crate::schema::users::dsl::*;
-
     let mut conn = app_state.conn()?;
 
-    let user = users
-        .filter(email.eq("testing@testing.local"))
-        .first::<User>(&mut conn)
-        .map_err(dev_user_lookup_error)?;
+    let user = crate::auth::dev_user(&mut conn).map_err(dev_user_lookup_error)?;
 
     // Check if user is banned
     if user.disabled {
@@ -230,7 +220,10 @@ pub async fn dev_login(
         return Ok(banned_redirect(reason));
     }
 
-    info!("Dev mode: auto-logged in as testing@testing.local");
+    info!(
+        "Dev mode: auto-logged in as {}",
+        crate::auth::DEV_USER_EMAIL
+    );
 
     add_session_cookie(&cookies, &app_state, &user);
 

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -120,18 +120,13 @@ fn proxy_request_user_id(
     conn: &mut diesel::pg::PgConnection,
     auth_token: Option<&str>,
 ) -> Result<Uuid, AppError> {
-    use crate::schema::users;
-
     if let Some(token) = auth_token {
         return crate::handlers::proxy_tokens::verify_and_get_user(app_state, conn, token)
             .map(|(user_id, _)| user_id);
     }
 
     if app_state.dev_mode {
-        return Ok(users::table
-            .filter(users::email.eq("testing@testing.local"))
-            .select(users::id)
-            .first::<Uuid>(conn)?);
+        return Ok(crate::auth::dev_user(conn)?.id);
     }
 
     Err(AppError::Unauthorized)

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -769,13 +769,8 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
 }
 
 fn get_dev_user_id(app_state: &AppState) -> Uuid {
-    use crate::schema::users;
-    use diesel::prelude::*;
-
     let mut conn = app_state.db_pool.get().expect("DB connection for dev mode");
-    let user: crate::models::User = users::table
-        .filter(users::email.eq("testing@testing.local"))
-        .first(&mut conn)
-        .expect("Test user must exist in dev mode");
-    user.id
+    crate::auth::dev_user(&mut conn)
+        .expect("Test user must exist in dev mode")
+        .id
 }

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -294,8 +294,6 @@ fn get_user_id_from_token(
     conn: &mut diesel::PgConnection,
     auth_token: Option<&str>,
 ) -> Option<Uuid> {
-    use crate::schema::users;
-
     if let Some(token) = auth_token {
         match super::super::proxy_tokens::verify_and_get_user(app_state, conn, token) {
             Ok((user_id, email)) => {
@@ -309,11 +307,7 @@ fn get_user_id_from_token(
     }
 
     if app_state.dev_mode {
-        users::table
-            .filter(users::email.eq("testing@testing.local"))
-            .select(users::id)
-            .first::<Uuid>(conn)
-            .ok()
+        crate::auth::dev_user(conn).map(|user| user.id).ok()
     } else {
         None
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -151,27 +151,24 @@ async fn main() -> anyhow::Result<()> {
     if args.dev_mode {
         use diesel::prelude::*;
         use models::NewUser;
-        use schema::users::dsl::*;
+        use schema::users;
 
         let mut conn = pool.get()?;
-        let test_user = users
-            .filter(email.eq("testing@testing.local"))
-            .first::<models::User>(&mut conn)
-            .optional()?;
+        let test_user = auth::dev_user(&mut conn).optional()?;
 
         if test_user.is_none() {
             let new_user = NewUser {
                 google_id: "dev_mode_test_user".to_string(),
-                email: "testing@testing.local".to_string(),
+                email: auth::DEV_USER_EMAIL.to_string(),
                 name: Some("Test User".to_string()),
                 avatar_url: None,
             };
 
-            diesel::insert_into(users)
+            diesel::insert_into(users::table)
                 .values(&new_user)
                 .execute(&mut conn)?;
 
-            tracing::info!("✓ Created test user: testing@testing.local");
+            tracing::info!("✓ Created test user: {}", auth::DEV_USER_EMAIL);
         }
     }
 


### PR DESCRIPTION
Fixes #978.

Adds `auth::DEV_USER_EMAIL` + `auth::dev_user(conn) -> QueryResult<User>`; converts all 9 literal sites (7 lookup implementations) across auth, main.rs seeding, dev_login, device dev path, sessions, launcher_socket, registration. Seeding keeps its create logic with the const. Also swapped one `users::dsl::*` glob for qualified `users::table` per repo convention.

Validation: fmt clean, backend clippy `-D warnings` clean, 111/111 tests, workspace check clean.