### PR TITLE
Stop clobbering server timestamps on live messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.39
+
+- **Live messages no longer have their server timestamp clobbered by the browser clock.** `handle_proxy_message` folds the server `created_at` into `_created_at`, but the component's live path re-ran `inject_message_metadata` with `Date::now()`, overwriting it. The live path now uses `inject_created_at_if_absent` — browser-clock fallback only when the key is missing (error envelopes, pre-#784 backends keep their tooltips). REST history replay keeps overwrite semantics as before. Four new tests pin the behavior, including the no-clobber case.
+
 ## 2.8.34
 
 - **Codex: drop cumulative `turn/diff/updated` cards and dedupe per-file patch updates.** Codex re-sends the entire turn diff on every edit tick, so transcripts accumulated O(ticks) redundant cards — each the size of the whole turn — on top of the per-file `item.completed{file_change}` diffs that already render the same edits. The events are now dropped in `group_messages` (before grouping, so Codex runs don't fragment around each dropped diff) with a no-op dispatcher arm kept for exhaustiveness. `item/fileChange/patchUpdated` events (also cumulative per file) now surface their `item_id` in `codex_event_item_id`, letting the existing group dedup keep only the final patch and collapse it against the matching lifecycle events. The `DiffCard` `cumulative` chip and `render_turn_diff` are deleted with their only producer.

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -23,8 +23,8 @@ use web_sys::Element;
 use yew::prelude::*;
 
 use super::helpers::{
-    autoscroll_transition, classify_output_msg_type, inject_message_metadata, is_claude_awaiting,
-    reconcile_pending_sends, ActivityTag,
+    autoscroll_transition, classify_output_msg_type, inject_created_at_if_absent,
+    inject_message_metadata, is_claude_awaiting, reconcile_pending_sends, ActivityTag,
 };
 use super::input_bar::{InputBar, InputBarInbound};
 use super::permission_handler::{
@@ -738,15 +738,19 @@ impl SessionView {
         ctx.props()
             .on_activity
             .emit((ctx.props().session.id, tag, js_sys::Date::now()));
-        // Inject _created_at for tooltip display. Live path has no server
-        // timestamp on the wire — use browser `now()` for the tooltip only;
-        // the reconnect-replay watermark is set separately from the
-        // server-assigned `created_at` in `WsEvent::Output` (closes #784).
+        // Inject _created_at for tooltip display only when the frame doesn't
+        // already carry one: `websocket.rs` folds the server-assigned
+        // `created_at` into the content before emitting `WsEvent::Output`,
+        // and that authoritative timestamp must win over the browser clock
+        // (#981). Frames without one (error envelopes, pre-#784 backends)
+        // fall back to `Date::now()`; the reconnect-replay watermark is set
+        // separately from the server `created_at` in `WsEvent::Output`
+        // (closes #784).
         let now_iso = js_sys::Date::new_0()
             .to_iso_string()
             .as_string()
             .unwrap_or_default();
-        let output = inject_message_metadata(&output, &now_iso, false, None, None);
+        let output = inject_created_at_if_absent(&output, &now_iso);
 
         reconcile_pending_sends(&mut self.pending_sends, tag, &output);
 

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -329,6 +329,33 @@ pub(super) fn inject_message_metadata(
     val.to_string()
 }
 
+/// Inject `_created_at` into a wire-JSON message string only when the key is
+/// absent, returning a new JSON string. Used by the live
+/// `handle_received_output` path: `websocket.rs` already folds the
+/// server-assigned `created_at` into `WsEvent::Output` content, and that
+/// authoritative timestamp must not be clobbered by the browser-clock
+/// fallback (#981). Frames that arrive without one (error envelopes, a
+/// pre-#784 backend) still get the `Date::now()` fallback for tooltips.
+///
+/// Returns the original `content` unchanged when the JSON parse fails or the
+/// value isn't an object — same contract as [`inject_message_metadata`].
+pub(super) fn inject_created_at_if_absent(content: &str, created_at: &str) -> String {
+    let Ok(mut val) = serde_json::from_str::<serde_json::Value>(content) else {
+        return content.to_string();
+    };
+    let Some(obj) = val.as_object_mut() else {
+        return content.to_string();
+    };
+    if obj.contains_key("_created_at") {
+        return content.to_string();
+    }
+    obj.insert(
+        "_created_at".to_string(),
+        serde_json::Value::String(created_at.to_string()),
+    );
+    val.to_string()
+}
+
 /// Drain pending optimistic-send entries when the server confirms our input.
 ///
 /// - [`ActivityTag::User`] echo: match by content (via [`extract_user_text`])
@@ -623,6 +650,47 @@ mod tests {
         // _created_at slot to inject into, return as-is so callers don't
         // re-serialize it into a quoted-string blob.
         let out = inject_message_metadata("\"hello\"", "ts", false, None, None);
+        assert_eq!(out, "\"hello\"");
+    }
+
+    // --- inject_created_at_if_absent ---
+
+    #[test]
+    fn inject_created_at_if_absent_preserves_existing_server_timestamp() {
+        // The live path: websocket.rs already folded the server `created_at`
+        // into the frame — the browser-clock fallback must not clobber it
+        // (#981).
+        let server_ts = "2026-05-18T12:00:00Z";
+        let input = format!(r#"{{"type":"assistant","content":"hi","_created_at":"{server_ts}"}}"#);
+        let out = inject_created_at_if_absent(&input, "2026-05-18T12:34:56Z");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v["_created_at"], server_ts,
+            "server timestamp must survive the component-side injection"
+        );
+    }
+
+    #[test]
+    fn inject_created_at_if_absent_adds_timestamp_when_missing() {
+        // Frames with no server timestamp (error envelopes, pre-#784
+        // backends) still get the browser-clock fallback for tooltips.
+        let out = inject_created_at_if_absent(
+            r#"{"type":"assistant","content":"hi"}"#,
+            "2026-05-18T12:34:56Z",
+        );
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["_created_at"], "2026-05-18T12:34:56Z");
+    }
+
+    #[test]
+    fn inject_created_at_if_absent_returns_input_unchanged_for_invalid_json() {
+        let out = inject_created_at_if_absent("not-json", "ts");
+        assert_eq!(out, "not-json");
+    }
+
+    #[test]
+    fn inject_created_at_if_absent_returns_input_unchanged_for_non_object_json() {
+        let out = inject_created_at_if_absent("\"hello\"", "ts");
         assert_eq!(out, "\"hello\"");
     }
 


### PR DESCRIPTION
Fixes #981.

`handle_proxy_message` injects the server `created_at`; the component's live path then re-injected browser `Date::now()`, overwriting it. New `inject_created_at_if_absent` helper used on the live path only — injects the fallback only when `_created_at` is absent. History replay path untouched.

Caller trace in the PR thread: `ReceivedOutput` ← `WsEvent::Output` ← `handle_proxy_message` (ClaudeOutput arm injects server value; Error arm has none → fallback still applies).

Validation: fmt clean, clippy `-D warnings` clean, 314/314 tests (4 new), wasm build clean.