### PR TITLE
Replace hand-rolled base64url codecs with base64 crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.40
+
+- **Hand-rolled base64url codecs replaced by the `base64` crate (×2, ~110 lines).** `shared/src/proxy_tokens.rs` and `proxy/src/util.rs` each reimplemented base64url; both now use a const lenient engine (URL_SAFE, no encode padding, `DecodePaddingMode::Indifferent`, allow-trailing-bits) that preserves every leniency the old decoders had: padding accepted anywhere it was before, whitespace pre-filtered, non-canonical trailing bits masked. One intentionally stricter case: length ≡ 1 (mod 4) inputs (which no encoder produces, and which the old code decoded into a garbage byte) now fail softly. Byte-identity pinned by RFC 4648 fixtures, an all-256-values round-trip, and a hardcoded `ProxyInitConfig` fixture. `base64` added to shared (WASM-safe).
+
 ## 2.8.34
 
 - **Codex: drop cumulative `turn/diff/updated` cards and dedupe per-file patch updates.** Codex re-sends the entire turn diff on every edit tick, so transcripts accumulated O(ticks) redundant cards — each the size of the whole turn — on top of the per-file `item.completed{file_change}` diffs that already render the same edits. The events are now dropped in `group_messages` (before grouping, so Codex runs don't fragment around each dropped diff) with a no-op dispatcher arm kept for exhaustiveness. `item/fileChange/patchUpdated` events (also cumulative per file) now surface their `item_id` in `codex_event_item_id`, letting the existing group dedup keep only the final patch and collapse it against the matching lifecycle events. The `DiffCard` `cumulative` chip and `render_turn_diff` are deleted with their only producer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,6 +3434,7 @@ dependencies = [
 name = "shared"
 version = "2.8.33"
 dependencies = [
+ "base64",
  "chrono",
  "claude-codes",
  "serde",

--- a/proxy/src/util.rs
+++ b/proxy/src/util.rs
@@ -1,6 +1,9 @@
 //! Utility functions for JWT parsing and encoding.
 
 use anyhow::Result;
+use base64::alphabet;
+use base64::engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig};
+use base64::Engine;
 use shared::ProxyInitConfig;
 
 /// Parse an init value which can be:
@@ -62,56 +65,79 @@ pub fn extract_email_from_jwt(token: &str) -> Option<String> {
         return None;
     }
 
-    // Decode payload (with padding fix for base64)
-    let payload = parts[1];
-    let padded = match payload.len() % 4 {
-        2 => format!("{}==", payload),
-        3 => format!("{}=", payload),
-        _ => payload.to_string(),
-    };
-
-    let decoded = base64_url_decode(&padded).ok()?;
+    // Decode payload
+    let decoded = base64_url_decode(parts[1]).ok()?;
     let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
 
     json.get("email").and_then(|e| e.as_str()).map(String::from)
 }
 
-/// Simple base64url decoder
-fn base64_url_decode(input: &str) -> Result<Vec<u8>> {
-    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+/// URL-safe base64 engine: decodes leniently (optional padding,
+/// non-canonical trailing bits) to keep accepting every input the previous
+/// hand-rolled decoder accepted.
+const BASE64_URL: GeneralPurpose = GeneralPurpose::new(
+    &alphabet::URL_SAFE,
+    GeneralPurposeConfig::new()
+        .with_encode_padding(false)
+        .with_decode_padding_mode(DecodePaddingMode::Indifferent)
+        .with_decode_allow_trailing_bits(true),
+);
 
-    let chars: Vec<u8> = input
+fn base64_url_decode(input: &str) -> Result<Vec<u8>> {
+    // The previous decoder ignored whitespace and `=` anywhere in the input.
+    let filtered: String = input
         .chars()
         .filter(|c| !c.is_whitespace() && *c != '=')
-        .map(|c| {
-            ALPHABET
-                .iter()
-                .position(|&x| x == c as u8)
-                .map(|p| p as u8)
-                .ok_or_else(|| anyhow::anyhow!("Invalid base64url character: {}", c))
-        })
-        .collect::<Result<Vec<_>>>()?;
+        .collect();
+    BASE64_URL
+        .decode(filtered)
+        .map_err(|e| anyhow::anyhow!("Invalid base64url: {}", e))
+}
 
-    let mut result = Vec::new();
-    let mut i = 0;
-    while i < chars.len() {
-        let b0 = chars[i];
-        let b1 = chars.get(i + 1).copied().unwrap_or(0);
-        let b2 = chars.get(i + 2).copied().unwrap_or(0);
-        let b3 = chars.get(i + 3).copied().unwrap_or(0);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        result.push((b0 << 2) | (b1 >> 4));
+    // base64url of {"email":"user@example.com"}
+    const PAYLOAD: &str = "eyJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20ifQ";
 
-        if i + 2 < chars.len() {
-            result.push((b1 << 4) | (b2 >> 2));
-        }
-
-        if i + 3 < chars.len() {
-            result.push((b2 << 6) | b3);
-        }
-
-        i += 4;
+    #[test]
+    fn test_extract_email_from_jwt() {
+        let jwt = format!("header.{}.signature", PAYLOAD);
+        assert_eq!(
+            extract_email_from_jwt(&jwt),
+            Some("user@example.com".to_string())
+        );
     }
 
-    Ok(result)
+    #[test]
+    fn test_extract_email_from_jwt_padded_payload() {
+        // The old decoder stripped `=` anywhere, so padded payloads decoded.
+        let jwt = format!("header.{}==.signature", PAYLOAD);
+        assert_eq!(
+            extract_email_from_jwt(&jwt),
+            Some("user@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_email_from_jwt_invalid() {
+        assert_eq!(extract_email_from_jwt("not-a-jwt"), None);
+        assert_eq!(extract_email_from_jwt("a.$$$.c"), None);
+    }
+
+    #[test]
+    fn test_base64_url_decode_fixtures() {
+        assert_eq!(
+            base64_url_decode("SGVsbG8sIFdvcmxkIQ").unwrap(),
+            b"Hello, World!".to_vec()
+        );
+        assert_eq!(base64_url_decode("-_8").unwrap(), vec![0xfb, 0xff]);
+        // Whitespace and `=` are ignored, as the old decoder did.
+        assert_eq!(
+            base64_url_decode("SGVs bG8s\nIFdvcmxkIQ==").unwrap(),
+            b"Hello, World!".to_vec()
+        );
+        assert!(base64_url_decode("ab$c").is_err());
+    }
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -20,3 +20,4 @@ claude-codes = { workspace = true }
 
 # Typed WebSocket endpoints (core traits only — WASM-safe, no features needed)
 ws-bridge = { workspace = true }
+base64 = "0.22"

--- a/shared/src/proxy_tokens.rs
+++ b/shared/src/proxy_tokens.rs
@@ -4,6 +4,9 @@
 //! These allow the proxy CLI to authenticate without going through
 //! the device flow each time.
 
+use base64::alphabet;
+use base64::engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig};
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -112,81 +115,28 @@ pub struct ProxyTokenListResponse {
 }
 
 // ============================================================================
-// Base64 URL-safe encoding/decoding (no external dependency needed)
+// Base64 URL-safe encoding/decoding
 // ============================================================================
 
-const BASE64_URL_ALPHABET: &[u8; 64] =
-    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+/// URL-safe base64 engine: encodes without padding; decodes leniently
+/// (optional padding, non-canonical trailing bits) to keep accepting every
+/// input the previous hand-rolled decoder accepted.
+const BASE64_URL: GeneralPurpose = GeneralPurpose::new(
+    &alphabet::URL_SAFE,
+    GeneralPurposeConfig::new()
+        .with_encode_padding(false)
+        .with_decode_padding_mode(DecodePaddingMode::Indifferent)
+        .with_decode_allow_trailing_bits(true),
+);
 
 fn base64_url_encode(input: &[u8]) -> String {
-    let mut result = String::new();
-    let mut i = 0;
-
-    while i < input.len() {
-        let b0 = input[i] as usize;
-        let b1 = if i + 1 < input.len() {
-            input[i + 1] as usize
-        } else {
-            0
-        };
-        let b2 = if i + 2 < input.len() {
-            input[i + 2] as usize
-        } else {
-            0
-        };
-
-        result.push(BASE64_URL_ALPHABET[b0 >> 2] as char);
-        result.push(BASE64_URL_ALPHABET[((b0 & 0x03) << 4) | (b1 >> 4)] as char);
-
-        if i + 1 < input.len() {
-            result.push(BASE64_URL_ALPHABET[((b1 & 0x0f) << 2) | (b2 >> 6)] as char);
-        }
-
-        if i + 2 < input.len() {
-            result.push(BASE64_URL_ALPHABET[b2 & 0x3f] as char);
-        }
-
-        i += 3;
-    }
-
-    result
+    BASE64_URL.encode(input)
 }
 
 fn base64_url_decode(input: &str) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-    let mut result = Vec::new();
-    let chars: Vec<u8> = input
-        .chars()
-        .filter(|c| !c.is_whitespace())
-        .map(|c| {
-            BASE64_URL_ALPHABET
-                .iter()
-                .position(|&x| x == c as u8)
-                .map(|p| p as u8)
-                .ok_or_else(|| format!("Invalid base64url character: {}", c))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let mut i = 0;
-    while i < chars.len() {
-        let b0 = chars[i];
-        let b1 = if i + 1 < chars.len() { chars[i + 1] } else { 0 };
-        let b2 = if i + 2 < chars.len() { chars[i + 2] } else { 0 };
-        let b3 = if i + 3 < chars.len() { chars[i + 3] } else { 0 };
-
-        result.push((b0 << 2) | (b1 >> 4));
-
-        if i + 2 < chars.len() {
-            result.push((b1 << 4) | (b2 >> 2));
-        }
-
-        if i + 3 < chars.len() {
-            result.push((b2 << 6) | b3);
-        }
-
-        i += 4;
-    }
-
-    Ok(result)
+    // The previous decoder ignored whitespace anywhere in the input.
+    let filtered: String = input.chars().filter(|c| !c.is_whitespace()).collect();
+    Ok(BASE64_URL.decode(filtered)?)
 }
 
 #[cfg(test)]
@@ -199,6 +149,66 @@ mod tests {
         let encoded = base64_url_encode(original);
         let decoded = base64_url_decode(&encoded).unwrap();
         assert_eq!(original.to_vec(), decoded);
+    }
+
+    #[test]
+    fn test_base64_url_roundtrip_all_byte_values() {
+        let original: Vec<u8> = (0u8..=255).collect();
+        let encoded = base64_url_encode(&original);
+        let decoded = base64_url_decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_base64_url_known_fixtures() {
+        // Outputs must match the previous hand-rolled encoder exactly.
+        assert_eq!(base64_url_encode(b""), "");
+        assert_eq!(base64_url_encode(b"f"), "Zg");
+        assert_eq!(base64_url_encode(b"fo"), "Zm8");
+        assert_eq!(base64_url_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_url_encode(b"Hello, World!"), "SGVsbG8sIFdvcmxkIQ");
+        // Bytes that exercise the URL-safe alphabet characters - and _
+        assert_eq!(base64_url_encode(&[0xfb, 0xff]), "-_8");
+
+        assert_eq!(base64_url_decode("Zg").unwrap(), b"f".to_vec());
+        assert_eq!(
+            base64_url_decode("SGVsbG8sIFdvcmxkIQ").unwrap(),
+            b"Hello, World!".to_vec()
+        );
+        assert_eq!(base64_url_decode("-_8").unwrap(), vec![0xfb, 0xff]);
+    }
+
+    #[test]
+    fn test_base64_url_decode_leniency() {
+        // Whitespace anywhere is ignored (as the old decoder did).
+        assert_eq!(
+            base64_url_decode("SGVs bG8s\nIFdvcmxkIQ").unwrap(),
+            b"Hello, World!".to_vec()
+        );
+        // Trailing padding is tolerated.
+        assert_eq!(
+            base64_url_decode("SGVsbG8sIFdvcmxkIQ==").unwrap(),
+            b"Hello, World!".to_vec()
+        );
+        // Non-canonical trailing bits are tolerated (as the old decoder did).
+        assert_eq!(base64_url_decode("Zh").unwrap(), b"f".to_vec());
+        // Invalid characters are rejected.
+        assert!(base64_url_decode("ab$c").is_err());
+        // Standard (non-URL-safe) alphabet is rejected.
+        assert!(base64_url_decode("+/").is_err());
+    }
+
+    #[test]
+    fn test_proxy_init_config_decode_fixture() {
+        // Encoded form of {"t":"tok","n":"pre"} produced by the previous
+        // hand-rolled encoder; must keep decoding.
+        let encoded = "eyJ0IjoidG9rIiwibiI6InByZSJ9";
+        let decoded = ProxyInitConfig::decode(encoded).unwrap();
+        assert_eq!(decoded.token, "tok");
+        assert_eq!(decoded.session_name_prefix, Some("pre".to_string()));
+
+        // And the encoder must reproduce it byte-for-byte.
+        assert_eq!(decoded.encode().unwrap(), encoded);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #990.

Both hand-rolled codecs (shared/proxy_tokens.rs ~70 lines, proxy/util.rs ~40 lines) replaced with a const lenient `GeneralPurpose` engine. Leniency parity analysis:

1. Padding: `DecodePaddingMode::Indifferent` + proxy keeps its strip-`=` filter (old proxy accepted `=` anywhere; old shared rejected — now uniformly tolerant, never less than before)
2. Whitespace: pre-filtered (crate is strict, old decoders ignored it)
3. Non-canonical trailing bits: `allow_trailing_bits(true)` (old behavior masked silently)
4. Intentionally stricter: len ≡ 1 (mod 4) inputs now fail softly instead of emitting a garbage byte — unproducible by any encoder; both call sites treat decode failure as soft

Byte-identity pinned: RFC 4648 fixtures, 256-byte roundtrip, hardcoded `ProxyInitConfig` fixture, JWT payload tests (plain/padded/invalid).

Validation: fmt clean, workspace clippy `-D warnings` clean, shared 48 + proxy 6 + backend 111 tests pass, shared wasm check clean.