### PR TITLE
require_admin reuses extract_user instead of reimplementing auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.41
+
+- **`require_admin` now reuses `auth::extract_user` instead of re-implementing the cookie→user→disabled-check sequence.** −23 lines and one auth path instead of two. Two deliberate consistency changes: admin endpoints honor the dev-mode bypass like every other handler (grants nothing — the seeded dev user has `is_admin = FALSE` by column default, so dev-mode admin requests still get 403 unless manually promoted), and a stale cookie for a deleted user now yields 401 instead of a 404, matching all other authed handlers.
+
 ## 2.8.35
 
 - **Delete dead `shared` types: `UserInfo`, `ApiError` (+ manual `Display`/`Error` impls), `DevicePollRequest`.** All three were grep-verified unreferenced across every consumer crate (`UserInfo` was a strict subset of `MeResponse`; `DevicePollRequest` an exact field duplicate of the live `DeviceFlowPollRequest`). `DevicePollResponse` stays — #1006 made it the canonical wire type. Pure deletions, −46 lines.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.41"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.41"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.41"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.41"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.41"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.41"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.41"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.41"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.41"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -22,38 +22,15 @@ use crate::{
     AppState,
 };
 
-use shared::protocol::SESSION_COOKIE_NAME;
-
 // ============================================================================
 // Admin Guard - extracts and validates admin user from cookies
 // ============================================================================
 
 /// Extract the current user from cookies and verify they are an admin.
 /// Returns the User if they are an admin, or an appropriate application error.
-pub async fn require_admin(app_state: &Arc<AppState>, cookies: &Cookies) -> Result<User, AppError> {
-    // Extract user ID from signed session cookie
-    let cookie = cookies
-        .signed(&app_state.cookie_key)
-        .get(SESSION_COOKIE_NAME)
-        .ok_or(AppError::Unauthorized)?;
+pub fn require_admin(app_state: &Arc<AppState>, cookies: &Cookies) -> Result<User, AppError> {
+    let user = crate::auth::extract_user(app_state, cookies)?;
 
-    let user_id: Uuid = cookie.value().parse().map_err(|_| AppError::Unauthorized)?;
-
-    // Fetch user from database
-    let mut conn = app_state.conn()?;
-
-    let user = schema::users::table
-        .find(user_id)
-        .first::<User>(&mut conn)
-        .map_err(|_| AppError::NotFound("admin user"))?;
-
-    // Check if user is disabled
-    if user.disabled {
-        warn!("Disabled user {} attempted admin access", user.email);
-        return Err(AppError::Forbidden);
-    }
-
-    // Check if user is admin
     if !user.is_admin {
         warn!("Non-admin user {} attempted admin access", user.email);
         return Err(AppError::Forbidden);
@@ -115,7 +92,7 @@ pub async fn get_stats(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
 ) -> Result<Json<AdminStats>, AppError> {
-    let admin = require_admin(&app_state, &cookies).await?;
+    let admin = require_admin(&app_state, &cookies)?;
     info!("Admin {} requested system stats", admin.email);
 
     let mut conn = app_state.conn()?;
@@ -193,7 +170,7 @@ pub async fn list_users(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
 ) -> Result<Json<AdminUsersResponse>, AppError> {
-    let admin = require_admin(&app_state, &cookies).await?;
+    let admin = require_admin(&app_state, &cookies)?;
     info!("Admin {} requested user list", admin.email);
 
     let mut conn = app_state.conn()?;
@@ -243,7 +220,7 @@ pub async fn update_user(
     Path(user_id): Path<Uuid>,
     Json(update): Json<UpdateUserRequest>,
 ) -> Result<EmptyResponse, AppError> {
-    let admin = require_admin(&app_state, &cookies).await?;
+    let admin = require_admin(&app_state, &cookies)?;
 
     // Prevent admin from demoting themselves
     if user_id == admin.id && update.is_admin == Some(false) {
@@ -353,7 +330,7 @@ pub async fn list_sessions(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
 ) -> Result<Json<AdminSessionsResponse>, AppError> {
-    let admin = require_admin(&app_state, &cookies).await?;
+    let admin = require_admin(&app_state, &cookies)?;
     info!("Admin {} requested sessions list", admin.email);
 
     let mut conn = app_state.conn()?;
@@ -401,7 +378,7 @@ pub async fn delete_session(
     cookies: Cookies,
     Path(session_id): Path<Uuid>,
 ) -> Result<EmptyResponse, AppError> {
-    let admin = require_admin(&app_state, &cookies).await?;
+    let admin = require_admin(&app_state, &cookies)?;
 
     let mut conn = app_state.conn()?;
 


### PR DESCRIPTION
Fixes #971.

`require_admin` is now `extract_user(...)?` + `is_admin` check (+7/−30; became sync, five call sites drop `.await`).

Documented consistency changes:
- Admin endpoints honor the dev-mode bypass like every other handler — grants nothing: dev user is seeded with `is_admin = FALSE` (column default), so 403 stands unless manually promoted
- Stale cookie for a deleted user: 401 instead of `NotFound("admin user")`, consistent with all authed handlers

Validation: fmt clean, backend clippy `-D warnings` clean, 111/111 tests, workspace check clean.