### PR TITLE
Extract shared ConfirmModal component from five duplicate sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.42
+
+- **One `ConfirmModal` component replaces five copy-pasted confirm dialogs.** Admin user actions, settings sessions/tokens panels, and the dashboard's Delete/Leave session modals all hand-rolled the same overlay + message + cancel/confirm markup. The new component parameterizes the three pre-existing CSS class families (`Standard` admin, `Panel` settings, `Danger` dashboard with title/warning) so the rendered DOM is byte-identical at every site; overlay-click-cancels and inner stop-propagation semantics preserved. The admin ban dialog (text-input modal) and token-renewed dialog (single "Done" button) were deliberately not migrated — they aren't confirm modals.
+
 ## 2.8.35
 
 - **Delete dead `shared` types: `UserInfo`, `ApiError` (+ manual `Display`/`Error` impls), `DevicePollRequest`.** All three were grep-verified unreferenced across every consumer crate (`UserInfo` was a strict subset of `MeResponse`; `DevicePollRequest` an exact field duplicate of the live `DeviceFlowPollRequest`). `DevicePollResponse` stays — #1006 made it the canonical wire type. Pure deletions, −46 lines.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.42"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.42"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.42"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.42"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.42"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.42"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.42"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.42"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.42"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/confirm_modal.rs
+++ b/frontend/src/components/confirm_modal.rs
@@ -1,0 +1,89 @@
+use yew::prelude::*;
+
+/// Visual style of the confirm modal. Each variant maps to an existing CSS
+/// class family so extracted call sites render pixel-identically.
+#[derive(Clone, Copy, PartialEq, Default)]
+pub enum ConfirmModalStyle {
+    /// `modal-content confirm-modal` container with `modal-*` buttons (admin page).
+    #[default]
+    Standard,
+    /// Bare `confirm-modal` container with `cancel-button`/`confirm-button` (settings panels).
+    Panel,
+    /// `modal-content delete-confirm` container with `modal-*` buttons (dashboard delete/leave).
+    Danger,
+}
+
+impl ConfirmModalStyle {
+    fn container_class(&self) -> &'static str {
+        match self {
+            Self::Standard => "modal-content confirm-modal",
+            Self::Panel => "confirm-modal",
+            Self::Danger => "modal-content delete-confirm",
+        }
+    }
+
+    fn actions_class(&self) -> &'static str {
+        match self {
+            Self::Panel => "confirm-actions",
+            Self::Standard | Self::Danger => "modal-actions",
+        }
+    }
+
+    fn cancel_class(&self) -> &'static str {
+        match self {
+            Self::Panel => "cancel-button",
+            Self::Standard | Self::Danger => "modal-cancel",
+        }
+    }
+
+    fn confirm_class(&self) -> &'static str {
+        match self {
+            Self::Panel => "confirm-button",
+            Self::Standard | Self::Danger => "modal-confirm",
+        }
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct ConfirmModalProps {
+    /// Main message body of the modal.
+    pub message: AttrValue,
+    /// Optional heading rendered above the message.
+    #[prop_or_default]
+    pub title: Option<AttrValue>,
+    /// Optional warning line rendered below the message.
+    #[prop_or_default]
+    pub warning: Option<AttrValue>,
+    /// Label for the confirm button.
+    #[prop_or(AttrValue::Static("Confirm"))]
+    pub confirm_label: AttrValue,
+    #[prop_or_default]
+    pub style: ConfirmModalStyle,
+    pub on_confirm: Callback<MouseEvent>,
+    pub on_cancel: Callback<MouseEvent>,
+}
+
+#[function_component(ConfirmModal)]
+pub fn confirm_modal(props: &ConfirmModalProps) -> Html {
+    html! {
+        <div class="modal-overlay" onclick={props.on_cancel.clone()}>
+            <div class={props.style.container_class()} onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                if let Some(title) = &props.title {
+                    <h2>{ title }</h2>
+                }
+                <p>{ &props.message }</p>
+                if let Some(warning) = &props.warning {
+                    <p class="modal-warning">{ warning }</p>
+                }
+                <div class={props.style.actions_class()}>
+                    <button class={props.style.cancel_class()} onclick={props.on_cancel.clone()}>
+                        { "Cancel" }
+                    </button>
+                    <button class={props.style.confirm_class()} onclick={props.on_confirm.clone()}>
+                        { &props.confirm_label }
+                    </button>
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -1,5 +1,6 @@
 pub mod charts;
 pub mod codex_renderer;
+mod confirm_modal;
 pub mod copy_button;
 mod copy_command;
 mod count_up;
@@ -18,6 +19,7 @@ mod tool_renderers;
 mod turn_metrics_pill;
 mod voice_input;
 
+pub use confirm_modal::{ConfirmModal, ConfirmModalStyle};
 pub use copy_command::CopyCommand;
 pub use count_up::CountUp;
 pub use launch_dialog::LaunchDialog;

--- a/frontend/src/pages/admin/mod.rs
+++ b/frontend/src/pages/admin/mod.rs
@@ -11,6 +11,7 @@ use overview_tab::AdminOverviewTab;
 use sessions_tab::AdminSessionsTab;
 use users_tab::AdminUsersTab;
 
+use crate::components::ConfirmModal;
 use crate::utils::{self, FetchError, On401};
 use crate::Route;
 use gloo_net::http::Request;
@@ -542,15 +543,11 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
             {
                 if let Some((ref message, ref action)) = *confirm_action {
                     html! {
-                        <div class="modal-overlay" onclick={on_cancel_confirm.clone()}>
-                            <div class="modal-content confirm-modal" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                                <p>{ message }</p>
-                                <div class="modal-actions">
-                                    <button class="modal-cancel" onclick={on_cancel_confirm.clone()}>{ "Cancel" }</button>
-                                    <button class="modal-confirm" onclick={action.clone()}>{ "Confirm" }</button>
-                                </div>
-                            </div>
-                        </div>
+                        <ConfirmModal
+                            message={message.clone()}
+                            on_confirm={action.clone()}
+                            on_cancel={on_cancel_confirm.clone()}
+                        />
                     }
                 } else {
                     html! {}

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -6,7 +6,7 @@ use super::types::{
     load_hidden_sessions, load_inactive_hidden, load_rail_position, load_show_cost,
     save_hidden_sessions, save_inactive_hidden, save_show_cost,
 };
-use crate::components::{LaunchDialog, TurnMetricsHeaderPill};
+use crate::components::{ConfirmModal, ConfirmModalStyle, LaunchDialog, TurnMetricsHeaderPill};
 use crate::hooks::{use_client_websocket, use_keyboard_nav, use_sessions, KeyboardNavConfig};
 use crate::pages::admin::AdminPage;
 use crate::pages::settings::SettingsPage;
@@ -914,17 +914,15 @@ pub fn dashboard_page() -> Html {
                         .unwrap_or("this session");
 
                     html! {
-                        <div class="modal-overlay" onclick={on_cancel_delete.clone()}>
-                            <div class="modal-content delete-confirm" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                                <h2>{ "Delete Session?" }</h2>
-                                <p>{ format!("Are you sure you want to delete \"{}\"?", session_name) }</p>
-                                <p class="modal-warning">{ "All message history and session metadata will be permanently removed." }</p>
-                                <div class="modal-actions">
-                                    <button class="modal-cancel" onclick={on_cancel_delete.clone()}>{ "Cancel" }</button>
-                                    <button class="modal-confirm" onclick={on_confirm_delete.clone()}>{ "Delete" }</button>
-                                </div>
-                            </div>
-                        </div>
+                        <ConfirmModal
+                            title="Delete Session?"
+                            message={format!("Are you sure you want to delete \"{}\"?", session_name)}
+                            warning="All message history and session metadata will be permanently removed."
+                            confirm_label="Delete"
+                            style={ConfirmModalStyle::Danger}
+                            on_confirm={on_confirm_delete.clone()}
+                            on_cancel={on_cancel_delete.clone()}
+                        />
                     }
                 } else {
                     html! {}
@@ -954,17 +952,15 @@ pub fn dashboard_page() -> Html {
                         .unwrap_or("this session");
 
                     html! {
-                        <div class="modal-overlay" onclick={on_cancel_leave.clone()}>
-                            <div class="modal-content delete-confirm" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                                <h2>{ "Leave Session?" }</h2>
-                                <p>{ format!("Are you sure you want to leave \"{}\"?", session_name) }</p>
-                                <p class="modal-warning">{ "You will need to be re-invited to access this session again." }</p>
-                                <div class="modal-actions">
-                                    <button class="modal-cancel" onclick={on_cancel_leave.clone()}>{ "Cancel" }</button>
-                                    <button class="modal-confirm" onclick={on_confirm_leave.clone()}>{ "Leave" }</button>
-                                </div>
-                            </div>
-                        </div>
+                        <ConfirmModal
+                            title="Leave Session?"
+                            message={format!("Are you sure you want to leave \"{}\"?", session_name)}
+                            warning="You will need to be re-invited to access this session again."
+                            confirm_label="Leave"
+                            style={ConfirmModalStyle::Danger}
+                            on_confirm={on_confirm_leave.clone()}
+                            on_cancel={on_cancel_leave.clone()}
+                        />
                     }
                 } else {
                     html! {}

--- a/frontend/src/pages/settings/sessions_panel.rs
+++ b/frontend/src/pages/settings/sessions_panel.rs
@@ -1,4 +1,4 @@
-use crate::components::ShareDialog;
+use crate::components::{ConfirmModal, ConfirmModalStyle, ShareDialog};
 use crate::utils::{self, On401};
 use gloo_net::http::Request;
 use shared::api::SessionsResponse;
@@ -232,19 +232,12 @@ pub fn sessions_panel(props: &SessionsPanelProps) -> Html {
             </section>
 
             if let Some((message, action)) = &*confirm_action {
-                <div class="modal-overlay" onclick={cancel_confirm.clone()}>
-                    <div class="confirm-modal" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                        <p>{ message }</p>
-                        <div class="confirm-actions">
-                            <button class="cancel-button" onclick={cancel_confirm.clone()}>
-                                { "Cancel" }
-                            </button>
-                            <button class="confirm-button" onclick={action.clone()}>
-                                { "Confirm" }
-                            </button>
-                        </div>
-                    </div>
-                </div>
+                <ConfirmModal
+                    message={message.clone()}
+                    style={ConfirmModalStyle::Panel}
+                    on_confirm={action.clone()}
+                    on_cancel={cancel_confirm.clone()}
+                />
             }
 
             if let Some(session_id) = *share_session_id {

--- a/frontend/src/pages/settings/tokens_panel.rs
+++ b/frontend/src/pages/settings/tokens_panel.rs
@@ -1,3 +1,4 @@
+use crate::components::{ConfirmModal, ConfirmModalStyle};
 use crate::utils::{self, On401};
 use gloo_net::http::Request;
 use shared::{
@@ -493,19 +494,12 @@ pub fn tokens_panel(props: &TokensPanelProps) -> Html {
             }
 
             if let Some((message, action)) = &*confirm_action {
-                <div class="modal-overlay" onclick={cancel_confirm.clone()}>
-                    <div class="confirm-modal" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                        <p>{ message }</p>
-                        <div class="confirm-actions">
-                            <button class="cancel-button" onclick={cancel_confirm.clone()}>
-                                { "Cancel" }
-                            </button>
-                            <button class="confirm-button" onclick={action.clone()}>
-                                { "Confirm" }
-                            </button>
-                        </div>
-                    </div>
-                </div>
+                <ConfirmModal
+                    message={message.clone()}
+                    style={ConfirmModalStyle::Panel}
+                    on_confirm={action.clone()}
+                    on_cancel={cancel_confirm.clone()}
+                />
             }
         </>
     }


### PR DESCRIPTION
Fixes #983.

New `components/confirm_modal.rs` with `message`/`title`/`warning`/`confirm_label`/`style`/`on_confirm`/`on_cancel`. `ConfirmModalStyle` maps to the three distinct CSS families verified at the call sites (Standard/admin, Panel/settings.css, Danger/keyboard.css) — rendered DOM byte-identical per site. Migrated: admin, sessions panel, tokens panel, dashboard Delete + Leave. Deliberately skipped: ban dialog (has input field), token-renewed dialog (not a confirm).

Validation: fmt clean, clippy `-D warnings` clean, 310/310 tests, wasm build clean.