### PR TITLE
Fetch session owner once per proxy output frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.43
+
+- **`handle_claude_output` reads the session row once per proxy output frame instead of twice.** The owner-only `select(sessions::user_id)` is hoisted above both consumers (image extraction and the message-insert gate); the full `Session` load — used only for `user_id` — is gone. Failure semantics per consumer are identical to before (lookup failure skips extraction and insert but never blocks `last_activity` or `OutputAck`); the second pool *checkout* is kept deliberately so no connection is held across CPU-bound base64 work and a transient pool error can't poison the ack path.
+
 ## 2.8.35
 
 - **Delete dead `shared` types: `UserInfo`, `ApiError` (+ manual `Display`/`Error` impls), `DevicePollRequest`.** All three were grep-verified unreferenced across every consumer crate (`UserInfo` was a strict subset of `MeResponse`; `DevicePollRequest` an exact field duplicate of the live `DeviceFlowPollRequest`). `DevicePollResponse` stays — #1006 made it the canonical wire type. Pure deletions, −46 lines.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.43"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.43"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.43"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.43"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.43"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.43"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.43"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.43"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.43"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.43"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.43"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -171,17 +171,11 @@ pub fn handle_claude_output(
         }
     }
 
-    // Extract base64 images from portal messages and replace with URLs.
-    // This keeps WebSocket messages small — browsers fetch images via HTTP.
-    //
-    // The inserted images need a `user_id` for the auth check on
-    // `/api/images/{id}` (#786). We don't yet have the `Session` row in scope
-    // here — the DB lookup below also reads it — so we do an early, cheap
-    // owner-only `.select` here. If we can't resolve a user_id we *skip*
-    // image extraction rather than silently drop ownership: the original
-    // base64 just stays inline in the broadcast (slower but correct), and
-    // nothing un-owned ever lands in the cache.
-    let inserting_user_id: Option<Uuid> = db_session_id.and_then(|sid| {
+    // Resolve the session owner ONCE for both consumers below: image
+    // extraction (auth check on `/api/images/{id}`, #786) and the message
+    // insert (fallback `user_id`). A single cheap owner-only `.select`
+    // replaces the previous pair of per-message session lookups (#977).
+    let session_user_id: Option<Uuid> = db_session_id.and_then(|sid| {
         use crate::schema::sessions;
         let mut conn = db_pool.get().ok()?;
         sessions::table
@@ -190,7 +184,15 @@ pub fn handle_claude_output(
             .first::<Uuid>(&mut conn)
             .ok()
     });
-    let content = match inserting_user_id {
+
+    // Extract base64 images from portal messages and replace with URLs.
+    // This keeps WebSocket messages small — browsers fetch images via HTTP.
+    //
+    // If we couldn't resolve a user_id we *skip* image extraction rather
+    // than silently drop ownership: the original base64 just stays inline
+    // in the broadcast (slower but correct), and nothing un-owned ever
+    // lands in the cache.
+    let content = match session_user_id {
         Some(uid) => extract_portal_images(content, image_store, uid, db_session_id),
         None => content,
     };
@@ -208,10 +210,9 @@ pub fn handle_claude_output(
     if let (Some(session_id), Ok(mut conn)) = (db_session_id, db_pool.get()) {
         use crate::schema::{messages, sessions};
 
-        if let Ok(session) = sessions::table
-            .find(session_id)
-            .first::<crate::models::Session>(&mut conn)
-        {
+        // Only insert when the owner lookup above resolved — same gating the
+        // previous per-insert `Session` load provided (no row, no insert).
+        if let Some(owner_user_id) = session_user_id {
             let role = shared::MessageRole::from_type_str(
                 content
                     .get("type")
@@ -223,7 +224,7 @@ pub fn handle_claude_output(
             let actual_user_id = sender_info
                 .as_ref()
                 .map(|(id, _)| *id)
-                .unwrap_or(session.user_id);
+                .unwrap_or(owner_user_id);
 
             let new_message = crate::models::NewMessage {
                 session_id,


### PR DESCRIPTION
Fixes #977.

Hot path: 2 session-row reads → 1 (owner-only select hoisted above both consumers; the full `Session` load was only used for `user_id`). Error-path union analyzed: each consumer sees exactly its old failure semantics; `last_activity` + `OutputAck` unaffected. Second pool checkout retained intentionally (no connection held across base64 work; ack path isolated from transient pool errors).

Validation: fmt clean, backend clippy `-D warnings` clean, 111/111 tests, workspace check clean.