### PR TITLE
Extract shared chart frame for LinePlot and StackedArea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.44
+
+- **Chart frame extracted: LinePlot and StackedArea share one frame implementation.** `charts/mod.rs` now hosts the `VIEW_*`/`PAD_*`/`PLOT_*` constants, `chart_empty`, `render_gridlines`, `render_x_labels`, `render_legend`, and a `chart_frame` wrapper (header + scale badge + legend + responsive SVG with rotated y-axis title); the component files keep only their geometry. StackedArea's local `value_to_y` wrapper (PAD_T baked in) deleted in favor of `scale::value_to_y` + explicit offset. Markup copied verbatim — zero rendered-output change; legend swatch styles deliberately stay per-component (they differ byte-wise). Two duplicate axis-format tests consolidated into one in scale.rs. Net −45 lines with each component file ~60% lighter on frame code.
+
 ## 2.8.35
 
 - **Delete dead `shared` types: `UserInfo`, `ApiError` (+ manual `Display`/`Error` impls), `DevicePollRequest`.** All three were grep-verified unreferenced across every consumer crate (`UserInfo` was a strict subset of `MeResponse`; `DevicePollRequest` an exact field duplicate of the live `DeviceFlowPollRequest`). `DevicePollResponse` stays — #1006 made it the canonical wire type. Pure deletions, −46 lines.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.44"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.44"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.44"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.44"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.44"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.44"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.44"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.44"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.44"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.44"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.44"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/charts/line_plot.rs
+++ b/frontend/src/components/charts/line_plot.rs
@@ -1,11 +1,11 @@
 //! Hand-rolled `<svg>` line-chart component.
 //!
-//! Built directly on top of the pure helpers in [`super::scale`]. Each chart
-//! on the Performance page (throughput, TTFT, cache hit, cost-per-token)
-//! mounts one of these with a list of named series; the component computes
-//! "nice" y-axis bounds, draws the gridlines + axis labels, and emits one
-//! `<polyline>` per series. Width is 100 % of the container via a responsive
-//! `viewBox`.
+//! Built directly on top of the pure helpers in [`super::scale`] and the
+//! shared frame helpers in [`super`]. Each chart on the Performance page
+//! (throughput, TTFT, cache hit, cost-per-token) mounts one of these with a
+//! list of named series; the component computes "nice" y-axis bounds, draws
+//! the gridlines + axis labels, and emits one `<polyline>` per series. Width
+//! is 100 % of the container via a responsive `viewBox`.
 //!
 //! No chart library. SVG is plain DOM strings.
 
@@ -13,8 +13,12 @@ use chrono::{DateTime, Utc};
 use yew::prelude::*;
 
 use super::scale::{
-    format_axis_value, series_points_with_axis, time_axis_ticks, y_axis_for_values,
-    y_axis_tick_labels, AxisScale, BucketKind, TickLabel,
+    series_points_with_axis, time_axis_ticks, y_axis_for_values, y_axis_tick_labels, AxisScale,
+    BucketKind,
+};
+use super::{
+    chart_empty, chart_frame, render_gridlines, render_legend, render_x_labels, PAD_L, PAD_T,
+    PLOT_H, PLOT_W,
 };
 
 /// One labelled line in the chart. `dashed = true` is used for p95 traces
@@ -50,25 +54,10 @@ pub struct LinePlotProps {
     pub axis_scale: AxisScale,
 }
 
-/// Internal SVG canvas size. We render at 800×260 in the viewBox and let CSS
-/// scale to the container width — same approach as the Sparkline.
-const VIEW_W: f32 = 800.0;
-const VIEW_H: f32 = 260.0;
-/// Padding on each side of the plot area to leave room for axis labels.
-const PAD_L: f32 = 66.0;
-const PAD_R: f32 = 12.0;
-const PAD_T: f32 = 12.0;
-const PAD_B: f32 = 36.0;
-
 #[function_component(LinePlot)]
 pub fn line_plot(props: &LinePlotProps) -> Html {
     if props.buckets.is_empty() || props.series.iter().all(|s| s.values.is_empty()) {
-        return html! {
-            <div class="performance-chart">
-                <h3 class="chart-title">{ &props.title }</h3>
-                <div class="chart-empty">{ "No data" }</div>
-            </div>
-        };
+        return chart_empty(&props.title);
     }
 
     // Gather all finite y-values across all series for the axis range.
@@ -81,18 +70,9 @@ pub fn line_plot(props: &LinePlotProps) -> Html {
         }
     }
     if all_y.is_empty() {
-        return html! {
-            <div class="performance-chart">
-                <h3 class="chart-title">{ &props.title }</h3>
-                <div class="chart-empty">{ "No data" }</div>
-            </div>
-        };
+        return chart_empty(&props.title);
     }
     let y_axis = y_axis_for_values(&all_y, props.axis_scale);
-
-    let plot_w = VIEW_W - PAD_L - PAD_R;
-    let plot_h = VIEW_H - PAD_T - PAD_B;
-    let viewbox = format!("0 0 {VIEW_W} {VIEW_H}");
 
     let x_ticks = time_axis_ticks(&props.buckets, props.bucket_kind, 6);
     let y_ticks = y_axis_tick_labels(&y_axis);
@@ -105,10 +85,10 @@ pub fn line_plot(props: &LinePlotProps) -> Html {
         let runs = contiguous_runs(&s.values);
         for (start_idx, run) in runs {
             let scaled_w = (run.len() as f32 - 1.0).max(0.0)
-                * (plot_w / (props.buckets.len() as f32 - 1.0).max(1.0));
+                * (PLOT_W / (props.buckets.len() as f32 - 1.0).max(1.0));
             let offset_x =
-                (start_idx as f32) * (plot_w / (props.buckets.len() as f32 - 1.0).max(1.0));
-            let points = series_points_with_axis(&run, scaled_w.max(0.0), plot_h, &y_axis);
+                (start_idx as f32) * (PLOT_W / (props.buckets.len() as f32 - 1.0).max(1.0));
+            let points = series_points_with_axis(&run, scaled_w.max(0.0), PLOT_H, &y_axis);
             if points.is_empty() {
                 continue;
             }
@@ -127,95 +107,32 @@ pub fn line_plot(props: &LinePlotProps) -> Html {
         }
     }
 
-    let gridlines: Html = y_ticks
-        .iter()
-        .map(|(v, frac)| {
-            let y = PAD_T + plot_h - frac * plot_h;
-            html! {
-                <>
-                    <line
-                        x1={format!("{:.2}", PAD_L)}
-                        x2={format!("{:.2}", PAD_L + plot_w)}
-                        y1={format!("{:.2}", y)}
-                        y2={format!("{:.2}", y)}
-                        class="chart-gridline"
-                    />
-                    <text
-                        x={format!("{:.2}", PAD_L - 6.0)}
-                        y={format!("{:.2}", y + 4.0)}
-                        class="chart-y-label"
-                        text-anchor="end"
-                    >
-                        { format_axis_value(*v) }
-                    </text>
-                </>
-            }
-        })
-        .collect();
+    let gridlines = render_gridlines(&y_ticks);
+    let x_labels = render_x_labels(&x_ticks);
+    let legend = render_legend(props.series.iter().map(|s| {
+        (
+            s.label.as_str(),
+            format!(
+                "background: {}; {}",
+                s.color,
+                if s.dashed { "background-image: repeating-linear-gradient(90deg, transparent 0 3px, var(--bg-darker) 3px 6px);" } else { "" }
+            ),
+        )
+    }));
 
-    let x_labels: Html = x_ticks
-        .iter()
-        .map(|TickLabel { frac, label }| {
-            let x = PAD_L + frac * plot_w;
-            html! {
-                <text
-                    x={format!("{:.2}", x)}
-                    y={format!("{:.2}", VIEW_H - PAD_B + 18.0)}
-                    class="chart-x-label"
-                    text-anchor="middle"
-                >
-                    { label.clone() }
-                </text>
-            }
-        })
-        .collect();
-
-    let legend: Html = props
-        .series
-        .iter()
-        .map(|s| {
-            html! {
-                <span class="chart-legend-item">
-                    <span class="chart-legend-swatch"
-                          style={format!(
-                              "background: {}; {}",
-                              s.color,
-                              if s.dashed { "background-image: repeating-linear-gradient(90deg, transparent 0 3px, var(--bg-darker) 3px 6px);" } else { "" }
-                          )}>
-                    </span>
-                    { &s.label }
-                </span>
-            }
-        })
-        .collect();
-
-    html! {
-        <div class="performance-chart">
-            <div class="chart-header">
-                <h3 class="chart-title">{ &props.title }</h3>
-                <span class="chart-scale-badge">{ props.axis_scale.label() }</span>
-            </div>
-            <div class="chart-legend">{ legend }</div>
-            <svg
-                class="performance-chart-svg"
-                viewBox={viewbox}
-                preserveAspectRatio="xMidYMid meet"
-            >
-                <text
-                    x={format!("{:.2}", 14.0)}
-                    y={format!("{:.2}", PAD_T + plot_h / 2.0)}
-                    class="chart-y-axis-title"
-                    text-anchor="middle"
-                    transform={format!("rotate(-90 14 {:.2})", PAD_T + plot_h / 2.0)}
-                >
-                    { &props.y_label }
-                </text>
+    chart_frame(
+        &props.title,
+        props.axis_scale,
+        &props.y_label,
+        legend,
+        html! {
+            <>
                 { gridlines }
                 { for polylines }
                 { x_labels }
-            </svg>
-        </div>
-    }
+            </>
+        },
+    )
 }
 
 /// Find every contiguous run of `Some(v)` values in the series. Returns
@@ -282,14 +199,5 @@ mod tests {
         let vals = vec![Some(1.0), Some(f64::NAN), Some(3.0)];
         let runs = contiguous_runs(&vals);
         assert_eq!(runs.len(), 2);
-    }
-
-    #[test]
-    fn format_axis_value_picks_compact_form() {
-        assert_eq!(format_axis_value(0.0), "0");
-        assert_eq!(format_axis_value(1.0), "1");
-        assert_eq!(format_axis_value(0.25), "0.25");
-        assert_eq!(format_axis_value(12.5), "12.5");
-        assert_eq!(format_axis_value(1500.0), "1.5k");
     }
 }

--- a/frontend/src/components/charts/mod.rs
+++ b/frontend/src/components/charts/mod.rs
@@ -11,7 +11,10 @@
 //!
 //! Pure math (axis bounds, tick formatting, polyline-point projection) lives
 //! in [`scale`]; both components import their helpers from there so they
-//! share the same nice-number / time-axis behavior.
+//! share the same nice-number / time-axis behavior. The shared chart frame
+//! (canvas constants, empty card, gridlines, x-axis labels, legend, and the
+//! header + svg wrapper) lives in this module so both components render the
+//! exact same chrome around their series geometry.
 
 pub mod line_plot;
 pub mod scale;
@@ -20,3 +23,133 @@ pub mod stacked_area;
 pub use line_plot::{LinePlot, LineSeries};
 pub use scale::{AxisScale, BucketKind};
 pub use stacked_area::{StackedArea, StackedSeries};
+
+use yew::prelude::*;
+
+use scale::{format_axis_value, TickLabel};
+
+/// Internal SVG canvas size. We render at 800×260 in the viewBox and let CSS
+/// scale to the container width — same approach as the Sparkline.
+const VIEW_W: f32 = 800.0;
+const VIEW_H: f32 = 260.0;
+/// Padding on each side of the plot area to leave room for axis labels.
+const PAD_L: f32 = 66.0;
+const PAD_R: f32 = 12.0;
+const PAD_T: f32 = 12.0;
+const PAD_B: f32 = 36.0;
+/// Plot-area size inside the axis-label padding.
+const PLOT_W: f32 = VIEW_W - PAD_L - PAD_R;
+const PLOT_H: f32 = VIEW_H - PAD_T - PAD_B;
+
+/// The "No data" placeholder card, shown when a chart has nothing to plot.
+fn chart_empty(title: &str) -> Html {
+    html! {
+        <div class="performance-chart">
+            <h3 class="chart-title">{ title }</h3>
+            <div class="chart-empty">{ "No data" }</div>
+        </div>
+    }
+}
+
+/// Horizontal gridlines plus their y-axis tick labels, one pair per tick.
+fn render_gridlines(y_ticks: &[(f64, f32)]) -> Html {
+    y_ticks
+        .iter()
+        .map(|(v, frac)| {
+            let y = PAD_T + PLOT_H - frac * PLOT_H;
+            html! {
+                <>
+                    <line
+                        x1={format!("{:.2}", PAD_L)}
+                        x2={format!("{:.2}", PAD_L + PLOT_W)}
+                        y1={format!("{:.2}", y)}
+                        y2={format!("{:.2}", y)}
+                        class="chart-gridline"
+                    />
+                    <text
+                        x={format!("{:.2}", PAD_L - 6.0)}
+                        y={format!("{:.2}", y + 4.0)}
+                        class="chart-y-label"
+                        text-anchor="end"
+                    >
+                        { format_axis_value(*v) }
+                    </text>
+                </>
+            }
+        })
+        .collect()
+}
+
+/// X-axis tick labels along the bottom edge of the plot area.
+fn render_x_labels(x_ticks: &[TickLabel]) -> Html {
+    x_ticks
+        .iter()
+        .map(|TickLabel { frac, label }| {
+            let x = PAD_L + frac * PLOT_W;
+            html! {
+                <text
+                    x={format!("{:.2}", x)}
+                    y={format!("{:.2}", VIEW_H - PAD_B + 18.0)}
+                    class="chart-x-label"
+                    text-anchor="middle"
+                >
+                    { label.clone() }
+                </text>
+            }
+        })
+        .collect()
+}
+
+/// Legend row: one swatch + label per series. Each caller supplies the full
+/// swatch `style` string, since swatch styling differs per chart (dashed
+/// overlay for p95 lines vs plain fill for stacked bands).
+fn render_legend<'a>(items: impl Iterator<Item = (&'a str, String)>) -> Html {
+    items
+        .map(|(label, style)| {
+            html! {
+                <span class="chart-legend-item">
+                    <span class="chart-legend-swatch" style={style}></span>
+                    { label }
+                </span>
+            }
+        })
+        .collect()
+}
+
+/// The common chart chrome: title + scale badge header, legend row, and the
+/// responsive `<svg>` with the rotated y-axis title. `body` is the chart's
+/// own geometry (gridlines, series shapes, x labels) rendered inside the svg.
+fn chart_frame(
+    title: &str,
+    axis_scale: AxisScale,
+    y_label: &str,
+    legend: Html,
+    body: Html,
+) -> Html {
+    let viewbox = format!("0 0 {VIEW_W} {VIEW_H}");
+    html! {
+        <div class="performance-chart">
+            <div class="chart-header">
+                <h3 class="chart-title">{ title }</h3>
+                <span class="chart-scale-badge">{ axis_scale.label() }</span>
+            </div>
+            <div class="chart-legend">{ legend }</div>
+            <svg
+                class="performance-chart-svg"
+                viewBox={viewbox}
+                preserveAspectRatio="xMidYMid meet"
+            >
+                <text
+                    x={format!("{:.2}", 14.0)}
+                    y={format!("{:.2}", PAD_T + PLOT_H / 2.0)}
+                    class="chart-y-axis-title"
+                    text-anchor="middle"
+                    transform={format!("rotate(-90 14 {:.2})", PAD_T + PLOT_H / 2.0)}
+                >
+                    { y_label }
+                </text>
+                { body }
+            </svg>
+        </div>
+    }
+}

--- a/frontend/src/components/charts/scale.rs
+++ b/frontend/src/components/charts/scale.rs
@@ -609,6 +609,18 @@ mod tests {
     }
 
     #[test]
+    fn format_axis_value_picks_compact_form() {
+        assert_eq!(format_axis_value(0.0), "0");
+        assert_eq!(format_axis_value(1.0), "1");
+        assert_eq!(format_axis_value(5.0), "5");
+        assert_eq!(format_axis_value(0.25), "0.25");
+        assert_eq!(format_axis_value(7.5), "7.5");
+        assert_eq!(format_axis_value(12.5), "12.5");
+        assert_eq!(format_axis_value(1500.0), "1.5k");
+        assert_eq!(format_axis_value(2500.0), "2.5k");
+    }
+
+    #[test]
     fn series_points_clamps_out_of_range() {
         // y_max=10 but value=20 → should clamp to top of chart, not flow off.
         let axis = YAxis::Linear {

--- a/frontend/src/components/charts/stacked_area.rs
+++ b/frontend/src/components/charts/stacked_area.rs
@@ -3,14 +3,18 @@
 //!
 //! Each band is a `<polygon>` of (x, y) points around the stacked region for
 //! one series. Stacks are computed in absolute counts; the y-axis is the total
-//! across all bands per bucket.
+//! across all bands per bucket. The chart chrome (frame, gridlines, labels,
+//! legend) comes from the shared helpers in [`super`].
 
 use chrono::{DateTime, Utc};
 use yew::prelude::*;
 
 use super::scale::{
-    format_axis_value, time_axis_ticks, value_to_y as scaled_value_to_y, y_axis_for_values,
-    y_axis_tick_labels, AxisScale, BucketKind, TickLabel,
+    time_axis_ticks, value_to_y, y_axis_for_values, y_axis_tick_labels, AxisScale, BucketKind,
+};
+use super::{
+    chart_empty, chart_frame, render_gridlines, render_legend, render_x_labels, PAD_L, PAD_T,
+    PLOT_H, PLOT_W,
 };
 
 /// One band in the stacked area. Order matters — bands are stacked in vector
@@ -34,22 +38,10 @@ pub struct StackedAreaProps {
     pub axis_scale: AxisScale,
 }
 
-const VIEW_W: f32 = 800.0;
-const VIEW_H: f32 = 260.0;
-const PAD_L: f32 = 66.0;
-const PAD_R: f32 = 12.0;
-const PAD_T: f32 = 12.0;
-const PAD_B: f32 = 36.0;
-
 #[function_component(StackedArea)]
 pub fn stacked_area(props: &StackedAreaProps) -> Html {
     if props.buckets.is_empty() || props.series.is_empty() {
-        return html! {
-            <div class="performance-chart">
-                <h3 class="chart-title">{ &props.title }</h3>
-                <div class="chart-empty">{ "No data" }</div>
-            </div>
-        };
+        return chart_empty(&props.title);
     }
 
     // Per-bucket total: sum of all bands at that x position.
@@ -62,18 +54,9 @@ pub fn stacked_area(props: &StackedAreaProps) -> Html {
     }
     let max_total = totals.iter().copied().fold(0.0_f64, f64::max);
     if max_total <= 0.0 {
-        return html! {
-            <div class="performance-chart">
-                <h3 class="chart-title">{ &props.title }</h3>
-                <div class="chart-empty">{ "No data" }</div>
-            </div>
-        };
+        return chart_empty(&props.title);
     }
     let y_axis = y_axis_for_values(&totals, props.axis_scale);
-
-    let plot_w = VIEW_W - PAD_L - PAD_R;
-    let plot_h = VIEW_H - PAD_T - PAD_B;
-    let viewbox = format!("0 0 {VIEW_W} {VIEW_H}");
 
     let x_ticks = time_axis_ticks(&props.buckets, props.bucket_kind, 6);
     let y_ticks = y_axis_tick_labels(&y_axis);
@@ -100,7 +83,7 @@ pub fn stacked_area(props: &StackedAreaProps) -> Html {
             for (i, t) in tops.iter_mut().enumerate().take(n_buckets) {
                 *t += s.values.get(i).copied().unwrap_or(0.0).max(0.0);
             }
-            // x positions: 0..plot_w evenly.
+            // x positions: 0..PLOT_W evenly.
             let last_idx = (n_buckets - 1).max(1) as f32;
             let mut points = String::new();
             // top, left → right
@@ -108,15 +91,15 @@ pub fn stacked_area(props: &StackedAreaProps) -> Html {
                 if !points.is_empty() {
                     points.push(' ');
                 }
-                let x = PAD_L + (i as f32 / last_idx) * plot_w;
-                let y = value_to_y(t, &y_axis, plot_h);
+                let x = PAD_L + (i as f32 / last_idx) * PLOT_W;
+                let y = PAD_T + value_to_y(t, &y_axis, PLOT_H);
                 points.push_str(&format!("{:.2},{:.2}", x, y));
             }
             // bottom, right → left
             for (i, &b) in bottom.iter().enumerate().rev().take(n_buckets) {
                 points.push(' ');
-                let x = PAD_L + (i as f32 / last_idx) * plot_w;
-                let y = value_to_y(b, &y_axis, plot_h);
+                let x = PAD_L + (i as f32 / last_idx) * PLOT_W;
+                let y = PAD_T + value_to_y(b, &y_axis, PLOT_H);
                 points.push_str(&format!("{:.2},{:.2}", x, y));
             }
             html! {
@@ -130,107 +113,26 @@ pub fn stacked_area(props: &StackedAreaProps) -> Html {
         })
         .collect();
 
-    let gridlines: Html = y_ticks
-        .iter()
-        .map(|(v, frac)| {
-            let y = PAD_T + plot_h - frac * plot_h;
-            html! {
-                <>
-                    <line
-                        x1={format!("{:.2}", PAD_L)}
-                        x2={format!("{:.2}", PAD_L + plot_w)}
-                        y1={format!("{:.2}", y)}
-                        y2={format!("{:.2}", y)}
-                        class="chart-gridline"
-                    />
-                    <text
-                        x={format!("{:.2}", PAD_L - 6.0)}
-                        y={format!("{:.2}", y + 4.0)}
-                        class="chart-y-label"
-                        text-anchor="end"
-                    >
-                        { format_axis_value(*v) }
-                    </text>
-                </>
-            }
-        })
-        .collect();
+    let gridlines = render_gridlines(&y_ticks);
+    let x_labels = render_x_labels(&x_ticks);
+    let legend = render_legend(
+        props
+            .series
+            .iter()
+            .map(|s| (s.label.as_str(), format!("background: {};", s.color))),
+    );
 
-    let x_labels: Html = x_ticks
-        .iter()
-        .map(|TickLabel { frac, label }| {
-            let x = PAD_L + frac * plot_w;
-            html! {
-                <text
-                    x={format!("{:.2}", x)}
-                    y={format!("{:.2}", VIEW_H - PAD_B + 18.0)}
-                    class="chart-x-label"
-                    text-anchor="middle"
-                >
-                    { label.clone() }
-                </text>
-            }
-        })
-        .collect();
-
-    let legend: Html = props
-        .series
-        .iter()
-        .map(|s| {
-            html! {
-                <span class="chart-legend-item">
-                    <span
-                        class="chart-legend-swatch"
-                        style={format!("background: {};", s.color)}
-                    ></span>
-                    { &s.label }
-                </span>
-            }
-        })
-        .collect();
-
-    html! {
-        <div class="performance-chart">
-            <div class="chart-header">
-                <h3 class="chart-title">{ &props.title }</h3>
-                <span class="chart-scale-badge">{ props.axis_scale.label() }</span>
-            </div>
-            <div class="chart-legend">{ legend }</div>
-            <svg
-                class="performance-chart-svg"
-                viewBox={viewbox}
-                preserveAspectRatio="xMidYMid meet"
-            >
-                <text
-                    x={format!("{:.2}", 14.0)}
-                    y={format!("{:.2}", PAD_T + plot_h / 2.0)}
-                    class="chart-y-axis-title"
-                    text-anchor="middle"
-                    transform={format!("rotate(-90 14 {:.2})", PAD_T + plot_h / 2.0)}
-                >
-                    { &props.y_label }
-                </text>
+    chart_frame(
+        &props.title,
+        props.axis_scale,
+        &props.y_label,
+        legend,
+        html! {
+            <>
                 { gridlines }
                 { polygons }
                 { x_labels }
-            </svg>
-        </div>
-    }
-}
-
-fn value_to_y(v: f64, axis: &super::scale::YAxis, plot_h: f32) -> f32 {
-    PAD_T + scaled_value_to_y(v, axis, plot_h)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn format_count_for_axis() {
-        assert_eq!(format_axis_value(0.0), "0");
-        assert_eq!(format_axis_value(5.0), "5");
-        assert_eq!(format_axis_value(2_500.0), "2.5k");
-        assert_eq!(format_axis_value(7.5), "7.5");
-    }
+            </>
+        },
+    )
 }


### PR DESCRIPTION
Fixes #984.

Shared frame in `charts/mod.rs` (constants, empty card, gridlines, x-labels, legend, `chart_frame` wrapper); components keep only geometry. `value_to_y` deduped via `scale::value_to_y` + explicit PAD_T. Note: `format_axis_value` and pub `value_to_y` had already been unified on main since the audit — this PR finishes the frame markup. Verbatim markup copy, zero rendered-output change; legend swatch styles deliberately per-component (byte-wise different).

Validation: fmt clean, clippy `-D warnings` clean, 309/309 tests (two duplicate tests consolidated to one), wasm check clean. Net −45 lines.