### PR TITLE
Return 400 for validation errors instead of 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.45
+
+- **Validation errors return 400 instead of 500.** Caller mistakes ("Invalid role" ×2 — now a shared `validate_member_role` helper — "User is already a member", "Owner cannot remove themselves", "Cannot change own role", "Invalid cron expression" ×2) were mapped to `AppError::Internal`, logging server faults for user typos and masking the message behind "Internal server error". All other `Internal` uses audited and left alone (genuine infra faults). Frontend: the share dialog's add-member 409 branch never fired (backend sent 500) — repointed at 400, so "User is already a member" / "Invalid role" now surface verbatim; the schedule dialog's generic `Error ({status})` display now shows the real cron message.
+
 ## 2.8.35
 
 - **Delete dead `shared` types: `UserInfo`, `ApiError` (+ manual `Display`/`Error` impls), `DevicePollRequest`.** All three were grep-verified unreferenced across every consumer crate (`UserInfo` was a strict subset of `MeResponse`; `DevicePollRequest` an exact field duplicate of the live `DeviceFlowPollRequest`). `DevicePollResponse` stays — #1006 made it the canonical wire type. Pure deletions, −46 lines.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.45"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.45"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.45"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.45"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.45"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.45"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.45"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.45"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.45"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.45"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.45"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -128,7 +128,7 @@ pub async fn create_task_handler(
     let fields: Vec<&str> = req.cron_expression.split_whitespace().collect();
     if fields.len() != 5 {
         warn!("Invalid cron expression: {}", req.cron_expression);
-        return Err(AppError::Internal("Invalid cron expression".to_string()));
+        return Err(AppError::BadRequest("Invalid cron expression"));
     }
 
     let mut conn = app_state.conn()?;
@@ -179,7 +179,7 @@ pub async fn update_task_handler(
         let fields: Vec<&str> = cron.split_whitespace().collect();
         if fields.len() != 5 {
             warn!("Invalid cron expression in update: {}", cron);
-            return Err(AppError::Internal("Invalid cron expression".to_string()));
+            return Err(AppError::BadRequest("Invalid cron expression"));
         }
     }
 

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -382,6 +382,14 @@ struct UserBasicInfo {
     name: Option<String>,
 }
 
+/// Validate a member role supplied by the caller
+fn validate_member_role(role: &str) -> Result<(), AppError> {
+    if role != "editor" && role != "viewer" {
+        return Err(AppError::BadRequest("Invalid role"));
+    }
+    Ok(())
+}
+
 /// List all members of a session
 pub async fn list_session_members(
     State(app_state): State<Arc<AppState>>,
@@ -431,9 +439,7 @@ pub async fn add_session_member(
     Path(session_id): Path<Uuid>,
     Json(req): Json<AddMemberRequest>,
 ) -> Result<EmptyResponse, AppError> {
-    if req.role != "editor" && req.role != "viewer" {
-        return Err(AppError::Internal("Invalid role".to_string()));
-    }
+    validate_member_role(&req.role)?;
 
     let mut conn = app_state.conn()?;
 
@@ -461,7 +467,7 @@ pub async fn add_session_member(
         .optional()?;
 
     if existing.is_some() {
-        return Err(AppError::Internal("User is already a member".to_string()));
+        return Err(AppError::BadRequest("User is already a member"));
     }
 
     let new_member = NewSessionMember {
@@ -502,9 +508,7 @@ pub async fn remove_session_member(
     }
 
     if is_owner && current_user_id == target_user_id {
-        return Err(AppError::Internal(
-            "Owner cannot remove themselves".to_string(),
-        ));
+        return Err(AppError::BadRequest("Owner cannot remove themselves"));
     }
 
     let deleted = diesel::delete(
@@ -528,9 +532,7 @@ pub async fn update_session_member_role(
     Path((session_id, target_user_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<UpdateMemberRoleRequest>,
 ) -> Result<EmptyResponse, AppError> {
-    if req.role != "editor" && req.role != "viewer" {
-        return Err(AppError::Internal("Invalid role".to_string()));
-    }
+    validate_member_role(&req.role)?;
 
     let mut conn = app_state.conn()?;
 
@@ -545,7 +547,7 @@ pub async fn update_session_member_role(
         .ok_or(AppError::Forbidden)?;
 
     if current_user_id == target_user_id {
-        return Err(AppError::Internal("Cannot change own role".to_string()));
+        return Err(AppError::BadRequest("Cannot change own role"));
     }
 
     let updated = diesel::update(

--- a/frontend/src/components/share_dialog.rs
+++ b/frontend/src/components/share_dialog.rs
@@ -124,10 +124,14 @@ impl Component for ShareDialog {
                                 "User not found".to_string(),
                             ));
                         }
-                        Ok(response) if response.status() == 409 => {
-                            link.send_message(ShareDialogMsg::SetError(
-                                "User is already a member".to_string(),
-                            ));
+                        Ok(response) if response.status() == 400 => {
+                            let msg = response
+                                .text()
+                                .await
+                                .ok()
+                                .filter(|t| !t.is_empty())
+                                .unwrap_or_else(|| "Failed to add member".to_string());
+                            link.send_message(ShareDialogMsg::SetError(msg));
                         }
                         Ok(response) => {
                             log::error!("Failed to add member: {}", response.status());


### PR DESCRIPTION
Fixes #975.

Backend: six validation sites Internal→BadRequest (+ `validate_member_role` helper deduping the role check). Audited every remaining `AppError::Internal` in handlers — all genuine server faults, left as 500.

Frontend: share dialog's add-member 409 branch never fired (backend sent 500) — now keyed to 400 and surfaces the server message; schedule dialog messaging improves for free (real cron error instead of masked 500).

Validation: fmt clean, backend clippy `-D warnings` clean, 111/111 tests, workspace check clean.