### PR TITLE
Consolidate clipboard copy and escape-key handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.46
+
+- **One clipboard helper and one escape-key implementation replace seven hand-rolled copies.** `copy_to_clipboard(text, copied, reset_ms)` (typed `web_sys` Clipboard API instead of the `js_sys::Reflect` dance) serves CopyButton/CopyCommand/CodeBlock with their original per-site reset timings preserved (1500/2000/2000ms). New `hooks/use_escape.rs`: `use_escape` (bubble, component lifetime) for the launch/schedule dialogs, `use_escape_capture(active, …)` for the ImageViewer (capture-phase, attached only while expanded, preventDefault+stopPropagation as before), and an `escape_listener` RAII helper for the struct-component ShareDialog — all three delegate to one implementation. Redundant `#[allow(dead_code)]` on ShareDialog's listener field removed. Net −45 lines.
+
 ## 2.8.35
 
 - **Delete dead `shared` types: `UserInfo`, `ApiError` (+ manual `Display`/`Error` impls), `DevicePollRequest`.** All three were grep-verified unreferenced across every consumer crate (`UserInfo` was a strict subset of `MeResponse`; `DevicePollRequest` an exact field duplicate of the live `DeviceFlowPollRequest`). `DevicePollResponse` stays — #1006 made it the canonical wire type. Pure deletions, −46 lines.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.46"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.46"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.46"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.46"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.46"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.46"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.46"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.46"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.46"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.46"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.46"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/copy_button.rs
+++ b/frontend/src/components/copy_button.rs
@@ -1,10 +1,24 @@
 //! Small reusable clipboard copy button.
 
 use gloo::timers::callback::Timeout;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{window, MouseEvent};
 use yew::prelude::*;
+
+/// Write `text` to the clipboard, set `copied` to `true` once the write
+/// completes, then reset it to `false` after `reset_ms` milliseconds.
+pub fn copy_to_clipboard(text: String, copied: UseStateHandle<bool>, reset_ms: u32) {
+    spawn_local(async move {
+        if let Some(window) = window() {
+            let clipboard = window.navigator().clipboard();
+            let promise = clipboard.write_text(&text);
+            let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+            copied.set(true);
+            let reset = copied.clone();
+            Timeout::new(reset_ms, move || reset.set(false)).forget();
+        }
+    });
+}
 
 #[derive(Properties, PartialEq)]
 pub struct CopyButtonProps {
@@ -26,23 +40,7 @@ pub fn copy_button(props: &CopyButtonProps) -> Html {
         Callback::from(move |e: MouseEvent| {
             e.stop_propagation();
             e.prevent_default();
-            let text = text.to_string();
-            let copied = copied.clone();
-            spawn_local(async move {
-                if let Some(window) = window() {
-                    let navigator = window.navigator();
-                    let clipboard = js_sys::Reflect::get(&navigator, &"clipboard".into())
-                        .ok()
-                        .and_then(|v| v.dyn_into::<web_sys::Clipboard>().ok());
-                    if let Some(clipboard) = clipboard {
-                        let promise = clipboard.write_text(&text);
-                        let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
-                        copied.set(true);
-                        let reset = copied.clone();
-                        Timeout::new(1500, move || reset.set(false)).forget();
-                    }
-                }
-            });
+            copy_to_clipboard(text.to_string(), copied.clone(), 1500);
         })
     };
 

--- a/frontend/src/components/copy_command.rs
+++ b/frontend/src/components/copy_command.rs
@@ -2,11 +2,9 @@
 //!
 //! A styled code block with a copy-to-clipboard button.
 
-use gloo::timers::callback::Timeout;
-use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::spawn_local;
-use web_sys::window;
 use yew::prelude::*;
+
+use crate::components::copy_button::copy_to_clipboard;
 
 #[derive(Properties, PartialEq, Clone)]
 pub struct CopyCommandProps {
@@ -26,33 +24,7 @@ pub fn copy_command(props: &CopyCommandProps) -> Html {
         let copied = copied.clone();
 
         Callback::from(move |_: MouseEvent| {
-            let command = command.clone();
-            let copied = copied.clone();
-
-            spawn_local(async move {
-                if let Some(window) = window() {
-                    let navigator = window.navigator();
-                    // Use js_sys to access clipboard
-                    let clipboard = js_sys::Reflect::get(&navigator, &"clipboard".into())
-                        .ok()
-                        .and_then(|v| v.dyn_into::<web_sys::Clipboard>().ok());
-
-                    if let Some(clipboard) = clipboard {
-                        let promise = clipboard.write_text(&command);
-                        let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
-
-                        // Show "Copied!" feedback
-                        copied.set(true);
-
-                        // Reset after 2 seconds
-                        let copied_reset = copied.clone();
-                        Timeout::new(2000, move || {
-                            copied_reset.set(false);
-                        })
-                        .forget();
-                    }
-                }
-            });
+            copy_to_clipboard(command.clone(), copied.clone(), 2000);
         })
     };
 

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -1,11 +1,11 @@
 use crate::components::ProxyTokenSetup;
+use crate::hooks::use_escape;
 use crate::utils::{self, FetchError, On401};
 use gloo::timers::callback::Timeout;
 use gloo_net::http::Request;
 use shared::api::{DirectoryListingResponse, LaunchRequest, ProbeAgentsResponse};
 use shared::{AgentInstall, AgentType, DirectoryEntry, LauncherInfo};
 use uuid::Uuid;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::HtmlInputElement;
 use yew::prelude::*;
@@ -435,20 +435,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     };
 
     // Close on Escape key
-    {
-        let on_close = props.on_close.clone();
-        use_effect_with((), move |_| {
-            let listener =
-                gloo::events::EventListener::new(&gloo::utils::document(), "keydown", move |e| {
-                    if let Ok(ke) = e.clone().dyn_into::<web_sys::KeyboardEvent>() {
-                        if ke.key() == "Escape" {
-                            on_close.emit(());
-                        }
-                    }
-                });
-            move || drop(listener)
-        });
-    }
+    use_escape(props.on_close.clone());
 
     // Build breadcrumb segments from current path
     let path_str = (*dir.path).clone();

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -4,13 +4,12 @@
 //! Supports: headings, bold, italic, strikethrough, links, code blocks,
 //! inline code, blockquotes, lists, and tables.
 
-use gloo::timers::callback::Timeout;
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
 use uuid::Uuid;
 use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::spawn_local;
-use web_sys::window;
 use yew::prelude::*;
+
+use crate::components::copy_button::copy_to_clipboard;
 
 /// Render markdown text as HTML, with a post-render hook that triggers KaTeX
 /// to render any LaTeX math expressions (`$...$`, `$$...$$`).
@@ -501,29 +500,7 @@ fn code_block(props: &CodeBlockProps) -> Html {
         let copied = copied.clone();
 
         Callback::from(move |_: MouseEvent| {
-            let code_text = code_text.clone();
-            let copied = copied.clone();
-
-            spawn_local(async move {
-                if let Some(window) = window() {
-                    let navigator = window.navigator();
-                    let clipboard = js_sys::Reflect::get(&navigator, &"clipboard".into())
-                        .ok()
-                        .and_then(|v| v.dyn_into::<web_sys::Clipboard>().ok());
-
-                    if let Some(clipboard) = clipboard {
-                        let promise = clipboard.write_text(&code_text);
-                        let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
-
-                        copied.set(true);
-                        let copied_reset = copied.clone();
-                        Timeout::new(2000, move || {
-                            copied_reset.set(false);
-                        })
-                        .forget();
-                    }
-                }
-            });
+            copy_to_clipboard(code_text.clone(), copied.clone(), 2000);
         })
     };
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -12,9 +12,9 @@ use crate::components::markdown::render_markdown_for_session;
 use crate::components::tool_renderers::{
     has_askuserquestion_answers, render_askuserquestion_result,
 };
+use crate::hooks::use_escape_capture;
 use serde::Deserialize;
 use uuid::Uuid;
-use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
 pub(crate) use assistant::assistant_label;
@@ -296,32 +296,7 @@ fn image_viewer(props: &ImageViewerProps) -> Html {
     // Close lightbox on Escape key (capture phase so it doesn't trigger nav mode)
     {
         let expanded = expanded.clone();
-        use_effect_with(*expanded, move |is_expanded| {
-            let listener = if *is_expanded {
-                let expanded = expanded.clone();
-                let options = gloo::events::EventListenerOptions {
-                    phase: gloo::events::EventListenerPhase::Capture,
-                    passive: false,
-                };
-                Some(gloo::events::EventListener::new_with_options(
-                    &gloo::utils::document(),
-                    "keydown",
-                    options,
-                    move |event| {
-                        if let Some(ke) = event.dyn_ref::<web_sys::KeyboardEvent>() {
-                            if ke.key() == "Escape" {
-                                ke.prevent_default();
-                                ke.stop_propagation();
-                                expanded.set(false);
-                            }
-                        }
-                    },
-                ))
-            } else {
-                None
-            };
-            move || drop(listener)
-        });
+        use_escape_capture(*expanded, Callback::from(move |()| expanded.set(false)));
     }
 
     let on_thumb_click = {

--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -1,3 +1,4 @@
+use crate::hooks::use_escape;
 use crate::utils::{self, On401};
 use gloo_net::http::Request;
 use shared::api::{
@@ -6,7 +7,6 @@ use shared::api::{
 };
 use shared::{LauncherInfo, SessionInfo};
 use uuid::Uuid;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
@@ -176,22 +176,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
     let folder = utils::extract_folder(&working_directory);
 
     // Close on Escape
-    {
-        let on_close = props.on_close.clone();
-        use_effect_with((), move |_| {
-            let listener = gloo::events::EventListener::new(
-                &gloo::utils::document(),
-                "keydown",
-                move |event| {
-                    let e: &web_sys::KeyboardEvent = event.unchecked_ref();
-                    if e.key() == "Escape" {
-                        on_close.emit(());
-                    }
-                },
-            );
-            move || drop(listener)
-        });
-    }
+    use_escape(props.on_close.clone());
 
     // Fetch launcher version for this session's hostname
     {

--- a/frontend/src/components/share_dialog.rs
+++ b/frontend/src/components/share_dialog.rs
@@ -4,11 +4,11 @@ use shared::api::{
     AddMemberRequest, SessionMemberInfo, SessionMembersResponse, UpdateMemberRoleRequest,
 };
 use uuid::Uuid;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::HtmlInputElement;
 use yew::prelude::*;
 
+use crate::hooks::escape_listener;
 use crate::utils::{self, On401};
 
 #[derive(Properties, PartialEq)]
@@ -37,7 +37,7 @@ pub struct ShareDialog {
     email_input: String,
     new_role: String,
     error: Option<String>,
-    #[allow(dead_code)] // RAII guard — must be held to keep listener active
+    // RAII guard — must be held to keep the Escape listener active
     _escape_listener: Option<EventListener>,
 }
 
@@ -47,13 +47,7 @@ impl Component for ShareDialog {
 
     fn create(ctx: &Context<Self>) -> Self {
         ctx.link().send_message(ShareDialogMsg::LoadMembers);
-        let on_close = ctx.props().on_close.clone();
-        let listener = EventListener::new(&gloo::utils::document(), "keydown", move |event| {
-            let e: &web_sys::KeyboardEvent = event.unchecked_ref();
-            if e.key() == "Escape" {
-                on_close.emit(());
-            }
-        });
+        let listener = escape_listener(ctx.props().on_close.clone());
         Self {
             members: Vec::new(),
             loading: true,

--- a/frontend/src/hooks/mod.rs
+++ b/frontend/src/hooks/mod.rs
@@ -3,9 +3,11 @@
 //! These hooks encapsulate reusable state logic to keep components clean and focused.
 
 mod use_client_websocket;
+mod use_escape;
 mod use_keyboard_nav;
 mod use_sessions;
 
 pub use use_client_websocket::use_client_websocket;
+pub use use_escape::{escape_listener, use_escape, use_escape_capture};
 pub use use_keyboard_nav::{use_keyboard_nav, KeyboardNavConfig};
 pub use use_sessions::use_sessions;

--- a/frontend/src/hooks/use_escape.rs
+++ b/frontend/src/hooks/use_escape.rs
@@ -1,0 +1,65 @@
+//! Hooks for closing overlays when the Escape key is pressed.
+
+use gloo::events::{EventListener, EventListenerOptions, EventListenerPhase};
+use wasm_bindgen::JsCast;
+use yew::prelude::*;
+
+/// Build a document-level `keydown` listener (bubble phase) that emits
+/// `on_close` when Escape is pressed.
+///
+/// For struct components that cannot use hooks: hold the returned listener
+/// (RAII guard) for as long as the handler should stay active. Function
+/// components should use [`use_escape`] instead.
+pub fn escape_listener(on_close: Callback<()>) -> EventListener {
+    EventListener::new(&gloo::utils::document(), "keydown", move |event| {
+        if let Some(ke) = event.dyn_ref::<web_sys::KeyboardEvent>() {
+            if ke.key() == "Escape" {
+                on_close.emit(());
+            }
+        }
+    })
+}
+
+/// Emit `on_close` when Escape is pressed anywhere in the document.
+///
+/// Attaches a bubble-phase document `keydown` listener for the lifetime of
+/// the component and removes it on unmount.
+#[hook]
+pub fn use_escape(on_close: Callback<()>) {
+    use_effect_with((), move |_| {
+        let listener = escape_listener(on_close);
+        move || drop(listener)
+    });
+}
+
+/// Capture-phase variant of [`use_escape`], attached only while `active`.
+///
+/// Consumes the Escape press (`prevent_default` + `stop_propagation`) before
+/// emitting `on_close`, so it never reaches bubble-phase handlers such as the
+/// keyboard-nav mode toggle.
+#[hook]
+pub fn use_escape_capture(active: bool, on_close: Callback<()>) {
+    use_effect_with(active, move |is_active| {
+        let listener = is_active.then(|| {
+            let options = EventListenerOptions {
+                phase: EventListenerPhase::Capture,
+                passive: false,
+            };
+            EventListener::new_with_options(
+                &gloo::utils::document(),
+                "keydown",
+                options,
+                move |event| {
+                    if let Some(ke) = event.dyn_ref::<web_sys::KeyboardEvent>() {
+                        if ke.key() == "Escape" {
+                            ke.prevent_default();
+                            ke.stop_propagation();
+                            on_close.emit(());
+                        }
+                    }
+                },
+            )
+        });
+        move || drop(listener)
+    });
+}


### PR DESCRIPTION
Fixes #982.

- `copy_to_clipboard(text, copied, reset_ms)` using typed `navigator().clipboard()` — per-site reset timings preserved exactly (1500/2000/2000ms)
- `hooks/use_escape.rs`: `use_escape` (bubble), `use_escape_capture` (ImageViewer's exact capture-phase/while-active/preventDefault semantics), `escape_listener` RAII for the struct-component ShareDialog — single-sourced logic
- Redundant `#[allow(dead_code)]` on underscore field removed
- Clipboard SVG icons deliberately not unified (visually different sizes/paths)

Validation: fmt clean, clippy `-D warnings` clean, 310/310 tests, wasm check clean. +98/−143.