### PR TITLE
Extract startup auto-update helper, merge update handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.47
+
+- **Startup auto-update ceremony extracted to `portal_update::startup_auto_update`; proxy update handlers merged.** The apply-pending + check + 4-arm `UpdateResult` match was copy-pasted across proxy startup, launcher startup, and `cmd_update`; it's now one helper with a `check` flag (both startups apply pending updates unconditionally but gate the GitHub check on `--no-update` — preserved exactly). Proxy's `handle_check_update`/`handle_force_update` + a third inline copy merged into `handle_update(check_only)` — the differing arms were provably unreachable per mode. Also: `binary_name_for` replaces the second platform match (a new test pins all six names byte-for-byte against release assets, including the darwin rename), and the Windows binary-swap dance is one `swap_binary` helper with a `SwapError` enum keying the two callers' divergent fallbacks. Launcher's `UpdateAndRestart` path deliberately untouched (distinct restart-anyway semantics).
+
 ## 2.8.35
 
 - **Delete dead `shared` types: `UserInfo`, `ApiError` (+ manual `Display`/`Error` impls), `DevicePollRequest`.** All three were grep-verified unreferenced across every consumer crate (`UserInfo` was a strict subset of `MeResponse`; `DevicePollRequest` an exact field duplicate of the live `DeviceFlowPollRequest`). `DevicePollResponse` stays — #1006 made it the canonical wire type. Pure deletions, −46 lines.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.47"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.47"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.47"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.47"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.47"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.47"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.47"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.47"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.47"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.47"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.47"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -139,26 +139,18 @@ async fn main() -> anyhow::Result<()> {
         eprintln!();
     }
 
-    // Apply pending updates (Windows only)
-    if let Ok(true) = portal_update::apply_pending_update() {
-        info!("Pending update applied successfully");
-    }
-
-    // Auto-update on startup (unless --no-update)
-    if !args.no_update {
-        match portal_update::check_for_update(BINARY_PREFIX, false).await {
-            Ok(portal_update::UpdateResult::UpToDate) => {}
-            Ok(portal_update::UpdateResult::Updated) => {
-                info!("Launcher updated, please restart");
-                std::process::exit(0);
-            }
-            Ok(portal_update::UpdateResult::UpdateAvailable { .. }) => {}
-            Err(e) => {
-                warn!(
-                    "Update check failed: {}. Continuing with current version.",
-                    e
-                );
-            }
+    // Apply pending updates, then auto-update on startup (unless --no-update)
+    match portal_update::startup_auto_update(BINARY_PREFIX, !args.no_update).await {
+        Ok(true) => {
+            info!("Launcher updated, please restart");
+            std::process::exit(0);
+        }
+        Ok(false) => {}
+        Err(e) => {
+            warn!(
+                "Update check failed: {}. Continuing with current version.",
+                e
+            );
         }
     }
 
@@ -234,16 +226,8 @@ async fn cmd_login(args: &Args) -> anyhow::Result<()> {
 
 /// `agent-portal update` — update binary and restart service if running
 async fn cmd_update() -> anyhow::Result<()> {
-    // Apply any pending updates first (Windows)
-    if let Ok(true) = portal_update::apply_pending_update() {
-        info!("Pending update applied successfully");
-    }
-
-    match portal_update::check_for_update(BINARY_PREFIX, false).await {
-        Ok(portal_update::UpdateResult::UpToDate) => {
-            println!("agent-portal is already up to date.");
-        }
-        Ok(portal_update::UpdateResult::Updated) => {
+    match portal_update::startup_auto_update(BINARY_PREFIX, true).await {
+        Ok(true) => {
             println!("agent-portal updated successfully.");
             // Restart the service if it's installed and running
             if service::is_installed() {
@@ -253,8 +237,8 @@ async fn cmd_update() -> anyhow::Result<()> {
                 println!("Service restarted.");
             }
         }
-        Ok(portal_update::UpdateResult::UpdateAvailable { version, .. }) => {
-            println!("Update available: {}", version);
+        Ok(false) => {
+            println!("agent-portal is already up to date.");
         }
         Err(e) => {
             anyhow::bail!("Update failed: {}", e);

--- a/portal-update/src/lib.rs
+++ b/portal-update/src/lib.rs
@@ -57,21 +57,25 @@ impl Platform {
             ("unknown", "unknown")
         };
 
-        let binary_name = match (os, arch) {
-            ("linux", "x86_64") => format!("{}-linux-x86_64", binary_prefix),
-            ("linux", "aarch64") => format!("{}-linux-aarch64", binary_prefix),
-            ("darwin", "aarch64") => format!("{}-darwin-aarch64", binary_prefix),
-            ("darwin", "x86_64") => format!("{}-darwin-x86_64", binary_prefix),
-            ("windows", "x86_64") => format!("{}-windows-x86_64.exe", binary_prefix),
-            _ => binary_prefix.to_string(),
-        };
-
         Platform {
             os,
             arch,
-            binary_name,
+            binary_name: binary_name_for(binary_prefix, os, arch),
         }
     }
+}
+
+/// Compose the release-asset name for a platform, e.g.
+/// `claude-portal-linux-x86_64` or `agent-portal-windows-x86_64.exe`.
+///
+/// Note: the `os` string uses the release-asset convention ("darwin", not
+/// "macos"); `Platform::current` performs that mapping.
+fn binary_name_for(binary_prefix: &str, os: &str, arch: &str) -> String {
+    if os == "unknown" {
+        return binary_prefix.to_string();
+    }
+    let ext = if os == "windows" { ".exe" } else { "" };
+    format!("{}-{}-{}{}", binary_prefix, os, arch, ext)
 }
 
 /// GitHub release asset from the API
@@ -248,24 +252,13 @@ fn install_binary(self_path: &std::path::Path, new_binary: &[u8]) -> Result<()> 
     // On Windows, we can't replace a running executable directly
     #[cfg(windows)]
     {
-        // Try to rename the current binary to .old first
-        let old_path = self_path.with_extension("old.exe");
-        let _ = fs::remove_file(&old_path); // Remove any existing .old file
-
-        match fs::rename(self_path, &old_path) {
-            Ok(_) => {
-                // Successfully moved current binary, now rename temp to current
-                if let Err(e) = fs::rename(&temp_path, self_path) {
-                    // Try to restore the old binary
-                    let _ = fs::rename(&old_path, self_path);
-                    bail!("Failed to install update: {}", e);
-                }
-                // Clean up old binary
-                let _ = fs::remove_file(&old_path);
+        match swap_binary(self_path, &temp_path) {
+            Ok(()) => {
                 info!("Update installed successfully");
                 return Ok(());
             }
-            Err(_) => {
+            Err(SwapError::InstallFailed(e)) => bail!("Failed to install update: {}", e),
+            Err(SwapError::CurrentLocked(_)) => {
                 // Binary is locked - save as pending update
                 let pending_path = self_path.with_extension("new.exe");
                 fs::rename(&temp_path, &pending_path).context("Failed to save pending update")?;
@@ -287,11 +280,45 @@ fn install_binary(self_path: &std::path::Path, new_binary: &[u8]) -> Result<()> 
     }
 }
 
+/// How the Windows binary-swap dance failed
+#[cfg(windows)]
+enum SwapError {
+    /// The running binary could not be moved aside (likely still locked).
+    CurrentLocked(std::io::Error),
+    /// The new binary could not be moved into place; the old binary was
+    /// restored.
+    InstallFailed(std::io::Error),
+}
+
+/// Replace `self_path` with `new_path` using the Windows rename dance:
+/// remove any stale `.old.exe`, rename the current binary to `.old.exe`,
+/// rename the new binary into place, and restore the old binary if that
+/// final rename fails.
+#[cfg(windows)]
+fn swap_binary(self_path: &std::path::Path, new_path: &std::path::Path) -> Result<(), SwapError> {
+    let old_path = self_path.with_extension("old.exe");
+    let _ = fs::remove_file(&old_path); // Remove any existing .old file
+
+    // Try to move current to old
+    fs::rename(self_path, &old_path).map_err(SwapError::CurrentLocked)?;
+
+    // Move new binary to current
+    if let Err(e) = fs::rename(new_path, self_path) {
+        // Try to restore the old binary
+        let _ = fs::rename(&old_path, self_path);
+        return Err(SwapError::InstallFailed(e));
+    }
+
+    // Clean up old binary
+    let _ = fs::remove_file(&old_path);
+    Ok(())
+}
+
 /// Check for and apply pending updates (Windows only)
 ///
 /// On Windows, if the binary was locked during an update, we save the new
 /// version as `.new.exe`. This function checks for and applies that update.
-pub fn apply_pending_update() -> Result<bool> {
+fn apply_pending_update() -> Result<bool> {
     #[cfg(windows)]
     {
         let self_path = std::env::current_exe().context("Failed to get current executable path")?;
@@ -299,33 +326,82 @@ pub fn apply_pending_update() -> Result<bool> {
         if pending_path.exists() {
             info!("Found pending update at {}", pending_path.display());
 
-            // Try to replace the current binary
-            let old_path = self_path.with_extension("old.exe");
-            let _ = fs::remove_file(&old_path);
-
-            // Try to move current to old
-            match fs::rename(&self_path, &old_path) {
-                Ok(_) => {
-                    // Move pending to current
-                    if let Err(e) = fs::rename(&pending_path, &self_path) {
-                        // Restore old binary
-                        let _ = fs::rename(&old_path, &self_path);
-                        warn!("Failed to apply pending update: {}", e);
-                        return Ok(false);
-                    }
-                    // Clean up
-                    let _ = fs::remove_file(&old_path);
+            return match swap_binary(&self_path, &pending_path) {
+                Ok(()) => {
                     info!("Pending update applied successfully");
-                    return Ok(true);
+                    Ok(true)
                 }
-                Err(e) => {
+                Err(SwapError::InstallFailed(e)) => {
+                    warn!("Failed to apply pending update: {}", e);
+                    Ok(false)
+                }
+                Err(SwapError::CurrentLocked(e)) => {
                     warn!("Cannot apply pending update (binary still locked?): {}", e);
-                    return Ok(false);
+                    Ok(false)
                 }
-            }
+            };
         }
     }
 
     // No pending update or not Windows
     Ok(false)
+}
+
+/// Run the startup auto-update ceremony.
+///
+/// Applies any pending update from a previous run (Windows only), then —
+/// when `check` is true — checks GitHub for a newer release and installs it.
+///
+/// Returns `Ok(true)` when the binary was replaced and the process should
+/// restart, `Ok(false)` when it is already current (or `check` is false).
+/// Callers decide whether a check failure is fatal.
+pub async fn startup_auto_update(binary_prefix: &str, check: bool) -> Result<bool> {
+    // Failure to apply a pending update is non-fatal; the swap is logged
+    // and retried on the next startup.
+    let _ = apply_pending_update();
+
+    if !check {
+        return Ok(false);
+    }
+
+    match check_for_update(binary_prefix, false).await? {
+        UpdateResult::Updated => Ok(true),
+        UpdateResult::UpToDate | UpdateResult::UpdateAvailable { .. } => Ok(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::binary_name_for;
+
+    /// Release-asset names must match the assets uploaded by
+    /// `.github/workflows/release.yml` byte for byte. Note the macOS assets
+    /// use "darwin", not "macos".
+    #[test]
+    fn binary_names_match_release_assets() {
+        assert_eq!(
+            binary_name_for("claude-portal", "linux", "x86_64"),
+            "claude-portal-linux-x86_64"
+        );
+        assert_eq!(
+            binary_name_for("claude-portal", "linux", "aarch64"),
+            "claude-portal-linux-aarch64"
+        );
+        assert_eq!(
+            binary_name_for("claude-portal", "darwin", "aarch64"),
+            "claude-portal-darwin-aarch64"
+        );
+        assert_eq!(
+            binary_name_for("claude-portal", "darwin", "x86_64"),
+            "claude-portal-darwin-x86_64"
+        );
+        assert_eq!(
+            binary_name_for("agent-portal", "windows", "x86_64"),
+            "agent-portal-windows-x86_64.exe"
+        );
+        assert_eq!(
+            binary_name_for("agent-portal", "unknown", "unknown"),
+            "agent-portal"
+        );
+    }
 }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -194,11 +194,16 @@ fn default_session_name() -> String {
     format!("{}-{}", hostname, timestamp)
 }
 
-/// Handle --check-update: check for updates without installing
-async fn handle_check_update() -> Result<()> {
-    ui::print_checking_for_updates();
+/// Handle --check-update / --update: query GitHub releases and either
+/// report on a newer version (`check_only`) or install it.
+async fn handle_update(check_only: bool) -> Result<()> {
+    if check_only {
+        ui::print_checking_for_updates();
+    } else {
+        ui::print_updating_from_github();
+    }
 
-    match update::check_for_update_github(true).await {
+    match update::check_for_update_github(check_only).await {
         Ok(update::UpdateResult::UpToDate) => {
             ui::print_up_to_date();
             Ok(())
@@ -207,40 +212,21 @@ async fn handle_check_update() -> Result<()> {
             version,
             download_url,
         }) => {
+            // Only returned with check_only=true
             ui::print_update_available(&version, &download_url);
             Ok(())
         }
         Ok(update::UpdateResult::Updated) => {
-            // Shouldn't happen with check_only=true
+            // Only returned with check_only=false
             ui::print_update_complete();
             Ok(())
         }
         Err(e) => {
-            ui::print_update_check_failed(&e.to_string());
-            Err(e)
-        }
-    }
-}
-
-/// Handle --update: force update from GitHub releases
-async fn handle_force_update() -> Result<()> {
-    ui::print_updating_from_github();
-
-    match update::check_for_update_github(false).await {
-        Ok(update::UpdateResult::UpToDate) => {
-            ui::print_up_to_date();
-            Ok(())
-        }
-        Ok(update::UpdateResult::Updated) => {
-            ui::print_update_complete();
-            Ok(())
-        }
-        Ok(update::UpdateResult::UpdateAvailable { .. }) => {
-            // Shouldn't happen with check_only=false
-            Ok(())
-        }
-        Err(e) => {
-            ui::print_update_failed(&e.to_string());
+            if check_only {
+                ui::print_update_check_failed(&e.to_string());
+            } else {
+                ui::print_update_failed(&e.to_string());
+            }
             Err(e)
         }
     }
@@ -256,39 +242,37 @@ async fn main() -> Result<()> {
 
     // Skip update checks and UI output entirely in shim mode
     if !args.shim {
-        if let Ok(true) = update::apply_pending_update() {
-            ui::print_pending_update_applied();
+        // Apply any pending update, then auto-update before anything else —
+        // unless updates are disabled (--no-update, --init, --logout) or an
+        // explicit update command is handled below with its own UI.
+        let auto_check = !args.no_update
+            && !args.check_update
+            && !args.update
+            && args.init.is_none()
+            && !args.logout;
+        match update::startup_auto_update(auto_check).await {
+            Ok(true) => {
+                ui::print_update_complete();
+                std::process::exit(0);
+            }
+            Ok(false) => {
+                // Continue normally
+            }
+            Err(e) => {
+                warn!(
+                    "Update check failed: {}. Continuing with current version.",
+                    e
+                );
+            }
         }
 
-        // Handle explicit update commands first
+        // Handle explicit update commands
         if args.check_update {
-            return handle_check_update().await;
+            return handle_update(true).await;
         }
 
         if args.update {
-            return handle_force_update().await;
-        }
-
-        // Check for updates before anything else (unless --no-update or --init/--logout)
-        if !args.no_update && args.init.is_none() && !args.logout {
-            match update::check_for_update_github(false).await {
-                Ok(update::UpdateResult::UpToDate) => {
-                    // Continue normally
-                }
-                Ok(update::UpdateResult::Updated) => {
-                    ui::print_update_complete();
-                    std::process::exit(0);
-                }
-                Ok(update::UpdateResult::UpdateAvailable { .. }) => {
-                    // Shouldn't happen since check_only=false, but handle gracefully
-                }
-                Err(e) => {
-                    warn!(
-                        "Update check failed: {}. Continuing with current version.",
-                        e
-                    );
-                }
-            }
+            return handle_update(false).await;
         }
     }
 

--- a/proxy/src/ui.rs
+++ b/proxy/src/ui.rs
@@ -249,12 +249,3 @@ pub fn print_update_failed(error: &str) {
     println!("  {} Update failed: {}", "✗".bright_red(), error);
     println!();
 }
-
-/// Print pending update applied message (Windows)
-pub fn print_pending_update_applied() {
-    println!();
-    println!(
-        "  {} Pending update applied successfully.",
-        "✓".bright_green()
-    );
-}

--- a/proxy/src/update.rs
+++ b/proxy/src/update.rs
@@ -2,11 +2,18 @@
 //!
 //! Thin wrapper around `portal_update` with the correct binary prefix.
 
-pub use portal_update::{apply_pending_update, UpdateResult};
+pub use portal_update::UpdateResult;
 
 const BINARY_PREFIX: &str = "claude-portal";
 
 /// Check for updates from GitHub releases
 pub async fn check_for_update_github(check_only: bool) -> anyhow::Result<UpdateResult> {
     portal_update::check_for_update(BINARY_PREFIX, check_only).await
+}
+
+/// Startup auto-update ceremony: apply any pending update, then — when
+/// `check` is true — check for and install the latest release. Returns
+/// Ok(true) if the binary was replaced and the process should restart.
+pub async fn startup_auto_update(check: bool) -> anyhow::Result<bool> {
+    portal_update::startup_auto_update(BINARY_PREFIX, check).await
 }


### PR DESCRIPTION
Fixes #991.

- `portal_update::startup_auto_update(prefix, check) -> Result<bool>` replaces 3 copy-pasted ceremonies; errors propagate so callers keep warn-vs-bail choices
- Proxy's two update handlers + inline startup match → one `handle_update(check_only)` (divergent arms were unreachable per mode)
- `binary_name_for` replaces the duplicated platform match — new test `binary_names_match_release_assets` pins all six names byte-for-byte (darwin cfg-rename untouched in the first dispatch)
- Windows `swap_binary` helper with `SwapError::{CurrentLocked, InstallFailed}` keying the callers' different fallbacks
- Launcher `UpdateAndRestart` deliberately untouched

Minor consolidations: proxy's Windows-only styled stdout box → library `info!`; launcher's unreachable "Update available" println removed.

Validation: fmt clean, clippy `-D warnings` clean on all three crates, all tests pass incl. new pin test, workspace check clean.