### PR TITLE
Share TurnMetric mapping, sender names, cursor parse helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.48
+
+- **REST and WS replay share their three duplicated helpers.** `TurnMetric::into_wire()` (the 24-field row→wire mapping, previously written out twice) lives on the model; `sender_names()` (the character-identical user-id→name-or-email lookup) and `parse_iso_cursor()` (with its four tests) live in `handlers/helpers.rs`. One deliberate fix: WS replay now strips trailing `Z` from `replay_after` like the REST path always did — Z-suffixed watermarks previously parsed to `None` and silently triggered a full-history replay. Net −29 lines.
+
 ## 2.8.36
 
 - **Remove the dashboard's dead cost-flash machinery.** `total_cost`/`cost_flash` were written on every Result message (with a 600ms flash-clear timeout) but never read by any `view()`, and the `on_cost_change` prop terminated in an explicit no-op callback "kept for API compatibility". Deleted end-to-end: the props, the `ClearCostFlash` msg arm, the struct fields, the whole Result-block cost computation in `handle_received_output`, and the no-op callback at the `<SessionView>` call site. −34 lines, one less fake data path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.48"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.48"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.48"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.48"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.48"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.48"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.48"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.48"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.48"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/helpers.rs
+++ b/backend/src/handlers/helpers.rs
@@ -1,13 +1,57 @@
-use crate::models::{NewDeletedSessionCosts, Session};
+use crate::models::{Message, NewDeletedSessionCosts, Session};
 use crate::schema::{
     deleted_session_costs, messages, pending_inputs, pending_permission_requests, session_members,
-    sessions,
+    sessions, users,
 };
+use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::PgConnection;
+use std::collections::{HashMap, HashSet};
 use tracing::error;
 use uuid::Uuid;
+
+/// Parse an ISO timestamp cursor, accepting both the fractional
+/// (`%Y-%m-%dT%H:%M:%S%.f`) and second-precision (`%Y-%m-%dT%H:%M:%S`)
+/// forms emitted by the frontend's `js_sys::Date.toISOString()` and by the
+/// backend's own `NaiveDateTime` serializer respectively. Shared by the REST
+/// `list_messages` pagination cursors and the WebSocket replay watermark.
+pub fn parse_iso_cursor(s: &str) -> Option<NaiveDateTime> {
+    // Trim trailing `Z` if present — `js_sys::Date::to_iso_string` emits
+    // `2026-05-17T12:34:56.789Z`, but `NaiveDateTime::parse_from_str` rejects
+    // the timezone marker on a naive timestamp.
+    let trimmed = s.strip_suffix('Z').unwrap_or(s);
+    NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%dT%H:%M:%S%.f")
+        .or_else(|_| NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%dT%H:%M:%S"))
+        .ok()
+}
+
+/// Look up display names for the senders of the user-role messages in
+/// `message_list`: collect the distinct `user_id`s, load `(id, name, email)`
+/// for each, and map to name-or-email. Shared by the REST `list_messages`
+/// handler and the WebSocket history replay so both enrich user messages
+/// identically. Lookup failures degrade to an empty map (no sender names)
+/// rather than erroring.
+pub fn sender_names(conn: &mut PgConnection, message_list: &[Message]) -> HashMap<Uuid, String> {
+    let user_ids: Vec<Uuid> = message_list
+        .iter()
+        .filter(|m| m.role == "user")
+        .map(|m| m.user_id)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    if user_ids.is_empty() {
+        return HashMap::new();
+    }
+    users::table
+        .filter(users::id.eq_any(&user_ids))
+        .select((users::id, users::name, users::email))
+        .load::<(Uuid, Option<String>, String)>(conn)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(id, name, email)| (id, name.unwrap_or(email)))
+        .collect()
+}
 
 /// Error type for helper operations
 pub struct DeleteSessionError(String);
@@ -170,4 +214,45 @@ pub fn delete_user_sessions(
         })?;
 
     Ok((deleted_sessions, deleted_messages, deleted_members))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_iso_cursor_accepts_fractional_seconds() {
+        let parsed = parse_iso_cursor("2026-05-17T12:34:56.789").expect("parse");
+        assert_eq!(
+            parsed.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+            "2026-05-17 12:34:56.789"
+        );
+    }
+
+    #[test]
+    fn parse_iso_cursor_accepts_second_precision() {
+        let parsed = parse_iso_cursor("2026-05-17T12:34:56").expect("parse");
+        assert_eq!(
+            parsed.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2026-05-17 12:34:56"
+        );
+    }
+
+    #[test]
+    fn parse_iso_cursor_strips_trailing_z() {
+        // js_sys::Date::to_iso_string emits a trailing 'Z' marker; the
+        // NaiveDateTime parser rejects timezone info, so the helper must
+        // trim it. Otherwise frontend-emitted timestamps would all 400.
+        let parsed = parse_iso_cursor("2026-05-17T12:34:56.789Z").expect("parse");
+        assert_eq!(
+            parsed.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+            "2026-05-17 12:34:56.789"
+        );
+    }
+
+    #[test]
+    fn parse_iso_cursor_rejects_garbage() {
+        assert!(parse_iso_cursor("not-a-timestamp").is_none());
+        assert!(parse_iso_cursor("").is_none());
+    }
 }

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -1,5 +1,6 @@
 use crate::auth::CurrentUserId;
 use crate::errors::AppError;
+use crate::handlers::helpers::{parse_iso_cursor, sender_names};
 use crate::handlers::session_access::verify_session_mutator;
 use crate::models::{Message, NewMessage};
 use crate::schema::messages;
@@ -8,11 +9,9 @@ use axum::{
     extract::{Path, Query, State},
     Json,
 };
-use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use shared::api::MessagesListResponse;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Hard upper bound on `limit` for `GET /api/sessions/{id}/messages`.
@@ -57,21 +56,6 @@ pub struct ListMessagesQuery {
     /// `created_at > after`.
     #[serde(default)]
     pub after: Option<String>,
-}
-
-/// Parse an ISO timestamp the same way the WebSocket replay path does
-/// (`web_client_socket.rs::replay_history`), accepting both the fractional
-/// (`%Y-%m-%dT%H:%M:%S%.f`) and second-precision (`%Y-%m-%dT%H:%M:%S`)
-/// forms emitted by the frontend's `js_sys::Date.toISOString()` and by the
-/// backend's own `NaiveDateTime` serializer respectively.
-fn parse_iso_cursor(s: &str) -> Option<NaiveDateTime> {
-    // Trim trailing `Z` if present — `js_sys::Date::to_iso_string` emits
-    // `2026-05-17T12:34:56.789Z`, but `NaiveDateTime::parse_from_str` rejects
-    // the timezone marker on a naive timestamp.
-    let trimmed = s.strip_suffix('Z').unwrap_or(s);
-    NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%dT%H:%M:%S%.f")
-        .or_else(|_| NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%dT%H:%M:%S"))
-        .ok()
 }
 
 /// Request body for creating a new message
@@ -230,26 +214,7 @@ pub async fn list_messages(
     };
 
     // Look up sender names for user-role messages
-    use crate::schema::users;
-    let user_ids: Vec<uuid::Uuid> = message_list
-        .iter()
-        .filter(|m| m.role == "user")
-        .map(|m| m.user_id)
-        .collect::<std::collections::HashSet<_>>()
-        .into_iter()
-        .collect();
-    let user_names: HashMap<uuid::Uuid, String> = if !user_ids.is_empty() {
-        users::table
-            .filter(users::id.eq_any(&user_ids))
-            .select((users::id, users::name, users::email))
-            .load::<(uuid::Uuid, Option<String>, String)>(&mut conn)
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(id, name, email)| (id, name.unwrap_or(email)))
-            .collect()
-    } else {
-        HashMap::new()
-    };
+    let user_names = sender_names(&mut conn, &message_list);
 
     let total = message_list.len() as i64;
     let enriched: Vec<MessageWithSender> = message_list
@@ -280,42 +245,6 @@ pub async fn list_messages(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_iso_cursor_accepts_fractional_seconds() {
-        let parsed = parse_iso_cursor("2026-05-17T12:34:56.789").expect("parse");
-        assert_eq!(
-            parsed.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
-            "2026-05-17 12:34:56.789"
-        );
-    }
-
-    #[test]
-    fn parse_iso_cursor_accepts_second_precision() {
-        let parsed = parse_iso_cursor("2026-05-17T12:34:56").expect("parse");
-        assert_eq!(
-            parsed.format("%Y-%m-%d %H:%M:%S").to_string(),
-            "2026-05-17 12:34:56"
-        );
-    }
-
-    #[test]
-    fn parse_iso_cursor_strips_trailing_z() {
-        // js_sys::Date::to_iso_string emits a trailing 'Z' marker; the
-        // NaiveDateTime parser rejects timezone info, so the helper must
-        // trim it. Otherwise frontend-emitted timestamps would all 400.
-        let parsed = parse_iso_cursor("2026-05-17T12:34:56.789Z").expect("parse");
-        assert_eq!(
-            parsed.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
-            "2026-05-17 12:34:56.789"
-        );
-    }
-
-    #[test]
-    fn parse_iso_cursor_rejects_garbage() {
-        assert!(parse_iso_cursor("not-a-timestamp").is_none());
-        assert!(parse_iso_cursor("").is_none());
-    }
 
     #[test]
     fn list_messages_query_defaults_all_none() {

--- a/backend/src/handlers/turn_metrics.rs
+++ b/backend/src/handlers/turn_metrics.rs
@@ -28,7 +28,6 @@ use diesel::prelude::*;
 use diesel::sql_types::{BigInt, Double, Nullable, Text, Timestamptz};
 use serde::Deserialize;
 use shared::api::{MetricBucket, MetricBucketsResponse, TurnMetricsResponse};
-use shared::TurnMetrics;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -55,40 +54,6 @@ fn verify_session_access(
     Ok(())
 }
 
-/// Map a DB `TurnMetric` row into the wire-facing `shared::TurnMetrics`
-/// shape. Field-by-field rather than `From` impl so the two structs stay
-/// explicitly synchronized without one silently picking up a stray field
-/// from the other.
-fn row_to_wire(row: TurnMetric) -> TurnMetrics {
-    TurnMetrics {
-        id: Some(row.id),
-        // Nullable in the DB (orphaned-from-session rows); the wire shape keeps
-        // a non-null `Uuid`, so fall back to nil for rows whose session is gone.
-        session_id: row.session_id.unwrap_or_default(),
-        user_message_id: row.user_message_id,
-        agent_type: row.agent_type,
-        model: row.model,
-        service_tier: row.service_tier,
-        started_at: row.started_at,
-        first_token_at: row.first_token_at,
-        completed_at: row.completed_at,
-        ttft_ms: row.ttft_ms,
-        total_duration_ms: row.total_duration_ms,
-        generation_duration_ms: row.generation_duration_ms,
-        max_inter_token_gap_ms: row.max_inter_token_gap_ms,
-        input_tokens: row.input_tokens,
-        output_tokens: row.output_tokens,
-        cache_creation_tokens: row.cache_creation_tokens,
-        cache_read_tokens: row.cache_read_tokens,
-        thinking_tokens: row.thinking_tokens,
-        stop_reason: row.stop_reason,
-        is_error: row.is_error,
-        tool_call_count: row.tool_call_count,
-        stream_restarts: row.stream_restarts,
-        total_cost_usd: row.total_cost_usd,
-    }
-}
-
 /// `GET /api/sessions/{id}/turn-metrics` — returns all per-turn metrics rows
 /// for the session, ordered by `started_at ASC` so the SessionView's
 /// pair-by-ordering join walks correctly without a second sort. No
@@ -112,7 +77,7 @@ pub async fn list_turn_metrics(
         .select(TurnMetric::as_select())
         .load(&mut conn)?;
 
-    let metrics = rows.into_iter().map(row_to_wire).collect();
+    let metrics = rows.into_iter().map(TurnMetric::into_wire).collect();
     Ok(Json(TurnMetricsResponse { metrics }))
 }
 
@@ -152,7 +117,7 @@ pub async fn list_recent_user_turn_metrics(
     // left→right oldest→newest without a second pass on the frontend.
     rows.reverse();
 
-    let metrics = rows.into_iter().map(row_to_wire).collect();
+    let metrics = rows.into_iter().map(TurnMetric::into_wire).collect();
     Ok(Json(TurnMetricsResponse { metrics }))
 }
 

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -1,4 +1,5 @@
 use super::WebClientSender;
+use crate::handlers::helpers::{parse_iso_cursor, sender_names};
 use diesel::prelude::*;
 use shared::ServerToClient;
 use tracing::{error, info};
@@ -40,11 +41,10 @@ pub(super) fn replay_history(
 
     use crate::schema::messages;
 
-    let replay_after_time = replay_after.as_ref().and_then(|ts| {
-        chrono::NaiveDateTime::parse_from_str(ts, "%Y-%m-%dT%H:%M:%S%.f")
-            .or_else(|_| chrono::NaiveDateTime::parse_from_str(ts, "%Y-%m-%dT%H:%M:%S"))
-            .ok()
-    });
+    // Same cursor parser as the REST `list_messages` handler — including the
+    // trailing-`Z` strip, so frontend `js_sys::Date.toISOString()` watermarks
+    // parse instead of silently falling back to a full-history replay.
+    let replay_after_time = replay_after.as_deref().and_then(parse_iso_cursor);
 
     let history: Vec<crate::models::Message> = if let Some(after) = replay_after_time {
         messages::table
@@ -75,26 +75,7 @@ pub(super) fn replay_history(
     }
 
     // Look up sender names for user-role messages
-    use crate::schema::users;
-    let user_ids: Vec<Uuid> = history
-        .iter()
-        .filter(|m| m.role == "user")
-        .map(|m| m.user_id)
-        .collect::<std::collections::HashSet<_>>()
-        .into_iter()
-        .collect();
-    let user_names: std::collections::HashMap<Uuid, String> = if !user_ids.is_empty() {
-        users::table
-            .filter(users::id.eq_any(&user_ids))
-            .select((users::id, users::name, users::email))
-            .load::<(Uuid, Option<String>, String)>(&mut conn)
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(id, name, email)| (id, name.unwrap_or(email)))
-            .collect()
-    } else {
-        std::collections::HashMap::new()
-    };
+    let user_names = sender_names(&mut conn, &history);
 
     // Surface the server-assigned `created_at` for the latest row so the
     // frontend can use it directly as its reconnect-replay watermark

--- a/backend/src/handlers/websocket/turn_metrics.rs
+++ b/backend/src/handlers/websocket/turn_metrics.rs
@@ -118,36 +118,9 @@ pub fn handle_turn_metrics_report(
     );
 
     // Mirror the saved row back onto the wire-facing shape so the broadcast
-    // carries the server-assigned `id`. Field-by-field rather than `..` so
-    // the `TurnMetrics` shape stays explicitly synchronized with the DB row.
-    let payload = TurnMetrics {
-        id: Some(inserted.id),
-        // Always the just-inserted session id (the DB column is now nullable —
-        // for orphaned-from-session rows — but a freshly inserted row always
-        // has one). Use the resolved local rather than unwrapping the Option.
-        session_id,
-        user_message_id: inserted.user_message_id,
-        agent_type: inserted.agent_type,
-        model: inserted.model,
-        service_tier: inserted.service_tier,
-        started_at: inserted.started_at,
-        first_token_at: inserted.first_token_at,
-        completed_at: inserted.completed_at,
-        ttft_ms: inserted.ttft_ms,
-        total_duration_ms: inserted.total_duration_ms,
-        generation_duration_ms: inserted.generation_duration_ms,
-        max_inter_token_gap_ms: inserted.max_inter_token_gap_ms,
-        input_tokens: inserted.input_tokens,
-        output_tokens: inserted.output_tokens,
-        cache_creation_tokens: inserted.cache_creation_tokens,
-        cache_read_tokens: inserted.cache_read_tokens,
-        thinking_tokens: inserted.thinking_tokens,
-        stop_reason: inserted.stop_reason,
-        is_error: inserted.is_error,
-        tool_call_count: inserted.tool_call_count,
-        stream_restarts: inserted.stream_restarts,
-        total_cost_usd: inserted.total_cost_usd,
-    };
+    // carries the server-assigned `id`. A freshly inserted row always has a
+    // `session_id`, so the wire shape's non-null fallback never fires here.
+    let payload = inserted.into_wire();
 
     // Per-session broadcast: feeds the `SessionView` per-turn footer (PR 2).
     // Reaches web clients that explicitly opened the session view.

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -358,6 +358,44 @@ pub struct TurnMetric {
     pub user_id: Uuid,
 }
 
+impl TurnMetric {
+    /// Map a DB `TurnMetric` row into the wire-facing `shared::TurnMetrics`
+    /// shape. Field-by-field rather than `From` impl so the two structs stay
+    /// explicitly synchronized without one silently picking up a stray field
+    /// from the other. Shared by the REST turn-metrics handlers and the
+    /// WebSocket persist-and-broadcast path.
+    pub fn into_wire(self) -> shared::TurnMetrics {
+        shared::TurnMetrics {
+            id: Some(self.id),
+            // Nullable in the DB (orphaned-from-session rows); the wire shape
+            // keeps a non-null `Uuid`, so fall back to nil for rows whose
+            // session is gone. Freshly inserted rows always carry one.
+            session_id: self.session_id.unwrap_or_default(),
+            user_message_id: self.user_message_id,
+            agent_type: self.agent_type,
+            model: self.model,
+            service_tier: self.service_tier,
+            started_at: self.started_at,
+            first_token_at: self.first_token_at,
+            completed_at: self.completed_at,
+            ttft_ms: self.ttft_ms,
+            total_duration_ms: self.total_duration_ms,
+            generation_duration_ms: self.generation_duration_ms,
+            max_inter_token_gap_ms: self.max_inter_token_gap_ms,
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            cache_creation_tokens: self.cache_creation_tokens,
+            cache_read_tokens: self.cache_read_tokens,
+            thinking_tokens: self.thinking_tokens,
+            stop_reason: self.stop_reason,
+            is_error: self.is_error,
+            tool_call_count: self.tool_call_count,
+            stream_restarts: self.stream_restarts,
+            total_cost_usd: self.total_cost_usd,
+        }
+    }
+}
+
 #[derive(Debug, Insertable)]
 #[diesel(table_name = crate::schema::turn_metrics)]
 pub struct NewTurnMetric {


### PR DESCRIPTION
Fixes #973.

- `TurnMetric::into_wire()` on the model replaces both 24-field copies (REST `row_to_wire` + WS inline)
- `sender_names()` and `parse_iso_cursor()` (tests moved along) in `handlers/helpers.rs`, used by both paths
- Documented fix: WS replay accepts Z-suffixed cursors instead of silently full-replaying (the messages.rs doc comment claimed parity that didn't exist — now it does)

Validation: fmt clean, backend clippy `-D warnings` clean, 111/111 tests, workspace check clean. +138/−167.