### PR TITLE
Use AsChangeset for task updates, type list_runs response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.49
+
+- **`update_task_handler` uses an `AsChangeset` struct instead of a ten-field load-merge-save; `list_runs` is typed.** `ScheduledTaskChangeset` (ten `Option`s built straight from the request; Diesel's default `treat_none_as_null = false` matches the old keep-existing semantics — verified safe since every updatable column is NOT NULL, so no `Option<Option<T>>` tri-state exists). The ownership pre-load stays (slimmed to an id select) deliberately: it must run before cron validation so nonexistent-task + invalid-cron stays 404, and the blanket diesel→AppError From would turn a filtered-update miss into a 500. `updated_at` still bumps on every request including empty bodies. `list_runs_handler` returns `Json<Vec<Session>>` instead of untyped `serde_json::Value` — byte-identical JSON.
+
 ## 2.8.36
 
 - **Remove the dashboard's dead cost-flash machinery.** `total_cost`/`cost_flash` were written on every Result message (with a 600ms flash-clear timeout) but never read by any `view()`, and the `on_cost_change` prop terminated in an explicit no-op callback "kept for API compatibility". Deleted end-to-end: the props, the `ClearCostFlash` msg arm, the struct fields, the whole Result-block cost computation in `handle_received_output`, and the no-op callback at the `<SessionView>` call site. −34 lines, one less fake data path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.49"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.49"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.49"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.49"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.49"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.49"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.49"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.49"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.49"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.49"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.49"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -20,7 +20,7 @@ use crate::{
     auth::CurrentUserId,
     errors::AppError,
     handlers::responses::EmptyResponse,
-    models::{NewScheduledTask, ScheduledTask},
+    models::{NewScheduledTask, ScheduledTask, ScheduledTaskChangeset, Session},
     schema::scheduled_tasks,
     AppState,
 };
@@ -168,10 +168,11 @@ pub async fn update_task_handler(
     let mut conn = app_state.conn()?;
 
     // Verify ownership
-    let existing: ScheduledTask = scheduled_tasks::table
+    scheduled_tasks::table
         .filter(scheduled_tasks::id.eq(task_id))
         .filter(scheduled_tasks::user_id.eq(user_id))
-        .first(&mut conn)
+        .select(scheduled_tasks::id)
+        .first::<Uuid>(&mut conn)
         .map_err(|_| AppError::NotFound("scheduled task"))?;
 
     // Validate cron if provided
@@ -183,47 +184,27 @@ pub async fn update_task_handler(
         }
     }
 
-    // Apply updates field by field (load-modify-save pattern)
-    let name = req.name.unwrap_or(existing.name);
-    let cron_expression = req.cron_expression.unwrap_or(existing.cron_expression);
-    let timezone = req.timezone.unwrap_or(existing.timezone);
-    let hostname = match req.hostname {
-        Some(h) => h,
-        None => existing.hostname,
+    let changeset = ScheduledTaskChangeset {
+        name: req.name,
+        cron_expression: req.cron_expression,
+        timezone: req.timezone,
+        hostname: req.hostname,
+        working_directory: req.working_directory,
+        prompt: req.prompt,
+        claude_args: req
+            .claude_args
+            .map(|args| serde_json::to_value(args).unwrap_or_default()),
+        agent_type: req.agent_type.map(|at| at.as_str().to_string()),
+        enabled: req.enabled,
+        max_runtime_minutes: req.max_runtime_minutes,
     };
-    let working_directory = req.working_directory.unwrap_or(existing.working_directory);
-    let prompt = req.prompt.unwrap_or(existing.prompt);
-    let claude_args = req
-        .claude_args
-        .map(|args| serde_json::to_value(args).unwrap_or_default())
-        .unwrap_or(existing.claude_args);
-    let agent_type = req
-        .agent_type
-        .map(|at| at.as_str().to_string())
-        .unwrap_or(existing.agent_type);
-    let enabled = req.enabled.unwrap_or(existing.enabled);
-    let max_runtime_minutes = req
-        .max_runtime_minutes
-        .unwrap_or(existing.max_runtime_minutes);
 
     let updated: ScheduledTask = diesel::update(
         scheduled_tasks::table
             .filter(scheduled_tasks::id.eq(task_id))
             .filter(scheduled_tasks::user_id.eq(user_id)),
     )
-    .set((
-        scheduled_tasks::name.eq(&name),
-        scheduled_tasks::cron_expression.eq(&cron_expression),
-        scheduled_tasks::timezone.eq(&timezone),
-        scheduled_tasks::hostname.eq(&hostname),
-        scheduled_tasks::working_directory.eq(&working_directory),
-        scheduled_tasks::prompt.eq(&prompt),
-        scheduled_tasks::claude_args.eq(&claude_args),
-        scheduled_tasks::agent_type.eq(&agent_type),
-        scheduled_tasks::enabled.eq(enabled),
-        scheduled_tasks::max_runtime_minutes.eq(max_runtime_minutes),
-        scheduled_tasks::updated_at.eq(diesel::dsl::now),
-    ))
+    .set((&changeset, scheduled_tasks::updated_at.eq(diesel::dsl::now)))
     .get_result(&mut conn)?;
 
     info!("Updated scheduled task '{}' ({})", updated.name, updated.id);
@@ -271,22 +252,23 @@ pub async fn list_runs_handler(
     State(app_state): State<Arc<AppState>>,
     CurrentUserId(user_id): CurrentUserId,
     Path(task_id): Path<Uuid>,
-) -> Result<Json<serde_json::Value>, AppError> {
+) -> Result<Json<Vec<Session>>, AppError> {
     let mut conn = app_state.conn()?;
 
     // Verify task ownership
-    let _task: ScheduledTask = scheduled_tasks::table
+    scheduled_tasks::table
         .filter(scheduled_tasks::id.eq(task_id))
         .filter(scheduled_tasks::user_id.eq(user_id))
-        .first(&mut conn)
+        .select(scheduled_tasks::id)
+        .first::<Uuid>(&mut conn)
         .map_err(|_| AppError::NotFound("scheduled task"))?;
 
     use crate::schema::sessions;
-    let runs: Vec<crate::models::Session> = sessions::table
+    let runs: Vec<Session> = sessions::table
         .filter(sessions::scheduled_task_id.eq(task_id))
         .order(sessions::created_at.desc())
         .limit(50)
         .load(&mut conn)?;
 
-    Ok(Json(serde_json::to_value(runs).unwrap_or_default()))
+    Ok(Json(runs))
 }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -280,6 +280,24 @@ pub struct NewScheduledTask {
     pub max_runtime_minutes: i32,
 }
 
+/// Partial update for a scheduled task. `None` fields are left unchanged
+/// (Diesel skips them with the default `treat_none_as_null = false`); all
+/// columns here are NOT NULL, so there is no set-to-null case to represent.
+#[derive(Debug, AsChangeset)]
+#[diesel(table_name = crate::schema::scheduled_tasks)]
+pub struct ScheduledTaskChangeset {
+    pub name: Option<String>,
+    pub cron_expression: Option<String>,
+    pub timezone: Option<String>,
+    pub hostname: Option<String>,
+    pub working_directory: Option<String>,
+    pub prompt: Option<String>,
+    pub claude_args: Option<serde_json::Value>,
+    pub agent_type: Option<String>,
+    pub enabled: Option<bool>,
+    pub max_runtime_minutes: Option<i32>,
+}
+
 // ============================================================================
 // Session Continuation Models
 // ============================================================================


### PR DESCRIPTION
Fixes #976.

- `ScheduledTaskChangeset` (AsChangeset, ten Options from the request) replaces the hand-rolled `unwrap_or(existing.x)` merge; no `Option<Option<T>>` tri-state needed (all updatable columns NOT NULL — documented on the struct)
- Ownership pre-load kept (slimmed to id select) so 404-before-cron-validation semantics hold; update stays filtered on id+user_id; `updated_at` bumps via set-tuple even on empty bodies (also avoids Diesel's empty-changeset error)
- `list_runs_handler`: `Json<Vec<Session>>` instead of `serde_json::Value` — same bytes
- shared/ untouched (no conflict surface with #995)

Validation: fmt clean, backend clippy `-D warnings` clean, 111/111 tests, workspace check clean.