### PR TITLE
Dedupe permission dialog keyboard nav and option rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.50
+
+- **Permission dialog: keyboard handler and option-row loop deduped between standard and ExitPlanMode variants.** `nav_keydown` (ArrowUp/k, ArrowDown/j, Enter/Space with preventDefault — verbatim in both dialogs before) and `render_options` (cursor, selected classes, click-to-confirm) are now shared; each dialog still builds its own options list (standard keeps the 3-option Allow-&-Remember variant). The question-header badge's two near-identical branches collapsed to one with a conditional `<span class="badge">` (empty `html!{}` renders nothing — DOM identical). AskUserQuestion's distinct Enter-to-submit handler untouched. Net −44 lines.
+
 ## 2.8.36
 
 - **Remove the dashboard's dead cost-flash machinery.** `total_cost`/`cost_flash` were written on every Result message (with a 600ms flash-clear timeout) but never read by any `view()`, and the `on_cost_change` prop terminated in an explicit no-op callback "kept for API compatibility". Deleted end-to-end: the props, the `ClearCostFlash` msg arm, the struct fields, the whole Result-block cost computation in `handle_received_output`, and the no-op callback at the `<SessionView>` call site. −34 lines, one less fake data path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.50"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.50"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.50"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.50"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.50"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.50"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.50"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.50"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.50"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.50"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.50"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/permission_dialog.rs
+++ b/frontend/src/pages/dashboard/permission_dialog.rs
@@ -67,17 +67,14 @@ pub fn permission_dialog(props: &PermissionDialogProps) -> Html {
     render_standard_permission(props)
 }
 
-/// Render the standard permission dialog (Allow/Deny)
-fn render_standard_permission(props: &PermissionDialogProps) -> Html {
-    let perm = &props.permission;
-    let input_preview = format_permission_input(&perm.tool_name, &perm.input);
-    let has_suggestions = !perm.permission_suggestions.is_empty();
-
+/// Build the keyboard navigation callback shared by permission dialogs
+/// (arrow/vim keys to move the selection, Enter/Space to confirm)
+fn nav_keydown(props: &PermissionDialogProps) -> Callback<KeyboardEvent> {
     let on_select_up = props.on_select_up.clone();
     let on_select_down = props.on_select_down.clone();
     let on_confirm = props.on_confirm.clone();
 
-    let onkeydown = Callback::from(move |e: KeyboardEvent| match e.key().as_str() {
+    Callback::from(move |e: KeyboardEvent| match e.key().as_str() {
         "ArrowUp" | "k" => {
             e.prevent_default();
             on_select_up.emit(());
@@ -91,7 +88,43 @@ fn render_standard_permission(props: &PermissionDialogProps) -> Html {
             on_confirm.emit(());
         }
         _ => {}
-    });
+    })
+}
+
+/// Render the selectable option rows shared by permission dialogs
+fn render_options(props: &PermissionDialogProps, options: &[(&str, &str)]) -> Html {
+    options
+        .iter()
+        .enumerate()
+        .map(|(i, (class, label))| {
+            let is_selected = i == props.selected;
+            let cursor = if is_selected { ">" } else { " " };
+            let item_class = if is_selected {
+                format!("permission-option selected {}", class)
+            } else {
+                format!("permission-option {}", class)
+            };
+            let on_select_and_confirm = props.on_select_and_confirm.clone();
+            let onclick = Callback::from(move |_| {
+                on_select_and_confirm.emit(i);
+            });
+            html! {
+                <div class={item_class} {onclick}>
+                    <span class="option-cursor">{ cursor }</span>
+                    <span class="option-label">{ *label }</span>
+                </div>
+            }
+        })
+        .collect::<Html>()
+}
+
+/// Render the standard permission dialog (Allow/Deny)
+fn render_standard_permission(props: &PermissionDialogProps) -> Html {
+    let perm = &props.permission;
+    let input_preview = format_permission_input(&perm.tool_name, &perm.input);
+    let has_suggestions = !perm.permission_suggestions.is_empty();
+
+    let onkeydown = nav_keydown(props);
 
     // Build options list
     let options: Vec<(&str, &str)> = if has_suggestions {
@@ -125,27 +158,7 @@ fn render_standard_permission(props: &PermissionDialogProps) -> Html {
                 </div>
             </div>
             <div class="permission-options">
-                {
-                    options.iter().enumerate().map(|(i, (class, label))| {
-                        let is_selected = i == props.selected;
-                        let cursor = if is_selected { ">" } else { " " };
-                        let item_class = if is_selected {
-                            format!("permission-option selected {}", class)
-                        } else {
-                            format!("permission-option {}", class)
-                        };
-                        let on_select_and_confirm = props.on_select_and_confirm.clone();
-                        let onclick = Callback::from(move |_| {
-                            on_select_and_confirm.emit(i);
-                        });
-                        html! {
-                            <div class={item_class} {onclick}>
-                                <span class="option-cursor">{ cursor }</span>
-                                <span class="option-label">{ *label }</span>
-                            </div>
-                        }
-                    }).collect::<Html>()
-                }
+                { render_options(props, &options) }
             </div>
             <div class="permission-hint">
                 { "↑↓ or tap to select" }
@@ -220,48 +233,29 @@ fn render_ask_user_question(props: &PermissionDialogProps, parsed: &AskUserQuest
 
                     html! {
                         <div class={question_class}>
-                            {
-                                if !q.header.is_empty() {
-                                    html! {
-                                        <div class="question-header-badge">
-                                            <span class="badge">{ &q.header }</span>
-                                            {
-                                                if is_multi {
-                                                    html! { <span class="multi-badge">{ "multi-select" }</span> }
-                                                } else {
-                                                    html! {}
-                                                }
-                                            }
-                                            {
-                                                if let Some(answer) = current_answer {
-                                                    html! { <span class="answer-badge">{ format!("✓ {}", answer) }</span> }
-                                                } else {
-                                                    html! {}
-                                                }
-                                            }
-                                        </div>
-                                    }
-                                } else {
-                                    html! {
-                                        <div class="question-header-badge">
-                                            {
-                                                if is_multi {
-                                                    html! { <span class="multi-badge">{ "multi-select" }</span> }
-                                                } else {
-                                                    html! {}
-                                                }
-                                            }
-                                            {
-                                                if let Some(answer) = current_answer {
-                                                    html! { <span class="answer-badge">{ format!("✓ {}", answer) }</span> }
-                                                } else {
-                                                    html! {}
-                                                }
-                                            }
-                                        </div>
+                            <div class="question-header-badge">
+                                {
+                                    if !q.header.is_empty() {
+                                        html! { <span class="badge">{ &q.header }</span> }
+                                    } else {
+                                        html! {}
                                     }
                                 }
-                            }
+                                {
+                                    if is_multi {
+                                        html! { <span class="multi-badge">{ "multi-select" }</span> }
+                                    } else {
+                                        html! {}
+                                    }
+                                }
+                                {
+                                    if let Some(answer) = current_answer {
+                                        html! { <span class="answer-badge">{ format!("✓ {}", answer) }</span> }
+                                    } else {
+                                        html! {}
+                                    }
+                                }
+                            </div>
                             <div class="question-text">{ &q.question }</div>
                             <div class="question-options">
                                 {
@@ -359,25 +353,7 @@ fn render_ask_user_question(props: &PermissionDialogProps, parsed: &AskUserQuest
 fn render_exitplanmode_permission(props: &PermissionDialogProps) -> Html {
     let perm = &props.permission;
 
-    let on_select_up = props.on_select_up.clone();
-    let on_select_down = props.on_select_down.clone();
-    let on_confirm = props.on_confirm.clone();
-
-    let onkeydown = Callback::from(move |e: KeyboardEvent| match e.key().as_str() {
-        "ArrowUp" | "k" => {
-            e.prevent_default();
-            on_select_up.emit(());
-        }
-        "ArrowDown" | "j" => {
-            e.prevent_default();
-            on_select_down.emit(());
-        }
-        "Enter" | " " => {
-            e.prevent_default();
-            on_confirm.emit(());
-        }
-        _ => {}
-    });
+    let onkeydown = nav_keydown(props);
 
     // Decode the per-tool input typed instead of JSON-poking field names.
     // `perm.input` stays a `serde_json::Value` envelope (it carries different shapes per tool);
@@ -432,27 +408,7 @@ fn render_exitplanmode_permission(props: &PermissionDialogProps) -> Html {
                 }
             </div>
             <div class="permission-options">
-                {
-                    options.iter().enumerate().map(|(i, (class, label))| {
-                        let is_selected = i == props.selected;
-                        let cursor = if is_selected { ">" } else { " " };
-                        let item_class = if is_selected {
-                            format!("permission-option selected {}", class)
-                        } else {
-                            format!("permission-option {}", class)
-                        };
-                        let on_select_and_confirm = props.on_select_and_confirm.clone();
-                        let onclick = Callback::from(move |_| {
-                            on_select_and_confirm.emit(i);
-                        });
-                        html! {
-                            <div class={item_class} {onclick}>
-                                <span class="option-cursor">{ cursor }</span>
-                                <span class="option-label">{ *label }</span>
-                            </div>
-                        }
-                    }).collect::<Html>()
-                }
+                { render_options(props, &options) }
             </div>
             <div class="permission-hint">
                 { "↑↓ or tap to select" }


### PR DESCRIPTION
Fixes #988.

`nav_keydown(props)` + `render_options(props, options)` shared between standard and ExitPlanMode dialogs (previously verbatim duplicates); header badge branches collapsed with a conditional span. Keyboard semantics preserved exactly (no number-key/Escape handling existed — none added). AskUserQuestion handler untouched.

Validation: fmt clean, clippy `-D warnings` clean, 310/310 tests, wasm build clean. Net −44 (463→419 lines).