### PR TITLE
Flatten ScheduledTask wire types around shared core struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.52
+
+- **ScheduledTask wire trio flattened around one `ScheduledTaskFields` core; MessageRole/PortalMessage serde simplified.** `ScheduledTaskConfig`/`CreateScheduledTaskRequest`/`ScheduledTaskInfo` repeated ~10 fields; they now `#[serde(flatten)]` a shared core (the `RegisterFields` pattern). Serialized key sets are byte-identical (only contiguous key order shifts; all consumers are serde) and Create's deserialization defaults are preserved exactly — five new wire-compat tests pin the JSON shapes including `last_session_id: null` and old-key-order parsing. As a side effect `task_to_config` became `pub(crate)` and launcher registration reuses it instead of hand-building the config. `MessageRole` gains `as_str()` with `Display` delegating (the `AgentType` pattern; `from_type_str` fallback verbatim), and `PortalMessage`'s always-"portal" `message_type` is now encoded once via a const + `with_content` constructor used by all six construction sites.
+
 ## 2.8.37
 
 - **Backend dead code: `NewSession`, `ImageStore::count()`, dangling device-error route.** `NewSession` was never inserted (all five insert sites use `NewSessionWithId`); `ImageStore::count()` had no callers and `with_defaults()` is now `#[cfg(test)]` (its only callers are tests); `routes::AUTH_DEVICE_ERROR` pointed at a route registered nowhere — invalid/expired device codes redirected to the SPA fallback with a `?message=` param nothing rendered. They now redirect to the device-code entry form so users can retry.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.52"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.52"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.52"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.52"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.52"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.52"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.52"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.52"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.52"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.52"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.52"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -11,7 +11,7 @@ use shared::api::{
     CreateScheduledTaskRequest, ScheduledTaskInfo, ScheduledTaskListResponse,
     UpdateScheduledTaskRequest,
 };
-use shared::{AgentType, ScheduledTaskConfig, ServerToLauncher};
+use shared::{AgentType, ScheduledTaskConfig, ScheduledTaskFields, ServerToLauncher};
 use std::sync::Arc;
 use tracing::{error, info, warn};
 use uuid::Uuid;
@@ -25,20 +25,27 @@ use crate::{
     AppState,
 };
 
+/// Extract the shared scheduled-task fields from a ScheduledTask model.
+fn task_to_fields(t: &ScheduledTask) -> ScheduledTaskFields {
+    ScheduledTaskFields {
+        name: t.name.clone(),
+        cron_expression: t.cron_expression.clone(),
+        timezone: t.timezone.clone(),
+        working_directory: t.working_directory.clone(),
+        prompt: t.prompt.clone(),
+        claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
+        agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
+        max_runtime_minutes: t.max_runtime_minutes,
+    }
+}
+
 /// Convert a ScheduledTask model to a ScheduledTaskInfo API response.
 fn task_to_info(t: ScheduledTask) -> ScheduledTaskInfo {
     ScheduledTaskInfo {
         id: t.id,
-        name: t.name,
-        cron_expression: t.cron_expression,
-        timezone: t.timezone,
+        fields: task_to_fields(&t),
         hostname: t.hostname,
-        working_directory: t.working_directory,
-        prompt: t.prompt,
-        claude_args: serde_json::from_value(t.claude_args).unwrap_or_default(),
-        agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
         enabled: t.enabled,
-        max_runtime_minutes: t.max_runtime_minutes,
         last_session_id: t.last_session_id,
         last_run_at: t.last_run_at.map(|dt| dt.and_utc().to_rfc3339()),
         created_at: t.created_at.and_utc().to_rfc3339(),
@@ -47,18 +54,11 @@ fn task_to_info(t: ScheduledTask) -> ScheduledTaskInfo {
 }
 
 /// Convert a ScheduledTask model to a ScheduledTaskConfig protocol message.
-fn task_to_config(t: &ScheduledTask) -> ScheduledTaskConfig {
+pub(crate) fn task_to_config(t: &ScheduledTask) -> ScheduledTaskConfig {
     ScheduledTaskConfig {
         id: t.id,
-        name: t.name.clone(),
-        cron_expression: t.cron_expression.clone(),
-        timezone: t.timezone.clone(),
-        working_directory: t.working_directory.clone(),
-        prompt: t.prompt.clone(),
-        claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
-        agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
+        fields: task_to_fields(t),
         enabled: t.enabled,
-        max_runtime_minutes: t.max_runtime_minutes,
         last_session_id: t.last_session_id,
     }
 }
@@ -125,9 +125,9 @@ pub async fn create_task_handler(
     Json(req): Json<CreateScheduledTaskRequest>,
 ) -> Result<Json<ScheduledTaskInfo>, AppError> {
     // Basic cron validation: must have 5 space-separated fields
-    let fields: Vec<&str> = req.cron_expression.split_whitespace().collect();
-    if fields.len() != 5 {
-        warn!("Invalid cron expression: {}", req.cron_expression);
+    let cron_fields: Vec<&str> = req.fields.cron_expression.split_whitespace().collect();
+    if cron_fields.len() != 5 {
+        warn!("Invalid cron expression: {}", req.fields.cron_expression);
         return Err(AppError::Internal("Invalid cron expression".to_string()));
     }
 
@@ -135,15 +135,15 @@ pub async fn create_task_handler(
 
     let new_task = NewScheduledTask {
         user_id,
-        name: req.name,
-        cron_expression: req.cron_expression,
-        timezone: req.timezone,
+        name: req.fields.name,
+        cron_expression: req.fields.cron_expression,
+        timezone: req.fields.timezone,
         hostname: req.hostname,
-        working_directory: req.working_directory,
-        prompt: req.prompt,
-        claude_args: serde_json::to_value(req.claude_args).unwrap_or_default(),
-        agent_type: req.agent_type.as_str().to_string(),
-        max_runtime_minutes: req.max_runtime_minutes,
+        working_directory: req.fields.working_directory,
+        prompt: req.fields.prompt,
+        claude_args: serde_json::to_value(req.fields.claude_args).unwrap_or_default(),
+        agent_type: req.fields.agent_type.as_str().to_string(),
+        max_runtime_minutes: req.fields.max_runtime_minutes,
     };
 
     let saved: ScheduledTask = diesel::insert_into(scheduled_tasks::table)

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -1,8 +1,8 @@
 use axum::extract::ws::WebSocket;
 use diesel::prelude::*;
 use shared::{
-    AgentType, LauncherEndpoint, LauncherToServer, ScheduledTaskConfig, ServerToClient,
-    ServerToLauncher, ServerToProxy, SessionStatus,
+    LauncherEndpoint, LauncherToServer, ScheduledTaskConfig, ServerToClient, ServerToLauncher,
+    ServerToProxy, SessionStatus,
 };
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -205,19 +205,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
         let task_configs: Vec<ScheduledTaskConfig> = tasks
             .iter()
             .filter(|t| t.hostname == launcher_hostname)
-            .map(|t| ScheduledTaskConfig {
-                id: t.id,
-                name: t.name.clone(),
-                cron_expression: t.cron_expression.clone(),
-                timezone: t.timezone.clone(),
-                working_directory: t.working_directory.clone(),
-                prompt: t.prompt.clone(),
-                claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
-                agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
-                enabled: t.enabled,
-                max_runtime_minutes: t.max_runtime_minutes,
-                last_session_id: t.last_session_id,
-            })
+            .map(crate::handlers::scheduled_tasks::task_to_config)
             .collect();
 
         if !task_configs.is_empty() {

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -130,16 +130,15 @@ pub fn spawn_output_forwarder(
                             None => Err(anyhow::anyhow!("no auth token available for upload")),
                         };
                         match result {
-                            Ok(url) => shared::PortalMessage {
-                                message_type: "portal".to_string(),
-                                content: vec![shared::PortalContent::Image {
+                            Ok(url) => shared::PortalMessage::with_content(vec![
+                                shared::PortalContent::Image {
                                     media_type,
                                     data: url,
                                     file_path: Some(file_path),
                                     file_size: Some(file_size),
                                     source_type: Some("url".to_string()),
-                                }],
-                            },
+                                },
+                            ]),
                             Err(e) => {
                                 warn!("Chunked image upload failed: {}", e);
                                 shared::PortalMessage::text(format!("Image upload failed: {}", e))

--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -232,7 +232,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                     let filtered: Vec<_> = data
                         .tasks
                         .into_iter()
-                        .filter(|t| t.working_directory == wd)
+                        .filter(|t| t.fields.working_directory == wd)
                         .collect();
                     tasks.set(filtered);
                 }
@@ -273,13 +273,13 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
         Callback::from(move |task_id: Uuid| {
             if let Some(task) = tasks.iter().find(|t| t.id == task_id) {
                 let (has_skip, other_args) =
-                    strip_skip_permissions_args(&task.claude_args, task.agent_type);
+                    strip_skip_permissions_args(&task.fields.claude_args, task.fields.agent_type);
                 form.set(TaskForm {
-                    name: task.name.clone(),
-                    cron_expression: task.cron_expression.clone(),
-                    timezone: task.timezone.clone(),
-                    prompt: task.prompt.clone(),
-                    max_runtime_minutes: task.max_runtime_minutes,
+                    name: task.fields.name.clone(),
+                    cron_expression: task.fields.cron_expression.clone(),
+                    timezone: task.fields.timezone.clone(),
+                    prompt: task.fields.prompt.clone(),
+                    max_runtime_minutes: task.fields.max_runtime_minutes,
                     extra_args: other_args.join(" "),
                     skip_permissions: has_skip,
                 });
@@ -334,15 +334,17 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                 let result = match mode {
                     Some(FormMode::Create) => {
                         let body = CreateScheduledTaskRequest {
-                            name: data.name.trim().to_string(),
-                            cron_expression: data.cron_expression.trim().to_string(),
-                            timezone: data.timezone.clone(),
+                            fields: shared::ScheduledTaskFields {
+                                name: data.name.trim().to_string(),
+                                cron_expression: data.cron_expression.trim().to_string(),
+                                timezone: data.timezone.clone(),
+                                working_directory: wd,
+                                prompt: data.prompt.clone(),
+                                claude_args: claude_args.clone(),
+                                agent_type,
+                                max_runtime_minutes: data.max_runtime_minutes,
+                            },
                             hostname: host,
-                            working_directory: wd,
-                            prompt: data.prompt.clone(),
-                            claude_args: claude_args.clone(),
-                            agent_type,
-                            max_runtime_minutes: data.max_runtime_minutes,
                         };
                         Request::post(&utils::api_url("/api/scheduled-tasks"))
                             .json(&body)
@@ -537,13 +539,13 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                             html! {
                                 <div class={classes!("sched-task-row", (!task.enabled).then_some("disabled"))}>
                                     <div class="sched-task-info">
-                                        <span class="sched-task-name">{ &task.name }</span>
-                                        <code class="sched-task-cron">{ &task.cron_expression }</code>
-                                        if task.timezone != "UTC" {
-                                            <span class="sched-task-tz">{ &task.timezone }</span>
+                                        <span class="sched-task-name">{ &task.fields.name }</span>
+                                        <code class="sched-task-cron">{ &task.fields.cron_expression }</code>
+                                        if task.fields.timezone != "UTC" {
+                                            <span class="sched-task-tz">{ &task.fields.timezone }</span>
                                         }
                                     </div>
-                                    <div class="sched-task-prompt-preview">{ &task.prompt }</div>
+                                    <div class="sched-task-prompt-preview">{ &task.fields.prompt }</div>
                                     <div class="sched-task-actions">
                                         <button class="sched-btn" onclick={Callback::from(move |_| on_edit.emit(task_id))}>
                                             { "Edit" }

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -253,7 +253,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                             let has = data
                                 .tasks
                                 .iter()
-                                .any(|t| t.working_directory == wd && t.enabled);
+                                .any(|t| t.fields.working_directory == wd && t.enabled);
                             stop_has_tasks.set(has);
                         }
                     });

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -193,14 +193,14 @@ pub async fn run_launcher_loop(
                             for task_to_fire in scheduler.fire_due_tasks() {
                                 info!(
                                     "Firing scheduled task '{}' ({})",
-                                    task_to_fire.config.name, task_to_fire.config.id
+                                    task_to_fire.config.fields.name, task_to_fire.config.id
                                 );
                                 let msg = LauncherToServer::RequestLaunch {
                                     request_id: task_to_fire.request_id,
-                                    working_directory: task_to_fire.config.working_directory.clone(),
-                                    session_name: Some(task_to_fire.config.name.clone()),
-                                    claude_args: task_to_fire.config.claude_args.clone(),
-                                    agent_type: task_to_fire.config.agent_type,
+                                    working_directory: task_to_fire.config.fields.working_directory.clone(),
+                                    session_name: Some(task_to_fire.config.fields.name.clone()),
+                                    claude_args: task_to_fire.config.fields.claude_args.clone(),
+                                    agent_type: task_to_fire.config.fields.agent_type,
                                     scheduled_task_id: Some(task_to_fire.config.id),
                                     last_session_id: task_to_fire.config.last_session_id,
                                 };

--- a/launcher/src/scheduler.rs
+++ b/launcher/src/scheduler.rs
@@ -74,12 +74,12 @@ impl Scheduler {
             .into_iter()
             .map(|config| {
                 let next_fire = if config.enabled && !running_task_ids.contains(&config.id) {
-                    compute_next_fire(&config.cron_expression, &config.timezone)
+                    compute_next_fire(&config.fields.cron_expression, &config.fields.timezone)
                 } else {
                     None
                 };
                 if let Some(ref next) = next_fire {
-                    info!("Task '{}': next fire at {}", config.name, next);
+                    info!("Task '{}': next fire at {}", config.fields.name, next);
                 }
                 ActiveTask { config, next_fire }
             })
@@ -184,10 +184,12 @@ impl Scheduler {
             if running_task_ids.contains(&task.config.id) {
                 info!(
                     "Skipping task '{}': previous run still active",
-                    task.config.name
+                    task.config.fields.name
                 );
-                task.next_fire =
-                    compute_next_fire(&task.config.cron_expression, &task.config.timezone);
+                task.next_fire = compute_next_fire(
+                    &task.config.fields.cron_expression,
+                    &task.config.fields.timezone,
+                );
                 continue;
             }
 
@@ -197,7 +199,7 @@ impl Scheduler {
                 PendingLaunch {
                     task_id: task.config.id,
                     last_session_id: task.config.last_session_id,
-                    prompt: task.config.prompt.clone(),
+                    prompt: task.config.fields.prompt.clone(),
                 },
             ));
             to_fire.push(TaskToFire {
@@ -205,10 +207,16 @@ impl Scheduler {
                 config: task.config.clone(),
             });
 
-            info!("Firing task '{}' ({})", task.config.name, task.config.id);
-            task.next_fire = compute_next_fire(&task.config.cron_expression, &task.config.timezone);
+            info!(
+                "Firing task '{}' ({})",
+                task.config.fields.name, task.config.id
+            );
+            task.next_fire = compute_next_fire(
+                &task.config.fields.cron_expression,
+                &task.config.fields.timezone,
+            );
             if let Some(ref next) = task.next_fire {
-                info!("Task '{}': next fire at {}", task.config.name, next);
+                info!("Task '{}': next fire at {}", task.config.fields.name, next);
             }
         }
 
@@ -241,7 +249,7 @@ impl Scheduler {
                 .tasks
                 .iter()
                 .find(|t| t.config.id == pending.task_id)
-                .map(|t| t.config.max_runtime_minutes)
+                .map(|t| t.config.fields.max_runtime_minutes)
                 .unwrap_or(30);
 
             self.running.insert(
@@ -338,15 +346,17 @@ mod tests {
     fn make_task(name: &str, cron: &str) -> ScheduledTaskConfig {
         ScheduledTaskConfig {
             id: Uuid::new_v4(),
-            name: name.to_string(),
-            cron_expression: cron.to_string(),
-            timezone: "UTC".to_string(),
-            working_directory: "/tmp".to_string(),
-            prompt: "test prompt".to_string(),
-            claude_args: vec![],
-            agent_type: AgentType::Claude,
+            fields: shared::ScheduledTaskFields {
+                name: name.to_string(),
+                cron_expression: cron.to_string(),
+                timezone: "UTC".to_string(),
+                working_directory: "/tmp".to_string(),
+                prompt: "test prompt".to_string(),
+                claude_args: vec![],
+                agent_type: AgentType::Claude,
+                max_runtime_minutes: 30,
+            },
             enabled: true,
-            max_runtime_minutes: 30,
             last_session_id: None,
         }
     }

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -671,27 +671,9 @@ pub struct MessagesListResponse<T> {
 /// Request to create a scheduled task
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateScheduledTaskRequest {
-    pub name: String,
-    pub cron_expression: String,
-    #[serde(default = "default_timezone")]
-    pub timezone: String,
+    #[serde(flatten)]
+    pub fields: crate::endpoints::ScheduledTaskFields,
     pub hostname: String,
-    pub working_directory: String,
-    pub prompt: String,
-    #[serde(default)]
-    pub claude_args: Vec<String>,
-    #[serde(default)]
-    pub agent_type: crate::AgentType,
-    #[serde(default = "default_max_runtime")]
-    pub max_runtime_minutes: i32,
-}
-
-fn default_timezone() -> String {
-    "UTC".to_string()
-}
-
-fn default_max_runtime() -> i32 {
-    30
 }
 
 /// Request to update a scheduled task (all fields optional)
@@ -723,16 +705,10 @@ pub struct UpdateScheduledTaskRequest {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScheduledTaskInfo {
     pub id: uuid::Uuid,
-    pub name: String,
-    pub cron_expression: String,
-    pub timezone: String,
+    #[serde(flatten)]
+    pub fields: crate::endpoints::ScheduledTaskFields,
     pub hostname: String,
-    pub working_directory: String,
-    pub prompt: String,
-    pub claude_args: Vec<String>,
-    pub agent_type: crate::AgentType,
     pub enabled: bool,
-    pub max_runtime_minutes: i32,
     pub last_session_id: Option<uuid::Uuid>,
     pub last_run_at: Option<String>,
     pub created_at: String,
@@ -1363,5 +1339,106 @@ mod tests {
         assert!(json.get("ttft_ms").is_none());
         let parsed: TurnMetrics = serde_json::from_value(json).unwrap();
         assert_eq!(parsed, metrics);
+    }
+
+    fn sample_task_fields() -> crate::endpoints::ScheduledTaskFields {
+        crate::endpoints::ScheduledTaskFields {
+            name: "nightly audit".to_string(),
+            cron_expression: "0 3 * * *".to_string(),
+            timezone: "UTC".to_string(),
+            working_directory: "/home/user/project".to_string(),
+            prompt: "Check deps".to_string(),
+            claude_args: vec!["--verbose".to_string()],
+            agent_type: crate::AgentType::Claude,
+            max_runtime_minutes: 30,
+        }
+    }
+
+    /// Pins the CreateScheduledTaskRequest wire shape: flattened fields must
+    /// produce the same keys/values as the pre-flatten struct, old field
+    /// order must still parse, and the timezone / max_runtime / claude_args /
+    /// agent_type defaults must be preserved.
+    #[test]
+    fn create_scheduled_task_request_wire_compat() {
+        let req = CreateScheduledTaskRequest {
+            fields: sample_task_fields(),
+            hostname: "buildbox".to_string(),
+        };
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{
+                "name": "nightly audit",
+                "cron_expression": "0 3 * * *",
+                "timezone": "UTC",
+                "hostname": "buildbox",
+                "working_directory": "/home/user/project",
+                "prompt": "Check deps",
+                "claude_args": ["--verbose"],
+                "agent_type": "claude",
+                "max_runtime_minutes": 30
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(serde_json::to_value(&req).unwrap(), expected);
+
+        // Old wire order (hostname between timezone and working_directory)
+        // still parses identically.
+        let parsed: CreateScheduledTaskRequest = serde_json::from_value(expected.clone()).unwrap();
+        assert_eq!(parsed.fields, req.fields);
+        assert_eq!(parsed.hostname, "buildbox");
+
+        // Optional fields keep their historical defaults when omitted.
+        let minimal = r#"{
+            "name": "n",
+            "cron_expression": "* * * * *",
+            "hostname": "h",
+            "working_directory": "/tmp",
+            "prompt": "p"
+        }"#;
+        let parsed: CreateScheduledTaskRequest = serde_json::from_str(minimal).unwrap();
+        assert_eq!(parsed.fields.timezone, "UTC");
+        assert_eq!(parsed.fields.max_runtime_minutes, 30);
+        assert!(parsed.fields.claude_args.is_empty());
+        assert_eq!(parsed.fields.agent_type, crate::AgentType::Claude);
+    }
+
+    /// Pins the ScheduledTaskInfo wire shape, including the always-serialized
+    /// `last_session_id: null` for None.
+    #[test]
+    fn scheduled_task_info_wire_compat() {
+        let info = ScheduledTaskInfo {
+            id: uuid::Uuid::nil(),
+            fields: sample_task_fields(),
+            hostname: "buildbox".to_string(),
+            enabled: true,
+            last_session_id: None,
+            last_run_at: Some("2026-01-01T00:00:00+00:00".to_string()),
+            created_at: "2026-01-01T00:00:00+00:00".to_string(),
+            updated_at: "2026-01-01T00:00:00+00:00".to_string(),
+        };
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{
+                "id": "00000000-0000-0000-0000-000000000000",
+                "name": "nightly audit",
+                "cron_expression": "0 3 * * *",
+                "timezone": "UTC",
+                "hostname": "buildbox",
+                "working_directory": "/home/user/project",
+                "prompt": "Check deps",
+                "claude_args": ["--verbose"],
+                "agent_type": "claude",
+                "enabled": true,
+                "max_runtime_minutes": 30,
+                "last_session_id": null,
+                "last_run_at": "2026-01-01T00:00:00+00:00",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00"
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(serde_json::to_value(&info).unwrap(), expected);
+
+        // Old wire order still parses identically.
+        let parsed: ScheduledTaskInfo = serde_json::from_value(expected).unwrap();
+        assert_eq!(parsed, info);
     }
 }

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -42,12 +42,13 @@ pub struct RegisterFields {
     pub claude_args: Vec<String>,
 }
 
-/// Configuration for a scheduled task, sent from backend to launcher via ScheduleSync.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ScheduledTaskConfig {
-    pub id: Uuid,
+/// Core scheduled-task fields shared by `ScheduledTaskConfig`,
+/// `CreateScheduledTaskRequest`, and `ScheduledTaskInfo` via `#[serde(flatten)]`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScheduledTaskFields {
     pub name: String,
     pub cron_expression: String,
+    #[serde(default = "default_timezone")]
     pub timezone: String,
     pub working_directory: String,
     pub prompt: String,
@@ -55,8 +56,25 @@ pub struct ScheduledTaskConfig {
     pub claude_args: Vec<String>,
     #[serde(default)]
     pub agent_type: AgentType,
-    pub enabled: bool,
+    #[serde(default = "default_max_runtime_minutes")]
     pub max_runtime_minutes: i32,
+}
+
+fn default_timezone() -> String {
+    "UTC".to_string()
+}
+
+fn default_max_runtime_minutes() -> i32 {
+    30
+}
+
+/// Configuration for a scheduled task, sent from backend to launcher via ScheduleSync.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduledTaskConfig {
+    pub id: Uuid,
+    #[serde(flatten)]
+    pub fields: ScheduledTaskFields,
+    pub enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_session_id: Option<Uuid>,
 }
@@ -1000,15 +1018,17 @@ mod tests {
         let msg = ServerToLauncher::ScheduleSync {
             tasks: vec![ScheduledTaskConfig {
                 id: Uuid::nil(),
-                name: "nightly audit".into(),
-                cron_expression: "0 3 * * *".into(),
-                timezone: "UTC".into(),
-                working_directory: "/home/user/project".into(),
-                prompt: "Check deps".into(),
-                claude_args: vec![],
-                agent_type: AgentType::Claude,
+                fields: ScheduledTaskFields {
+                    name: "nightly audit".into(),
+                    cron_expression: "0 3 * * *".into(),
+                    timezone: "UTC".into(),
+                    working_directory: "/home/user/project".into(),
+                    prompt: "Check deps".into(),
+                    claude_args: vec![],
+                    agent_type: AgentType::Claude,
+                    max_runtime_minutes: 30,
+                },
                 enabled: true,
-                max_runtime_minutes: 30,
                 last_session_id: None,
             }],
         };
@@ -1018,10 +1038,71 @@ mod tests {
         match parsed {
             ServerToLauncher::ScheduleSync { tasks } => {
                 assert_eq!(tasks.len(), 1);
-                assert_eq!(tasks[0].name, "nightly audit");
+                assert_eq!(tasks[0].fields.name, "nightly audit");
             }
             _ => panic!("Wrong variant"),
         }
+    }
+
+    /// Pins the ScheduledTaskConfig wire shape: flattened fields must produce
+    /// the same keys/values as the pre-flatten struct, and JSON in the old
+    /// field order (as emitted by older backends) must still deserialize.
+    #[test]
+    fn scheduled_task_config_wire_compat() {
+        let config = ScheduledTaskConfig {
+            id: Uuid::nil(),
+            fields: ScheduledTaskFields {
+                name: "nightly audit".into(),
+                cron_expression: "0 3 * * *".into(),
+                timezone: "UTC".into(),
+                working_directory: "/home/user/project".into(),
+                prompt: "Check deps".into(),
+                claude_args: vec!["--verbose".into()],
+                agent_type: AgentType::Claude,
+                max_runtime_minutes: 30,
+            },
+            enabled: true,
+            last_session_id: None,
+        };
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{
+                "id": "00000000-0000-0000-0000-000000000000",
+                "name": "nightly audit",
+                "cron_expression": "0 3 * * *",
+                "timezone": "UTC",
+                "working_directory": "/home/user/project",
+                "prompt": "Check deps",
+                "claude_args": ["--verbose"],
+                "agent_type": "claude",
+                "enabled": true,
+                "max_runtime_minutes": 30
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(serde_json::to_value(&config).unwrap(), expected);
+
+        // Old wire order (enabled before max_runtime_minutes) still parses.
+        let old_wire = r#"{
+            "id": "00000000-0000-0000-0000-000000000000",
+            "name": "nightly audit",
+            "cron_expression": "0 3 * * *",
+            "timezone": "UTC",
+            "working_directory": "/home/user/project",
+            "prompt": "Check deps",
+            "claude_args": ["--verbose"],
+            "agent_type": "claude",
+            "enabled": true,
+            "max_runtime_minutes": 30,
+            "last_session_id": "11111111-1111-1111-1111-111111111111"
+        }"#;
+        let parsed: ScheduledTaskConfig = serde_json::from_str(old_wire).unwrap();
+        assert_eq!(parsed.fields.name, "nightly audit");
+        assert_eq!(parsed.fields.max_runtime_minutes, 30);
+        assert!(parsed.enabled);
+        assert_eq!(
+            parsed.last_session_id,
+            Some(Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap())
+        );
     }
 
     #[test]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -268,9 +268,9 @@ pub enum MessageRole {
     Unknown,
 }
 
-impl std::fmt::Display for MessageRole {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
+impl MessageRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
             Self::System => "system",
             Self::Assistant => "assistant",
             Self::User => "user",
@@ -278,12 +278,10 @@ impl std::fmt::Display for MessageRole {
             Self::Error => "error",
             Self::Portal => "portal",
             Self::Unknown => "unknown",
-        };
-        f.write_str(s)
+        }
     }
-}
 
-impl MessageRole {
+    /// Parse a message-type string; any unrecognized value maps to `Unknown`.
     pub fn from_type_str(s: &str) -> Self {
         match s {
             "system" => Self::System,
@@ -294,6 +292,12 @@ impl MessageRole {
             "portal" => Self::Portal,
             _ => Self::Unknown,
         }
+    }
+}
+
+impl std::fmt::Display for MessageRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -308,24 +312,29 @@ pub struct PortalMessage {
 }
 
 impl PortalMessage {
-    pub fn text(text: String) -> Self {
+    /// The invariant `"type"` tag value for portal messages.
+    pub const MESSAGE_TYPE: &'static str = "portal";
+
+    /// Build a portal message with the invariant `"type":"portal"` tag.
+    pub fn with_content(content: Vec<PortalContent>) -> Self {
         Self {
-            message_type: "portal".to_string(),
-            content: vec![PortalContent::Text { text }],
+            message_type: Self::MESSAGE_TYPE.to_string(),
+            content,
         }
     }
 
+    pub fn text(text: String) -> Self {
+        Self::with_content(vec![PortalContent::Text { text }])
+    }
+
     pub fn image(media_type: String, data: String) -> Self {
-        Self {
-            message_type: "portal".to_string(),
-            content: vec![PortalContent::Image {
-                media_type,
-                data,
-                file_path: None,
-                file_size: None,
-                source_type: None,
-            }],
-        }
+        Self::with_content(vec![PortalContent::Image {
+            media_type,
+            data,
+            file_path: None,
+            file_size: None,
+            source_type: None,
+        }])
     }
 
     pub fn image_with_info(
@@ -334,26 +343,20 @@ impl PortalMessage {
         file_path: Option<String>,
         file_size: Option<u64>,
     ) -> Self {
-        Self {
-            message_type: "portal".to_string(),
-            content: vec![PortalContent::Image {
-                media_type,
-                data,
-                file_path,
-                file_size,
-                source_type: None,
-            }],
-        }
+        Self::with_content(vec![PortalContent::Image {
+            media_type,
+            data,
+            file_path,
+            file_size,
+            source_type: None,
+        }])
     }
 
     /// Build a collapsible "portal features reminder" message — same envelope
     /// as text/image portal messages, rendered with a header bar and a
     /// click-to-expand body on the frontend.
     pub fn reminder(title: String, body: String) -> Self {
-        Self {
-            message_type: "portal".to_string(),
-            content: vec![PortalContent::Reminder { title, body }],
-        }
+        Self::with_content(vec![PortalContent::Reminder { title, body }])
     }
 
     pub fn continuation_prompt(
@@ -362,15 +365,12 @@ impl PortalMessage {
         status: String,
         source_message: String,
     ) -> Self {
-        Self {
-            message_type: "portal".to_string(),
-            content: vec![PortalContent::ContinuationPrompt {
-                continuation_id,
-                reset_at,
-                status,
-                source_message,
-            }],
-        }
+        Self::with_content(vec![PortalContent::ContinuationPrompt {
+            continuation_id,
+            reset_at,
+            status,
+            source_message,
+        }])
     }
 
     pub fn to_json(&self) -> serde_json::Value {
@@ -516,5 +516,48 @@ mod tests {
 
         let replaced: SessionStatus = serde_json::from_str("\"replaced\"").unwrap();
         assert_eq!(replaced, SessionStatus::Replaced);
+    }
+
+    #[test]
+    fn message_role_as_str_matches_serde_encoding() {
+        let roles = [
+            MessageRole::System,
+            MessageRole::Assistant,
+            MessageRole::User,
+            MessageRole::Result,
+            MessageRole::Error,
+            MessageRole::Portal,
+            MessageRole::Unknown,
+        ];
+        for role in roles {
+            // Display / as_str must agree with the serde wire encoding.
+            let json = serde_json::to_string(&role).unwrap();
+            assert_eq!(json, format!("\"{}\"", role.as_str()));
+            assert_eq!(role.to_string(), role.as_str());
+            // from_type_str round-trips every known encoding.
+            assert_eq!(MessageRole::from_type_str(role.as_str()), role);
+        }
+        // Unrecognized strings fall back to Unknown.
+        assert_eq!(
+            MessageRole::from_type_str("not-a-role"),
+            MessageRole::Unknown
+        );
+        assert_eq!(MessageRole::from_type_str(""), MessageRole::Unknown);
+    }
+
+    #[test]
+    fn portal_message_serializes_with_portal_tag() {
+        let msg = PortalMessage::text("hello".to_string());
+        let json = msg.to_json();
+        assert_eq!(json["type"], "portal");
+        assert_eq!(json["content"][0]["type"], "text");
+        assert_eq!(json["content"][0]["text"], "hello");
+
+        let custom = PortalMessage::with_content(vec![PortalContent::Reminder {
+            title: "t".to_string(),
+            body: "b".to_string(),
+        }]);
+        assert_eq!(custom.message_type, PortalMessage::MESSAGE_TYPE);
+        assert_eq!(custom.to_json()["type"], "portal");
     }
 }


### PR DESCRIPTION
Fixes #995.

- `ScheduledTaskFields` core + `#[serde(flatten)]` in Config/Create/Info (RegisterFields pattern); all construction sites updated across backend/frontend/launcher
- Wire format: key sets byte-identical, only contiguous key order shifts (serde consumers are order-insensitive); Create's defaults (UTC/30/[]/Claude) preserved; Config/Info deserialization strictly more lenient (accepts missing core fields — only our backend produces them)
- 5 new wire-compat pin tests
- `MessageRole::as_str()` + delegating Display; `from_type_str` fallback verbatim
- `PortalMessage::MESSAGE_TYPE` const + `with_content` constructor replaces 6 repeated literals
- Bonus overlap with #972: `task_to_config` now `pub(crate)` and reused by launcher registration

Validation: fmt clean, workspace clippy `-D warnings` clean, 542 workspace tests pass, wasm checks clean.