### PR TITLE
Shim: dedupe wiggum prompt, writes, args; remove dead paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.53
+
+- **Shim cleanup: wiggum prompt single-sourced, one write_line, dead channel and fake retries gone, shared claude arg builder.** The wiggum DONE-loop prompt suffix existed in three byte-identical copies (drift would silently break loop semantics) — now `wiggum_prompt()` next to `WiggumState`. All six serialize→write→newline→flush sites in the shim use one generic `write_line` (newline/flush errors at four raw sites now surface like write errors instead of being ignored). The stdin-line channel feeding an empty select arm is deleted. Both "retry the same failing constructor" fallbacks (`warn!("continuing without persistence")` then `?`, and `unwrap_or_else(|_| …unwrap())`) reduced to honest single calls. `claude_cli_args()` in spawn.rs builds the CLI flag list once for the lib spawn, its diagnostic log, and the shim's respawn — a flag change can't miss the shim anymore. Net −56 lines.
+
 ## 2.8.37
 
 - **Backend dead code: `NewSession`, `ImageStore::count()`, dangling device-error route.** `NewSession` was never inserted (all five insert sites use `NewSessionWithId`); `ImageStore::count()` had no callers and `with_defaults()` is now `#[cfg(test)]` (its only callers are tests); `routes::AUTH_DEVICE_ERROR` pointed at a route registered nowhere — invalid/expired device codes redirected to the SPA fallback with a `?message=` param nothing rendered. They now redirect to the device-code entry form so users can retry.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.53"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.53"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.53"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.53"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.53"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.53"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.53"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.53"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.53"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.53"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.53"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -13,6 +13,7 @@ pub mod proxy_session;
 mod spawn;
 
 pub use agent::ClaudeAgent;
+pub use spawn::claude_cli_args;
 
 // Re-export the proxy session helpers used by the proxy binary.
 pub use proxy_session::{

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -9,6 +9,7 @@ mod ws_reader;
 
 pub(crate) use portal_reminder::inject_portal_reminder;
 
+pub use wiggum::wiggum_prompt;
 pub use ws_reader::{classify_portal_input, RoutedPortalInput};
 
 use std::sync::Arc;
@@ -218,17 +219,7 @@ impl<'a, A: Agent> SessionState<'a, A> {
         input_tx: mpsc::UnboundedSender<PortalInput>,
         input_rx: &'a mut mpsc::UnboundedReceiver<PortalInput>,
     ) -> Result<Self> {
-        let output_buffer = match PendingOutputBuffer::new(config.session_id) {
-            Ok(buf) => buf,
-            Err(e) => {
-                warn!(
-                    "Failed to create output buffer, continuing without persistence: {}",
-                    e
-                );
-                PendingOutputBuffer::new(config.session_id)?
-            }
-        };
-        let output_buffer = Arc::new(Mutex::new(output_buffer));
+        let output_buffer = Arc::new(Mutex::new(PendingOutputBuffer::new(config.session_id)?));
 
         Ok(Self {
             config,
@@ -893,17 +884,14 @@ async fn run_main_loop<A: Agent>(
                     &state.git_metadata,
                 )
                 .await;
-                let wiggum_prompt = format!(
-                    "{}\n\nTake action on the directions above until fully complete. If complete, respond only with DONE.",
-                    wiggum_input.text
-                );
+                let prompt = wiggum_prompt(&wiggum_input.text);
                 state.wiggum_state = Some(WiggumState {
                     original_prompt: wiggum_input.text,
                     iteration: 1,
                     loop_start: Instant::now(),
                     loop_durations: Vec::new(),
                 });
-                if let Err(e) = claude_session.send_input(serde_json::Value::String(wiggum_prompt)).await {
+                if let Err(e) = claude_session.send_input(serde_json::Value::String(prompt)).await {
                     error!("Failed to send wiggum prompt to Claude: {}", e);
                     return ConnectionResult::ClaudeExited;
                 }

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -18,6 +18,15 @@ use super::{format_duration, ConnectionResult, SharedWsWrite};
 /// Maximum iterations for wiggum mode before auto-stopping
 const WIGGUM_MAX_ITERATIONS: u32 = 50;
 
+/// Build the wiggum loop prompt sent to the agent: the original user prompt
+/// plus the instruction suffix whose exact wording drives DONE-loop detection.
+pub fn wiggum_prompt(original: &str) -> String {
+    format!(
+        "{}\n\nTake action on the directions above until fully complete. If complete, respond only with DONE.",
+        original
+    )
+}
+
 /// Wiggum mode state
 #[derive(Debug, Clone)]
 pub struct WiggumState {
@@ -142,12 +151,9 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
                         state.loop_start = Instant::now();
 
                         // Resend the prompt
-                        let wiggum_prompt = format!(
-                            "{}\n\nTake action on the directions above until fully complete. If complete, respond only with DONE.",
-                            state.original_prompt
-                        );
+                        let prompt = wiggum_prompt(&state.original_prompt);
                         if let Err(e) = claude_session
-                            .send_input(serde_json::Value::String(wiggum_prompt))
+                            .send_input(serde_json::Value::String(prompt))
                             .await
                         {
                             error!("Failed to resend wiggum prompt: {}", e);

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -12,6 +12,36 @@ use claude_codes::AsyncClient as ClaudeAsyncClient;
 use session_lib::error::SessionError;
 use session_lib::snapshot::SessionConfig;
 
+/// Build the argument list for the `claude` CLI (everything after the binary
+/// path). Shared by the library spawn path and the proxy's shim mode so flag
+/// changes can't drift between the two.
+pub fn claude_cli_args(session_id: uuid::Uuid, resume: bool, extra_args: &[String]) -> Vec<String> {
+    let mut args: Vec<String> = [
+        "--print",
+        "--verbose",
+        "--output-format",
+        "stream-json",
+        "--input-format",
+        "stream-json",
+        "--permission-prompt-tool",
+        "stdio",
+        "--replay-user-messages",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    if resume {
+        args.push("--resume".to_string());
+    } else {
+        args.push("--session-id".to_string());
+    }
+    args.push(session_id.to_string());
+
+    args.extend(extra_args.iter().cloned());
+    args
+}
+
 /// Spawn the Claude process and return its async client.
 pub(crate) async fn spawn_claude(
     config: &SessionConfig,
@@ -20,54 +50,18 @@ pub(crate) async fn spawn_claude(
 
     log_claude_info(claude_path);
 
+    let args = claude_cli_args(config.session_id, config.resume, &config.extra_args);
+
     let mut cmd = Command::new(claude_path);
-    cmd.arg("--print")
-        .arg("--verbose")
-        .arg("--output-format")
-        .arg("stream-json")
-        .arg("--input-format")
-        .arg("stream-json")
-        .arg("--permission-prompt-tool")
-        .arg("stdio")
-        .arg("--replay-user-messages");
-
-    if config.resume {
-        cmd.arg("--resume").arg(config.session_id.to_string());
-    } else {
-        cmd.arg("--session-id").arg(config.session_id.to_string());
-    }
-
-    for arg in &config.extra_args {
-        cmd.arg(arg);
-    }
-
+    cmd.args(&args);
     cmd.current_dir(&config.working_directory);
 
     // Log the full command for diagnostics.
-    let args: Vec<_> = std::iter::once(claude_path.to_string_lossy().to_string())
-        .chain(
-            [
-                "--print",
-                "--verbose",
-                "--output-format",
-                "stream-json",
-                "--input-format",
-                "stream-json",
-                "--permission-prompt-tool",
-                "stdio",
-                "--replay-user-messages",
-            ]
-            .iter()
-            .map(|s| s.to_string()),
-        )
-        .chain(if config.resume {
-            vec!["--resume".to_string(), config.session_id.to_string()]
-        } else {
-            vec!["--session-id".to_string(), config.session_id.to_string()]
-        })
-        .chain(config.extra_args.iter().cloned())
-        .collect();
-    tracing::info!("Spawning Claude: {}", args.join(" "));
+    tracing::info!(
+        "Spawning Claude: {} {}",
+        claude_path.to_string_lossy(),
+        args.join(" ")
+    );
 
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::session::{
-    ack_portal_input, connect_to_backend, get_git_branch, register_session, Backoff,
+    ack_portal_input, connect_to_backend, get_git_branch, register_session, wiggum_prompt, Backoff,
     PermissionResponseData, ProxySessionConfig, SharedWsWrite, WsEvent,
 };
 use anyhow::Result;
@@ -23,6 +23,7 @@ use claude_codes::io::{
     ControlResponsePayload, PermissionResult, UserMessage,
 };
 use claude_codes::{ClaudeInput, ClaudeOutput};
+use claude_session_lib::claude_cli_args;
 use session_lib::output_buffer::PendingOutputBuffer;
 use shared::ProxyToServer;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -78,10 +79,7 @@ pub async fn run_shim(config: ProxySessionConfig) -> Result<()> {
     });
 
     // Output buffer for reliable delivery to portal
-    let output_buffer = Arc::new(Mutex::new(
-        PendingOutputBuffer::new(config.session_id)
-            .unwrap_or_else(|_| PendingOutputBuffer::new(config.session_id).unwrap()),
-    ));
+    let output_buffer = Arc::new(Mutex::new(PendingOutputBuffer::new(config.session_id)?));
 
     // Channel for portal-sent message texts (for user echo dedup in VS Code).
     // The sender is used in the WS connection loop; the receiver lives in the
@@ -123,25 +121,11 @@ pub async fn run_shim(config: ProxySessionConfig) -> Result<()> {
 /// Spawn the claude binary with piped stdin/stdout/stderr.
 fn spawn_claude(config: &ProxySessionConfig) -> Result<tokio::process::Child> {
     let mut cmd = Command::new("claude");
-    cmd.arg("--print")
-        .arg("--verbose")
-        .arg("--output-format")
-        .arg("stream-json")
-        .arg("--input-format")
-        .arg("stream-json")
-        .arg("--permission-prompt-tool")
-        .arg("stdio")
-        .arg("--replay-user-messages");
-
-    if config.resume {
-        cmd.arg("--resume").arg(config.session_id.to_string());
-    } else {
-        cmd.arg("--session-id").arg(config.session_id.to_string());
-    }
-
-    for arg in &config.claude_args {
-        cmd.arg(arg);
-    }
+    cmd.args(claude_cli_args(
+        config.session_id,
+        config.resume,
+        &config.claude_args,
+    ));
 
     cmd.current_dir(&config.working_directory);
     cmd.stdin(std::process::Stdio::piped());
@@ -251,15 +235,10 @@ async fn run_shim_loop(
             // Forward to VS Code stdout (when appropriate)
             if forward_to_vscode {
                 let mut stdout = our_stdout_for_reader.lock().await;
-                if let Err(e) = stdout.write_all(line.as_bytes()).await {
+                if let Err(e) = write_line(&mut *stdout, &line).await {
                     error!("Failed to write to stdout: {}", e);
                     break;
                 }
-                if let Err(e) = stdout.write_all(b"\n").await {
-                    error!("Failed to write newline to stdout: {}", e);
-                    break;
-                }
-                let _ = stdout.flush().await;
             }
 
             // Dispatch for portal forwarding (independent of VS Code decision).
@@ -328,7 +307,6 @@ async fn run_shim_loop(
     let claude_stdin_for_reader = claude_stdin.clone();
     let permissions_for_stdin = permissions.clone();
     let filtering_for_stdin = filtering_active.clone();
-    let (stdin_line_tx, mut stdin_line_rx) = mpsc::unbounded_channel::<String>();
 
     let stdin_reader_task = tokio::spawn(async move {
         while let Ok(Some(line)) = own_stdin_reader.next_line().await {
@@ -363,18 +341,10 @@ async fn run_shim_loop(
 
             // Always forward stdin to claude (transparency)
             let mut stdin = claude_stdin_for_reader.lock().await;
-            if let Err(e) = stdin.write_all(line.as_bytes()).await {
+            if let Err(e) = write_line(&mut *stdin, &line).await {
                 error!("Failed to write to claude stdin: {}", e);
                 break;
             }
-            if let Err(e) = stdin.write_all(b"\n").await {
-                error!("Failed to write newline to claude stdin: {}", e);
-                break;
-            }
-            let _ = stdin.flush().await;
-
-            // Also notify the WS loop (for input forwarding to portal if needed)
-            let _ = stdin_line_tx.send(line);
         }
         info!("Own stdin ended (parent process disconnected)");
     });
@@ -456,7 +426,6 @@ async fn run_shim_loop(
             conn,
             &mut output_line_rx,
             &mut perm_request_rx,
-            &mut stdin_line_rx,
             claude_stdin.clone(),
             permissions.clone(),
             output_buffer.clone(),
@@ -519,7 +488,6 @@ async fn run_shim_connection(
     conn: crate::session::NativeConnection,
     output_line_rx: &mut mpsc::UnboundedReceiver<(u64, serde_json::Value)>,
     perm_request_rx: &mut mpsc::UnboundedReceiver<ProxyToServer>,
-    stdin_line_rx: &mut mpsc::UnboundedReceiver<String>,
     claude_stdin: Arc<Mutex<tokio::process::ChildStdin>>,
     permissions: Arc<Mutex<HashMap<String, PermissionState>>>,
     output_buffer: Arc<Mutex<PendingOutputBuffer>>,
@@ -546,9 +514,7 @@ async fn run_shim_connection(
                         let claude_input =
                             ClaudeInput::user_message(&input.text, config.session_id);
                         if let Ok(json_line) = serde_json::to_string(&claude_input) {
-                            if let Err(e) =
-                                write_json_line_and_flush(&mut *stdin, &json_line).await
-                            {
+                            if let Err(e) = write_line(&mut *stdin, &json_line).await {
                                 error!("Failed to write portal input to claude: {}", e);
                                 break ShimConnectionResult::ClaudeExited;
                             }
@@ -562,17 +528,12 @@ async fn run_shim_connection(
                             "Portal wiggum input: {}",
                             &prompt_text[..prompt_text.len().min(60)]
                         );
-                        let wiggum_prompt = format!(
-                            "{}\n\nTake action on the directions above until fully complete. If complete, respond only with DONE.",
-                            prompt_text
-                        );
-                        let _ = portal_text_tx.send(wiggum_prompt.clone());
+                        let prompt = wiggum_prompt(&prompt_text);
+                        let _ = portal_text_tx.send(prompt.clone());
                         let mut stdin = claude_stdin.lock().await;
-                        let input = ClaudeInput::user_message(&wiggum_prompt, config.session_id);
+                        let input = ClaudeInput::user_message(&prompt, config.session_id);
                         if let Ok(json_line) = serde_json::to_string(&input) {
-                            if let Err(e) =
-                                write_json_line_and_flush(&mut *stdin, &json_line).await
-                            {
+                            if let Err(e) = write_line(&mut *stdin, &json_line).await {
                                 error!("Failed to write wiggum input to claude: {}", e);
                                 break ShimConnectionResult::ClaudeExited;
                             }
@@ -604,12 +565,10 @@ async fn run_shim_connection(
                             let ctrl_response: ControlResponseMessage = build_control_response(&perm_response).into();
                             if let Ok(json_line) = serde_json::to_string(&ctrl_response) {
                                 let mut stdin = claude_stdin.lock().await;
-                                if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
+                                if let Err(e) = write_line(&mut *stdin, &json_line).await {
                                     error!("Failed to write permission response to claude: {}", e);
                                     break ShimConnectionResult::ClaudeExited;
                                 }
-                                let _ = stdin.write_all(b"\n").await;
-                                let _ = stdin.flush().await;
                             }
                         }
                     }
@@ -633,12 +592,10 @@ async fn run_shim_connection(
                         let mut stdin = claude_stdin.lock().await;
                         let input = ClaudeInput::interrupt();
                         if let Ok(json_line) = serde_json::to_string(&input) {
-                            if let Err(e) = stdin.write_all(json_line.as_bytes()).await {
+                            if let Err(e) = write_line(&mut *stdin, &json_line).await {
                                 error!("Failed to write interrupt to claude: {}", e);
                                 break ShimConnectionResult::ClaudeExited;
                             }
-                            let _ = stdin.write_all(b"\n").await;
-                            let _ = stdin.flush().await;
                         }
                     }
                     Some(WsEvent::FileDownloadRequest(request)) => {
@@ -679,9 +636,6 @@ async fn run_shim_connection(
                     break ShimConnectionResult::Disconnected;
                 }
             }
-
-            // Drain stdin lines (actual forwarding happens in the stdin reader task)
-            _ = stdin_line_rx.recv() => {}
         }
     };
 
@@ -689,11 +643,12 @@ async fn run_shim_connection(
     result
 }
 
-async fn write_json_line_and_flush<W>(writer: &mut W, json_line: &str) -> std::io::Result<()>
+/// Write a line followed by a newline, then flush.
+async fn write_line<W>(writer: &mut W, line: &str) -> std::io::Result<()>
 where
     W: tokio::io::AsyncWrite + Unpin,
 {
-    writer.write_all(json_line.as_bytes()).await?;
+    writer.write_all(line.as_bytes()).await?;
     writer.write_all(b"\n").await?;
     writer.flush().await
 }


### PR DESCRIPTION
Fixes #992.

- `wiggum_prompt()` replaces 3 byte-identical copies (verified identical before consolidating)
- `write_line` (generic AsyncWrite) consolidates 6 write sites; newline/flush errors now surface at the 4 sites that ignored them
- Dead `stdin_line_tx/rx` channel + empty select arm deleted
- Fake retry fallbacks (`PendingOutputBuffer::new` retried after logging "continuing without persistence") → single honest call
- `claude_cli_args()` shared by lib spawn (built once for Command + log, byte-identical log) and shim respawn

Validation: fmt clean, clippy `-D warnings` clean on proxy+lib, 7/7 tests, workspace check clean. Net −56.