### PR TITLE
Dedupe admin PATCH-user handlers and auth/me fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.54
+
+- **Admin page: three PATCH-user handlers deduped; `/api/auth/me` no longer fetched redundantly.** `patch_user(user_id, body) -> bool` + `update_user_in(users, id, f)` collapse the toggle-admin/unban/confirm-ban triple to one-liners. The dashboard's leave-confirm now uses the `current_user_id` it already holds (typed `Option<Uuid>` now) instead of a second network round-trip, and the admin modal receives the id as a prop, skipping its own me-fetch; the standalone `/admin` route keeps its original fetch with 401→Home / 403→denied handling.
+
 ## 2.8.37
 
 - **Backend dead code: `NewSession`, `ImageStore::count()`, dangling device-error route.** `NewSession` was never inserted (all five insert sites use `NewSessionWithId`); `ImageStore::count()` had no callers and `with_defaults()` is now `#[cfg(test)]` (its only callers are tests); `routes::AUTH_DEVICE_ERROR` pointed at a route registered nowhere — invalid/expired device codes redirected to the SPA fallback with a `?message=` param nothing rendered. They now redirect to the device-code entry form so users can retry.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.54"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.54"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.54"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.54"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.54"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.54"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.54"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.54"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.54"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.54"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.54"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/admin/mod.rs
+++ b/frontend/src/pages/admin/mod.rs
@@ -43,6 +43,41 @@ enum AdminTab {
 #[derive(Properties, PartialEq)]
 pub struct AdminPageProps {
     pub on_close: Callback<()>,
+    /// Current user's id when the parent already knows it (e.g. the dashboard
+    /// modal); skips the redundant `/api/auth/me` fetch.
+    #[prop_or_default]
+    pub current_user_id: Option<Uuid>,
+}
+
+/// PATCH a user via the admin API. Returns true when the server applied the
+/// update (HTTP 204).
+async fn patch_user(user_id: Uuid, body: &UpdateUserRequest) -> bool {
+    let api_endpoint = utils::api_url(&format!("/api/admin/users/{}", user_id));
+    match Request::patch(&api_endpoint)
+        .json(body)
+        .unwrap()
+        .send()
+        .await
+    {
+        Ok(response) => response.status() == 204,
+        Err(e) => {
+            log::error!("Failed to update user: {:?}", e);
+            false
+        }
+    }
+}
+
+/// Apply `f` to the matching user in the local list and re-set the state.
+fn update_user_in(
+    users: &UseStateHandle<Vec<AdminUserInfo>>,
+    user_id: Uuid,
+    f: impl FnOnce(&mut AdminUserInfo),
+) {
+    let mut updated = (**users).clone();
+    if let Some(user) = updated.iter_mut().find(|u| u.id == user_id) {
+        f(user);
+    }
+    users.set(updated);
 }
 
 #[function_component(AdminPage)]
@@ -53,7 +88,7 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
     let sessions = use_state(Vec::<AdminSessionInfo>::new);
     let loading = use_state(|| true);
     let error = use_state(|| None::<String>);
-    let current_user_id = use_state(|| None::<Uuid>);
+    let current_user_id = use_state(|| props.current_user_id);
     let confirm_action = use_state(|| None::<(String, Callback<MouseEvent>)>);
     // Ban dialog state - when set, shows ban modal with reason input
     let ban_dialog = use_state(|| None::<Uuid>);
@@ -61,31 +96,33 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
 
     let navigator = use_navigator().unwrap();
 
-    // Fetch current user to get their ID
+    // Fetch current user to get their ID (skipped when the parent supplied it)
     {
         let current_user_id = current_user_id.clone();
         let error = error.clone();
         let navigator = navigator.clone();
         use_effect_with((), move |_| {
-            spawn_local(async move {
-                match utils::fetch_json::<MeResponse>("/api/auth/me", On401::Ignore).await {
-                    Ok(me) => {
-                        current_user_id.set(Some(me.id));
+            if current_user_id.is_none() {
+                spawn_local(async move {
+                    match utils::fetch_json::<MeResponse>("/api/auth/me", On401::Ignore).await {
+                        Ok(me) => {
+                            current_user_id.set(Some(me.id));
+                        }
+                        Err(FetchError::Status(401)) => {
+                            navigator.push(&Route::Home);
+                        }
+                        Err(FetchError::Status(403)) => {
+                            error.set(Some(
+                                "Access denied. Admin privileges required.".to_string(),
+                            ));
+                        }
+                        Err(FetchError::Network(e)) => {
+                            error.set(Some(format!("Failed to fetch user: {}", e)));
+                        }
+                        Err(_) => {}
                     }
-                    Err(FetchError::Status(401)) => {
-                        navigator.push(&Route::Home);
-                    }
-                    Err(FetchError::Status(403)) => {
-                        error.set(Some(
-                            "Access denied. Admin privileges required.".to_string(),
-                        ));
-                    }
-                    Err(FetchError::Network(e)) => {
-                        error.set(Some(format!("Failed to fetch user: {}", e)));
-                    }
-                    Err(_) => {}
-                }
-            });
+                });
+            }
             || ()
         });
     }
@@ -225,29 +262,12 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
                 let confirm = confirm_inner.clone();
                 let new_admin_status = !is_currently_admin;
                 spawn_local(async move {
-                    let api_endpoint = utils::api_url(&format!("/api/admin/users/{}", user_id));
                     let body = UpdateUserRequest {
                         is_admin: Some(new_admin_status),
                         ..Default::default()
                     };
-                    match Request::patch(&api_endpoint)
-                        .json(&body)
-                        .unwrap()
-                        .send()
-                        .await
-                    {
-                        Ok(response) => {
-                            if response.status() == 204 {
-                                let mut updated = (*users).clone();
-                                if let Some(user) = updated.iter_mut().find(|u| u.id == user_id) {
-                                    user.is_admin = new_admin_status;
-                                }
-                                users.set(updated);
-                            }
-                        }
-                        Err(e) => {
-                            log::error!("Failed to update user: {:?}", e);
-                        }
+                    if patch_user(user_id, &body).await {
+                        update_user_in(&users, user_id, |u| u.is_admin = new_admin_status);
                     }
                     confirm.set(None);
                 });
@@ -279,31 +299,13 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
                     let users = users_inner.clone();
                     let confirm = confirm_inner.clone();
                     spawn_local(async move {
-                        let api_endpoint = utils::api_url(&format!("/api/admin/users/{}", user_id));
                         let body = UpdateUserRequest {
                             disabled: Some(false),
                             ban_reason: Some(None),
                             ..Default::default()
                         };
-                        match Request::patch(&api_endpoint)
-                            .json(&body)
-                            .unwrap()
-                            .send()
-                            .await
-                        {
-                            Ok(response) => {
-                                if response.status() == 204 {
-                                    let mut updated = (*users).clone();
-                                    if let Some(user) = updated.iter_mut().find(|u| u.id == user_id)
-                                    {
-                                        user.disabled = false;
-                                    }
-                                    users.set(updated);
-                                }
-                            }
-                            Err(e) => {
-                                log::error!("Failed to update user: {:?}", e);
-                            }
+                        if patch_user(user_id, &body).await {
+                            update_user_in(&users, user_id, |u| u.disabled = false);
                         }
                         confirm.set(None);
                     });
@@ -329,7 +331,6 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
 
             if let Some(user_id) = *ban_dialog {
                 spawn_local(async move {
-                    let api_endpoint = utils::api_url(&format!("/api/admin/users/{}", user_id));
                     let body = UpdateUserRequest {
                         disabled: Some(true),
                         ban_reason: Some(if reason.is_empty() {
@@ -339,24 +340,8 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
                         }),
                         ..Default::default()
                     };
-                    match Request::patch(&api_endpoint)
-                        .json(&body)
-                        .unwrap()
-                        .send()
-                        .await
-                    {
-                        Ok(response) => {
-                            if response.status() == 204 {
-                                let mut updated = (*users).clone();
-                                if let Some(user) = updated.iter_mut().find(|u| u.id == user_id) {
-                                    user.disabled = true;
-                                }
-                                users.set(updated);
-                            }
-                        }
-                        Err(e) => {
-                            log::error!("Failed to ban user: {:?}", e);
-                        }
+                    if patch_user(user_id, &body).await {
+                        update_user_in(&users, user_id, |u| u.disabled = true);
                     }
                     ban_dialog.set(None);
                 });

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -75,7 +75,7 @@ pub fn dashboard_page() -> Html {
     let pending_leave = use_state(|| None::<Uuid>);
     let pending_delete = use_state(|| None::<Uuid>);
     let is_admin = use_state(|| false);
-    let current_user_id = use_state(|| None::<String>);
+    let current_user_id = use_state(|| None::<Uuid>);
     let app_title = use_state(|| "Agent Portal".to_string());
     let server_version = use_state(String::new);
     let activated_sessions = use_state(HashSet::<Uuid>::new);
@@ -140,7 +140,7 @@ pub fn dashboard_page() -> Html {
                 if let Ok(me) = utils::fetch_json::<MeResponse>("/api/auth/me", On401::Ignore).await
                 {
                     is_admin.set(me.is_admin);
-                    current_user_id.set(Some(me.id.to_string()));
+                    current_user_id.set(Some(me.id));
                 }
             });
             || ()
@@ -350,16 +350,13 @@ pub fn dashboard_page() -> Html {
     let on_confirm_leave = {
         let pending_leave = pending_leave.clone();
         let refresh = sessions_hook.refresh.clone();
+        let current_user_id = current_user_id.clone();
         Callback::from(move |_| {
             if let Some(session_id) = *pending_leave {
                 let refresh = refresh.clone();
                 let pending_leave = pending_leave.clone();
+                let user_id = *current_user_id;
                 spawn_local(async move {
-                    let user_id = utils::fetch_json::<MeResponse>("/api/auth/me", On401::Ignore)
-                        .await
-                        .ok()
-                        .map(|me| me.id.to_string());
-
                     if let Some(user_id) = user_id {
                         let api_endpoint = utils::api_url(&format!(
                             "/api/sessions/{}/members/{}",
@@ -836,7 +833,7 @@ pub fn dashboard_page() -> Html {
                                                 on_message_sent={on_message_sent.clone()}
                                                 on_branch_change={on_branch_change.clone()}
                                                 on_activity={on_activity.clone()}
-                                                current_user_id={(*current_user_id).clone()}
+                                                current_user_id={current_user_id.map(|id| id.to_string())}
                                                 interrupt_signal={*interrupt_signal}
                                             />
                                         </div>
@@ -926,7 +923,7 @@ pub fn dashboard_page() -> Html {
             // Admin modal — full-page overlay preserves dashboard state
             if *show_admin {
                 <div class="full-page-modal">
-                    <AdminPage on_close={close_admin.clone()} />
+                    <AdminPage on_close={close_admin.clone()} current_user_id={*current_user_id} />
                 </div>
             }
 


### PR DESCRIPTION
Fixes #987.

- `patch_user` + `update_user_in` replace the build-request → PATCH → on-204-mutate dance ×3 (non-204 stays silent as before; one log message consolidated)
- Leave-confirm uses held state instead of re-fetching /api/auth/me (one fewer request); admin modal gets `current_user_id` as an optional prop — standalone /admin route keeps the original fetch + status handling
- Diff kept tight to avoid #983 conflicts (modal markup untouched)

Validation: fmt clean, clippy `-D warnings` clean, 310/310 tests, wasm build clean. +69/−87.