### PR TITLE
Dedupe native crate helpers, remove dead config fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.56
+
+- **Native-crate misc dedup: hostname helper, default session name, dead config fields, heartbeat constant.** `hostname_or_unknown()` in claude-session-lib replaces 7 inline copies (unified on `to_string_lossy`; non-UTF-8 edge cases now render lossily instead of three different fallback strings — normal hostnames byte-identical; portal-auth keeps its copy rather than inverting the dependency graph, and one proxy site keeps its no-fallback `Option<String>` semantics deliberately). `default_session_name` moved next to `ProxySessionConfig`. Write-only `ProxyConfig` fields removed: `SessionAuth.user_id`, `session_prefix` (+ setter + init-URL plumbing), `Preferences.auto_open_browser`. `atomic_save` delegates to `save_with_lock`. `probe.rs` uses `AgentType::as_str()`. Launcher's heartbeat cadence moved to `shared/src/protocol.rs` as `LAUNCHER_HEARTBEAT_INTERVAL_SECS` with a doc note that the backend deliberately has no staleness timeout (liveness = the WS connection). Two issue items were already done on main (#1003 removed the RegisterFields duplication and the `unreachable!`). Net −46 lines.
+
 ## 2.8.37
 
 - **Backend dead code: `NewSession`, `ImageStore::count()`, dangling device-error route.** `NewSession` was never inserted (all five insert sites use `NewSessionWithId`); `ImageStore::count()` had no callers and `with_defaults()` is now `#[cfg(test)]` (its only callers are tests); `routes::AUTH_DEVICE_ERROR` pointed at a route registered nowhere — invalid/expired device codes redirected to the SPA fallback with a `?message=` param nothing rendered. They now redirect to the device-code entry form so users can retry.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,6 @@ dependencies = [
  "croner",
  "directories",
  "dirs",
- "hostname",
  "portal-auth",
  "portal-update",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.56"
 dependencies = [
  "anyhow",
  "chrono",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.56"
 dependencies = [
  "anyhow",
  "axum",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.56"
 dependencies = [
  "anyhow",
  "base64",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.56"
 dependencies = [
  "anyhow",
  "base64",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.56"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.56"
 dependencies = [
  "base64",
  "chrono",
@@ -2691,7 +2691,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.56"
 dependencies = [
  "anyhow",
  "colored",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.56"
 dependencies = [
  "anyhow",
  "hex",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.56"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.56"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.56"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -16,8 +16,8 @@ pub use agent::ClaudeAgent;
 
 // Re-export the proxy session helpers used by the proxy binary.
 pub use proxy_session::{
-    run_connection_loop, ConnectionResult, LoopResult, PortalInput, ProxySessionConfig,
-    SessionState,
+    default_session_name, hostname_or_unknown, run_connection_loop, ConnectionResult, LoopResult,
+    PortalInput, ProxySessionConfig, SessionState,
 };
 
 // Convenience re-exports so existing consumers don't all have to add

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -77,6 +77,24 @@ pub struct ProxySessionConfig {
     pub codex_thread_id_sink: Option<CodexThreadIdSink>,
 }
 
+/// The local hostname, or `"unknown"` when the OS lookup fails.
+/// Non-UTF-8 hostnames are converted lossily (invalid bytes become U+FFFD).
+pub fn hostname_or_unknown() -> String {
+    hostname::get()
+        .map(|h| h.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// Default session name when the user doesn't supply one:
+/// `<hostname>-<YYYYmmdd-HHMMSS>` (local time).
+pub fn default_session_name() -> String {
+    format!(
+        "{}-{}",
+        hostname_or_unknown(),
+        chrono::Local::now().format("%Y%m%d-%H%M%S")
+    )
+}
+
 /// Exponential backoff helper
 pub struct Backoff {
     current: u64,
@@ -480,10 +498,7 @@ async fn run_single_connection<A: Agent>(session: &mut SessionState<'_, A>) -> C
 
     // Send a portal message with session details
     {
-        let hostname = hostname::get()
-            .ok()
-            .and_then(|h| h.into_string().ok())
-            .unwrap_or_else(|| "unknown".to_string());
+        let hostname = hostname_or_unknown();
 
         let status_line = if session.first_connection {
             "**Session started**".to_string()
@@ -593,10 +608,7 @@ pub async fn register_session(
 ) -> Result<u32, Duration> {
     info!("Registering session...");
 
-    let hostname = hostname::get()
-        .ok()
-        .and_then(|h| h.into_string().ok())
-        .unwrap_or_else(|| "unknown".to_string());
+    let hostname = hostname_or_unknown();
 
     let register_msg = ProxyToServer::Register(shared::RegisterFields {
         session_id: config.session_id,

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -31,9 +31,6 @@ tracing-subscriber = { workspace = true }
 # UUID
 uuid = { workspace = true }
 
-# Hostname
-hostname = "0.4"
-
 # Time
 chrono = { workspace = true, features = ["std", "clock"] }
 chrono-tz = "0.10"

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -7,7 +7,8 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+const HEARTBEAT_INTERVAL: Duration =
+    Duration::from_secs(shared::protocol::LAUNCHER_HEARTBEAT_INTERVAL_SECS);
 const MAX_BACKOFF: Duration = Duration::from_secs(shared::protocol::MAX_RECONNECT_BACKOFF_SECS);
 
 pub async fn run_launcher_loop(
@@ -37,9 +38,7 @@ pub async fn run_launcher_loop(
                     launcher_id,
                     launcher_name: launcher_name.to_string(),
                     auth_token: auth_token.map(|s| s.to_string()),
-                    hostname: hostname::get()
-                        .map(|h| h.to_string_lossy().to_string())
-                        .unwrap_or_default(),
+                    hostname: claude_session_lib::hostname_or_unknown(),
                     version: Some(env!("CARGO_PKG_VERSION").to_string()),
                     working_directory: std::env::current_dir()
                         .ok()

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -179,11 +179,10 @@ async fn main() -> anyhow::Result<()> {
             Some(result.access_token)
         }
     };
-    let launcher_name = args.name.or(config.name).unwrap_or_else(|| {
-        hostname::get()
-            .map(|h| h.to_string_lossy().to_string())
-            .unwrap_or_else(|_| "unknown".to_string())
-    });
+    let launcher_name = args
+        .name
+        .or(config.name)
+        .unwrap_or_else(claude_session_lib::hostname_or_unknown);
 
     let launcher_id = Uuid::new_v4();
 

--- a/launcher/src/pastebin.rs
+++ b/launcher/src/pastebin.rs
@@ -50,9 +50,7 @@ fn build_info() -> String {
 }
 
 fn system_info() -> String {
-    let hostname = hostname::get()
-        .map(|h| h.to_string_lossy().to_string())
-        .unwrap_or_else(|_| "<unknown>".into());
+    let hostname = claude_session_lib::hostname_or_unknown();
 
     let uname = std::process::Command::new("uname")
         .arg("-a")

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -135,19 +135,10 @@ impl ProcessManager {
             Some(id) => (id, true),
             None => (Uuid::new_v4(), false),
         };
-        let default_name = {
-            let hostname = hostname::get()
-                .ok()
-                .and_then(|h| h.into_string().ok())
-                .unwrap_or_else(|| "unknown".to_string());
-            let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
-            format!("{}-{}", hostname, timestamp)
-        };
         let name = params
             .session_name
-            .as_deref()
-            .unwrap_or(&default_name)
-            .to_string();
+            .clone()
+            .unwrap_or_else(claude_session_lib::default_session_name);
 
         let git_branch = get_git_branch(&working_directory);
 

--- a/proxy/src/commands.rs
+++ b/proxy/src/commands.rs
@@ -24,7 +24,7 @@ pub fn handle_init(
     init_value: &str,
     backend_url_override: Option<&str>,
 ) -> Result<()> {
-    let (parsed_backend_url, token, session_prefix) = util::parse_init_value(init_value)?;
+    let (parsed_backend_url, token) = util::parse_init_value(init_value)?;
 
     // Resolve backend URL: CLI override > parsed from init value (required)
     let backend_url = backend_url_override
@@ -43,12 +43,10 @@ pub fn handle_init(
     config.set_session_auth(
         cwd.to_string(),
         SessionAuth {
-            user_id: String::new(),
             auth_token: token,
             user_email: user_email.clone(),
             last_used: chrono::Utc::now().to_rfc3339(),
             backend_url: Some(backend_url.clone()),
-            session_prefix: session_prefix.clone(),
         },
     );
 
@@ -57,11 +55,6 @@ pub fn handle_init(
 
     // Also set as the global default so it works in other directories
     config.preferences.default_backend_url = Some(backend_url.clone());
-
-    // Save session name prefix if provided
-    if let Some(prefix) = session_prefix {
-        config.set_session_prefix(cwd, &prefix);
-    }
 
     config.atomic_save()?;
 

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -43,23 +43,17 @@ pub struct DirectorySession {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionAuth {
-    pub user_id: String,
     pub auth_token: String,
     pub user_email: Option<String>,
     pub last_used: String,
     #[serde(default)]
     pub backend_url: Option<String>,
-    #[serde(default)]
-    pub session_prefix: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Preferences {
     #[serde(default)]
     pub default_backend_url: Option<String>,
-
-    #[serde(default)]
-    pub auto_open_browser: bool,
 }
 
 /// File lock for atomic config operations
@@ -170,25 +164,9 @@ impl ProxyConfig {
     /// This prevents race conditions when multiple proxy instances run in the same directory
     pub fn atomic_save(&self) -> Result<()> {
         let path = Self::config_path()?;
-
-        // Create parent directory if it doesn't exist
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).context("Failed to create config directory")?;
-        }
-
-        // Acquire lock
-        let _lock = ConfigLock::acquire(&path)?;
-
-        // Write to temp file first
-        let temp_path = path.with_extension("tmp");
-        let contents = serde_json::to_string_pretty(self).context("Failed to serialize config")?;
-        fs::write(&temp_path, &contents).context("Failed to write temp config file")?;
-
-        // Atomic rename
-        fs::rename(&temp_path, &path).context("Failed to rename config file")?;
-
+        let lock = ConfigLock::acquire(&path)?;
+        self.save_with_lock(&lock)
         // Lock is released on drop
-        Ok(())
     }
 
     /// Load config with file locking (for read-modify-write operations)
@@ -250,12 +228,6 @@ impl ProxyConfig {
     pub fn set_backend_url(&mut self, working_dir: &str, url: &str) {
         if let Some(auth) = self.sessions.get_mut(working_dir) {
             auth.backend_url = Some(url.to_string());
-        }
-    }
-
-    pub fn set_session_prefix(&mut self, working_dir: &str, prefix: &str) {
-        if let Some(auth) = self.sessions.get_mut(working_dir) {
-            auth.session_prefix = Some(prefix.to_string());
         }
     }
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use claude_session_lib::ClaudeAgent;
+use claude_session_lib::{default_session_name, ClaudeAgent};
 use session_lib::{Session, SessionConfig};
 use shared::api::{ResolveProxySessionRequest, ResolveProxySessionResponse};
 
@@ -183,15 +183,6 @@ fn init_tracing(session_id_tag: Option<Uuid>, verbose: bool) {
         // Interactive: human-readable format
         tracing_subscriber::fmt().with_env_filter(env_filter).init();
     }
-}
-
-fn default_session_name() -> String {
-    let hostname = hostname::get()
-        .ok()
-        .and_then(|h| h.into_string().ok())
-        .unwrap_or_else(|| "unknown".to_string());
-    let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
-    format!("{}-{}", hostname, timestamp)
 }
 
 /// Handle --check-update: check for updates without installing
@@ -688,12 +679,10 @@ async fn resolve_auth_token(
     config.set_session_auth(
         cwd.to_string(),
         SessionAuth {
-            user_id: result.user_id,
             auth_token: result.access_token.clone(),
             user_email: Some(result.user_email),
             last_used: chrono::Utc::now().to_rfc3339(),
             backend_url: None,
-            session_prefix: None,
         },
     );
     config.atomic_save()?;

--- a/proxy/src/util.rs
+++ b/proxy/src/util.rs
@@ -8,8 +8,8 @@ use shared::ProxyInitConfig;
 /// - Just the base64 config part
 /// - A raw JWT token
 ///
-/// Returns (backend_url, token, session_prefix)
-pub fn parse_init_value(value: &str) -> Result<(Option<String>, String, Option<String>)> {
+/// Returns (backend_url, token)
+pub fn parse_init_value(value: &str) -> Result<(Option<String>, String)> {
     // Check if it's a URL
     if value.starts_with("http://") || value.starts_with("https://") {
         return parse_init_url(value);
@@ -17,18 +17,18 @@ pub fn parse_init_value(value: &str) -> Result<(Option<String>, String, Option<S
 
     // Check if it looks like a JWT (three base64 parts separated by dots)
     if value.contains('.') && value.split('.').count() == 3 {
-        return Ok((None, value.to_string(), None));
+        return Ok((None, value.to_string()));
     }
 
     // Try to decode as ProxyInitConfig
     match ProxyInitConfig::decode(value) {
-        Ok(config) => Ok((None, config.token, config.session_name_prefix)),
-        Err(_) => Ok((None, value.to_string(), None)),
+        Ok(config) => Ok((None, config.token)),
+        Err(_) => Ok((None, value.to_string())),
     }
 }
 
 /// Parse a full init URL
-fn parse_init_url(value: &str) -> Result<(Option<String>, String, Option<String>)> {
+fn parse_init_url(value: &str) -> Result<(Option<String>, String)> {
     use anyhow::Context;
 
     let url = url::Url::parse(value).context("Invalid init URL")?;
@@ -48,7 +48,7 @@ fn parse_init_url(value: &str) -> Result<(Option<String>, String, Option<String>
         let config = ProxyInitConfig::decode(config_part)
             .map_err(|e| anyhow::anyhow!("Failed to decode init config from URL: {}", e))?;
 
-        return Ok((Some(ws_url), config.token, config.session_name_prefix));
+        return Ok((Some(ws_url), config.token));
     }
 
     anyhow::bail!("Invalid init URL format. Expected: https://server.com/p/{{config}}")

--- a/session-lib/src/probe.rs
+++ b/session-lib/src/probe.rs
@@ -27,10 +27,7 @@ pub fn probe_all_agents() -> Vec<(AgentType, ProbeResult)> {
 /// Probe one agent. Returns the resolved binary path (via `which`) and the
 /// `--version` output trimmed. `installed` is true iff `--version` exited 0.
 pub fn probe_agent(agent: AgentType) -> ProbeResult {
-    let name = match agent {
-        AgentType::Claude => "claude",
-        AgentType::Codex => "codex",
-    };
+    let name = agent.as_str();
 
     let resolved_path = which::which(name).ok();
     if resolved_path.is_none() {

--- a/shared/src/protocol.rs
+++ b/shared/src/protocol.rs
@@ -15,3 +15,11 @@ pub const DEVICE_CODE_EXPIRES_SECS: u64 = 300;
 /// Used by proxy/launcher to cap exponential backoff, and by the backend
 /// to determine how long to wait before cleaning up stale sessions.
 pub const MAX_RECONNECT_BACKOFF_SECS: u64 = 30;
+
+/// Interval (in seconds) between launcher heartbeats on the launcher
+/// WebSocket. The backend has no explicit heartbeat timeout — launcher
+/// liveness is the WebSocket connection itself — but it treats each
+/// heartbeat's `running_sessions` as the authoritative process list when
+/// reconciling desired sessions (see `LauncherToServer::LauncherHeartbeat`
+/// handling in the backend's launcher socket).
+pub const LAUNCHER_HEARTBEAT_INTERVAL_SECS: u64 = 30;


### PR DESCRIPTION
Fixes #993.

- `hostname_or_unknown()` ×7 (portal-auth copy kept — dep graph; one proxy `Option<String>` site kept — no-fallback wire semantics); edge-case diffs documented in changelog, normal hostnames byte-identical
- `default_session_name` shared; dead `ProxyConfig` fields removed (`user_id`, `session_prefix`+setter+init-URL plumbing, `auto_open_browser`) — serde tolerates stale keys
- `atomic_save` = acquire lock + delegate; `probe.rs` uses `AgentType::as_str()`; `LAUNCHER_HEARTBEAT_INTERVAL_SECS` → shared/protocol.rs
- Already done on main, skipped: RegisterFields helper, `unreachable!` removal (both via #1003)

Validation: fmt clean, workspace clippy `-D warnings` clean, 101 tests pass across 6 crates, workspace check clean. Net −46.