### PR TITLE
Reuse scheduled task sync helper for launcher registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.57
+
+- **Launcher registration reuses the scheduled-task sync helpers instead of hand-building `ScheduledTaskConfig`.** The 45-line registration block (including a redundant hostname re-fetch from the launchers map) is now one call to a new `send_initial_schedule_sync(app_state, user_id, launcher_id, hostname, launcher_name)` — a single-launcher variant chosen deliberately over the broadcast `send_schedule_sync`, which (a) targets all of a user's launchers and (b) always sends even when empty (needed so deletes clear state), whereas registration historically sends nothing when no enabled tasks match the hostname. Both variants share a new `load_enabled_tasks` and all config construction flows through `task_to_config`, so the #995 field flatten lands in exactly one place. Same mpsc delivery, same log line.
+
 ## 2.8.37
 
 - **Backend dead code: `NewSession`, `ImageStore::count()`, dangling device-error route.** `NewSession` was never inserted (all five insert sites use `NewSessionWithId`); `ImageStore::count()` had no callers and `with_defaults()` is now `#[cfg(test)]` (its only callers are tests); `routes::AUTH_DEVICE_ERROR` pointed at a route registered nowhere — invalid/expired device codes redirected to the SPA fallback with a `?message=` param nothing rendered. They now redirect to the device-code entry form so users can retry.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.34"
+version = "2.8.57"
 dependencies = [
  "anyhow",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.34"
+version = "2.8.57"
 dependencies = [
  "anyhow",
  "axum",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.34"
+version = "2.8.57"
 dependencies = [
  "anyhow",
  "base64",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.34"
+version = "2.8.57"
 dependencies = [
  "anyhow",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.34"
+version = "2.8.57"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.34"
+version = "2.8.57"
 dependencies = [
  "base64",
  "chrono",
@@ -2692,7 +2692,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.34"
+version = "2.8.57"
 dependencies = [
  "anyhow",
  "colored",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.34"
+version = "2.8.57"
 dependencies = [
  "anyhow",
  "hex",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.34"
+version = "2.8.57"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.34"
+version = "2.8.57"
 dependencies = [
  "chrono",
  "claude-codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.34"
+version = "2.8.57"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -63,19 +63,28 @@ fn task_to_config(t: &ScheduledTask) -> ScheduledTaskConfig {
     }
 }
 
+/// Load a user's enabled scheduled tasks. Returns None if no DB connection.
+fn load_enabled_tasks(app_state: &AppState, user_id: Uuid) -> Option<Vec<ScheduledTask>> {
+    match app_state.db_pool.get() {
+        Ok(mut conn) => Some(
+            scheduled_tasks::table
+                .filter(scheduled_tasks::user_id.eq(user_id))
+                .filter(scheduled_tasks::enabled.eq(true))
+                .load(&mut conn)
+                .unwrap_or_default(),
+        ),
+        Err(e) => {
+            error!("Failed to get DB connection for ScheduleSync: {}", e);
+            None
+        }
+    }
+}
+
 /// Send ScheduleSync to all connected launchers for a user.
 /// Filters tasks by launcher hostname.
 fn send_schedule_sync(app_state: &AppState, user_id: Uuid) {
-    let tasks: Vec<ScheduledTask> = match app_state.db_pool.get() {
-        Ok(mut conn) => scheduled_tasks::table
-            .filter(scheduled_tasks::user_id.eq(user_id))
-            .filter(scheduled_tasks::enabled.eq(true))
-            .load(&mut conn)
-            .unwrap_or_default(),
-        Err(e) => {
-            error!("Failed to get DB connection for ScheduleSync: {}", e);
-            return;
-        }
+    let Some(tasks) = load_enabled_tasks(app_state, user_id) else {
+        return;
     };
 
     let launchers = app_state.session_manager.get_launchers_for_user(&user_id);
@@ -95,6 +104,44 @@ fn send_schedule_sync(app_state: &AppState, user_id: Uuid) {
                 launcher.launcher_name, launcher.launcher_id
             );
         }
+    }
+}
+
+/// Send the initial ScheduleSync to a single newly-registered launcher.
+/// Filters the user's enabled tasks by the launcher's hostname and, unlike
+/// the broadcast in `send_schedule_sync`, sends nothing when no tasks match.
+pub(crate) fn send_initial_schedule_sync(
+    app_state: &AppState,
+    user_id: Uuid,
+    launcher_id: Uuid,
+    hostname: &str,
+    launcher_name: &str,
+) {
+    let Some(tasks) = load_enabled_tasks(app_state, user_id) else {
+        return;
+    };
+
+    let task_configs: Vec<ScheduledTaskConfig> = tasks
+        .iter()
+        .filter(|t| t.hostname == hostname)
+        .map(task_to_config)
+        .collect();
+
+    if task_configs.is_empty() {
+        return;
+    }
+
+    let count = task_configs.len();
+    if app_state.session_manager.send_to_launcher(
+        &launcher_id,
+        ServerToLauncher::ScheduleSync {
+            tasks: task_configs,
+        },
+    ) {
+        info!(
+            "Sent initial ScheduleSync with {} tasks to launcher '{}'",
+            count, launcher_name
+        );
     }
 }
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -1,8 +1,8 @@
 use axum::extract::ws::WebSocket;
 use diesel::prelude::*;
 use shared::{
-    AgentType, LauncherEndpoint, LauncherToServer, ScheduledTaskConfig, ServerToClient,
-    ServerToLauncher, ServerToProxy, SessionStatus,
+    LauncherEndpoint, LauncherToServer, ServerToClient, ServerToLauncher, ServerToProxy,
+    SessionStatus,
 };
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -187,50 +187,13 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
     );
 
     // Send initial ScheduleSync with the user's scheduled tasks
-    if let Ok(mut db_conn) = app_state.db_pool.get() {
-        use crate::schema::scheduled_tasks;
-        let launcher_hostname = app_state
-            .session_manager
-            .launchers
-            .get(&launcher_id)
-            .map(|l| l.hostname.clone())
-            .unwrap_or_default();
-
-        let tasks: Vec<crate::models::ScheduledTask> = scheduled_tasks::table
-            .filter(scheduled_tasks::user_id.eq(user_id))
-            .filter(scheduled_tasks::enabled.eq(true))
-            .load(&mut db_conn)
-            .unwrap_or_default();
-
-        let task_configs: Vec<ScheduledTaskConfig> = tasks
-            .iter()
-            .filter(|t| t.hostname == launcher_hostname)
-            .map(|t| ScheduledTaskConfig {
-                id: t.id,
-                name: t.name.clone(),
-                cron_expression: t.cron_expression.clone(),
-                timezone: t.timezone.clone(),
-                working_directory: t.working_directory.clone(),
-                prompt: t.prompt.clone(),
-                claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
-                agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
-                enabled: t.enabled,
-                max_runtime_minutes: t.max_runtime_minutes,
-                last_session_id: t.last_session_id,
-            })
-            .collect();
-
-        if !task_configs.is_empty() {
-            let count = task_configs.len();
-            let _ = tx_for_sync.send(ServerToLauncher::ScheduleSync {
-                tasks: task_configs,
-            });
-            info!(
-                "Sent initial ScheduleSync with {} tasks to launcher '{}'",
-                count, launcher_name
-            );
-        }
-    }
+    crate::handlers::scheduled_tasks::send_initial_schedule_sync(
+        &app_state,
+        user_id,
+        launcher_id,
+        &hostname,
+        &launcher_name,
+    );
 
     let continuation_configs =
         super::continuations::load_scheduled_continuations(&app_state, launcher_id, user_id);


### PR DESCRIPTION
Fixes #972.

Single-launcher `send_initial_schedule_sync` variant (broadcast doesn't fit: targets all launchers; always sends even when empty — registration must send nothing on no-match, preserved exactly). Shared `load_enabled_tasks` with the broadcast path; all `ScheduledTaskConfig` construction flows through `task_to_config`. Same sender, same log line.

Note: expect a deliberate conflict with #995's incidental touch of the same registration block — resolution will take this PR's helper call.

Validation: fmt clean, backend clippy `-D warnings` clean, 111/111 tests, workspace check clean.