### PR TITLE
Seed thinking chip odometer across tool-call splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.67
+
+- **Thinking-token chip no longer "resets" after tool calls.** The CLI's `estimated_tokens` is cumulative across a turn, but each tool call or assistant message splits the marker run into a new `Thinking` group, mounting a fresh `CountUp` whose odometer re-raced from 0 up to the full cumulative total — most visibly right after the final edit before the answer. `CountUp` gains a `start` prop (consulted on mount, clamped to `0..=target`), and a new `thinking_chip_starts` pass seeds each chip with the previous burst's peak within the same turn, resetting at turn terminators. The count now reads continuously across splits; if the marker stream ever restarts low, the clamp degrades to a static display rather than a backwards animation. Pinned by a grouping test (`[0, 150, 0]` across a split + terminator).
+
 ## 2.8.66
 
 - **Cargo hygiene: tokio narrowed from `full` to 11 measured features; tower-http to `cors` only; nine deps hoisted to workspace.** The tokio feature set (`fs, io-std, io-util, macros, net, process, rt, rt-multi-thread, signal, sync, time`) was determined by grepping actual per-crate usage, not guesswork — five member crates also dropped their own `features = ["full"]` overrides. tower-http's unused `fs`/`trace`/`compression-full` removed (lockfile −92 lines). `serde`/`serde_json`/`uuid`/`chrono`/`thiserror`/`tracing`/`anyhow`/`hostname`/`directories` now use `workspace = true` across session-lib, claude-session-lib, codex-session-lib, portal-auth, portal-update, proxy, launcher (with per-crate feature additions like chrono `clock` made explicit where crates had been riding feature unification). claude-session-lib's unused `thiserror` and `directories` deps deleted; session-lib's thiserror moved 1→2. WASM targets verified unregressed; all three binaries link.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.66"
+version = "2.8.67"
 dependencies = [
  "anyhow",
  "chrono",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.66"
+version = "2.8.67"
 dependencies = [
  "anyhow",
  "axum",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.66"
+version = "2.8.67"
 dependencies = [
  "anyhow",
  "base64",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.66"
+version = "2.8.67"
 dependencies = [
  "anyhow",
  "base64",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.66"
+version = "2.8.67"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.66"
+version = "2.8.67"
 dependencies = [
  "base64",
  "chrono",
@@ -2609,7 +2609,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.66"
+version = "2.8.67"
 dependencies = [
  "anyhow",
  "colored",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.66"
+version = "2.8.67"
 dependencies = [
  "anyhow",
  "hex",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.66"
+version = "2.8.67"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.66"
+version = "2.8.67"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.66"
+version = "2.8.67"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/count_up.rs
+++ b/frontend/src/components/count_up.rs
@@ -6,9 +6,9 @@
 //! when the target keeps growing (e.g. live `thinking_tokens` estimates arriving
 //! one after another), the number keeps ticking upward smoothly instead of
 //! snapping back to 0 and re-racing on every update. On mount the current value
-//! is 0, so the first reveal still rolls 0→target. The timer is dropped once the
-//! target is reached and on unmount, so historical transcript cards never leave
-//! an interval running.
+//! is `start` (0 by default), so the first reveal rolls start→target. The timer
+//! is dropped once the target is reached and on unmount, so historical
+//! transcript cards never leave an interval running.
 
 use std::cell::Cell;
 use std::rc::Rc;
@@ -27,6 +27,13 @@ const FRAME_MS: u32 = 40;
 pub struct CountUpProps {
     /// Final value to roll up to. Values `<= 0` render a static `0`.
     pub target: i64,
+    /// Value the odometer starts from on mount, clamped to `0..=target`.
+    /// Lets a chip that logically continues an earlier count — e.g. a
+    /// thinking burst whose run was split by a tool call — pick up where its
+    /// predecessor left off instead of re-racing from 0. Consulted only on
+    /// mount; later target changes resume from the displayed value as before.
+    #[prop_or(0)]
+    pub start: i64,
     /// Optional label rendered immediately after the number (e.g. `" thinking"`).
     #[prop_or_default]
     pub suffix: AttrValue,
@@ -39,7 +46,8 @@ pub struct CountUpProps {
 #[function_component(CountUp)]
 pub fn count_up(props: &CountUpProps) -> Html {
     let target = props.target.max(0);
-    let value = use_state(|| 0i64);
+    let initial = props.start.clamp(0, target);
+    let value = use_state(|| initial);
     // Hold the live interval so we can cancel it both when it reaches the target
     // and on unmount (dropping the `Interval` cancels it).
     let interval = use_mut_ref(|| None::<Interval>);

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -334,6 +334,45 @@ pub fn group_is_turn_terminator(group: &MessageGroup) -> bool {
     }
 }
 
+/// Per-group odometer seed for the `thinking` chips: for each group, the
+/// running `thinking_tokens` maximum across *earlier* groups in the same
+/// turn (0 for non-`Thinking` groups).
+///
+/// The Claude CLI's `estimated_tokens` is cumulative across a turn, but a
+/// run of markers gets split into separate `Thinking` groups whenever a
+/// tool call or assistant message lands between them. Each split mounts a
+/// fresh chip whose odometer would otherwise re-race from 0 up to the full
+/// cumulative total — visually "resetting" the count after every tool use,
+/// including the final one before the answer. Seeding each chip with the
+/// previous burst's max keeps the count continuous across splits. The
+/// running max resets at turn terminators so the next turn's first chip
+/// starts from 0 again. Callers clamp the seed to the chip's own target,
+/// so a marker stream that ever restarts low degrades to a static display
+/// rather than a backwards animation.
+pub fn thinking_chip_starts(groups: &[MessageGroup]) -> Vec<i64> {
+    let mut running_max = 0i64;
+    groups
+        .iter()
+        .map(|group| match group {
+            MessageGroup::IdentityGroup {
+                category: GroupCategory::Thinking,
+                messages,
+                ..
+            } => {
+                let start = running_max;
+                running_max = running_max.max(thinking_tokens_estimate(messages));
+                start
+            }
+            _ => {
+                if group_is_turn_terminator(group) {
+                    running_max = 0;
+                }
+                0
+            }
+        })
+        .collect()
+}
+
 /// Walk `messages` and collapse consecutive same-category runs into
 /// `MessageGroup::IdentityGroup`. Mixed / `None` messages become
 /// `MessageGroup::Single`.

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -11,7 +11,7 @@ use yew::prelude::*;
 #[cfg(test)]
 use grouping::classify;
 use grouping::{extract_raw_iso, visible_group_indices, GroupCategory};
-pub use grouping::{group_is_turn_terminator, group_messages, MessageGroup};
+pub use grouping::{group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroup};
 use types::{user_meta_from_json, ClaudeMessage};
 
 /// Format an already-extracted `_created_at` ISO string as local time.
@@ -143,6 +143,12 @@ pub struct MessageGroupRendererProps {
     pub continuation_statuses: HashMap<Uuid, String>,
     #[prop_or_default]
     pub on_schedule_continuation: Callback<Uuid>,
+    /// Odometer seed for `Thinking` groups: the running thinking-token max
+    /// across earlier bursts in the same turn (see
+    /// `grouping::thinking_chip_starts`). Keeps the count continuous when a
+    /// tool call splits a thinking run instead of re-racing each chip from 0.
+    #[prop_or(0)]
+    pub thinking_start: i64,
 }
 
 #[function_component(MessageGroupRenderer)]
@@ -169,13 +175,18 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
             // ticks upward live as more markers stream in.
             if *category == GroupCategory::Thinking {
                 let tokens = grouping::thinking_tokens_estimate(messages);
+                // Seed the odometer with the previous burst's max from this
+                // turn so a run split by a tool call continues counting
+                // instead of re-racing from 0 (clamped inside CountUp, so a
+                // lower-than-seed target renders statically, never reversed).
+                let start = props.thinking_start;
                 return html! {
                     <div class="claude-message thinking-pulse-group" title={ts.unwrap_or_default()}>
                         <div class="message-header">
                             <span class="message-type-badge thinking">{ "thinking" }</span>
                             if tokens > 0 {
                                 <span class="message-count" title={format!("~{} thinking tokens", tokens)}>
-                                    <crate::components::CountUp target={tokens} suffix={" tokens"} compact={true} />
+                                    <crate::components::CountUp target={tokens} {start} suffix={" tokens"} compact={true} />
                                 </span>
                             }
                         </div>
@@ -719,6 +730,68 @@ mod tests {
         assert_eq!(grouping::thinking_tokens_estimate(&messages), 250);
         // No markers / unparseable input yields 0 (chip hides).
         assert_eq!(grouping::thinking_tokens_estimate(&[]), 0);
+    }
+
+    /// When a tool call splits a thinking run, the later chip's odometer is
+    /// seeded with the earlier burst's peak so the (turn-cumulative) count
+    /// continues instead of re-racing from 0. Terminators reset the seed so
+    /// the next turn's first chip starts at 0 again.
+    #[test]
+    fn thinking_chip_starts_seed_across_splits_and_reset_on_terminator() {
+        let result_message = serde_json::json!({
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "duration_ms": 100,
+            "duration_api_ms": 80,
+            "num_turns": 1,
+            "session_id": "01890000-0000-7000-8000-000000000001",
+            "total_cost_usd": 0.0,
+            "_created_at": "2026-05-17T10:00:00.000Z",
+        })
+        .to_string();
+        let messages = vec![
+            // Turn 1, burst 1: climbs to 150.
+            thinking_tokens_message(50),
+            thinking_tokens_message(150),
+            // Tool call splits the run.
+            read_tool_result_user_message("toolu_01"),
+            // Turn 1, burst 2: cumulative continues to 400.
+            thinking_tokens_message(300),
+            thinking_tokens_message(400),
+            result_message,
+            // Turn 2, burst 1: fresh turn, fresh count.
+            thinking_tokens_message(60),
+        ];
+        let groups = group_for_tests(&messages);
+        let starts = grouping::thinking_chip_starts(&groups);
+        assert_eq!(starts.len(), groups.len());
+        // Burst 1 starts at 0; burst 2 is seeded with burst 1's peak; the
+        // turn-2 burst starts at 0 again after the Result terminator.
+        let thinking_starts: Vec<i64> = groups
+            .iter()
+            .zip(&starts)
+            .filter_map(|(g, s)| match g {
+                MessageGroup::IdentityGroup {
+                    category: GroupCategory::Thinking,
+                    ..
+                } => Some(*s),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(thinking_starts, vec![0, 150, 0]);
+        // Non-thinking groups carry a 0 seed.
+        for (g, s) in groups.iter().zip(&starts) {
+            if !matches!(
+                g,
+                MessageGroup::IdentityGroup {
+                    category: GroupCategory::Thinking,
+                    ..
+                }
+            ) {
+                assert_eq!(*s, 0);
+            }
+        }
     }
 
     #[test]

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -24,7 +24,9 @@ pub use confirm_modal::{ConfirmModal, ConfirmModalStyle};
 pub use copy_command::CopyCommand;
 pub use count_up::CountUp;
 pub use launch_dialog::LaunchDialog;
-pub use message_renderer::{group_is_turn_terminator, group_messages, MessageGroupRenderer};
+pub use message_renderer::{
+    group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroupRenderer,
+};
 pub use proxy_token_setup::ProxyTokenSetup;
 pub use schedule_dialog::ScheduleDialog;
 pub use share_dialog::ShareDialog;

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -9,7 +9,9 @@
 //! `tasks_panel.rs`.
 
 use crate::components::message_renderer::MessageRenderer;
-use crate::components::{group_is_turn_terminator, group_messages, MessageGroupRenderer};
+use crate::components::{
+    group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroupRenderer,
+};
 use crate::utils::{self, On401};
 use gloo::timers::callback::Timeout;
 use shared::api::{ErrorMessage, TurnMetricsResponse};
@@ -469,6 +471,9 @@ impl Component for SessionView {
                 }
             })
             .collect();
+        // Seed each thinking chip's odometer with the prior burst's max in
+        // its turn so tool-call splits don't re-race the count from 0.
+        let thinking_starts = thinking_chip_starts(&groups);
 
         html! {
             <div class="session-view">
@@ -478,7 +483,8 @@ impl Component for SessionView {
                             groups.into_iter().enumerate().map(|(i, group)| {
                                 let key = group.key(i);
                                 let metrics = group_metrics.get(i).cloned().flatten();
-                                html! { <MessageGroupRenderer {key} group={group} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
+                                let thinking_start = thinking_starts.get(i).copied().unwrap_or(0);
+                                html! { <MessageGroupRenderer {key} group={group} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} {thinking_start} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
                             }).collect::<Html>()
                         }
                         { for self.pending_sends.iter().enumerate().map(|(i, json)| {


### PR DESCRIPTION
Fixes the thinking-token count visually resetting after tool calls (most noticeably after the final edit of a turn).

Root cause: `estimated_tokens` is turn-cumulative, but tool calls split the marker run into separate `Thinking` groups; each split mounts a fresh `CountUp` that re-races 0 → full cumulative total.

- `CountUp` gains `start` (mount-time seed, clamped to `0..=target` — a low-restarting marker stream degrades to a static display, never a backwards animation)
- New `grouping::thinking_chip_starts(&groups)`: running per-turn thinking max carried into each chip, reset at turn terminators; computed in `SessionView::view()` alongside the existing metrics pairing
- Test pins seeds `[0, 150, 0]` across a tool-call split and a Result terminator

Validation: fmt clean, clippy `-D warnings` clean, 316/316 tests, wasm check clean.