### PR TITLE
Show thinking block signature on label mouseover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.70
+
+- **Thinking blocks expose their encrypted signature on mouseover.** `claude-codes`' `ThinkingBlock` carries a `signature` (the encrypted attestation of the thinking content) alongside `thinking`, but the renderer only ever showed the text. The `thinking` label (`frontend/src/components/message_renderer/renderers/assistant.rs`) now carries a `title` tooltip with the full signature (or "No signature on this thinking block." when absent), and `.thinking-label` gets `cursor: help` + `width: fit-content` so the hover affordance is discoverable and hugs the label text.
+
 ## 2.8.69
 
 - **Codex bash command cards no longer overflow horizontally.** A Codex command rendered into `<pre class="tool-input-content">` (`frontend/src/components/codex_renderer/tools.rs`), but `.tool-input-content` was never styled — so the bare `<pre>` defaulted to `white-space: pre` and a long single-line command ran off the side of the card instead of wrapping, the way Claude's bash card and Codex's own `.tool-result-content` already do. Added a `.tool-input-content` rule to `frontend/styles/tools/base.css` mirroring `.tool-result-content` (`white-space: pre-wrap; word-break: break-word;` plus the shared mono font/size), so the command wraps and stays contained. Also fixes the Codex web-search query `<pre>` that shares the class.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.69"
+version = "2.8.70"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers/assistant.rs
+++ b/frontend/src/components/message_renderer/renderers/assistant.rs
@@ -205,9 +205,14 @@ pub fn render_content_blocks(blocks: &[ContentBlock], session_id: Uuid) -> Html 
                             render_image_source(&img.source, None)
                         }
                         ContentBlock::Thinking(th) => {
+                            let sig_title = if th.signature.is_empty() {
+                                "No signature on this thinking block.".to_string()
+                            } else {
+                                format!("Encrypted thinking signature:\n{}", th.signature)
+                            };
                             html! {
                                 <div class="thinking-block">
-                                    <span class="thinking-label">{ "thinking" }</span>
+                                    <span class="thinking-label" title={sig_title}>{ "thinking" }</span>
                                     if th.thinking.trim().is_empty() {
                                         <div class="thinking-content muted" title="Thinking text was omitted by the model; the encrypted signature is preserved in the raw message.">
                                             { "thinking omitted" }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -752,7 +752,9 @@
     letter-spacing: 0.05em;
     color: var(--text-muted);
     display: block;
+    width: fit-content;
     margin-bottom: 0.25rem;
+    cursor: help;
 }
 
 .thinking-content {


### PR DESCRIPTION
## What
`claude-codes`' `ThinkingBlock` carries a `signature` field (the encrypted attestation of the thinking content) alongside `thinking`, but the renderer only ever displayed the text. This surfaces the signature as a hover tooltip on the `thinking` label.

## Change
- `frontend/src/components/message_renderer/renderers/assistant.rs`: the `thinking` label now has a `title` showing the full signature (or "No signature on this thinking block." when empty — e.g. streaming/omitted cases).
- `frontend/styles/messages.css`: `.thinking-label` gets `cursor: help` + `width: fit-content` so the hover affordance is discoverable and the hover target hugs the label text rather than spanning the full row.

## Verify
`cargo check -p frontend --target wasm32-unknown-unknown` passes.

Version bumped 2.8.69 → 2.8.70; CHANGELOG updated.