### PR TITLE
Render Codex collabAgentToolCall spawnAgent items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.71
+
+- **Codex `collabAgentToolCall` / `spawnAgent` items now render as a tool card (closes #1049).** Codex's multi-agent collaboration calls aren't modeled in the `codex-codes` `ThreadItem`, so they previously fell through to the raw-JSON fallback card. Added a local mirror `CollabAgentToolCallItem` (+ `AgentState`) to the `#[serde(untagged)] CodexItem` enum in `frontend/src/components/codex_renderer/events.rs` — same pattern as the existing `ContextCompactionItem` mirror — tagged `TODO(SDK)` pending an upstream `codex-codes` variant. `render_collab_agent_tool_call` (`codex_renderer/tools.rs`) shows a 🤖 "Spawn Agent" card: status + model + reasoning effort as meta, the spawn prompt as expandable `pre`, and a compact child-agent list (thread id → status). Dispatched in `codex_renderer.rs`; sparkline `classify_codex_event` updated for exhaustiveness. New deserialization test from the real wire payload; 317 frontend tests pass.
+
 ## 2.8.70
 
 - **Thinking blocks expose their encrypted signature on mouseover.** `claude-codes`' `ThinkingBlock` carries a `signature` (the encrypted attestation of the thinking content) alongside `thinking`, but the renderer only ever showed the text. The `thinking` label (`frontend/src/components/message_renderer/renderers/assistant.rs`) now carries a `title` tooltip with the full signature (or "No signature on this thinking block." when absent), and `.thinking-label` gets `cursor: help` + `width: fit-content` so the hover affordance is discoverable and hugs the label text.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.68"
+version = "2.8.71"
 dependencies = [
  "anyhow",
  "chrono",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.68"
+version = "2.8.71"
 dependencies = [
  "anyhow",
  "axum",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.68"
+version = "2.8.71"
 dependencies = [
  "anyhow",
  "base64",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.68"
+version = "2.8.71"
 dependencies = [
  "anyhow",
  "base64",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.68"
+version = "2.8.71"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.68"
+version = "2.8.71"
 dependencies = [
  "base64",
  "chrono",
@@ -2609,7 +2609,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.68"
+version = "2.8.71"
 dependencies = [
  "anyhow",
  "colored",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.68"
+version = "2.8.71"
 dependencies = [
  "anyhow",
  "hex",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.68"
+version = "2.8.71"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.68"
+version = "2.8.71"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.70"
+version = "2.8.71"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -14,8 +14,8 @@ use events::thread_item_id;
 pub use events::{codex_event_item_id, is_codex_terminal_event, CodexEvent, CodexItem};
 use events::{CodexError, CodexUsage, ContextCompactedParams, TurnPlanStep};
 use tools::{
-    render_command_execution, render_diff_card, render_file_change, render_mcp_tool_call,
-    render_todo_list, render_web_search,
+    render_collab_agent_tool_call, render_command_execution, render_diff_card, render_file_change,
+    render_mcp_tool_call, render_todo_list, render_web_search,
 };
 
 // --- Components ---
@@ -144,6 +144,7 @@ fn render_item(item: Option<&CodexItem>, completed: bool, session_id: Uuid) -> H
     };
     match item {
         CodexItem::ContextCompaction(_) => render_context_compaction_item(completed),
+        CodexItem::CollabAgentToolCall(it) => render_collab_agent_tool_call(it, completed),
         CodexItem::Thread(item) => match item {
             ThreadItem::AgentMessage(it) => render_agent_message(&it.text, completed, session_id),
             ThreadItem::Reasoning(it) => render_reasoning(&it.text, completed),
@@ -698,6 +699,66 @@ mod tests {
         assert_eq!(
             codex_event_item_id(json).as_deref(),
             Some("9edb35c0-6b6b-407f-84e3-d03a03050a2a")
+        );
+    }
+
+    /// agent-portal#1049 — Codex emits multi-agent `collabAgentToolCall`
+    /// items (e.g. `spawnAgent`) that codex-codes does not model as a
+    /// `ThreadItem` variant. They must parse into the local
+    /// `CodexItem::CollabAgentToolCall` mirror and render through the spawn-agent
+    /// card, not fall through to the raw JSON renderer.
+    #[test]
+    fn event_item_completed_collab_agent_tool_call() {
+        let json = r#"{
+            "type": "item.completed",
+            "item": {
+                "type": "collabAgentToolCall",
+                "tool": "spawnAgent",
+                "id": "call_i1HC5jbTllWgsrMnJjqmRU05",
+                "model": "gpt-5.5",
+                "reasoningEffort": "medium",
+                "status": "completed",
+                "senderThreadId": "019ed195-44b1-77e0-a234-10307ce08eac",
+                "receiverThreadIds": ["019ed247-768f-7603-8c71-911fd841766e"],
+                "agentsStates": {
+                    "019ed247-768f-7603-8c71-911fd841766e": { "status": "pendingInit" }
+                },
+                "prompt": "In /home/... inspect the current main branch shape ..."
+            }
+        }"#;
+        let event: CodexEvent = serde_json::from_str(json).unwrap();
+        let CodexEvent::ItemCompleted {
+            item: Some(CodexItem::CollabAgentToolCall(item)),
+        } = event
+        else {
+            panic!(
+                "expected ItemCompleted{{CollabAgentToolCall}}, got {:?}",
+                event
+            );
+        };
+        assert_eq!(item.id, "call_i1HC5jbTllWgsrMnJjqmRU05");
+        assert_eq!(item.tool.as_deref(), Some("spawnAgent"));
+        assert_eq!(item.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(item.reasoning_effort.as_deref(), Some("medium"));
+        assert_eq!(item.status.as_deref(), Some("completed"));
+        assert_eq!(
+            item.sender_thread_id.as_deref(),
+            Some("019ed195-44b1-77e0-a234-10307ce08eac")
+        );
+        assert_eq!(
+            item.receiver_thread_ids,
+            vec!["019ed247-768f-7603-8c71-911fd841766e".to_string()]
+        );
+        assert_eq!(item.agents_states.len(), 1);
+        assert_eq!(
+            item.agents_states["019ed247-768f-7603-8c71-911fd841766e"].status,
+            "pendingInit"
+        );
+        assert!(item.prompt.as_deref().unwrap().contains("main branch"));
+
+        assert_eq!(
+            codex_event_item_id(json).as_deref(),
+            Some("call_i1HC5jbTllWgsrMnJjqmRU05")
         );
     }
 

--- a/frontend/src/components/codex_renderer/events.rs
+++ b/frontend/src/components/codex_renderer/events.rs
@@ -96,6 +96,8 @@ pub enum CodexItem {
     // TODO(SDK #930): move this variant to codex-codes once the generated
     // ThreadItem model includes `contextCompaction`.
     ContextCompaction(ContextCompactionItem),
+    // TODO(SDK): codex-codes has no collabAgentToolCall ThreadItem variant; local mirror — see agent-portal#1049
+    CollabAgentToolCall(CollabAgentToolCallItem),
     Thread(ThreadItem),
 }
 
@@ -110,6 +112,50 @@ pub struct ContextCompactionItem {
 enum ContextCompactionItemType {
     #[serde(rename = "contextCompaction", alias = "context_compaction")]
     ContextCompaction,
+}
+
+/// Local mirror of Codex's `collabAgentToolCall` item (multi-agent
+/// collaboration: `spawnAgent` and friends). codex-codes does not model this
+/// as a `ThreadItem` variant yet, so it would otherwise fall through to the
+/// raw-JSON renderer. See agent-portal#1049.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollabAgentToolCallItem {
+    pub id: String,
+    /// Discriminant gate for the untagged `CodexItem` enum — without a typed
+    /// `type` field this struct (all-optional otherwise) would shadow every
+    /// upstream `ThreadItem` carrying an `id`.
+    #[serde(rename = "type")]
+    item_type: CollabAgentToolCallItemType,
+    /// The collaboration tool invoked, e.g. `"spawnAgent"`.
+    #[serde(default)]
+    pub tool: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default, rename = "reasoningEffort", alias = "reasoning_effort")]
+    pub reasoning_effort: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default, rename = "senderThreadId", alias = "sender_thread_id")]
+    pub sender_thread_id: Option<String>,
+    #[serde(default, rename = "receiverThreadIds", alias = "receiver_thread_ids")]
+    pub receiver_thread_ids: Vec<String>,
+    /// Child-agent thread id → its current state.
+    #[serde(default, rename = "agentsStates", alias = "agents_states")]
+    pub agents_states: std::collections::BTreeMap<String, AgentState>,
+    #[serde(default)]
+    pub prompt: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum CollabAgentToolCallItemType {
+    #[serde(rename = "collabAgentToolCall", alias = "collab_agent_tool_call")]
+    CollabAgentToolCall,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentState {
+    #[serde(default)]
+    pub status: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -292,6 +338,7 @@ pub fn thread_item_id(item: &ThreadItem) -> &str {
 pub fn codex_item_id(item: &CodexItem) -> &str {
     match item {
         CodexItem::ContextCompaction(it) => &it.id,
+        CodexItem::CollabAgentToolCall(it) => &it.id,
         CodexItem::Thread(it) => thread_item_id(it),
     }
 }

--- a/frontend/src/components/codex_renderer/tools.rs
+++ b/frontend/src/components/codex_renderer/tools.rs
@@ -1,3 +1,4 @@
+use super::events::CollabAgentToolCallItem;
 use super::item_card_classes;
 use crate::components::diff::{DiffCard, DiffSource};
 use crate::components::expandable::ExpandableText;
@@ -227,4 +228,73 @@ pub(super) fn render_todo_list(items: &[TodoItem], completed: bool) -> Html {
         </div>
     };
     tool_card("\u{2611}", "Todo List".into(), None, body, completed)
+}
+
+pub(super) fn render_collab_agent_tool_call(it: &CollabAgentToolCallItem, completed: bool) -> Html {
+    // Card title: "Spawn Agent" for the common spawnAgent tool, otherwise
+    // surface the raw tool name so unrecognized collaboration tools still read.
+    let name = match it.tool.as_deref() {
+        Some("spawnAgent") | None => "Spawn Agent".to_string(),
+        Some(other) => format!("Agent: {}", other),
+    };
+
+    // Status line mirrors render_command_execution's composition: the item
+    // status plus model + reasoning-effort meta when present.
+    let mut status_text = it
+        .status
+        .clone()
+        .unwrap_or_else(|| "running...".to_string());
+    let mut meta_bits: Vec<String> = Vec::new();
+    if let Some(model) = it.model.as_deref().filter(|s| !s.is_empty()) {
+        meta_bits.push(model.to_string());
+    }
+    if let Some(effort) = it.reasoning_effort.as_deref().filter(|s| !s.is_empty()) {
+        meta_bits.push(format!("effort: {}", effort));
+    }
+    if !meta_bits.is_empty() {
+        status_text = format!("{} \u{00b7} {}", status_text, meta_bits.join(" \u{00b7} "));
+    }
+
+    let prompt = it.prompt.as_deref().unwrap_or("");
+
+    let body = html! {
+        <>
+            {
+                if !prompt.is_empty() {
+                    html! {
+                        <ExpandableText
+                            full_text={prompt.to_string()}
+                            max_len=500
+                            tag="pre"
+                            class={classes!("tool-input-content")}
+                        />
+                    }
+                } else {
+                    html! {}
+                }
+            }
+            {
+                if !it.agents_states.is_empty() {
+                    html! {
+                        <div class="codex-todo-list">
+                            { for it.agents_states.iter().map(|(thread_id, state)| {
+                                html! {
+                                    <div class="codex-todo">
+                                        <span class="codex-todo-marker">{ "\u{1F916}" }</span>
+                                        <span class="codex-todo-text">
+                                            { format!("{} \u{2014} {}", thread_id, state.status) }
+                                        </span>
+                                    </div>
+                                }
+                            })}
+                        </div>
+                    }
+                } else {
+                    html! {}
+                }
+            }
+        </>
+    };
+
+    tool_card("\u{1F916}", name, Some(status_text), body, completed)
 }

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -231,7 +231,9 @@ fn classify_codex_event(output: &str) -> Option<ActivityTag> {
         CodexEvent::ItemStarted { item: Some(item) }
         | CodexEvent::ItemUpdated { item: Some(item) }
         | CodexEvent::ItemCompleted { item: Some(item) } => match item {
-            CodexItem::ContextCompaction(_) => Some(ActivityTag::Assistant),
+            CodexItem::ContextCompaction(_) | CodexItem::CollabAgentToolCall(_) => {
+                Some(ActivityTag::Assistant)
+            }
             CodexItem::Thread(ThreadItem::Error(_)) => Some(ActivityTag::Error),
             CodexItem::Thread(ThreadItem::CommandExecution(ref it))
                 if command_execution_reads_file(&it.command) =>


### PR DESCRIPTION
Closes #1049.

## Problem
Codex's multi-agent collaboration calls (`type: "collabAgentToolCall"`, `tool: "spawnAgent"`) aren't modeled in the `codex-codes` `ThreadItem`, so they fell through the typed model to the raw-JSON fallback card instead of rendering as a proper tool card.

## Change
- `frontend/src/components/codex_renderer/events.rs`: added a local mirror `CollabAgentToolCallItem` (+ `AgentState`) and a `CodexItem::CollabAgentToolCall` variant on the `#[serde(untagged)]` enum — same established pattern as the existing `ContextCompactionItem` mirror. Tagged `TODO(SDK)` pending an upstream `codex-codes` `ThreadItem` variant.
- `frontend/src/components/codex_renderer/tools.rs`: `render_collab_agent_tool_call` — 🤖 "Spawn Agent" card with status + model + reasoning-effort meta, the spawn prompt as an expandable `pre`, and a compact child-agent list (thread id → status).
- `frontend/src/components/codex_renderer.rs`: dispatch + new deserialization test built from the real wire payload.
- `frontend/src/pages/dashboard/session_view/helpers.rs`: `classify_codex_event` updated for match exhaustiveness.

## Verify
`cargo check -p frontend --target wasm32-unknown-unknown` clean; `cargo clippy -p frontend --target wasm32-unknown-unknown` no warnings; 317 frontend tests pass.

Version 2.8.70 → 2.8.71; CHANGELOG updated.