### PR TITLE
Bundle spawn_ws_reader channels into a struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.72
+
+- **`spawn_ws_reader` no longer takes 11 arguments (closes #1052).** The reader's eight `mpsc`/`oneshot` senders are bundled into a new `WsReaderChannels` struct (`claude-session-lib/src/proxy_session/ws_reader.rs`), dropping the signature to three params (`ws_read`, `channels`, `heartbeat`) and removing the `#[allow(clippy::too_many_arguments)]` plus its stale `// TODO … issue #271` comment (the referenced issue was closed without the refactor being done). The struct is destructured at the top of the function so the body and the call site (`proxy_session/mod.rs`) are otherwise unchanged — pure mechanical refactor, no behavior change. Clippy passes with the allow removed.
+
 ## 2.8.71
 
 - **Codex `collabAgentToolCall` / `spawnAgent` items now render as a tool card (closes #1049).** Codex's multi-agent collaboration calls aren't modeled in the `codex-codes` `ThreadItem`, so they previously fell through to the raw-JSON fallback card. Added a local mirror `CollabAgentToolCallItem` (+ `AgentState`) to the `#[serde(untagged)] CodexItem` enum in `frontend/src/components/codex_renderer/events.rs` — same pattern as the existing `ContextCompactionItem` mirror — tagged `TODO(SDK)` pending an upstream `codex-codes` variant. `render_collab_agent_tool_call` (`codex_renderer/tools.rs`) shows a 🤖 "Spawn Agent" card: status + model + reasoning effort as meta, the spawn prompt as expandable `pre`, and a compact child-agent list (thread id → status). Dispatched in `codex_renderer.rs`; sparkline `classify_codex_event` updated for exhaustiveness. New deserialization test from the real wire payload; 317 frontend tests pass.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.71"
+version = "2.8.72"
 dependencies = [
  "anyhow",
  "chrono",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.71"
+version = "2.8.72"
 dependencies = [
  "anyhow",
  "axum",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.71"
+version = "2.8.72"
 dependencies = [
  "anyhow",
  "base64",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.71"
+version = "2.8.72"
 dependencies = [
  "anyhow",
  "base64",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.71"
+version = "2.8.72"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.71"
+version = "2.8.72"
 dependencies = [
  "base64",
  "chrono",
@@ -2609,7 +2609,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.71"
+version = "2.8.72"
 dependencies = [
  "anyhow",
  "colored",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.71"
+version = "2.8.72"
 dependencies = [
  "anyhow",
  "hex",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.71"
+version = "2.8.72"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.71"
+version = "2.8.72"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.71"
+version = "2.8.72"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -34,7 +34,9 @@ use git_metadata::{
 };
 use output_forwarder::spawn_output_forwarder;
 use wiggum::{handle_session_event_with_wiggum, WiggumState};
-use ws_reader::{spawn_ws_reader, FileDownloadEvent, FileReceiveState, FileUploadEvent};
+use ws_reader::{
+    spawn_ws_reader, FileDownloadEvent, FileReceiveState, FileUploadEvent, WsReaderChannels,
+};
 
 /// Type alias for the native WebSocket connection
 pub type NativeConnection = ws_bridge::native_client::Connection<SessionEndpoint>;
@@ -766,16 +768,18 @@ async fn run_message_loop<A: Agent>(
     // Spawn WebSocket reader task
     let reader_task = spawn_ws_reader(
         ws_read,
-        session.input_tx.clone(),
-        perm_tx,
-        ack_tx,
-        disconnect_tx,
-        wiggum_tx,
-        graceful_shutdown_tx,
-        session_terminated_tx,
+        WsReaderChannels {
+            input_tx: session.input_tx.clone(),
+            perm_tx,
+            ack_tx,
+            disconnect_tx,
+            wiggum_tx,
+            graceful_shutdown_tx,
+            session_terminated_tx,
+            file_upload_tx,
+            file_download_tx,
+        },
         heartbeat.clone(),
-        file_upload_tx,
-        file_download_tx,
     );
 
     // Create connection state (per-connection channels and timing)

--- a/claude-session-lib/src/proxy_session/ws_reader.rs
+++ b/claude-session-lib/src/proxy_session/ws_reader.rs
@@ -111,21 +111,39 @@ pub(super) enum WsMessageResult {
     SessionTerminated,
 }
 
+/// Outbound channels the WebSocket reader dispatches received messages into.
+///
+/// Bundles every `mpsc`/`oneshot` sender used by [`spawn_ws_reader`] so the
+/// spawn signature stays small. Field names mirror the call-site locals.
+pub(super) struct WsReaderChannels {
+    pub input_tx: mpsc::UnboundedSender<super::PortalInput>,
+    pub perm_tx: mpsc::UnboundedSender<PermissionResponseData>,
+    pub ack_tx: mpsc::UnboundedSender<u64>,
+    pub disconnect_tx: tokio::sync::oneshot::Sender<()>,
+    pub wiggum_tx: mpsc::UnboundedSender<super::PortalInput>,
+    pub graceful_shutdown_tx: mpsc::UnboundedSender<GracefulShutdown>,
+    pub session_terminated_tx: tokio::sync::oneshot::Sender<()>,
+    pub file_upload_tx: mpsc::UnboundedSender<FileUploadEvent>,
+    pub file_download_tx: mpsc::UnboundedSender<FileDownloadEvent>,
+}
+
 /// Spawn the WebSocket reader task
-#[allow(clippy::too_many_arguments)] // TODO: refactor to event enum (issue #271)
 pub(super) fn spawn_ws_reader(
     mut ws_read: WsRead,
-    input_tx: mpsc::UnboundedSender<super::PortalInput>,
-    perm_tx: mpsc::UnboundedSender<PermissionResponseData>,
-    ack_tx: mpsc::UnboundedSender<u64>,
-    disconnect_tx: tokio::sync::oneshot::Sender<()>,
-    wiggum_tx: mpsc::UnboundedSender<super::PortalInput>,
-    graceful_shutdown_tx: mpsc::UnboundedSender<GracefulShutdown>,
-    session_terminated_tx: tokio::sync::oneshot::Sender<()>,
+    channels: WsReaderChannels,
     heartbeat: session_lib::heartbeat::HeartbeatTracker,
-    file_upload_tx: mpsc::UnboundedSender<FileUploadEvent>,
-    file_download_tx: mpsc::UnboundedSender<FileDownloadEvent>,
 ) -> tokio::task::JoinHandle<()> {
+    let WsReaderChannels {
+        input_tx,
+        perm_tx,
+        ack_tx,
+        disconnect_tx,
+        wiggum_tx,
+        graceful_shutdown_tx,
+        session_terminated_tx,
+        file_upload_tx,
+        file_download_tx,
+    } = channels;
     tokio::spawn(async move {
         while let Some(result) = ws_read.recv().await {
             match result {


### PR DESCRIPTION
Closes #1052.

## Problem
`spawn_ws_reader` took 11 arguments (8 `mpsc`/`oneshot` senders plus stream + tracker), suppressed with `#[allow(clippy::too_many_arguments)]`. Its `// TODO: refactor to event enum (issue #271)` pointed at a CLOSED issue whose refactor was never done.

## Change
- `claude-session-lib/src/proxy_session/ws_reader.rs`: new `WsReaderChannels` struct bundles the eight senders; `spawn_ws_reader` now takes `(ws_read, channels, heartbeat)`. The struct is destructured at the top of the function, so the body is byte-for-byte unchanged. Removed the `#[allow]` and the stale TODO.
- `claude-session-lib/src/proxy_session/mod.rs`: call site constructs `WsReaderChannels { … }`; import updated.

Pure mechanical refactor — no behavior change.

## Verify
`cargo clippy -p claude-session-lib` is clean **with the `#[allow]` removed** (no `too_many_arguments` warning returns); `cargo fmt` applied.

Version 2.8.71 → 2.8.72; CHANGELOG updated.