### PR TITLE
Count sub-agent tokens in Claude session totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.73
+
+- **Session token totals now include sub-agent (Task tool) tokens for Claude sessions.** `store_result_metadata` wrote `sessions.output_tokens` straight from `result.usage`, which covers only the *parent* conversation — sub-agents (Explore/Plan/etc.) run as separate API conversations whose tokens arrive on `task_notification` frames (`TaskUsage.total_tokens`) and were never aggregated, so per-session totals and the admin spend dashboard under-counted. `SessionManager` gains a `subagent_tokens` map; each completed `task_notification` (the SDK emits it once per task, with cumulative `total_tokens`) adds into the session's running total, and `store_result_metadata` folds that into `output_tokens` at result time. Cost (`total_cost_usd`) was already inclusive via the CLI's session-wide figure, so this closes the cost-right/tokens-low asymmetry. New `task_notification_exposes_total_tokens` test pins the wire contract the fold depends on. (Codex sub-agent tokens are a separate path with an unresolved delivery question and are not covered here. The per-turn `turn_metrics` footer is also a separate path, unchanged.)
+
 ## 2.8.72
 
 - **`spawn_ws_reader` no longer takes 11 arguments (closes #1052).** The reader's eight `mpsc`/`oneshot` senders are bundled into a new `WsReaderChannels` struct (`claude-session-lib/src/proxy_session/ws_reader.rs`), dropping the signature to three params (`ws_read`, `channels`, `heartbeat`) and removing the `#[allow(clippy::too_many_arguments)]` plus its stale `// TODO … issue #271` comment (the referenced issue was closed without the refactor being done). The struct is destructured at the top of the function so the body and the call site (`proxy_session/mod.rs`) are otherwise unchanged — pure mechanical refactor, no behavior change. Clippy passes with the allow removed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.72"
+version = "2.8.73"
 dependencies = [
  "anyhow",
  "chrono",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.72"
+version = "2.8.73"
 dependencies = [
  "anyhow",
  "axum",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.72"
+version = "2.8.73"
 dependencies = [
  "anyhow",
  "base64",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.72"
+version = "2.8.73"
 dependencies = [
  "anyhow",
  "base64",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.72"
+version = "2.8.73"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.72"
+version = "2.8.73"
 dependencies = [
  "base64",
  "chrono",
@@ -2609,7 +2609,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.72"
+version = "2.8.73"
 dependencies = [
  "anyhow",
  "colored",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.72"
+version = "2.8.73"
 dependencies = [
  "anyhow",
  "hex",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.72"
+version = "2.8.73"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.72"
+version = "2.8.73"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.72"
+version = "2.8.73"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -155,11 +155,29 @@ pub fn handle_claude_output(
                         content
                     );
                 }
-                if sys.is_task_notification() && sys.as_task_notification().is_none() {
-                    warn!(
-                        "task_notification message matched subtype but failed struct parse: {}",
-                        content
-                    );
+                if sys.is_task_notification() {
+                    match sys.as_task_notification() {
+                        Some(notif) => {
+                            // A sub-agent (Task tool) just finished. Its tokens
+                            // aren't in the parent's `result.usage`, so fold the
+                            // completed task's cumulative `total_tokens` into the
+                            // session's running sub-agent total (see
+                            // `SessionManager::subagent_tokens`). `task_notification`
+                            // fires once per task, so summing is exact.
+                            if let (Some(sid), Some(usage)) = (db_session_id, notif.usage.as_ref())
+                            {
+                                session_manager
+                                    .subagent_tokens
+                                    .entry(sid)
+                                    .and_modify(|v| *v += usage.total_tokens as i64)
+                                    .or_insert(usage.total_tokens as i64);
+                            }
+                        }
+                        None => warn!(
+                            "task_notification message matched subtype but failed struct parse: {}",
+                            content
+                        ),
+                    }
                 }
             }
         }
@@ -255,7 +273,12 @@ pub fn handle_claude_output(
             }
 
             if role == shared::MessageRole::Result {
-                store_result_metadata(&mut conn, session_id, &content);
+                let subagent_tokens = session_manager
+                    .subagent_tokens
+                    .get(&session_id)
+                    .map(|v| *v)
+                    .unwrap_or(0);
+                store_result_metadata(&mut conn, session_id, &content, subagent_tokens);
             }
 
             session_manager.queue_truncation(session_id);
@@ -306,10 +329,14 @@ pub fn handle_claude_output(
 /// Extract and store cost and token usage from result messages.
 /// Tries typed deserialization via `claude_codes::io::ResultMessage` first,
 /// falls back to manual JSON extraction for forward compatibility.
+/// `subagent_tokens` is the session's running total of sub-agent (Task tool)
+/// tokens, folded into `output_tokens` because `result.usage` covers only the
+/// parent conversation. See `SessionManager::subagent_tokens`.
 fn store_result_metadata(
     conn: &mut diesel::PgConnection,
     session_id: Uuid,
     content: &serde_json::Value,
+    subagent_tokens: i64,
 ) {
     use crate::schema::sessions;
 
@@ -326,7 +353,7 @@ fn store_result_metadata(
             if let Err(e) = diesel::update(sessions::table.find(session_id))
                 .set((
                     sessions::input_tokens.eq(usage.input_tokens as i64),
-                    sessions::output_tokens.eq(usage.output_tokens as i64),
+                    sessions::output_tokens.eq(usage.output_tokens as i64 + subagent_tokens),
                     sessions::cache_creation_tokens.eq(usage.cache_creation_input_tokens as i64),
                     sessions::cache_read_tokens.eq(usage.cache_read_input_tokens as i64),
                 ))
@@ -371,7 +398,7 @@ fn store_result_metadata(
         if let Err(e) = diesel::update(sessions::table.find(session_id))
             .set((
                 sessions::input_tokens.eq(input_tokens.unwrap_or(0)),
-                sessions::output_tokens.eq(output_tokens.unwrap_or(0)),
+                sessions::output_tokens.eq(output_tokens.unwrap_or(0) + subagent_tokens),
                 sessions::cache_creation_tokens.eq(cache_creation.unwrap_or(0)),
                 sessions::cache_read_tokens.eq(cache_read.unwrap_or(0)),
             ))
@@ -444,5 +471,31 @@ mod tests {
         assert_eq!(parse_send_mode("normal"), Some(SendMode::Normal));
         assert_eq!(parse_send_mode("wiggum"), Some(SendMode::Wiggum));
         assert_eq!(parse_send_mode("unknown"), None);
+    }
+
+    /// Guards the wire contract the sub-agent token fold relies on: a
+    /// `task_notification` system message must parse and expose
+    /// `usage.total_tokens`. If the SDK reshapes this, the fold silently stops
+    /// counting — so pin it.
+    #[test]
+    fn task_notification_exposes_total_tokens() {
+        let content = serde_json::json!({
+            "type": "system",
+            "subtype": "task_notification",
+            "session_id": "s1",
+            "task_id": "t1",
+            "status": "completed",
+            "summary": "done",
+            "usage": { "duration_ms": 1000, "tool_uses": 3, "total_tokens": 68694 }
+        });
+        let parsed = shared::ClaudeOutput::deserialize(&content).expect("parses as ClaudeOutput");
+        let shared::ClaudeOutput::System(sys) = parsed else {
+            panic!("expected a system message");
+        };
+        assert!(sys.is_task_notification());
+        let notif = sys
+            .as_task_notification()
+            .expect("task_notification struct parse");
+        assert_eq!(notif.usage.expect("usage present").total_tokens, 68694);
     }
 }

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -53,6 +53,14 @@ pub struct SessionManager {
     pub pending_launch_sessions: Arc<DashMap<Uuid, Uuid>>,
     /// Tracks who sent the last input for each session (session_id → (user_id, display_name))
     pub last_input_sender: Arc<DashMap<Uuid, (Uuid, String)>>,
+    /// Running lifetime total of sub-agent (Task tool) tokens per session.
+    /// Claude's `result.usage` reports only the parent conversation; sub-agents
+    /// run as separate API conversations whose tokens arrive on `task_notification`
+    /// frames (`TaskUsage.total_tokens`, cumulative-per-task, emitted once at
+    /// completion). We sum each completed task's total here and fold it into the
+    /// session's `output_tokens` at result time so session totals (and the admin
+    /// spend dashboard) don't under-count sub-agent usage.
+    pub subagent_tokens: Arc<DashMap<Uuid, i64>>,
     /// Monotonic counter for connection generations (prevents stale cleanup)
     gen_counter: Arc<AtomicU64>,
     /// Current connection generation per session
@@ -75,6 +83,7 @@ impl Default for SessionManager {
             pending_file_downloads: Arc::new(DashMap::new()),
             pending_launch_sessions: Arc::new(DashMap::new()),
             last_input_sender: Arc::new(DashMap::new()),
+            subagent_tokens: Arc::new(DashMap::new()),
             gen_counter: Arc::new(AtomicU64::new(1)),
             connection_gen: Arc::new(DashMap::new()),
         }


### PR DESCRIPTION
Folds Claude sub-agent (Task tool) token usage into session token totals, per the investigation that confirmed the under-count. Scoped to Claude sessions, folding into `output_tokens` (no migration), as requested.

## Problem
`store_result_metadata` set `sessions.output_tokens` from `result.usage` only — the **parent** conversation. Sub-agents (Explore/Plan/etc.) run as separate API conversations; their tokens arrive on `task_notification` system frames (`TaskUsage.total_tokens`) and were never aggregated. So per-session token totals and the admin spend dashboard under-counted. (Cost was already correct — `total_cost_usd` is the CLI's session-wide figure — which is exactly the cost-right/tokens-low tell.)

## Change
- `SessionManager` gains `subagent_tokens: DashMap<Uuid, i64>` — a running lifetime total per session.
- In `handle_claude_output`, each completed `task_notification` (emitted once per task, carrying cumulative `total_tokens`) adds into that session's total.
- `store_result_metadata` takes the accumulated `subagent_tokens` and folds it into `output_tokens` (both the typed and the JSON-fallback write paths).
- New `task_notification_exposes_total_tokens` test pins the wire contract the fold relies on (catches an SDK reshape that would silently stop counting).

## Semantics note
Accumulated lifetime-cumulative (not reset per turn) so `output_tokens` tracks alongside the session-cumulative `total_cost_usd` and stays meaningful under the admin dashboard's cross-session `SUM`.

## Out of scope
- **Codex** sub-agent (`spawnAgent`) tokens — separate path with an unresolved question of whether child-thread usage is even delivered to the parent.
- The per-turn `turn_metrics` footer/pill — a separate proxy-side path (`claude-session-lib/io_task.rs`); can fold there too as a follow-up if you want the live per-turn number to include sub-agents.

## Verify
`cargo build -p backend`, `cargo clippy -p backend` clean; new test passes.

Version 2.8.72 → 2.8.73; CHANGELOG updated.