### PR TITLE
Add free-text answer to AskUserQuestion frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.76
+
+- **AskUserQuestion frames now have a free-text "something else" answer.** The interactive question dialog (`permission_dialog.rs` `render_ask_user_question`) previously only let you pick a preset option, railroading you when none fit. Each question now has a `Something else…` text row; typing sets that question's answer to your custom text, and it shows as selected (matching no option / multi-select join). A blank field un-answers the question (`permission_handler.rs` removes rather than stores an empty string), so it doesn't falsely satisfy the submit gate. Because Codex's `ToolRequestUserInput` is normalized to the same `AskUserQuestion` permission shape and rendered by this same frame, both Claude and Codex questions get the escape hatch from one change. CSS for the input in `permissions.css`. 317 frontend tests pass.
+
 ## 2.8.75
 
 - **Launch/restore hardening, phase 1 of 4: typed exit reason + deterministic resume.** First slice of the session launch/restore refactor. Two structural gaps fixed:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.75"
+version = "2.8.76"
 dependencies = [
  "anyhow",
  "chrono",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.75"
+version = "2.8.76"
 dependencies = [
  "anyhow",
  "axum",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.75"
+version = "2.8.76"
 dependencies = [
  "anyhow",
  "base64",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.75"
+version = "2.8.76"
 dependencies = [
  "anyhow",
  "base64",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.75"
+version = "2.8.76"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.75"
+version = "2.8.76"
 dependencies = [
  "base64",
  "chrono",
@@ -2611,7 +2611,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.75"
+version = "2.8.76"
 dependencies = [
  "anyhow",
  "colored",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.75"
+version = "2.8.76"
 dependencies = [
  "anyhow",
  "hex",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.75"
+version = "2.8.76"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.75"
+version = "2.8.76"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.75"
+version = "2.8.76"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/permission_dialog.rs
+++ b/frontend/src/pages/dashboard/permission_dialog.rs
@@ -1,7 +1,7 @@
 //! Permission dialog components for tool authorization and user questions
 
 use std::collections::{HashMap, HashSet};
-use web_sys::KeyboardEvent;
+use web_sys::{HtmlInputElement, KeyboardEvent};
 use yew::prelude::*;
 
 use shared::{AllowedPrompt, ToolInput};
@@ -304,6 +304,53 @@ fn render_ask_user_question(props: &PermissionDialogProps, parsed: &AskUserQuest
                                         }
                                     }).collect::<Html>()
                                 }
+                                { {
+                                    // Free-text escape hatch so users aren't railroaded into
+                                    // the preset options (mirrors AskUserQuestion's built-in
+                                    // "Other"). Covers Claude and Codex, which share this frame.
+                                    // The answer is whatever is typed; it's "selected" when the
+                                    // current answer matches no option (single) or the toggled
+                                    // multi-select join.
+                                    let joined_multi: String = multi_selected
+                                        .iter()
+                                        .filter_map(|&i| q.options.get(i).map(|o| o.label.clone()))
+                                        .collect::<Vec<_>>()
+                                        .join(", ");
+                                    let matches_option =
+                                        q.options.iter().any(|o| current_answer == Some(&o.label));
+                                    let matches_multi = !joined_multi.is_empty()
+                                        && current_answer.map(|a| a == &joined_multi).unwrap_or(false);
+                                    let custom_value = match current_answer {
+                                        Some(a) if !matches_option && !matches_multi => a.clone(),
+                                        _ => String::new(),
+                                    };
+                                    let custom_selected = !custom_value.is_empty();
+                                    let row_class = if custom_selected {
+                                        "question-option custom selected"
+                                    } else {
+                                        "question-option custom"
+                                    };
+                                    let icon = if custom_selected { "●" } else { "○" };
+                                    let on_set_answer = props.on_set_answer.clone();
+                                    let oninput = Callback::from(move |e: InputEvent| {
+                                        let value = e.target_unchecked_into::<HtmlInputElement>().value();
+                                        on_set_answer.emit((q_idx, value));
+                                    });
+                                    html! {
+                                        <div class={row_class}>
+                                            <span class="option-icon">{ icon }</span>
+                                            <div class="option-content">
+                                                <input
+                                                    type="text"
+                                                    class="question-custom-input"
+                                                    placeholder="Something else…"
+                                                    value={custom_value}
+                                                    {oninput}
+                                                />
+                                            </div>
+                                        </div>
+                                    }
+                                } }
                             </div>
                             {
                                 // For multi-select questions, show a "Set Answer" button

--- a/frontend/src/pages/dashboard/session_view/permission_handler.rs
+++ b/frontend/src/pages/dashboard/session_view/permission_handler.rs
@@ -148,7 +148,14 @@ impl Component for PermissionHandler {
                 true
             }
             PermissionHandlerMsg::SetQuestionAnswer(question_idx, answer) => {
-                self.question_answers.insert(question_idx, answer);
+                // A blank answer (e.g. a cleared "something else" field)
+                // un-answers the question rather than counting an empty string
+                // as a valid answer.
+                if answer.trim().is_empty() {
+                    self.question_answers.remove(&question_idx);
+                } else {
+                    self.question_answers.insert(question_idx, answer);
+                }
                 self.multi_select_options.remove(&question_idx);
                 true
             }

--- a/frontend/styles/permissions.css
+++ b/frontend/styles/permissions.css
@@ -258,6 +258,32 @@
     color: var(--accent);
 }
 
+/* Free-text "something else" row: the option frame stays put (no pointer
+   cursor — the input owns interaction) and the text field fills it. */
+.ask-user-question .question-option.custom {
+    cursor: default;
+}
+
+.ask-user-question .question-custom-input {
+    width: 100%;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.85rem;
+    padding: 0.3rem 0.45rem;
+}
+
+.ask-user-question .question-custom-input::placeholder {
+    color: var(--text-muted);
+}
+
+.ask-user-question .question-custom-input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
 .ask-user-question .option-content {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
The interactive question dialog only let users pick a preset option — no escape hatch, so it railroaded them when none fit.

## Change
- `permission_dialog.rs` (`render_ask_user_question`): each question gets a `Something else…` text row. Typing sets that question's answer to the custom text via the existing `on_set_answer` callback; it renders as selected when the current answer matches no preset option (single-select) or the toggled multi-select join.
- `permission_handler.rs` (`SetQuestionAnswer`): a blank answer now *removes* the question's answer instead of storing `""`, so an empty custom field doesn't falsely satisfy the "all answered" submit gate.
- `permissions.css`: styling for `.question-custom-input`.

## Both agents, one frame
Codex's `ToolRequestUserInput` is normalized on the proxy side to a `CodexPermissionInput::AskUserQuestion` whose `tool_name()` is `"AskUserQuestion"` and whose `{questions}` shape parses via the same `parse_ask_user_question`. So Claude and Codex questions render through this one frame — the escape hatch covers both.

## Verify
`cargo clippy -p frontend --target wasm32-unknown-unknown` clean; 317 frontend tests pass.

Version 2.8.75 → 2.8.76.