### PR TITLE
Fix AskUserQuestion "Other" input losing focus every keystroke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,6 +544,59 @@ sessions::table.filter(sessions::id.eq(...))
 
 ## Code Conventions
 
+### Doing It The Right Way
+
+When you hit a bug, fix the **root cause** with the idiomatic pattern — don't paper
+over it with a workaround that leaves the trap in place for the next person.
+Concretely, that means:
+
+- **Fix the cause, not the symptom.** If focus bounces, a controlled input is
+  being recreated — fix the ownership, don't add a `setTimeout`-style refocus hack.
+- **Use the framework's grain.** Reach for the idiomatic construct (a keyed
+  sub-component, a hook, a typed enum variant) before hand-rolling.
+- **Land it cleanly.** Work on a fresh branch off `main` (don't pile onto
+  unrelated WIP), bump the version, and verify it builds before handing it back.
+- **Leave a marker.** Capture the non-obvious "why" in a doc comment so the fix
+  isn't silently reverted later.
+
+**Concrete pattern — focus-stable text inputs in Yew.** A controlled
+`<input value={…}>` whose value is re-derived from parent props and round-tripped
+through parent state on every keystroke gets its DOM node torn down and rebuilt
+per keystroke — focus and the caret bounce out. Don't band-aid it with manual
+refocus. Instead, **own the draft in a keyed sub-component** with local
+`use_state`, notify the parent via a callback, and re-seed from props only on
+genuine external changes:
+
+```rust
+// ❌ WRONG - controlled input re-derived from parent props inside a
+//            re-rendering `fn -> Html`; node is recreated each keystroke
+let oninput = Callback::from(move |e: InputEvent| {
+    on_set_answer.emit((q_idx, value_of(e)));   // round-trips through parent state
+});
+html! { <input value={parent_derived_value} {oninput} /> }
+
+// ✅ RIGHT - keyed sub-component owns the draft locally; node is stable
+#[function_component(CustomAnswerInput)]
+fn custom_answer_input(props: &CustomAnswerInputProps) -> Html {
+    let draft = use_state(|| props.initial.clone());
+    // re-seed only when `initial` changes from the outside (no-op while typing)
+    { let draft = draft.clone();
+      use_effect_with(props.initial.clone(), move |initial| {
+          if *draft != *initial { draft.set(initial.clone()); }
+          || () }); }
+    let oninput = { let draft = draft.clone(); let on_input = props.on_input.clone();
+        Callback::from(move |e: InputEvent| {
+            let v = e.target_unchecked_into::<HtmlInputElement>().value();
+            draft.set(v.clone()); on_input.emit(v); }) };
+    html! { <input value={(*draft).clone()} {oninput} /> }
+}
+// rendered with a stable key so Yew preserves the instance across re-renders:
+//   <CustomAnswerInput key={format!("custom-{q_idx}")} .. />
+```
+
+See `frontend/src/pages/dashboard/permission_dialog.rs` (`CustomAnswerInput`) for
+the live example.
+
 ### Dead Code
 
 **Remove dead code aggressively.** Do not:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.79"
+version = "2.8.80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.79"
+version = "2.8.80"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.79"
+version = "2.8.80"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.79"
+version = "2.8.80"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.79"
+version = "2.8.80"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.79"
+version = "2.8.80"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.79"
+version = "2.8.80"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.79"
+version = "2.8.80"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.79"
+version = "2.8.80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.79"
+version = "2.8.80"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.79"
+version = "2.8.80"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/permission_dialog.rs
+++ b/frontend/src/pages/dashboard/permission_dialog.rs
@@ -168,6 +168,79 @@ fn render_standard_permission(props: &PermissionDialogProps) -> Html {
 }
 
 /// Render the AskUserQuestion specialized UI - supports multiple questions
+/// Free-text "Other" answer row for [`render_ask_user_question`].
+///
+/// Deliberately its own keyed component. The field used to live inline in
+/// `render_ask_user_question` — a plain `fn -> Html` the parent re-renders on
+/// every keystroke. As a controlled `<input value={…}>` re-derived from parent
+/// props each render, the DOM node was rebuilt per keystroke, so focus (and the
+/// caret) bounced out of the field.
+///
+/// Owning the draft in local `use_state` keeps the node stable: keystrokes
+/// touch local state only, the parent is notified via `on_input`, and the field
+/// re-seeds from `initial` solely when the answer changes from the outside
+/// (e.g. the user clicks a preset option, which clears the draft).
+#[derive(Properties, PartialEq)]
+struct CustomAnswerInputProps {
+    /// The custom answer text, or empty when a preset option/multi-select join
+    /// is the active selection. Re-seeds the field only on external changes.
+    initial: String,
+    /// Whether the typed answer is the active selection (drives the icon).
+    selected: bool,
+    /// Emits the typed text upward (the parent binds the question index).
+    on_input: Callback<String>,
+}
+
+#[function_component(CustomAnswerInput)]
+fn custom_answer_input(props: &CustomAnswerInputProps) -> Html {
+    let draft = use_state(|| props.initial.clone());
+
+    // Re-seed only when `initial` changes from the outside (selecting a preset
+    // clears it). While typing, `draft` and `initial` stay in lockstep, so this
+    // is a no-op on keystrokes and never fights the user's caret.
+    {
+        let draft = draft.clone();
+        use_effect_with(props.initial.clone(), move |initial| {
+            if *draft != *initial {
+                draft.set(initial.clone());
+            }
+            || ()
+        });
+    }
+
+    let oninput = {
+        let draft = draft.clone();
+        let on_input = props.on_input.clone();
+        Callback::from(move |e: InputEvent| {
+            let value = e.target_unchecked_into::<HtmlInputElement>().value();
+            draft.set(value.clone());
+            on_input.emit(value);
+        })
+    };
+
+    let row_class = if props.selected {
+        "question-option custom selected"
+    } else {
+        "question-option custom"
+    };
+    let icon = if props.selected { "●" } else { "○" };
+
+    html! {
+        <div class={row_class}>
+            <span class="option-icon">{ icon }</span>
+            <div class="option-content">
+                <input
+                    type="text"
+                    class="question-custom-input"
+                    placeholder="Something else…"
+                    value={(*draft).clone()}
+                    {oninput}
+                />
+            </div>
+        </div>
+    }
+}
+
 fn render_ask_user_question(props: &PermissionDialogProps, parsed: &AskUserQuestionInput) -> Html {
     let total_questions = parsed.questions.len();
     let answers_count = props.question_answers.len();
@@ -310,7 +383,8 @@ fn render_ask_user_question(props: &PermissionDialogProps, parsed: &AskUserQuest
                                     // "Other"). Covers Claude and Codex, which share this frame.
                                     // The answer is whatever is typed; it's "selected" when the
                                     // current answer matches no option (single) or the toggled
-                                    // multi-select join.
+                                    // multi-select join. Rendered via the keyed CustomAnswerInput
+                                    // so typing doesn't tear down the field (see its doc comment).
                                     let joined_multi: String = multi_selected
                                         .iter()
                                         .filter_map(|&i| q.options.get(i).map(|o| o.label.clone()))
@@ -325,30 +399,17 @@ fn render_ask_user_question(props: &PermissionDialogProps, parsed: &AskUserQuest
                                         _ => String::new(),
                                     };
                                     let custom_selected = !custom_value.is_empty();
-                                    let row_class = if custom_selected {
-                                        "question-option custom selected"
-                                    } else {
-                                        "question-option custom"
-                                    };
-                                    let icon = if custom_selected { "●" } else { "○" };
                                     let on_set_answer = props.on_set_answer.clone();
-                                    let oninput = Callback::from(move |e: InputEvent| {
-                                        let value = e.target_unchecked_into::<HtmlInputElement>().value();
+                                    let on_input = Callback::from(move |value: String| {
                                         on_set_answer.emit((q_idx, value));
                                     });
                                     html! {
-                                        <div class={row_class}>
-                                            <span class="option-icon">{ icon }</span>
-                                            <div class="option-content">
-                                                <input
-                                                    type="text"
-                                                    class="question-custom-input"
-                                                    placeholder="Something else…"
-                                                    value={custom_value}
-                                                    {oninput}
-                                                />
-                                            </div>
-                                        </div>
+                                        <CustomAnswerInput
+                                            key={format!("custom-{q_idx}")}
+                                            initial={custom_value}
+                                            selected={custom_selected}
+                                            {on_input}
+                                        />
                                     }
                                 } }
                             </div>


### PR DESCRIPTION
## Problem

Typing in the **"Other" / free-text answer** of an `AskUserQuestion` permission dialog bounced focus out of the field on **every keystroke** — you could only enter one character at a time before having to re-click.

## Root cause

`frontend/src/pages/dashboard/permission_dialog.rs` rendered the field inline in `render_ask_user_question` (a plain `fn -> Html`) as a **controlled** input:

```rust
<input value={custom_value} {oninput} />   // value re-derived from parent props
```

Each keystroke emitted `on_set_answer` → `PermissionHandler` updated `question_answers` → the whole dialog re-rendered → `custom_value` was recomputed and the input DOM node (an unkeyed trailing sibling after a `.collect::<Html>()` option list) was torn down and rebuilt. Focus and the caret died with it.

## Fix

Extract the field into a **keyed `CustomAnswerInput`** function component that:
- owns its draft in local `use_state` (keystrokes touch local state only),
- notifies the parent via an `on_input: Callback<String>`,
- re-seeds from `initial` **only** on genuine external changes (e.g. clicking a preset option clears it) via `use_effect_with`,
- is rendered with `key={format!("custom-{q_idx}")}` so Yew preserves the instance across parent re-renders.

The node is now stable; focus and caret stay put while typing. Behaviour (custom-vs-preset selection, the "●/○" icon, multi-select join) is unchanged.

## Docs

Adds a **"Doing It The Right Way"** section to `CLAUDE.md` capturing the focus-stable-input pattern (keyed sub-component + local draft) as the idiomatic fix, with ✅/❌ examples.

## Verification

- `cargo check -p frontend --target wasm32-unknown-unknown` ✅
- `cargo fmt --check -p frontend` ✅
- `cargo clippy -p frontend --target wasm32-unknown-unknown` — no warnings ✅
- Version bumped `2.8.79 → 2.8.80`

🤖 Generated with [Claude Code](https://claude.com/claude-code)