### PR TITLE
Map timezone abbreviations to IANA so scheduled tasks don't silently use UTC (#1064)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.80"
+version = "2.8.81"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -184,7 +184,9 @@ pub async fn create_task_handler(
         user_id,
         name: req.fields.name,
         cron_expression: req.fields.cron_expression,
-        timezone: req.fields.timezone,
+        // Normalize abbreviations (PST/EST/…) to IANA so the launcher's
+        // chrono_tz parse succeeds instead of silently using UTC (#1064).
+        timezone: shared::timezone::canonicalize_timezone(&req.fields.timezone),
         hostname: req.hostname,
         working_directory: req.fields.working_directory,
         prompt: req.fields.prompt,
@@ -234,7 +236,10 @@ pub async fn update_task_handler(
     let changeset = ScheduledTaskChangeset {
         name: req.name,
         cron_expression: req.cron_expression,
-        timezone: req.timezone,
+        // Normalize abbreviations to IANA on update too (#1064).
+        timezone: req
+            .timezone
+            .map(|tz| shared::timezone::canonicalize_timezone(&tz)),
         hostname: req.hostname,
         working_directory: req.working_directory,
         prompt: req.prompt,

--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -33,6 +33,22 @@ fn version_sufficient(version: &str) -> bool {
     have >= need
 }
 
+/// The browser's IANA timezone (e.g. `America/Los_Angeles`) via
+/// `Intl.DateTimeFormat().resolvedOptions().timeZone`, or `"UTC"` if it can't
+/// be read. Seeding the schedule field with this starts it as a valid IANA name
+/// instead of an abbreviation the launcher can't parse (#1064).
+fn detected_timezone() -> String {
+    let fmt = js_sys::Intl::DateTimeFormat::new(&js_sys::Array::new(), &js_sys::Object::new());
+    js_sys::Reflect::get(
+        &fmt.resolved_options(),
+        &wasm_bindgen::JsValue::from_str("timeZone"),
+    )
+    .ok()
+    .and_then(|v| v.as_string())
+    .filter(|s| !s.is_empty())
+    .unwrap_or_else(|| "UTC".to_string())
+}
+
 #[derive(Properties, PartialEq)]
 pub struct ScheduleDialogProps {
     pub session: SessionInfo,
@@ -139,7 +155,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
         let error_msg = error_msg.clone();
         Callback::from(move |_| {
             form.set(TaskForm {
-                timezone: "UTC".to_string(),
+                timezone: detected_timezone(),
                 max_runtime_minutes: 30,
                 skip_permissions: true,
                 ..Default::default()
@@ -221,7 +237,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                             fields: shared::ScheduledTaskFields {
                                 name: data.name.trim().to_string(),
                                 cron_expression: data.cron_expression.trim().to_string(),
-                                timezone: data.timezone.clone(),
+                                timezone: shared::timezone::canonicalize_timezone(&data.timezone),
                                 working_directory: wd,
                                 prompt: data.prompt.clone(),
                                 claude_args: claude_args.clone(),
@@ -240,7 +256,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                         let body = UpdateScheduledTaskRequest {
                             name: Some(data.name.trim().to_string()),
                             cron_expression: Some(data.cron_expression.trim().to_string()),
-                            timezone: Some(data.timezone.clone()),
+                            timezone: Some(shared::timezone::canonicalize_timezone(&data.timezone)),
                             prompt: Some(data.prompt.clone()),
                             max_runtime_minutes: Some(data.max_runtime_minutes),
                             claude_args: Some(claude_args.clone()),
@@ -473,10 +489,18 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                                             <label>{ "Timezone" }</label>
                                             <input
                                                 type="text"
-                                                placeholder="UTC"
+                                                list="sched-tz-list"
+                                                placeholder="America/Los_Angeles"
                                                 value={form.timezone.clone()}
                                                 oninput={set_field(|f, v| f.timezone = v)}
                                             />
+                                            <datalist id="sched-tz-list">
+                                                {
+                                                    shared::timezone::COMMON_IANA_ZONES.iter().map(|tz| {
+                                                        html! { <option value={*tz} /> }
+                                                    }).collect::<Html>()
+                                                }
+                                            </datalist>
                                         </div>
                                         <div class="sched-field sched-field-sm">
                                             <label>{ "Timeout (min)" }</label>

--- a/launcher/src/scheduler.rs
+++ b/launcher/src/scheduler.rs
@@ -317,10 +317,17 @@ fn compute_next_fire(cron_expr: &str, timezone: &str) -> Option<DateTime<Utc>> {
         }
     };
 
-    let tz: chrono_tz::Tz = match timezone.parse() {
+    // Canonicalize common abbreviations (PST/EST/…) to IANA names first;
+    // chrono_tz only accepts IANA. Unknown values pass through and fail the
+    // parse below, falling back to UTC. See issue #1064.
+    let canonical = shared::timezone::canonicalize_timezone(timezone);
+    let tz: chrono_tz::Tz = match canonical.parse() {
         Ok(t) => t,
         Err(_) => {
-            error!("Invalid timezone '{}', falling back to UTC", timezone);
+            error!(
+                "Unrecognized timezone '{}' (resolved '{}'), falling back to UTC",
+                timezone, canonical
+            );
             chrono_tz::UTC
         }
     };
@@ -409,6 +416,19 @@ mod tests {
     fn compute_next_fire_invalid_timezone_falls_back_to_utc() {
         let result = compute_next_fire("0 3 * * *", "Invalid/Timezone");
         assert!(result.is_some());
+    }
+
+    #[test]
+    fn compute_next_fire_accepts_abbreviation() {
+        // "PST" used to silently fall back to UTC (issue #1064); it must now
+        // resolve to the same instant as its IANA equivalent.
+        let abbrev = compute_next_fire("0 3 * * *", "PST");
+        let iana = compute_next_fire("0 3 * * *", "America/Los_Angeles");
+        assert!(abbrev.is_some());
+        // Compare at second granularity: croner carries the sub-second fraction
+        // of each call's `Utc::now()` into the result, so the two instants differ
+        // by microseconds even though they resolve to the same scheduled second.
+        assert_eq!(abbrev.map(|d| d.timestamp()), iana.map(|d| d.timestamp()));
     }
 
     #[test]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -19,6 +19,9 @@ pub mod protocol;
 // String/number formatting helpers shared between frontend and native crates
 pub mod fmt;
 
+// Timezone canonicalization (abbreviation -> IANA) shared across crates
+pub mod timezone;
+
 // API client types and trait
 pub mod api;
 pub use api::{

--- a/shared/src/timezone.rs
+++ b/shared/src/timezone.rs
@@ -1,0 +1,106 @@
+//! Timezone canonicalization shared by the scheduler (launcher), the task API
+//! (backend), and the schedule dialog (frontend).
+//!
+//! The launcher's scheduler resolves a task's `timezone` with
+//! `chrono_tz::Tz`, which only accepts IANA names (e.g. `America/Los_Angeles`).
+//! Users naturally type abbreviations like `PST`/`PDT`, which silently failed
+//! to parse and fell back to UTC — firing scheduled tasks 7–8 hours off with no
+//! visible error (see issue #1064).
+//!
+//! This module maps common abbreviations to IANA zones so they resolve
+//! correctly, and is intentionally dependency-free (pure string mapping) so it
+//! stays WASM-compatible for the frontend. IANA validation still happens where
+//! `chrono_tz` is available (the launcher); everything here only canonicalizes.
+
+/// Map a common timezone abbreviation (case-insensitive) to a canonical IANA
+/// zone name, or `None` if the input isn't a recognized abbreviation.
+///
+/// Abbreviations are inherently ambiguous (e.g. `CST` is US Central *or* China
+/// Standard); these resolve to the North American zones this tool's users mean.
+/// Anything not listed should be treated as an IANA name by the caller.
+pub fn abbrev_to_iana(input: &str) -> Option<&'static str> {
+    let key = input.trim().to_ascii_uppercase();
+    Some(match key.as_str() {
+        "UTC" | "GMT" | "Z" | "ZULU" => "UTC",
+        "PT" | "PST" | "PDT" => "America/Los_Angeles",
+        "MT" | "MST" | "MDT" => "America/Denver",
+        "CT" | "CST" | "CDT" => "America/Chicago",
+        "ET" | "EST" | "EDT" => "America/New_York",
+        "AKT" | "AKST" | "AKDT" => "America/Anchorage",
+        "HT" | "HST" => "Pacific/Honolulu",
+        "BST" => "Europe/London",
+        "CET" | "CEST" => "Europe/Paris",
+        "IST" => "Asia/Kolkata",
+        "JST" => "Asia/Tokyo",
+        "AEST" | "AEDT" => "Australia/Sydney",
+        _ => return None,
+    })
+}
+
+/// Canonicalize a user-supplied timezone string to an IANA name when possible.
+///
+/// Recognized abbreviations are mapped to their IANA zone; everything else is
+/// returned trimmed and unchanged for the caller to parse/validate as an IANA
+/// name. Never fails — an unknown value is passed through verbatim so the caller
+/// can decide how to handle it.
+pub fn canonicalize_timezone(input: &str) -> String {
+    abbrev_to_iana(input)
+        .map(str::to_string)
+        .unwrap_or_else(|| input.trim().to_string())
+}
+
+/// Common IANA zones offered as suggestions in the schedule dialog. Not
+/// exhaustive — the field still accepts any IANA name (or a mapped abbrev).
+pub const COMMON_IANA_ZONES: &[&str] = &[
+    "UTC",
+    "America/Los_Angeles",
+    "America/Denver",
+    "America/Chicago",
+    "America/New_York",
+    "America/Anchorage",
+    "Pacific/Honolulu",
+    "Europe/London",
+    "Europe/Paris",
+    "Asia/Kolkata",
+    "Asia/Tokyo",
+    "Australia/Sydney",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_us_abbreviations_case_insensitively() {
+        assert_eq!(abbrev_to_iana("PST"), Some("America/Los_Angeles"));
+        assert_eq!(abbrev_to_iana("pdt"), Some("America/Los_Angeles"));
+        assert_eq!(abbrev_to_iana(" PT "), Some("America/Los_Angeles"));
+        assert_eq!(abbrev_to_iana("EST"), Some("America/New_York"));
+        assert_eq!(abbrev_to_iana("CT"), Some("America/Chicago"));
+    }
+
+    #[test]
+    fn utc_aliases_map_to_utc() {
+        assert_eq!(abbrev_to_iana("UTC"), Some("UTC"));
+        assert_eq!(abbrev_to_iana("gmt"), Some("UTC"));
+        assert_eq!(abbrev_to_iana("Z"), Some("UTC"));
+    }
+
+    #[test]
+    fn unknown_and_iana_names_are_not_abbreviations() {
+        assert_eq!(abbrev_to_iana("America/Los_Angeles"), None);
+        assert_eq!(abbrev_to_iana("Mars/Olympus"), None);
+        assert_eq!(abbrev_to_iana(""), None);
+    }
+
+    #[test]
+    fn canonicalize_maps_abbrev_and_passes_through_iana() {
+        assert_eq!(canonicalize_timezone("PST"), "America/Los_Angeles");
+        assert_eq!(
+            canonicalize_timezone("  America/New_York  "),
+            "America/New_York"
+        );
+        // Unknown input is preserved (trimmed) for the caller to validate.
+        assert_eq!(canonicalize_timezone(" Invalid/Zone "), "Invalid/Zone");
+    }
+}


### PR DESCRIPTION
Closes #1064.

## Problem

The launcher scheduler resolves a task's `timezone` with `chrono_tz::Tz`, which only accepts **IANA** names (`America/Los_Angeles`). The schedule dialog's timezone field is free-text, so users typed abbreviations like `PST`/`PDT`. Those failed to parse and **silently fell back to UTC** — firing scheduled tasks 7–8 hours off, with only an `ERROR` log line as a clue. Observed live on `meawoppl-fc` (`Invalid timezone 'PST', falling back to UTC`).

## Fix (all four layers)

- **shared** — new `timezone` module: `canonicalize_timezone` / `abbrev_to_iana` / `COMMON_IANA_ZONES`. Dependency-free string mapping (stays WASM-compatible). Maps common North American + a few international abbreviations to IANA; passes IANA names through unchanged. Unit-tested.
- **launcher** — canonicalize before the `chrono_tz` parse, so existing `PST`-style tasks resolve correctly instead of silently using UTC. Reworded the fallback log. New test asserts `"PST"` resolves to the same scheduled second as `"America/Los_Angeles"`.
- **backend** — canonicalize on task create/update, so stored values become IANA going forward.
- **frontend** — default the schedule dialog's timezone to the browser's detected IANA zone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) instead of `"UTC"`, offer a `<datalist>` of common zones, and canonicalize the typed value on submit — so abbreviations never reach the DB in the first place.

This is defense-in-depth: existing bad rows resolve correctly (launcher), and new entries are normalized at every write path (frontend + backend).

## Verification

- `cargo test -p shared -p agent-portal` — shared 34 ✅, launcher 65 ✅ (incl. new tz tests)
- `cargo build -p shared --target wasm32-unknown-unknown` ✅ (WASM-safe)
- `cargo check -p backend` ✅ · `cargo check -p frontend --target wasm32-unknown-unknown` ✅
- `cargo fmt --check` ✅ · clippy (shared/launcher/backend/frontend) — no warnings ✅
- Version bumped `2.8.80 → 2.8.81`

## Note on ambiguity

Abbreviations are inherently ambiguous (`CST` = US Central *or* China Standard); the map resolves to the North American zones this tool's users mean, and the frontend now steers people toward real IANA names so the abbrev map is mostly a back-compat safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)