### PR TITLE
Show all open repo PRs in the session pill (list + numbers + tooltip)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.8.80"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.8.80"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.8.80"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.8.80"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.8.80"
+version = "2.9.0"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.8.80"
+version = "2.9.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.8.80"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.8.80"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.8.80"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.8.80"
+version = "2.9.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.8.81"
+version = "2.9.0"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/2026-06-18-150000_add_open_prs_to_sessions/down.sql
+++ b/backend/migrations/2026-06-18-150000_add_open_prs_to_sessions/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN open_prs;

--- a/backend/migrations/2026-06-18-150000_add_open_prs_to_sessions/up.sql
+++ b/backend/migrations/2026-06-18-150000_add_open_prs_to_sessions/up.sql
@@ -1,0 +1,4 @@
+-- All open PRs in the session's repo, as a JSON array of {number, url, branch}.
+-- Backs the session pill's PR list. Defaults to an empty array so existing rows
+-- and inserts that don't set it are valid.
+ALTER TABLE sessions ADD COLUMN open_prs JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -253,6 +253,7 @@ fn handle_proxy_message(
             git_branch,
             pr_url,
             repo_url,
+            open_prs,
         } => {
             handle_session_update(
                 session_manager,
@@ -263,6 +264,7 @@ fn handle_proxy_message(
                 git_branch,
                 pr_url,
                 repo_url,
+                open_prs,
             );
         }
         ProxyToServer::InputAck {
@@ -318,10 +320,14 @@ fn handle_session_update(
     git_branch: Option<String>,
     pr_url: Option<String>,
     repo_url: Option<String>,
+    open_prs: Vec<shared::PrRef>,
 ) {
     let Some(current_session_id) = db_session_id else {
         return;
     };
+    // Store as a JSON array; the column is `jsonb NOT NULL DEFAULT '[]'`.
+    let open_prs_json =
+        serde_json::to_value(&open_prs).unwrap_or_else(|_| serde_json::Value::Array(Vec::new()));
     let mut conn = match db_pool.get() {
         Ok(conn) => conn,
         Err(e) => {
@@ -347,14 +353,19 @@ fn handle_session_update(
             sessions::git_branch.eq(&git_branch),
             sessions::pr_url.eq(&pr_url),
             sessions::repo_url.eq(&repo_url),
+            sessions::open_prs.eq(&open_prs_json),
         ))
         .execute(&mut conn)
     {
         error!("Failed to update session metadata: {}", e);
     } else {
         info!(
-            "Updated session {}: branch={:?} pr_url={:?} repo_url={:?}",
-            current_session_id, git_branch, pr_url, repo_url
+            "Updated session {}: branch={:?} pr_url={:?} repo_url={:?} open_prs={}",
+            current_session_id,
+            git_branch,
+            pr_url,
+            repo_url,
+            open_prs.len()
         );
 
         if let Some(ref key) = session_key {
@@ -365,6 +376,7 @@ fn handle_session_update(
                     git_branch,
                     pr_url,
                     repo_url,
+                    open_prs,
                 },
             );
         }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -61,6 +61,10 @@ pub struct Session {
     pub launch_failure_count: i32,
     pub last_launch_attempt_at: Option<NaiveDateTime>,
     pub launch_lease_until: Option<NaiveDateTime>,
+    /// All open PRs in the repo as a JSON array of `shared::PrRef`
+    /// (`[{number,url,branch}]`). Surfaces on the wire via `SessionWithRole`'s
+    /// flatten, where the frontend deserializes it into `Vec<PrRef>`.
+    pub open_prs: serde_json::Value,
 }
 
 /// Insertable session that specifies the ID (so we can use Claude's session ID)

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -168,6 +168,7 @@ diesel::table! {
         launch_failure_count -> Int4,
         last_launch_attempt_at -> Nullable<Timestamp>,
         launch_lease_until -> Nullable<Timestamp>,
+        open_prs -> Jsonb,
     }
 }
 

--- a/claude-session-lib/src/proxy_session/git_metadata.rs
+++ b/claude-session-lib/src/proxy_session/git_metadata.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use claude_codes::io::ContentBlock;
 use claude_codes::ClaudeOutput;
-use shared::ProxyToServer;
+use shared::{PrRef, ProxyToServer};
 use tokio::sync::Mutex;
 use tracing::{debug, error};
 use uuid::Uuid;
@@ -16,6 +16,7 @@ pub(super) struct GitMetadataState {
     pub current_branch: Arc<Mutex<Option<String>>>,
     pub current_pr_url: Arc<Mutex<Option<String>>>,
     pub current_repo_url: Arc<Mutex<Option<String>>>,
+    pub current_open_prs: Arc<Mutex<Vec<PrRef>>>,
 }
 
 impl GitMetadataState {
@@ -24,6 +25,7 @@ impl GitMetadataState {
             current_branch: Arc::new(Mutex::new(git_branch)),
             current_pr_url: Arc::new(Mutex::new(None)),
             current_repo_url: Arc::new(Mutex::new(None)),
+            current_open_prs: Arc::new(Mutex::new(Vec::new())),
         }
     }
 }
@@ -113,6 +115,57 @@ pub(super) fn get_pr_url(cwd: &str, branch: &str) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+/// List all open PRs in the repo via the `gh` CLI, sorted by number ascending.
+/// Returns an empty list if `gh` is unavailable, errors, or there are none.
+pub(super) fn get_open_prs(cwd: &str) -> Vec<PrRef> {
+    let output = std::process::Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "number,url,headRefName",
+        ])
+        .current_dir(cwd)
+        .output()
+        .ok();
+    let Some(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    // Parse via Value so we don't depend on a serde-derive struct here.
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).unwrap_or(serde_json::Value::Null);
+    let mut prs: Vec<PrRef> = parsed
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    let number = item.get("number")?.as_i64()?;
+                    let url = item.get("url")?.as_str()?.to_string();
+                    let branch = item
+                        .get("headRefName")
+                        .and_then(|b| b.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    Some(PrRef {
+                        number,
+                        url,
+                        branch,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    prs.sort_by_key(|p| p.number);
+    prs
+}
+
 pub(super) fn claude_output_has_git_signal(output: &ClaudeOutput) -> bool {
     if let ClaudeOutput::User(user) = output {
         for block in &user.message.content {
@@ -189,16 +242,19 @@ pub(super) async fn check_and_send_branch_update(
         .as_deref()
         .and_then(|b| get_pr_url(working_directory, b));
     let new_repo_url = get_repo_url(working_directory);
+    let new_open_prs = get_open_prs(working_directory);
 
     let mut branch_guard = state.current_branch.lock().await;
     let mut pr_guard = state.current_pr_url.lock().await;
     let mut repo_guard = state.current_repo_url.lock().await;
+    let mut open_prs_guard = state.current_open_prs.lock().await;
 
     let branch_changed = *branch_guard != new_branch;
     let pr_changed = *pr_guard != new_pr_url;
     let repo_changed = *repo_guard != new_repo_url;
+    let open_prs_changed = *open_prs_guard != new_open_prs;
 
-    if branch_changed || pr_changed || repo_changed {
+    if branch_changed || pr_changed || repo_changed || open_prs_changed {
         if branch_changed {
             debug!(
                 "Git branch changed: {:?} -> {:?}",
@@ -208,19 +264,29 @@ pub(super) async fn check_and_send_branch_update(
         if pr_changed {
             debug!("PR URL changed: {:?} -> {:?}", *pr_guard, new_pr_url);
         }
+        if open_prs_changed {
+            debug!(
+                "Open PRs changed: {} -> {}",
+                open_prs_guard.len(),
+                new_open_prs.len()
+            );
+        }
         *branch_guard = new_branch.clone();
         *pr_guard = new_pr_url.clone();
         *repo_guard = new_repo_url.clone();
+        *open_prs_guard = new_open_prs.clone();
 
         drop(branch_guard);
         drop(pr_guard);
         drop(repo_guard);
+        drop(open_prs_guard);
 
         let update_msg = ProxyToServer::SessionUpdate {
             session_id,
             git_branch: new_branch,
             pr_url: new_pr_url,
             repo_url: new_repo_url,
+            open_prs: new_open_prs,
         };
 
         let mut ws = ws_write.lock().await;

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -30,7 +30,7 @@ pub use git_metadata::{get_git_branch, get_repo_url};
 
 use git_metadata::{
     check_and_send_branch_update, check_and_send_branch_update_if_branch_changed,
-    codex_output_has_git_signal, get_pr_url, GitMetadataState, GitRefreshTrigger,
+    codex_output_has_git_signal, get_open_prs, get_pr_url, GitMetadataState, GitRefreshTrigger,
 };
 use output_forwarder::spawn_output_forwarder;
 use wiggum::{handle_session_event_with_wiggum, WiggumState};
@@ -458,17 +458,20 @@ async fn run_single_connection<A: Agent>(session: &mut SessionState<'_, A>) -> C
         Err(RegisterError::Rejected) => return ConnectionResult::RegistrationRejected,
     };
 
-    // Look up PR URL and repo URL for the current branch and send as SessionUpdate
+    // Look up PR URL, repo URL, and the repo's open PRs for the current branch
+    // and send as the initial SessionUpdate (so the pill populates immediately).
     let repo_url = get_repo_url(&session.config.working_directory);
     let pr_url = config_with_branch
         .git_branch
         .as_deref()
         .and_then(|b| get_pr_url(&session.config.working_directory, b));
+    let open_prs = get_open_prs(&session.config.working_directory);
     let update_msg = ProxyToServer::SessionUpdate {
         session_id: config_with_branch.session_id,
         git_branch: config_with_branch.git_branch.clone(),
         pr_url,
         repo_url,
+        open_prs,
     };
     if conn.send(update_msg).await.is_err() {
         error!("Failed to send initial session update");

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -612,17 +612,19 @@ pub fn dashboard_page() -> Html {
         let set_sessions = sessions_hook.set_sessions.clone();
         let sessions = sessions.clone();
         Callback::from(
-            move |(session_id, branch, pr_url, repo_url): (
+            move |(session_id, branch, pr_url, repo_url, open_prs): (
                 Uuid,
                 Option<String>,
                 Option<String>,
                 Option<String>,
+                Vec<shared::PrRef>,
             )| {
                 let mut updated = sessions.clone();
                 if let Some(session) = updated.iter_mut().find(|s| s.id == session_id) {
                     session.git_branch = branch;
                     session.pr_url = pr_url;
                     session.repo_url = repo_url;
+                    session.open_prs = open_prs;
                 }
                 set_sessions.emit(updated);
             },

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -554,35 +554,47 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             html! {}
         };
 
-        let repo_option = if let Some(ref url) = session.pr_url {
-            let pr_number = url.rsplit('/').next().unwrap_or("").to_string();
-            let label = if pr_number.is_empty() {
-                "Open PR".to_string()
+        let repo_option = {
+            // Repo root link on top, then one row per open PR sorted by number.
+            let repo_link = if let Some(ref url) = session.repo_url {
+                let href = url.clone();
+                html! {
+                    <a class="pill-menu-option pr-link" href={href} target="_blank"
+                       onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                        { "Open Repository" }
+                        <span class="option-hint">{ "GitHub" }</span>
+                    </a>
+                }
             } else {
-                format!("Open PR #{}", pr_number)
+                html! {}
             };
-            let href = url.clone();
-            html! {
-                <a class="pill-menu-option pr-link" href={href} target="_blank"
-                   onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                    { label }
-                    <span class="option-hint">{ "GitHub" }</span>
-                </a>
-            }
-        } else if let Some(ref url) = session.repo_url {
-            let href = url.clone();
-            html! {
-                <a class="pill-menu-option pr-link" href={href} target="_blank"
-                   onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                    { "Open Repository" }
-                    <span class="option-hint">{ "GitHub" }</span>
-                </a>
-            }
-        } else {
-            html! {
-                <span class="pill-menu-option disabled">
-                    { "No Repository Detected" }
-                </span>
+
+            let mut prs = session.open_prs.clone();
+            prs.sort_by_key(|p| p.number);
+            let pr_rows = prs
+                .iter()
+                .map(|pr| {
+                    let href = pr.url.clone();
+                    let branch = pr.branch.clone();
+                    html! {
+                        <a class="pill-menu-option pr-link" href={href} target="_blank"
+                           title={branch.clone()}
+                           onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                            { format!("Open PR #{}", pr.number) }
+                            <span class="option-hint">{ branch }</span>
+                        </a>
+                    }
+                })
+                .collect::<Html>();
+
+            if session.repo_url.is_none() && prs.is_empty() {
+                html! {
+                    <span class="pill-menu-option disabled">
+                        { "No Repository Detected" }
+                    </span>
+                }
+            } else {
+                html! { <>{ repo_link }{ pr_rows }</> }
             }
         };
 
@@ -814,13 +826,27 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                         <span class="pill-hostname">{ hostname }</span>
                         { version_badge }
                     </span>
-                    {
-                        if let Some(ref branch) = session.git_branch {
+                    { {
+                        // Show open PR numbers (each with its branch as a hover
+                        // tooltip); fall back to the branch name, then "No VCS".
+                        let mut prs = session.open_prs.clone();
+                        prs.sort_by_key(|p| p.number);
+                        if !prs.is_empty() {
+                            html! {
+                                <span class="pill-branch pill-prs">
+                                    { for prs.iter().map(|pr| html! {
+                                        <span class="pill-pr-num" title={pr.branch.clone()}>
+                                            { format!("#{}", pr.number) }
+                                        </span>
+                                    }) }
+                                </span>
+                            }
+                        } else if let Some(ref branch) = session.git_branch {
                             html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
                         } else {
                             html! { <span class="pill-branch pill-no-vcs">{ "No VCS" }</span> }
                         }
-                    }
+                    } }
                 </span>
                 // Codex text badge removed — the agent-type watermark behind the
                 // pill (anthropic-mark.svg / openai-mark.png) carries this signal.

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -46,7 +46,13 @@ pub struct SessionViewProps {
     pub on_connected_change: Callback<(Uuid, bool)>,
     pub on_message_sent: Callback<Uuid>,
     #[allow(clippy::type_complexity)]
-    pub on_branch_change: Callback<(Uuid, Option<String>, Option<String>, Option<String>)>,
+    pub on_branch_change: Callback<(
+        Uuid,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Vec<shared::PrRef>,
+    )>,
     #[prop_or_default]
     pub on_activity: Callback<(Uuid, ActivityTag, f64)>,
     #[prop_or_default]
@@ -63,7 +69,12 @@ pub enum SessionViewMsg {
     WebSocketError(String),
     AttemptReconnect,
     CheckAwaiting,
-    BranchChanged(Option<String>, Option<String>, Option<String>),
+    BranchChanged(
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Vec<shared::PrRef>,
+    ),
     /// PermissionHandler is mounted and handed us its inbound-request
     /// dispatcher. We store it so live `WsEvent::Permission` frames can be
     /// forwarded without the parent owning any permission state.
@@ -356,11 +367,11 @@ impl Component for SessionView {
                     .emit((session_id, is_awaiting));
                 false
             }
-            SessionViewMsg::BranchChanged(branch, pr_url, repo_url) => {
+            SessionViewMsg::BranchChanged(branch, pr_url, repo_url, open_prs) => {
                 let session_id = ctx.props().session.id;
                 ctx.props()
                     .on_branch_change
-                    .emit((session_id, branch, pr_url, repo_url));
+                    .emit((session_id, branch, pr_url, repo_url, open_prs));
                 false
             }
             SessionViewMsg::TasksDispatcherRegistered(dispatcher) => {
@@ -565,9 +576,10 @@ impl SessionView {
                 }
                 false
             }
-            WsEvent::BranchChanged(branch, pr_url, repo_url) => {
-                ctx.link()
-                    .send_message(SessionViewMsg::BranchChanged(branch, pr_url, repo_url));
+            WsEvent::BranchChanged(branch, pr_url, repo_url, open_prs) => {
+                ctx.link().send_message(SessionViewMsg::BranchChanged(
+                    branch, pr_url, repo_url, open_prs,
+                ));
                 false
             }
             WsEvent::TurnMetrics(metrics) => {

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -26,7 +26,12 @@ pub enum WsEvent {
     /// initial load.
     HistoryBatch(Vec<String>, Option<String>),
     Permission(PendingPermission),
-    BranchChanged(Option<String>, Option<String>, Option<String>),
+    BranchChanged(
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Vec<shared::PrRef>,
+    ),
     ContinuationStatus {
         continuation_id: Uuid,
         status: String,
@@ -199,8 +204,11 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
             git_branch,
             pr_url,
             repo_url,
+            open_prs,
         } => {
-            on_event.emit(WsEvent::BranchChanged(git_branch, pr_url, repo_url));
+            on_event.emit(WsEvent::BranchChanged(
+                git_branch, pr_url, repo_url, open_prs,
+            ));
         }
         // PR 2 of N: route the typed per-turn metrics frame into the
         // SessionView instead of silently dropping it. The previous
@@ -522,7 +530,7 @@ mod tests {
             WsEvent::Output(_, _) => "Output",
             WsEvent::HistoryBatch(_, _) => "HistoryBatch",
             WsEvent::Permission(_) => "Permission",
-            WsEvent::BranchChanged(_, _, _) => "BranchChanged",
+            WsEvent::BranchChanged(_, _, _, _) => "BranchChanged",
             WsEvent::ContinuationStatus { .. } => "ContinuationStatus",
             WsEvent::TurnMetrics(_) => "TurnMetrics",
         }

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -275,6 +275,23 @@
     font-size: 0.65rem;
 }
 
+/* Open-PR numbers on the collapsed pill: one span per PR, each carrying its
+   branch name as a hover tooltip. LTR so "#34 #35" reads left-to-right (the
+   plain branch view uses rtl to keep the tail visible when truncated). */
+.pill-branch.pill-prs {
+    direction: ltr;
+    font-style: normal;
+}
+
+.pill-pr-num {
+    margin-inline-end: 5px;
+    cursor: help;
+}
+
+.pill-pr-num:last-child {
+    margin-inline-end: 0;
+}
+
 .session-pill.status-disconnected .pill-branch {
     color: var(--text-secondary);
 }

--- a/shared/src/endpoints.rs
+++ b/shared/src/endpoints.rs
@@ -233,6 +233,9 @@ pub enum ProxyToServer {
         pr_url: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none", default)]
         repo_url: Option<String>,
+        /// All open PRs in the repo, sorted by number.
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        open_prs: Vec<crate::PrRef>,
     },
 
     /// Acknowledge receipt of input messages
@@ -438,6 +441,9 @@ pub enum ServerToClient {
         pr_url: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none", default)]
         repo_url: Option<String>,
+        /// All open PRs in the repo, sorted by number.
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        open_prs: Vec<crate::PrRef>,
     },
 
     /// User spend data update

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -207,6 +207,20 @@ pub struct LauncherInfo {
     pub version: String,
 }
 
+/// A single open GitHub pull request associated with a session's repository.
+///
+/// Carried as a list so the session pill can show every open PR (one row per
+/// PR, repo-root link above them) and use the branch as a hover tooltip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrRef {
+    /// PR number (e.g. 34). Used for the `#34` pill label and sort order.
+    pub number: i64,
+    /// Full GitHub PR URL.
+    pub url: String,
+    /// Head branch name (`headRefName`), shown as the pill tooltip.
+    pub branch: String,
+}
+
 /// API types for HTTP endpoints
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SessionInfo {
@@ -235,6 +249,10 @@ pub struct SessionInfo {
     /// GitHub repository URL
     #[serde(default)]
     pub repo_url: Option<String>,
+    /// All open PRs in the session's repo, sorted by number. Drives the pill's
+    /// PR list (one row each) and the `#34 #35` collapsed label.
+    #[serde(default)]
+    pub open_prs: Vec<PrRef>,
     /// Which agent CLI backs this session (claude or codex)
     #[serde(default)]
     pub agent_type: AgentType,


### PR DESCRIPTION
Replaces the pill's single PR link with **all open PRs** in the session's repo.

## UI

- **Collapsed pill:** shows open PR numbers (`#34 #35 …`) in place of the branch name. Each `#N` carries its head branch as a **hover tooltip**. Falls back to the branch name, then `No VCS`, when there are no open PRs.
- **Dropdown:** the **GitHub repo-root link on top**, then **one row per open PR sorted by number** — each row `Open PR #N` with the branch shown as hint + tooltip.

## Data path

| Layer | Change |
|---|---|
| **shared** | New `PrRef { number, url, branch }`; `SessionInfo.open_prs: Vec<PrRef>`; `open_prs` added to both `SessionUpdate` variants (`#[serde(default)]`). |
| **detection** (`claude-session-lib`) | `get_open_prs` via `gh pr list --state open --limit 100 --json number,url,headRefName`, sorted by number. Folded into `check_and_send_branch_update` (refreshes on git/gh signals + every 100 msgs) **and** the initial registration `SessionUpdate` so the list shows immediately. |
| **backend** | New `open_prs jsonb NOT NULL DEFAULT '[]'` column (mirrors `claude_args`); persisted + broadcast on `SessionUpdate`. Surfaces to the frontend via `SessionWithRole`'s flatten of `Session`. |
| **frontend** | `open_prs` threaded through the `BranchChanged` event chain into the session list; pill label + dropdown rendering; CSS for the inline `#N` numbers (LTR, `cursor: help`). |

## Design decisions (confirmed with the requester)

- **Scope = all open PRs in the repo** (`gh pr list`), not just worktree branches.
- **Pill face shows PR numbers**, not the branch (branch moves to the per-number tooltip).
- Persisted as `jsonb` (not transient) so the numbers render on dashboard load from REST, matching the old `pr_url` behavior. No CI schema check exists; `schema.rs` updated to match the migration; migrations are embedded and auto-run at startup.

## Verification

- `cargo build -p shared --target wasm32-unknown-unknown` ✅ (WASM-safe; `PrRef` is dependency-free)
- `cargo test -p shared -p claude-session-lib -p agent-portal` ✅
- `cargo check -p backend` ✅ · `cargo check -p frontend --target wasm32-unknown-unknown` ✅
- `cargo fmt --check` ✅ · clippy (shared/csl/launcher/backend/frontend) — no warnings ✅
- **Minor** bump `2.8.80 → 2.9.0` (new feature; also sidesteps the `2.8.81` in-flight in #1066)

🤖 Generated with [Claude Code](https://claude.com/claude-code)