### PR TITLE
Fix AskUserQuestion 1-char input: dialog was stealing focus on every render

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.9.1"
+version = "2.9.2"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/permission_handler.rs
+++ b/frontend/src/pages/dashboard/session_view/permission_handler.rs
@@ -85,6 +85,13 @@ pub struct PermissionHandler {
     multi_select_options: HashMap<usize, HashSet<usize>>,
     question_answers: QuestionAnswers,
     dialog_ref: NodeRef,
+    /// Focus the dialog container exactly once when it appears, never on the
+    /// re-renders that typing triggers. Without this gate, `rendered()` called
+    /// `el.focus()` after *every* render, so each keystroke in the "Other"
+    /// field yanked focus back to the container — you could only enter one
+    /// character at a time. Set when a request arrives or the session regains
+    /// focus; cleared once consumed in `rendered()`.
+    needs_focus: bool,
 }
 
 impl Component for PermissionHandler {
@@ -104,14 +111,29 @@ impl Component for PermissionHandler {
             multi_select_options: HashMap::new(),
             question_answers: QuestionAnswers::new(),
             dialog_ref: NodeRef::default(),
+            needs_focus: false,
         }
     }
 
+    fn changed(&mut self, ctx: &Context<Self>, old_props: &Self::Properties) -> bool {
+        // Re-grab keyboard-nav focus only when the session transitions *into*
+        // focus with a dialog already pending — not on unrelated prop changes
+        // (which would re-introduce the focus-steal during typing).
+        if ctx.props().focused && !old_props.focused && self.request.is_some() {
+            self.needs_focus = true;
+        }
+        true
+    }
+
     fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
-        if self.request.is_some() && ctx.props().focused {
+        // Only when a dialog just appeared (or the session regained focus),
+        // and only while this session is focused — clear the flag once we've
+        // actually grabbed focus, so typing-triggered re-renders never refocus.
+        if self.needs_focus && ctx.props().focused {
             if let Some(el) = self.dialog_ref.cast::<web_sys::HtmlElement>() {
                 let _ = el.focus();
             }
+            self.needs_focus = false;
         }
     }
 
@@ -123,6 +145,9 @@ impl Component for PermissionHandler {
                 self.selected = 0;
                 self.question_answers.clear();
                 self.multi_select_options.clear();
+                // A dialog just appeared — grab keyboard-nav focus once on the
+                // next render (consumed in `rendered`), not on every keystroke.
+                self.needs_focus = true;
                 if was_empty {
                     ctx.props().on_pending_changed.emit(true);
                 }


### PR DESCRIPTION
## The actual root cause (third time's the charm — found by reading, not guessing)

`PermissionHandler::rendered()` called `dialog_ref.focus()` after **every** render while a request was pending:

```rust
fn rendered(&mut self, ctx, _first_render) {
    if self.request.is_some() && ctx.props().focused {
        if let Some(el) = self.dialog_ref.cast::<web_sys::HtmlElement>() {
            let _ = el.focus();   // ← runs on EVERY render
        }
    }
}
```

Typing in the "Other" field dispatches `SetQuestionAnswer` → re-render → `rendered()` → `el.focus()` **yanks focus from the `<input>` back to the dialog container**. First char lands; the next keypress goes to the container → **one character at a time**.

This is **independent of the input's markup**, which is exactly why the two prior attempts had no effect:
- **#1065** (keyed sub-component + local state) — couldn't help; focus was being stolen by the container.
- **#1069** (move input out of the option list, key the rows) — same.

I was debugging the wrong layer twice. Apologies for the churn.

## Fix

Focus the container **only when the dialog appears**, never on typing-triggered re-renders:
- `needs_focus` flag set when a request arrives (`Receive`) or the session transitions back into focus (`changed()`, guarded to the false→true edge so unrelated prop changes don't refocus).
- Consumed once in `rendered()` (still gated on `focused`).
- Keyboard nav (arrows/Enter) still grabs focus on open; typing no longer loses it.

Patch bump **2.9.1 → 2.9.2**.

## Confidence + verification

Higher confidence than the prior two: this is a concrete logic bug (focus-on-every-render) that explains both the symptom **and** why the markup fixes did nothing. Still — I can't exercise focus headlessly here, so the real confirmation is your deploy test. After redeploy, **hard-refresh** (Cmd/Ctrl+Shift+R) to avoid cached WASM, then type a sentence into "Other".

🤖 Generated with [Claude Code](https://claude.com/claude-code)