### PR TITLE
Codex bash status: fade + checkmark on running→completed (palette colors)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.9.2"
+version = "2.9.3"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer/tools.rs
+++ b/frontend/src/components/codex_renderer/tools.rs
@@ -13,13 +13,7 @@ use yew::prelude::*;
 /// and a tool-use-header with icon + name + optional `status` meta line.
 /// Returns `html! {}` when `body` is empty so callers can short-circuit
 /// empty-data cases by handing in a no-op body.
-fn tool_card(
-    icon: &str,
-    name: String,
-    status: Option<String>,
-    body: Html,
-    completed: bool,
-) -> Html {
+fn tool_card(icon: &str, name: String, status: Option<Html>, body: Html, completed: bool) -> Html {
     html! {
         <div class={item_card_classes(completed)}>
             <div class="message-body">
@@ -40,6 +34,36 @@ fn tool_card(
     }
 }
 
+/// Build the command-execution status meta: an outcome-colored label
+/// (palette: `--success` / `--error` / `--warning`) with a ✓/✗ glyph that
+/// pops in on completion. Styling + the fade live in `messages.css`
+/// (`.codex-cmd-status` / `.codex-cmd-glyph`).
+fn command_status_meta(it: &CommandExecutionItem, completed: bool) -> Html {
+    if !completed {
+        return html! { <span class="codex-cmd-status running">{ "running\u{2026}" }</span> };
+    }
+    let (kind, glyph, label) = match it.exit_code {
+        Some(0) => ("ok", "\u{2713}", "completed".to_string()),
+        Some(code) => ("err", "\u{2717}", format!("exit {code}")),
+        None => match it.status {
+            CommandExecutionStatus::Completed => ("ok", "\u{2713}", "completed".to_string()),
+            CommandExecutionStatus::Failed => ("err", "\u{2717}", "failed".to_string()),
+            CommandExecutionStatus::Declined => ("err", "\u{2717}", "declined".to_string()),
+            CommandExecutionStatus::InProgress => ("running", "", "running\u{2026}".to_string()),
+        },
+    };
+    html! {
+        <span class={classes!("codex-cmd-status", kind)}>
+            { if glyph.is_empty() {
+                html! {}
+            } else {
+                html! { <span class="codex-cmd-glyph">{ glyph }</span> }
+            } }
+            { label }
+        </span>
+    }
+}
+
 pub(super) fn render_command_execution(it: &CommandExecutionItem, completed: bool) -> Html {
     let cmd = if it.command.is_empty() {
         "(unknown command)"
@@ -47,16 +71,6 @@ pub(super) fn render_command_execution(it: &CommandExecutionItem, completed: boo
         it.command.as_str()
     };
     let out = it.aggregated_output.as_deref().unwrap_or("");
-
-    let status_text = if completed {
-        match it.exit_code {
-            Some(0) => "completed".to_string(),
-            Some(code) => format!("exit {}", code),
-            None => command_status_label(&it.status).to_string(),
-        }
-    } else {
-        "running...".to_string()
-    };
 
     let is_error = it.exit_code.is_some_and(|c| c != 0);
 
@@ -88,16 +102,8 @@ pub(super) fn render_command_execution(it: &CommandExecutionItem, completed: boo
         </>
     };
 
-    tool_card("$", "Bash".into(), Some(status_text), body, completed)
-}
-
-fn command_status_label(status: &CommandExecutionStatus) -> &'static str {
-    match status {
-        CommandExecutionStatus::InProgress => "in_progress",
-        CommandExecutionStatus::Completed => "completed",
-        CommandExecutionStatus::Failed => "failed",
-        CommandExecutionStatus::Declined => "declined",
-    }
+    let status = command_status_meta(it, completed);
+    tool_card("$", "Bash".into(), Some(status), body, completed)
 }
 
 fn patch_status_label(status: &PatchApplyStatus) -> &'static str {
@@ -136,7 +142,7 @@ pub(super) fn render_file_change(it: &FileChangeItem, completed: bool) -> Html {
     tool_card(
         "\u{1f4dd}",
         "File Changes".into(),
-        Some(status_label),
+        Some(html! { { status_label } }),
         body,
         completed,
     )
@@ -183,7 +189,7 @@ pub(super) fn render_mcp_tool_call(it: &McpToolCallItem, completed: bool) -> Htm
     tool_card(
         "\u{1f50c}",
         format!("{} / {}", server, tool),
-        Some(status),
+        Some(html! { { status } }),
         html! {},
         completed,
     )
@@ -296,5 +302,11 @@ pub(super) fn render_collab_agent_tool_call(it: &CollabAgentToolCallItem, comple
         </>
     };
 
-    tool_card("\u{1F916}", name, Some(status_text), body, completed)
+    tool_card(
+        "\u{1F916}",
+        name,
+        Some(html! { { status_text } }),
+        body,
+        completed,
+    )
 }

--- a/frontend/styles/base.css
+++ b/frontend/styles/base.css
@@ -10,6 +10,7 @@
     --link-visited: #9d7cd8;
     --success: #9ece6a;
     --error: #f7768e;
+    --warning: #e0af68;
     --border: #292e42;
     --font-mono: 'Courier New', Consolas, 'Liberation Mono', monospace;
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -280,7 +280,7 @@
 .codex-item-in-progress .tool-use-header::before,
 .codex-item-in-progress .message-header::before {
     content: "\25CF"; /* filled bullet */
-    color: #e0af68; /* tokyo-night orange — matches portal "in-flight" cues */
+    color: var(--warning); /* tokyo-night orange — portal "in-flight" cue */
     margin-right: 0.5rem;
     animation: codex-item-pulse 1.5s ease-in-out infinite;
     font-size: 0.7em;
@@ -294,16 +294,62 @@
 }
 
 .codex-item-in-progress .tool-meta {
-    color: #e0af68;
+    color: var(--warning);
     font-style: italic;
 }
 
-/* Honour reduced-motion: skip the pulse, keep the dot static. */
+/* Command-execution status meta (Bash cards): outcome color from the palette,
+ * with a ✓/✗ glyph that pops in when the running→completed event lands. The
+ * card's DOM node is reused across that transition (shared dedup key), so the
+ * pulse stops and this completed status fades/pops in rather than snapping. */
+.codex-cmd-status {
+    transition: color 0.25s ease;
+}
+
+.codex-cmd-status.running {
+    color: var(--warning);
+    font-style: italic;
+}
+
+.codex-cmd-status.ok {
+    color: var(--success);
+}
+
+.codex-cmd-status.err {
+    color: var(--error);
+}
+
+.codex-cmd-glyph {
+    display: inline-block;
+    margin-right: 0.3em;
+    animation: codex-check-pop 0.25s ease-out;
+}
+
+@keyframes codex-check-pop {
+    from {
+        opacity: 0;
+        transform: scale(0.6);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+/* Honour reduced-motion: skip the pulse and the check pop, keep colors static. */
 @media (prefers-reduced-motion: reduce) {
     .codex-item-in-progress .tool-use-header::before,
     .codex-item-in-progress .message-header::before {
         animation: none;
         opacity: 0.85;
+    }
+
+    .codex-cmd-glyph {
+        animation: none;
+    }
+
+    .codex-cmd-status {
+        transition: none;
     }
 }
 


### PR DESCRIPTION
Makes the Codex command-execution (Bash) card transition from **running… → completed** render nicely instead of snapping, per request: **fade + checkmark**, with colors matched to the palette.

## What changed

- **Checkmark that pops in:** a ✓ (success) / ✗ (failure) glyph animates in (`codex-check-pop`, ~250ms scale+fade) when the `item.completed` event lands. The card's DOM node is reused across the dedup swap (shared key), so the in-flight pulse stops and the completed status fades/pops in rather than hard-cutting.
- **Palette colors:** outcome color now comes from the palette — `--success` (green) / `--error` (red) / `--warning` (in-progress orange). I promoted the previously-hardcoded `#e0af68` to a new `--warning` CSS var and switched the in-flight cues to use it, so the codex status colors are palette-consistent (your "match the palette in general" note).
- **Reduced motion:** the pop + color transition are disabled under `prefers-reduced-motion`.

## Implementation

Widened `tool_card`'s status param from `Option<String>` to `Option<Html>` so the Bash card can render a classed `.codex-cmd-status` span with the glyph; the other callers (file-change, mcp, collab-agent) pass their plain status text unchanged.

## Verification

`cargo check` (frontend/wasm), `cargo fmt --check`, `cargo clippy` (frontend/wasm) all clean. **2.9.2 → 2.9.3.**

⚠️ I can't verify rendering/animation headlessly here (no browser tooling), so the visual is best confirmed on deploy. Not auto-merged — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)