### PR TITLE
Codex bash status: animated running ellipsis + pop-in on completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.9.3"
+version = "2.9.4"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer/tools.rs
+++ b/frontend/src/components/codex_renderer/tools.rs
@@ -39,8 +39,17 @@ fn tool_card(icon: &str, name: String, status: Option<Html>, body: Html, complet
 /// pops in on completion. Styling + the fade live in `messages.css`
 /// (`.codex-cmd-status` / `.codex-cmd-glyph`).
 fn command_status_meta(it: &CommandExecutionItem, completed: bool) -> Html {
+    // "running" with a CSS-animated ellipsis (. .. ... cycling); the empty
+    // `.codex-running-dots` span is filled by the `codex-running-dots` keyframes.
+    let running = || {
+        html! {
+            <span class="codex-cmd-status running">
+                { "running" }<span class="codex-running-dots"></span>
+            </span>
+        }
+    };
     if !completed {
-        return html! { <span class="codex-cmd-status running">{ "running\u{2026}" }</span> };
+        return running();
     }
     let (kind, glyph, label) = match it.exit_code {
         Some(0) => ("ok", "\u{2713}", "completed".to_string()),
@@ -49,16 +58,13 @@ fn command_status_meta(it: &CommandExecutionItem, completed: bool) -> Html {
             CommandExecutionStatus::Completed => ("ok", "\u{2713}", "completed".to_string()),
             CommandExecutionStatus::Failed => ("err", "\u{2717}", "failed".to_string()),
             CommandExecutionStatus::Declined => ("err", "\u{2717}", "declined".to_string()),
-            CommandExecutionStatus::InProgress => ("running", "", "running\u{2026}".to_string()),
+            CommandExecutionStatus::InProgress => return running(),
         },
     };
+    // `done` drives the pop-in; `ok`/`err` the palette color.
     html! {
-        <span class={classes!("codex-cmd-status", kind)}>
-            { if glyph.is_empty() {
-                html! {}
-            } else {
-                html! { <span class="codex-cmd-glyph">{ glyph }</span> }
-            } }
+        <span class={classes!("codex-cmd-status", "done", kind)}>
+            <span class="codex-cmd-glyph">{ glyph }</span>
             { label }
         </span>
     }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -303,6 +303,7 @@
  * card's DOM node is reused across that transition (shared dedup key), so the
  * pulse stops and this completed status fades/pops in rather than snapping. */
 .codex-cmd-status {
+    display: inline-block;
     transition: color 0.25s ease;
 }
 
@@ -317,6 +318,49 @@
 
 .codex-cmd-status.err {
     color: var(--error);
+}
+
+/* Animated ellipsis after "running": cycles . → .. → ... → . The span is
+ * empty in markup; the dots come from the keyframes. Fixed inline-block width
+ * reserves space for three dots so the row doesn't jiggle as they change. */
+.codex-running-dots {
+    display: inline-block;
+    width: 1.1em;
+    text-align: left;
+}
+
+.codex-running-dots::after {
+    content: ".";
+    animation: codex-running-dots 1.2s steps(1, end) infinite;
+}
+
+@keyframes codex-running-dots {
+    0% {
+        content: ".";
+    }
+    33% {
+        content: "..";
+    }
+    66% {
+        content: "...";
+    }
+}
+
+/* Completed status pops in (scale + fade) when it replaces the running label,
+ * so running → completed/failed morphs rather than snapping. */
+.codex-cmd-status.done {
+    animation: codex-status-pop 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes codex-status-pop {
+    from {
+        opacity: 0;
+        transform: scale(0.8) translateY(1px);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+    }
 }
 
 .codex-cmd-glyph {
@@ -344,7 +388,13 @@
         opacity: 0.85;
     }
 
-    .codex-cmd-glyph {
+    .codex-cmd-glyph,
+    .codex-cmd-status.done {
+        animation: none;
+    }
+
+    .codex-running-dots::after {
+        content: "\2026"; /* static ellipsis, no cycling */
         animation: none;
     }
 


### PR DESCRIPTION
Builds on #1071. Two requested touches to the Codex Bash command status:

- **Animated ellipsis** — "running" now cycles `.` → `..` → `...` → `.` via CSS keyframes (an empty `.codex-running-dots` span filled by the animation; fixed inline-block width so the row doesn't jiggle as dots change).
- **Pop-in on completion** — when the completed/failed status replaces the running label, it pops in (scale + fade with a springy `cubic-bezier`), so running → completed/failed **morphs** rather than snapping. The ✓/✗ glyph keeps its own pop for a little extra emphasis.
- **Reduced motion** — dots fall back to a static ellipsis and the pops are disabled.

Colors still come from the palette (`--success` / `--error` / `--warning`).

`cargo check` (wasm) / `fmt` / `clippy` clean. **2.9.3 → 2.9.4.**

⚠️ Animation is visual-only — can't verify headlessly; eyeball on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)