### PR TITLE
Homogenize completion messages: "completed"/"failed" label left of the ✓/✗

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.9.4"
+version = "2.9.5"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -245,6 +245,7 @@ fn render_turn_completed(
     html! {
         <div class="claude-message result-message success">
             <div class="result-stats-bar">
+                <span class="result-done-label success">{ "completed" }</span>
                 <span class="result-status success">{ "\u{2713}" }</span>
                 {
                     if let Some(ms) = duration_ms {

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -465,6 +465,7 @@ pub fn render_result_message(
                     { error_html }
                     <div class={classes!("claude-message", "result-message", status_class)}>
                         <div class="result-stats-bar">
+                            <span class={classes!("result-done-label", status_class)}>{ "failed" }</span>
                             <span class={classes!("result-status", status_class)}>{ "✗" }</span>
                             <span class="stat-item duration" title={timing_tooltip.clone()}>
                                 { format_duration(duration_ms) }
@@ -481,6 +482,9 @@ pub fn render_result_message(
     html! {
         <div class={classes!("claude-message", "result-message", status_class)}>
             <div class="result-stats-bar">
+                <span class={classes!("result-done-label", status_class)}>
+                    { if is_error { "failed" } else { "completed" } }
+                </span>
                 <span class={classes!("result-status", status_class)}>
                     { if is_error { "✗" } else { "✓" } }
                 </span>

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -894,6 +894,21 @@
     color: var(--error);
 }
 
+/* "completed" / "failed" label shown to the LEFT of the ✓/✗ glyph. Matches the
+ * codex Bash card's completed status — palette color, normal weight. The
+ * stats-bar's flex `gap` spaces it from the glyph. */
+.result-message .result-done-label {
+    font-size: 0.8rem;
+}
+
+.result-message .result-done-label.success {
+    color: var(--success);
+}
+
+.result-message .result-done-label.error {
+    color: var(--error);
+}
+
 .result-message .stat-item {
     color: var(--text-secondary);
     cursor: help;


### PR DESCRIPTION
Both completion "terminal" messages now carry a palette-colored outcome label to the **left** of the status glyph, matching the Codex Bash card's completed text + color.

- **Codex turn-completed message** (`render_turn_completed`): adds `completed` (green) before the `✓`.
- **Claude result message** (`ResultMessage` renderer, both the API-error and normal branches): adds `completed` (green, success) / `failed` (red, error) before the `✓`/`✗`.
- Colors from the palette (`--success` / `--error`), normal weight — same text/color as the Bash card's `completed`. The stats-bar flex `gap` spaces it from the glyph.

`cargo check` (wasm) / `fmt` / `clippy` clean. **2.9.4 → 2.9.5.**

⚠️ Visual-only — eyeball on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)