### PR TITLE
Completion messages: ✓/✗ glyph to the left of completed/failed label

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.9.5"
+version = "2.9.6"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -245,8 +245,8 @@ fn render_turn_completed(
     html! {
         <div class="claude-message result-message success">
             <div class="result-stats-bar">
-                <span class="result-done-label success">{ "completed" }</span>
                 <span class="result-status success">{ "\u{2713}" }</span>
+                <span class="result-done-label success">{ "completed" }</span>
                 {
                     if let Some(ms) = duration_ms {
                         html! {

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -465,8 +465,8 @@ pub fn render_result_message(
                     { error_html }
                     <div class={classes!("claude-message", "result-message", status_class)}>
                         <div class="result-stats-bar">
-                            <span class={classes!("result-done-label", status_class)}>{ "failed" }</span>
                             <span class={classes!("result-status", status_class)}>{ "✗" }</span>
+                            <span class={classes!("result-done-label", status_class)}>{ "failed" }</span>
                             <span class="stat-item duration" title={timing_tooltip.clone()}>
                                 { format_duration(duration_ms) }
                             </span>
@@ -482,11 +482,11 @@ pub fn render_result_message(
     html! {
         <div class={classes!("claude-message", "result-message", status_class)}>
             <div class="result-stats-bar">
-                <span class={classes!("result-done-label", status_class)}>
-                    { if is_error { "failed" } else { "completed" } }
-                </span>
                 <span class={classes!("result-status", status_class)}>
                     { if is_error { "✗" } else { "✓" } }
+                </span>
+                <span class={classes!("result-done-label", status_class)}>
+                    { if is_error { "failed" } else { "completed" } }
                 </span>
                 <span class="stat-item duration" title={timing_tooltip.clone()}>
                     { format_duration(duration_ms) }


### PR DESCRIPTION
Fixes the order from #1073 — the check goes **left** of the text now: `✓ completed` / `✗ failed`, matching the Codex Bash card (glyph then text). Applied to both the Codex turn-completed message and the Claude result message (normal + API-error branches).

`cargo check` (wasm) / `fmt` / `clippy` clean. **2.9.5 → 2.9.6.** Visual-only — eyeball on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)