### PR TITLE
Codex completion line: don't show 'completed' twice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.9.6"
+version = "2.9.7"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -293,7 +293,10 @@ fn render_turn_completed(
                     }
                 }
                 {
-                    if let Some(status) = status {
+                    // The `✓ completed` label already conveys a normal finish;
+                    // only surface the raw status when it says something else
+                    // (a non-"completed" stop reason), so it isn't shown twice.
+                    if let Some(status) = status.filter(|s| !s.eq_ignore_ascii_case("completed")) {
                         html! {
                             <span class="stat-item stop-reason" title={status_title.clone()}>
                                 { status }


### PR DESCRIPTION
The Codex turn-completed message already rendered the turn's `status` string ("completed") in a `stop-reason` stat-item; the new `✓ completed` label (#1073/#1074) made it appear twice.

Fix: suppress that stat-item when `status` is `"completed"` (case-insensitive) — the label already conveys a normal finish — while still surfacing any other stop reason.

`cargo check` (wasm) / `fmt` / `clippy` clean. **2.9.6 → 2.9.7.** Visual-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)