### PR TITLE
Inter-agent messaging: list your sessions + post a message into one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.9.7"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.9.7"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.9.7"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.9.7"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.9.7"
+version = "2.10.0"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.9.7"
+version = "2.10.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.9.7"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.9.7"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.9.7"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.9.7"
+version = "2.10.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.9.7"
+version = "2.10.0"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -1,0 +1,167 @@
+//! Inter-agent messaging: list the caller's sessions and post a message into
+//! one, delivered as an input turn to that session's agent.
+//!
+//! Auth accepts either a browser session cookie (the web page) or a `Bearer`
+//! proxy token (programmatic/agent callers), and is scoped to a single user —
+//! you can only see and message your own sessions.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
+use diesel::prelude::*;
+use tower_cookies::Cookies;
+use tracing::info;
+use uuid::Uuid;
+
+use shared::api::{
+    AgentSessionInfo, AgentSessionsResponse, SendAgentMessageRequest, SendAgentMessageResponse,
+};
+use shared::ServerToProxy;
+
+use crate::errors::AppError;
+use crate::models::{NewPendingInput, Session};
+use crate::AppState;
+
+/// Resolve the calling user from a `Bearer` proxy token if present, otherwise
+/// from the browser session cookie.
+fn resolve_user(
+    app_state: &AppState,
+    headers: &HeaderMap,
+    cookies: &Cookies,
+) -> Result<Uuid, AppError> {
+    if let Some(token) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+    {
+        let mut conn = app_state.conn()?;
+        let (user_id, _email) =
+            crate::handlers::proxy_tokens::verify_and_get_user(app_state, &mut conn, token)?;
+        return Ok(user_id);
+    }
+    crate::auth::extract_user_id(app_state, cookies)
+}
+
+/// Look up a display name for `user_id` (name, falling back to email).
+fn user_display_name(conn: &mut crate::db::DbConnection, user_id: Uuid) -> String {
+    use crate::schema::users;
+    users::table
+        .find(user_id)
+        .select(users::name)
+        .first::<Option<String>>(conn)
+        .ok()
+        .flatten()
+        .or_else(|| {
+            users::table
+                .find(user_id)
+                .select(users::email)
+                .first::<String>(conn)
+                .ok()
+        })
+        .unwrap_or_else(|| "portal".to_string())
+}
+
+/// GET /api/agent/sessions — the caller's sessions, for picking a recipient.
+/// Excludes replaced rows and scheduled-task sessions.
+pub async fn list_agent_sessions(
+    State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    cookies: Cookies,
+) -> Result<Json<AgentSessionsResponse>, AppError> {
+    let user_id = resolve_user(&app_state, &headers, &cookies)?;
+    let mut conn = app_state.conn()?;
+
+    use crate::schema::{session_members, sessions};
+    let rows: Vec<Session> = sessions::table
+        .inner_join(session_members::table.on(session_members::session_id.eq(sessions::id)))
+        .filter(session_members::user_id.eq(user_id))
+        .filter(sessions::status.ne("replaced"))
+        .filter(sessions::scheduled_task_id.is_null())
+        .select(Session::as_select())
+        .order(sessions::last_activity.desc())
+        .load(&mut conn)?;
+
+    let sessions = rows
+        .into_iter()
+        .map(|s| AgentSessionInfo {
+            id: s.id,
+            session_name: s.session_name,
+            working_directory: s.working_directory,
+            agent_type: s.agent_type,
+            status: s.status,
+            hostname: s.hostname,
+        })
+        .collect();
+
+    Ok(Json(AgentSessionsResponse { sessions }))
+}
+
+/// POST /api/agent/sessions/{id}/message — inject a message into a session as
+/// an input turn (same pipeline as a user typing in the web client).
+pub async fn send_agent_message(
+    State(app_state): State<Arc<AppState>>,
+    Path(target_id): Path<Uuid>,
+    headers: HeaderMap,
+    cookies: Cookies,
+    Json(req): Json<SendAgentMessageRequest>,
+) -> Result<Json<SendAgentMessageResponse>, AppError> {
+    let user_id = resolve_user(&app_state, &headers, &cookies)?;
+    let message = req.message.trim();
+    if message.is_empty() {
+        return Err(AppError::BadRequest("message is empty"));
+    }
+
+    let mut conn = app_state.conn()?;
+    use crate::schema::{pending_inputs, session_members, sessions};
+
+    // Authorize: the caller must be a member of the target session.
+    let session: Session = sessions::table
+        .inner_join(session_members::table.on(session_members::session_id.eq(sessions::id)))
+        .filter(sessions::id.eq(target_id))
+        .filter(session_members::user_id.eq(user_id))
+        .select(Session::as_select())
+        .first(&mut conn)
+        .map_err(|_| AppError::NotFound("session"))?;
+
+    // Attribute the message so the recipient knows where it came from.
+    let sender = user_display_name(&mut conn, user_id);
+    let content = serde_json::Value::String(format!("[portal message from {sender}]\n{message}"));
+
+    // Mirror the WS input path: bump the per-session seq, persist a pending
+    // input row, then forward to the live proxy (queued if disconnected).
+    let seq: i64 = diesel::update(sessions::table.find(target_id))
+        .set(sessions::input_seq.eq(sessions::input_seq + 1))
+        .returning(sessions::input_seq)
+        .get_result(&mut conn)?;
+
+    let new_input = NewPendingInput {
+        session_id: target_id,
+        seq_num: seq,
+        content: serde_json::to_string(&content).unwrap_or_default(),
+        send_mode: None,
+    };
+    diesel::insert_into(pending_inputs::table)
+        .values(&new_input)
+        .execute(&mut conn)?;
+
+    let delivered = app_state.session_manager.send_to_session(
+        &session.session_key,
+        ServerToProxy::SequencedInput {
+            session_id: target_id,
+            seq,
+            content,
+            send_mode: None,
+        },
+    );
+
+    info!(
+        "Agent message: user {} -> session {} (seq {}, live={})",
+        user_id, target_id, seq, delivered
+    );
+
+    Ok(Json(SendAgentMessageResponse { delivered, seq }))
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod agent_comms;
 pub mod auth;
 pub mod config;
 pub mod device_flow;

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -119,6 +119,16 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             "/api/sessions/{id}/turn-metrics",
             get(handlers::turn_metrics::list_turn_metrics),
         )
+        // Inter-agent messaging: list your sessions, post a message into one
+        // (cookie or Bearer-token auth; same-user only).
+        .route(
+            "/api/agent/sessions",
+            get(handlers::agent_comms::list_agent_sessions),
+        )
+        .route(
+            "/api/agent/sessions/{id}/message",
+            post(handlers::agent_comms::send_agent_message),
+        )
         .route(
             "/api/metrics/recent",
             get(handlers::turn_metrics::list_recent_user_turn_metrics),

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -8,8 +8,8 @@ pub mod utils;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use pages::{
-    access_denied::AccessDeniedPage, admin::AdminPage, banned::BannedPage,
-    dashboard::DashboardPage, settings::SettingsPage, splash::SplashPage,
+    access_denied::AccessDeniedPage, admin::AdminPage, agent_messaging::AgentMessagingPage,
+    banned::BannedPage, dashboard::DashboardPage, settings::SettingsPage, splash::SplashPage,
 };
 use yew::prelude::*;
 use yew_router::prelude::*;
@@ -24,6 +24,8 @@ pub enum Route {
     Settings,
     #[at("/admin")]
     Admin,
+    #[at("/agents")]
+    Agents,
     #[at("/banned")]
     Banned,
     #[at("/access-denied")]
@@ -52,6 +54,7 @@ fn switch(routes: Route) -> Html {
         Route::Dashboard => html! { <DashboardPage /> },
         Route::Settings => html! { <SettingsRoute /> },
         Route::Admin => html! { <AdminRoute /> },
+        Route::Agents => html! { <AgentMessagingPage /> },
         Route::Banned => html! { <BannedPage /> },
         Route::AccessDenied => html! { <AccessDeniedPage /> },
     }

--- a/frontend/src/pages/agent_messaging.rs
+++ b/frontend/src/pages/agent_messaging.rs
@@ -1,0 +1,160 @@
+//! Agent Messaging page: list your sessions and send a message into one. The
+//! message is delivered to that session's agent as an input turn. Backed by
+//! `GET /api/agent/sessions` and `POST /api/agent/sessions/{id}/message`.
+
+use gloo_net::http::Request;
+use shared::api::{
+    AgentSessionInfo, AgentSessionsResponse, SendAgentMessageRequest, SendAgentMessageResponse,
+};
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlTextAreaElement;
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+use crate::utils::{self, On401};
+use crate::Route;
+
+#[function_component(AgentMessagingPage)]
+pub fn agent_messaging_page() -> Html {
+    let sessions = use_state(Vec::<AgentSessionInfo>::new);
+    let selected = use_state(|| None::<Uuid>);
+    let message = use_state(String::new);
+    let status = use_state(|| None::<String>);
+    let loading = use_state(|| true);
+
+    // Load the caller's sessions once on mount.
+    {
+        let sessions = sessions.clone();
+        let loading = loading.clone();
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                match utils::fetch_json::<AgentSessionsResponse>(
+                    "/api/agent/sessions",
+                    On401::Logout,
+                )
+                .await
+                {
+                    Ok(resp) => sessions.set(resp.sessions),
+                    Err(e) => log::error!("Failed to load sessions: {:?}", e),
+                }
+                loading.set(false);
+            });
+            || ()
+        });
+    }
+
+    let on_message_input = {
+        let message = message.clone();
+        Callback::from(move |e: InputEvent| {
+            message.set(e.target_unchecked_into::<HtmlTextAreaElement>().value());
+        })
+    };
+
+    let on_send = {
+        let selected = selected.clone();
+        let message = message.clone();
+        let status = status.clone();
+        Callback::from(move |_: MouseEvent| {
+            let Some(target) = *selected else {
+                status.set(Some("Pick a session first.".to_string()));
+                return;
+            };
+            let text = (*message).trim().to_string();
+            if text.is_empty() {
+                status.set(Some("Type a message first.".to_string()));
+                return;
+            }
+            let message = message.clone();
+            let status = status.clone();
+            spawn_local(async move {
+                let body = SendAgentMessageRequest { message: text };
+                let result = Request::post(&utils::api_url(&format!(
+                    "/api/agent/sessions/{}/message",
+                    target
+                )))
+                .json(&body)
+                .unwrap()
+                .send()
+                .await;
+                match result {
+                    Ok(resp) if resp.ok() => match resp.json::<SendAgentMessageResponse>().await {
+                        Ok(r) => {
+                            status.set(Some(if r.delivered {
+                                format!("Delivered (seq {}).", r.seq)
+                            } else {
+                                format!("Queued for the session's reconnect (seq {}).", r.seq)
+                            }));
+                            message.set(String::new());
+                        }
+                        Err(_) => status.set(Some("Sent, but the response was unreadable.".into())),
+                    },
+                    Ok(resp) => status.set(Some(format!("Failed: HTTP {}", resp.status()))),
+                    Err(e) => status.set(Some(format!("Failed: {}", e))),
+                }
+            });
+        })
+    };
+
+    html! {
+        <div class="agent-messaging-page" style="max-width:760px; margin:0 auto; padding:1rem;">
+            <div style="display:flex; align-items:center; gap:0.75rem; margin-bottom:1rem;">
+                <Link<Route> to={Route::Dashboard} classes="back-link">{ "← Dashboard" }</Link<Route>>
+                <h1 style="margin:0; font-size:1.2rem;">{ "Agent Messaging" }</h1>
+            </div>
+            <p style="color:var(--text-secondary); margin-bottom:1rem;">
+                { "Send a message into one of your sessions — it arrives as an input turn to that session's agent." }
+            </p>
+
+            {
+                if *loading {
+                    html! { <p>{ "Loading sessions\u{2026}" }</p> }
+                } else if sessions.is_empty() {
+                    html! { <p style="color:var(--text-muted);">{ "No sessions found." }</p> }
+                } else {
+                    html! {
+                        <div style="display:flex; flex-direction:column; gap:0.4rem; margin-bottom:1rem;">
+                            { for sessions.iter().map(|s| {
+                                let id = s.id;
+                                let is_sel = *selected == Some(id);
+                                let selected = selected.clone();
+                                let onclick = Callback::from(move |_| selected.set(Some(id)));
+                                let border = if is_sel { "var(--accent)" } else { "var(--border)" };
+                                html! {
+                                    <button type="button" {onclick}
+                                        style={format!("text-align:left; padding:0.5rem 0.7rem; border-radius:4px; border:1px solid {}; background:rgba(0,0,0,0.2); color:var(--text-primary); cursor:pointer;", border)}>
+                                        <div style="font-weight:600;">{ &s.session_name }</div>
+                                        <div style="font-size:0.75rem; color:var(--text-secondary);">
+                                            { format!("{} \u{00b7} {} \u{00b7} {} \u{00b7} {}", s.agent_type, s.status, s.hostname, s.working_directory) }
+                                        </div>
+                                    </button>
+                                }
+                            }) }
+                        </div>
+                    }
+                }
+            }
+
+            <textarea
+                placeholder="Message to send\u{2026}"
+                value={(*message).clone()}
+                oninput={on_message_input}
+                rows="4"
+                style="width:100%; padding:0.6rem; border-radius:4px; border:1px solid var(--border); background:var(--bg-darker); color:var(--text-primary); font-family:inherit; resize:vertical;"
+            />
+            <div style="display:flex; align-items:center; gap:0.75rem; margin-top:0.6rem;">
+                <button type="button" onclick={on_send}
+                    style="padding:0.5rem 1rem; border-radius:4px; border:none; background:var(--accent); color:var(--bg-dark); font-weight:600; cursor:pointer;">
+                    { "Send" }
+                </button>
+                {
+                    if let Some(msg) = &*status {
+                        html! { <span style="color:var(--text-secondary); font-size:0.85rem;">{ msg }</span> }
+                    } else {
+                        html! {}
+                    }
+                }
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -1,5 +1,6 @@
 pub mod access_denied;
 pub mod admin;
+pub mod agent_messaging;
 pub mod banned;
 pub mod dashboard;
 pub mod settings;

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -925,6 +925,44 @@ pub struct MetricBucketsResponse {
     pub buckets: Vec<MetricBucket>,
 }
 
+// ---- Inter-agent messaging --------------------------------------------------
+
+/// One of the caller's sessions, as listed for the agent-messaging page/API
+/// (`GET /api/agent/sessions`). A lightweight summary — enough to pick a
+/// recipient — not the full `SessionInfo`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentSessionInfo {
+    pub id: Uuid,
+    pub session_name: String,
+    pub working_directory: String,
+    pub agent_type: String,
+    pub status: String,
+    pub hostname: String,
+}
+
+/// Response for `GET /api/agent/sessions`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentSessionsResponse {
+    #[serde(default)]
+    pub sessions: Vec<AgentSessionInfo>,
+}
+
+/// Body for `POST /api/agent/sessions/{id}/message`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SendAgentMessageRequest {
+    pub message: String,
+}
+
+/// Response for `POST /api/agent/sessions/{id}/message`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SendAgentMessageResponse {
+    /// True if a live proxy received it; false means it was queued for the
+    /// session's next reconnect.
+    pub delivered: bool,
+    /// The input sequence number assigned to the injected message.
+    pub seq: i64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -25,7 +25,8 @@ pub mod timezone;
 // API client types and trait
 pub mod api;
 pub use api::{
-    CodexPermissionInput, CompactionExtra, InitExtra, ModelUsage, ModelUsageEntry,
+    AgentSessionInfo, AgentSessionsResponse, CodexPermissionInput, CompactionExtra, InitExtra,
+    ModelUsage, ModelUsageEntry, SendAgentMessageRequest, SendAgentMessageResponse,
     SoundSettingsResponse, TaskNotificationExtra, TurnMetrics, TurnMetricsResponse,
 };
 


### PR DESCRIPTION
A simple way for one session to message another (the start of agent-to-agent comms). Scope per request: **HTTP API + a human web page** (agent env-var auto-access deferred).

## API
- **`GET /api/agent/sessions`** — your sessions (id, name, working dir, agent type, status, host), for picking a recipient. Excludes replaced + scheduled-task sessions.
- **`POST /api/agent/sessions/{id}/message`** `{ "message": "…" }` → injects the text into the target session as an **input turn**, reusing the existing WS input pipeline (bump `input_seq`, persist a `pending_inputs` row, `send_to_session(SequencedInput)`; queued if the proxy is offline). Attributed as `[portal message from <name>]`. Returns `{ delivered, seq }`.
- **Auth:** either a browser session cookie (the page) or an `Authorization: Bearer <proxy-token>` (programmatic callers). **Same-user only** — you can only see/message your own sessions.

## Web page
`/agents` (`AgentMessagingPage`): lists your sessions, pick one, type a message, send; shows delivered/queued feedback. Reachable at `/agents` with a "← Dashboard" link (same URL-route pattern as Settings/Admin, which also have no dashboard nav button).

## Deferred (follow-up)
Injecting `PORTAL_BACKEND_URL` / `PORTAL_SESSION_TOKEN` / `PORTAL_SESSION_ID` into spawned agents + advertising these endpoints in the portal agent-reminder, so agents discover and use this unprompted. (You didn't select it; the API already supports Bearer-token callers when you want it.)

## Verification
`cargo check` (backend + frontend/wasm), `cargo fmt --check`, `cargo clippy` (backend + frontend), `check-no-json-macro.py`, shared wasm build — all clean. **2.9.7 → 2.10.0.**

⚠️ The endpoints + page can't be exercised headlessly here — verify on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)