### PR TITLE
agent-portal message CLI: agent-to-agent messaging via the launcher binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.10.0"
+version = "2.11.0"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -127,9 +127,17 @@ pub async fn send_agent_message(
         .first(&mut conn)
         .map_err(|_| AppError::NotFound("session"))?;
 
-    // Attribute the message so the recipient knows where it came from.
-    let sender = user_display_name(&mut conn, user_id);
-    let content = serde_json::Value::String(format!("[portal message from {sender}]\n{message}"));
+    // Attribute the message so the recipient knows where it came from. An
+    // agent sender supplies its own session id (`from`); the human web page
+    // doesn't, so fall back to the sending user's display name.
+    let bumper = match req.from.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(from) => format!("[message from agent {from}]"),
+        None => format!(
+            "[portal message from {}]",
+            user_display_name(&mut conn, user_id)
+        ),
+    };
+    let content = serde_json::Value::String(format!("{bumper}\n{message}"));
 
     // Mirror the WS input path: bump the per-session seq, persist a pending
     // input row, then forward to the live proxy (queued if disconnected).

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -56,6 +56,10 @@ pub(crate) async fn spawn_claude(
     cmd.args(&args);
     cmd.current_dir(&config.working_directory);
 
+    // Expose this session's id so tools the agent spawns (notably
+    // `agent-portal message send`) can attribute messages as coming from it.
+    cmd.env("PORTAL_SESSION_ID", config.session_id.to_string());
+
     // Log the full command for diagnostics.
     tracing::info!(
         "Spawning Claude: {} {}",

--- a/frontend/src/pages/agent_messaging.rs
+++ b/frontend/src/pages/agent_messaging.rs
@@ -68,7 +68,10 @@ pub fn agent_messaging_page() -> Html {
             let message = message.clone();
             let status = status.clone();
             spawn_local(async move {
-                let body = SendAgentMessageRequest { message: text };
+                let body = SendAgentMessageRequest {
+                    message: text,
+                    from: None,
+                };
                 let result = Request::post(&utils::api_url(&format!(
                     "/api/agent/sessions/{}/message",
                     target

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod connection;
+mod message;
 mod pastebin;
 mod path_policy;
 mod process_manager;
@@ -56,6 +57,24 @@ enum Command {
     Service {
         #[command(subcommand)]
         action: ServiceAction,
+    },
+    /// Message your other agent sessions
+    Message {
+        #[command(subcommand)]
+        action: MessageAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum MessageAction {
+    /// List your sessions (agents) you can message
+    List,
+    /// Send a message into another session's agent
+    Send {
+        /// Target session id
+        agent_id: String,
+        /// Message text
+        message: String,
     },
 }
 
@@ -123,6 +142,14 @@ async fn main() -> anyhow::Result<()> {
                 ServiceAction::Restart => service::restart(),
                 ServiceAction::Logs { lines, follow } => service::logs(lines, follow),
                 ServiceAction::Pastebin => pastebin::upload_diagnostics().await,
+            };
+        }
+        Some(Command::Message { action }) => {
+            return match action {
+                MessageAction::List => message::list().await,
+                MessageAction::Send { agent_id, message } => {
+                    message::send(&agent_id, &message).await
+                }
             };
         }
         None => {}

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -1,0 +1,90 @@
+//! `agent-portal message` subcommands: list your sessions and send a message
+//! into one. A thin client over the backend's `/api/agent/*` endpoints,
+//! authenticated with the launcher's stored proxy token (`launcher.json`) — so
+//! an agent can just shell out to `agent-portal message send …` with no extra
+//! credentials. The message is delivered to the target session's agent as an
+//! input turn, attributed with this session's id (`$PORTAL_SESSION_ID`).
+
+use anyhow::{anyhow, Context, Result};
+
+use shared::api::{AgentSessionsResponse, SendAgentMessageRequest, SendAgentMessageResponse};
+
+/// Resolve the HTTP API base URL and auth token from the launcher config.
+fn api_base() -> Result<(String, String)> {
+    let config = crate::config::load_config();
+    let token = config
+        .auth_token
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| anyhow!("Not authenticated — run `agent-portal login` first"))?;
+    let ws_url = config
+        .backend_url
+        .unwrap_or_else(|| shared::default_backend_url().to_string());
+    // The config stores the WebSocket URL; the HTTP API shares the host.
+    let http = ws_url
+        .replacen("wss://", "https://", 1)
+        .replacen("ws://", "http://", 1);
+    Ok((http.trim_end_matches('/').to_string(), token))
+}
+
+/// `agent-portal message list` — print the caller's sessions (agents).
+pub async fn list() -> Result<()> {
+    let (base, token) = api_base()?;
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/api/agent/sessions"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .context("request to backend failed")?;
+    if !resp.status().is_success() {
+        return Err(anyhow!("backend returned {}", resp.status()));
+    }
+    let data: AgentSessionsResponse = resp.json().await.context("malformed response")?;
+    if data.sessions.is_empty() {
+        println!("No sessions found.");
+        return Ok(());
+    }
+    let self_id = std::env::var("PORTAL_SESSION_ID").ok();
+    for s in &data.sessions {
+        let marker = if self_id.as_deref() == Some(&s.id.to_string()) {
+            " (this session)"
+        } else {
+            ""
+        };
+        println!(
+            "{}  {}  [{}/{}]  {}{}",
+            s.id, s.session_name, s.agent_type, s.status, s.working_directory, marker
+        );
+    }
+    Ok(())
+}
+
+/// `agent-portal message send <agent-id> <message>` — deliver a message into a
+/// session as an input turn.
+pub async fn send(agent_id: &str, message: &str) -> Result<()> {
+    let (base, token) = api_base()?;
+    let from = std::env::var("PORTAL_SESSION_ID")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/api/agent/sessions/{agent_id}/message"))
+        .bearer_auth(&token)
+        .json(&SendAgentMessageRequest {
+            message: message.to_string(),
+            from,
+        })
+        .send()
+        .await
+        .context("request to backend failed")?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!("backend returned {}: {}", status, body.trim()));
+    }
+    let data: SendAgentMessageResponse = resp.json().await.context("malformed response")?;
+    if data.delivered {
+        println!("Delivered (seq {}).", data.seq);
+    } else {
+        println!("Queued for the session's reconnect (seq {}).", data.seq);
+    }
+    Ok(())
+}

--- a/shared/src/api.rs
+++ b/shared/src/api.rs
@@ -951,6 +951,11 @@ pub struct AgentSessionsResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SendAgentMessageRequest {
     pub message: String,
+    /// Sender's session id, when sent by an agent (the `agent-portal message
+    /// send` CLI fills this from `$PORTAL_SESSION_ID`). Drives the recipient's
+    /// attribution bumper. Absent for the human web page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from: Option<String>,
 }
 
 /// Response for `POST /api/agent/sessions/{id}/message`.


### PR DESCRIPTION
Makes agent-to-agent messaging usable from inside an agent: shell out to the `agent-portal` launcher binary (already on PATH), which reuses the launcher's stored creds — **no env-injected secrets, no token plumbing**.

## CLI (`agent-portal message …`)
- **`list`** — your sessions (id, name, agent/status, dir; marks the current one).
- **`send <agent-id> "message"`** — delivers the text into that session's agent as an input turn.

Reads `backend_url` + `auth_token` from `launcher.json`, derives the HTTP base (`wss://`→`https://`), and calls the `/api/agent/*` endpoints (#1077) with the proxy token as `Bearer` (via `reqwest`).

## Attribution bumper
`SendAgentMessageRequest` gains an optional `from` (sender session id). The CLI fills it from **`$PORTAL_SESSION_ID`**, which the launcher now injects into the spawned `claude` process, so the recipient sees **`[message from agent <session-id>]`**. The human web page sends no `from`, so it falls back to the sender's display name.

## Delivery model
Inject (per discussion): the message arrives as an **input turn** to the target agent — natural back-and-forth, no polling, no mailbox. A distinct **`OtherAgent` transcript role/rendering** is a planned follow-up (needs care around claude's user-echo) — separate issue.

## Caveats
- **Codex** agents don't get `PORTAL_SESSION_ID` yet (it's injected in the claude spawn path; codex is launched via the codex-codes app-server). They fall back to user attribution until a follow-up wires it in.

## Verification
`cargo check` (shared/launcher/backend/claude-session-lib + frontend wasm), `cargo fmt --check`, `cargo clippy` (native + frontend), `check-no-json-macro.py` — all clean. **2.10.0 → 2.11.0.**

⚠️ The CLI + endpoints can't be exercised headlessly here — verify on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)