### PR TITLE
Attribute agent messages from CLAUDE_CODE_SESSION_ID (drop env injection)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.11.0"
+version = "2.11.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -55,10 +55,9 @@ pub(crate) async fn spawn_claude(
     let mut cmd = Command::new(claude_path);
     cmd.args(&args);
     cmd.current_dir(&config.working_directory);
-
-    // Expose this session's id so tools the agent spawns (notably
-    // `agent-portal message send`) can attribute messages as coming from it.
-    cmd.env("PORTAL_SESSION_ID", config.session_id.to_string());
+    // Note: no need to inject a session-id env var — Claude Code already
+    // exports `CLAUDE_CODE_SESSION_ID` (equal to the `--session-id` we pass) to
+    // the tools it spawns, which `agent-portal message` reads for attribution.
 
     // Log the full command for diagnostics.
     tracing::info!(

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -3,11 +3,23 @@
 //! authenticated with the launcher's stored proxy token (`launcher.json`) — so
 //! an agent can just shell out to `agent-portal message send …` with no extra
 //! credentials. The message is delivered to the target session's agent as an
-//! input turn, attributed with this session's id (`$PORTAL_SESSION_ID`).
+//! input turn, attributed with the sender's session id.
 
 use anyhow::{anyhow, Context, Result};
 
 use shared::api::{AgentSessionsResponse, SendAgentMessageRequest, SendAgentMessageResponse};
+
+/// The calling agent's own session id, read from whatever it already exposes —
+/// no portal-side injection needed. Claude Code sets `CLAUDE_CODE_SESSION_ID`
+/// to the id we spawned it with (`--session-id <portal id>`), so it equals the
+/// portal session id. `PORTAL_SESSION_ID` is kept as a manual/explicit
+/// override. Returns `None` for callers that expose neither (e.g. a human
+/// shell), in which case the recipient falls back to user attribution.
+fn sender_session_id() -> Option<String> {
+    ["CLAUDE_CODE_SESSION_ID", "PORTAL_SESSION_ID"]
+        .into_iter()
+        .find_map(|key| std::env::var(key).ok().filter(|v| !v.is_empty()))
+}
 
 /// Resolve the HTTP API base URL and auth token from the launcher config.
 fn api_base() -> Result<(String, String)> {
@@ -43,7 +55,7 @@ pub async fn list() -> Result<()> {
         println!("No sessions found.");
         return Ok(());
     }
-    let self_id = std::env::var("PORTAL_SESSION_ID").ok();
+    let self_id = sender_session_id();
     for s in &data.sessions {
         let marker = if self_id.as_deref() == Some(&s.id.to_string()) {
             " (this session)"
@@ -62,9 +74,7 @@ pub async fn list() -> Result<()> {
 /// session as an input turn.
 pub async fn send(agent_id: &str, message: &str) -> Result<()> {
     let (base, token) = api_base()?;
-    let from = std::env::var("PORTAL_SESSION_ID")
-        .ok()
-        .filter(|s| !s.is_empty());
+    let from = sender_session_id();
     let resp = reqwest::Client::new()
         .post(format!("{base}/api/agent/sessions/{agent_id}/message"))
         .bearer_auth(&token)


### PR DESCRIPTION
Per the "key it off something the agent already knows" idea — turns out Claude Code already hands its session id to every tool subprocess:

```
CLAUDE_CODE_SESSION_ID=<uuid>
```

and because the proxy spawns claude with `--session-id <portal-session-id>`, **that env var equals the portal session id** (verified on a live agent; survives `--resume` too). So the `agent-portal message` CLI now reads it directly for sender attribution — **no injection needed**.

- `message.rs`: `sender_session_id()` reads `CLAUDE_CODE_SESSION_ID` first, then `PORTAL_SESSION_ID` (kept only as a manual override). Used by both `send` (the `from` bumper) and `list` (the "(this session)" marker).
- `spawn.rs`: **removed** the `cmd.env("PORTAL_SESSION_ID", …)` injection — redundant; claude provides the right value by construction.

Process-tree/PID matching (the other idea floated) would've been far more fragile; this is exact and zero-cost.

`cargo check` (launcher + claude-session-lib), `fmt`, `clippy` clean. **2.11.0 → 2.11.1.**

Codex still doesn't export an equivalent, so codex senders fall back to user attribution — tracked in #1079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)