### PR TITLE
Codex sender attribution via CODEX_THREAD_ID (no injection)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.11.1"
+version = "2.11.2"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -9,16 +9,28 @@ use anyhow::{anyhow, Context, Result};
 
 use shared::api::{AgentSessionsResponse, SendAgentMessageRequest, SendAgentMessageResponse};
 
-/// The calling agent's own session id, read from whatever it already exposes —
-/// no portal-side injection needed. Claude Code sets `CLAUDE_CODE_SESSION_ID`
-/// to the id we spawned it with (`--session-id <portal id>`), so it equals the
-/// portal session id. `PORTAL_SESSION_ID` is kept as a manual/explicit
-/// override. Returns `None` for callers that expose neither (e.g. a human
-/// shell), in which case the recipient falls back to user attribution.
+/// The calling agent's own portal session id, read from whatever the agent
+/// already exposes — no portal-side injection needed:
+///
+/// - Claude Code sets `CLAUDE_CODE_SESSION_ID` to the id we spawn it with
+///   (`--session-id <portal id>`), so it already *is* the portal session id.
+/// - Codex sets `CODEX_THREAD_ID`, which is *not* the portal id, so we reverse
+///   it through the launcher's `codex_threads.json` map to the portal session.
+/// - `PORTAL_SESSION_ID` is honored as a manual/explicit override.
+///
+/// Returns `None` when none apply (e.g. a human shell), in which case the
+/// recipient falls back to user attribution.
 fn sender_session_id() -> Option<String> {
-    ["CLAUDE_CODE_SESSION_ID", "PORTAL_SESSION_ID"]
-        .into_iter()
-        .find_map(|key| std::env::var(key).ok().filter(|v| !v.is_empty()))
+    let env = |key: &str| std::env::var(key).ok().filter(|v| !v.is_empty());
+
+    if let Some(id) = env("CLAUDE_CODE_SESSION_ID").or_else(|| env("PORTAL_SESSION_ID")) {
+        return Some(id);
+    }
+    if let Some(thread_id) = env("CODEX_THREAD_ID") {
+        return crate::process_manager::session_id_for_codex_thread(&thread_id)
+            .map(|id| id.to_string());
+    }
+    None
 }
 
 /// Resolve the HTTP API base URL and auth token from the launcher config.

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -52,6 +52,16 @@ fn load_codex_thread_id(session_id: Uuid) -> Option<String> {
     load_codex_threads().get(&session_id).cloned()
 }
 
+/// Reverse of the persisted map: given a codex thread id (which a codex agent
+/// exposes as `$CODEX_THREAD_ID`), find the portal session id it belongs to.
+/// Lets `agent-portal message` attribute codex senders with no injection.
+pub(crate) fn session_id_for_codex_thread(thread_id: &str) -> Option<Uuid> {
+    load_codex_threads()
+        .into_iter()
+        .find(|(_, tid)| tid == thread_id)
+        .map(|(session_id, _)| session_id)
+}
+
 fn make_codex_thread_id_sink(session_id: Uuid) -> CodexThreadIdSink {
     std::sync::Arc::new(move |thread_id: String| {
         let mut map = load_codex_threads();


### PR DESCRIPTION
Confirmed on a live codex agent: codex exposes **`CODEX_THREAD_ID`** to its tool subprocesses, and the launcher already persists a `session_id → thread_id` map in `codex_threads.json`. So the CLI reverse-maps the thread id to the portal session id **locally** — no injection, no upstream SDK change, no backend involvement.

- `process_manager::session_id_for_codex_thread(thread_id) -> Option<Uuid>` — reverse lookup over the persisted map.
- `message.rs` `sender_session_id()`:
  - `CLAUDE_CODE_SESSION_ID` / `PORTAL_SESSION_ID` → used directly (already the portal id).
  - `CODEX_THREAD_ID` → reverse-mapped through `codex_threads.json` → portal session id.

Both agent types now self-attribute with **zero injection**, purely from env they already carry. The bumper's sender id is therefore always a real portal session id, so `agent-portal message send <that-id> …` replies work for codex too.

`cargo check` / `fmt` / `clippy` (launcher) clean. **2.11.1 → 2.11.2.** Closes the codex half of #1079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)