### PR TITLE
Render inter-agent messages as a distinct "other-agent" type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.11.2"
+version = "2.12.0"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -81,6 +81,50 @@ pub fn render_optimistic_user_message(
     }
 }
 
+/// Parse the `[message from agent <session-id>]\n<body>` bumper that
+/// `agent-portal message` prepends to inter-agent messages. Returns
+/// `(sender_session_id, body)` when it matches.
+fn parse_other_agent_message(text: &str) -> Option<(String, String)> {
+    let rest = text.strip_prefix("[message from agent ")?;
+    let close = rest.find(']')?;
+    let sender = rest[..close].trim().to_string();
+    if sender.is_empty() {
+        return None;
+    }
+    let body = rest[close + 1..]
+        .trim_start_matches(['\n', ' '])
+        .to_string();
+    Some((sender, body))
+}
+
+/// Render an inter-agent message as its own type: a distinct badge + accent
+/// (the sender's short session id, full id on hover) so it reads as coming
+/// from another agent rather than the viewer's own input.
+fn render_other_agent_message(
+    sender: &str,
+    body: &str,
+    timestamp: Option<&str>,
+    session_id: Uuid,
+) -> Html {
+    let short = sender.split('-').next().unwrap_or(sender);
+    html! {
+        <div class="claude-message user-message other-agent-message">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
+                <span class="message-type-badge other-agent"
+                    title={format!("Message from agent session {sender}")}>
+                    { format!("\u{21a9} agent {short}") }
+                </span>
+                <CopyButton text={body.to_string()} title="Copy message" />
+            </div>
+            <div class="message-body">
+                <div class="user-text">
+                    { render_markdown_for_session(&preserve_user_newlines(body), session_id) }
+                </div>
+            </div>
+        </div>
+    }
+}
+
 pub fn render_user_message(
     msg: &shared::UserMessage,
     meta: &UserMessageMeta,
@@ -94,6 +138,15 @@ pub fn render_user_message(
     };
     let pending_class = if meta.pending { " pending" } else { "" };
     let (text_content, has_tool_results) = user_message_text_and_tool_results(msg);
+
+    // Messages injected by `agent-portal message` arrive (echoed by the agent)
+    // as a user message prefixed with the `[message from agent <id>]` bumper.
+    // Render those as their own "other-agent" type rather than the user's own.
+    if !has_tool_results {
+        if let Some((sender, body)) = parse_other_agent_message(&text_content) {
+            return render_other_agent_message(&sender, &body, timestamp, session_id);
+        }
+    }
 
     if has_tool_results {
         html! {

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -124,6 +124,19 @@
     color: #7dcfff;
 }
 
+/* Inter-agent message (`agent-portal message send`): the "external" link hue
+   so it reads as coming from another agent, distinct from the user's own. */
+.message-type-badge.other-agent {
+    background: rgba(187, 154, 247, 0.2);
+    color: var(--link-color);
+    text-transform: none;
+}
+
+.other-agent-message {
+    border-left: 3px solid var(--link-color);
+    background: rgba(187, 154, 247, 0.04);
+}
+
 .portal-message {
     border-left: 3px solid #7dcfff;
 }


### PR DESCRIPTION
Closes #1079.

Messages sent via `agent-portal message` are injected into the target session and **echoed back by the agent as a normal `user` message** carrying the `[message from agent <session-id>]` bumper. The transcript renderer now **detects that bumper** and renders the message as its own type:

- A distinct **`↩ agent <short-id>`** badge in the palette's "external/link" purple (full session id on hover), plus a left accent + faint tint — so it reads as coming from another agent, not the viewer's own input.
- The raw bumper is stripped from the displayed body.

## Why detection, not a new `MessageRole`
The message physically arrives as the agent's echoed `user` turn (`--replay-user-messages`). A separate stored `OtherAgent` message would collide with that echo (the dedupe problem noted in #1079). Detecting the bumper on the **single echoed message** and styling by origin sidesteps that entirely — one message, no duplication, no protocol/DB/migration change.

## Verification
`cargo check` (frontend/wasm), `cargo fmt --check`, `cargo clippy` (frontend) — clean. **→ 2.12.0.**

⚠️ Visual-only — eyeball on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)