### PR TITLE
Fix agent message send 500 (best-effort writes, like the WS input path)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.1"
+version = "2.12.2"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -14,7 +14,7 @@ use axum::{
 };
 use diesel::prelude::*;
 use tower_cookies::Cookies;
-use tracing::info;
+use tracing::{error, info};
 use uuid::Uuid;
 
 use shared::api::{
@@ -139,12 +139,23 @@ pub async fn send_agent_message(
     };
     let content = serde_json::Value::String(format!("{bumper}\n{message}"));
 
-    // Mirror the WS input path: bump the per-session seq, persist a pending
-    // input row, then forward to the live proxy (queued if disconnected).
-    let seq: i64 = diesel::update(sessions::table.find(target_id))
+    // Mirror the WS input path's *tolerant* handling (see `handle_web_input`):
+    // the seq bump and the pending-input row are best-effort — that path
+    // `.unwrap_or`s the update and only logs an INSERT failure, then still
+    // delivers live. Propagating these as `?` is what turned a latent input-
+    // pipeline write error (one the WS path silently swallows) into a 500 on
+    // every send. Delivering to the live proxy is what actually matters.
+    let seq: i64 = match diesel::update(sessions::table.find(target_id))
         .set(sessions::input_seq.eq(sessions::input_seq + 1))
         .returning(sessions::input_seq)
-        .get_result(&mut conn)?;
+        .get_result(&mut conn)
+    {
+        Ok(seq) => seq,
+        Err(e) => {
+            error!("Failed to bump input_seq for session {}: {}", target_id, e);
+            1
+        }
+    };
 
     let new_input = NewPendingInput {
         session_id: target_id,
@@ -152,9 +163,15 @@ pub async fn send_agent_message(
         content: serde_json::to_string(&content).unwrap_or_default(),
         send_mode: None,
     };
-    diesel::insert_into(pending_inputs::table)
+    if let Err(e) = diesel::insert_into(pending_inputs::table)
         .values(&new_input)
-        .execute(&mut conn)?;
+        .execute(&mut conn)
+    {
+        error!(
+            "Failed to persist pending input for session {} (delivering live anyway): {}",
+            target_id, e
+        );
+    }
 
     let delivered = app_state.session_manager.send_to_session(
         &session.session_key,


### PR DESCRIPTION
## Bug
`agent-portal message send` → **500 "Database query failed"** on every send; `message list` works.

## Cause (no backend log needed to localize)
The two input-write paths handle DB errors **oppositely**:
- **WS path** (`handle_web_input`, web UI) is tolerant — seq bump `.unwrap_or(1)`, `pending_inputs` INSERT `if let Err(e) { error!(…) }`. It **swallows** write errors and delivers live.
- **`agent_comms` send** used `?` on both → any DB error becomes `AppError::DbQuery` → **500**.

So there's a **latent input-pipeline write error the WS path has been silently swallowing**; the agent send path is just the first to surface it (and `list`, a pure SELECT, never hits it). It is *not* target-specific (matches the report: every target, incl. self, fails identically).

## Fix
Align the agent send path to the proven WS path: the seq bump and `pending_inputs` persist are **best-effort (logged on failure)**, and the message is always forwarded to the live proxy. No more 500 on these writes — delivering to the live agent is what matters.

## Still open (root cause)
The underlying write error also breaks `pending_inputs` reconnect-replay for the web path (silently). It's logged on the backend as `Database query failed: <e>` — grab that line and I'll fix the actual constraint/column issue too.

`cargo check` / `fmt` / `clippy` (backend) clean. **2.12.1 → 2.12.2.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)