### PR TITLE
Migration-drift hygiene docs + unified swallowed-write alert marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,26 @@ diesel migration generate add_feature_name
 
 **If renaming existing migrations:** After renaming a migration directory, existing databases need their `__diesel_schema_migrations` table updated. See `scripts/fix_migration_names.sql` for an example.
 
+### Migration hygiene: avoiding "recorded-but-not-applied" drift
+
+The backend trusts `__diesel_schema_migrations`: at startup it only runs migrations **not listed** there. If that table claims a migration is applied but the actual DDL never ran, Diesel **skips it**, the backend starts cleanly, and the missing column only surfaces as a **runtime write failure** (e.g. `column "send_mode" of relation "pending_inputs" does not exist`). This bit us once — every input INSERT failed (silently on the web path, as a 500 on the agent path) while reads worked.
+
+To avoid it:
+
+- **Never hand-edit `__diesel_schema_migrations` without making the schema match.** Reconciling renamed migrations (`fix_migration_names.sql`) inserts version rows — only do that when the columns those migrations add **physically exist**. After any such reconcile, verify with `\d <table>`.
+- **Don't restore partial/mismatched DB snapshots** (a snapshot of the migrations table without the corresponding columns produces exactly this drift).
+- **Symptom → fix:** a `column "…" does not exist` at runtime on a table whose migration *is* recorded means recorded-but-not-applied drift. Fix by applying the column directly (`ALTER TABLE … ADD COLUMN IF NOT EXISTS …` matching the migration's `up.sql`); the migrations table already records it, so future restarts stay consistent.
+
+### Schema-drift alerting
+
+DB write failures on the input path are **swallowed** (logged, then delivery continues) so a transient DB hiccup never drops a live message. The downside is drift can hide in the logs. Both write paths emit a stable marker — alert on it:
+
+```
+PENDING_INPUT_PERSIST_FAILED   # pending_inputs INSERT failed (web + agent paths)
+```
+
+A recurring `PENDING_INPUT_PERSIST_FAILED` right after a deploy almost always means schema drift (a migration recorded-but-not-applied) — see above. A one-off is likely a transient DB blip.
+
 ### Adding a New API Endpoint
 
 1. **Add handler** in `backend/src/handlers/`:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.2"
+version = "2.12.3"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -152,7 +152,7 @@ pub async fn send_agent_message(
     {
         Ok(seq) => seq,
         Err(e) => {
-            error!("Failed to bump input_seq for session {}: {}", target_id, e);
+            error!("INPUT_SEQ_BUMP_FAILED session={}: {}", target_id, e);
             1
         }
     };
@@ -167,8 +167,10 @@ pub async fn send_agent_message(
         .values(&new_input)
         .execute(&mut conn)
     {
+        // Same stable marker as the WS input path so one alert rule catches
+        // both. See CLAUDE.md "Schema-drift alerting".
         error!(
-            "Failed to persist pending input for session {} (delivering live anyway): {}",
+            "PENDING_INPUT_PERSIST_FAILED session={} (delivered live): {}",
             target_id, e
         );
     }

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -428,7 +428,10 @@ fn handle_web_input(
                 .values(&new_input)
                 .execute(&mut conn)
             {
-                error!("Failed to store pending input: {}", e);
+                // Stable marker for log-based alerting: a recurring persist
+                // failure here usually means schema drift (e.g. a migration
+                // recorded-but-not-applied). See CLAUDE.md "Schema-drift alerting".
+                error!("PENDING_INPUT_PERSIST_FAILED session={}: {}", session_id, e);
             }
             next_seq
         }


### PR DESCRIPTION
Two of the three guards from the `send_mode` post-mortem (CI schema-diff guard ships separately):

**1. CLAUDE.md — migration hygiene + alerting.** Documents the "recorded-but-not-applied" drift that caused the incident: the backend skips migrations listed in `__diesel_schema_migrations`, so a recorded-but-unapplied migration starts cleanly and only fails at the first runtime write. Covers how it happens (hand-editing the migrations table, partial snapshot restores), how to avoid it, and the symptom→fix (`ALTER TABLE … ADD COLUMN IF NOT EXISTS …`). Adds a "Schema-drift alerting" section.

**2. Unified swallowed-write marker.** The input-persist failure was logged inconsistently — `"Failed to store pending input"` (web path) vs `"Failed to persist pending input"` (agent path) — so one alert grep couldn't catch both. Both now emit **`PENDING_INPUT_PERSIST_FAILED`**; seq-bump failures emit `INPUT_SEQ_BUMP_FAILED`. A recurring `PENDING_INPUT_PERSIST_FAILED` right after a deploy ⇒ schema drift.

`cargo check` / `fmt` / `clippy` (backend) clean. **2.12.2 → 2.12.3.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)