### PR TITLE
Extract shared SessionManager::enqueue_input (web + agent input paths)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.3"
+version = "2.12.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.3"
+version = "2.12.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.3"
+version = "2.12.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.3"
+version = "2.12.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.3"
+version = "2.12.4"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.3"
+version = "2.12.4"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.3"
+version = "2.12.4"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.3"
+version = "2.12.4"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.3"
+version = "2.12.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.3"
+version = "2.12.4"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.3"
+version = "2.12.4"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -14,16 +14,15 @@ use axum::{
 };
 use diesel::prelude::*;
 use tower_cookies::Cookies;
-use tracing::{error, info};
+use tracing::info;
 use uuid::Uuid;
 
 use shared::api::{
     AgentSessionInfo, AgentSessionsResponse, SendAgentMessageRequest, SendAgentMessageResponse,
 };
-use shared::ServerToProxy;
 
 use crate::errors::AppError;
-use crate::models::{NewPendingInput, Session};
+use crate::models::Session;
 use crate::AppState;
 
 /// Resolve the calling user from a `Bearer` proxy token if present, otherwise
@@ -116,7 +115,7 @@ pub async fn send_agent_message(
     }
 
     let mut conn = app_state.conn()?;
-    use crate::schema::{pending_inputs, session_members, sessions};
+    use crate::schema::{session_members, sessions};
 
     // Authorize: the caller must be a member of the target session.
     let session: Session = sessions::table
@@ -139,56 +138,24 @@ pub async fn send_agent_message(
     };
     let content = serde_json::Value::String(format!("{bumper}\n{message}"));
 
-    // Mirror the WS input path's *tolerant* handling (see `handle_web_input`):
-    // the seq bump and the pending-input row are best-effort — that path
-    // `.unwrap_or`s the update and only logs an INSERT failure, then still
-    // delivers live. Propagating these as `?` is what turned a latent input-
-    // pipeline write error (one the WS path silently swallows) into a 500 on
-    // every send. Delivering to the live proxy is what actually matters.
-    let seq: i64 = match diesel::update(sessions::table.find(target_id))
-        .set(sessions::input_seq.eq(sessions::input_seq + 1))
-        .returning(sessions::input_seq)
-        .get_result(&mut conn)
-    {
-        Ok(seq) => seq,
-        Err(e) => {
-            error!("INPUT_SEQ_BUMP_FAILED session={}: {}", target_id, e);
-            1
-        }
-    };
-
-    let new_input = NewPendingInput {
-        session_id: target_id,
-        seq_num: seq,
-        content: serde_json::to_string(&content).unwrap_or_default(),
-        send_mode: None,
-    };
-    if let Err(e) = diesel::insert_into(pending_inputs::table)
-        .values(&new_input)
-        .execute(&mut conn)
-    {
-        // Same stable marker as the WS input path so one alert rule catches
-        // both. See CLAUDE.md "Schema-drift alerting".
-        error!(
-            "PENDING_INPUT_PERSIST_FAILED session={} (delivered live): {}",
-            target_id, e
-        );
-    }
-
-    let delivered = app_state.session_manager.send_to_session(
+    // Seq bump + best-effort persist + live delivery, shared with the web
+    // input path (see SessionManager::enqueue_input). DB write faults are
+    // logged, not fatal — the message still reaches a live agent.
+    let outcome = app_state.session_manager.enqueue_input(
+        &app_state.db_pool,
         &session.session_key,
-        ServerToProxy::SequencedInput {
-            session_id: target_id,
-            seq,
-            content,
-            send_mode: None,
-        },
+        target_id,
+        content,
+        None,
     );
 
     info!(
-        "Agent message: user {} -> session {} (seq {}, live={})",
-        user_id, target_id, seq, delivered
+        "Agent message: user {} -> session {} (seq {}, delivered={}, persisted={})",
+        user_id, target_id, outcome.seq, outcome.delivered, outcome.persisted
     );
 
-    Ok(Json(SendAgentMessageResponse { delivered, seq }))
+    Ok(Json(SendAgentMessageResponse {
+        delivered: outcome.delivered,
+        seq: outcome.seq,
+    }))
 }

--- a/backend/src/handlers/websocket/session_manager/input_queue.rs
+++ b/backend/src/handlers/websocket/session_manager/input_queue.rs
@@ -1,0 +1,114 @@
+//! Shared enqueue path for session input.
+//!
+//! Both the web-client input handler (`handle_web_input`) and the
+//! agent-messaging send endpoint (`agent_comms::send_agent_message`) route a
+//! message into a session through here, so they can't drift in their
+//! seq/persist/deliver semantics. (They previously had two copies of this
+//! logic with *different* error handling — one swallowed DB errors, one `?`'d
+//! them — which is why a single write fault 500'd one path and was silent on
+//! the other.)
+//!
+//! Semantics: bump the per-session input sequence, best-effort persist a
+//! pending-input row (the reconnect-replay buffer), then deliver to the live
+//! proxy. DB hiccups are logged, never fatal — delivering to the live agent is
+//! what matters, and persistence only governs replay if the proxy reconnects.
+
+use diesel::prelude::*;
+use shared::{SendMode, ServerToProxy};
+use tracing::error;
+use uuid::Uuid;
+
+use crate::db::DbPool;
+use crate::models::NewPendingInput;
+
+use super::{SessionId, SessionManager};
+
+/// Outcome of [`SessionManager::enqueue_input`].
+pub(crate) struct EnqueueOutcome {
+    /// Sequence number assigned (0 if no DB connection was available).
+    pub seq: i64,
+    /// Whether the message reached a live proxy (vs. queued for reconnect).
+    pub delivered: bool,
+    /// Whether the pending-input row was persisted. `false` ⇒ it won't replay
+    /// if the proxy reconnects; logged as `PENDING_INPUT_PERSIST_FAILED`.
+    pub persisted: bool,
+}
+
+impl SessionManager {
+    /// Bump the session's input sequence, best-effort persist a pending-input
+    /// row, and forward the message to the live proxy (queued if disconnected).
+    pub(crate) fn enqueue_input(
+        &self,
+        db_pool: &DbPool,
+        session_key: &SessionId,
+        session_id: Uuid,
+        content: serde_json::Value,
+        send_mode: Option<SendMode>,
+    ) -> EnqueueOutcome {
+        use crate::schema::{pending_inputs, sessions};
+
+        let mut persisted = false;
+        let seq = match db_pool.get() {
+            Ok(mut conn) => {
+                let next_seq: i64 = match diesel::update(sessions::table.find(session_id))
+                    .set(sessions::input_seq.eq(sessions::input_seq + 1))
+                    .returning(sessions::input_seq)
+                    .get_result(&mut conn)
+                {
+                    Ok(s) => s,
+                    Err(e) => {
+                        error!("INPUT_SEQ_BUMP_FAILED session={}: {}", session_id, e);
+                        1
+                    }
+                };
+
+                let new_input = NewPendingInput {
+                    session_id,
+                    seq_num: next_seq,
+                    content: serde_json::to_string(&content).unwrap_or_default(),
+                    send_mode: send_mode.as_ref().map(|m| m.as_str().to_string()),
+                };
+                match diesel::insert_into(pending_inputs::table)
+                    .values(&new_input)
+                    .execute(&mut conn)
+                {
+                    Ok(_) => persisted = true,
+                    Err(e) => {
+                        error!("PENDING_INPUT_PERSIST_FAILED session={}: {}", session_id, e)
+                    }
+                }
+                next_seq
+            }
+            Err(e) => {
+                error!(
+                    "Failed to get DB connection to enqueue input for session {}: {}",
+                    session_id, e
+                );
+                0
+            }
+        };
+
+        let delivered = if seq > 0 {
+            self.send_to_session(
+                session_key,
+                ServerToProxy::SequencedInput {
+                    session_id,
+                    seq,
+                    content,
+                    send_mode,
+                },
+            )
+        } else {
+            self.send_to_session(
+                session_key,
+                ServerToProxy::ClaudeInput { content, send_mode },
+            )
+        };
+
+        EnqueueOutcome {
+            seq,
+            delivered,
+            persisted,
+        }
+    }
+}

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 
 mod client_fanout;
 mod correlation;
+mod input_queue;
 mod launcher_registry;
 mod pending_queue;
 mod proxy_lifecycle;

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -3,7 +3,6 @@ use super::replay::replay_history;
 use super::uploads::{handle_file_upload_chunk, handle_file_upload_start, PendingUpload};
 use super::{SessionId, SessionManager, WebClientSender};
 use crate::handlers::session_access::is_session_mutator;
-use crate::models::NewPendingInput;
 use crate::AppState;
 use axum::extract::ws::WebSocket;
 use diesel::prelude::*;
@@ -408,59 +407,12 @@ fn handle_web_input(
         }
     }
 
-    let seq = match db_pool.get() {
-        Ok(mut conn) => {
-            use crate::schema::{pending_inputs, sessions};
-
-            let next_seq: i64 = diesel::update(sessions::table.find(session_id))
-                .set(sessions::input_seq.eq(sessions::input_seq + 1))
-                .returning(sessions::input_seq)
-                .get_result(&mut conn)
-                .unwrap_or(1);
-
-            let new_input = NewPendingInput {
-                session_id,
-                seq_num: next_seq,
-                content: serde_json::to_string(&content).unwrap_or_default(),
-                send_mode: send_mode.map(|mode| mode.as_str().to_string()),
-            };
-            if let Err(e) = diesel::insert_into(pending_inputs::table)
-                .values(&new_input)
-                .execute(&mut conn)
-            {
-                // Stable marker for log-based alerting: a recurring persist
-                // failure here usually means schema drift (e.g. a migration
-                // recorded-but-not-applied). See CLAUDE.md "Schema-drift alerting".
-                error!("PENDING_INPUT_PERSIST_FAILED session={}: {}", session_id, e);
-            }
-            next_seq
-        }
-        Err(e) => {
-            error!("Failed to get db connection for pending input: {}", e);
-            0
-        }
-    };
-
-    if seq > 0 {
-        if !session_manager.send_to_session(
-            key,
-            ServerToProxy::SequencedInput {
-                session_id,
-                seq,
-                content,
-                send_mode,
-            },
-        ) {
-            warn!(
-                "Failed to send to session '{}', session not found in SessionManager (input queued)",
-                key
-            );
-        }
-    } else if !session_manager
-        .send_to_session(key, ServerToProxy::ClaudeInput { content, send_mode })
-    {
+    // Seq bump + best-effort persist + live delivery, shared with the
+    // agent-messaging send path (see SessionManager::enqueue_input).
+    let outcome = session_manager.enqueue_input(db_pool, key, session_id, content, send_mode);
+    if !outcome.delivered {
         warn!(
-            "Failed to send to session '{}', session not found in SessionManager",
+            "Failed to send to session '{}', session not found in SessionManager (input queued)",
             key
         );
     }


### PR DESCRIPTION
Consolidates the duplicated session-input queue logic that caused the swallow-vs-500 asymmetry.

**Before:** `handle_web_input` (web_client_socket) and `send_agent_message` (agent_comms) each had their own copy of:
```
UPDATE sessions.input_seq → INSERT pending_inputs → send_to_session(SequencedInput)
```
with *different* error handling — the web path `.unwrap_or`/`if let Err` swallowed DB faults, the agent path `?`'d them into 500s. Same interface, two implementations that drifted.

**After:** one helper, **`SessionManager::enqueue_input`** (new `session_manager/input_queue.rs` submodule), owns the tolerant semantics (DB hiccups logged, never fatal; deliver live regardless) and returns `EnqueueOutcome { seq, delivered, persisted }`. Both call sites route through it — they can't diverge again. Pure behavior-preserving refactor.

`persisted` is now surfaced in the agent-send log and is the hook for the future "delivered but not persisted" response/UI signal (the surfacing decision we discussed) — that becomes a one-place change.

`cargo check` / `fmt` / `clippy` (backend) clean. **2.12.3 → 2.12.4.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)