### PR TITLE
Label inter-agent messages by sender agent type ("Message from Codex (…)")

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.4"
+version = "2.12.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.4"
+version = "2.12.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.4"
+version = "2.12.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.4"
+version = "2.12.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.4"
+version = "2.12.5"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.4"
+version = "2.12.5"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.4"
+version = "2.12.5"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.4"
+version = "2.12.5"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.4"
+version = "2.12.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.4"
+version = "2.12.5"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.4"
+version = "2.12.5"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -127,10 +127,25 @@ pub async fn send_agent_message(
         .map_err(|_| AppError::NotFound("session"))?;
 
     // Attribute the message so the recipient knows where it came from. An
-    // agent sender supplies its own session id (`from`); the human web page
-    // doesn't, so fall back to the sending user's display name.
+    // agent sender supplies its own session id (`from`); we tag the bumper with
+    // that session's agent type (claude/codex) so the UI can render
+    // "Message from Codex (<short>)". The human web page sends no `from`, so
+    // fall back to the sending user's display name.
     let bumper = match req.from.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-        Some(from) => format!("[message from agent {from}]"),
+        Some(from) => {
+            let sender_agent = from
+                .parse::<Uuid>()
+                .ok()
+                .and_then(|id| {
+                    sessions::table
+                        .find(id)
+                        .select(sessions::agent_type)
+                        .first::<String>(&mut conn)
+                        .ok()
+                })
+                .unwrap_or_else(|| "agent".to_string());
+            format!("[message from {sender_agent} {from}]")
+        }
         None => format!(
             "[portal message from {}]",
             user_display_name(&mut conn, user_id)

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -84,35 +84,50 @@ pub fn render_optimistic_user_message(
 /// Parse the `[message from agent <session-id>]\n<body>` bumper that
 /// `agent-portal message` prepends to inter-agent messages. Returns
 /// `(sender_session_id, body)` when it matches.
-fn parse_other_agent_message(text: &str) -> Option<(String, String)> {
-    let rest = text.strip_prefix("[message from agent ")?;
+/// Parse the inter-agent bumper `[message from <agent_type> <session-id>]\n<body>`
+/// (older messages use the literal `agent` in place of the type). Returns
+/// `(agent_type, sender_session_id, body)`.
+fn parse_other_agent_message(text: &str) -> Option<(String, String, String)> {
+    let rest = text.strip_prefix("[message from ")?;
     let close = rest.find(']')?;
-    let sender = rest[..close].trim().to_string();
+    let (agent_type, sender) = rest[..close].trim().split_once(' ')?;
+    let sender = sender.trim();
     if sender.is_empty() {
         return None;
     }
     let body = rest[close + 1..]
         .trim_start_matches(['\n', ' '])
         .to_string();
-    Some((sender, body))
+    Some((agent_type.trim().to_string(), sender.to_string(), body))
+}
+
+/// Friendly display name for a sender's agent type.
+fn agent_label(agent_type: &str) -> &'static str {
+    match agent_type.to_ascii_lowercase().as_str() {
+        "claude" => "Claude",
+        "codex" => "Codex",
+        _ => "agent",
+    }
 }
 
 /// Render an inter-agent message as its own type: a distinct badge + accent
-/// (the sender's short session id, full id on hover) so it reads as coming
-/// from another agent rather than the viewer's own input.
+/// reading e.g. "Message from Codex (9466a628)" (full session id on hover), so
+/// it's clearly from another agent rather than the viewer's own input.
 fn render_other_agent_message(
+    agent_type: &str,
     sender: &str,
     body: &str,
     timestamp: Option<&str>,
     session_id: Uuid,
 ) -> Html {
     let short = sender.split('-').next().unwrap_or(sender);
+    let label = agent_label(agent_type);
     html! {
         <div class="claude-message user-message other-agent-message">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge other-agent"
-                    title={format!("Message from agent session {sender}")}>
-                    { format!("\u{21a9} agent {short}") }
+                    title={format!("Message from {label} session {sender}")}>
+                    { format!("Message from {label} ({short})") }
                 </span>
                 <CopyButton text={body.to_string()} title="Copy message" />
             </div>
@@ -143,8 +158,8 @@ pub fn render_user_message(
     // as a user message prefixed with the `[message from agent <id>]` bumper.
     // Render those as their own "other-agent" type rather than the user's own.
     if !has_tool_results {
-        if let Some((sender, body)) = parse_other_agent_message(&text_content) {
-            return render_other_agent_message(&sender, &body, timestamp, session_id);
+        if let Some((agent_type, sender, body)) = parse_other_agent_message(&text_content) {
+            return render_other_agent_message(&agent_type, &sender, &body, timestamp, session_id);
         }
     }
 


### PR DESCRIPTION
The other-agent message badge now reads **"Message from Codex (9466a628)"** instead of "↩ agent 9466a628" — naming the sender's agent.

Knowing the agent type requires the backend (only it can resolve a session id → `agent_type`), so the attribution bumper now carries it:

- **backend** (`agent_comms`): looks up the sender session's `agent_type` and tags the bumper → `[message from <agent_type> <session-id>]` (falls back to `agent` if unresolved).
- **frontend** (`renderers`): parses `<agent_type> <id>` from the bumper and renders **"Message from {Claude|Codex|agent} (<short>)"**, full session id on hover. Older `[message from agent <id>]` messages still parse (labeled "agent").

`cargo check` (frontend/wasm + backend), `fmt`, `clippy` clean. **2.12.4 → 2.12.5.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)