### PR TITLE
Add frontend renderer safety-net tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.5"
+version = "2.12.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.5"
+version = "2.12.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.5"
+version = "2.12.6"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.5"
+version = "2.12.6"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.5"
+version = "2.12.6"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.5"
+version = "2.12.6"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.5"
+version = "2.12.6"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.5"
+version = "2.12.6"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.5"
+version = "2.12.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.5"
+version = "2.12.6"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.5"
+version = "2.12.6"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/markdown.rs
+++ b/frontend/src/components/markdown.rs
@@ -1012,6 +1012,16 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_math_skips_fenced_code() {
+        let input = "Before\n```rust\nlet s = \"$not_math$\";\n```\nAfter $real_math$.";
+        let (out, blocks) = extract_math_placeholders(input);
+
+        assert_eq!(blocks, vec!["$real_math$"]);
+        assert!(out.contains("let s = \"$not_math$\";"));
+        assert_eq!(restore_math(&out, &blocks), input);
+    }
+
+    #[test]
     fn test_extract_math_skips_dollar_amounts() {
         // "$5 and $10" looks like inline math to a naïve scanner but isn't.
         let input = "I have $5 and $10 left.";
@@ -1114,6 +1124,30 @@ Where:\n\
     }
 
     #[test]
+    fn hash_and_absolute_paths_are_regular_links() {
+        assert_eq!(
+            classify_link_destination("#details", None),
+            LinkDestination::ExternalOrRelative("#details".to_string())
+        );
+        assert_eq!(
+            classify_link_destination("/api/sessions", None),
+            LinkDestination::ExternalOrRelative("/api/sessions".to_string())
+        );
+    }
+
+    #[test]
+    fn non_link_angle_destinations_render_as_literal_text() {
+        assert_eq!(
+            classify_link_destination("crate::components::Thing", None),
+            LinkDestination::LiteralAngleText
+        );
+        assert_eq!(
+            classify_link_destination("not a url", None),
+            LinkDestination::LiteralAngleText
+        );
+    }
+
+    #[test]
     fn portal_file_markdown_link_rewrites_description_to_download_href() {
         let session_id = Uuid::parse_str("11111111-2222-3333-4444-555555555555")
             .expect("static uuid should parse");
@@ -1122,6 +1156,23 @@ Where:\n\
             classify_link_destination("portal://file/docs/portal link.svg", Some(session_id)),
             LinkDestination::PortalDownload(
                 "/api/sessions/11111111-2222-3333-4444-555555555555/files/pull?path=docs%2Fportal%20link.svg"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn portal_file_markdown_link_encodes_nested_special_chars() {
+        let session_id = Uuid::parse_str("11111111-2222-3333-4444-555555555555")
+            .expect("static uuid should parse");
+
+        assert_eq!(
+            classify_link_destination(
+                "portal://file/reports/final report (v2).md",
+                Some(session_id)
+            ),
+            LinkDestination::PortalDownload(
+                "/api/sessions/11111111-2222-3333-4444-555555555555/files/pull?path=reports%2Ffinal%20report%20(v2).md"
                     .to_string()
             )
         );

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -610,6 +610,23 @@ mod tests {
         .to_string()
     }
 
+    fn plain_user_text_from_sender(text: &str, user_id: &str, name: &str) -> String {
+        serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": text}]
+            },
+            "_sender": {
+                "user_id": user_id,
+                "name": name,
+            },
+            "session_id": "01890000-0000-7000-8000-000000000001",
+            "_created_at": "2026-05-17T10:00:00.000Z",
+        })
+        .to_string()
+    }
+
     fn codex_item_started_agent_message(text: &str) -> String {
         serde_json::json!({
             "type": "item.started",
@@ -681,6 +698,37 @@ mod tests {
     }
 
     #[test]
+    fn user_grouping_splits_by_sender_identity() {
+        let messages = vec![
+            plain_user_text_from_sender("first from me", "user_a", "Matt"),
+            plain_user_text_from_sender("second from me", "user_a", "Matt"),
+            plain_user_text_from_sender("from someone else", "user_b", "Alex"),
+            plain_user_text_from_sender("back to me", "user_a", "Matt"),
+        ];
+
+        let groups = group_messages(&messages, shared::AgentType::Claude, Some("user_a"));
+        assert_eq!(groups.len(), 3);
+
+        let labels: Vec<_> = groups
+            .iter()
+            .map(|group| match group {
+                MessageGroup::IdentityGroup {
+                    category: GroupCategory::User,
+                    label,
+                    ..
+                } => label.as_str(),
+                other => panic!("expected User identity group, got {:?}", other),
+            })
+            .collect();
+        assert_eq!(labels, vec!["You", "Alex", "You"]);
+
+        match &groups[0] {
+            MessageGroup::IdentityGroup { messages, .. } => assert_eq!(messages.len(), 2),
+            other => panic!("expected first User group, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn user_run_breaks_on_intervening_assistant() {
         let messages = vec![
             plain_user_text("question one"),
@@ -689,6 +737,50 @@ mod tests {
         ];
         let groups = group_for_tests(&messages);
         assert_eq!(groups.len(), 3);
+    }
+
+    #[test]
+    fn turn_terminator_detection_covers_claude_and_codex() {
+        let claude_result = serde_json::json!({
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "duration_ms": 100,
+            "duration_api_ms": 80,
+            "num_turns": 1,
+            "session_id": "01890000-0000-7000-8000-000000000001",
+            "total_cost_usd": 0.0,
+            "_created_at": "2026-05-17T10:00:00.000Z",
+        })
+        .to_string();
+        let codex_completed = serde_json::json!({
+            "type": "turn.completed",
+            "usage": {"input_tokens": 1, "output_tokens": 2},
+            "_created_at": "2026-05-17T10:00:00.000Z",
+        })
+        .to_string();
+        let codex_failed = serde_json::json!({
+            "type": "turn.failed",
+            "error": {"message": "nope"},
+            "_created_at": "2026-05-17T10:00:00.000Z",
+        })
+        .to_string();
+
+        for json in [claude_result, codex_completed, codex_failed] {
+            assert!(
+                group_is_turn_terminator(&MessageGroup::Single(json)),
+                "single terminator frame should be recognized"
+            );
+        }
+        assert!(!group_is_turn_terminator(&MessageGroup::Single(
+            plain_user_text("hello")
+        )));
+        assert!(!group_is_turn_terminator(&MessageGroup::IdentityGroup {
+            category: GroupCategory::User,
+            label: "You".to_string(),
+            badge_class: "user".to_string(),
+            messages: vec![plain_user_text("hello")],
+        }));
     }
 
     /// A run of `thinking_tokens` markers must collapse into a single


### PR DESCRIPTION
## Summary
- add markdown regression coverage for fenced-code math, portal file link encoding, and literal/non-link classification
- add message renderer grouping coverage for sender-aware user runs and Claude/Codex turn terminators
- bump workspace version to 2.12.6 per repo policy

## Verification
- cargo fmt --check
- cargo test -p frontend --lib
- cargo clippy -p frontend --all-targets -- -D warnings

This PR is intentionally test-only before the larger frontend renderer and markdown refactors.