### PR TITLE
Neutralize protocol variants: ClaudeInput/Output -> AgentInput/Output (#2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.10"
+version = "2.12.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.10"
+version = "2.12.11"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.10"
+version = "2.12.11"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.10"
+version = "2.12.11"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.10"
+version = "2.12.11"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.10"
+version = "2.12.11"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.10"
+version = "2.12.11"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.10"
+version = "2.12.11"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.10"
+version = "2.12.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.10"
+version = "2.12.11"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.10"
+version = "2.12.11"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -111,7 +111,7 @@ pub fn handle_session_limit_reached(
     if let Some(key) = session_key {
         session_manager.broadcast_to_web_clients(
             key,
-            ServerToClient::ClaudeOutput {
+            ServerToClient::AgentOutput {
                 content: portal.to_json(),
                 sender_user_id: None,
                 sender_name: None,
@@ -279,7 +279,7 @@ fn update_terminal_status(
                     let row_created_at = insert_portal_message(&mut conn, &session, &portal);
                     app_state.session_manager.broadcast_to_web_clients(
                         &session_id.to_string(),
-                        ServerToClient::ClaudeOutput {
+                        ServerToClient::AgentOutput {
                             content: portal.to_json(),
                             sender_user_id: None,
                             sender_name: None,

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -315,7 +315,7 @@ pub fn handle_claude_output(
     if let Some(ref key) = session_key {
         session_manager.broadcast_to_web_clients(
             key,
-            ServerToClient::ClaudeOutput {
+            ServerToClient::AgentOutput {
                 content,
                 sender_user_id: sender_info.as_ref().map(|(id, _)| id.to_string()),
                 sender_name: sender_info.as_ref().map(|(_, name)| name.clone()),

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -195,7 +195,7 @@ fn handle_proxy_message(
                 return ControlFlow::Break(());
             }
         }
-        ProxyToServer::ClaudeOutput {
+        ProxyToServer::AgentOutput {
             content,
             agent_type,
         } => {

--- a/backend/src/handlers/websocket/session_manager/client_fanout.rs
+++ b/backend/src/handlers/websocket/session_manager/client_fanout.rs
@@ -108,11 +108,11 @@ mod tests {
 
         assert!(matches!(
             rx1.try_recv().unwrap(),
-            ServerToClient::ClaudeOutput { .. }
+            ServerToClient::AgentOutput { .. }
         ));
         assert!(matches!(
             rx2.try_recv().unwrap(),
-            ServerToClient::ClaudeOutput { .. }
+            ServerToClient::AgentOutput { .. }
         ));
     }
 
@@ -131,7 +131,7 @@ mod tests {
 
         assert!(matches!(
             rx2.try_recv().unwrap(),
-            ServerToClient::ClaudeOutput { .. }
+            ServerToClient::AgentOutput { .. }
         ));
 
         let clients = mgr.web_clients.get("s1").unwrap();
@@ -158,11 +158,11 @@ mod tests {
 
         assert!(matches!(
             rx1.try_recv().unwrap(),
-            ServerToClient::ClaudeOutput { .. }
+            ServerToClient::AgentOutput { .. }
         ));
         assert!(matches!(
             rx2.try_recv().unwrap(),
-            ServerToClient::ClaudeOutput { .. }
+            ServerToClient::AgentOutput { .. }
         ));
         let clients = mgr.web_clients.get("s1").unwrap();
         assert_eq!(clients.len(), 2);
@@ -179,7 +179,7 @@ mod tests {
 
         assert!(matches!(
             rx.try_recv().unwrap(),
-            ServerToClient::ClaudeOutput { .. }
+            ServerToClient::AgentOutput { .. }
         ));
     }
 

--- a/backend/src/handlers/websocket/session_manager/input_queue.rs
+++ b/backend/src/handlers/websocket/session_manager/input_queue.rs
@@ -101,7 +101,7 @@ impl SessionManager {
         } else {
             self.send_to_session(
                 session_key,
-                ServerToProxy::ClaudeInput { content, send_mode },
+                ServerToProxy::AgentInput { content, send_mode },
             )
         };
 

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -129,7 +129,7 @@ pub(super) mod test_support {
     }
 
     pub fn make_client_msg() -> ServerToClient {
-        ServerToClient::ClaudeOutput {
+        ServerToClient::AgentOutput {
             content: serde_json::json!({"text": "hello"}),
             sender_user_id: None,
             sender_name: None,

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -99,7 +99,7 @@ fn handle_web_client_message(
             session_key,
             verified_session_id,
         ),
-        ClientToServer::ClaudeInput { content, send_mode } => {
+        ClientToServer::AgentInput { content, send_mode } => {
             // Gate on editor/owner role — re-queried on each input so role
             // revocations take effect immediately for already-connected viewers.
             // See `session_access::is_session_mutator` for the layered rules.
@@ -396,7 +396,7 @@ fn handle_web_input(
 
             session_manager.broadcast_to_web_clients(
                 key,
-                ServerToClient::ClaudeOutput {
+                ServerToClient::AgentOutput {
                     content: portal.to_json(),
                     sender_user_id: None,
                     sender_name: None,

--- a/claude-session-lib/src/proxy_session/ws_reader.rs
+++ b/claude-session-lib/src/proxy_session/ws_reader.rs
@@ -205,7 +205,7 @@ async fn handle_ws_message(
     }
 
     match proxy_msg {
-        ServerToProxy::ClaudeInput { content, send_mode } => {
+        ServerToProxy::AgentInput { content, send_mode } => {
             return route_portal_input(content, send_mode, None, input_tx, wiggum_tx);
         }
         ServerToProxy::SequencedInput {

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -704,7 +704,7 @@ impl SessionView {
         self.pending_sends.push(optimistic_msg);
 
         if let Some(ref sender) = self.ws_sender {
-            let msg = ClientToServer::ClaudeInput {
+            let msg = ClientToServer::AgentInput {
                 content: serde_json::Value::String(input),
                 send_mode: if send_mode == SendMode::Normal {
                     None

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -581,7 +581,7 @@ impl InputBar {
             }
 
             let combined = build_upload_message(&user_input, &uploaded_files);
-            on_send_frame.emit(ClientToServer::ClaudeInput {
+            on_send_frame.emit(ClientToServer::AgentInput {
                 content: serde_json::Value::String(combined),
                 send_mode: None,
             });

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -125,7 +125,7 @@ pub fn connect_websocket(
 /// Handle incoming server message and emit appropriate events
 fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
     match msg {
-        ServerToClient::ClaudeOutput {
+        ServerToClient::AgentOutput {
             content,
             sender_user_id,
             sender_name,
@@ -269,7 +269,7 @@ mod tests {
         let (tx, mut rx) = futures_channel::mpsc::unbounded::<ClientToServer>();
 
         for i in 0..N {
-            let msg = ClientToServer::ClaudeInput {
+            let msg = ClientToServer::AgentInput {
                 content: serde_json::Value::String(format!("msg-{i}")),
                 send_mode: None,
             };
@@ -279,7 +279,7 @@ mod tests {
 
         for i in 0..N {
             match rx.try_recv() {
-                Ok(ClientToServer::ClaudeInput { content, .. }) => {
+                Ok(ClientToServer::AgentInput { content, .. }) => {
                     assert_eq!(
                         content.as_str(),
                         Some(format!("msg-{i}").as_str()),
@@ -331,7 +331,7 @@ mod tests {
             send_message(&tx_a, ClientToServer::Interrupt);
             send_message(
                 &tx_b,
-                ClientToServer::ClaudeInput {
+                ClientToServer::AgentInput {
                     content: serde_json::Value::String(format!("b-{i}")),
                     send_mode: None,
                 },
@@ -391,7 +391,7 @@ mod tests {
     fn claude_output_with_created_at_emits_server_timestamp() {
         let (cb, sink) = capture();
         let server_ts = "2026-05-18T12:34:56.789012".to_string();
-        let msg = ServerToClient::ClaudeOutput {
+        let msg = ServerToClient::AgentOutput {
             content: serde_json::json!({"type": "assistant", "text": "hi"}),
             sender_user_id: None,
             sender_name: None,
@@ -432,7 +432,7 @@ mod tests {
     #[test]
     fn claude_output_without_created_at_emits_none_watermark() {
         let (cb, sink) = capture();
-        let msg = ServerToClient::ClaudeOutput {
+        let msg = ServerToClient::AgentOutput {
             content: serde_json::json!({"type": "assistant"}),
             sender_user_id: None,
             sender_name: None,

--- a/proxy/src/session.rs
+++ b/proxy/src/session.rs
@@ -79,7 +79,7 @@ async fn handle_server_message(
     ws_write: &SharedWsWrite,
 ) -> bool {
     match server_msg {
-        ServerToProxy::ClaudeInput { content, send_mode } => {
+        ServerToProxy::AgentInput { content, send_mode } => {
             event_tx.send(input_event(content, send_mode, None)).is_ok()
         }
         ServerToProxy::SequencedInput {

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -23,7 +23,8 @@ pub enum ClientToServer {
     Register(RegisterFields),
 
     /// User sends input to Claude
-    ClaudeInput {
+    #[serde(rename = "ClaudeInput")]
+    AgentInput {
         content: serde_json::Value,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         send_mode: Option<SendMode>,
@@ -51,7 +52,8 @@ pub enum ClientToServer {
 #[serde(tag = "type")]
 pub enum ServerToClient {
     /// Output from Claude Code
-    ClaudeOutput {
+    #[serde(rename = "ClaudeOutput")]
+    AgentOutput {
         content: serde_json::Value,
         #[serde(skip_serializing_if = "Option::is_none", default)]
         sender_user_id: Option<String>,

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn client_to_server_claude_input_roundtrip() {
-        let msg = ClientToServer::ClaudeInput {
+        let msg = ClientToServer::AgentInput {
             content: serde_json::json!({"text": "hi"}),
             send_mode: None,
         };
@@ -112,7 +112,7 @@ mod tests {
         assert!(json.contains(r#""type":"ClaudeInput""#));
         let parsed: ClientToServer = serde_json::from_str(&json).unwrap();
         match parsed {
-            ClientToServer::ClaudeInput { send_mode, .. } => {
+            ClientToServer::AgentInput { send_mode, .. } => {
                 assert!(send_mode.is_none());
             }
             _ => panic!("Wrong variant"),
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn server_to_client_output_roundtrip() {
-        let msg = ServerToClient::ClaudeOutput {
+        let msg = ServerToClient::AgentOutput {
             content: serde_json::json!({"type": "assistant", "text": "hello"}),
             sender_user_id: None,
             sender_name: None,
@@ -131,7 +131,7 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerToClient = serde_json::from_str(&json).unwrap();
         match parsed {
-            ServerToClient::ClaudeOutput {
+            ServerToClient::AgentOutput {
                 content,
                 agent_type,
                 created_at,
@@ -154,7 +154,7 @@ mod tests {
         let json = r#"{"type":"ClaudeOutput","content":{"hello":"world"}}"#;
         let parsed: ServerToClient = serde_json::from_str(json).unwrap();
         match parsed {
-            ServerToClient::ClaudeOutput { created_at, .. } => {
+            ServerToClient::AgentOutput { created_at, .. } => {
                 assert!(created_at.is_none());
             }
             _ => panic!("Wrong variant"),
@@ -219,7 +219,7 @@ mod tests {
         let json = r#"{"type":"ClaudeOutput","content":{"hello":"world"}}"#;
         let parsed: ProxyToServer = serde_json::from_str(json).unwrap();
         match parsed {
-            ProxyToServer::ClaudeOutput { agent_type, .. } => {
+            ProxyToServer::AgentOutput { agent_type, .. } => {
                 assert_eq!(agent_type, AgentType::Claude);
             }
             _ => panic!("Wrong variant"),
@@ -228,7 +228,7 @@ mod tests {
         let json = r#"{"type":"ClaudeOutput","content":{"hello":"world"}}"#;
         let parsed: ServerToClient = serde_json::from_str(json).unwrap();
         match parsed {
-            ServerToClient::ClaudeOutput { agent_type, .. } => {
+            ServerToClient::AgentOutput { agent_type, .. } => {
                 assert_eq!(agent_type, AgentType::Claude);
             }
             _ => panic!("Wrong variant"),

--- a/shared/src/endpoints/session.rs
+++ b/shared/src/endpoints/session.rs
@@ -25,7 +25,8 @@ pub enum ProxyToServer {
     Register(RegisterFields),
 
     /// Raw output from Claude Code (unsequenced fallback)
-    ClaudeOutput {
+    #[serde(rename = "ClaudeOutput")]
+    AgentOutput {
         content: serde_json::Value,
         /// Which agent's wire format the `content` JSON came from.
         ///
@@ -137,7 +138,8 @@ pub enum ServerToProxy {
     Heartbeat,
 
     /// User input (unsequenced fallback)
-    ClaudeInput {
+    #[serde(rename = "ClaudeInput")]
+    AgentInput {
         content: serde_json::Value,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         send_mode: Option<SendMode>,


### PR DESCRIPTION
**Item #2** (agent-neutral protocol naming), slice 1 — the contract for #1/#3.

Renames the four WebSocket protocol enum variants `ClaudeInput`/`ClaudeOutput` → `AgentInput`/`AgentOutput` (in `ClientToServer`/`ServerToClient`/`ProxyToServer`/`ServerToProxy`). Each renamed variant carries `#[serde(rename = "Claude…")]` so the **wire JSON is byte-for-byte identical** — pure Rust-identifier neutralization, zero compat risk. Consumer match-arms/constructors updated across backend, frontend, proxy, claude-session-lib.

**Deliberately untouched** (the overload trap): the re-exported `claude_codes::ClaudeOutput` *type* and the frontend `ClaudeMessage` lenient parser — neither is a protocol variant.

**Verified:** shared native + wasm32; backend/proxy/launcher/session-libs `cargo check`; frontend wasm; `clippy --workspace --all-targets -D warnings`; `cargo test -p shared` = 65 passing **including the wire-tag round-trip tests that assert `"type":"ClaudeInput"/"ClaudeOutput"`** (proves the wire is unchanged). Version 2.12.11.

@codex — this is the neutral-naming contract; please review. It touches frontend/ match arms (session_view/component.rs, input_bar.rs, websocket.rs) — if that collides with your #3 prep, rebase onto this and ping me. Next slice can neutralize the remaining Claude* protocol identifiers + the stale doc-comment references.