### PR TITLE
Add AgentFrame renderer dispatch scaffold (#3 prep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.11"
+version = "2.12.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.11"
+version = "2.12.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.11"
+version = "2.12.12"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.11"
+version = "2.12.12"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.11"
+version = "2.12.12"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.11"
+version = "2.12.12"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.11"
+version = "2.12.12"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.11"
+version = "2.12.12"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.11"
+version = "2.12.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.11"
+version = "2.12.12"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.11"
+version = "2.12.12"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/agent_frame.rs
+++ b/frontend/src/components/agent_frame.rs
@@ -1,0 +1,271 @@
+//! Normalized parse layer for agent transcript frames.
+//!
+//! This module is intentionally render-free. It captures the dispatch order
+//! currently embedded in `message_renderer::MessageRenderer`: parse
+//! protocol-agnostic Claude/Portal/User shapes first, then Codex-specific
+//! shapes only for Codex sessions, then raw JSON. Later renderer-unification
+//! work can switch on `AgentFrame` instead of reparsing in separate renderer
+//! trees.
+
+use super::codex_renderer::CodexEvent;
+use super::message_renderer::types::ClaudeMessage;
+
+#[derive(Debug, Clone)]
+pub enum AgentFrame {
+    Claude(ClaudeMessage),
+    Codex(CodexEvent),
+    RawJson,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentFrameKind {
+    ClaudeSystem,
+    ClaudeAssistant,
+    ClaudeResult,
+    ClaudeUser,
+    ClaudeError,
+    ClaudeRateLimitEvent,
+    Portal,
+    OptimisticUser,
+    CodexThreadStarted,
+    CodexTurnStarted,
+    CodexTurnCompleted,
+    CodexTurnFailed,
+    CodexItemStarted,
+    CodexItemUpdated,
+    CodexItemCompleted,
+    CodexError,
+    CodexTurnDiffUpdated,
+    CodexFileChangePatchUpdated,
+    CodexTurnPlanUpdated,
+    CodexPlanDelta,
+    CodexReasoningSummaryPartAdded,
+    CodexReasoningTextDelta,
+    CodexThreadCompacted,
+    RawJson,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameRenderer {
+    Claude,
+    Codex,
+    RawJson,
+}
+
+pub struct AgentFrameRegistry;
+
+impl AgentFrameRegistry {
+    pub fn parse(json: &str, agent_type: shared::AgentType) -> AgentFrame {
+        AgentFrame::parse(json, agent_type)
+    }
+
+    pub fn renderer_for(frame: &AgentFrame) -> FrameRenderer {
+        FrameRenderer::for_kind(frame.kind())
+    }
+}
+
+impl AgentFrame {
+    pub fn parse(json: &str, agent_type: shared::AgentType) -> Self {
+        if let Ok(message) = ClaudeMessage::parse(json) {
+            if !matches!(message, ClaudeMessage::Unknown) {
+                return Self::Claude(message);
+            }
+        }
+
+        if agent_type == shared::AgentType::Codex {
+            if let Ok(event) = serde_json::from_str::<CodexEvent>(json) {
+                if !matches!(event, CodexEvent::Unknown) {
+                    return Self::Codex(event);
+                }
+            }
+        }
+
+        Self::RawJson
+    }
+
+    pub fn kind(&self) -> AgentFrameKind {
+        match self {
+            Self::Claude(message) => message.kind(),
+            Self::Codex(event) => event.kind(),
+            Self::RawJson => AgentFrameKind::RawJson,
+        }
+    }
+}
+
+impl FrameRenderer {
+    fn for_kind(kind: AgentFrameKind) -> Self {
+        match kind {
+            AgentFrameKind::ClaudeSystem
+            | AgentFrameKind::ClaudeAssistant
+            | AgentFrameKind::ClaudeResult
+            | AgentFrameKind::ClaudeUser
+            | AgentFrameKind::ClaudeError
+            | AgentFrameKind::ClaudeRateLimitEvent
+            | AgentFrameKind::Portal
+            | AgentFrameKind::OptimisticUser => Self::Claude,
+            AgentFrameKind::CodexThreadStarted
+            | AgentFrameKind::CodexTurnStarted
+            | AgentFrameKind::CodexTurnCompleted
+            | AgentFrameKind::CodexTurnFailed
+            | AgentFrameKind::CodexItemStarted
+            | AgentFrameKind::CodexItemUpdated
+            | AgentFrameKind::CodexItemCompleted
+            | AgentFrameKind::CodexError
+            | AgentFrameKind::CodexTurnDiffUpdated
+            | AgentFrameKind::CodexFileChangePatchUpdated
+            | AgentFrameKind::CodexTurnPlanUpdated
+            | AgentFrameKind::CodexPlanDelta
+            | AgentFrameKind::CodexReasoningSummaryPartAdded
+            | AgentFrameKind::CodexReasoningTextDelta
+            | AgentFrameKind::CodexThreadCompacted => Self::Codex,
+            AgentFrameKind::RawJson => Self::RawJson,
+        }
+    }
+}
+
+impl ClaudeMessage {
+    fn kind(&self) -> AgentFrameKind {
+        match self {
+            Self::System(_) => AgentFrameKind::ClaudeSystem,
+            Self::Assistant(_) => AgentFrameKind::ClaudeAssistant,
+            Self::Result(_) => AgentFrameKind::ClaudeResult,
+            Self::User(_) => AgentFrameKind::ClaudeUser,
+            Self::Error(_) => AgentFrameKind::ClaudeError,
+            Self::Portal(_) => AgentFrameKind::Portal,
+            Self::RateLimitEvent(_) => AgentFrameKind::ClaudeRateLimitEvent,
+            Self::OptimisticUser(_) => AgentFrameKind::OptimisticUser,
+            Self::Unknown => AgentFrameKind::RawJson,
+        }
+    }
+}
+
+impl CodexEvent {
+    fn kind(&self) -> AgentFrameKind {
+        match self {
+            Self::ThreadStarted { .. } => AgentFrameKind::CodexThreadStarted,
+            Self::TurnStarted {} => AgentFrameKind::CodexTurnStarted,
+            Self::TurnCompleted { .. } => AgentFrameKind::CodexTurnCompleted,
+            Self::TurnFailed { .. } => AgentFrameKind::CodexTurnFailed,
+            Self::ItemStarted { .. } => AgentFrameKind::CodexItemStarted,
+            Self::ItemUpdated { .. } => AgentFrameKind::CodexItemUpdated,
+            Self::ItemCompleted { .. } => AgentFrameKind::CodexItemCompleted,
+            Self::Error { .. } => AgentFrameKind::CodexError,
+            Self::TurnDiffUpdated { .. } => AgentFrameKind::CodexTurnDiffUpdated,
+            Self::FileChangePatchUpdated { .. } => AgentFrameKind::CodexFileChangePatchUpdated,
+            Self::TurnPlanUpdated { .. } => AgentFrameKind::CodexTurnPlanUpdated,
+            Self::PlanDelta { .. } => AgentFrameKind::CodexPlanDelta,
+            Self::ReasoningSummaryPartAdded { .. } => {
+                AgentFrameKind::CodexReasoningSummaryPartAdded
+            }
+            Self::ReasoningTextDelta { .. } => AgentFrameKind::CodexReasoningTextDelta,
+            Self::ThreadCompacted { .. } => AgentFrameKind::CodexThreadCompacted,
+            Self::Unknown => AgentFrameKind::RawJson,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_for(agent_type: shared::AgentType, json: serde_json::Value) -> AgentFrame {
+        AgentFrameRegistry::parse(&json.to_string(), agent_type)
+    }
+
+    #[test]
+    fn parses_claude_assistant_frame_to_claude_renderer() {
+        let frame = parse_for(
+            shared::AgentType::Claude,
+            serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-5-20250929",
+                    "content": [{"type": "text", "text": "hello"}]
+                },
+                "session_id": "01890000-0000-7000-8000-000000000001"
+            }),
+        );
+
+        assert_eq!(frame.kind(), AgentFrameKind::ClaudeAssistant);
+        assert_eq!(
+            AgentFrameRegistry::renderer_for(&frame),
+            FrameRenderer::Claude
+        );
+    }
+
+    #[test]
+    fn parses_portal_frame_before_agent_specific_fallback() {
+        let frame = parse_for(
+            shared::AgentType::Codex,
+            serde_json::json!({
+                "type": "portal",
+                "content": [{"type": "text", "text": "Connection restored"}]
+            }),
+        );
+
+        assert_eq!(frame.kind(), AgentFrameKind::Portal);
+        assert_eq!(
+            AgentFrameRegistry::renderer_for(&frame),
+            FrameRenderer::Claude
+        );
+    }
+
+    #[test]
+    fn parses_optimistic_user_frame_before_agent_specific_fallback() {
+        let frame = parse_for(
+            shared::AgentType::Codex,
+            serde_json::json!({
+                "type": "user",
+                "content": "pending prompt",
+                "_pending": true
+            }),
+        );
+
+        assert_eq!(frame.kind(), AgentFrameKind::OptimisticUser);
+        assert_eq!(
+            AgentFrameRegistry::renderer_for(&frame),
+            FrameRenderer::Claude
+        );
+    }
+
+    #[test]
+    fn parses_codex_turn_completed_only_for_codex_sessions() {
+        let json = serde_json::json!({
+            "type": "turn.completed",
+            "usage": {"input_tokens": 1, "output_tokens": 2}
+        });
+
+        let codex = parse_for(shared::AgentType::Codex, json.clone());
+        assert_eq!(codex.kind(), AgentFrameKind::CodexTurnCompleted);
+        assert_eq!(
+            AgentFrameRegistry::renderer_for(&codex),
+            FrameRenderer::Codex
+        );
+
+        let claude = parse_for(shared::AgentType::Claude, json);
+        assert_eq!(claude.kind(), AgentFrameKind::RawJson);
+        assert_eq!(
+            AgentFrameRegistry::renderer_for(&claude),
+            FrameRenderer::RawJson
+        );
+    }
+
+    #[test]
+    fn unknown_codex_event_stays_raw_json() {
+        let frame = parse_for(
+            shared::AgentType::Codex,
+            serde_json::json!({
+                "type": "future.event",
+                "payload": {"value": 1}
+            }),
+        );
+
+        assert_eq!(frame.kind(), AgentFrameKind::RawJson);
+        assert_eq!(
+            AgentFrameRegistry::renderer_for(&frame),
+            FrameRenderer::RawJson
+        );
+    }
+}

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use uuid::Uuid;
 use yew::prelude::*;
 
+use super::agent_frame::{AgentFrame, AgentFrameRegistry, FrameRenderer};
 #[cfg(test)]
 use grouping::classify;
 use grouping::{extract_raw_iso, visible_group_indices, GroupCategory};
@@ -57,7 +58,7 @@ pub struct MessageRendererProps {
 pub fn message_renderer(props: &MessageRendererProps) -> Html {
     let raw_iso = extract_raw_iso(&props.json);
     let ts = raw_iso.as_deref().and_then(local_timestamp);
-    let parsed = ClaudeMessage::parse(&props.json);
+    let frame = AgentFrameRegistry::parse(&props.json, props.agent_type);
 
     // Dispatch on the message shape, not the agent. `User` (the proxy's
     // synthetic echo) and `Portal` (the backend's portal-content envelope)
@@ -66,61 +67,61 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
     // into raw JSON blocks. Codex-specific shapes (`item.started`,
     // `turn.completed`, …) don't match any `ClaudeMessage` variant and fall
     // through to the codex renderer below.
-    match parsed {
-        Ok(ClaudeMessage::System(msg)) => {
-            return renderers::render_system_message(&msg, ts.as_deref());
-        }
-        Ok(ClaudeMessage::Assistant(msg)) => {
-            return renderers::render_assistant_message(
-                &msg,
-                ts.as_deref(),
-                raw_iso.as_deref(),
-                props.session_id,
-            );
-        }
-        Ok(ClaudeMessage::Result(msg)) => {
-            return renderers::render_result_message(&msg, props.turn_metrics.as_ref());
-        }
-        Ok(ClaudeMessage::User(msg)) => {
-            let meta = user_meta_from_json(&props.json);
-            return renderers::render_user_message(
-                &msg,
-                &meta,
-                props.current_user_id.as_deref(),
-                ts.as_deref(),
-                props.session_id,
-            );
-        }
-        Ok(ClaudeMessage::OptimisticUser(msg)) => {
-            return renderers::render_optimistic_user_message(
-                &msg,
-                props.current_user_id.as_deref(),
-                ts.as_deref(),
-                props.session_id,
-            );
-        }
-        Ok(ClaudeMessage::Error(msg)) => {
-            return renderers::render_error_message(&msg, ts.as_deref());
-        }
-        Ok(ClaudeMessage::Portal(msg)) => {
-            return renderers::render_portal_message(
+    match AgentFrameRegistry::renderer_for(&frame) {
+        FrameRenderer::Claude => match frame {
+            AgentFrame::Claude(ClaudeMessage::System(msg)) => {
+                renderers::render_system_message(&msg, ts.as_deref())
+            }
+            AgentFrame::Claude(ClaudeMessage::Assistant(msg)) => {
+                renderers::render_assistant_message(
+                    &msg,
+                    ts.as_deref(),
+                    raw_iso.as_deref(),
+                    props.session_id,
+                )
+            }
+            AgentFrame::Claude(ClaudeMessage::Result(msg)) => {
+                renderers::render_result_message(&msg, props.turn_metrics.as_ref())
+            }
+            AgentFrame::Claude(ClaudeMessage::User(msg)) => {
+                let meta = user_meta_from_json(&props.json);
+                renderers::render_user_message(
+                    &msg,
+                    &meta,
+                    props.current_user_id.as_deref(),
+                    ts.as_deref(),
+                    props.session_id,
+                )
+            }
+            AgentFrame::Claude(ClaudeMessage::OptimisticUser(msg)) => {
+                renderers::render_optimistic_user_message(
+                    &msg,
+                    props.current_user_id.as_deref(),
+                    ts.as_deref(),
+                    props.session_id,
+                )
+            }
+            AgentFrame::Claude(ClaudeMessage::Error(msg)) => {
+                renderers::render_error_message(&msg, ts.as_deref())
+            }
+            AgentFrame::Claude(ClaudeMessage::Portal(msg)) => renderers::render_portal_message(
                 &msg,
                 ts.as_deref(),
                 props.session_id,
                 &props.continuation_statuses,
                 props.on_schedule_continuation.clone(),
-            );
+            ),
+            AgentFrame::Claude(ClaudeMessage::RateLimitEvent(msg)) => {
+                renderers::render_rate_limit_event(&msg, ts.as_deref())
+            }
+            AgentFrame::Claude(ClaudeMessage::Unknown)
+            | AgentFrame::Codex(_)
+            | AgentFrame::RawJson => render_raw_json(&props.json),
+        },
+        FrameRenderer::Codex => {
+            html! { <super::codex_renderer::CodexMessageRenderer json={props.json.clone()} session_id={props.session_id} turn_metrics={props.turn_metrics.clone()} /> }
         }
-        Ok(ClaudeMessage::RateLimitEvent(msg)) => {
-            return renderers::render_rate_limit_event(&msg, ts.as_deref());
-        }
-        Ok(ClaudeMessage::Unknown) | Err(_) => {}
-    }
-
-    if props.agent_type == shared::AgentType::Codex {
-        html! { <super::codex_renderer::CodexMessageRenderer json={props.json.clone()} session_id={props.session_id} turn_metrics={props.turn_metrics.clone()} /> }
-    } else {
-        render_raw_json(&props.json)
+        FrameRenderer::RawJson => render_raw_json(&props.json),
     }
 }
 

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_frame;
 pub mod charts;
 pub mod codex_renderer;
 mod confirm_modal;


### PR DESCRIPTION
## Summary
- Add a frontend-only `AgentFrame` parse model that normalizes Claude/Portal/User, Codex, and raw JSON transcript frames.
- Add a small renderer registry that maps parsed frame kinds to the existing Claude, Codex, or raw renderer families.
- Route `MessageRenderer` through the registry while preserving the existing renderer functions and behavior.
- Bump workspace version to 2.12.12.

## Verification
- `cargo fmt --check`
- `cargo test -p frontend`
- `cargo clippy -p frontend --all-targets -- -D warnings`
- `cargo check -p frontend --target wasm32-unknown-unknown`

## Notes
This is the first small #3 prep slice after #1098. It intentionally avoids deep renderer surgery: the existing Claude and Codex renderers still own the actual HTML, but the top-level dispatch now has one normalized parse model for future renderer registry work.