### PR TITLE
Use AgentFrame for grouped message rendering (#3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.12"
+version = "2.12.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.12"
+version = "2.12.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.12"
+version = "2.12.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.12"
+version = "2.12.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.12"
+version = "2.12.13"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.12"
+version = "2.12.13"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.12"
+version = "2.12.13"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.12"
+version = "2.12.13"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.12"
+version = "2.12.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.12"
+version = "2.12.13"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.12"
+version = "2.12.13"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -242,21 +242,24 @@ fn render_identity_group_part(
     continuation_statuses: &HashMap<Uuid, String>,
     on_schedule_continuation: Callback<Uuid>,
 ) -> Html {
-    match ClaudeMessage::parse(json) {
-        Ok(ClaudeMessage::User(msg)) => renderers::render_user_message_content(&msg, session_id),
-        Ok(ClaudeMessage::OptimisticUser(msg)) => {
+    let frame = AgentFrameRegistry::parse(json, agent_type);
+    match frame {
+        AgentFrame::Claude(ClaudeMessage::User(msg)) => {
+            renderers::render_user_message_content(&msg, session_id)
+        }
+        AgentFrame::Claude(ClaudeMessage::OptimisticUser(msg)) => {
             renderers::render_optimistic_user_message_content(&msg, session_id)
         }
-        Ok(ClaudeMessage::Assistant(msg)) => {
+        AgentFrame::Claude(ClaudeMessage::Assistant(msg)) => {
             renderers::render_assistant_message_content(&msg, session_id)
         }
-        Ok(ClaudeMessage::Portal(msg)) => renderers::render_portal_message_content(
+        AgentFrame::Claude(ClaudeMessage::Portal(msg)) => renderers::render_portal_message_content(
             &msg,
             session_id,
             continuation_statuses,
             on_schedule_continuation,
         ),
-        _ if agent_type == shared::AgentType::Codex => {
+        AgentFrame::Codex(_) => {
             super::codex_renderer::render_codex_message_content(json, session_id)
         }
         _ => html! {},


### PR DESCRIPTION
## Summary
- Route grouped-message content rendering through `AgentFrameRegistry`.
- Remove the local direct `ClaudeMessage::parse` plus Codex fallback branch from `render_identity_group_part`.
- Preserve existing grouped HTML renderers and behavior; this is another small renderer-unification prep slice.
- Bump workspace version to 2.12.13.

## Verification
- `cargo fmt --check`
- `cargo test -p frontend message_renderer`
- `cargo clippy -p frontend --all-targets -- -D warnings`
- `cargo check -p frontend --target wasm32-unknown-unknown`
- `cargo test -p frontend`
