### PR TITLE
session-lib: AgentAdapter trait + ClaudeAdapter (refactor #1, slice 2a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.14"
+version = "2.12.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.14"
+version = "2.12.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.14"
+version = "2.12.15"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.14"
+version = "2.12.15"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.14"
+version = "2.12.15"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.14"
+version = "2.12.15"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.14"
+version = "2.12.15"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.14"
+version = "2.12.15"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.14"
+version = "2.12.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.14"
+version = "2.12.15"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.14"
+version = "2.12.15"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/docs/design/session-adapter.md
+++ b/docs/design/session-adapter.md
@@ -1,0 +1,122 @@
+# Design: agent-neutral Session boundary (refactor item #1)
+
+**Status:** design slice for review (Claude draft → Codex review). No `session.rs`
+changes until the trait shape is agreed.
+
+## Goal
+
+`Session<A>` core must stop matching concrete `claude_codes` / `codex_codes`
+types. Today `session-lib/src/session.rs::next_event` matches
+`ClaudeOutput::{Result, ControlRequest, ControlResponse}` directly, and
+`send_input`/`respond_permission` build `ClaudeInput` / route claude-vs-codex
+`IoCommand` variants. That structural coupling is why `codex-session-lib` carries
+a parallel `io_task`/`handler` instead of reusing `Session`.
+
+Fix: an **adapter** owns all protocol parse/serialize and exposes only **neutral
+decisions**. Concrete protocol enums stay *inside* the adapter (never surface
+into `session.rs`, not even via associated types).
+
+## What `session.rs` decides today (the classification to neutralize)
+
+From `next_event` on each `ClaudeOutput`:
+- `Result` with `is_error` + "No conversation found" → `SessionNotFound`.
+- `ControlRequest(CanUseTool)` → emit `PermissionRequest { request_id, tool_name, input, suggestions }`, set `WaitingForPermission`, stash `PendingPermission`.
+- `ControlResponse` → skip (internal ack, no-op).
+- anything else → user-visible `Output` (buffer + forward).
+
+Input side: `send_input` → `ClaudeInput::user_message(text, id)`;
+`respond_permission` → claude `PermissionResponse` vs codex `CodexApproval`.
+
+## Proposed neutral types
+
+```rust
+/// One neutral decision produced by the adapter from a unit of agent output.
+pub enum AgentOutput {
+    /// User-visible output to forward/persist verbatim (opaque wire JSON).
+    Visible(serde_json::Value),
+    /// A permission/control request awaiting a response.
+    PermissionRequest {
+        request_id: String,              // neutral correlation id
+        tool_name: String,
+        input: serde_json::Value,
+        suggestions: Vec<PermissionSuggestion>, // see "open question" below
+    },
+    /// End-of-turn terminator + optional result summary/metrics.
+    TurnEnd { result: Option<TurnResult> },
+    /// Hard session limit with reset info.
+    SessionLimit { reset_at: String, source_message: String, prompt: String },
+    /// Fatal "conversation not found" → maps to SessionNotFound.
+    NotFound,
+    /// Internal ack / nothing for the consumer — Session skips it.
+    Noop,
+}
+
+/// Neutral permission decision (already ~PermissionResponse, minus claude types).
+pub struct PermissionDecision {
+    pub allow: bool,
+    pub modified_input: Option<serde_json::Value>,
+    pub remember: Vec<RememberRule>,     // see "open question"
+    pub reason: Option<String>,
+}
+
+/// Opaque transport payload the I/O task writes to the agent. The adapter
+/// produces it; Session never inspects it.
+pub struct TransportPayload(/* bytes or serde_json::Value, opaque */);
+```
+
+## Proposed trait
+
+```rust
+pub trait AgentAdapter: Send + 'static {
+    /// Parse + classify one unit of agent stdout into 0..n neutral decisions.
+    /// The adapter owns protocol parsing; `raw` is the opaque transport unit.
+    fn classify(&mut self, raw: RawUnit) -> Vec<AgentOutput>;
+
+    /// Build the payload for plain user text.
+    fn user_input(&self, text: &str, session_id: Uuid) -> TransportPayload;
+
+    /// Build the payload responding to a prior PermissionRequest.
+    fn permission_response(&self, request_id: &str, decision: PermissionDecision)
+        -> TransportPayload;
+
+    /// Optional control inputs (interrupt, etc.).
+    fn interrupt(&self) -> Option<TransportPayload> { None }
+}
+```
+
+`Session<A: AgentAdapter>` then:
+- `next_event` matches on `AgentOutput` variants only (no `ClaudeOutput`), keeping
+  the same state transitions (`WaitingForPermission`, `Exited`, `SessionNotFound`)
+  and buffering.
+- `send_input` calls `adapter.user_input(..)`; `respond_permission` calls
+  `adapter.permission_response(..)`. The `IoCommand` union
+  (`PermissionResponse` vs `CodexApproval`) collapses into one
+  `IoCommand::Send(TransportPayload)`.
+
+## Migration (behavior-preserving, staged)
+
+1. **This design** → review/agree the trait shape. (no code)
+2. **ClaudeAdapter only**: move the claude classification (the `next_event`
+   matches) and `ClaudeInput` construction into `ClaudeAdapter`; rewrite
+   `session.rs` to be adapter-generic. Verified behavior-identical (existing
+   tests + proxy smoke). Claude path only.
+3. **CodexAdapter**: implement `AgentAdapter` for the codex app-server protocol,
+   replacing `RawOutput`/`CodexPermissionRequest`/`CodexApproval` special-casing.
+4. **Collapse**: route `codex-session-lib` through the shared `Session<CodexAdapter>`
+   and delete its parallel `io_task`/`handler`.
+
+## Open questions for review
+
+- **`PermissionSuggestion` / `Permission`**: these are `claude_codes` types that
+  currently surface in `SessionEvent::PermissionRequest` and `PermissionResponse`.
+  Fully neutralizing means introducing neutral `Suggestion`/`RememberRule` types
+  and converting in the adapter. Do we neutralize these now (bigger blast into the
+  proxy/backend consumers of `SessionEvent`) or keep them opaque (`serde_json::Value`)
+  for slice 1 and neutralize in a follow-up? (Claude leans: opaque `Value` for
+  slice 1 to keep it contained.)
+- **Who parses?** Proposal puts parsing in `adapter.classify(raw)`. Alternative
+  keeps the I/O task parsing and passes typed-but-opaque handles — rejected, as it
+  re-leaks concrete types.
+- **`RawUnit`/`TransportPayload` concrete form**: bytes vs `serde_json::Value`.
+  (Claude leans `serde_json::Value` for JSON-line protocols; revisit if a binary
+  transport appears.)

--- a/session-lib/src/adapter.rs
+++ b/session-lib/src/adapter.rs
@@ -1,0 +1,472 @@
+//! Agent-neutral adapter boundary (refactor item #1, slice 2a — additive).
+//!
+//! An [`AgentAdapter`] owns all protocol parse/serialize for one agent backend
+//! and exposes only **neutral decisions** to the generic `Session<A>` core.
+//! Concrete protocol enums (`claude_codes::*`, `codex_codes::*`) stay *inside*
+//! the adapter and never surface into `session.rs`.
+//!
+//! This slice introduces the trait, the neutral types, and a [`ClaudeAdapter`]
+//! whose [`classify`](AgentAdapter::classify) is a pure function mirroring
+//! exactly what `session.rs::next_event` currently decides for `ClaudeOutput`.
+//! It is **not** yet wired into `session.rs`; that happens in a later slice.
+//!
+//! See `docs/design/session-adapter.md` for the full design.
+
+use uuid::Uuid;
+
+/// One unit of agent stdout, as opaque wire JSON. The adapter parses it.
+pub type RawUnit = serde_json::Value;
+
+/// Opaque payload the I/O task writes to the agent. The adapter produces it;
+/// `Session` never inspects it.
+pub type TransportPayload = serde_json::Value;
+
+/// A neutral decision produced by the adapter from one unit of agent output.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AgentOutput {
+    /// User-visible output to forward/persist verbatim (opaque wire JSON).
+    Visible(serde_json::Value),
+    /// A permission/control request awaiting a response.
+    PermissionRequest {
+        /// Neutral correlation id for the later [`AgentAdapter::permission_response`].
+        request_id: String,
+        /// Stringly-typed tool name (the same key the claude path carries
+        /// verbatim from `ToolUseRequest`).
+        tool_name: String,
+        /// Tool input parameters.
+        input: serde_json::Value,
+        /// Opaque suggested permissions (claude `PermissionSuggestion`s
+        /// serialized to JSON for slice 1). See design doc open questions.
+        suggestions: Vec<serde_json::Value>,
+    },
+    /// Fatal "conversation not found" → maps to `SessionEvent::SessionNotFound`.
+    NotFound,
+    /// Internal ack / nothing for the consumer — `Session` skips it.
+    Noop,
+}
+
+/// Neutral permission decision — the agent-agnostic form of
+/// [`crate::io::PermissionResponse`], minus the concrete `claude_codes` types.
+#[derive(Debug, Clone, Default)]
+pub struct PermissionDecision {
+    /// Whether to allow the tool use.
+    pub allow: bool,
+    /// Optional modified input (for edit suggestions).
+    pub modified_input: Option<serde_json::Value>,
+    /// Permissions to remember for future similar operations. Opaque for
+    /// slice 1 (claude `Permission`s serialized to JSON).
+    pub remember: Vec<serde_json::Value>,
+    /// Reason for denial (used when `allow` is false).
+    pub reason: Option<String>,
+}
+
+/// Per-agent protocol parse/serialize boundary for the generic `Session<A>`.
+///
+/// The adapter owns all concrete-protocol knowledge. `Session` only ever sees
+/// neutral [`AgentOutput`] / [`PermissionDecision`] and opaque
+/// [`TransportPayload`]s.
+pub trait AgentAdapter: Send + 'static {
+    /// Parse + classify one unit of agent stdout into 0..n neutral decisions.
+    ///
+    /// `&mut self` so future stateful adapters (e.g. codex, which threads a
+    /// request-id ↔ tool map) can update internal state. Claude is stateless
+    /// and 1:1 (one `RawUnit` → exactly one `AgentOutput`).
+    fn classify(&mut self, raw: RawUnit) -> Vec<AgentOutput>;
+
+    /// Build the transport payload for plain user text.
+    fn user_input(&self, text: &str, session_id: Uuid) -> TransportPayload;
+
+    /// Build the transport payload responding to a prior `PermissionRequest`.
+    fn permission_response(
+        &self,
+        request_id: &str,
+        decision: PermissionDecision,
+    ) -> TransportPayload;
+
+    /// Optional control inputs (interrupt, etc.).
+    fn interrupt(&self) -> Option<TransportPayload> {
+        None
+    }
+}
+
+/// Claude-protocol adapter. Stateless for now; a unit struct.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ClaudeAdapter;
+
+impl AgentAdapter for ClaudeAdapter {
+    fn classify(&mut self, raw: RawUnit) -> Vec<AgentOutput> {
+        use claude_codes::io::ControlRequestPayload;
+        use claude_codes::ClaudeOutput;
+
+        // Parse failure → forward verbatim, never panic. Mirrors the proxy/io
+        // path which keeps unparseable JSON visible rather than dropping it.
+        let output: ClaudeOutput = match serde_json::from_value(raw.clone()) {
+            Ok(output) => output,
+            Err(_) => return vec![AgentOutput::Visible(raw)],
+        };
+
+        match output {
+            // "No conversation found" → session not found locally. Any other
+            // Result is ordinary user-visible output.
+            ClaudeOutput::Result(ref res) => {
+                if res.is_error
+                    && res
+                        .errors
+                        .iter()
+                        .any(|e| e.contains("No conversation found"))
+                {
+                    vec![AgentOutput::NotFound]
+                } else {
+                    vec![AgentOutput::Visible(raw)]
+                }
+            }
+            // Tool permission request → neutral PermissionRequest. Any other
+            // ControlRequest variant (hooks, mcp, initialize) is forwarded
+            // verbatim, matching `next_event`'s fall-through.
+            ClaudeOutput::ControlRequest(ref req) => {
+                if let ControlRequestPayload::CanUseTool(ref tool_req) = req.request {
+                    let suggestions = tool_req
+                        .permission_suggestions
+                        .iter()
+                        .map(|s| serde_json::to_value(s).unwrap_or(serde_json::Value::Null))
+                        .collect();
+                    vec![AgentOutput::PermissionRequest {
+                        request_id: req.request_id.clone(),
+                        tool_name: tool_req.tool_name.clone(),
+                        input: tool_req.input.clone(),
+                        suggestions,
+                    }]
+                } else {
+                    vec![AgentOutput::Visible(raw)]
+                }
+            }
+            // Control responses are CLI acks — internal, the consumer skips.
+            ClaudeOutput::ControlResponse(_) => vec![AgentOutput::Noop],
+            // Everything else (System, User, Assistant, Error, RateLimitEvent)
+            // is user-visible.
+            _ => vec![AgentOutput::Visible(raw)],
+        }
+    }
+
+    fn user_input(&self, text: &str, session_id: Uuid) -> TransportPayload {
+        let input = claude_codes::ClaudeInput::user_message(text, session_id);
+        serde_json::to_value(&input).unwrap_or(serde_json::Value::Null)
+    }
+
+    fn permission_response(
+        &self,
+        request_id: &str,
+        decision: PermissionDecision,
+    ) -> TransportPayload {
+        use claude_codes::io::{ControlResponse, PermissionResult};
+
+        // Mirrors `session.rs::respond_permission` (claude path):
+        // - input defaults to an empty object when not modified,
+        // - non-empty remembered permissions use the typed-permissions allow,
+        // - deny carries the reason, defaulting to "User denied".
+        let ctrl_response = if decision.allow {
+            let input_value = decision
+                .modified_input
+                .unwrap_or(serde_json::Value::Object(Default::default()));
+            if decision.remember.is_empty() {
+                ControlResponse::from_result(request_id, PermissionResult::allow(input_value))
+            } else {
+                ControlResponse::from_result(
+                    request_id,
+                    PermissionResult::allow_with_permissions(input_value, decision.remember),
+                )
+            }
+        } else {
+            let reason = decision.reason.unwrap_or_else(|| "User denied".to_string());
+            ControlResponse::from_result(request_id, PermissionResult::deny(reason))
+        };
+
+        serde_json::to_value(&ctrl_response).unwrap_or(serde_json::Value::Null)
+    }
+
+    fn interrupt(&self) -> Option<TransportPayload> {
+        Some(
+            serde_json::to_value(claude_codes::ClaudeInput::interrupt())
+                .unwrap_or(serde_json::Value::Null),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // --- classify golden tests ---------------------------------------------
+
+    #[test]
+    fn classify_assistant_message_is_visible() {
+        let raw = json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hi"}]
+            }
+        });
+        let mut adapter = ClaudeAdapter;
+        assert_eq!(
+            adapter.classify(raw.clone()),
+            vec![AgentOutput::Visible(raw)]
+        );
+    }
+
+    #[test]
+    fn classify_user_message_is_visible() {
+        let raw = json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}]
+            }
+        });
+        let mut adapter = ClaudeAdapter;
+        assert_eq!(
+            adapter.classify(raw.clone()),
+            vec![AgentOutput::Visible(raw)]
+        );
+    }
+
+    #[test]
+    fn classify_ordinary_result_is_visible() {
+        let raw = json!({
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "duration_ms": 100,
+            "duration_api_ms": 200,
+            "num_turns": 1,
+            "result": "Done",
+            "session_id": "abc",
+            "total_cost_usd": 0.01
+        });
+        let mut adapter = ClaudeAdapter;
+        assert_eq!(
+            adapter.classify(raw.clone()),
+            vec![AgentOutput::Visible(raw)]
+        );
+    }
+
+    #[test]
+    fn classify_no_conversation_found_result_is_not_found() {
+        // Exactly the shape `next_event` keys on: is_error + an errors entry
+        // containing "No conversation found".
+        let raw = json!({
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": true,
+            "duration_ms": 0,
+            "duration_api_ms": 0,
+            "num_turns": 0,
+            "session_id": "27934753-425a-4182-892c-6b1c15050c3f",
+            "total_cost_usd": 0,
+            "errors": ["No conversation found with session ID: d56965c9-c855-4042-a8f5-f12bbb14d6f6"]
+        });
+        let mut adapter = ClaudeAdapter;
+        assert_eq!(adapter.classify(raw), vec![AgentOutput::NotFound]);
+    }
+
+    #[test]
+    fn classify_error_result_without_no_conversation_is_visible() {
+        // is_error but a *different* error string → still user-visible,
+        // mirroring `next_event`'s `.any(... "No conversation found")` guard.
+        let raw = json!({
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": true,
+            "duration_ms": 0,
+            "duration_api_ms": 0,
+            "num_turns": 0,
+            "session_id": "abc",
+            "total_cost_usd": 0,
+            "errors": ["Some other failure"]
+        });
+        let mut adapter = ClaudeAdapter;
+        assert_eq!(
+            adapter.classify(raw.clone()),
+            vec![AgentOutput::Visible(raw)]
+        );
+    }
+
+    #[test]
+    fn classify_can_use_tool_is_permission_request() {
+        let raw = json!({
+            "type": "control_request",
+            "request_id": "perm-abc123",
+            "request": {
+                "subtype": "can_use_tool",
+                "tool_name": "Write",
+                "input": {"file_path": "/tmp/hello.py", "content": "print('hi')"},
+                "permission_suggestions": [
+                    {"type": "setMode", "mode": "acceptEdits", "destination": "session"}
+                ]
+            }
+        });
+        let mut adapter = ClaudeAdapter;
+        let out = adapter.classify(raw);
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            AgentOutput::PermissionRequest {
+                request_id,
+                tool_name,
+                input,
+                suggestions,
+            } => {
+                assert_eq!(request_id, "perm-abc123");
+                assert_eq!(tool_name, "Write");
+                assert_eq!(input["file_path"], json!("/tmp/hello.py"));
+                assert_eq!(input["content"], json!("print('hi')"));
+                assert_eq!(suggestions.len(), 1);
+                assert_eq!(suggestions[0]["type"], json!("setMode"));
+                assert_eq!(suggestions[0]["mode"], json!("acceptEdits"));
+            }
+            other => panic!("expected PermissionRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_non_can_use_tool_control_request_is_visible() {
+        // An initialize control request is not a CanUseTool → forwarded verbatim.
+        let raw = json!({
+            "type": "control_request",
+            "request_id": "init-1",
+            "request": {"subtype": "initialize"}
+        });
+        let mut adapter = ClaudeAdapter;
+        assert_eq!(
+            adapter.classify(raw.clone()),
+            vec![AgentOutput::Visible(raw)]
+        );
+    }
+
+    #[test]
+    fn classify_control_response_is_noop() {
+        let raw = json!({
+            "type": "control_response",
+            "response": {"subtype": "success", "request_id": "req-1"}
+        });
+        let mut adapter = ClaudeAdapter;
+        assert_eq!(adapter.classify(raw), vec![AgentOutput::Noop]);
+    }
+
+    #[test]
+    fn classify_garbage_is_visible_no_panic() {
+        let raw = json!({"totally": "unrecognized", "shape": [1, 2, 3]});
+        let mut adapter = ClaudeAdapter;
+        assert_eq!(
+            adapter.classify(raw.clone()),
+            vec![AgentOutput::Visible(raw)]
+        );
+
+        // A non-object value also must not panic.
+        let scalar = json!(42);
+        assert_eq!(
+            adapter.classify(scalar.clone()),
+            vec![AgentOutput::Visible(scalar)]
+        );
+    }
+
+    // --- input / permission serialization tests ----------------------------
+
+    #[test]
+    fn user_input_builds_claude_user_message() {
+        let adapter = ClaudeAdapter;
+        let session_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let payload = adapter.user_input("Hello, Claude!", session_id);
+        assert_eq!(payload["type"], json!("user"));
+        assert_eq!(payload["message"]["role"], json!("user"));
+        assert_eq!(
+            payload["message"]["content"][0]["text"],
+            json!("Hello, Claude!")
+        );
+        assert_eq!(
+            payload["session_id"],
+            json!("550e8400-e29b-41d4-a716-446655440000")
+        );
+    }
+
+    #[test]
+    fn permission_response_allow_uses_empty_input_by_default() {
+        let adapter = ClaudeAdapter;
+        let payload = adapter.permission_response(
+            "req-1",
+            PermissionDecision {
+                allow: true,
+                ..Default::default()
+            },
+        );
+        let inner = &payload["response"];
+        assert_eq!(inner["subtype"], json!("success"));
+        assert_eq!(inner["request_id"], json!("req-1"));
+        assert_eq!(inner["response"]["behavior"], json!("allow"));
+        // input defaults to an empty object (mirrors respond_permission).
+        assert_eq!(inner["response"]["updatedInput"], json!({}));
+        assert!(inner["response"].get("updatedPermissions").is_none());
+    }
+
+    #[test]
+    fn permission_response_allow_with_modified_input_and_remember() {
+        let adapter = ClaudeAdapter;
+        let perm =
+            serde_json::to_value(claude_codes::Permission::allow_tool("Bash", "npm test")).unwrap();
+        let payload = adapter.permission_response(
+            "req-2",
+            PermissionDecision {
+                allow: true,
+                modified_input: Some(json!({"command": "npm test"})),
+                remember: vec![perm],
+                reason: None,
+            },
+        );
+        let result = &payload["response"]["response"];
+        assert_eq!(result["behavior"], json!("allow"));
+        assert_eq!(result["updatedInput"], json!({"command": "npm test"}));
+        assert_eq!(result["updatedPermissions"][0]["type"], json!("addRules"));
+        assert_eq!(
+            result["updatedPermissions"][0]["rules"][0]["toolName"],
+            json!("Bash")
+        );
+    }
+
+    #[test]
+    fn permission_response_deny_uses_reason_with_default() {
+        let adapter = ClaudeAdapter;
+
+        // Explicit reason.
+        let payload = adapter.permission_response(
+            "req-3",
+            PermissionDecision {
+                allow: false,
+                reason: Some("nope".to_string()),
+                ..Default::default()
+            },
+        );
+        let result = &payload["response"]["response"];
+        assert_eq!(result["behavior"], json!("deny"));
+        assert_eq!(result["message"], json!("nope"));
+
+        // Default reason mirrors respond_permission's "User denied".
+        let payload = adapter.permission_response(
+            "req-4",
+            PermissionDecision {
+                allow: false,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            payload["response"]["response"]["message"],
+            json!("User denied")
+        );
+    }
+
+    #[test]
+    fn interrupt_builds_interrupt_payload() {
+        let adapter = ClaudeAdapter;
+        let payload = adapter.interrupt().expect("claude supports interrupt");
+        assert_eq!(payload["subtype"], json!("interrupt"));
+    }
+}

--- a/session-lib/src/lib.rs
+++ b/session-lib/src/lib.rs
@@ -16,6 +16,7 @@
 //! Heterogeneous consumers (e.g. the launcher) wrap the per-agent
 //! `Session<A>` in an enum at the dispatch boundary.
 
+pub mod adapter;
 pub mod agent;
 pub mod buffer;
 pub mod error;
@@ -27,6 +28,7 @@ pub mod session;
 pub mod snapshot;
 pub mod turn_tracker;
 
+pub use adapter::{AgentAdapter, AgentOutput, ClaudeAdapter, PermissionDecision};
 pub use agent::Agent;
 pub use buffer::{BufferedOutput, OutputBuffer};
 pub use error::SessionError;


### PR DESCRIPTION
**Item #1 (agent-neutral Session boundary), slice 2a — ADDITIVE, no `session.rs` change.** Design: `docs/design/session-adapter.md` (signed off by @codex).

Introduces the neutral adapter contract that lets `Session<A>` stop matching `claude_codes` types (wiring is slice 2b):
- `session-lib/src/adapter.rs`: `AgentAdapter` trait (`classify(raw) -> Vec<AgentOutput>`, `user_input`/`permission_response`/`interrupt` → opaque `TransportPayload`); neutral types `RawUnit`/`TransportPayload = serde_json::Value`, `AgentOutput {Visible, PermissionRequest, NotFound, Noop}`, `PermissionDecision` (permissions opaque `Vec<Value>` for slice 1, per agreement).
- `ClaudeAdapter::classify` mirrors `session.rs::next_event` **exactly**: `Result`+"No conversation found"→`NotFound`, other `Result`→`Visible`, `ControlRequest(CanUseTool)`→`PermissionRequest`, `ControlResponse`→`Noop`, else `Visible`; **parse failure → `Visible(raw)`, never panics**. `user_input`/`permission_response` replicate `send_input`/`respond_permission`'s Claude payloads.
- **14 golden tests** pin the behavior (Result, not-found, CanUseTool permission, non-CanUseTool, ControlResponse, visible assistant/user, malformed JSON) — these guard the slice-2b `session.rs` rewrite.

Verified: `cargo test -p session-lib` 33 pass, `clippy -p session-lib -D warnings` clean, fmt clean. (session-lib is native-only; wasm N/A.) Version 2.12.14.

@codex — this is the ClaudeAdapter slice you signed off; review the trait+classify shape. Slice 2b (Session\<A:AgentAdapter\> wiring, behavior-preserving, guarded by these tests) is next.