### PR TITLE
session-lib: next_event dispatches via ClaudeAdapter::classify (#1 slice 2b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.16"
+version = "2.12.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.16"
+version = "2.12.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.16"
+version = "2.12.17"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.16"
+version = "2.12.17"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.16"
+version = "2.12.17"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.16"
+version = "2.12.17"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.16"
+version = "2.12.17"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.16"
+version = "2.12.17"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.16"
+version = "2.12.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.16"
+version = "2.12.17"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.16"
+version = "2.12.17"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -7,11 +7,12 @@
 use std::marker::PhantomData;
 
 use chrono::Utc;
-use claude_codes::io::{ControlResponse, PermissionResult};
-use claude_codes::{ClaudeInput, ClaudeOutput};
+use claude_codes::io::{ControlResponse, PermissionResult, PermissionSuggestion};
+use claude_codes::ClaudeInput;
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
+use crate::adapter::{AgentAdapter, AgentOutput, ClaudeAdapter};
 use crate::agent::Agent;
 use crate::buffer::OutputBuffer;
 use crate::error::SessionError;
@@ -172,55 +173,61 @@ impl<A: Agent> Session<A> {
                 Some(IoEvent::Output(boxed_output)) => {
                     let output = *boxed_output;
 
-                    // Buffer the output.
+                    // Buffer the raw output before classifying (preserve ordering).
                     let output_value = serde_json::to_value(&output).unwrap_or_default();
-                    self.buffer.push(output_value);
+                    self.buffer.push(output_value.clone());
 
-                    // Check for "No conversation found" error (session not found locally).
-                    if let ClaudeOutput::Result(ref res) = output {
-                        if res.is_error
-                            && res
-                                .errors
-                                .iter()
-                                .any(|e| e.contains("No conversation found"))
-                        {
-                            self.state = SessionState::Exited { code: 1 };
-                            self.command_tx = None;
-                            self.event_rx = None;
-                            return Some(SessionEvent::SessionNotFound);
-                        }
-                    }
-
-                    // Permission requests are emitted as `PermissionRequest`,
-                    // not `Output`, so the consumer doesn't see them twice.
-                    if let ClaudeOutput::ControlRequest(ref req) = output {
-                        if let claude_codes::io::ControlRequestPayload::CanUseTool(ref tool_req) =
-                            req.request
-                        {
-                            let request_id = req.request_id.clone();
-                            self.pending_permission = Some(PendingPermission {
-                                request_id: request_id.clone(),
-                                tool_name: tool_req.tool_name.clone(),
-                                input: tool_req.input.clone(),
-                                requested_at: Utc::now(),
-                            });
-                            self.state = SessionState::WaitingForPermission;
-
-                            return Some(SessionEvent::PermissionRequest {
+                    // Delegate protocol classification to the agent adapter. Claude
+                    // is 1:1 (one raw unit → one decision) but handle the Vec
+                    // generally so the loop matches the trait contract.
+                    let mut adapter = ClaudeAdapter;
+                    let mut visible = false;
+                    for decision in adapter.classify(output_value) {
+                        match decision {
+                            AgentOutput::NotFound => {
+                                self.state = SessionState::Exited { code: 1 };
+                                self.command_tx = None;
+                                self.event_rx = None;
+                                return Some(SessionEvent::SessionNotFound);
+                            }
+                            AgentOutput::PermissionRequest {
                                 request_id,
-                                tool_name: tool_req.tool_name.clone(),
-                                input: tool_req.input.clone(),
-                                permission_suggestions: tool_req.permission_suggestions.clone(),
-                            });
+                                tool_name,
+                                input,
+                                suggestions,
+                            } => {
+                                // Recover the typed suggestions from the adapter's
+                                // opaque JSON round-trip (it serialized them).
+                                let permission_suggestions: Vec<PermissionSuggestion> = suggestions
+                                    .into_iter()
+                                    .filter_map(|s| serde_json::from_value(s).ok())
+                                    .collect();
+                                self.pending_permission = Some(PendingPermission {
+                                    request_id: request_id.clone(),
+                                    tool_name: tool_name.clone(),
+                                    input: input.clone(),
+                                    requested_at: Utc::now(),
+                                });
+                                self.state = SessionState::WaitingForPermission;
+                                return Some(SessionEvent::PermissionRequest {
+                                    request_id,
+                                    tool_name,
+                                    input,
+                                    permission_suggestions,
+                                });
+                            }
+                            // Internal ack / nothing for the consumer — skip it and
+                            // let the outer loop pull the next event.
+                            AgentOutput::Noop => {}
+                            // User-visible output: forward the ORIGINAL typed value.
+                            AgentOutput::Visible(_) => visible = true,
                         }
                     }
 
-                    // Skip ControlResponse (acks from Claude, not useful to callers).
-                    if matches!(output, ClaudeOutput::ControlResponse(_)) {
-                        continue;
+                    if visible {
+                        return Some(SessionEvent::Output(Box::new(output)));
                     }
-
-                    return Some(SessionEvent::Output(Box::new(output)));
+                    continue;
                 }
                 Some(IoEvent::RawOutput(value)) => {
                     self.buffer.push(value.clone());


### PR DESCRIPTION
**Item #1 (agent-neutral Session boundary), slice 2b** — the payoff of 2a (#1101). `session.rs::next_event` now delegates `ClaudeOutput` classification to `ClaudeAdapter::classify`; **zero `ClaudeOutput::` variant matches remain in `session.rs`**.

Contained + behavior-preserving — only the Claude `IoEvent::Output` arm changed (the Codex `RawOutput`/`CodexPermissionRequest` arms are untouched):
- raw value **buffered before classify** (preserves current ordering — per @codex's note);
- `NotFound` → `SessionNotFound` + Exited state; `PermissionRequest` → same `PendingPermission`/`WaitingForPermission` + `SessionEvent::PermissionRequest` (suggestions round-tripped back to typed `PermissionSuggestion`); `Noop` → skip (like the old `ControlResponse` `continue`); `Visible` → forwards the **original typed** `ClaudeOutput` (no re-parse, `SessionEvent::Output` unchanged).

Behavior is guarded by 2a's **14 golden tests** + existing session tests (33 pass). Consumers (claude-session-lib, proxy, backend) compile; clippy `-D warnings` + fmt clean. Version 2.12.17 (Codex has 2.12.16 for the next #3 slice; merge order: #3 → this).

@codex — hot-path review please. After this, the remaining #1 work is: fold io_task's session-limit/metrics detection into the adapter, then genericize `Session<A: AgentAdapter>` + the CodexAdapter, then collapse codex-session-lib.