### PR TITLE
Move message renderer dispatch into module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.17"
+version = "2.12.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.17"
+version = "2.12.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.17"
+version = "2.12.18"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.17"
+version = "2.12.18"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.17"
+version = "2.12.18"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.17"
+version = "2.12.18"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.17"
+version = "2.12.18"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.17"
+version = "2.12.18"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.17"
+version = "2.12.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.17"
+version = "2.12.18"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.17"
+version = "2.12.18"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -1,0 +1,146 @@
+use super::renderers;
+use super::types::{user_meta_from_json, ClaudeMessage};
+use crate::components::agent_frame::{AgentFrame, AgentFrameRegistry, FrameRenderer};
+use serde_json::Value;
+use std::collections::HashMap;
+use uuid::Uuid;
+use yew::prelude::*;
+
+pub(crate) struct FrameRenderContext<'a> {
+    pub json: &'a str,
+    pub agent_type: shared::AgentType,
+    pub session_id: Uuid,
+    pub timestamp: Option<&'a str>,
+    pub raw_iso: Option<&'a str>,
+    pub current_user_id: Option<&'a str>,
+    pub turn_metrics: Option<&'a shared::TurnMetrics>,
+    pub continuation_statuses: &'a HashMap<Uuid, String>,
+    pub on_schedule_continuation: Callback<Uuid>,
+}
+
+pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
+    let frame = AgentFrameRegistry::parse(ctx.json, ctx.agent_type);
+
+    // Dispatch on the message shape, not the agent. `User` (the proxy's
+    // synthetic echo) and `Portal` (the backend's portal-content envelope)
+    // are protocol-agnostic and must render the same way on Claude and
+    // Codex sessions. Codex-specific shapes (`item.started`,
+    // `turn.completed`, ...) fall through to the Codex renderer below.
+    match AgentFrameRegistry::renderer_for(&frame) {
+        FrameRenderer::Claude => match frame {
+            AgentFrame::Claude(ClaudeMessage::System(msg)) => {
+                renderers::render_system_message(&msg, ctx.timestamp)
+            }
+            AgentFrame::Claude(ClaudeMessage::Assistant(msg)) => {
+                renderers::render_assistant_message(
+                    &msg,
+                    ctx.timestamp,
+                    ctx.raw_iso,
+                    ctx.session_id,
+                )
+            }
+            AgentFrame::Claude(ClaudeMessage::Result(msg)) => {
+                renderers::render_result_message(&msg, ctx.turn_metrics)
+            }
+            AgentFrame::Claude(ClaudeMessage::User(msg)) => {
+                let meta = user_meta_from_json(ctx.json);
+                renderers::render_user_message(
+                    &msg,
+                    &meta,
+                    ctx.current_user_id,
+                    ctx.timestamp,
+                    ctx.session_id,
+                )
+            }
+            AgentFrame::Claude(ClaudeMessage::OptimisticUser(msg)) => {
+                renderers::render_optimistic_user_message(
+                    &msg,
+                    ctx.current_user_id,
+                    ctx.timestamp,
+                    ctx.session_id,
+                )
+            }
+            AgentFrame::Claude(ClaudeMessage::Error(msg)) => {
+                renderers::render_error_message(&msg, ctx.timestamp)
+            }
+            AgentFrame::Claude(ClaudeMessage::Portal(msg)) => renderers::render_portal_message(
+                &msg,
+                ctx.timestamp,
+                ctx.session_id,
+                ctx.continuation_statuses,
+                ctx.on_schedule_continuation,
+            ),
+            AgentFrame::Claude(ClaudeMessage::RateLimitEvent(msg)) => {
+                renderers::render_rate_limit_event(&msg, ctx.timestamp)
+            }
+            AgentFrame::Claude(ClaudeMessage::Unknown)
+            | AgentFrame::Codex(_)
+            | AgentFrame::RawJson => render_raw_json(ctx.json),
+        },
+        FrameRenderer::Codex => match frame {
+            AgentFrame::Codex(event) => crate::components::codex_renderer::render_codex_frame(
+                &event,
+                ctx.session_id,
+                ctx.turn_metrics,
+            ),
+            _ => html! {},
+        },
+        FrameRenderer::RawJson => render_raw_json(ctx.json),
+    }
+}
+
+pub(crate) fn render_identity_group_part(
+    json: &str,
+    agent_type: shared::AgentType,
+    session_id: Uuid,
+    continuation_statuses: &HashMap<Uuid, String>,
+    on_schedule_continuation: Callback<Uuid>,
+) -> Html {
+    let frame = AgentFrameRegistry::parse(json, agent_type);
+    match frame {
+        AgentFrame::Claude(ClaudeMessage::User(msg)) => {
+            renderers::render_user_message_content(&msg, session_id)
+        }
+        AgentFrame::Claude(ClaudeMessage::OptimisticUser(msg)) => {
+            renderers::render_optimistic_user_message_content(&msg, session_id)
+        }
+        AgentFrame::Claude(ClaudeMessage::Assistant(msg)) => {
+            renderers::render_assistant_message_content(&msg, session_id)
+        }
+        AgentFrame::Claude(ClaudeMessage::Portal(msg)) => renderers::render_portal_message_content(
+            &msg,
+            session_id,
+            continuation_statuses,
+            on_schedule_continuation,
+        ),
+        AgentFrame::Codex(event) => {
+            crate::components::codex_renderer::render_codex_frame_content(&event, session_id)
+        }
+        _ => html! {},
+    }
+}
+
+fn render_raw_json(json: &str) -> Html {
+    let display = serde_json::from_str::<Value>(json)
+        .ok()
+        .and_then(|v| serde_json::to_string_pretty(&v).ok())
+        .unwrap_or_else(|| json.to_string());
+
+    html! {
+        <div class="claude-message raw-message">
+            <div class="message-header">
+                <span class="message-type-badge raw">{ "Unrecognized Message" }</span>
+            </div>
+            <div class="message-body">
+                <pre class="raw-json">{ display }</pre>
+                <p class="raw-message-hint">
+                    { "This message type is not yet supported by the portal. " }
+                    <a href="https://github.com/meawoppl/rust-code-agent-sdks/issues"
+                       target="_blank" rel="noopener noreferrer">
+                        { "Report this issue" }
+                    </a>
+                </p>
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -1,19 +1,18 @@
+mod dispatch;
 mod grouping;
 mod renderers;
 pub mod turn_metrics_footer;
 pub mod types;
 
-use serde_json::Value;
 use std::collections::HashMap;
 use uuid::Uuid;
 use yew::prelude::*;
 
-use super::agent_frame::{AgentFrame, AgentFrameRegistry, FrameRenderer};
+use dispatch::FrameRenderContext;
 #[cfg(test)]
 use grouping::classify;
 use grouping::{extract_raw_iso, visible_group_indices, GroupCategory};
 pub use grouping::{group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroup};
-use types::{user_meta_from_json, ClaudeMessage};
 
 /// Format an already-extracted `_created_at` ISO string as local time.
 /// Takes the `extract_raw_iso` result rather than the raw JSON so the
@@ -58,76 +57,17 @@ pub struct MessageRendererProps {
 pub fn message_renderer(props: &MessageRendererProps) -> Html {
     let raw_iso = extract_raw_iso(&props.json);
     let ts = raw_iso.as_deref().and_then(local_timestamp);
-    let frame = AgentFrameRegistry::parse(&props.json, props.agent_type);
-
-    // Dispatch on the message shape, not the agent. `User` (the proxy's
-    // synthetic echo) and `Portal` (the backend's portal-content envelope)
-    // are protocol-agnostic and must render the same way on Claude and
-    // Codex sessions — otherwise the Codex renderer's catch-all turns them
-    // into raw JSON blocks. Codex-specific shapes (`item.started`,
-    // `turn.completed`, …) don't match any `ClaudeMessage` variant and fall
-    // through to the codex renderer below.
-    match AgentFrameRegistry::renderer_for(&frame) {
-        FrameRenderer::Claude => match frame {
-            AgentFrame::Claude(ClaudeMessage::System(msg)) => {
-                renderers::render_system_message(&msg, ts.as_deref())
-            }
-            AgentFrame::Claude(ClaudeMessage::Assistant(msg)) => {
-                renderers::render_assistant_message(
-                    &msg,
-                    ts.as_deref(),
-                    raw_iso.as_deref(),
-                    props.session_id,
-                )
-            }
-            AgentFrame::Claude(ClaudeMessage::Result(msg)) => {
-                renderers::render_result_message(&msg, props.turn_metrics.as_ref())
-            }
-            AgentFrame::Claude(ClaudeMessage::User(msg)) => {
-                let meta = user_meta_from_json(&props.json);
-                renderers::render_user_message(
-                    &msg,
-                    &meta,
-                    props.current_user_id.as_deref(),
-                    ts.as_deref(),
-                    props.session_id,
-                )
-            }
-            AgentFrame::Claude(ClaudeMessage::OptimisticUser(msg)) => {
-                renderers::render_optimistic_user_message(
-                    &msg,
-                    props.current_user_id.as_deref(),
-                    ts.as_deref(),
-                    props.session_id,
-                )
-            }
-            AgentFrame::Claude(ClaudeMessage::Error(msg)) => {
-                renderers::render_error_message(&msg, ts.as_deref())
-            }
-            AgentFrame::Claude(ClaudeMessage::Portal(msg)) => renderers::render_portal_message(
-                &msg,
-                ts.as_deref(),
-                props.session_id,
-                &props.continuation_statuses,
-                props.on_schedule_continuation.clone(),
-            ),
-            AgentFrame::Claude(ClaudeMessage::RateLimitEvent(msg)) => {
-                renderers::render_rate_limit_event(&msg, ts.as_deref())
-            }
-            AgentFrame::Claude(ClaudeMessage::Unknown)
-            | AgentFrame::Codex(_)
-            | AgentFrame::RawJson => render_raw_json(&props.json),
-        },
-        FrameRenderer::Codex => match frame {
-            AgentFrame::Codex(event) => super::codex_renderer::render_codex_frame(
-                &event,
-                props.session_id,
-                props.turn_metrics.as_ref(),
-            ),
-            _ => html! {},
-        },
-        FrameRenderer::RawJson => render_raw_json(&props.json),
-    }
+    dispatch::render_frame(FrameRenderContext {
+        json: &props.json,
+        agent_type: props.agent_type,
+        session_id: props.session_id,
+        timestamp: ts.as_deref(),
+        raw_iso: raw_iso.as_deref(),
+        current_user_id: props.current_user_id.as_deref(),
+        turn_metrics: props.turn_metrics.as_ref(),
+        continuation_statuses: &props.continuation_statuses,
+        on_schedule_continuation: props.on_schedule_continuation.clone(),
+    })
 }
 
 #[derive(Properties, PartialEq)]
@@ -226,7 +166,7 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                             let key = extract_raw_iso(json)
                                 .map(|iso| format!("m-{}", iso))
                                 .unwrap_or_else(|| format!("m{}", i));
-                            html! { <div {key} class="grouped-message-part">{ render_identity_group_part(json, props.agent_type, props.session_id, &props.continuation_statuses, props.on_schedule_continuation.clone()) }</div> }
+                            html! { <div {key} class="grouped-message-part">{ dispatch::render_identity_group_part(json, props.agent_type, props.session_id, &props.continuation_statuses, props.on_schedule_continuation.clone()) }</div> }
                         })}
                     </div>
                     if let Some(iso) = last_iso {
@@ -237,62 +177,6 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                 </div>
             }
         }
-    }
-}
-
-fn render_identity_group_part(
-    json: &str,
-    agent_type: shared::AgentType,
-    session_id: Uuid,
-    continuation_statuses: &HashMap<Uuid, String>,
-    on_schedule_continuation: Callback<Uuid>,
-) -> Html {
-    let frame = AgentFrameRegistry::parse(json, agent_type);
-    match frame {
-        AgentFrame::Claude(ClaudeMessage::User(msg)) => {
-            renderers::render_user_message_content(&msg, session_id)
-        }
-        AgentFrame::Claude(ClaudeMessage::OptimisticUser(msg)) => {
-            renderers::render_optimistic_user_message_content(&msg, session_id)
-        }
-        AgentFrame::Claude(ClaudeMessage::Assistant(msg)) => {
-            renderers::render_assistant_message_content(&msg, session_id)
-        }
-        AgentFrame::Claude(ClaudeMessage::Portal(msg)) => renderers::render_portal_message_content(
-            &msg,
-            session_id,
-            continuation_statuses,
-            on_schedule_continuation,
-        ),
-        AgentFrame::Codex(event) => {
-            super::codex_renderer::render_codex_frame_content(&event, session_id)
-        }
-        _ => html! {},
-    }
-}
-
-fn render_raw_json(json: &str) -> Html {
-    let display = serde_json::from_str::<Value>(json)
-        .ok()
-        .and_then(|v| serde_json::to_string_pretty(&v).ok())
-        .unwrap_or_else(|| json.to_string());
-
-    html! {
-        <div class="claude-message raw-message">
-            <div class="message-header">
-                <span class="message-type-badge raw">{ "Unrecognized Message" }</span>
-            </div>
-            <div class="message-body">
-                <pre class="raw-json">{ display }</pre>
-                <p class="raw-message-hint">
-                    { "This message type is not yet supported by the portal. " }
-                    <a href="https://github.com/meawoppl/rust-code-agent-sdks/issues"
-                       target="_blank" rel="noopener noreferrer">
-                        { "Report this issue" }
-                    </a>
-                </p>
-            </div>
-        </div>
     }
 }
 


### PR DESCRIPTION
## Summary
- add `message_renderer::dispatch` for frame-to-renderer routing
- keep `MessageRenderer` focused on timestamp extraction and render context setup
- move raw JSON and grouped identity-part dispatch into the same dispatch module
- bump workspace version to 2.12.18

## Notes
This is the next #3 renderer-unification slice after the AgentFrame/registry work. It keeps `agent_frame.rs` render-free and preserves the existing Claude/Codex/raw HTML paths; the change is structural only.

## Verification
- `cargo fmt --check`
- `cargo test -p frontend`
- `cargo clippy -p frontend --all-targets -- -D warnings`
- `cargo check -p frontend --target wasm32-unknown-unknown`
