### PR TITLE
Extract grouped message renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.18"
+version = "2.12.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.18"
+version = "2.12.19"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.18"
+version = "2.12.19"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.18"
+version = "2.12.19"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.18"
+version = "2.12.19"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.18"
+version = "2.12.19"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.18"
+version = "2.12.19"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.18"
+version = "2.12.19"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.18"
+version = "2.12.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.18"
+version = "2.12.19"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.18"
+version = "2.12.19"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/group_renderer.rs
+++ b/frontend/src/components/message_renderer/group_renderer.rs
@@ -1,0 +1,118 @@
+use super::dispatch;
+use super::grouping::{
+    extract_raw_iso, thinking_tokens_estimate, visible_group_indices, GroupCategory, MessageGroup,
+};
+use super::local_timestamp;
+use std::collections::HashMap;
+use uuid::Uuid;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct MessageGroupRendererProps {
+    pub group: MessageGroup,
+    pub session_id: Uuid,
+    #[prop_or_default]
+    pub agent_type: shared::AgentType,
+    #[prop_or_default]
+    pub current_user_id: Option<String>,
+    /// Per-turn metrics for the terminator card in this group, if the group
+    /// is a `Single` carrying a terminator and the SessionView has a matching
+    /// metrics entry. Forwarded to the inner `MessageRenderer` for the
+    /// `Single` variant only — `IdentityGroup`s never contain terminator
+    /// shapes (`Result` / `turn.completed` always render as `Single`).
+    #[prop_or_default]
+    pub turn_metrics: Option<shared::TurnMetrics>,
+    #[prop_or_default]
+    pub continuation_statuses: HashMap<Uuid, String>,
+    #[prop_or_default]
+    pub on_schedule_continuation: Callback<Uuid>,
+    /// Odometer seed for `Thinking` groups: the running thinking-token max
+    /// across earlier bursts in the same turn (see
+    /// `grouping::thinking_chip_starts`). Keeps the count continuous when a
+    /// tool call splits a thinking run instead of re-racing each chip from 0.
+    #[prop_or(0)]
+    pub thinking_start: i64,
+}
+
+#[function_component(MessageGroupRenderer)]
+pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
+    match &props.group {
+        MessageGroup::Single(json) => {
+            html! { <super::MessageRenderer json={json.clone()} session_id={props.session_id} agent_type={props.agent_type} current_user_id={props.current_user_id.clone()} turn_metrics={props.turn_metrics.clone()} continuation_statuses={props.continuation_statuses.clone()} on_schedule_continuation={props.on_schedule_continuation.clone()} /> }
+        }
+        MessageGroup::IdentityGroup {
+            category,
+            label,
+            badge_class,
+            messages,
+        } => {
+            let ts = messages
+                .first()
+                .and_then(|json| extract_raw_iso(json))
+                .and_then(|iso| local_timestamp(&iso));
+
+            // A run of `thinking_tokens` markers collapses to a single compact
+            // chip: the `thinking` badge plus an odometer climbing to the run's
+            // running thinking-token estimate. No body — these markers carry
+            // none. Each marker reports the cumulative estimate, so the chip
+            // ticks upward live as more markers stream in.
+            if *category == GroupCategory::Thinking {
+                let tokens = thinking_tokens_estimate(messages);
+                // Seed the odometer with the previous burst's max from this
+                // turn so a run split by a tool call continues counting
+                // instead of re-racing from 0 (clamped inside CountUp, so a
+                // lower-than-seed target renders statically, never reversed).
+                let start = props.thinking_start;
+                return html! {
+                    <div class="claude-message thinking-pulse-group" title={ts.unwrap_or_default()}>
+                        <div class="message-header">
+                            <span class="message-type-badge thinking">{ "thinking" }</span>
+                            if tokens > 0 {
+                                <span class="message-count" title={format!("~{} thinking tokens", tokens)}>
+                                    <crate::components::CountUp target={tokens} {start} suffix={" tokens"} compact={true} />
+                                </span>
+                            }
+                        </div>
+                    </div>
+                };
+            }
+
+            let last_iso = messages.last().and_then(|json| extract_raw_iso(json));
+            let wrapper_class = match category {
+                GroupCategory::User => "user-message",
+                GroupCategory::Portal => "portal-message",
+                GroupCategory::Assistant | GroupCategory::Codex => "assistant-message",
+                // Handled above with an early return; arm kept for exhaustiveness.
+                GroupCategory::Thinking => "assistant-message",
+            };
+            let visible = visible_group_indices(*category, messages);
+            let visible_count = visible.len();
+            html! {
+                <div class={classes!("claude-message", wrapper_class)}>
+                    <div class="message-header" title={ts.unwrap_or_default()}>
+                        <span class={classes!("message-type-badge", badge_class.clone())}>{ label }</span>
+                        if visible_count > 1 {
+                            <span class="message-count" title={format!("{} consecutive messages", visible_count)}>
+                                { format!("× {}", visible_count) }
+                            </span>
+                        }
+                    </div>
+                    <div class="message-body grouped-message-body">
+                        { for visible.iter().map(|&i| {
+                            let json = &messages[i];
+                            let key = extract_raw_iso(json)
+                                .map(|iso| format!("m-{}", iso))
+                                .unwrap_or_else(|| format!("m{}", i));
+                            html! { <div {key} class="grouped-message-part">{ dispatch::render_identity_group_part(json, props.agent_type, props.session_id, &props.continuation_statuses, props.on_schedule_continuation.clone()) }</div> }
+                        })}
+                    </div>
+                    if let Some(iso) = last_iso {
+                        <div class="message-footer">
+                            <crate::components::time_ago::TimeAgo iso={iso} />
+                        </div>
+                    }
+                </div>
+            }
+        }
+    }
+}

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -1,4 +1,5 @@
 mod dispatch;
+mod group_renderer;
 mod grouping;
 mod renderers;
 pub mod turn_metrics_footer;
@@ -9,15 +10,18 @@ use uuid::Uuid;
 use yew::prelude::*;
 
 use dispatch::FrameRenderContext;
+pub use group_renderer::MessageGroupRenderer;
 #[cfg(test)]
 use grouping::classify;
-use grouping::{extract_raw_iso, visible_group_indices, GroupCategory};
-pub use grouping::{group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroup};
+use grouping::extract_raw_iso;
+pub use grouping::{group_is_turn_terminator, group_messages, thinking_chip_starts};
+#[cfg(test)]
+use grouping::{visible_group_indices, GroupCategory, MessageGroup};
 
 /// Format an already-extracted `_created_at` ISO string as local time.
 /// Takes the `extract_raw_iso` result rather than the raw JSON so the
 /// message string is parsed once per render, not once per consumer.
-fn local_timestamp(iso: &str) -> Option<String> {
+pub(super) fn local_timestamp(iso: &str) -> Option<String> {
     let ms = js_sys::Date::parse(iso);
     if ms.is_nan() {
         return None;
@@ -68,116 +72,6 @@ pub fn message_renderer(props: &MessageRendererProps) -> Html {
         continuation_statuses: &props.continuation_statuses,
         on_schedule_continuation: props.on_schedule_continuation.clone(),
     })
-}
-
-#[derive(Properties, PartialEq)]
-pub struct MessageGroupRendererProps {
-    pub group: MessageGroup,
-    pub session_id: Uuid,
-    #[prop_or_default]
-    pub agent_type: shared::AgentType,
-    #[prop_or_default]
-    pub current_user_id: Option<String>,
-    /// Per-turn metrics for the terminator card in this group, if the group
-    /// is a `Single` carrying a terminator and the SessionView has a matching
-    /// metrics entry. Forwarded to the inner `MessageRenderer` for the
-    /// `Single` variant only — `IdentityGroup`s never contain terminator
-    /// shapes (`Result` / `turn.completed` always render as `Single`).
-    #[prop_or_default]
-    pub turn_metrics: Option<shared::TurnMetrics>,
-    #[prop_or_default]
-    pub continuation_statuses: HashMap<Uuid, String>,
-    #[prop_or_default]
-    pub on_schedule_continuation: Callback<Uuid>,
-    /// Odometer seed for `Thinking` groups: the running thinking-token max
-    /// across earlier bursts in the same turn (see
-    /// `grouping::thinking_chip_starts`). Keeps the count continuous when a
-    /// tool call splits a thinking run instead of re-racing each chip from 0.
-    #[prop_or(0)]
-    pub thinking_start: i64,
-}
-
-#[function_component(MessageGroupRenderer)]
-pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
-    match &props.group {
-        MessageGroup::Single(json) => {
-            html! { <MessageRenderer json={json.clone()} session_id={props.session_id} agent_type={props.agent_type} current_user_id={props.current_user_id.clone()} turn_metrics={props.turn_metrics.clone()} continuation_statuses={props.continuation_statuses.clone()} on_schedule_continuation={props.on_schedule_continuation.clone()} /> }
-        }
-        MessageGroup::IdentityGroup {
-            category,
-            label,
-            badge_class,
-            messages,
-        } => {
-            let ts = messages
-                .first()
-                .and_then(|json| extract_raw_iso(json))
-                .and_then(|iso| local_timestamp(&iso));
-
-            // A run of `thinking_tokens` markers collapses to a single compact
-            // chip: the `thinking` badge plus an odometer climbing to the run's
-            // running thinking-token estimate. No body — these markers carry
-            // none. Each marker reports the cumulative estimate, so the chip
-            // ticks upward live as more markers stream in.
-            if *category == GroupCategory::Thinking {
-                let tokens = grouping::thinking_tokens_estimate(messages);
-                // Seed the odometer with the previous burst's max from this
-                // turn so a run split by a tool call continues counting
-                // instead of re-racing from 0 (clamped inside CountUp, so a
-                // lower-than-seed target renders statically, never reversed).
-                let start = props.thinking_start;
-                return html! {
-                    <div class="claude-message thinking-pulse-group" title={ts.unwrap_or_default()}>
-                        <div class="message-header">
-                            <span class="message-type-badge thinking">{ "thinking" }</span>
-                            if tokens > 0 {
-                                <span class="message-count" title={format!("~{} thinking tokens", tokens)}>
-                                    <crate::components::CountUp target={tokens} {start} suffix={" tokens"} compact={true} />
-                                </span>
-                            }
-                        </div>
-                    </div>
-                };
-            }
-
-            let last_iso = messages.last().and_then(|json| extract_raw_iso(json));
-            let wrapper_class = match category {
-                GroupCategory::User => "user-message",
-                GroupCategory::Portal => "portal-message",
-                GroupCategory::Assistant | GroupCategory::Codex => "assistant-message",
-                // Handled above with an early return; arm kept for exhaustiveness.
-                GroupCategory::Thinking => "assistant-message",
-            };
-            let visible = visible_group_indices(*category, messages);
-            let visible_count = visible.len();
-            html! {
-                <div class={classes!("claude-message", wrapper_class)}>
-                    <div class="message-header" title={ts.unwrap_or_default()}>
-                        <span class={classes!("message-type-badge", badge_class.clone())}>{ label }</span>
-                        if visible_count > 1 {
-                            <span class="message-count" title={format!("{} consecutive messages", visible_count)}>
-                                { format!("× {}", visible_count) }
-                            </span>
-                        }
-                    </div>
-                    <div class="message-body grouped-message-body">
-                        { for visible.iter().map(|&i| {
-                            let json = &messages[i];
-                            let key = extract_raw_iso(json)
-                                .map(|iso| format!("m-{}", iso))
-                                .unwrap_or_else(|| format!("m{}", i));
-                            html! { <div {key} class="grouped-message-part">{ dispatch::render_identity_group_part(json, props.agent_type, props.session_id, &props.continuation_statuses, props.on_schedule_continuation.clone()) }</div> }
-                        })}
-                    </div>
-                    if let Some(iso) = last_iso {
-                        <div class="message-footer">
-                            <crate::components::time_ago::TimeAgo iso={iso} />
-                        </div>
-                    }
-                </div>
-            }
-        }
-    }
 }
 
 // --- Utility functions (used by renderers and tool_renderers) ---


### PR DESCRIPTION
## Summary
- move `MessageGroupRenderer` and its props into `message_renderer/group_renderer.rs`
- keep `message_renderer/mod.rs` focused on the single-frame renderer and shared helpers
- re-export `MessageGroupRenderer` so existing call sites stay unchanged
- bump workspace version to 2.12.19

## Notes
This is another #3 renderer-unification cleanup slice. It is intended to be behavior-preserving: grouped rendering still uses the same `MessageGroup` shapes, thinking chip logic, visible Codex item filtering, and `dispatch::render_identity_group_part` path introduced in #1105.

## Verification
- `cargo fmt --check`
- `cargo test -p frontend`
- `cargo clippy -p frontend --all-targets -- -D warnings`
- `cargo check -p frontend --target wasm32-unknown-unknown`
