### PR TITLE
Track Codex subagent token metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.20"
+version = "2.12.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.20"
+version = "2.12.21"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.20"
+version = "2.12.21"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.20"
+version = "2.12.21"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.20"
+version = "2.12.21"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.20"
+version = "2.12.21"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.20"
+version = "2.12.21"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.20"
+version = "2.12.21"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.20"
+version = "2.12.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.20"
+version = "2.12.21"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.20"
+version = "2.12.21"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/turn_metrics.rs
+++ b/backend/src/handlers/turn_metrics.rs
@@ -226,6 +226,10 @@ struct AggregateRow {
     cache_read_tokens_sum: i64,
     #[diesel(sql_type = BigInt)]
     cache_creation_tokens_sum: i64,
+    #[diesel(sql_type = BigInt)]
+    thinking_tokens_sum: i64,
+    #[diesel(sql_type = BigInt)]
+    subagent_tokens_sum: i64,
     #[diesel(sql_type = Nullable<Double>)]
     total_cost_usd_sum: Option<f64>,
 }
@@ -301,6 +305,8 @@ pub async fn list_aggregated_turn_metrics(
             COALESCE(SUM(tm.output_tokens), 0)::bigint AS output_tokens_sum, \
             COALESCE(SUM(tm.cache_read_tokens), 0)::bigint AS cache_read_tokens_sum, \
             COALESCE(SUM(tm.cache_creation_tokens), 0)::bigint AS cache_creation_tokens_sum, \
+            COALESCE(SUM(tm.thinking_tokens), 0)::bigint AS thinking_tokens_sum, \
+            COALESCE(SUM(tm.subagent_tokens), 0)::bigint AS subagent_tokens_sum, \
             SUM(tm.total_cost_usd)::float8 AS total_cost_usd_sum \
         FROM turn_metrics tm \
         WHERE tm.user_id = $2 \
@@ -389,6 +395,8 @@ pub async fn list_aggregated_turn_metrics(
                 output_tokens_sum: row.output_tokens_sum,
                 cache_read_tokens_sum: row.cache_read_tokens_sum,
                 cache_creation_tokens_sum: row.cache_creation_tokens_sum,
+                thinking_tokens_sum: row.thinking_tokens_sum,
+                subagent_tokens_sum: row.subagent_tokens_sum,
                 total_cost_usd_sum: row.total_cost_usd_sum,
                 stop_reason_counts,
             }
@@ -480,6 +488,8 @@ mod tests {
                 output_tokens_sum: 12_345,
                 cache_read_tokens_sum: 1_000,
                 cache_creation_tokens_sum: 200,
+                thinking_tokens_sum: 300,
+                subagent_tokens_sum: 900,
                 total_cost_usd_sum: Some(0.18),
                 stop_reason_counts: {
                     let mut m = BTreeMap::new();

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -4,7 +4,7 @@
 //! manages multi-turn conversations via thread/turn lifecycle. Converts
 //! JSON-RPC notifications into exec-format JSONL events for the frontend.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 use std::time::Instant;
 
@@ -215,6 +215,7 @@ pub(crate) async fn codex_io_task(
     // can plug it into the finalized `TurnMetrics`.
     let mut current_turn_usage: Option<codex_codes::TokenUsageBreakdown> = None;
     let mut current_turn_model: Option<String> = None;
+    let mut subagent_token_tracker = CodexSubagentTokenTracker::new(thread_id.clone());
 
     loop {
         if turn_active {
@@ -232,6 +233,13 @@ pub(crate) async fn codex_io_task(
                                 if let codex_codes::Notification::TurnStarted(p) = notif {
                                     current_turn_id = Some(p.turn.id.clone());
                                     current_turn_model = thread_model.clone();
+                                    subagent_token_tracker.start_parent_turn();
+                                }
+                                if let codex_codes::Notification::ThreadStarted(p) = notif {
+                                    subagent_token_tracker.observe_thread_started(
+                                        &p.thread.id,
+                                        p.thread.parent_thread_id.as_deref(),
+                                    );
                                 }
                                 if let codex_codes::Notification::ModelRerouted(p) = notif {
                                     let matches_current_turn = current_turn_id
@@ -249,18 +257,33 @@ pub(crate) async fn codex_io_task(
                                 if let codex_codes::Notification::ThreadTokenUsageUpdated(p) =
                                     notif
                                 {
-                                    latest_token_usage = Some((
-                                        p.turn_id.clone(),
-                                        CodexUsageEvent {
-                                            last: p.token_usage.last.clone(),
-                                            total: p.token_usage.total.clone(),
-                                            model_context_window: p.token_usage.model_context_window,
-                                        },
-                                    ));
-                                    // Latch the per-turn breakdown so the
-                                    // finalized `TurnMetrics` can carry
-                                    // the token counts.
-                                    current_turn_usage = Some(p.token_usage.last.clone());
+                                    let is_current_main_turn = p.thread_id == thread_id
+                                        && current_turn_id
+                                            .as_deref()
+                                            .is_some_and(|turn_id| turn_id == p.turn_id);
+                                    if is_current_main_turn {
+                                        latest_token_usage = Some((
+                                            p.turn_id.clone(),
+                                            CodexUsageEvent {
+                                                last: p.token_usage.last.clone(),
+                                                total: p.token_usage.total.clone(),
+                                                model_context_window: p
+                                                    .token_usage
+                                                    .model_context_window,
+                                            },
+                                        ));
+                                        // Latch the per-turn breakdown so the
+                                        // finalized `TurnMetrics` can carry
+                                        // the main-thread token counts.
+                                        current_turn_usage = Some(p.token_usage.last.clone());
+                                    } else {
+                                        subagent_token_tracker
+                                            .observe_token_usage(
+                                                &p.thread_id,
+                                                &p.turn_id,
+                                                &p.token_usage.last,
+                                            );
+                                    }
                                 }
                                 // Content / tool frames for the metrics tracker.
                                 // Pragmatic "first content frame" definition for
@@ -358,13 +381,8 @@ pub(crate) async fn codex_io_task(
                                         .as_ref()
                                         .map(|u| u.reasoning_output_tokens)
                                         .unwrap_or(0),
-                                    // Subagent (sub-thread) token attribution
-                                    // lands in the companion Codex PR, which
-                                    // accumulates child-thread usage (threads
-                                    // whose `parent_thread_id` is this turn's
-                                    // thread) and folds it in here. Reported
-                                    // as 0 until then.
-                                    subagent_tokens: 0,
+                                    subagent_tokens: subagent_token_tracker
+                                        .take_current_turn_tokens(),
                                     stop_reason: Some(status.to_string()),
                                     is_error,
                                     total_cost_usd: None,
@@ -386,6 +404,7 @@ pub(crate) async fn codex_io_task(
                                     }
                                 }
                                 current_turn_model = None;
+                                subagent_token_tracker.end_parent_turn();
                             }
                             let latest_usage_for_msg =
                                 if let codex_codes::ServerMessage::Notification(
@@ -673,6 +692,72 @@ fn non_empty_string(value: String) -> Option<String> {
     }
 }
 
+#[derive(Debug, Clone)]
+struct CodexSubagentTokenTracker {
+    parent_thread_id: String,
+    subagent_thread_ids: HashSet<String>,
+    parent_turn_active: bool,
+    current_turn_tokens_by_child_turn: HashMap<(String, String), i64>,
+}
+
+impl CodexSubagentTokenTracker {
+    fn new(parent_thread_id: String) -> Self {
+        Self {
+            parent_thread_id,
+            subagent_thread_ids: HashSet::new(),
+            parent_turn_active: false,
+            current_turn_tokens_by_child_turn: HashMap::new(),
+        }
+    }
+
+    fn start_parent_turn(&mut self) {
+        self.parent_turn_active = true;
+        self.current_turn_tokens_by_child_turn.clear();
+    }
+
+    fn end_parent_turn(&mut self) {
+        self.parent_turn_active = false;
+    }
+
+    fn observe_thread_started(&mut self, thread_id: &str, parent_thread_id: Option<&str>) {
+        if parent_thread_id == Some(self.parent_thread_id.as_str()) {
+            self.subagent_thread_ids.insert(thread_id.to_string());
+        }
+    }
+
+    fn observe_token_usage(
+        &mut self,
+        thread_id: &str,
+        turn_id: &str,
+        usage: &codex_codes::TokenUsageBreakdown,
+    ) {
+        if !self.parent_turn_active || !self.subagent_thread_ids.contains(thread_id) {
+            return;
+        }
+        self.current_turn_tokens_by_child_turn.insert(
+            (thread_id.to_string(), turn_id.to_string()),
+            token_breakdown_total(usage),
+        );
+    }
+
+    fn take_current_turn_tokens(&mut self) -> i64 {
+        let total = self.current_turn_tokens_by_child_turn.values().sum();
+        self.current_turn_tokens_by_child_turn.clear();
+        total
+    }
+}
+
+fn token_breakdown_total(usage: &codex_codes::TokenUsageBreakdown) -> i64 {
+    if usage.total_tokens > 0 {
+        usage.total_tokens
+    } else {
+        usage.input_tokens
+            + usage.cached_input_tokens
+            + usage.output_tokens
+            + usage.reasoning_output_tokens
+    }
+}
+
 fn configured_codex_model(overrides: &[(String, String)], trailing: &[String]) -> Option<String> {
     overrides
         .iter()
@@ -760,5 +845,80 @@ mod tests {
         let trailing = strings(&[]);
 
         assert!(configured_codex_model(&overrides, &trailing).is_none());
+    }
+
+    fn usage(
+        total: i64,
+        input: i64,
+        cached: i64,
+        output: i64,
+        reasoning: i64,
+    ) -> codex_codes::TokenUsageBreakdown {
+        codex_codes::TokenUsageBreakdown {
+            input_tokens: input,
+            cached_input_tokens: cached,
+            output_tokens: output,
+            reasoning_output_tokens: reasoning,
+            total_tokens: total,
+        }
+    }
+
+    #[test]
+    fn subagent_tracker_counts_child_thread_usage_during_parent_turn() {
+        let mut tracker = CodexSubagentTokenTracker::new("parent-thread".to_string());
+        tracker.observe_thread_started("child-thread", Some("parent-thread"));
+
+        tracker.start_parent_turn();
+        tracker.observe_token_usage("child-thread", "child-turn-1", &usage(37, 0, 0, 0, 0));
+        tracker.observe_token_usage("child-thread", "child-turn-2", &usage(11, 0, 0, 0, 0));
+
+        assert_eq!(tracker.take_current_turn_tokens(), 48);
+        tracker.end_parent_turn();
+    }
+
+    #[test]
+    fn subagent_tracker_uses_last_usage_per_child_turn() {
+        let mut tracker = CodexSubagentTokenTracker::new("parent-thread".to_string());
+        tracker.observe_thread_started("child-thread", Some("parent-thread"));
+
+        tracker.start_parent_turn();
+        tracker.observe_token_usage("child-thread", "child-turn", &usage(37, 0, 0, 0, 0));
+        tracker.observe_token_usage("child-thread", "child-turn", &usage(41, 0, 0, 0, 0));
+
+        assert_eq!(tracker.take_current_turn_tokens(), 41);
+    }
+
+    #[test]
+    fn subagent_tracker_ignores_parent_sibling_and_inactive_usage() {
+        let mut tracker = CodexSubagentTokenTracker::new("parent-thread".to_string());
+        tracker.observe_thread_started("child-thread", Some("parent-thread"));
+        tracker.observe_thread_started("sibling-thread", Some("other-parent"));
+
+        tracker.observe_token_usage("child-thread", "child-turn", &usage(100, 0, 0, 0, 0));
+        tracker.start_parent_turn();
+        tracker.observe_token_usage("parent-thread", "parent-turn", &usage(100, 0, 0, 0, 0));
+        tracker.observe_token_usage("sibling-thread", "sibling-turn", &usage(100, 0, 0, 0, 0));
+        tracker.observe_token_usage("unknown-thread", "unknown-turn", &usage(100, 0, 0, 0, 0));
+
+        assert_eq!(tracker.take_current_turn_tokens(), 0);
+    }
+
+    #[test]
+    fn subagent_tracker_resets_on_new_parent_turn() {
+        let mut tracker = CodexSubagentTokenTracker::new("parent-thread".to_string());
+        tracker.observe_thread_started("child-thread", Some("parent-thread"));
+
+        tracker.start_parent_turn();
+        tracker.observe_token_usage("child-thread", "child-turn", &usage(7, 0, 0, 0, 0));
+        assert_eq!(tracker.take_current_turn_tokens(), 7);
+        tracker.end_parent_turn();
+
+        tracker.start_parent_turn();
+        assert_eq!(tracker.take_current_turn_tokens(), 0);
+    }
+
+    #[test]
+    fn token_breakdown_total_falls_back_when_total_tokens_missing() {
+        assert_eq!(token_breakdown_total(&usage(0, 10, 3, 5, 2)), 20);
     }
 }

--- a/frontend/src/components/message_renderer/turn_metrics_footer.rs
+++ b/frontend/src/components/message_renderer/turn_metrics_footer.rs
@@ -32,6 +32,8 @@
 //!   (output_tokens)` out — `compact_count` returns the integer for values
 //!   `< 1000`, and a one-decimal-k abbreviation (`"1.5k"`, `"2.1k"`) for
 //!   `≥ 1000`. Always renders (zero tokens is a meaningful signal).
+//! - **Thinking/subagent tokens**: rendered as count-up chips after the
+//!   regular text chips when the corresponding counter is positive.
 //! - **Cache hit %**: `cache_read / (input + cache_read + cache_creation) *
 //!   100`. Omitted when all three are zero — for Codex turns this is
 //!   universally true today (the proxy doesn't surface cache breakdown), so
@@ -172,11 +174,10 @@ pub fn build_chip_list(metrics: &TurnMetrics) -> Vec<String> {
 /// `result-message` card; chips are separated by the `·` character (a
 /// `<span class="turn-metric-sep">` so the CSS can dim it independently).
 ///
-/// The text chips come from [`build_chip_list`]. The reasoning-token chip is
-/// rendered separately as an animated odometer (`CountUp`) — it rolls 0→total
-/// on mount — and is appended last. It only appears when `thinking_tokens > 0`,
-/// which is the Codex reasoning case; Claude turns record `0` here (the wire
-/// folds reasoning into `output_tokens`) so the chip naturally drops.
+/// The text chips come from [`build_chip_list`]. The reasoning-token and
+/// subagent-token chips are rendered separately as animated odometers
+/// (`CountUp`) — they roll 0→total on mount — and are appended last. They only
+/// appear when their counters are positive.
 ///
 /// Takes an `Option` and renders nothing for `None` so callers can pass
 /// their `Option<&TurnMetrics>` straight through.
@@ -189,7 +190,8 @@ pub fn render_turn_metrics_footer(metrics: Option<&TurnMetrics>) -> Html {
 
     let text_chips = build_chip_list(metrics);
     let has_thinking = metrics.thinking_tokens > 0;
-    if text_chips.is_empty() && !has_thinking {
+    let has_subagent = metrics.subagent_tokens > 0;
+    if text_chips.is_empty() && !has_thinking && !has_subagent {
         return html! {};
     }
 
@@ -201,6 +203,13 @@ pub fn render_turn_metrics_footer(metrics: Option<&TurnMetrics>) -> Html {
         chips.push(html! {
             <span class="turn-metric-chip thinking-chip">
                 <CountUp target={metrics.thinking_tokens} suffix={" thinking"} compact={true} />
+            </span>
+        });
+    }
+    if has_subagent {
+        chips.push(html! {
+            <span class="turn-metric-chip subagent-chip">
+                <CountUp target={metrics.subagent_tokens} suffix={" subagent"} compact={true} />
             </span>
         });
     }

--- a/frontend/src/components/turn_metrics_pill.rs
+++ b/frontend/src/components/turn_metrics_pill.rs
@@ -21,6 +21,8 @@ pub enum SparklineMetric {
     Ttft,
     MaxGap,
     CacheHit,
+    Thinking,
+    Subagent,
 }
 
 impl SparklineMetric {
@@ -30,6 +32,8 @@ impl SparklineMetric {
             Self::Ttft => "TTFT",
             Self::MaxGap => "max gap",
             Self::CacheHit => "cache hit",
+            Self::Thinking => "thinking",
+            Self::Subagent => "subagent",
         }
     }
 
@@ -39,6 +43,8 @@ impl SparklineMetric {
             SparklineMetric::Ttft,
             SparklineMetric::MaxGap,
             SparklineMetric::CacheHit,
+            SparklineMetric::Thinking,
+            SparklineMetric::Subagent,
         ]
     }
 }
@@ -154,6 +160,8 @@ fn metric_value(m: &TurnMetrics, metric: SparklineMetric) -> Option<f64> {
             }
             Some((m.cache_read_tokens as f64 / denom) * 100.0)
         }
+        SparklineMetric::Thinking => (m.thinking_tokens > 0).then_some(m.thinking_tokens as f64),
+        SparklineMetric::Subagent => (m.subagent_tokens > 0).then_some(m.subagent_tokens as f64),
     }
 }
 
@@ -165,6 +173,16 @@ fn format_current_value(metric: SparklineMetric, value: f64) -> String {
         SparklineMetric::Ttft => format!("TTFT {value:.2}s"),
         SparklineMetric::MaxGap => format!("gap {value:.1}s"),
         SparklineMetric::CacheHit => format!("cache {:.0}%", value),
+        SparklineMetric::Thinking => format!("{} thinking", compact_metric_count(value)),
+        SparklineMetric::Subagent => format!("{} subagent", compact_metric_count(value)),
+    }
+}
+
+fn compact_metric_count(value: f64) -> String {
+    if value < 1000.0 {
+        format!("{value:.0}")
+    } else {
+        format!("{:.1}k", value / 1000.0)
     }
 }
 
@@ -412,6 +430,28 @@ mod tests {
     }
 
     #[test]
+    fn project_auxiliary_tokens_skips_zero_and_keeps_positive_values() {
+        let mut first = mk(Some("gpt-5"), Some("standard"), 0);
+        first.thinking_tokens = 0;
+        first.subagent_tokens = 0;
+        let mut second = mk(Some("gpt-5"), Some("standard"), 1);
+        second.thinking_tokens = 1500;
+        second.subagent_tokens = 275;
+        let buf = vec![first, second];
+
+        let model = Some("gpt-5".to_string());
+        let tier = Some("standard".to_string());
+        assert_eq!(
+            project_metric(&buf, &model, &tier, SparklineMetric::Thinking),
+            vec![1500.0]
+        );
+        assert_eq!(
+            project_metric(&buf, &model, &tier, SparklineMetric::Subagent),
+            vec![275.0]
+        );
+    }
+
+    #[test]
     fn format_current_value_formats_each_metric() {
         assert_eq!(
             format_current_value(SparklineMetric::TokPerSec, 47.234),
@@ -428,6 +468,14 @@ mod tests {
         assert_eq!(
             format_current_value(SparklineMetric::CacheHit, 83.7),
             "cache 84%"
+        );
+        assert_eq!(
+            format_current_value(SparklineMetric::Thinking, 1500.0),
+            "1.5k thinking"
+        );
+        assert_eq!(
+            format_current_value(SparklineMetric::Subagent, 275.0),
+            "275 subagent"
         );
     }
 }

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -411,6 +411,10 @@ fn render_charts(
     // ------------ e) Cost per output token (skips codex / no-cost rows) ------
     let cost_series = build_cost_per_token_series(&indexed, &bucket_axis, &active_pairs);
 
+    // ------------ f) Auxiliary token volume (reasoning + subagents) ----------
+    let auxiliary_token_series =
+        build_auxiliary_token_series(&indexed, &bucket_axis, &active_pairs);
+
     html! {
         <div class="performance-charts">
             <LinePlot
@@ -451,6 +455,14 @@ fn render_charts(
                 buckets={bucket_axis.clone()}
                 bucket_kind={bucket_kind}
                 series={cost_series}
+                axis_scale={axis_scale}
+            />
+            <LinePlot
+                title="Auxiliary tokens"
+                y_label="tokens"
+                buckets={bucket_axis.clone()}
+                bucket_kind={bucket_kind}
+                series={auxiliary_token_series}
                 axis_scale={axis_scale}
             />
         </div>
@@ -640,6 +652,49 @@ fn build_cost_per_token_series(
     out
 }
 
+/// Plot reasoning/thinking tokens and subagent tokens per bucket. The two
+/// lines share the model/tier color; subagent tokens use the dashed variant so
+/// the relationship stays readable even when multiple pairs are active.
+fn build_auxiliary_token_series(
+    indexed: &BTreeMap<(GroupKey, DateTime<Utc>), &MetricBucket>,
+    bucket_axis: &[DateTime<Utc>],
+    active_pairs: &[GroupKey],
+) -> Vec<LineSeries> {
+    let mut out: Vec<LineSeries> = Vec::new();
+    for (idx, pair) in active_pairs.iter().enumerate() {
+        let color = pair_color(idx);
+        let label = pair_label(pair);
+        let mut thinking_vals: Vec<Option<f64>> = Vec::with_capacity(bucket_axis.len());
+        let mut subagent_vals: Vec<Option<f64>> = Vec::with_capacity(bucket_axis.len());
+        for ts in bucket_axis {
+            let row = indexed.get(&(pair.clone(), *ts));
+            thinking_vals.push(row.and_then(|r| positive_i64(r.thinking_tokens_sum)));
+            subagent_vals.push(row.and_then(|r| positive_i64(r.subagent_tokens_sum)));
+        }
+        if thinking_vals.iter().any(Option::is_some) {
+            out.push(LineSeries {
+                label: format!("{label} thinking"),
+                color: color.to_string(),
+                dashed: false,
+                values: thinking_vals,
+            });
+        }
+        if subagent_vals.iter().any(Option::is_some) {
+            out.push(LineSeries {
+                label: format!("{label} subagent"),
+                color: color.to_string(),
+                dashed: true,
+                values: subagent_vals,
+            });
+        }
+    }
+    out
+}
+
+fn positive_i64(value: i64) -> Option<f64> {
+    (value > 0).then_some(value as f64)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -672,6 +727,8 @@ mod tests {
             output_tokens_sum: 200,
             cache_read_tokens_sum: 500,
             cache_creation_tokens_sum: 100,
+            thinking_tokens_sum: 0,
+            subagent_tokens_sum: 0,
             total_cost_usd_sum: Some(0.05),
             stop_reason_counts: counts,
         }
@@ -877,6 +934,29 @@ mod tests {
         // $0.10 / 100 out * 1000 = $1.00 per 1k out
         let v = series[0].values[0].unwrap();
         assert!((v - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn build_auxiliary_token_series_splits_thinking_and_subagent() {
+        let t1 = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+        let mut b = mk_bucket(t1, Some("gpt-5"), Some("standard"), None, None, vec![]);
+        b.thinking_tokens_sum = 1500;
+        b.subagent_tokens_sum = 275;
+        let buckets = vec![b];
+        let axis = distinct_bucket_starts(&buckets);
+        let pairs = distinct_pairs(&buckets);
+        let mut indexed: BTreeMap<(GroupKey, DateTime<Utc>), &MetricBucket> = BTreeMap::new();
+        for bb in &buckets {
+            indexed.insert((bucket_group_key(bb), bb.bucket_start), bb);
+        }
+
+        let series = build_auxiliary_token_series(&indexed, &axis, &pairs);
+        assert_eq!(series.len(), 2);
+        assert_eq!(series[0].label, "gpt-5 thinking");
+        assert_eq!(series[0].values, vec![Some(1500.0)]);
+        assert_eq!(series[1].label, "gpt-5 subagent");
+        assert!(series[1].dashed);
+        assert_eq!(series[1].values, vec![Some(275.0)]);
     }
 
     #[test]

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -997,6 +997,11 @@
     white-space: nowrap;
 }
 
+.turn-metric-chip.thinking-chip,
+.turn-metric-chip.subagent-chip {
+    color: var(--accent-secondary, var(--accent));
+}
+
 .turn-metric-sep {
     color: var(--text-muted, var(--text-secondary));
     opacity: 0.5;

--- a/shared/src/api/metrics.rs
+++ b/shared/src/api/metrics.rs
@@ -200,6 +200,10 @@ pub struct MetricBucket {
     pub output_tokens_sum: i64,
     pub cache_read_tokens_sum: i64,
     pub cache_creation_tokens_sum: i64,
+    #[serde(default)]
+    pub thinking_tokens_sum: i64,
+    #[serde(default)]
+    pub subagent_tokens_sum: i64,
     // Cost
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_cost_usd_sum: Option<f64>,

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -328,6 +328,8 @@ mod tests {
             output_tokens_sum: 3_400,
             cache_read_tokens_sum: 800,
             cache_creation_tokens_sum: 200,
+            thinking_tokens_sum: 120,
+            subagent_tokens_sum: 450,
             total_cost_usd_sum: Some(0.18),
             stop_reason_counts: counts,
         };
@@ -357,6 +359,8 @@ mod tests {
             output_tokens_sum: 0,
             cache_read_tokens_sum: 0,
             cache_creation_tokens_sum: 0,
+            thinking_tokens_sum: 0,
+            subagent_tokens_sum: 0,
             total_cost_usd_sum: None,
             stop_reason_counts: BTreeMap::new(),
         };


### PR DESCRIPTION
## Summary
- attribute Codex child-thread token deltas into TurnMetrics.subagent_tokens while keeping main-thread token usage separate
- expose thinking/subagent token sums in the metrics aggregate API
- surface auxiliary token usage in the turn footer, dashboard metric pill, and Settings > Performance chart

## Notes
- Uses typed Codex app-server events: ThreadStarted identifies child threads via parent_thread_id, and ThreadTokenUsageUpdated.last supplies per-update token deltas.
- SDK tracking issue for Claude rollup/subagent fields: https://github.com/meawoppl/rust-code-agent-sdks/issues/168

## Verification
- cargo fmt --check
- cargo test -p codex-session-lib -p shared
- cargo test -p frontend
- cargo build -p shared --target wasm32-unknown-unknown
- env -u NO_COLOR trunk build
- cargo test -p backend
- cargo clippy --workspace --all-targets -- -D warnings