### PR TITLE
Extract SessionView buffer state helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.21"
+version = "2.12.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.21"
+version = "2.12.22"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.21"
+version = "2.12.22"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.21"
+version = "2.12.22"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.21"
+version = "2.12.22"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.21"
+version = "2.12.22"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.21"
+version = "2.12.22"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.21"
+version = "2.12.22"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.21"
+version = "2.12.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.21"
+version = "2.12.22"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.21"
+version = "2.12.22"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -32,6 +32,10 @@ use super::input_bar::{InputBar, InputBarInbound};
 use super::permission_handler::{
     build_permission_response, PermissionHandler, PermissionResponseKind,
 };
+use super::state::{
+    insert_turn_metrics_sorted, push_message_with_limit, retain_newest_items,
+    sort_turn_metrics_by_start,
+};
 use super::tasks_panel::{derive_task_events, TasksInbound, TasksPanel};
 use super::types::{PendingPermission, WsSender, MAX_MESSAGES_PER_SESSION};
 use super::websocket::{connect_websocket, send_message, WsEvent};
@@ -426,12 +430,12 @@ impl Component for SessionView {
                 // started_at ASC defensively even though the backend
                 // already orders that way — the join walk depends on
                 // strict order.
-                metrics.sort_by_key(|m| m.started_at);
+                sort_turn_metrics_by_start(&mut metrics);
                 self.turn_metrics = metrics;
                 true
             }
             SessionViewMsg::TurnMetricsReceived(metrics) => {
-                self.insert_turn_metrics(*metrics);
+                insert_turn_metrics_sorted(&mut self.turn_metrics, *metrics);
                 true
             }
             SessionViewMsg::ScheduleLimitContinuation(continuation_id) => {
@@ -555,10 +559,7 @@ impl SessionView {
             }
             WsEvent::HistoryBatch(messages, last_created_at) => {
                 self.messages.extend(messages);
-                if self.messages.len() > MAX_MESSAGES_PER_SESSION {
-                    let excess = self.messages.len() - MAX_MESSAGES_PER_SESSION;
-                    self.messages.drain(0..excess);
-                }
+                retain_newest_items(&mut self.messages, MAX_MESSAGES_PER_SESSION);
                 // Set the reconnect-replay watermark to the server-assigned
                 // timestamp of the latest message in the batch (closes
                 // #784). Empty batches (or a pre-#784 backend that didn't
@@ -598,31 +599,6 @@ impl SessionView {
         }
     }
 
-    /// Insert a single live `TurnMetrics` into the buffer, preserving
-    /// `started_at ASC` order and deduping by `id`.
-    ///
-    /// Dedup matters because two paths can deliver the same row: the REST
-    /// hydration loads the canonical DB-ordered list, and the broadcast
-    /// pipeline replays whatever the backend pushed. If the user reconnects
-    /// shortly after a turn completed, the broadcast for that row may
-    /// arrive after the REST hydration that already contains it — without
-    /// dedup the chip strip would be paired against the wrong turn from
-    /// that point on. Match on `Some(id)` so two backfilled `None` rows
-    /// (impossible today but a defensive guard) don't collapse together.
-    fn insert_turn_metrics(&mut self, metrics: TurnMetrics) {
-        if let Some(new_id) = metrics.id {
-            if let Some(slot) = self.turn_metrics.iter_mut().find(|m| m.id == Some(new_id)) {
-                *slot = metrics;
-                return;
-            }
-        }
-        let pos = self
-            .turn_metrics
-            .binary_search_by(|m| m.started_at.cmp(&metrics.started_at))
-            .unwrap_or_else(|p| p);
-        self.turn_metrics.insert(pos, metrics);
-    }
-
     /// Hydrate the message buffer + task panel from a REST history batch.
     /// Each message is classified once via [`classify_output_msg_type`],
     /// task events are forwarded to the panel via [`derive_task_events`],
@@ -635,8 +611,7 @@ impl SessionView {
         last_timestamp: Option<String>,
     ) {
         if messages.len() > MAX_MESSAGES_PER_SESSION {
-            let excess = messages.len() - MAX_MESSAGES_PER_SESSION;
-            messages.drain(0..excess);
+            retain_newest_items(&mut messages, MAX_MESSAGES_PER_SESSION);
         }
         let session_id = ctx.props().session.id;
         self.dispatch_tasks(TasksInbound::ClearForReplay);
@@ -746,11 +721,7 @@ impl SessionView {
 
         reconcile_pending_sends(&mut self.pending_sends, tag, &output);
 
-        self.messages.push(output);
-        if self.messages.len() > MAX_MESSAGES_PER_SESSION {
-            let excess = self.messages.len() - MAX_MESSAGES_PER_SESSION;
-            self.messages.drain(0..excess);
-        }
+        push_message_with_limit(&mut self.messages, output, MAX_MESSAGES_PER_SESSION);
         true
     }
 

--- a/frontend/src/pages/dashboard/session_view/mod.rs
+++ b/frontend/src/pages/dashboard/session_view/mod.rs
@@ -17,6 +17,7 @@ pub(super) mod helpers;
 mod history;
 mod input_bar;
 mod permission_handler;
+mod state;
 mod tasks_panel;
 mod types;
 mod websocket;

--- a/frontend/src/pages/dashboard/session_view/state.rs
+++ b/frontend/src/pages/dashboard/session_view/state.rs
@@ -1,0 +1,165 @@
+//! Pure state helpers for `SessionView` buffers.
+//!
+//! These helpers keep retention and turn-metric ordering rules out of the
+//! component event loop. They mutate only the buffer passed to them, which
+//! makes the invariants easy to unit-test without mounting Yew.
+
+use shared::TurnMetrics;
+
+/// Trim a newest-first-retained message buffer to `max_len`.
+///
+/// `SessionView` appends messages in chronological order, so retaining the
+/// tail keeps the newest rows and drops only old history.
+pub(super) fn retain_newest_items<T>(items: &mut Vec<T>, max_len: usize) {
+    if items.len() > max_len {
+        let excess = items.len() - max_len;
+        items.drain(0..excess);
+    }
+}
+
+/// Append one live message and apply the same retention rule as history
+/// hydration and replay batches.
+pub(super) fn push_message_with_limit(messages: &mut Vec<String>, message: String, max_len: usize) {
+    messages.push(message);
+    retain_newest_items(messages, max_len);
+}
+
+/// Insert one live `TurnMetrics` into the buffer, preserving `started_at ASC`
+/// order and deduping by populated DB `id`.
+///
+/// Dedup matters because REST hydration and websocket broadcasts can deliver
+/// the same row during reconnect. Rows with `None` ids are not deduped: today
+/// live backend broadcasts have ids, but keeping `None` rows distinct avoids
+/// collapsing future backfills before they are persisted.
+pub(super) fn insert_turn_metrics_sorted(buffer: &mut Vec<TurnMetrics>, metrics: TurnMetrics) {
+    if let Some(new_id) = metrics.id {
+        if let Some(slot) = buffer.iter_mut().find(|m| m.id == Some(new_id)) {
+            *slot = metrics;
+            return;
+        }
+    }
+
+    let pos = buffer
+        .binary_search_by(|m| m.started_at.cmp(&metrics.started_at))
+        .unwrap_or_else(|p| p);
+    buffer.insert(pos, metrics);
+}
+
+/// Sort a hydrated metrics batch defensively before the view pairs the Nth
+/// terminator card with the Nth metrics row.
+pub(super) fn sort_turn_metrics_by_start(metrics: &mut [TurnMetrics]) {
+    metrics.sort_by_key(|m| m.started_at);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use uuid::Uuid;
+
+    fn metric(id: Option<Uuid>, started_secs: i64, output_tokens: i64) -> TurnMetrics {
+        TurnMetrics {
+            id,
+            session_id: Uuid::nil(),
+            user_message_id: None,
+            agent_type: "claude".to_string(),
+            model: None,
+            service_tier: None,
+            started_at: Utc.timestamp_opt(started_secs, 0).unwrap(),
+            first_token_at: None,
+            completed_at: None,
+            ttft_ms: None,
+            total_duration_ms: None,
+            generation_duration_ms: None,
+            max_inter_token_gap_ms: None,
+            input_tokens: 0,
+            output_tokens,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            thinking_tokens: 0,
+            subagent_tokens: 0,
+            stop_reason: None,
+            is_error: false,
+            tool_call_count: 0,
+            stream_restarts: 0,
+            total_cost_usd: None,
+        }
+    }
+
+    #[test]
+    fn retain_newest_items_keeps_tail() {
+        let mut messages = vec!["old".to_string(), "middle".to_string(), "new".to_string()];
+
+        retain_newest_items(&mut messages, 2);
+
+        assert_eq!(messages, vec!["middle", "new"]);
+    }
+
+    #[test]
+    fn retain_newest_items_noops_when_within_limit() {
+        let mut messages = vec!["one".to_string(), "two".to_string()];
+
+        retain_newest_items(&mut messages, 2);
+
+        assert_eq!(messages, vec!["one", "two"]);
+    }
+
+    #[test]
+    fn push_message_with_limit_appends_then_trims_oldest() {
+        let mut messages = vec!["one".to_string(), "two".to_string()];
+
+        push_message_with_limit(&mut messages, "three".to_string(), 2);
+
+        assert_eq!(messages, vec!["two", "three"]);
+    }
+
+    #[test]
+    fn insert_turn_metrics_sorted_preserves_started_at_order() {
+        let mut buffer = vec![metric(None, 20, 20), metric(None, 40, 40)];
+
+        insert_turn_metrics_sorted(&mut buffer, metric(None, 30, 30));
+
+        let starts: Vec<_> = buffer.iter().map(|m| m.started_at.timestamp()).collect();
+        assert_eq!(starts, vec![20, 30, 40]);
+    }
+
+    #[test]
+    fn insert_turn_metrics_sorted_replaces_matching_id() {
+        let id = Uuid::new_v4();
+        let mut buffer = vec![metric(Some(id), 20, 20)];
+
+        insert_turn_metrics_sorted(&mut buffer, metric(Some(id), 30, 99));
+
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(buffer[0].started_at.timestamp(), 30);
+        assert_eq!(buffer[0].output_tokens, 99);
+    }
+
+    #[test]
+    fn insert_turn_metrics_sorted_keeps_none_id_rows_distinct() {
+        let mut buffer = vec![metric(None, 20, 20)];
+
+        insert_turn_metrics_sorted(&mut buffer, metric(None, 20, 99));
+
+        assert_eq!(buffer.len(), 2);
+        assert_eq!(
+            buffer.iter().map(|m| m.output_tokens).collect::<Vec<_>>(),
+            vec![99, 20]
+        );
+    }
+
+    #[test]
+    fn sort_turn_metrics_by_start_orders_hydrated_batch() {
+        let mut metrics = vec![metric(None, 30, 30), metric(None, 10, 10)];
+
+        sort_turn_metrics_by_start(&mut metrics);
+
+        assert_eq!(
+            metrics
+                .iter()
+                .map(|m| m.started_at.timestamp())
+                .collect::<Vec<_>>(),
+            vec![10, 30]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Extract SessionView message retention and turn-metrics buffer rules into `session_view/state.rs`
- Reuse the helpers from history replay, REST hydration, live websocket output, and live metrics insertion
- Add focused tests for newest-item retention, live append trimming, sorted metric insertion, id deduplication, and hydration sorting
- Bump workspace version to 2.12.22

## Verification
- `cargo fmt --check`
- `cargo test -p frontend`
- `cargo clippy -p frontend --all-targets -- -D warnings`

Frontend-only; intentionally avoids `shared/`, `session-lib/`, `claude-session-lib/`, and backend while Claude works on the adapter fold.