### PR TITLE
Stabilize session pill ordering + focus for same-repo agents (#1094)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.22"
+version = "2.12.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.22"
+version = "2.12.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.22"
+version = "2.12.23"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.22"
+version = "2.12.23"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.22"
+version = "2.12.23"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.22"
+version = "2.12.23"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.22"
+version = "2.12.23"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.22"
+version = "2.12.23"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.22"
+version = "2.12.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.22"
+version = "2.12.23"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.22"
+version = "2.12.23"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/mod.rs
+++ b/frontend/src/pages/dashboard/mod.rs
@@ -8,6 +8,7 @@
 
 mod page;
 mod permission_dialog;
+mod session_order;
 mod session_rail;
 mod session_view;
 mod types;

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -1,5 +1,6 @@
 //! Dashboard page - Main session management interface
 
+use super::session_order;
 use super::session_rail::{ActivityRef, SessionRail};
 use super::session_view::SessionView;
 use super::types::{
@@ -95,7 +96,11 @@ pub fn dashboard_page() -> Html {
     let show_launch_dialog = use_state(|| false);
     let show_admin = use_state(|| false);
     let show_settings = use_state(|| false);
-    let focused_index = use_state(|| 0usize);
+    // Focus is tracked by `session_id` (the source of truth), not by array
+    // index — see `session_order` / issue #1094. The display index is derived
+    // from this each render, so a reordered poll never bounces focus onto a
+    // different session.
+    let focused_id = use_state(|| None::<Uuid>);
     let awaiting_sessions = use_state(HashSet::<Uuid>::new);
     let hidden_sessions = use_state(load_hidden_sessions);
     let inactive_hidden = use_state(load_inactive_hidden);
@@ -182,23 +187,15 @@ pub fn dashboard_page() -> Html {
         });
     }
 
-    // Get DB-authoritative sessions sorted by repo name, then hostname. A
-    // disconnected, unpaused session is desired-running and should stay visible
-    // while the launcher reconciles it.
+    // Get DB-authoritative sessions in a total, deterministic display order
+    // (see `session_order`). A disconnected, unpaused session is
+    // desired-running and should stay visible while the launcher reconciles it.
     let active_sessions: Vec<SessionInfo> = {
         let mut sorted: Vec<SessionInfo> = sessions.to_vec();
-        sorted.sort_by(|a, b| {
-            let folder_a = utils::extract_folder(&a.working_directory);
-            let folder_b = utils::extract_folder(&b.working_directory);
-            match folder_a.to_lowercase().cmp(&folder_b.to_lowercase()) {
-                std::cmp::Ordering::Equal => {
-                    let hostname_a = &a.hostname;
-                    let hostname_b = &b.hostname;
-                    hostname_a.to_lowercase().cmp(&hostname_b.to_lowercase())
-                }
-                other => other,
-            }
-        });
+        // Total, deterministic order keyed down to the unique session id, so
+        // the displayed order is a pure function of the session *set* and never
+        // depends on the order `/api/sessions` happened to return (issue #1094).
+        sorted.sort_by(session_order::session_display_cmp);
         sorted
     };
 
@@ -211,11 +208,22 @@ pub fn dashboard_page() -> Html {
         hidden
     };
 
+    // Derive the focused display index from the focused session id against the
+    // current sorted order. Falls back to the first non-hidden session when the
+    // focused id is absent (nothing focused yet, or the focused session was
+    // deleted / left). The rail, keyboard nav, and focus render all consume
+    // this derived index.
+    let focused_index: usize = session_order::resolve_focus_index(
+        &active_sessions,
+        *focused_id,
+        &effective_hidden_sessions,
+    );
+
     // On initial load, focus first non-hidden session and activate all non-hidden sessions
     {
         let active_sessions = active_sessions.clone();
         let effective_hidden_sessions = effective_hidden_sessions.clone();
-        let focused_index = focused_index.clone();
+        let focused_id = focused_id.clone();
         let initial_focus_set = initial_focus_set.clone();
         let activated_sessions = activated_sessions.clone();
 
@@ -223,12 +231,15 @@ pub fn dashboard_page() -> Html {
             (active_sessions.len(), loading),
             move |(session_count, is_loading)| {
                 if !*initial_focus_set && !*is_loading && *session_count > 0 {
-                    let first_non_hidden_idx = active_sessions
+                    // Focus the first non-hidden session by id (falls through to
+                    // the first session if all are hidden).
+                    let first_focus = active_sessions
                         .iter()
-                        .position(|s| !effective_hidden_sessions.contains(&s.id))
-                        .unwrap_or(0);
+                        .find(|s| !effective_hidden_sessions.contains(&s.id))
+                        .or_else(|| active_sessions.first())
+                        .map(|s| s.id);
 
-                    focused_index.set(first_non_hidden_idx);
+                    focused_id.set(first_focus);
 
                     // Activate all non-hidden sessions so they load in background
                     let mut activated = (*activated_sessions).clone();
@@ -250,17 +261,13 @@ pub fn dashboard_page() -> Html {
     {
         let sessions_at_launch = sessions_at_launch.clone();
         let active_sessions = active_sessions.clone();
-        let focused_index = focused_index.clone();
+        let focused_id = focused_id.clone();
         let activated_sessions = activated_sessions.clone();
 
         use_effect_with(active_sessions.clone(), move |sessions| {
             if let Some(ref snapshot) = *sessions_at_launch {
-                if let Some((idx, session)) = sessions
-                    .iter()
-                    .enumerate()
-                    .find(|(_, s)| !snapshot.contains(&s.id))
-                {
-                    focused_index.set(idx);
+                if let Some(session) = sessions.iter().find(|s| !snapshot.contains(&s.id)) {
+                    focused_id.set(Some(session.id));
                     let mut activated = (*activated_sessions).clone();
                     activated.insert(session.id);
                     activated_sessions.set(activated);
@@ -273,14 +280,17 @@ pub fn dashboard_page() -> Html {
 
     // Session selection callback
     let on_select_session = {
-        let focused_index = focused_index.clone();
+        let focused_id = focused_id.clone();
         let activated_sessions = activated_sessions.clone();
         let active_sessions = active_sessions.clone();
+        // The rail / keyboard nav emit a display index valid against the order
+        // that produced the current render; translate it to the session id so
+        // focus stays attached to that session across later reorders.
         Callback::from(move |index: usize| {
             crate::audio::ensure_audio_context();
             crate::audio::play_sound(crate::audio::SoundEvent::SessionSwap);
-            focused_index.set(index);
             if let Some(session) = active_sessions.get(index) {
+                focused_id.set(Some(session.id));
                 let mut activated = (*activated_sessions).clone();
                 activated.insert(session.id);
                 activated_sessions.set(activated);
@@ -311,7 +321,7 @@ pub fn dashboard_page() -> Html {
     // Use the keyboard navigation hook
     let keyboard_nav = use_keyboard_nav(KeyboardNavConfig {
         sessions: active_sessions.clone(),
-        focused_index: *focused_index,
+        focused_index,
         hidden_sessions: effective_hidden_sessions.clone(),
         connected_sessions: (*connected_sessions).clone(),
         inactive_hidden: *inactive_hidden,
@@ -804,7 +814,7 @@ pub fn dashboard_page() -> Html {
                     // Session Rail
                     <SessionRail
                         sessions={active_sessions.clone()}
-                        focused_index={*focused_index}
+                        focused_index={focused_index}
                         awaiting_sessions={(*awaiting_sessions).clone()}
                         hidden_sessions={effective_hidden_sessions.clone()}
                         inactive_hidden={*inactive_hidden}
@@ -825,7 +835,7 @@ pub fn dashboard_page() -> Html {
                     <div class={classes!("session-views-container", if keyboard_nav.nav_mode { Some("nav-mode") } else { None })}>
                         {
                             active_sessions.iter().enumerate().map(|(index, session)| {
-                                let is_focused = index == *focused_index;
+                                let is_focused = index == focused_index;
                                 let is_activated = activated_sessions.contains(&session.id);
                                 if is_activated {
                                     html! {

--- a/frontend/src/pages/dashboard/session_order.rs
+++ b/frontend/src/pages/dashboard/session_order.rs
@@ -1,0 +1,217 @@
+//! Deterministic session display ordering + focus resolution (issue #1094).
+//!
+//! Why this exists: the dashboard polls `/api/sessions` every few seconds, and
+//! the backend orders rows by `last_activity DESC` — an activity-sensitive
+//! order that reshuffles between polls. The rail previously sorted only on
+//! folder name then hostname, so multiple agents in the *same* repo/worktree
+//! family (identical folder + host) compared **equal**, and Rust's `sort_by`
+//! gives no order guarantee for equal keys. Combined with focus being tracked
+//! by array *index*, a reshuffled poll could slide the focused index onto a
+//! different session — the "focus bounce" users saw with several same-repo
+//! agents running.
+//!
+//! Fix: a **total** comparator whose final tie-breaker is the unique session
+//! `id`, so the displayed order is a pure function of the *set* of sessions
+//! (independent of the source/poll order), plus focus tracked by `id` and
+//! resolved to an index only at render time via [`resolve_focus_index`].
+
+use std::cmp::Ordering;
+use std::collections::HashSet;
+
+use shared::SessionInfo;
+use uuid::Uuid;
+
+/// Total, deterministic display-order key for a session.
+///
+/// Lexicographic tuple, coarsest discriminant first:
+/// 1. display folder (lowercased) — groups sessions by repo/worktree leaf name
+/// 2. full working directory (lowercased) — separates sibling worktrees that
+///    share a leaf name
+/// 3. git branch — distinct worktrees of one repo differ here
+/// 4. agent type — claude vs codex in the same dir
+/// 5. hostname — same dir mirrored across machines
+/// 6. created-at then session name — stable human-meaningful ordering
+/// 7. `id` — unique final tie-breaker, so no two sessions ever compare equal
+///
+/// Because the key ends in the unique `id`, the order is *total*: the same set
+/// of sessions always sorts identically no matter what order the poll returned
+/// them in.
+fn display_sort_key(
+    s: &SessionInfo,
+) -> (String, String, String, String, String, String, String, Uuid) {
+    (
+        crate::utils::extract_folder(&s.working_directory).to_lowercase(),
+        s.working_directory.to_lowercase(),
+        s.git_branch.clone().unwrap_or_default(),
+        s.agent_type.as_str().to_string(),
+        s.hostname.to_lowercase(),
+        s.created_at.clone(),
+        s.session_name.clone(),
+        s.id,
+    )
+}
+
+/// Total ordering comparator for the session rail. See [`display_sort_key`].
+pub(super) fn session_display_cmp(a: &SessionInfo, b: &SessionInfo) -> Ordering {
+    display_sort_key(a).cmp(&display_sort_key(b))
+}
+
+/// Resolve the focused session's index in the *currently displayed* order.
+///
+/// Focus is stored by `session_id` (the source of truth), so a reorder or a
+/// refreshed poll never changes which session is focused. This maps that id
+/// back to a display index for the rail / keyboard nav.
+///
+/// Falls back to the first non-hidden session (then `0`) when the focused id
+/// is absent — e.g. nothing focused yet, or the focused session disappeared
+/// (deleted / left). That fallback is the intended "focus moved because the
+/// session is gone" behavior from the issue's acceptance criteria.
+pub(super) fn resolve_focus_index(
+    sessions: &[SessionInfo],
+    focused_id: Option<Uuid>,
+    hidden: &HashSet<Uuid>,
+) -> usize {
+    if let Some(id) = focused_id {
+        if let Some(idx) = sessions.iter().position(|s| s.id == id) {
+            return idx;
+        }
+    }
+    sessions
+        .iter()
+        .position(|s| !hidden.contains(&s.id))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::{AgentType, SessionInfo, SessionStatus};
+
+    fn session(id: Uuid, dir: &str, host: &str, branch: Option<&str>) -> SessionInfo {
+        SessionInfo {
+            id,
+            user_id: Uuid::nil(),
+            session_name: String::new(),
+            session_key: String::new(),
+            working_directory: dir.to_string(),
+            status: SessionStatus::Active,
+            last_activity: String::new(),
+            created_at: String::new(),
+            updated_at: String::new(),
+            git_branch: branch.map(|b| b.to_string()),
+            my_role: "owner".to_string(),
+            hostname: host.to_string(),
+            launcher_id: None,
+            pr_url: None,
+            repo_url: None,
+            open_prs: Vec::new(),
+            agent_type: AgentType::Claude,
+            client_version: None,
+            scheduled_task_id: None,
+            paused: false,
+            claude_args: Vec::new(),
+        }
+    }
+
+    /// The unique-id tie-breaker makes ordering independent of input order:
+    /// same folder + same host + different ids must sort identically no matter
+    /// how the poll happened to return them.
+    #[test]
+    fn same_folder_same_host_orders_stably_regardless_of_input_order() {
+        let a = Uuid::from_u128(1);
+        let b = Uuid::from_u128(2);
+        let c = Uuid::from_u128(3);
+        let mk = || {
+            vec![
+                session(a, "/home/me/repo", "host", None),
+                session(b, "/home/me/repo", "host", None),
+                session(c, "/home/me/repo", "host", None),
+            ]
+        };
+
+        let mut forward = mk();
+        forward.sort_by(session_display_cmp);
+
+        let mut reversed = mk();
+        reversed.reverse();
+        reversed.sort_by(session_display_cmp);
+
+        let ids = |v: &[SessionInfo]| v.iter().map(|s| s.id).collect::<Vec<_>>();
+        assert_eq!(ids(&forward), ids(&reversed));
+        // And it's the id order, since every other key is equal.
+        assert_eq!(ids(&forward), vec![a, b, c]);
+    }
+
+    /// Two worktrees of the same repo (same leaf folder, different full path +
+    /// branch) get a stable, distinct ordering.
+    #[test]
+    fn two_worktrees_same_repo_order_stably() {
+        let a = Uuid::from_u128(10);
+        let b = Uuid::from_u128(20);
+        let mk = || {
+            vec![
+                session(b, "/home/me/repo-wt2", "host", Some("feature")),
+                session(a, "/home/me/repo-wt1", "host", Some("main")),
+            ]
+        };
+        let mut first = mk();
+        first.sort_by(session_display_cmp);
+        let mut second = mk();
+        second.reverse();
+        second.sort_by(session_display_cmp);
+
+        let ids = |v: &[SessionInfo]| v.iter().map(|s| s.id).collect::<Vec<_>>();
+        assert_eq!(ids(&first), ids(&second));
+        // wt1 sorts before wt2 on the full-working-directory key.
+        assert_eq!(ids(&first), vec![a, b]);
+    }
+
+    /// Focus stays attached to its session id even after the surrounding list
+    /// is reordered (the core anti-bounce guarantee).
+    #[test]
+    fn focus_follows_id_across_reorder() {
+        let a = Uuid::from_u128(1);
+        let b = Uuid::from_u128(2);
+        let c = Uuid::from_u128(3);
+        let hidden = HashSet::new();
+
+        let order1 = vec![
+            session(a, "/a", "h", None),
+            session(b, "/b", "h", None),
+            session(c, "/c", "h", None),
+        ];
+        assert_eq!(resolve_focus_index(&order1, Some(b), &hidden), 1);
+
+        // A later poll surfaces the same sessions in a different order; focus
+        // by id resolves to b's NEW index, not the stale 1.
+        let order2 = vec![
+            session(c, "/c", "h", None),
+            session(b, "/b", "h", None),
+            session(a, "/a", "h", None),
+        ];
+        assert_eq!(resolve_focus_index(&order2, Some(b), &hidden), 1);
+
+        let order3 = vec![
+            session(b, "/b", "h", None),
+            session(a, "/a", "h", None),
+            session(c, "/c", "h", None),
+        ];
+        assert_eq!(resolve_focus_index(&order3, Some(b), &hidden), 0);
+    }
+
+    /// A disappeared focus id falls back to the first non-hidden session.
+    #[test]
+    fn missing_focus_falls_back_to_first_non_hidden() {
+        let a = Uuid::from_u128(1);
+        let b = Uuid::from_u128(2);
+        let gone = Uuid::from_u128(99);
+        let mut hidden = HashSet::new();
+        hidden.insert(a);
+
+        let sessions = vec![session(a, "/a", "h", None), session(b, "/b", "h", None)];
+        // a is hidden → first non-hidden is b at index 1.
+        assert_eq!(resolve_focus_index(&sessions, Some(gone), &hidden), 1);
+        // None focus behaves the same.
+        assert_eq!(resolve_focus_index(&sessions, None, &hidden), 1);
+    }
+}


### PR DESCRIPTION
Fixes #1094.

## Problem

Running multiple agents against the same repo/worktree family made the dashboard pills reorder and the focused session bounce during polling — even when the user didn't switch sessions. Two root causes:

1. **Non-total sort.** The rail sorted only on folder name then hostname, so same-folder + same-host sessions compared **equal**. `sort_by` gives no order guarantee for equal keys, and `/api/sessions` polls (backend-ordered by `last_activity DESC`) arrive in varying source order → equal-looking pills shuffled between ticks.
2. **Index-based focus.** Focus was an array index. When the order shifted, the same index pointed at a *different* session — the visible focus bounce.

## Fix

- **`session_order` module** — a *total* comparator keyed down to the unique session `id` (`folder → working_dir → branch → agent → host → created_at → name → id`), so the displayed order is a pure function of the session **set**, independent of poll order. Documented + unit-tested.
- **Focus by `session_id`** — `focused_id: Option<Uuid>` is the source of truth; the display index is derived each render via `resolve_focus_index`, falling back to the first non-hidden session when the focused id is absent (focused session deleted/left). The rail + keyboard nav still operate on the derived index; `on_select` translates the emitted index back to an id, so focus survives reorders.

**No backend change needed** — the total frontend sort neutralizes the backend's activity-sensitive source order, so I left `list_sessions` alone (lower risk).

## Acceptance criteria → coverage

- Same folder + host + different ids → stable order ✅
- Two worktrees, different branches → stable order ✅
- Focus stays on the same `session_id` after a reordered poll ✅
- Disappeared focus falls back deterministically ✅
- Sort behavior lives in a documented helper/test, not inline ✅

## Test
- `cargo test -p frontend` — 341 pass incl. 4 new `session_order` tests.
- `cargo check -p frontend --target wasm32-unknown-unknown`, `clippy -D warnings`, `fmt --check` all clean.

Version 2.12.23 (coordinated with @codex — io_task-fold rolls to 2.12.24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)