### PR TITLE
Group repo links in session pill submenu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.24"
+version = "2.12.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.24"
+version = "2.12.25"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.24"
+version = "2.12.25"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.24"
+version = "2.12.25"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.24"
+version = "2.12.25"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.24"
+version = "2.12.25"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.24"
+version = "2.12.25"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.24"
+version = "2.12.25"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.24"
+version = "2.12.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.24"
+version = "2.12.25"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.24"
+version = "2.12.25"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -9,7 +9,7 @@ use crate::utils::{self, On401};
 use gloo::events::EventListener;
 use gloo::timers::callback::Interval;
 use shared::api::ScheduledTaskListResponse;
-use shared::SessionInfo;
+use shared::{PrRef, SessionInfo};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -50,6 +50,49 @@ pub struct SparklineView {
 impl SparklineView {
     pub fn is_empty(&self) -> bool {
         self.ticks.is_empty() && self.compaction_ranges.is_empty() && self.task_ranges.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pr(number: i64, branch: &str) -> PrRef {
+        PrRef {
+            number,
+            url: format!("https://github.com/example/repo/pull/{number}"),
+            branch: branch.to_string(),
+        }
+    }
+
+    #[test]
+    fn sorted_prs_orders_by_number() {
+        let prs = vec![pr(42, "z"), pr(7, "a"), pr(13, "m")];
+
+        let sorted = sorted_prs(&prs);
+
+        assert_eq!(
+            sorted.iter().map(|pr| pr.number).collect::<Vec<_>>(),
+            vec![7, 13, 42]
+        );
+    }
+
+    #[test]
+    fn repo_pr_menu_hint_describes_collapsed_content() {
+        assert_eq!(
+            repo_pr_menu_hint(Some("https://github.com/r/o"), 0),
+            "Repository"
+        );
+        assert_eq!(
+            repo_pr_menu_hint(Some("https://github.com/r/o"), 1),
+            "Repository + 1 PR"
+        );
+        assert_eq!(
+            repo_pr_menu_hint(Some("https://github.com/r/o"), 3),
+            "Repository + PRs"
+        );
+        assert_eq!(repo_pr_menu_hint(None, 1), "1 PR");
+        assert_eq!(repo_pr_menu_hint(None, 4), "PRs");
     }
 }
 
@@ -215,6 +258,82 @@ fn menu_option(extra: Classes, label: &str, hint: &str, onclick: Callback<MouseE
             { label }
             <span class="option-hint">{ hint }</span>
         </button>
+    }
+}
+
+fn sorted_prs(prs: &[PrRef]) -> Vec<PrRef> {
+    let mut prs = prs.to_vec();
+    prs.sort_by_key(|p| p.number);
+    prs
+}
+
+fn repo_pr_menu_hint(repo_url: Option<&str>, pr_count: usize) -> &'static str {
+    match (repo_url.is_some(), pr_count) {
+        (true, 0) => "Repository",
+        (true, 1) => "Repository + 1 PR",
+        (true, _) => "Repository + PRs",
+        (false, 1) => "1 PR",
+        (false, _) => "PRs",
+    }
+}
+
+fn repo_pr_submenu(session: &SessionInfo) -> Html {
+    let prs = sorted_prs(&session.open_prs);
+    if session.repo_url.is_none() && prs.is_empty() {
+        return html! {
+            <span class="pill-menu-option disabled">
+                { "No Repository Detected" }
+            </span>
+        };
+    }
+
+    let repo_link = if let Some(ref url) = session.repo_url {
+        let href = url.clone();
+        html! {
+            <a class="pill-menu-option pr-link" href={href} target="_blank"
+               onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                { "Open Repository" }
+                <span class="option-hint">{ "GitHub" }</span>
+            </a>
+        }
+    } else {
+        html! {}
+    };
+
+    let pr_rows = prs
+        .iter()
+        .map(|pr| {
+            let href = pr.url.clone();
+            let branch = pr.branch.clone();
+            html! {
+                <a class="pill-menu-option pr-link" href={href} target="_blank"
+                   title={branch.clone()}
+                   onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                    { format!("Open PR #{}", pr.number) }
+                    <span class="option-hint">{ branch }</span>
+                </a>
+            }
+        })
+        .collect::<Html>();
+
+    html! {
+        <div class="pill-menu-submenu">
+            <button
+                type="button"
+                class="pill-menu-option repo-submenu-trigger"
+                aria-haspopup="true"
+                onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}
+            >
+                { "Repo / PRs" }
+                <span class="option-hint">
+                    { repo_pr_menu_hint(session.repo_url.as_deref(), prs.len()) }
+                </span>
+            </button>
+            <div class="pill-submenu-panel" role="menu">
+                { repo_link }
+                { pr_rows }
+            </div>
+        </div>
     }
 }
 
@@ -554,49 +673,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             html! {}
         };
 
-        let repo_option = {
-            // Repo root link on top, then one row per open PR sorted by number.
-            let repo_link = if let Some(ref url) = session.repo_url {
-                let href = url.clone();
-                html! {
-                    <a class="pill-menu-option pr-link" href={href} target="_blank"
-                       onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                        { "Open Repository" }
-                        <span class="option-hint">{ "GitHub" }</span>
-                    </a>
-                }
-            } else {
-                html! {}
-            };
-
-            let mut prs = session.open_prs.clone();
-            prs.sort_by_key(|p| p.number);
-            let pr_rows = prs
-                .iter()
-                .map(|pr| {
-                    let href = pr.url.clone();
-                    let branch = pr.branch.clone();
-                    html! {
-                        <a class="pill-menu-option pr-link" href={href} target="_blank"
-                           title={branch.clone()}
-                           onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                            { format!("Open PR #{}", pr.number) }
-                            <span class="option-hint">{ branch }</span>
-                        </a>
-                    }
-                })
-                .collect::<Html>();
-
-            if session.repo_url.is_none() && prs.is_empty() {
-                html! {
-                    <span class="pill-menu-option disabled">
-                        { "No Repository Detected" }
-                    </span>
-                }
-            } else {
-                html! { <>{ repo_link }{ pr_rows }</> }
-            }
-        };
+        let repo_option = repo_pr_submenu(session);
 
         let share_option = if session.my_role == "owner" {
             let on_share = close_then(menu_session.clone(), {
@@ -829,8 +906,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     { {
                         // Show open PR numbers (each with its branch as a hover
                         // tooltip); fall back to the branch name, then "No VCS".
-                        let mut prs = session.open_prs.clone();
-                        prs.sort_by_key(|p| p.number);
+                        let prs = sorted_prs(&session.open_prs);
                         if !prs.is_empty() {
                             html! {
                                 <span class="pill-branch pill-prs">

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -673,6 +673,15 @@
         justify-content: center;
     }
 
+    .pill-submenu-panel {
+        position: static;
+        min-width: 0;
+        max-width: none;
+        max-height: 240px;
+        margin: 0 0.4rem 0.4rem;
+        box-shadow: none;
+    }
+
     .permission-option {
         min-height: 44px;
         padding: 0.5rem 0.6rem;

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -512,7 +512,7 @@
     min-width: 160px;
     display: none;
     flex-direction: column;
-    overflow: hidden;
+    overflow: visible;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     z-index: 100;
 }
@@ -584,6 +584,51 @@ a.pill-menu-option.pr-link {
 
 a.pill-menu-option.pr-link:hover {
     background: rgba(122, 162, 247, 0.15);
+}
+
+.pill-menu-submenu {
+    position: relative;
+}
+
+.pill-menu-submenu > .pill-menu-option {
+    width: 100%;
+}
+
+.repo-submenu-trigger {
+    position: relative;
+    padding-right: 1.8rem;
+}
+
+.repo-submenu-trigger::after {
+    content: "›";
+    position: absolute;
+    right: 0.7rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+.pill-submenu-panel {
+    position: absolute;
+    left: calc(100% + 4px);
+    top: 0;
+    display: none;
+    min-width: 220px;
+    max-width: 320px;
+    max-height: min(360px, calc(100vh - 2rem));
+    overflow-y: auto;
+    flex-direction: column;
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.pill-menu-submenu:hover .pill-submenu-panel,
+.pill-menu-submenu:focus-within .pill-submenu-panel {
+    display: flex;
 }
 
 .pill-menu-option.disabled {


### PR DESCRIPTION
## Summary
- collapse the session pill repo/open-PR rows into one Repo / PRs submenu entry
- keep repo and PR links sorted and available in a hover/focus flyout
- add touch-friendly submenu styling and helper tests for PR ordering/menu hints

Fixes #1091

## Verification
- cargo fmt --check
- cargo test -p frontend session_rail
- cargo clippy -p frontend --all-targets -- -D warnings
- env -u NO_COLOR trunk build