### PR TITLE
Simplify session pill order to folder → agent → id (drop flap-prone branch key)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.26"
+version = "2.12.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.26"
+version = "2.12.27"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.26"
+version = "2.12.27"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.26"
+version = "2.12.27"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.26"
+version = "2.12.27"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.26"
+version = "2.12.27"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.26"
+version = "2.12.27"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.26"
+version = "2.12.27"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.26"
+version = "2.12.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.26"
+version = "2.12.27"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.26"
+version = "2.12.27"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_order.rs
+++ b/frontend/src/pages/dashboard/session_order.rs
@@ -24,29 +24,23 @@ use uuid::Uuid;
 /// Total, deterministic display-order key for a session.
 ///
 /// Lexicographic tuple, coarsest discriminant first:
-/// 1. display folder (lowercased) — groups sessions by repo/worktree leaf name
-/// 2. full working directory (lowercased) — separates sibling worktrees that
-///    share a leaf name
-/// 3. git branch — distinct worktrees of one repo differ here
-/// 4. agent type — claude vs codex in the same dir
-/// 5. hostname — same dir mirrored across machines
-/// 6. created-at then session name — stable human-meaningful ordering
-/// 7. `id` — unique final tie-breaker, so no two sessions ever compare equal
+/// 1. top-level folder name (lowercased) — groups sessions by repo
+/// 2. agent type — orders the agents working that repo (e.g. claude, codex)
+/// 3. `id` — unique final tie-breaker, so no two sessions ever compare equal
+///
+/// Deliberately **does not** key on `git_branch` (or working_directory /
+/// hostname / timestamps). Branch is derived by best-effort detection that can
+/// flap between polls (and is wrong under worktrees — see #1067); keying on it
+/// made pills reorder when the branch reading changed. Folder + agent + id is
+/// the stable identity that doesn't move when branch detection wobbles.
 ///
 /// Because the key ends in the unique `id`, the order is *total*: the same set
 /// of sessions always sorts identically no matter what order the poll returned
-/// them in.
-fn display_sort_key(
-    s: &SessionInfo,
-) -> (String, String, String, String, String, String, String, Uuid) {
+/// them in, and never depends on branch state.
+fn display_sort_key(s: &SessionInfo) -> (String, String, Uuid) {
     (
         crate::utils::extract_folder(&s.working_directory).to_lowercase(),
-        s.working_directory.to_lowercase(),
-        s.git_branch.clone().unwrap_or_default(),
         s.agent_type.as_str().to_string(),
-        s.hostname.to_lowercase(),
-        s.created_at.clone(),
-        s.session_name.clone(),
         s.id,
     )
 }
@@ -162,8 +156,43 @@ mod tests {
 
         let ids = |v: &[SessionInfo]| v.iter().map(|s| s.id).collect::<Vec<_>>();
         assert_eq!(ids(&first), ids(&second));
-        // wt1 sorts before wt2 on the full-working-directory key.
+        // wt1 sorts before wt2 on the top-level folder name.
         assert_eq!(ids(&first), vec![a, b]);
+    }
+
+    /// Two different agents in the same repo order by agent type, and that
+    /// order is immune to `git_branch` flapping — the case Matt flagged.
+    /// Branch detection wobbles (and is wrong under worktrees, #1067), so it
+    /// must not participate in ordering.
+    #[test]
+    fn two_agents_same_repo_order_by_agent_ignoring_branch() {
+        let claude = Uuid::from_u128(100);
+        let codex = Uuid::from_u128(200);
+        let mk = || {
+            let mut c = session(claude, "/home/me/app", "h", Some("main"));
+            c.agent_type = AgentType::Claude;
+            let mut x = session(codex, "/home/me/app", "h", Some("feature"));
+            x.agent_type = AgentType::Codex;
+            vec![x, c] // codex-first input order on purpose
+        };
+
+        let mut v = mk();
+        v.sort_by(session_display_cmp);
+        // "claude" < "codex" → claude first, regardless of input order.
+        assert_eq!(
+            v.iter().map(|s| s.id).collect::<Vec<_>>(),
+            vec![claude, codex]
+        );
+
+        // Flip/clear both branches — order must NOT change (branch isn't keyed).
+        let mut v2 = mk();
+        v2[0].git_branch = Some("totally-different".to_string());
+        v2[1].git_branch = None;
+        v2.sort_by(session_display_cmp);
+        assert_eq!(
+            v2.iter().map(|s| s.id).collect::<Vec<_>>(),
+            vec![claude, codex]
+        );
     }
 
     /// Focus stays attached to its session id even after the surrounding list


### PR DESCRIPTION
Follow-up to #1094, per Matt: the comparator keyed on `git_branch` (plus working_directory / hostname / timestamps). **`git_branch` is best-effort detection that flaps between polls and is wrong under worktrees (#1067)** — so keying on it made pills reorder whenever the branch reading wobbled, even with no real change.

## Change
Reduce the sort key to the stable identity:

```
top-level folder name  →  agent type  →  session id
```

- Two agents in the same repo (claude + codex) order deterministically **by agent** (`claude` < `codex`) and **never move when branch detection wobbles**.
- The unique `id` tail keeps the order **total**, so it's still independent of poll order — no reshuffling of equal-keyed pills.
- Focus is still tracked by `session_id` (unchanged from #1094).

## Test
New `two_agents_same_repo_order_by_agent_ignoring_branch` pins the exact scenario and asserts the order is unchanged after flipping/clearing both sessions' branches. All 5 `session_order` tests + WASM build + clippy + fmt green.

Version 2.12.27. @codex — frontend/`session_order.rs` is your domain; quick review please (small, well-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)