### PR TITLE
Add typed inter-agent message events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.27"
+version = "2.12.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.27"
+version = "2.12.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.27"
+version = "2.12.28"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.27"
+version = "2.12.28"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.27"
+version = "2.12.28"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.27"
+version = "2.12.28"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.27"
+version = "2.12.28"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.27"
+version = "2.12.28"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.27"
+version = "2.12.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.27"
+version = "2.12.28"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.27"
+version = "2.12.28"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -126,12 +126,12 @@ pub async fn send_agent_message(
         .first(&mut conn)
         .map_err(|_| AppError::NotFound("session"))?;
 
-    // Attribute the message so the recipient knows where it came from. An
-    // agent sender supplies its own session id (`from`); we tag the bumper with
-    // that session's agent type (claude/codex) so the UI can render
-    // "Message from Codex (<short>)". The human web page sends no `from`, so
-    // fall back to the sending user's display name.
-    let bumper = match req.from.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+    // Attribute the message so the recipient knows where it came from. Agent
+    // senders get an explicit portal event payload; the proxy converts it to
+    // agent-facing text, and the frontend renders the typed event directly.
+    // The human web page sends no `from`, so fall back to a plain text portal
+    // message with the sender display name in the prompt text.
+    let content = match req.from.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
         Some(from) => {
             let sender_agent = from
                 .parse::<Uuid>()
@@ -144,14 +144,19 @@ pub async fn send_agent_message(
                         .ok()
                 })
                 .unwrap_or_else(|| "agent".to_string());
-            format!("[message from {sender_agent} {from}]")
+            shared::PortalMessage::agent_message(
+                sender_agent,
+                from.to_string(),
+                message.to_string(),
+            )
+            .to_json()
         }
-        None => format!(
-            "[portal message from {}]",
-            user_display_name(&mut conn, user_id)
-        ),
+        None => serde_json::Value::String(format!(
+            "[portal message from {}]\n{}",
+            user_display_name(&mut conn, user_id),
+            message
+        )),
     };
-    let content = serde_json::Value::String(format!("{bumper}\n{message}"));
 
     // Seq bump + best-effort persist + live delivery, shared with the web
     // input path (see SessionManager::enqueue_input). DB write faults are

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -12,6 +12,7 @@ pub(crate) use portal_reminder::inject_portal_reminder;
 pub use wiggum::wiggum_prompt;
 pub use ws_reader::{classify_portal_input, RoutedPortalInput};
 
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -211,6 +212,9 @@ pub struct PermissionResponseData {
 /// Portal-originated user input plus optional backend ack metadata.
 pub struct PortalInput {
     pub text: String,
+    /// Optional typed portal event that should replace the agent's echoed user
+    /// text in the transcript.
+    pub display_event: Option<serde_json::Value>,
     pub ack: Option<PortalInputAck>,
 }
 
@@ -218,6 +222,13 @@ pub struct PortalInputAck {
     pub session_id: Uuid,
     pub seq: i64,
 }
+
+pub(crate) struct PendingInputDisplayEvent {
+    pub echoed_text: String,
+    pub content: serde_json::Value,
+}
+
+pub(crate) type PendingInputDisplayEvents = Arc<Mutex<VecDeque<PendingInputDisplayEvent>>>;
 
 /// Signal for graceful server shutdown with recommended reconnect delay
 pub struct GracefulShutdown {
@@ -349,6 +360,9 @@ struct ConnectionState {
     /// [`CodexThreadIdSink`] doc. Cloned out of `ProxySessionConfig` so
     /// the per-connection state doesn't need to carry a config reference.
     codex_thread_id_sink: Option<CodexThreadIdSink>,
+    /// Typed portal events waiting to replace the corresponding echoed user
+    /// message from the agent process.
+    pending_input_display_events: PendingInputDisplayEvents,
 }
 
 /// Run the WebSocket connection loop with auto-reconnect
@@ -754,6 +768,9 @@ async fn run_message_loop<A: Agent>(
     // Shared state for tracking git branch, PR URL, and repo URL updates
     let git_metadata = GitMetadataState::new(config.git_branch.clone());
 
+    let pending_input_display_events: PendingInputDisplayEvents =
+        Arc::new(Mutex::new(VecDeque::new()));
+
     // Spawn output forwarder task with buffer
     let output_task = spawn_output_forwarder(
         output_rx,
@@ -766,6 +783,7 @@ async fn run_message_loop<A: Agent>(
         session.output_buffer.clone(),
         max_image_mb,
         config.agent_type,
+        pending_input_display_events.clone(),
     );
 
     // Spawn WebSocket reader task
@@ -808,6 +826,7 @@ async fn run_message_loop<A: Agent>(
         git_metadata,
         git_refresh: GitRefreshTrigger::default(),
         codex_thread_id_sink: config.codex_thread_id_sink.clone(),
+        pending_input_display_events,
     };
 
     // On the very first connection of this session, inject the portal
@@ -910,6 +929,14 @@ async fn run_main_loop<A: Agent>(
                 .await;
 
                 debug!("sending to claude process: {}", truncate(&input.text, 100));
+
+                if let Some(display_event) = input.display_event.clone() {
+                    let mut pending = state.pending_input_display_events.lock().await;
+                    pending.push_back(PendingInputDisplayEvent {
+                        echoed_text: input.text.clone(),
+                        content: display_event,
+                    });
+                }
 
                 if let Err(e) = claude_session
                     .send_input(serde_json::Value::String(input.text))

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -18,7 +18,7 @@ use super::git_metadata::{
     check_and_send_branch_update, claude_output_has_git_signal, GitMetadataState, GitRefreshTrigger,
 };
 use super::image_uploader::upload_image;
-use super::{format_duration, truncate, SharedWsWrite};
+use super::{format_duration, truncate, PendingInputDisplayEvents, SharedWsWrite};
 
 /// Images at or above this raw-byte size get sent via the chunked upload
 /// stream (`/ws/session/upload`) instead of inlined as base64 on the main
@@ -41,6 +41,7 @@ pub fn spawn_output_forwarder(
     output_buffer: std::sync::Arc<tokio::sync::Mutex<PendingOutputBuffer>>,
     max_image_mb: u32,
     agent_type: AgentType,
+    pending_input_display_events: PendingInputDisplayEvents,
 ) -> tokio::task::JoinHandle<()> {
     let max_bytes = max_image_mb as usize * 1024 * 1024;
     tokio::spawn(async move {
@@ -76,9 +77,16 @@ pub fn spawn_output_forwarder(
             // (raw bytes for large images, base64 strings for small ones).
             let image_items = extract_image_work_items(&output, &mut image_read_map, max_bytes);
 
-            // Serialize and buffer with sequence number
-            let content = serde_json::to_value(&output)
-                .unwrap_or(serde_json::Value::String(format!("{:?}", output)));
+            // Serialize and buffer with sequence number. Typed portal inputs
+            // sent via `agent-portal message` are delivered to the agent as
+            // readable text, but their echoed user message should render as
+            // the original event envelope rather than a string-prefix parse.
+            let content = replacement_input_display_event(&output, &pending_input_display_events)
+                .await
+                .unwrap_or_else(|| {
+                    serde_json::to_value(&output)
+                        .unwrap_or(serde_json::Value::String(format!("{:?}", output)))
+                });
 
             // Add to buffer and get sequence number
             let seq = {
@@ -185,6 +193,33 @@ enum ImageWorkItem {
     },
     /// Image exceeded the hard cap; this is a textual rejection notice.
     TooLarge(shared::PortalMessage),
+}
+
+async fn replacement_input_display_event(
+    output: &ClaudeOutput,
+    pending_input_display_events: &PendingInputDisplayEvents,
+) -> Option<serde_json::Value> {
+    let echoed_text = user_text_echo(output)?;
+    let mut pending = pending_input_display_events.lock().await;
+    let pos = pending
+        .iter()
+        .position(|event| event.echoed_text == echoed_text)?;
+    pending.remove(pos).map(|event| event.content)
+}
+
+fn user_text_echo(output: &ClaudeOutput) -> Option<String> {
+    let ClaudeOutput::User(user) = output else {
+        return None;
+    };
+    let mut text_blocks = user.message.content.iter().filter_map(|block| match block {
+        ContentBlock::Text(text) => Some(text.text.clone()),
+        _ => None,
+    });
+    let text = text_blocks.next()?;
+    if text_blocks.next().is_some() {
+        return None;
+    }
+    Some(text)
 }
 
 /// Return the MIME type for a supported image extension, or None.

--- a/claude-session-lib/src/proxy_session/ws_reader.rs
+++ b/claude-session-lib/src/proxy_session/ws_reader.rs
@@ -49,11 +49,21 @@ pub fn classify_portal_input(
     send_mode: Option<SendMode>,
     ack: Option<super::PortalInputAck>,
 ) -> RoutedPortalInput {
-    let text = match content {
-        serde_json::Value::String(s) => s,
-        other => other.to_string(),
+    let (text, display_event) = match content {
+        serde_json::Value::String(s) => (s, None),
+        other => match serde_json::from_value::<shared::PortalMessage>(other.clone())
+            .ok()
+            .and_then(|msg| msg.agent_facing_text())
+        {
+            Some(text) => (text, Some(other)),
+            None => (other.to_string(), None),
+        },
     };
-    let input = super::PortalInput { text, ack };
+    let input = super::PortalInput {
+        text,
+        display_event,
+        ack,
+    };
     if send_mode == Some(SendMode::Wiggum) {
         RoutedPortalInput::Wiggum(input)
     } else {
@@ -333,4 +343,42 @@ async fn handle_ws_message(
     }
 
     WsMessageResult::Continue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_agent_message_portal_input_keeps_display_event() {
+        let content = shared::PortalMessage::agent_message(
+            "codex".to_string(),
+            "12345678-0000-0000-0000-000000000000".to_string(),
+            "hello".to_string(),
+        )
+        .to_json();
+
+        let RoutedPortalInput::Input(input) = classify_portal_input(content.clone(), None, None)
+        else {
+            panic!("expected normal input");
+        };
+
+        assert_eq!(
+            input.text,
+            "[message from codex 12345678-0000-0000-0000-000000000000]\nhello"
+        );
+        assert_eq!(input.display_event, Some(content));
+    }
+
+    #[test]
+    fn classify_plain_string_input_has_no_display_event() {
+        let RoutedPortalInput::Input(input) =
+            classify_portal_input(serde_json::Value::String("hello".to_string()), None, None)
+        else {
+            panic!("expected normal input");
+        };
+
+        assert_eq!(input.text, "hello");
+        assert!(input.display_event.is_none());
+    }
 }

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -81,12 +81,9 @@ pub fn render_optimistic_user_message(
     }
 }
 
-/// Parse the `[message from agent <session-id>]\n<body>` bumper that
-/// `agent-portal message` prepends to inter-agent messages. Returns
-/// `(sender_session_id, body)` when it matches.
-/// Parse the inter-agent bumper `[message from <agent_type> <session-id>]\n<body>`
-/// (older messages use the literal `agent` in place of the type). Returns
-/// `(agent_type, sender_session_id, body)`.
+/// Legacy fallback for inter-agent messages stored before the portal
+/// `agent_message` event existed. New messages render from typed
+/// `PortalContent::AgentMessage` instead of this text prefix.
 fn parse_other_agent_message(text: &str) -> Option<(String, String, String)> {
     let rest = text.strip_prefix("[message from ")?;
     let close = rest.find(']')?;
@@ -154,9 +151,8 @@ pub fn render_user_message(
     let pending_class = if meta.pending { " pending" } else { "" };
     let (text_content, has_tool_results) = user_message_text_and_tool_results(msg);
 
-    // Messages injected by `agent-portal message` arrive (echoed by the agent)
-    // as a user message prefixed with the `[message from agent <id>]` bumper.
-    // Render those as their own "other-agent" type rather than the user's own.
+    // Legacy rows from before the typed `PortalContent::AgentMessage` event
+    // still replay as user text with a source bumper.
     if !has_tool_results {
         if let Some((agent_type, sender, body)) = parse_other_agent_message(&text_content) {
             return render_other_agent_message(&agent_type, &sender, &body, timestamp, session_id);

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -13,11 +13,27 @@ pub fn render_portal_message(
     continuation_statuses: &HashMap<Uuid, String>,
     on_schedule_continuation: Callback<Uuid>,
 ) -> Html {
+    if let [shared::PortalContent::AgentMessage {
+        from_agent_type,
+        from_session_id,
+        text,
+    }] = msg.content.as_slice()
+    {
+        return render_agent_message_event(
+            from_agent_type,
+            from_session_id,
+            text,
+            timestamp,
+            session_id,
+        );
+    }
+
     let copy_text: String = msg
         .content
         .iter()
         .filter_map(|c| match c {
             shared::PortalContent::Text { text } => Some(text.clone()),
+            shared::PortalContent::AgentMessage { text, .. } => Some(text.clone()),
             _ => None,
         })
         .collect::<Vec<_>>()
@@ -95,6 +111,57 @@ fn render_portal_content(
             source_message,
             on_schedule_continuation,
         ),
+        shared::PortalContent::AgentMessage {
+            from_agent_type,
+            from_session_id,
+            text,
+        } => render_agent_message_body(from_agent_type, from_session_id, text, session_id),
+    }
+}
+
+fn agent_label(agent_type: &str) -> &'static str {
+    match agent_type.to_ascii_lowercase().as_str() {
+        "claude" => "Claude",
+        "codex" => "Codex",
+        _ => "agent",
+    }
+}
+
+fn render_agent_message_event(
+    from_agent_type: &str,
+    from_session_id: &str,
+    text: &str,
+    timestamp: Option<&str>,
+    session_id: Uuid,
+) -> Html {
+    let short = from_session_id.split('-').next().unwrap_or(from_session_id);
+    let label = agent_label(from_agent_type);
+    html! {
+        <div class="claude-message user-message other-agent-message agent-message-event">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
+                <span class="message-type-badge other-agent"
+                    title={format!("Message from {label} session {from_session_id}")}>
+                    { format!("Message from {label} ({short})") }
+                </span>
+                <CopyButton text={text.to_string()} title="Copy message" />
+            </div>
+            <div class="message-body">
+                { render_agent_message_body(from_agent_type, from_session_id, text, session_id) }
+            </div>
+        </div>
+    }
+}
+
+fn render_agent_message_body(
+    _from_agent_type: &str,
+    _from_session_id: &str,
+    text: &str,
+    session_id: Uuid,
+) -> Html {
+    html! {
+        <div class="user-text">
+            { render_markdown_for_session(&text.replace('\n', "  \n"), session_id) }
+        </div>
     }
 }
 

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -137,6 +137,28 @@
     background: rgba(187, 154, 247, 0.04);
 }
 
+.agent-message-event {
+    animation: agent-message-arrive 360ms ease-out;
+}
+
+@keyframes agent-message-arrive {
+    from {
+        background: rgba(187, 154, 247, 0.16);
+        transform: translateY(4px);
+    }
+
+    to {
+        background: rgba(187, 154, 247, 0.04);
+        transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-message-event {
+        animation: none;
+    }
+}
+
 .portal-message {
     border-left: 3px solid #7dcfff;
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -390,6 +390,33 @@ impl PortalMessage {
         }])
     }
 
+    /// Build an explicit inter-agent message event. The proxy converts this
+    /// envelope to agent-facing text before delivery, while the frontend
+    /// renders the typed event directly.
+    pub fn agent_message(from_agent_type: String, from_session_id: String, text: String) -> Self {
+        Self::with_content(vec![PortalContent::AgentMessage {
+            from_agent_type,
+            from_session_id,
+            text,
+        }])
+    }
+
+    /// Text form to send to the agent for portal event envelopes that have an
+    /// agent-facing representation.
+    pub fn agent_facing_text(&self) -> Option<String> {
+        let [PortalContent::AgentMessage {
+            from_agent_type,
+            from_session_id,
+            text,
+        }] = self.content.as_slice()
+        else {
+            return None;
+        };
+        Some(format!(
+            "[message from {from_agent_type} {from_session_id}]\n{text}"
+        ))
+    }
+
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or_default()
     }
@@ -430,6 +457,14 @@ pub enum PortalContent {
         status: String,
         source_message: String,
     },
+    /// Typed event for an inter-agent message. This replaces UI parsing of
+    /// the agent-facing `[message from ...]` text prefix for new messages.
+    #[serde(rename = "agent_message")]
+    AgentMessage {
+        from_agent_type: String,
+        from_session_id: String,
+        text: String,
+    },
 }
 
 impl std::fmt::Debug for PortalContent {
@@ -466,6 +501,16 @@ impl std::fmt::Debug for PortalContent {
                 .field("reset_at", reset_at)
                 .field("status", status)
                 .field("source_message", source_message)
+                .finish(),
+            Self::AgentMessage {
+                from_agent_type,
+                from_session_id,
+                text,
+            } => f
+                .debug_struct("AgentMessage")
+                .field("from_agent_type", from_agent_type)
+                .field("from_session_id", from_session_id)
+                .field("text", text)
                 .finish(),
         }
     }
@@ -570,5 +615,25 @@ mod tests {
         }]);
         assert_eq!(custom.message_type, PortalMessage::MESSAGE_TYPE);
         assert_eq!(custom.to_json()["type"], "portal");
+    }
+
+    #[test]
+    fn portal_agent_message_serializes_and_has_agent_facing_text() {
+        let msg = PortalMessage::agent_message(
+            "codex".to_string(),
+            "12345678-0000-0000-0000-000000000000".to_string(),
+            "hello from another agent".to_string(),
+        );
+        let json = msg.to_json();
+        assert_eq!(json["type"], "portal");
+        assert_eq!(json["content"][0]["type"], "agent_message");
+        assert_eq!(json["content"][0]["from_agent_type"], "codex");
+        assert_eq!(json["content"][0]["text"], "hello from another agent");
+        assert_eq!(
+            msg.agent_facing_text().as_deref(),
+            Some(
+                "[message from codex 12345678-0000-0000-0000-000000000000]\nhello from another agent"
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a typed PortalContent::AgentMessage event for agent-to-agent messages
- send the typed event from the agent-message API, convert it to agent-facing text at the proxy boundary, and replace the echoed user frame with the typed portal event before buffering/broadcast
- render typed agent-message events with the inter-agent styling plus a reduced-motion-safe arrival animation; keep the old prefix parser only as legacy replay fallback

## Verification
- cargo fmt --check
- cargo test -p shared portal_agent_message_serializes_and_has_agent_facing_text
- cargo test -p claude-session-lib classify_
- cargo check -p claude-session-lib -p frontend
- NO_COLOR=false trunk build
- cargo check -p backend
