### PR TITLE
Add record-level provenance for inter-agent messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.28"
+version = "2.12.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.28"
+version = "2.12.29"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.28"
+version = "2.12.29"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.28"
+version = "2.12.29"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.28"
+version = "2.12.29"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.28"
+version = "2.12.29"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.28"
+version = "2.12.29"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.28"
+version = "2.12.29"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.28"
+version = "2.12.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.28"
+version = "2.12.29"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.28"
+version = "2.12.29"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/2026-06-25-204200_add_message_provenance_and_clear_history/down.sql
+++ b/backend/migrations/2026-06-25-204200_add_message_provenance_and_clear_history/down.sql
@@ -1,0 +1,6 @@
+-- This drops the provenance columns but cannot restore the temporary message
+-- history deleted by up.sql.
+ALTER TABLE messages
+    DROP COLUMN provenance_agent_type,
+    DROP COLUMN provenance_session_id,
+    DROP COLUMN provenance_kind;

--- a/backend/migrations/2026-06-25-204200_add_message_provenance_and_clear_history/up.sql
+++ b/backend/migrations/2026-06-25-204200_add_message_provenance_and_clear_history/up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE messages
+    ADD COLUMN provenance_kind VARCHAR(32),
+    ADD COLUMN provenance_session_id UUID,
+    ADD COLUMN provenance_agent_type VARCHAR(16);
+
+-- Message rows are temporary portal display history. Clear existing transcript
+-- rows so rendering can rely on record-level provenance for all future rows
+-- instead of preserving legacy content-envelope detection. Agent CLI context is
+-- stored outside this table and is unaffected. turn_metrics.user_message_id is
+-- ON DELETE SET NULL, so durable metrics rows remain.
+DELETE FROM messages;

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -78,6 +78,8 @@ pub struct MessageWithSender {
     pub message: Message,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<shared::MessageOrigin>,
 }
 
 /// Create a new message for a session
@@ -99,6 +101,9 @@ pub async fn create_message(
         content: req.content,
         user_id: current_user_id,
         agent_type: session.agent_type.clone(),
+        provenance_kind: None,
+        provenance_session_id: None,
+        provenance_agent_type: None,
     };
 
     let message: Message = diesel::insert_into(messages::table)
@@ -209,9 +214,11 @@ pub async fn list_messages(
             } else {
                 None
             };
+            let origin = msg.origin();
             MessageWithSender {
                 message: msg,
                 sender_name,
+                origin,
             }
         })
         .collect();

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -117,6 +117,7 @@ pub fn handle_session_limit_reached(
                 sender_name: None,
                 agent_type: session.agent_type.parse().unwrap_or_default(),
                 created_at: row_created_at,
+                origin: None,
             },
         );
     }
@@ -285,6 +286,7 @@ fn update_terminal_status(
                             sender_name: None,
                             agent_type: session.agent_type.parse().unwrap_or_default(),
                             created_at: row_created_at,
+                            origin: None,
                         },
                     );
                 }
@@ -352,6 +354,9 @@ fn insert_portal_message(
         content: serde_json::to_string(&portal.to_json()).unwrap_or_default(),
         user_id: session.user_id,
         agent_type: session.agent_type.clone(),
+        provenance_kind: None,
+        provenance_session_id: None,
+        provenance_agent_type: None,
     };
     match diesel::insert_into(messages::table)
         .values(&new_message)

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -2,7 +2,9 @@ use super::{ProxySender, SessionManager};
 use crate::db::DbPool;
 use diesel::prelude::*;
 use serde::Deserialize;
-use shared::{AgentType, SendMode, ServerToClient, ServerToProxy};
+use shared::{
+    AgentType, MessageOrigin, PortalContent, PortalMessage, SendMode, ServerToClient, ServerToProxy,
+};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -214,6 +216,9 @@ pub fn handle_claude_output(
         Some(uid) => extract_portal_images(content, image_store, uid, db_session_id),
         None => content,
     };
+    let normalized = normalize_output_content(content);
+    let content = normalized.content;
+    let origin = normalized.origin.clone();
 
     // Insert the message FIRST and recover the server-assigned `created_at`
     // so the live broadcast carries the same timestamp the historical-read
@@ -250,6 +255,9 @@ pub fn handle_claude_output(
                 content: content.to_string(),
                 user_id: actual_user_id,
                 agent_type: agent_type.as_str().to_string(),
+                provenance_kind: normalized.provenance_kind.clone(),
+                provenance_session_id: normalized.provenance_session_id,
+                provenance_agent_type: normalized.provenance_agent_type.clone(),
             };
 
             match diesel::insert_into(messages::table)
@@ -321,8 +329,54 @@ pub fn handle_claude_output(
                 sender_name: sender_info.as_ref().map(|(_, name)| name.clone()),
                 agent_type,
                 created_at: row_created_at,
+                origin,
             },
         );
+    }
+}
+
+struct NormalizedOutputContent {
+    content: serde_json::Value,
+    origin: Option<MessageOrigin>,
+    provenance_kind: Option<String>,
+    provenance_session_id: Option<Uuid>,
+    provenance_agent_type: Option<String>,
+}
+
+fn normalize_output_content(content: serde_json::Value) -> NormalizedOutputContent {
+    let base = NormalizedOutputContent {
+        content,
+        origin: None,
+        provenance_kind: None,
+        provenance_session_id: None,
+        provenance_agent_type: None,
+    };
+
+    let Ok(portal) = serde_json::from_value::<PortalMessage>(base.content.clone()) else {
+        return base;
+    };
+    let [PortalContent::AgentMessage {
+        from_agent_type,
+        from_session_id,
+        text,
+    }] = portal.content.as_slice()
+    else {
+        return base;
+    };
+    let Ok(from_session_id) = from_session_id.parse::<Uuid>() else {
+        return base;
+    };
+
+    let origin = MessageOrigin::InterAgent {
+        from_session_id,
+        from_agent_type: from_agent_type.clone(),
+    };
+    NormalizedOutputContent {
+        content: PortalMessage::text(text.clone()).to_json(),
+        origin: Some(origin),
+        provenance_kind: Some("inter_agent".to_string()),
+        provenance_session_id: Some(from_session_id),
+        provenance_agent_type: Some(from_agent_type.clone()),
     }
 }
 
@@ -497,5 +551,32 @@ mod tests {
             .as_task_notification()
             .expect("task_notification struct parse");
         assert_eq!(notif.usage.expect("usage present").total_tokens, 68694);
+    }
+
+    #[test]
+    fn normalize_output_content_moves_agent_message_attribution_to_origin() {
+        let sender = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let content = PortalMessage::agent_message(
+            "claude".to_string(),
+            sender.to_string(),
+            "hello from peer".to_string(),
+        )
+        .to_json();
+
+        let normalized = normalize_output_content(content);
+
+        assert_eq!(normalized.provenance_kind.as_deref(), Some("inter_agent"));
+        assert_eq!(normalized.provenance_session_id, Some(sender));
+        assert_eq!(normalized.provenance_agent_type.as_deref(), Some("claude"));
+        assert_eq!(
+            normalized.origin,
+            Some(MessageOrigin::InterAgent {
+                from_session_id: sender,
+                from_agent_type: "claude".to_string()
+            })
+        );
+        assert_eq!(normalized.content["type"], "portal");
+        assert_eq!(normalized.content["content"][0]["type"], "text");
+        assert_eq!(normalized.content["content"][0]["text"], "hello from peer");
     }
 }

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -133,6 +133,12 @@ pub(super) fn replay_history(
                     "_created_at".to_string(),
                     serde_json::Value::String(created_at_str),
                 );
+                if let Some(origin) = msg.origin() {
+                    obj.insert(
+                        "_origin".to_string(),
+                        serde_json::to_value(origin).unwrap_or(serde_json::Value::Null),
+                    );
+                }
             }
             val
         })

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -135,6 +135,7 @@ pub(super) mod test_support {
             sender_name: None,
             agent_type: shared::AgentType::Claude,
             created_at: None,
+            origin: None,
         }
     }
 }

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -375,6 +375,9 @@ fn handle_web_input(
                     content: serde_json::to_string(&portal.to_json()).unwrap_or_default(),
                     user_id,
                     agent_type: session.agent_type.clone(),
+                    provenance_kind: None,
+                    provenance_session_id: None,
+                    provenance_agent_type: None,
                 };
                 match diesel::insert_into(messages::table)
                     .values(&new_message)
@@ -402,6 +405,7 @@ fn handle_web_input(
                     sender_name: None,
                     agent_type,
                     created_at: row_created_at,
+                    origin: None,
                 },
             );
         }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -99,6 +99,27 @@ pub struct Message {
     pub created_at: NaiveDateTime,
     pub user_id: Uuid,
     pub agent_type: String,
+    pub provenance_kind: Option<String>,
+    pub provenance_session_id: Option<Uuid>,
+    pub provenance_agent_type: Option<String>,
+}
+
+impl Message {
+    pub fn origin(&self) -> Option<shared::MessageOrigin> {
+        match (
+            self.provenance_kind.as_deref(),
+            self.provenance_session_id,
+            self.provenance_agent_type.as_deref(),
+        ) {
+            (Some("inter_agent"), Some(from_session_id), Some(from_agent_type)) => {
+                Some(shared::MessageOrigin::InterAgent {
+                    from_session_id,
+                    from_agent_type: from_agent_type.to_string(),
+                })
+            }
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Insertable)]
@@ -109,6 +130,9 @@ pub struct NewMessage {
     pub content: String,
     pub user_id: Uuid,
     pub agent_type: String,
+    pub provenance_kind: Option<String>,
+    pub provenance_session_id: Option<Uuid>,
+    pub provenance_agent_type: Option<String>,
 }
 
 // ============================================================================

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -26,6 +26,11 @@ diesel::table! {
         user_id -> Uuid,
         #[max_length = 16]
         agent_type -> Varchar,
+        #[max_length = 32]
+        provenance_kind -> Nullable<Varchar>,
+        provenance_session_id -> Nullable<Uuid>,
+        #[max_length = 16]
+        provenance_agent_type -> Nullable<Varchar>,
     }
 }
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -81,62 +81,6 @@ pub fn render_optimistic_user_message(
     }
 }
 
-/// Legacy fallback for inter-agent messages stored before the portal
-/// `agent_message` event existed. New messages render from typed
-/// `PortalContent::AgentMessage` instead of this text prefix.
-fn parse_other_agent_message(text: &str) -> Option<(String, String, String)> {
-    let rest = text.strip_prefix("[message from ")?;
-    let close = rest.find(']')?;
-    let (agent_type, sender) = rest[..close].trim().split_once(' ')?;
-    let sender = sender.trim();
-    if sender.is_empty() {
-        return None;
-    }
-    let body = rest[close + 1..]
-        .trim_start_matches(['\n', ' '])
-        .to_string();
-    Some((agent_type.trim().to_string(), sender.to_string(), body))
-}
-
-/// Friendly display name for a sender's agent type.
-fn agent_label(agent_type: &str) -> &'static str {
-    match agent_type.to_ascii_lowercase().as_str() {
-        "claude" => "Claude",
-        "codex" => "Codex",
-        _ => "agent",
-    }
-}
-
-/// Render an inter-agent message as its own type: a distinct badge + accent
-/// reading e.g. "Message from Codex (9466a628)" (full session id on hover), so
-/// it's clearly from another agent rather than the viewer's own input.
-fn render_other_agent_message(
-    agent_type: &str,
-    sender: &str,
-    body: &str,
-    timestamp: Option<&str>,
-    session_id: Uuid,
-) -> Html {
-    let short = sender.split('-').next().unwrap_or(sender);
-    let label = agent_label(agent_type);
-    html! {
-        <div class="claude-message user-message other-agent-message">
-            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
-                <span class="message-type-badge other-agent"
-                    title={format!("Message from {label} session {sender}")}>
-                    { format!("Message from {label} ({short})") }
-                </span>
-                <CopyButton text={body.to_string()} title="Copy message" />
-            </div>
-            <div class="message-body">
-                <div class="user-text">
-                    { render_markdown_for_session(&preserve_user_newlines(body), session_id) }
-                </div>
-            </div>
-        </div>
-    }
-}
-
 pub fn render_user_message(
     msg: &shared::UserMessage,
     meta: &UserMessageMeta,
@@ -150,14 +94,6 @@ pub fn render_user_message(
     };
     let pending_class = if meta.pending { " pending" } else { "" };
     let (text_content, has_tool_results) = user_message_text_and_tool_results(msg);
-
-    // Legacy rows from before the typed `PortalContent::AgentMessage` event
-    // still replay as user text with a source bumper.
-    if !has_tool_results {
-        if let Some((agent_type, sender, body)) = parse_other_agent_message(&text_content) {
-            return render_other_agent_message(&agent_type, &sender, &body, timestamp, session_id);
-        }
-    }
 
     if has_tool_results {
         html! {

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -13,16 +13,15 @@ pub fn render_portal_message(
     continuation_statuses: &HashMap<Uuid, String>,
     on_schedule_continuation: Callback<Uuid>,
 ) -> Html {
-    if let [shared::PortalContent::AgentMessage {
-        from_agent_type,
+    if let Some(shared::MessageOrigin::InterAgent {
         from_session_id,
-        text,
-    }] = msg.content.as_slice()
+        from_agent_type,
+    }) = &msg.origin
     {
         return render_agent_message_event(
+            msg,
             from_agent_type,
             from_session_id,
-            text,
             timestamp,
             session_id,
         );
@@ -33,7 +32,6 @@ pub fn render_portal_message(
         .iter()
         .filter_map(|c| match c {
             shared::PortalContent::Text { text } => Some(text.clone()),
-            shared::PortalContent::AgentMessage { text, .. } => Some(text.clone()),
             _ => None,
         })
         .collect::<Vec<_>>()
@@ -111,11 +109,9 @@ fn render_portal_content(
             source_message,
             on_schedule_continuation,
         ),
-        shared::PortalContent::AgentMessage {
-            from_agent_type,
-            from_session_id,
-            text,
-        } => render_agent_message_body(from_agent_type, from_session_id, text, session_id),
+        shared::PortalContent::AgentMessage { text, .. } => {
+            render_markdown_for_session(text, session_id)
+        }
     }
 }
 
@@ -128,13 +124,18 @@ fn agent_label(agent_type: &str) -> &'static str {
 }
 
 fn render_agent_message_event(
+    msg: &PortalMessage,
     from_agent_type: &str,
-    from_session_id: &str,
-    text: &str,
+    from_session_id: &Uuid,
     timestamp: Option<&str>,
     session_id: Uuid,
 ) -> Html {
-    let short = from_session_id.split('-').next().unwrap_or(from_session_id);
+    let from_session_id = from_session_id.to_string();
+    let text = portal_text(msg);
+    let short = from_session_id
+        .split('-')
+        .next()
+        .unwrap_or(&from_session_id);
     let label = agent_label(from_agent_type);
     html! {
         <div class="claude-message user-message other-agent-message agent-message-event">
@@ -146,23 +147,29 @@ fn render_agent_message_event(
                 <CopyButton text={text.to_string()} title="Copy message" />
             </div>
             <div class="message-body">
-                { render_agent_message_body(from_agent_type, from_session_id, text, session_id) }
+                { render_agent_message_body(&text, session_id) }
             </div>
         </div>
     }
 }
 
-fn render_agent_message_body(
-    _from_agent_type: &str,
-    _from_session_id: &str,
-    text: &str,
-    session_id: Uuid,
-) -> Html {
+fn render_agent_message_body(text: &str, session_id: Uuid) -> Html {
     html! {
         <div class="user-text">
             { render_markdown_for_session(&text.replace('\n', "  \n"), session_id) }
         </div>
     }
+}
+
+fn portal_text(msg: &PortalMessage) -> String {
+    msg.content
+        .iter()
+        .filter_map(|content| match content {
+            shared::PortalContent::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
 }
 
 fn render_continuation_prompt(

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -24,6 +24,8 @@ pub enum ClaudeMessage {
 pub struct PortalMessage {
     #[serde(default)]
     pub content: Vec<shared::PortalContent>,
+    #[serde(default, rename = "_origin")]
+    pub origin: Option<shared::MessageOrigin>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -636,6 +636,7 @@ impl SessionView {
                     m.role == "user",
                     m.user_id.as_deref(),
                     m.sender_name.as_deref(),
+                    m.origin.as_ref(),
                 )
             })
             .collect();

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -302,6 +302,7 @@ pub(super) fn inject_message_metadata(
     role_user: bool,
     user_id: Option<&str>,
     sender_name: Option<&str>,
+    origin: Option<&shared::MessageOrigin>,
 ) -> String {
     let Ok(mut val) = serde_json::from_str::<serde_json::Value>(content) else {
         return content.to_string();
@@ -328,6 +329,12 @@ pub(super) fn inject_message_metadata(
         "_created_at".to_string(),
         serde_json::Value::String(created_at.to_string()),
     );
+    if let Some(origin) = origin {
+        obj.insert(
+            "_origin".to_string(),
+            serde_json::to_value(origin).unwrap_or(serde_json::Value::Null),
+        );
+    }
     val.to_string()
 }
 
@@ -601,11 +608,37 @@ mod tests {
             false,
             None,
             None,
+            None,
         );
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["_created_at"], "2026-05-18T12:00:00Z");
         // Non-user role should never get _sender injected.
         assert!(v.get("_sender").is_none());
+    }
+
+    #[test]
+    fn inject_message_metadata_adds_origin_when_present() {
+        let from_session_id =
+            uuid::Uuid::parse_str("11111111-1111-1111-1111-111111111111").expect("uuid");
+        let origin = shared::MessageOrigin::InterAgent {
+            from_session_id,
+            from_agent_type: "claude".to_string(),
+        };
+        let out = inject_message_metadata(
+            r#"{"type":"portal","content":[{"type":"text","text":"hello"}]}"#,
+            "2026-05-18T12:00:00Z",
+            false,
+            None,
+            None,
+            Some(&origin),
+        );
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["_origin"]["kind"], "inter_agent");
+        assert_eq!(
+            v["_origin"]["from_session_id"],
+            "11111111-1111-1111-1111-111111111111"
+        );
+        assert_eq!(v["_origin"]["from_agent_type"], "claude");
     }
 
     #[test]
@@ -616,6 +649,7 @@ mod tests {
             true,
             Some("uid-1"),
             Some("Alice"),
+            None,
         );
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["_created_at"], "2026-05-18T12:00:00Z");
@@ -631,6 +665,7 @@ mod tests {
             true,
             None,
             None,
+            None,
         );
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["_created_at"], "2026-05-18T12:00:00Z");
@@ -642,7 +677,7 @@ mod tests {
     fn inject_message_metadata_returns_input_unchanged_for_invalid_json() {
         // Malformed wire frame: the caller still pushes the raw string so
         // the message doesn't silently disappear from the list.
-        let out = inject_message_metadata("not-json", "ts", false, None, None);
+        let out = inject_message_metadata("not-json", "ts", false, None, None, None);
         assert_eq!(out, "not-json");
     }
 
@@ -651,7 +686,7 @@ mod tests {
         // Valid JSON but not an object (e.g. a top-level string) — no
         // _created_at slot to inject into, return as-is so callers don't
         // re-serialize it into a quoted-string blob.
-        let out = inject_message_metadata("\"hello\"", "ts", false, None, None);
+        let out = inject_message_metadata("\"hello\"", "ts", false, None, None, None);
         assert_eq!(out, "\"hello\"");
     }
 

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -135,6 +135,7 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
             // the live and historical-read paths stay agent-agnostic.
             agent_type: _,
             created_at,
+            origin,
         } => {
             // Inject _sender into content for the renderer if sender info is
             // present. Also fold `created_at` into the content as
@@ -144,7 +145,7 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
             // changing the event signature again.
             let mut content_val = content;
             let needs_sender = sender_user_id.is_some() || sender_name.is_some();
-            if needs_sender || created_at.is_some() {
+            if needs_sender || created_at.is_some() || origin.is_some() {
                 if let Some(obj) = content_val.as_object_mut() {
                     if needs_sender {
                         #[derive(serde::Serialize)]
@@ -165,6 +166,12 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
                         obj.insert(
                             "_created_at".to_string(),
                             serde_json::Value::String(ts.clone()),
+                        );
+                    }
+                    if let Some(origin) = origin {
+                        obj.insert(
+                            "_origin".to_string(),
+                            serde_json::to_value(origin).unwrap_or(serde_json::Value::Null),
                         );
                     }
                 }
@@ -397,6 +404,7 @@ mod tests {
             sender_name: None,
             agent_type: shared::AgentType::Claude,
             created_at: Some(server_ts.clone()),
+            origin: None,
         };
 
         handle_proxy_message(msg, &cb);
@@ -438,6 +446,7 @@ mod tests {
             sender_name: None,
             agent_type: shared::AgentType::Claude,
             created_at: None,
+            origin: None,
         };
 
         handle_proxy_message(msg, &cb);

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -47,6 +47,9 @@ pub struct MessageData {
     /// Display name of the sender (looked up from users table)
     #[serde(default)]
     pub sender_name: Option<String>,
+    /// Typed provenance for records produced by another agent session.
+    #[serde(default)]
+    pub origin: Option<shared::MessageOrigin>,
 }
 
 /// Response from the messages API endpoint — the shared envelope

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -5,7 +5,10 @@ use ws_bridge::WsEndpoint;
 use super::types::{
     FileUploadChunkFields, FileUploadStartFields, PermissionResponseFields, RegisterFields,
 };
-use crate::{AgentType, PermissionSuggestion, SendMode, SessionCost, SessionStatus, TurnMetrics};
+use crate::{
+    AgentType, MessageOrigin, PermissionSuggestion, SendMode, SessionCost, SessionStatus,
+    TurnMetrics,
+};
 
 pub struct ClientEndpoint;
 
@@ -83,6 +86,8 @@ pub enum ServerToClient {
         /// with older backends.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         created_at: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        origin: Option<MessageOrigin>,
     },
 
     /// Batch of historical messages for replay.

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -127,6 +127,7 @@ mod tests {
             sender_name: None,
             agent_type: AgentType::Codex,
             created_at: Some("2026-05-18T12:34:56.789012".to_string()),
+            origin: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerToClient = serde_json::from_str(&json).unwrap();

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -285,6 +285,15 @@ pub enum MessageRole {
     Unknown,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MessageOrigin {
+    InterAgent {
+        from_session_id: Uuid,
+        from_agent_type: String,
+    },
+}
+
 impl MessageRole {
     pub fn as_str(&self) -> &'static str {
         match self {


### PR DESCRIPTION
## Summary
- add nullable message provenance columns and derive typed MessageOrigin for live, replay, and REST history frames
- normalize typed inter-agent portal events into plain portal text plus provenance metadata at persistence time
- remove frontend content-prefix detection so inter-agent rendering uses record metadata instead of message body text
- bump workspace version to 2.12.29

## Migration note
This migration intentionally deletes rows from the temporary messages table after adding provenance columns. Portal transcript backscroll resets, but agent CLI context and durable turn_metrics rows are preserved; turn_metrics.user_message_id is ON DELETE SET NULL.

## Verification
- NO_COLOR=false trunk build
- cargo check -p shared -p backend -p frontend
- cargo test -p shared server_to_client_output_roundtrip
- cargo test -p backend normalize_output_content_moves_agent_message_attribution_to_origin
- cargo test -p frontend inject_message_metadata_adds_origin_when_present
- cargo test -p frontend message_renderer
- ./scripts/check-migration-names.sh
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace