### PR TITLE
Fix data-plane WS wedge / no-reconnect after backend restart (#926)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.30"
+version = "2.12.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.30"
+version = "2.12.31"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.30"
+version = "2.12.31"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.30"
+version = "2.12.31"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.30"
+version = "2.12.31"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.30"
+version = "2.12.31"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.30"
+version = "2.12.31"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.30"
+version = "2.12.31"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.30"
+version = "2.12.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.30"
+version = "2.12.31"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.30"
+version = "2.12.31"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -67,3 +67,94 @@ findings converged ~1:1, and the breakdown below is mutually agreed).
 device_flow HTML/handler split (→ #4/#6), exponential-backoff consolidation into
 a shared util (→ #1), the child-dispatcher registration pattern (frontend),
 `performance_panel` query extraction (→ #9).
+
+---
+
+# Round 2 — Next 10 (consensus 2026-06-25, Claude + Codex)
+
+Round 1 (above) + token-accounting, SDK modernization, pill-ordering, and the
+record-level message-provenance rebuild have all landed. This round was scoped
+by **reading the code broadly** (4 parallel survey agents over
+backend / session-libs / frontend / proxy+launcher) + a Codex repo/CI scan, not
+just the issue tracker. Organized by **outcome**, not issue number.
+
+## Reliability (top priority — user-visible dead sessions / leaks)
+1. **WS data-plane reconnect after backend restart** (#926) — sessions go dead
+   silently.
+2. **Child-process / zombie cleanup on stop/cancel** (#927) — survey found 4
+   concrete leak sites: `proxy/src/shim.rs` stdin-EOF orphans the stdout/stderr
+   reader tasks (and reconnect `continue` doesn't cancel the reader task);
+   `launcher/src/process_manager.rs:~238` `task.handle.abort()` cancels the
+   tokio task but doesn't SIGKILL the claude child; `scheduler` keeps stale
+   `running` entries when `SessionExited` is lost. Fix with a `CancellationToken`
+   per connection + explicit `kill()` before abort + a scheduler age-out.
+3. **UI→proxy delivery semantics / ack idempotency** (#939) — plus
+   `launcher/src/connection.rs` can drop a `SessionExited` on disconnect, so the
+   scheduler relaunches a dead session. Wants a buffered at-least-once story.
+
+## Delivery velocity (dev-loop multipliers)
+4. **Version bump on merge, not per-PR** (#1096) — killed most of our parallel-PR
+   coordination tax. **+ CI frontend-rebuild 3×:** the backend embeds
+   `frontend/dist`, so the clippy / test / backend jobs each `trunk build` the
+   frontend every run. Add a no-dist Rust-check mode (or a built-dist cache
+   artifact) so pure-Rust checks don't rebuild WASM.
+
+## Testability
+5. **Migration apply/revert harness** on a disposable DB + invariants for
+   destructive migrations (folds #922) — the provenance `DELETE FROM messages`
+   was safe but relied on *manual* FK reasoning. Plus **characterization tests**
+   for the session core (`session-lib/src/session.rs::next_event` has 1 test)
+   and the missing backend auth/registration coverage
+   (`registration.rs::user_is_authorized_for_session` is untested).
+
+## Architecture
+6. **io_task-fold → generic `Session<A>` → collapse `codex-session-lib`** (#1) —
+   survey: ~60-80 lines of duplicated terminator/finalization logic across the
+   two `io_task.rs`. Characterization-tests-first. *(Holds on Matt's go for the
+   detection→adapter / retry-action→io_task split.)*
+7. **Dashboard state → reducers + hooks** (#920/#9) — `page.rs` carries 24
+   `use_state` + ~114 cloning callbacks → O(sessions) full-tree re-renders per
+   event; move per-session state into `SessionView`.
+8. **Renderer split by family + `AgentFrame` as the only parse point** (#859) —
+   survey: JSON re-parsed per render (`dispatch.rs`) and the sparkline tick
+   re-renders all pills every 100ms.
+
+## Observability
+9. **Structured lifecycle events/metrics** — reconnect attempts, input-ack
+   latency, child spawn/kill, message provenance. Not an existing issue but the
+   thing that makes #926/#927/#939 *diagnosable*. Split by event source
+   (backend / proxy / launcher = Claude; frontend = Codex).
+
+## Correctness / polish (opportunistic, picked by domain — don't block architecture)
+10. **#1067** worktree branch detection (pin-to-launch + best-effort + SDK
+    issue), **#827** Codex file-change permission filenames, **#1076**
+    AskUserQuestion checkbox-clear.
+
+## Cross-cutting policy (continuous, not ranked projects)
+- Panic/`unwrap` cleanup in production paths (survey flagged `heartbeat.rs`
+  mutex-poison via `.lock().unwrap()`, `proxy_tokens.rs` token-expiry unwrap,
+  `background.rs:151` swallowed DB error via `.unwrap_or_default()`); add a small
+  clippy deny baseline, then clean per touched area.
+- Typed SDK upstreaming (claude-codes / codex-codes) over JSON-poking.
+- Split oversized modules (`shared/api`, `endpoints`, frontend monoliths) **when
+  touched**, not as a standalone sweep.
+- Keep `node_modules` / generated assets out of analysis/line-count paths.
+
+## Ownership
+- **Claude:** reliability (#926/#927/#939), CI+migrations (#1096, #4, #5),
+  session abstraction (#1), backend observability.
+- **Codex:** dashboard reducers (#920), renderer split (#859), frontend
+  correctness (#827/#1076), frontend observability.
+- **Both:** #1067 by domain; cross-cutting policy in each owner's area.
+
+## Sequencing (agreed)
+- **Reliability ships in thin, independently-mergeable slices, first:**
+  #926 (reconnect — characterization then fix) → #927 (process cleanup) →
+  #939 (delivery semantics). Don't mix hot reliability fixes with the generic
+  `Session<A>` refactor.
+- **#1 io_task-fold stays behind the reliability trio** (and behind its own
+  characterization tests).
+- **Observability (#9) is folded into the reliability fixes** where it makes them
+  diagnosable — not one giant metrics PR.
+- **Codex (parallel):** #920 reducers → #859 renderer split, with #1076 as a
+  small interleave.

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -895,8 +895,43 @@ async fn run_main_loop<A: Agent>(
                     );
                     return ConnectionResult::Disconnected(state.connection_start.elapsed());
                 }
-                let mut ws = state.ws_write.lock().await;
-                let _ = ws.send(ProxyToServer::Heartbeat).await;
+                // Bound the heartbeat lock+send. On a half-dead socket (e.g.
+                // after a backend restart) the send can block forever; that
+                // starves this `select!` so the disconnect / graceful-shutdown
+                // arms never fire and the data plane reconnects never — the
+                // session is "shown but not connected" until the launcher is
+                // restarted (#926). Timing out the lock acquisition *and* the
+                // send makes this heartbeat a true watchdog: even if another
+                // ws_write send is wedged holding the lock, this fires and
+                // returns `Disconnected`, letting `run_connection_loop`'s
+                // reconnect/backoff recover the connection.
+                let send = async {
+                    let mut ws = state.ws_write.lock().await;
+                    ws.send(ProxyToServer::Heartbeat).await
+                };
+                match tokio::time::timeout(
+                    session_lib::heartbeat::HEARTBEAT_TIMEOUT,
+                    send,
+                )
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        warn!("Heartbeat send failed ({e}), forcing reconnect");
+                        return ConnectionResult::Disconnected(
+                            state.connection_start.elapsed(),
+                        );
+                    }
+                    Err(_) => {
+                        warn!(
+                            "Heartbeat send blocked >{}s (dead socket), forcing reconnect",
+                            session_lib::heartbeat::HEARTBEAT_TIMEOUT.as_secs()
+                        );
+                        return ConnectionResult::Disconnected(
+                            state.connection_start.elapsed(),
+                        );
+                    }
+                }
             }
 
             Some(()) = recv_option(&mut state.session_terminated_rx) => {


### PR DESCRIPTION
Fixes #926. **Round 2, reliability slice 1.**

## Problem
After a backend restart (graceful "Server is restarting"), a launcher-managed session's **data-plane** WS (`/ws/session`) went permanently silent and never reconnected — the control plane recovered, so the session looked alive in the UI but accepted no I/O ("shown but not connected") until the launcher was manually restarted.

## Root cause
`run_main_loop`'s heartbeat `select!` arm did `ws_write.lock().await` then `ws.send(Heartbeat).await` with **no bound**. On a half-dead socket the send blocks forever, starving the `select!` so the `disconnect_rx` / `graceful_shutdown_rx` arms never fire — and `run_connection_loop`'s reconnect/backoff loop never runs. (Confirmed by the production journal in the issue: the data plane logged its shutdown notice once, then total silence.)

## Fix
Bound the heartbeat **lock + send** with `HEARTBEAT_TIMEOUT` (15s). A timeout *or* a send error returns `ConnectionResult::Disconnected`, so the existing reconnect/backoff loop recovers the data plane. Bounding lock-acquisition (not just the send) makes the heartbeat a true **watchdog**: even if another `ws_write` send is wedged holding the lock, this arm fires and forces a reconnect. Healthy sends are instant, so the bound only ever catches the pathological wedge.

## Testability note
The proxy connection loop drives a concrete WS sink (no trait seam), so a unit test of the wedge needs WS mocking — that's exactly Round 2 item #5 (characterization harness). This slice is the targeted, low-risk fix the issue's own analysis prescribes; I kept it minimal per our "thin reliability slices" sequencing.

## Also in this PR
Folds in the agreed **`REFACTOR_PLAN.md` Round 2 — Next 10** (outcome-organized consensus from a broad code survey) — doc-only, bundled here so we don't burn a separate version bump while #1096 (bump-on-merge) is still pending.

Build + clippy + fmt clean. Version 2.12.31. @codex — proxy/reliability is my domain; quick review when you have a sec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)