### PR TITLE
Refactor dashboard session state into reducer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.31"
+version = "2.12.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.31"
+version = "2.12.32"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.31"
+version = "2.12.32"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.31"
+version = "2.12.32"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.31"
+version = "2.12.32"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.31"
+version = "2.12.32"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.31"
+version = "2.12.32"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.31"
+version = "2.12.32"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.31"
+version = "2.12.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.31"
+version = "2.12.32"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.31"
+version = "2.12.32"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/mod.rs
+++ b/frontend/src/pages/dashboard/mod.rs
@@ -7,6 +7,7 @@
 //! - `PermissionDialog`: Permission prompt and AskUserQuestion dialogs
 
 mod page;
+mod page_state;
 mod permission_dialog;
 mod session_order;
 mod session_rail;

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -1,5 +1,6 @@
 //! Dashboard page - Main session management interface
 
+use super::page_state::{active_session_ids, DashboardSessionAction, DashboardSessionState};
 use super::session_order;
 use super::session_rail::{ActivityRef, SessionRail};
 use super::session_view::SessionView;
@@ -100,25 +101,19 @@ pub fn dashboard_page() -> Html {
     // index — see `session_order` / issue #1094. The display index is derived
     // from this each render, so a reordered poll never bounces focus onto a
     // different session.
-    let focused_id = use_state(|| None::<Uuid>);
-    let awaiting_sessions = use_state(HashSet::<Uuid>::new);
-    let hidden_sessions = use_state(load_hidden_sessions);
+    let session_state = use_reducer_eq(|| DashboardSessionState::new(load_hidden_sessions()));
     let inactive_hidden = use_state(load_inactive_hidden);
     let show_cost = use_state(load_show_cost);
     let rail_position = use_state(load_rail_position);
-    let connected_sessions = use_state(HashSet::<Uuid>::new);
     let pending_leave = use_state(|| None::<Uuid>);
     let pending_delete = use_state(|| None::<Uuid>);
     let is_admin = use_state(|| false);
     let current_user_id = use_state(|| None::<Uuid>);
     let app_title = use_state(|| "Agent Portal".to_string());
     let server_version = use_state(String::new);
-    let activated_sessions = use_state(HashSet::<Uuid>::new);
     // Activity buffer: mutations don't trigger page re-renders.
     // SessionRail reads this on its own 100 ms tick instead.
     let activity_timestamps = use_memo((), |_| ActivityRef::default());
-    let initial_focus_set = use_state(|| false);
-    let sessions_at_launch = use_state(|| None::<HashSet<Uuid>>);
 
     // Detect spend tier changes and trigger timed animation
     {
@@ -203,7 +198,7 @@ pub fn dashboard_page() -> Html {
     // sessions: they remain available in the hidden rail section but do not
     // participate in focus, activation, waiting counts, or keyboard rotation.
     let effective_hidden_sessions: HashSet<Uuid> = {
-        let mut hidden = (*hidden_sessions).clone();
+        let mut hidden = session_state.hidden_sessions.clone();
         hidden.extend(active_sessions.iter().filter(|s| s.paused).map(|s| s.id));
         hidden
     };
@@ -215,7 +210,7 @@ pub fn dashboard_page() -> Html {
     // this derived index.
     let focused_index: usize = session_order::resolve_focus_index(
         &active_sessions,
-        *focused_id,
+        session_state.focused_id,
         &effective_hidden_sessions,
     );
 
@@ -223,34 +218,35 @@ pub fn dashboard_page() -> Html {
     {
         let active_sessions = active_sessions.clone();
         let effective_hidden_sessions = effective_hidden_sessions.clone();
-        let focused_id = focused_id.clone();
-        let initial_focus_set = initial_focus_set.clone();
-        let activated_sessions = activated_sessions.clone();
+        let session_state = session_state.clone();
 
         use_effect_with(
-            (active_sessions.len(), loading),
-            move |(session_count, is_loading)| {
-                if !*initial_focus_set && !*is_loading && *session_count > 0 {
+            (
+                active_sessions.clone(),
+                effective_hidden_sessions.clone(),
+                loading,
+            ),
+            move |(sessions, hidden_sessions, is_loading)| {
+                if !*is_loading && !sessions.is_empty() {
                     // Focus the first non-hidden session by id (falls through to
                     // the first session if all are hidden).
-                    let first_focus = active_sessions
+                    let first_focus = sessions
                         .iter()
-                        .find(|s| !effective_hidden_sessions.contains(&s.id))
-                        .or_else(|| active_sessions.first())
+                        .find(|s| !hidden_sessions.contains(&s.id))
+                        .or_else(|| sessions.first())
                         .map(|s| s.id);
 
-                    focused_id.set(first_focus);
-
                     // Activate all non-hidden sessions so they load in background
-                    let mut activated = (*activated_sessions).clone();
-                    for s in &active_sessions {
-                        if !effective_hidden_sessions.contains(&s.id) {
-                            activated.insert(s.id);
-                        }
-                    }
-                    activated_sessions.set(activated);
+                    let activate_ids = sessions
+                        .iter()
+                        .filter(|s| !hidden_sessions.contains(&s.id))
+                        .map(|s| s.id)
+                        .collect();
 
-                    initial_focus_set.set(true);
+                    session_state.dispatch(DashboardSessionAction::InitializeFocus {
+                        focus_id: first_focus,
+                        activate_ids,
+                    });
                 }
                 || ()
             },
@@ -259,29 +255,19 @@ pub fn dashboard_page() -> Html {
 
     // Auto-focus newly launched session when it appears in the session list
     {
-        let sessions_at_launch = sessions_at_launch.clone();
-        let active_sessions = active_sessions.clone();
-        let focused_id = focused_id.clone();
-        let activated_sessions = activated_sessions.clone();
+        let session_state = session_state.clone();
 
-        use_effect_with(active_sessions.clone(), move |sessions| {
-            if let Some(ref snapshot) = *sessions_at_launch {
-                if let Some(session) = sessions.iter().find(|s| !snapshot.contains(&s.id)) {
-                    focused_id.set(Some(session.id));
-                    let mut activated = (*activated_sessions).clone();
-                    activated.insert(session.id);
-                    activated_sessions.set(activated);
-                    sessions_at_launch.set(None);
-                }
-            }
+        use_effect_with(active_session_ids(&active_sessions), move |session_ids| {
+            session_state.dispatch(DashboardSessionAction::FocusNewlyLaunched(
+                session_ids.clone(),
+            ));
             || ()
         });
     }
 
     // Session selection callback
     let on_select_session = {
-        let focused_id = focused_id.clone();
-        let activated_sessions = activated_sessions.clone();
+        let session_state = session_state.clone();
         let active_sessions = active_sessions.clone();
         // The rail / keyboard nav emit a display index valid against the order
         // that produced the current render; translate it to the session id so
@@ -290,21 +276,16 @@ pub fn dashboard_page() -> Html {
             crate::audio::ensure_audio_context();
             crate::audio::play_sound(crate::audio::SoundEvent::SessionSwap);
             if let Some(session) = active_sessions.get(index) {
-                focused_id.set(Some(session.id));
-                let mut activated = (*activated_sessions).clone();
-                activated.insert(session.id);
-                activated_sessions.set(activated);
+                session_state.dispatch(DashboardSessionAction::FocusAndActivate(session.id));
             }
         })
     };
 
     // Activation callback for keyboard nav
     let on_activate = {
-        let activated_sessions = activated_sessions.clone();
+        let session_state = session_state.clone();
         Callback::from(move |session_id: Uuid| {
-            let mut activated = (*activated_sessions).clone();
-            activated.insert(session_id);
-            activated_sessions.set(activated);
+            session_state.dispatch(DashboardSessionAction::Activate(session_id));
         })
     };
 
@@ -323,7 +304,7 @@ pub fn dashboard_page() -> Html {
         sessions: active_sessions.clone(),
         focused_index,
         hidden_sessions: effective_hidden_sessions.clone(),
-        connected_sessions: (*connected_sessions).clone(),
+        connected_sessions: session_state.connected_sessions.clone(),
         inactive_hidden: *inactive_hidden,
         on_select: on_select_session.clone(),
         on_activate,
@@ -468,43 +449,40 @@ pub fn dashboard_page() -> Html {
     };
 
     let on_launch_success = {
-        let sessions_at_launch = sessions_at_launch.clone();
+        let session_state = session_state.clone();
         let active_sessions = active_sessions.clone();
         Callback::from(move |_| {
-            let snapshot: HashSet<Uuid> = active_sessions.iter().map(|s| s.id).collect();
-            sessions_at_launch.set(Some(snapshot));
+            session_state.dispatch(DashboardSessionAction::StoreLaunchSnapshot(
+                active_session_ids(&active_sessions),
+            ));
         })
     };
 
     // Session state callbacks
     let on_awaiting_change = {
-        let awaiting_sessions = awaiting_sessions.clone();
+        let session_state = session_state.clone();
         Callback::from(move |(session_id, is_awaiting): (Uuid, bool)| {
-            let currently_awaiting = awaiting_sessions.contains(&session_id);
+            let currently_awaiting = session_state.awaiting_sessions.contains(&session_id);
             if currently_awaiting == is_awaiting {
                 return;
             }
-            let mut set = (*awaiting_sessions).clone();
             if is_awaiting {
-                set.insert(session_id);
                 crate::audio::play_sound(crate::audio::SoundEvent::AwaitingInput);
-            } else {
-                set.remove(&session_id);
             }
-            awaiting_sessions.set(set);
+            session_state.dispatch(DashboardSessionAction::SetAwaiting {
+                session_id,
+                awaiting: is_awaiting,
+            });
         })
     };
 
     let on_connected_change = {
-        let connected_sessions = connected_sessions.clone();
+        let session_state = session_state.clone();
         Callback::from(move |(session_id, connected): (Uuid, bool)| {
-            let mut set = (*connected_sessions).clone();
-            if connected {
-                set.insert(session_id);
-            } else {
-                set.remove(&session_id);
-            }
-            connected_sessions.set(set);
+            session_state.dispatch(DashboardSessionAction::SetConnected {
+                session_id,
+                connected,
+            });
         })
     };
 
@@ -529,23 +507,26 @@ pub fn dashboard_page() -> Html {
 
     let on_toggle_pause = {
         let refresh = sessions_hook.refresh.clone();
-        let hidden_sessions = hidden_sessions.clone();
+        let session_state = session_state.clone();
         Callback::from(move |(session_id, pause): (Uuid, bool)| {
             let refresh = refresh.clone();
-            let hidden_sessions = hidden_sessions.clone();
+            let session_state = session_state.clone();
             spawn_local(async move {
                 let action = if pause { "pause" } else { "resume" };
                 let url = utils::api_url(&format!("/api/sessions/{}/{}", session_id, action));
                 match Request::post(&url).send().await {
                     Ok(resp) if resp.status() == 202 => {
-                        let mut set = (*hidden_sessions).clone();
+                        let mut set = session_state.hidden_sessions.clone();
                         if pause {
                             set.insert(session_id);
                         } else {
                             set.remove(&session_id);
                         }
                         save_hidden_sessions(&set);
-                        hidden_sessions.set(set);
+                        session_state.dispatch(DashboardSessionAction::SetHidden {
+                            session_id,
+                            hidden: pause,
+                        });
                         refresh.emit(());
                     }
                     Ok(resp) => {
@@ -565,16 +546,17 @@ pub fn dashboard_page() -> Html {
     };
 
     let on_toggle_hidden = {
-        let hidden_sessions = hidden_sessions.clone();
+        let session_state = session_state.clone();
         Callback::from(move |session_id: Uuid| {
-            let mut set = (*hidden_sessions).clone();
-            if set.contains(&session_id) {
-                set.remove(&session_id);
-            } else {
+            let hidden = !session_state.hidden_sessions.contains(&session_id);
+            let mut set = session_state.hidden_sessions.clone();
+            if hidden {
                 set.insert(session_id);
+            } else {
+                set.remove(&session_id);
             }
             save_hidden_sessions(&set);
-            hidden_sessions.set(set);
+            session_state.dispatch(DashboardSessionAction::SetHidden { session_id, hidden });
         })
     };
 
@@ -597,11 +579,9 @@ pub fn dashboard_page() -> Html {
     };
 
     let on_message_sent = {
-        let awaiting_sessions = awaiting_sessions.clone();
+        let session_state = session_state.clone();
         Callback::from(move |current_session_id: Uuid| {
-            let mut set = (*awaiting_sessions).clone();
-            set.remove(&current_session_id);
-            awaiting_sessions.set(set);
+            session_state.dispatch(DashboardSessionAction::MessageSent(current_session_id));
         })
     };
 
@@ -642,7 +622,8 @@ pub fn dashboard_page() -> Html {
     };
 
     // Computed values
-    let waiting_count = awaiting_sessions
+    let waiting_count = session_state
+        .awaiting_sessions
         .iter()
         .filter(|id| !effective_hidden_sessions.contains(id))
         .count();
@@ -815,10 +796,10 @@ pub fn dashboard_page() -> Html {
                     <SessionRail
                         sessions={active_sessions.clone()}
                         focused_index={focused_index}
-                        awaiting_sessions={(*awaiting_sessions).clone()}
+                        awaiting_sessions={session_state.awaiting_sessions.clone()}
                         hidden_sessions={effective_hidden_sessions.clone()}
                         inactive_hidden={*inactive_hidden}
-                        connected_sessions={(*connected_sessions).clone()}
+                        connected_sessions={session_state.connected_sessions.clone()}
                         nav_mode={keyboard_nav.nav_mode}
                         activity_timestamps={(*activity_timestamps).clone()}
                         server_version={(*server_version).clone()}
@@ -836,7 +817,7 @@ pub fn dashboard_page() -> Html {
                         {
                             active_sessions.iter().enumerate().map(|(index, session)| {
                                 let is_focused = index == focused_index;
-                                let is_activated = activated_sessions.contains(&session.id);
+                                let is_activated = session_state.activated_sessions.contains(&session.id);
                                 if is_activated {
                                     html! {
                                         <div

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -1,0 +1,246 @@
+//! Pure reducer state for the dashboard's session-tracking UI.
+//!
+//! `DashboardPage` still owns side effects such as localStorage writes and
+//! network calls. This reducer keeps the id/set bookkeeping in one tested
+//! place so the page component can stay focused on orchestration.
+
+use shared::SessionInfo;
+use std::collections::HashSet;
+use std::rc::Rc;
+use uuid::Uuid;
+use yew::Reducible;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct DashboardSessionState {
+    pub focused_id: Option<Uuid>,
+    pub awaiting_sessions: HashSet<Uuid>,
+    pub hidden_sessions: HashSet<Uuid>,
+    pub connected_sessions: HashSet<Uuid>,
+    pub activated_sessions: HashSet<Uuid>,
+    pub initial_focus_set: bool,
+    pub sessions_at_launch: Option<HashSet<Uuid>>,
+}
+
+impl DashboardSessionState {
+    pub fn new(hidden_sessions: HashSet<Uuid>) -> Self {
+        Self {
+            focused_id: None,
+            awaiting_sessions: HashSet::new(),
+            hidden_sessions,
+            connected_sessions: HashSet::new(),
+            activated_sessions: HashSet::new(),
+            initial_focus_set: false,
+            sessions_at_launch: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum DashboardSessionAction {
+    InitializeFocus {
+        focus_id: Option<Uuid>,
+        activate_ids: Vec<Uuid>,
+    },
+    FocusAndActivate(Uuid),
+    Activate(Uuid),
+    SetAwaiting {
+        session_id: Uuid,
+        awaiting: bool,
+    },
+    SetConnected {
+        session_id: Uuid,
+        connected: bool,
+    },
+    SetHidden {
+        session_id: Uuid,
+        hidden: bool,
+    },
+    MessageSent(Uuid),
+    StoreLaunchSnapshot(Vec<Uuid>),
+    FocusNewlyLaunched(Vec<Uuid>),
+}
+
+impl Reducible for DashboardSessionState {
+    type Action = DashboardSessionAction;
+
+    fn reduce(self: Rc<Self>, action: Self::Action) -> Rc<Self> {
+        let mut state = (*self).clone();
+
+        match action {
+            DashboardSessionAction::InitializeFocus {
+                focus_id,
+                activate_ids,
+            } => {
+                if state.initial_focus_set {
+                    return self;
+                }
+                state.focused_id = focus_id;
+                state.activated_sessions.extend(activate_ids);
+                state.initial_focus_set = true;
+            }
+            DashboardSessionAction::FocusAndActivate(session_id) => {
+                state.focused_id = Some(session_id);
+                state.activated_sessions.insert(session_id);
+            }
+            DashboardSessionAction::Activate(session_id) => {
+                state.activated_sessions.insert(session_id);
+            }
+            DashboardSessionAction::SetAwaiting {
+                session_id,
+                awaiting,
+            } => {
+                let changed = set_membership(&mut state.awaiting_sessions, session_id, awaiting);
+                if !changed {
+                    return self;
+                }
+            }
+            DashboardSessionAction::SetConnected {
+                session_id,
+                connected,
+            } => {
+                let changed = set_membership(&mut state.connected_sessions, session_id, connected);
+                if !changed {
+                    return self;
+                }
+            }
+            DashboardSessionAction::SetHidden { session_id, hidden } => {
+                let changed = set_membership(&mut state.hidden_sessions, session_id, hidden);
+                if !changed {
+                    return self;
+                }
+            }
+            DashboardSessionAction::MessageSent(session_id) => {
+                if !state.awaiting_sessions.remove(&session_id) {
+                    return self;
+                }
+            }
+            DashboardSessionAction::StoreLaunchSnapshot(session_ids) => {
+                state.sessions_at_launch = Some(session_ids.into_iter().collect());
+            }
+            DashboardSessionAction::FocusNewlyLaunched(session_ids) => {
+                let Some(snapshot) = &state.sessions_at_launch else {
+                    return self;
+                };
+                let Some(new_session_id) =
+                    session_ids.into_iter().find(|id| !snapshot.contains(id))
+                else {
+                    return self;
+                };
+
+                state.focused_id = Some(new_session_id);
+                state.activated_sessions.insert(new_session_id);
+                state.sessions_at_launch = None;
+            }
+        }
+
+        Rc::new(state)
+    }
+}
+
+pub(super) fn active_session_ids(sessions: &[SessionInfo]) -> Vec<Uuid> {
+    sessions.iter().map(|s| s.id).collect()
+}
+
+fn set_membership(set: &mut HashSet<Uuid>, id: Uuid, present: bool) -> bool {
+    if present {
+        set.insert(id)
+    } else {
+        set.remove(&id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    fn reduce(
+        state: DashboardSessionState,
+        action: DashboardSessionAction,
+    ) -> Rc<DashboardSessionState> {
+        Rc::new(state).reduce(action)
+    }
+
+    #[test]
+    fn initialize_focus_runs_once_and_activates_visible_sessions() {
+        let initial = DashboardSessionState::new(HashSet::new());
+        let state = reduce(
+            initial,
+            DashboardSessionAction::InitializeFocus {
+                focus_id: Some(id(1)),
+                activate_ids: vec![id(1), id(2)],
+            },
+        );
+
+        assert_eq!(state.focused_id, Some(id(1)));
+        assert!(state.initial_focus_set);
+        assert_eq!(state.activated_sessions, HashSet::from_iter([id(1), id(2)]));
+
+        let state = state.reduce(DashboardSessionAction::InitializeFocus {
+            focus_id: Some(id(3)),
+            activate_ids: vec![id(3)],
+        });
+
+        assert_eq!(state.focused_id, Some(id(1)));
+        assert_eq!(state.activated_sessions, HashSet::from_iter([id(1), id(2)]));
+    }
+
+    #[test]
+    fn focus_and_activate_keeps_focus_by_session_id() {
+        let state = reduce(
+            DashboardSessionState::new(HashSet::new()),
+            DashboardSessionAction::FocusAndActivate(id(42)),
+        );
+
+        assert_eq!(state.focused_id, Some(id(42)));
+        assert!(state.activated_sessions.contains(&id(42)));
+    }
+
+    #[test]
+    fn focus_newly_launched_uses_snapshot_delta() {
+        let state = reduce(
+            DashboardSessionState::new(HashSet::new()),
+            DashboardSessionAction::StoreLaunchSnapshot(vec![id(1), id(2)]),
+        );
+
+        let state = state.reduce(DashboardSessionAction::FocusNewlyLaunched(vec![
+            id(1),
+            id(2),
+            id(3),
+        ]));
+
+        assert_eq!(state.focused_id, Some(id(3)));
+        assert!(state.activated_sessions.contains(&id(3)));
+        assert_eq!(state.sessions_at_launch, None);
+    }
+
+    #[test]
+    fn awaiting_connected_hidden_and_sent_actions_update_sets() {
+        let state = DashboardSessionState::new(HashSet::new());
+        let state = reduce(
+            state,
+            DashboardSessionAction::SetAwaiting {
+                session_id: id(1),
+                awaiting: true,
+            },
+        );
+        let state = state.reduce(DashboardSessionAction::SetConnected {
+            session_id: id(2),
+            connected: true,
+        });
+        let state = state.reduce(DashboardSessionAction::SetHidden {
+            session_id: id(3),
+            hidden: true,
+        });
+
+        assert!(state.awaiting_sessions.contains(&id(1)));
+        assert!(state.connected_sessions.contains(&id(2)));
+        assert!(state.hidden_sessions.contains(&id(3)));
+
+        let state = state.reduce(DashboardSessionAction::MessageSent(id(1)));
+        assert!(!state.awaiting_sessions.contains(&id(1)));
+    }
+}


### PR DESCRIPTION
## Summary
- add a pure `DashboardSessionState` reducer for dashboard session UI bookkeeping
- move focus, activated, awaiting, connected, hidden, and launch-snapshot state transitions out of `page.rs`
- keep side effects such as localStorage writes, sounds, and network refreshes in the component

## Verification
- cargo check -p frontend
- cargo test -p frontend page_state
- cargo clippy -p frontend --all-targets -- -D warnings
- cargo fmt --check
- git diff --check

Version: 2.12.32, reserved to merge after #1119 / 2.12.31.