### PR TITLE
Group-kill the agent process on stop to fix orphan leak (#927)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.32"
+version = "2.12.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.32"
+version = "2.12.33"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.32"
+version = "2.12.33"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.32"
+version = "2.12.33"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.32"
+version = "2.12.33"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.32"
+version = "2.12.33"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.32"
+version = "2.12.33"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.32"
+version = "2.12.33"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,12 +3290,13 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.32"
+version = "2.12.33"
 dependencies = [
  "anyhow",
  "chrono",
  "claude-codes",
  "directories",
+ "libc",
  "serde",
  "serde_json",
  "shared",
@@ -3352,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.32"
+version = "2.12.33"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.32"
+version = "2.12.33"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/agent.rs
+++ b/claude-session-lib/src/agent.rs
@@ -24,7 +24,7 @@ impl Agent for ClaudeAgent {
         // surfaced via the event channel — see the `Err(e) =>` branch below.
         let handle = tokio::spawn(async move {
             let session_id = config.session_id;
-            let client = match spawn_claude(&config).await {
+            let (client, pid) = match spawn_claude(&config).await {
                 Ok(c) => c,
                 Err(e) => {
                     let _ = event_tx.send(IoEvent::Error(e));
@@ -32,6 +32,9 @@ impl Agent for ClaudeAgent {
                     return;
                 }
             };
+            // Surface the OS pid so `Session::stop` can group-kill the agent
+            // tree instead of relying on `kill_on_drop` (#927).
+            let _ = event_tx.send(IoEvent::AgentStarted { pid });
             claude_io_task(session_id, client, command_rx, event_tx).await;
         });
         Ok(handle)

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -43,9 +43,13 @@ pub fn claude_cli_args(session_id: uuid::Uuid, resume: bool, extra_args: &[Strin
 }
 
 /// Spawn the Claude process and return its async client.
+/// Spawn the `claude` CLI and return the client plus the OS process id (when
+/// available). The pid lets `Session::stop` signal the agent's process group
+/// directly, rather than relying solely on `kill_on_drop` (which the SDK's
+/// detached-task ownership of the `Child` defeats — see #927).
 pub(crate) async fn spawn_claude(
     config: &SessionConfig,
-) -> Result<ClaudeAsyncClient, SessionError> {
+) -> Result<(ClaudeAsyncClient, Option<u32>), SessionError> {
     let claude_path = config.claude_path.as_deref().unwrap_or(Path::new("claude"));
 
     log_claude_info(claude_path);
@@ -75,11 +79,21 @@ pub(crate) async fn spawn_claude(
         // left holding its transcript and a WebSocket open.
         .kill_on_drop(true);
 
-    let child = cmd.spawn().map_err(SessionError::SpawnFailed)?;
+    // Put the agent in its own process group so `Session::stop` can signal the
+    // whole tree (claude + tools it spawns), not just the immediate PID. We
+    // can't rely on `kill_on_drop` alone: the SDK's `AsyncClient` keeps the
+    // `Child` alive in detached internal tasks, so an aborted I/O task never
+    // drops it and the claude process is orphaned (#927).
+    #[cfg(unix)]
+    cmd.process_group(0);
 
-    ClaudeAsyncClient::new(child).map_err(|e| {
+    let child = cmd.spawn().map_err(SessionError::SpawnFailed)?;
+    let pid = child.id();
+
+    let client = ClaudeAsyncClient::new(child).map_err(|e| {
         SessionError::CommunicationError(format!("Failed to create ClaudeAsyncClient: {}", e))
-    })
+    })?;
+    Ok((client, pid))
 }
 
 /// Log the resolved path and version of the claude binary for diagnostics.

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -366,7 +366,11 @@ async fn run_session_task(
             } => r,
             _ = cancel.cancelled() => {
                 info!("Session {} cancelled by stop request", config.session_id);
-                let _ = session.stop().await;
+                // Surface stop errors: `stop()` now group-kills the agent
+                // process (#927), so a failure here means a possible orphan.
+                if let Err(e) = session.stop().await {
+                    warn!("Session {} stop failed on cancel: {}", config.session_id, e);
+                }
                 return TaskOutcome {
                     exit_code: Some(0),
                     reason: SessionExitReason::Stopped,
@@ -374,7 +378,9 @@ async fn run_session_task(
             }
         };
 
-        let _ = session.stop().await;
+        if let Err(e) = session.stop().await {
+            warn!("Session {} stop failed: {}", config.session_id, e);
+        }
 
         let alive = started.elapsed();
         match result {

--- a/session-lib/Cargo.toml
+++ b/session-lib/Cargo.toml
@@ -22,3 +22,8 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 directories = { workspace = true }
 which = "8.0.0"
+
+# Unix-only: signal the agent's process group on stop/drop so the agent
+# process can't be orphaned when `kill_on_drop` doesn't fire (#927).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -33,6 +33,13 @@ pub enum IoCommand {
 
 /// Events emitted from the per-agent I/O task back up to `Session<A>`.
 pub enum IoEvent {
+    /// The agent OS process has been spawned; carries its pid (when the
+    /// platform exposes one). `Session` records it so `stop()` can signal the
+    /// agent's process group directly rather than relying on `kill_on_drop`,
+    /// which the SDK's detached-task ownership of the child defeats (#927).
+    AgentStarted {
+        pid: Option<u32>,
+    },
     /// Typed output from a claude-protocol session.
     Output(Box<ClaudeOutput>),
     /// Raw JSON output from a non-claude agent (e.g. Codex JSONL).

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -50,6 +50,11 @@ pub struct Session<A: Agent> {
     /// command channel alone does not end it. Aborting drops the task's client,
     /// which (with `kill_on_drop` on the spawn) kills the child.
     io_task: Option<tokio::task::JoinHandle<()>>,
+    /// OS pid of the agent process, learned from `IoEvent::AgentStarted`.
+    /// `stop()` uses it to signal the agent's process group directly, since
+    /// `kill_on_drop` doesn't fire when the SDK keeps the child alive in
+    /// detached tasks (#927).
+    agent_pid: Option<u32>,
     _agent: PhantomData<A>,
 }
 
@@ -62,6 +67,54 @@ impl<A: Agent> Drop for Session<A> {
         if let Some(handle) = self.io_task.take() {
             handle.abort();
         }
+        // Capture a queued AgentStarted pid (sync `try_recv`) so an
+        // immediate-drop-after-spawn still reaps the agent (#927 review).
+        self.capture_pending_agent_pid();
+        // Best-effort SIGKILL of the agent's process group. Drop can't await,
+        // so we can't do the graceful SIGTERM dance `stop()` does — but a
+        // synchronous group SIGKILL still prevents the orphan (#927) that
+        // `kill_on_drop` misses.
+        #[cfg(unix)]
+        if let Some(pid) = self.agent_pid.take() {
+            signal_process_group(pid, libc::SIGKILL);
+        }
+    }
+}
+
+/// Signal the process group led by `pid` (the agent was spawned as a group
+/// leader, so its pgid == pid). Negative pid targets the whole group, reaping
+/// tools the agent spawned. Best-effort: a dead group yields `ESRCH`, ignored.
+#[cfg(unix)]
+fn signal_process_group(pid: u32, sig: libc::c_int) {
+    // SAFETY: `kill(2)` with a group target and a fixed signal has no memory
+    // safety implications; the worst case is `ESRCH` for an already-dead group.
+    unsafe {
+        libc::kill(-(pid as i32), sig);
+    }
+}
+
+#[cfg(all(test, unix))]
+mod kill_tests {
+    use super::signal_process_group;
+    use std::os::unix::process::CommandExt;
+    use std::process::Command;
+
+    /// The whole point of #927: a SIGKILL to the agent's *group* reaps the
+    /// process even when the immediate child handle is never dropped. Spawn a
+    /// long `sleep` as its own group leader, group-kill it, and confirm it dies.
+    #[test]
+    fn group_kill_reaps_a_detached_process() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("60").process_group(0); // own group: pgid == pid
+        let mut child = cmd.spawn().expect("spawn sleep");
+        let pid = child.id();
+
+        signal_process_group(pid, libc::SIGKILL);
+
+        // `wait` reaps promptly because the process was killed; a leaked
+        // process would hang here. The exit is signal-terminated, not success.
+        let status = child.wait().expect("wait on killed child");
+        assert!(!status.success(), "process should have been killed");
     }
 }
 
@@ -87,6 +140,7 @@ impl<A: Agent> Session<A> {
             pending_permission: None,
             event_rx: Some(event_rx),
             io_task: Some(handle),
+            agent_pid: None,
             _agent: PhantomData,
         })
     }
@@ -127,6 +181,7 @@ impl<A: Agent> Session<A> {
             pending_permission: snapshot.pending_permission,
             event_rx,
             io_task,
+            agent_pid: None,
             _agent: PhantomData,
         })
     }
@@ -170,6 +225,11 @@ impl<A: Agent> Session<A> {
             let event_rx = self.event_rx.as_mut()?;
 
             match event_rx.recv().await {
+                Some(IoEvent::AgentStarted { pid }) => {
+                    // Record the agent pid for `stop()`'s group-kill (#927);
+                    // not a consumer-facing event, so keep looping.
+                    self.agent_pid = pid;
+                }
                 Some(IoEvent::Output(boxed_output)) => {
                     let output = *boxed_output;
 
@@ -409,8 +469,25 @@ impl<A: Agent> Session<A> {
         Ok(())
     }
 
+    /// Drain any queued events to capture a not-yet-consumed
+    /// `IoEvent::AgentStarted` pid. `next_event` normally records it, but an
+    /// immediate stop/cancel right after spawn can run before `next_event`
+    /// ever drains the channel — without this, the group-kill in `stop()` /
+    /// `Drop` would be skipped and the agent orphaned anyway (#927 review).
+    fn capture_pending_agent_pid(&mut self) {
+        if let Some(rx) = self.event_rx.as_mut() {
+            while let Ok(event) = rx.try_recv() {
+                if let IoEvent::AgentStarted { pid } = event {
+                    self.agent_pid = pid;
+                }
+            }
+        }
+    }
+
     /// Gracefully stop the session and reap the agent process.
     pub async fn stop(&mut self) -> Result<(), SessionError> {
+        // Capture a queued pid before dropping the receiver below.
+        self.capture_pending_agent_pid();
         // Drop the channels first so the I/O task stops accepting input.
         self.command_tx = None;
         self.event_rx = None;
@@ -423,6 +500,17 @@ impl<A: Agent> Session<A> {
         if let Some(handle) = self.io_task.take() {
             handle.abort();
             let _ = handle.await;
+        }
+        // Explicitly terminate the agent's process group. `kill_on_drop` is
+        // unreliable here — the SDK's `AsyncClient` keeps the child alive in
+        // detached tasks, so aborting the I/O task doesn't drop (and thus
+        // doesn't kill) it, orphaning the agent process (#927). SIGTERM first
+        // for a clean shutdown, then SIGKILL after a short grace period.
+        #[cfg(unix)]
+        if let Some(pid) = self.agent_pid.take() {
+            signal_process_group(pid, libc::SIGTERM);
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            signal_process_group(pid, libc::SIGKILL);
         }
         self.state = SessionState::Exited { code: 0 };
         Ok(())


### PR DESCRIPTION
Fixes #927. **Round 2, reliability slice 2.**

## Problem
Stopped/cancelled launcher sessions leaked their `claude` child process — production saw **8 orphaned `claude --resume` processes and 20 GB RSS**, reaped only by restarting the unit (one leaked per scheduled-task fire).

## Root cause
`Session::stop` aborts the I/O task and relies on `kill_on_drop`. But the orphans were **alive, not zombies** — the SDK's `AsyncClient` keeps the `Child` in detached internal tasks, so aborting the I/O task never drops (or kills) it. And `abort()` can't run cleanup, so there's no graceful kill path.

## Fix (agent-neutral; Claude path populated)
- Spawn the claude agent in its **own process group** (`process_group(0)`, Unix) and surface its pid via a new `IoEvent::AgentStarted { pid }`.
- `Session` records the pid; **`stop()` now SIGTERM → 500ms grace → SIGKILL the agent's process *group*** (catches tools it spawned). `Drop` does a best-effort group SIGKILL (synchronous, no await). Unix-only via a new `libc` dep; non-Unix falls back to prior `kill_on_drop`.
- `process_manager` **surfaces `stop()` errors** instead of `let _ =`.

## Codex scope
Codex's app-server is spawned by the SDK (`CodexAsyncClient::start_with`) — no `Command`/process-group access and the pid isn't exposed — so it doesn't set `agent_pid` and falls back to the existing behavior (**no regression**). The machinery (`AgentStarted` / `agent_pid` / group-kill) is agent-neutral and ready to extend when the SDK exposes the pid. Flagged as a follow-up.

## Test
`group_kill_reaps_a_detached_process` spawns a `sleep` as a group leader and confirms the group SIGKILL reaps it — validates the core mechanism without needing the full Session machinery. (A full orphan-reaping integration test is Round 2 testability item #5.)

Build (native + WASM) + clippy + fmt + `cargo test -p session-lib` (34) green. Version 2.12.33. @codex — proxy/launcher reliability is my domain; quick review when free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)