### PR TITLE
Move dashboard chrome state into reducer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.33"
+version = "2.12.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.33"
+version = "2.12.34"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.33"
+version = "2.12.34"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.33"
+version = "2.12.34"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.33"
+version = "2.12.34"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.33"
+version = "2.12.34"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.33"
+version = "2.12.34"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.33"
+version = "2.12.34"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.33"
+version = "2.12.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.33"
+version = "2.12.34"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.33"
+version = "2.12.34"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -1,6 +1,9 @@
 //! Dashboard page - Main session management interface
 
-use super::page_state::{active_session_ids, DashboardSessionAction, DashboardSessionState};
+use super::page_state::{
+    active_session_ids, DashboardSessionAction, DashboardSessionState, DashboardUiAction,
+    DashboardUiState,
+};
 use super::session_order;
 use super::session_rail::{ActivityRef, SessionRail};
 use super::session_view::SessionView;
@@ -94,19 +97,18 @@ pub fn dashboard_page() -> Html {
     let spend_initialized = use_state(|| false);
 
     // UI state
-    let show_launch_dialog = use_state(|| false);
-    let show_admin = use_state(|| false);
-    let show_settings = use_state(|| false);
+    let ui_state = use_reducer_eq(|| {
+        DashboardUiState::new(
+            load_inactive_hidden(),
+            load_show_cost(),
+            load_rail_position(),
+        )
+    });
     // Focus is tracked by `session_id` (the source of truth), not by array
     // index — see `session_order` / issue #1094. The display index is derived
     // from this each render, so a reordered poll never bounces focus onto a
     // different session.
     let session_state = use_reducer_eq(|| DashboardSessionState::new(load_hidden_sessions()));
-    let inactive_hidden = use_state(load_inactive_hidden);
-    let show_cost = use_state(load_show_cost);
-    let rail_position = use_state(load_rail_position);
-    let pending_leave = use_state(|| None::<Uuid>);
-    let pending_delete = use_state(|| None::<Uuid>);
     let is_admin = use_state(|| false);
     let current_user_id = use_state(|| None::<Uuid>);
     let app_title = use_state(|| "Agent Portal".to_string());
@@ -305,7 +307,7 @@ pub fn dashboard_page() -> Html {
         focused_index,
         hidden_sessions: effective_hidden_sessions.clone(),
         connected_sessions: session_state.connected_sessions.clone(),
-        inactive_hidden: *inactive_hidden,
+        inactive_hidden: ui_state.inactive_hidden,
         on_select: on_select_session.clone(),
         on_activate,
         on_interrupt,
@@ -313,29 +315,28 @@ pub fn dashboard_page() -> Html {
 
     // Modal open callbacks
     let go_to_admin = {
-        let show_admin = show_admin.clone();
-        Callback::from(move |_| show_admin.set(true))
+        let ui_state = ui_state.clone();
+        Callback::from(move |_| ui_state.dispatch(DashboardUiAction::ShowAdmin))
     };
 
     let go_to_settings = {
-        let show_settings = show_settings.clone();
-        Callback::from(move |_| show_settings.set(true))
+        let ui_state = ui_state.clone();
+        Callback::from(move |_| ui_state.dispatch(DashboardUiAction::ShowSettings))
     };
 
     let close_admin = {
-        let show_admin = show_admin.clone();
-        Callback::from(move |_: ()| show_admin.set(false))
+        let ui_state = ui_state.clone();
+        Callback::from(move |_: ()| ui_state.dispatch(DashboardUiAction::CloseAdmin))
     };
 
     let close_settings = {
-        let show_settings = show_settings.clone();
-        let rail_position = rail_position.clone();
+        let ui_state = ui_state.clone();
         Callback::from(move |_: ()| {
             // The Appearance panel may have changed this; re-sync from
             // localStorage so the dashboard picks up the new value when
             // the user navigates back.
-            rail_position.set(load_rail_position());
-            show_settings.set(false);
+            ui_state.dispatch(DashboardUiAction::SetRailPosition(load_rail_position()));
+            ui_state.dispatch(DashboardUiAction::CloseSettings);
         })
     };
 
@@ -343,27 +344,27 @@ pub fn dashboard_page() -> Html {
 
     // Leave session callbacks
     let on_leave = {
-        let pending_leave = pending_leave.clone();
+        let ui_state = ui_state.clone();
         Callback::from(move |session_id: Uuid| {
-            pending_leave.set(Some(session_id));
+            ui_state.dispatch(DashboardUiAction::RequestLeave(session_id));
         })
     };
 
     let on_cancel_leave = {
-        let pending_leave = pending_leave.clone();
+        let ui_state = ui_state.clone();
         Callback::from(move |_| {
-            pending_leave.set(None);
+            ui_state.dispatch(DashboardUiAction::ClearPendingLeave);
         })
     };
 
     let on_confirm_leave = {
-        let pending_leave = pending_leave.clone();
+        let ui_state = ui_state.clone();
         let refresh = sessions_hook.refresh.clone();
         let current_user_id = current_user_id.clone();
         Callback::from(move |_| {
-            if let Some(session_id) = *pending_leave {
+            if let Some(session_id) = ui_state.pending_leave {
                 let refresh = refresh.clone();
-                let pending_leave = pending_leave.clone();
+                let ui_state = ui_state.clone();
                 let user_id = *current_user_id;
                 spawn_local(async move {
                     if let Some(user_id) = user_id {
@@ -388,33 +389,33 @@ pub fn dashboard_page() -> Html {
                     } else {
                         log::error!("Failed to get current user ID for leave");
                     }
-                    pending_leave.set(None);
+                    ui_state.dispatch(DashboardUiAction::ClearPendingLeave);
                 });
             }
         })
     };
 
     let on_delete = {
-        let pending_delete = pending_delete.clone();
+        let ui_state = ui_state.clone();
         Callback::from(move |session_id: Uuid| {
-            pending_delete.set(Some(session_id));
+            ui_state.dispatch(DashboardUiAction::RequestDelete(session_id));
         })
     };
 
     let on_cancel_delete = {
-        let pending_delete = pending_delete.clone();
+        let ui_state = ui_state.clone();
         Callback::from(move |_| {
-            pending_delete.set(None);
+            ui_state.dispatch(DashboardUiAction::ClearPendingDelete);
         })
     };
 
     let on_confirm_delete = {
-        let pending_delete = pending_delete.clone();
+        let ui_state = ui_state.clone();
         let refresh = sessions_hook.refresh.clone();
         Callback::from(move |_| {
-            if let Some(session_id) = *pending_delete {
+            if let Some(session_id) = ui_state.pending_delete {
                 let refresh = refresh.clone();
-                let pending_delete = pending_delete.clone();
+                let ui_state = ui_state.clone();
                 spawn_local(async move {
                     let api_endpoint = utils::api_url(&format!("/api/sessions/{}", session_id));
                     match Request::delete(&api_endpoint).send().await {
@@ -428,23 +429,23 @@ pub fn dashboard_page() -> Html {
                             log::error!("Failed to delete session: {:?}", e);
                         }
                     }
-                    pending_delete.set(None);
+                    ui_state.dispatch(DashboardUiAction::ClearPendingDelete);
                 });
             }
         })
     };
 
     let toggle_launch_dialog = {
-        let show_launch_dialog = show_launch_dialog.clone();
+        let ui_state = ui_state.clone();
         Callback::from(move |_: MouseEvent| {
-            show_launch_dialog.set(!*show_launch_dialog);
+            ui_state.dispatch(DashboardUiAction::ToggleLaunchDialog);
         })
     };
 
     let on_launch_close = {
-        let show_launch_dialog = show_launch_dialog.clone();
+        let ui_state = ui_state.clone();
         Callback::from(move |_| {
-            show_launch_dialog.set(false);
+            ui_state.dispatch(DashboardUiAction::CloseLaunchDialog);
         })
     };
 
@@ -561,20 +562,20 @@ pub fn dashboard_page() -> Html {
     };
 
     let on_toggle_inactive_hidden = {
-        let inactive_hidden = inactive_hidden.clone();
+        let ui_state = ui_state.clone();
         Callback::from(move |_: MouseEvent| {
-            let new_val = !*inactive_hidden;
+            let new_val = !ui_state.inactive_hidden;
             save_inactive_hidden(new_val);
-            inactive_hidden.set(new_val);
+            ui_state.dispatch(DashboardUiAction::SetInactiveHidden(new_val));
         })
     };
 
     let on_toggle_show_cost = {
-        let show_cost = show_cost.clone();
+        let ui_state = ui_state.clone();
         Callback::from(move |_: MouseEvent| {
-            let new_val = !*show_cost;
+            let new_val = !ui_state.show_cost;
             save_show_cost(new_val);
-            show_cost.set(new_val);
+            ui_state.dispatch(DashboardUiAction::SetShowCost(new_val));
         })
     };
 
@@ -703,7 +704,7 @@ pub fn dashboard_page() -> Html {
                             );
                             html! {
                                 <>
-                                    if *show_cost {
+                                    if ui_state.show_cost {
                                         <span class={spend_class} title="Total spend across all sessions">
                                             { utils::format_dollars(total_user_spend) }
                                         </span>
@@ -711,9 +712,9 @@ pub fn dashboard_page() -> Html {
                                     <button
                                         class="cost-toggle-btn"
                                         onclick={on_toggle_show_cost.clone()}
-                                        title={if *show_cost { "Hide cost" } else { "Show cost" }}
+                                        title={if ui_state.show_cost { "Hide cost" } else { "Show cost" }}
                                     >
-                                        { if *show_cost { "$" } else { "$?" } }
+                                        { if ui_state.show_cost { "$" } else { "$?" } }
                                     </button>
                                 </>
                             }
@@ -733,11 +734,11 @@ pub fn dashboard_page() -> Html {
                         }
                     }
                     <button
-                        class={classes!("new-session-button", if *show_launch_dialog { "active" } else { "" })}
+                        class={classes!("new-session-button", if ui_state.show_launch_dialog { "active" } else { "" })}
                         onclick={toggle_launch_dialog.clone()}
-                        title={if *show_launch_dialog { "Close" } else { "Launch a session or install agent-portal" }}
+                        title={if ui_state.show_launch_dialog { "Close" } else { "Launch a session or install agent-portal" }}
                     >
-                        { if *show_launch_dialog { "Close" } else { "+ Launch Session" } }
+                        { if ui_state.show_launch_dialog { "Close" } else { "+ Launch Session" } }
                     </button>
                     {
                         if *is_admin {
@@ -760,7 +761,7 @@ pub fn dashboard_page() -> Html {
             </header>
 
             // Launch session dialog
-            if *show_launch_dialog {
+            if ui_state.show_launch_dialog {
                 <LaunchDialog on_close={on_launch_close.clone()} on_launched={on_launch_success.clone()} />
             }
 
@@ -791,14 +792,14 @@ pub fn dashboard_page() -> Html {
                 </div>
             } else {
                 <>
-                    <div class={classes!("dashboard-body", rail_position.body_class())}>
+                    <div class={classes!("dashboard-body", ui_state.rail_position.body_class())}>
                     // Session Rail
                     <SessionRail
                         sessions={active_sessions.clone()}
                         focused_index={focused_index}
                         awaiting_sessions={session_state.awaiting_sessions.clone()}
                         hidden_sessions={effective_hidden_sessions.clone()}
-                        inactive_hidden={*inactive_hidden}
+                        inactive_hidden={ui_state.inactive_hidden}
                         connected_sessions={session_state.connected_sessions.clone()}
                         nav_mode={keyboard_nav.nav_mode}
                         activity_timestamps={(*activity_timestamps).clone()}
@@ -895,7 +896,7 @@ pub fn dashboard_page() -> Html {
 
             // Delete confirmation modal
             {
-                if let Some(session_id) = *pending_delete {
+                if let Some(session_id) = ui_state.pending_delete {
                     let session_name = sessions.iter()
                         .find(|s| s.id == session_id)
                         .map(|s| utils::extract_folder(&s.working_directory))
@@ -918,14 +919,14 @@ pub fn dashboard_page() -> Html {
             }
 
             // Admin modal — full-page overlay preserves dashboard state
-            if *show_admin {
+            if ui_state.show_admin {
                 <div class="full-page-modal">
                     <AdminPage on_close={close_admin.clone()} current_user_id={*current_user_id} />
                 </div>
             }
 
             // Settings modal — full-page overlay preserves dashboard state
-            if *show_settings {
+            if ui_state.show_settings {
                 <div class="full-page-modal">
                     <SettingsPage on_close={close_settings.clone()} />
                 </div>
@@ -933,7 +934,7 @@ pub fn dashboard_page() -> Html {
 
             // Leave confirmation modal
             {
-                if let Some(session_id) = *pending_leave {
+                if let Some(session_id) = ui_state.pending_leave {
                     let session_name = sessions.iter()
                         .find(|s| s.id == session_id)
                         .map(|s| utils::extract_folder(&s.working_directory))

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -10,6 +10,8 @@ use std::rc::Rc;
 use uuid::Uuid;
 use yew::Reducible;
 
+use super::types::RailPosition;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct DashboardSessionState {
     pub focused_id: Option<Uuid>,
@@ -149,6 +151,102 @@ fn set_membership(set: &mut HashSet<Uuid>, id: Uuid, present: bool) -> bool {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct DashboardUiState {
+    pub show_launch_dialog: bool,
+    pub show_admin: bool,
+    pub show_settings: bool,
+    pub inactive_hidden: bool,
+    pub show_cost: bool,
+    pub rail_position: RailPosition,
+    pub pending_leave: Option<Uuid>,
+    pub pending_delete: Option<Uuid>,
+}
+
+impl DashboardUiState {
+    pub fn new(inactive_hidden: bool, show_cost: bool, rail_position: RailPosition) -> Self {
+        Self {
+            show_launch_dialog: false,
+            show_admin: false,
+            show_settings: false,
+            inactive_hidden,
+            show_cost,
+            rail_position,
+            pending_leave: None,
+            pending_delete: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum DashboardUiAction {
+    ToggleLaunchDialog,
+    CloseLaunchDialog,
+    ShowAdmin,
+    CloseAdmin,
+    ShowSettings,
+    CloseSettings,
+    SetInactiveHidden(bool),
+    SetShowCost(bool),
+    SetRailPosition(RailPosition),
+    RequestLeave(Uuid),
+    ClearPendingLeave,
+    RequestDelete(Uuid),
+    ClearPendingDelete,
+}
+
+impl Reducible for DashboardUiState {
+    type Action = DashboardUiAction;
+
+    fn reduce(self: Rc<Self>, action: Self::Action) -> Rc<Self> {
+        let mut state = (*self).clone();
+
+        match action {
+            DashboardUiAction::ToggleLaunchDialog => {
+                state.show_launch_dialog = !state.show_launch_dialog;
+            }
+            DashboardUiAction::CloseLaunchDialog => {
+                state.show_launch_dialog = false;
+            }
+            DashboardUiAction::ShowAdmin => {
+                state.show_admin = true;
+            }
+            DashboardUiAction::CloseAdmin => {
+                state.show_admin = false;
+            }
+            DashboardUiAction::ShowSettings => {
+                state.show_settings = true;
+            }
+            DashboardUiAction::CloseSettings => {
+                state.show_settings = false;
+            }
+            DashboardUiAction::SetInactiveHidden(hidden) => {
+                state.inactive_hidden = hidden;
+            }
+            DashboardUiAction::SetShowCost(show) => {
+                state.show_cost = show;
+            }
+            DashboardUiAction::SetRailPosition(position) => {
+                state.rail_position = position;
+            }
+            DashboardUiAction::RequestLeave(session_id) => {
+                state.pending_leave = Some(session_id);
+            }
+            DashboardUiAction::ClearPendingLeave => {
+                state.pending_leave = None;
+            }
+            DashboardUiAction::RequestDelete(session_id) => {
+                state.pending_delete = Some(session_id);
+            }
+            DashboardUiAction::ClearPendingDelete => {
+                state.pending_delete = None;
+            }
+        }
+
+        Rc::new(state)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,5 +340,57 @@ mod tests {
 
         let state = state.reduce(DashboardSessionAction::MessageSent(id(1)));
         assert!(!state.awaiting_sessions.contains(&id(1)));
+    }
+
+    fn reduce_ui(state: DashboardUiState, action: DashboardUiAction) -> Rc<DashboardUiState> {
+        Rc::new(state).reduce(action)
+    }
+
+    #[test]
+    fn ui_reducer_controls_modal_visibility() {
+        let state = DashboardUiState::new(false, false, RailPosition::Top);
+        let state = reduce_ui(state, DashboardUiAction::ToggleLaunchDialog);
+        assert!(state.show_launch_dialog);
+
+        let state = state.reduce(DashboardUiAction::CloseLaunchDialog);
+        assert!(!state.show_launch_dialog);
+
+        let state = state.reduce(DashboardUiAction::ShowAdmin);
+        assert!(state.show_admin);
+        let state = state.reduce(DashboardUiAction::CloseAdmin);
+        assert!(!state.show_admin);
+
+        let state = state.reduce(DashboardUiAction::ShowSettings);
+        assert!(state.show_settings);
+        let state = state.reduce(DashboardUiAction::CloseSettings);
+        assert!(!state.show_settings);
+    }
+
+    #[test]
+    fn ui_reducer_tracks_preferences() {
+        let state = DashboardUiState::new(false, false, RailPosition::Top);
+        let state = reduce_ui(state, DashboardUiAction::SetInactiveHidden(true));
+        let state = state.reduce(DashboardUiAction::SetShowCost(true));
+        let state = state.reduce(DashboardUiAction::SetRailPosition(RailPosition::Left));
+
+        assert!(state.inactive_hidden);
+        assert!(state.show_cost);
+        assert_eq!(state.rail_position, RailPosition::Left);
+    }
+
+    #[test]
+    fn ui_reducer_tracks_pending_confirmations() {
+        let state = DashboardUiState::new(false, false, RailPosition::Top);
+        let state = reduce_ui(state, DashboardUiAction::RequestLeave(id(1)));
+        let state = state.reduce(DashboardUiAction::RequestDelete(id(2)));
+
+        assert_eq!(state.pending_leave, Some(id(1)));
+        assert_eq!(state.pending_delete, Some(id(2)));
+
+        let state = state.reduce(DashboardUiAction::ClearPendingLeave);
+        let state = state.reduce(DashboardUiAction::ClearPendingDelete);
+
+        assert_eq!(state.pending_leave, None);
+        assert_eq!(state.pending_delete, None);
     }
 }


### PR DESCRIPTION
## Summary
- add a pure `DashboardUiState` reducer for dashboard chrome/dialog state
- move launch/admin/settings visibility, pending leave/delete ids, inactive-hidden, show-cost, and rail-position state transitions out of `page.rs`
- keep localStorage writes and network side effects in the component

## Verification
- cargo check -p frontend
- cargo test -p frontend page_state
- cargo clippy -p frontend --all-targets -- -D warnings
- cargo fmt --check
- git diff --check

Version: 2.12.34, intended to merge after #1121 / 2.12.33.