### PR TITLE
Render typed inter-agent events from user echoes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.34"
+version = "2.12.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.34"
+version = "2.12.35"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.34"
+version = "2.12.35"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.34"
+version = "2.12.35"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.34"
+version = "2.12.35"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.34"
+version = "2.12.35"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.34"
+version = "2.12.35"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.34"
+version = "2.12.35"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.34"
+version = "2.12.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.34"
+version = "2.12.35"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.34"
+version = "2.12.35"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -61,6 +61,10 @@ pub fn render_optimistic_user_message(
     timestamp: Option<&str>,
     session_id: Uuid,
 ) -> Html {
+    if let Some(event) = portal::agent_message_event_from_text(&msg.content) {
+        return portal::render_agent_message_event(&event, timestamp, session_id);
+    }
+
     let label = match &msg.sender {
         Some(sender) if current_user_id != Some(sender.user_id.as_str()) => sender.name.clone(),
         _ => "You".to_string(),
@@ -101,6 +105,8 @@ pub fn render_user_message(
                 <div class="message-body">{ render_user_message_content(msg, session_id) }</div>
             </div>
         }
+    } else if let Some(event) = portal::agent_message_event_from_text(&text_content) {
+        portal::render_agent_message_event(&event, timestamp, session_id)
     } else if !text_content.is_empty() {
         html! {
             <div class={format!("claude-message user-message{}", pending_class)}>
@@ -123,6 +129,10 @@ pub fn render_optimistic_user_message_content(
     msg: &OptimisticUserMessage,
     session_id: Uuid,
 ) -> Html {
+    if let Some(event) = portal::agent_message_event_from_text(&msg.content) {
+        return portal::render_agent_message_body(&event.text, session_id);
+    }
+
     html! {
         <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&msg.content), session_id) }</div>
     }
@@ -141,6 +151,8 @@ pub fn render_user_message_content(msg: &shared::UserMessage, session_id: Uuid) 
         render_content_blocks(&msg.message.content, session_id)
     } else if text_content.is_empty() {
         html! {}
+    } else if let Some(event) = portal::agent_message_event_from_text(&text_content) {
+        portal::render_agent_message_body(&event.text, session_id)
     } else {
         html! {
             <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&text_content), session_id) }</div>

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -113,7 +113,7 @@ fn agent_label(agent_type: &str) -> &'static str {
     }
 }
 
-fn render_agent_message_event(
+fn render_agent_message_event_card(
     event: &AgentMessageEvent,
     timestamp: Option<&str>,
     session_id: Uuid,
@@ -140,7 +140,7 @@ fn render_agent_message_event(
     }
 }
 
-fn render_agent_message_body(text: &str, session_id: Uuid) -> Html {
+pub(crate) fn render_agent_message_body(text: &str, session_id: Uuid) -> Html {
     html! {
         <div class="user-text">
             { render_markdown_for_session(&text.replace('\n', "  \n"), session_id) }
@@ -160,13 +160,13 @@ fn portal_text(msg: &PortalMessage) -> String {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct AgentMessageEvent {
-    from_agent_type: String,
-    from_session_id: String,
-    text: String,
+pub(crate) struct AgentMessageEvent {
+    pub(crate) from_agent_type: String,
+    pub(crate) from_session_id: String,
+    pub(crate) text: String,
 }
 
-fn agent_message_event(msg: &PortalMessage) -> Option<AgentMessageEvent> {
+pub(crate) fn agent_message_event(msg: &PortalMessage) -> Option<AgentMessageEvent> {
     if let Some(shared::MessageOrigin::InterAgent {
         from_session_id,
         from_agent_type,
@@ -197,6 +197,19 @@ fn agent_message_event(msg: &PortalMessage) -> Option<AgentMessageEvent> {
         from_session_id: from_session_id.clone(),
         text: text.clone(),
     })
+}
+
+pub(crate) fn agent_message_event_from_text(text: &str) -> Option<AgentMessageEvent> {
+    let msg = serde_json::from_str::<PortalMessage>(text).ok()?;
+    agent_message_event(&msg)
+}
+
+pub(crate) fn render_agent_message_event(
+    event: &AgentMessageEvent,
+    timestamp: Option<&str>,
+    session_id: Uuid,
+) -> Html {
+    render_agent_message_event_card(event, timestamp, session_id)
 }
 
 fn render_continuation_prompt(
@@ -368,6 +381,22 @@ mod tests {
             "11111111-1111-1111-1111-111111111111"
         );
         assert_eq!(event.text, "hello from stale proxy");
+    }
+
+    #[test]
+    fn agent_message_event_parses_typed_portal_event_from_user_text() {
+        let msg = shared::PortalMessage::with_content(agent_message_content());
+        let text = serde_json::to_string(&msg).expect("portal json");
+
+        let event = agent_message_event_from_text(&text).expect("event");
+
+        assert_eq!(event.from_agent_type, "claude");
+        assert_eq!(
+            event.from_session_id,
+            "11111111-1111-1111-1111-111111111111"
+        );
+        assert_eq!(event.text, "hello from stale proxy");
+        assert!(agent_message_event_from_text("[message from claude 1111]\nbody").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- render whole user-message/optimistic echoes that contain a typed PortalMessage::AgentMessage as the existing other-agent card
- keep the fallback typed-only; no text-prefix parsing is restored
- reuse body-only rendering for grouped content to avoid nested message cards
- bump workspace version to 2.12.35

## Root cause
A stale or Codex-target path can surface the typed PortalMessage envelope inside a user-role echo. The existing #1118 fallback only ran on type=portal frames, so user-role frames rendered the envelope as markdown in a You bubble.

## Tests
- cargo test -p frontend agent_message_event
- cargo check -p frontend
- cargo clippy -p frontend --all-targets -- -D warnings
- cargo fmt --check
- git diff --check