### PR TITLE
Carry typed display_event to Codex's synthetic echo (durable inter-agent card fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.35"
+version = "2.12.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.35"
+version = "2.12.36"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.35"
+version = "2.12.36"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.35"
+version = "2.12.36"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.35"
+version = "2.12.36"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.35"
+version = "2.12.36"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.35"
+version = "2.12.36"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.35"
+version = "2.12.36"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.35"
+version = "2.12.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.35"
+version = "2.12.36"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.35"
+version = "2.12.36"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -78,7 +78,14 @@ pub(crate) async fn claude_io_task(
             // Handle incoming commands (input to send to Claude).
             Some(cmd) = command_rx.recv() => {
                 let result = match cmd {
-                    IoCommand::Input { input, delivered } => {
+                    // `display_event` is for agents that don't echo (Codex);
+                    // claude echoes its input and the proxy swaps the typed
+                    // event in via output_forwarder, so it's ignored here.
+                    IoCommand::Input {
+                        input,
+                        delivered,
+                        display_event: _,
+                    } => {
                         // Each fresh user input gets its own retry budget.
                         rate_limit_attempts = 0;
                         current_turn_was_rate_limited = false;
@@ -329,6 +336,7 @@ pub(crate) async fn claude_io_task(
                                     IoCommand::Input {
                                         input: new_input,
                                         delivered,
+                                        display_event: _,
                                     } => {
                                         // User typed something while we were waiting
                                         // — honor that, abandon the retry, and reset

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -965,16 +965,29 @@ async fn run_main_loop<A: Agent>(
 
                 debug!("sending to claude process: {}", truncate(&input.text, 100));
 
-                if let Some(display_event) = input.display_event.clone() {
-                    let mut pending = state.pending_input_display_events.lock().await;
-                    pending.push_back(PendingInputDisplayEvent {
-                        echoed_text: input.text.clone(),
-                        content: display_event,
-                    });
+                // Two mechanisms deliver the typed display event, exactly one
+                // per agent — never both:
+                //  - Claude echoes its input, so we stash the event here for the
+                //    output_forwarder to swap in on the matching ClaudeOutput::User.
+                //  - Codex doesn't echo, so its io-task emits the event itself
+                //    (handed in via send_input_with_display below).
+                // Gate the stash on Claude: pushing for Codex would leak the
+                // VecDeque entry forever, since nothing consumes it there (#1124).
+                if state.agent_type == shared::AgentType::Claude {
+                    if let Some(display_event) = input.display_event.clone() {
+                        let mut pending = state.pending_input_display_events.lock().await;
+                        pending.push_back(PendingInputDisplayEvent {
+                            echoed_text: input.text.clone(),
+                            content: display_event,
+                        });
+                    }
                 }
 
                 if let Err(e) = claude_session
-                    .send_input(serde_json::Value::String(input.text))
+                    .send_input_with_display(
+                        serde_json::Value::String(input.text),
+                        input.display_event,
+                    )
                     .await
                 {
                     error!("Failed to send to Claude: {}", e);

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -25,7 +25,11 @@ use crate::handler::handle_codex_server_message;
 use crate::helpers::{extract_prompt_text, parse_request_id};
 
 type DeliveryAck = oneshot::Sender<Result<(), String>>;
-type QueuedPrompt = (String, Option<DeliveryAck>);
+/// Queued user prompt: (agent-facing prompt text, delivery ack, optional typed
+/// display event). The display event — when present — is an inter-agent
+/// `PortalContent::AgentMessage` envelope the synthetic echo emits verbatim so
+/// it renders as the provenance card instead of a raw user bubble (#inter-agent).
+type QueuedPrompt = (String, Option<DeliveryAck>, Option<Box<serde_json::Value>>);
 
 /// Background task for Codex sessions.
 pub(crate) async fn codex_io_task(
@@ -426,13 +430,16 @@ pub(crate) async fn codex_io_task(
                                 );
                             if turn_ended {
                                 turn_active = false;
-                                if let Some((prompt, delivered)) = queued_prompts.pop_front() {
+                                if let Some((prompt, delivered, display_event)) =
+                                    queued_prompts.pop_front()
+                                {
                                     turn_tracker
                                         .start(Instant::now(), chrono::Utc::now());
                                     turn_active = start_codex_turn(
                                         &mut client,
                                         &thread_id,
                                         prompt,
+                                        display_event,
                                         delivered,
                                         &event_tx,
                                     )
@@ -541,14 +548,18 @@ pub(crate) async fn codex_io_task(
                                 tracing::error!("Failed to send Codex approval: {}", e);
                             }
                         }
-                        IoCommand::Input { input, delivered } => {
+                        IoCommand::Input {
+                            input,
+                            delivered,
+                            display_event,
+                        } => {
                             let prompt = extract_prompt_text(&input);
                             if !prompt.is_empty() {
                                 tracing::info!(
                                     "Queued Codex input received during active turn ({} pending)",
                                     queued_prompts.len() + 1
                                 );
-                                queued_prompts.push_back((prompt, delivered));
+                                queued_prompts.push_back((prompt, delivered, display_event));
                             } else if let Some(delivered) = delivered {
                                 let _ = delivered.send(Ok(()));
                             }
@@ -560,7 +571,11 @@ pub(crate) async fn codex_io_task(
         } else {
             // No active turn: wait for user input.
             match command_rx.recv().await {
-                Some(IoCommand::Input { input, delivered }) => {
+                Some(IoCommand::Input {
+                    input,
+                    delivered,
+                    display_event,
+                }) => {
                     let prompt = extract_prompt_text(&input);
                     if prompt.is_empty() {
                         if let Some(delivered) = delivered {
@@ -569,9 +584,15 @@ pub(crate) async fn codex_io_task(
                         continue;
                     }
                     turn_tracker.start(Instant::now(), chrono::Utc::now());
-                    turn_active =
-                        start_codex_turn(&mut client, &thread_id, prompt, delivered, &event_tx)
-                            .await;
+                    turn_active = start_codex_turn(
+                        &mut client,
+                        &thread_id,
+                        prompt,
+                        display_event,
+                        delivered,
+                        &event_tx,
+                    )
+                    .await;
                 }
                 Some(IoCommand::PermissionResponse(_)) => continue,
                 Some(IoCommand::CodexApproval { .. }) => {
@@ -590,19 +611,40 @@ async fn start_codex_turn(
     client: &mut CodexAsyncClient,
     thread_id: &str,
     prompt: String,
+    display_event: Option<Box<serde_json::Value>>,
     delivered: Option<DeliveryAck>,
     event_tx: &mpsc::UnboundedSender<IoEvent>,
 ) -> bool {
     // Codex's app-server protocol doesn't echo user input, so the frontend's
-    // optimistic-send pending entry would never clear. Synthesize an echo here
-    // in a shape that matches both the ClaudeOutput::User parse and the
-    // frontend's content-based pending-match. Skip <system-reminder> wrappers
-    // (portal reminder injection) because those shouldn't appear in transcript.
+    // optimistic-send pending entry would never clear. Synthesize a transcript
+    // entry here. Skip <system-reminder> wrappers (portal reminder injection)
+    // which shouldn't appear in transcript. The agent always receives `prompt`
+    // (the agent-facing text); only the *display* differs.
     if !prompt.starts_with("<system-reminder>") {
-        let echo = UserEchoEvent::new(prompt);
-        let _ = event_tx.send(IoEvent::RawOutput(to_raw_output(&echo)));
-        return start_codex_turn_request(client, thread_id, echo.content, delivered, event_tx)
-            .await;
+        match display_event {
+            // Inter-agent message: emit the typed PortalContent::AgentMessage
+            // event verbatim so it renders as the provenance card (matching the
+            // claude echo-replacement path), not a raw "You" bubble.
+            Some(event) => {
+                let _ = event_tx.send(IoEvent::RawOutput(*event));
+                return start_codex_turn_request(client, thread_id, prompt, delivered, event_tx)
+                    .await;
+            }
+            // Plain user input: synthesize a user echo in a shape that matches
+            // ClaudeOutput::User parse + the frontend's content-based pending-match.
+            None => {
+                let echo = UserEchoEvent::new(prompt);
+                let _ = event_tx.send(IoEvent::RawOutput(to_raw_output(&echo)));
+                return start_codex_turn_request(
+                    client,
+                    thread_id,
+                    echo.content,
+                    delivered,
+                    event_tx,
+                )
+                .await;
+            }
+        }
     }
 
     start_codex_turn_request(client, thread_id, prompt, delivered, event_tx).await

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -21,6 +21,14 @@ pub enum IoCommand {
     Input {
         input: ClaudeInput,
         delivered: Option<oneshot::Sender<Result<(), String>>>,
+        /// Optional typed portal event to display in place of the agent's echo
+        /// of this input (e.g. an inter-agent `PortalContent::AgentMessage`).
+        /// Claude relies on the proxy's echo-replacement and ignores this;
+        /// Codex — which doesn't echo — emits this verbatim as its synthetic
+        /// echo so inter-agent messages render as the typed card with
+        /// provenance instead of a raw `[message from …]` / JSON user bubble.
+        /// Boxed to keep this variant from dominating `IoCommand`'s size.
+        display_event: Option<Box<serde_json::Value>>,
     },
     /// Permission response for Claude's `can_use_tool` control flow.
     PermissionResponse(ControlResponse),

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -363,6 +363,19 @@ impl<A: Agent> Session<A> {
     /// The content can be a JSON string value for plain text, or a more
     /// complex JSON structure if needed.
     pub async fn send_input(&mut self, content: serde_json::Value) -> Result<(), SessionError> {
+        self.send_input_with_display(content, None).await
+    }
+
+    /// Like [`send_input`](Self::send_input), but carries an optional typed
+    /// portal `display_event` to render in place of the agent's echo (see
+    /// [`IoCommand::Input::display_event`]). The proxy passes the inter-agent
+    /// `PortalContent::AgentMessage` envelope here so the Codex path (which
+    /// can't rely on echo-replacement) still renders the typed card.
+    pub async fn send_input_with_display(
+        &mut self,
+        content: serde_json::Value,
+        display_event: Option<serde_json::Value>,
+    ) -> Result<(), SessionError> {
         if let SessionState::Exited { code } = self.state {
             return Err(SessionError::AlreadyExited(code));
         }
@@ -378,6 +391,7 @@ impl<A: Agent> Session<A> {
                 .send(IoCommand::Input {
                     input,
                     delivered: Some(delivered_tx),
+                    display_event: display_event.map(Box::new),
                 })
                 .map_err(|_| SessionError::CommunicationError("I/O task closed".to_string()))?;
             delivered_rx


### PR DESCRIPTION
Durable root fix for inter-agent messages rendering as a raw-JSON **"You" bubble** in Codex sessions. Companion to @codex's frontend guard (#1123, merged) — that renders the card from the user frame; **this closes the hole at the source.**

## Root cause (traced end-to-end with @codex, both ends converged)
Codex's app-server **doesn't echo user input**, so `codex-session-lib::start_codex_turn` synthesizes a `UserEchoEvent` — a `type:"user"` frame. That renders via the user-message path (the "You" bubble), **bypassing the portal `AgentMessage` card entirely**. The proxy's echo-replacement (`output_forwarder::replacement_input_display_event`) only matches `ClaudeOutput::User`, never Codex's `RawOutput` echo. So Codex-target inter-agent messages never got the typed card: **raw JSON** on a stale proxy (Matt's symptom), `[message from …]` text on a current one. None of #1115/#1117/#1118 ever covered this path.

## Fix
Thread the typed `display_event` (the inter-agent `PortalContent::AgentMessage` envelope the proxy's `classify_portal_input` already produces) through `IoCommand::Input` → new `Session::send_input_with_display`. When present, Codex's synthetic echo **emits that event verbatim** → renders as the provenance card via the *same typed path* as Claude — while the agent still receives the agent-facing text. Claude ignores the field (keeps its echo-replacement). Boxed to keep `IoCommand`'s variant size down (clippy `large_enum_variant`).

## Test
Build (native + WASM) + clippy (`-D` clean) + fmt + `cargo test` (session-lib 21, codex-session-lib 34, claude-session-lib 12) all green. Version 2.12.36.

@codex — this is the durable half we agreed; quick review (it's session-lib/proxy/codex-session-lib, my domain, but you traced it with me). Together with #1123 the Codex inter-agent path is fixed both at source and defensively at render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)