### PR TITLE
Input delivery-progress contract + ServerReceived stage (#939 slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.36"
+version = "2.12.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.36"
+version = "2.12.37"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.36"
+version = "2.12.37"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.36"
+version = "2.12.37"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.36"
+version = "2.12.37"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.36"
+version = "2.12.37"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.36"
+version = "2.12.37"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.36"
+version = "2.12.37"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.36"
+version = "2.12.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.36"
+version = "2.12.37"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.36"
+version = "2.12.37"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -99,18 +99,39 @@ fn handle_web_client_message(
             session_key,
             verified_session_id,
         ),
-        ClientToServer::AgentInput { content, send_mode } => {
+        ClientToServer::AgentInput {
+            content,
+            send_mode,
+            client_msg_id,
+        } => {
             // Gate on editor/owner role — re-queried on each input so role
             // revocations take effect immediately for already-connected viewers.
             // See `session_access::is_session_mutator` for the layered rules.
             if let Some(session_id) = *verified_session_id {
                 if !is_session_mutator(app_state, session_id, user_id) {
+                    if let Some(id) = client_msg_id {
+                        let _ = tx.send(ServerToClient::InputProgress {
+                            client_msg_id: id,
+                            stage: shared::InputDeliveryStage::Failed,
+                            message: Some("permission denied".to_string()),
+                        });
+                    }
                     let _ = tx.send(ServerToClient::Error {
                         message: "You don't have permission to send input to this session"
                             .to_string(),
                     });
                     return false;
                 }
+            }
+            // First delivery stage: the backend accepted the input frame. Later
+            // stages (ProxyReceived / AgentAccepted) come from the proxy ack
+            // path — a follow-up slice threads client_msg_id through there.
+            if let Some(id) = client_msg_id {
+                let _ = tx.send(ServerToClient::InputProgress {
+                    client_msg_id: id,
+                    stage: shared::InputDeliveryStage::ServerReceived,
+                    message: None,
+                });
             }
             handle_web_input(
                 session_manager,

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -687,6 +687,10 @@ impl SessionView {
                 } else {
                     Some(send_mode)
                 },
+                // TODO(delivery-progress): assign a real id + consume
+                // ServerToClient::InputProgress to drive the staged pending UI
+                // (Codex's slice). None keeps the legacy reconciliation path.
+                client_msg_id: None,
             };
             send_message(sender, msg);
         }

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -584,6 +584,9 @@ impl InputBar {
             on_send_frame.emit(ClientToServer::AgentInput {
                 content: serde_json::Value::String(combined),
                 send_mode: None,
+                // TODO(delivery-progress): real id + InputProgress consumption
+                // lands in the staged-UI slice (Codex).
+                client_msg_id: None,
             });
 
             link.send_message(InputBarMsg::FileUploaded(

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -279,6 +279,7 @@ mod tests {
             let msg = ClientToServer::AgentInput {
                 content: serde_json::Value::String(format!("msg-{i}")),
                 send_mode: None,
+                client_msg_id: None,
             };
             send_message(&tx, msg);
         }
@@ -341,6 +342,7 @@ mod tests {
                 ClientToServer::AgentInput {
                     content: serde_json::Value::String(format!("b-{i}")),
                     send_mode: None,
+                    client_msg_id: None,
                 },
             );
         }

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -10,6 +10,25 @@ use crate::{
     TurnMetrics,
 };
 
+/// Stages a user input passes through end to end, named by **transport fact**
+/// (not implied model semantics) so the UI never claims "the model has it"
+/// before it does. The frontend may relabel for display (e.g. `ProxyReceived`
+/// → "At local proxy", `AgentAccepted` → "In agent stream"). Carried on
+/// [`ServerToClient::InputProgress`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InputDeliveryStage {
+    /// Backend accepted the WebSocket input frame.
+    ServerReceived,
+    /// Proxy/launcher received the sequenced input from the backend.
+    ProxyReceived,
+    /// Delivered into the agent's stream (stdin write for Claude / turn start
+    /// for Codex). The optimistic "pending" row clears at this stage.
+    AgentAccepted,
+    /// Delivery failed; `InputProgress.message` carries the reason.
+    Failed,
+}
+
 pub struct ClientEndpoint;
 
 impl WsEndpoint for ClientEndpoint {
@@ -25,12 +44,19 @@ pub enum ClientToServer {
     /// Register to receive updates for a session
     Register(RegisterFields),
 
-    /// User sends input to Claude
+    /// User sends input to the agent.
     #[serde(rename = "ClaudeInput")]
     AgentInput {
         content: serde_json::Value,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         send_mode: Option<SendMode>,
+        /// Browser-assigned correlation id for delivery tracking. The backend
+        /// echoes it on every `ServerToClient::InputProgress` so the frontend
+        /// can advance the matching optimistic row through its delivery stages.
+        /// `None` from older clients (and the legacy content-reconciliation
+        /// path still covers those).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        client_msg_id: Option<Uuid>,
     },
 
     /// User's permission decision
@@ -103,6 +129,19 @@ pub enum ServerToClient {
         messages: Vec<serde_json::Value>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         last_created_at: Option<String>,
+    },
+
+    /// Delivery-progress update for a previously-sent `AgentInput`, keyed by
+    /// its browser-assigned `client_msg_id`. The frontend advances the matching
+    /// optimistic row through its stages and keeps it "pending"-styled until
+    /// `AgentAccepted` (the message is in the agent's stream). See
+    /// [`InputDeliveryStage`].
+    InputProgress {
+        client_msg_id: Uuid,
+        stage: InputDeliveryStage,
+        /// Populated for `Failed` (the delivery error), absent otherwise.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
     },
 
     /// Permission request from Claude (tool wants to execute)

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -104,18 +104,69 @@ mod tests {
 
     #[test]
     fn client_to_server_claude_input_roundtrip() {
+        let id = uuid::Uuid::from_u128(7);
         let msg = ClientToServer::AgentInput {
             content: serde_json::json!({"text": "hi"}),
             send_mode: None,
+            client_msg_id: Some(id),
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"ClaudeInput""#));
         let parsed: ClientToServer = serde_json::from_str(&json).unwrap();
         match parsed {
-            ClientToServer::AgentInput { send_mode, .. } => {
+            ClientToServer::AgentInput {
+                send_mode,
+                client_msg_id,
+                ..
+            } => {
                 assert!(send_mode.is_none());
+                assert_eq!(client_msg_id, Some(id));
             }
             _ => panic!("Wrong variant"),
+        }
+    }
+
+    /// Older clients omit `client_msg_id`; the field must default to `None`.
+    #[test]
+    fn client_input_without_client_msg_id_defaults_none() {
+        let json = r#"{"type":"ClaudeInput","content":{"text":"hi"}}"#;
+        let parsed: ClientToServer = serde_json::from_str(json).unwrap();
+        match parsed {
+            ClientToServer::AgentInput { client_msg_id, .. } => {
+                assert_eq!(client_msg_id, None);
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn input_progress_roundtrips_with_stage() {
+        use crate::InputDeliveryStage;
+        let id = uuid::Uuid::from_u128(42);
+        for (stage, tag) in [
+            (InputDeliveryStage::ServerReceived, "server_received"),
+            (InputDeliveryStage::ProxyReceived, "proxy_received"),
+            (InputDeliveryStage::AgentAccepted, "agent_accepted"),
+            (InputDeliveryStage::Failed, "failed"),
+        ] {
+            let msg = ServerToClient::InputProgress {
+                client_msg_id: id,
+                stage,
+                message: None,
+            };
+            let json = serde_json::to_string(&msg).unwrap();
+            assert!(json.contains(&format!(r#""stage":"{tag}""#)), "{json}");
+            match serde_json::from_str::<ServerToClient>(&json).unwrap() {
+                ServerToClient::InputProgress {
+                    client_msg_id,
+                    stage: parsed_stage,
+                    ..
+                } => {
+                    assert_eq!(client_msg_id, id);
+                    assert_eq!(parsed_stage, stage);
+                }
+                _ => panic!("Wrong variant"),
+            }
         }
     }
 


### PR DESCRIPTION
First slice of the homogenized user-message **delivery-progress** tracking Matt asked for: keep the optimistic row "pending" until the message is in the agent's stream, but show progression through the intermediate stages — replacing today's content-reconciliation guesswork.

## Contract (shared)
- `ClientToServer::AgentInput` gains a browser-assigned **`client_msg_id: Option<Uuid>`** (`#[serde(default)]`, wire-compatible — older clients send `None` and keep the legacy path).
- **`InputDeliveryStage { ServerReceived, ProxyReceived, AgentAccepted, Failed }`** — named by *transport fact*, not model semantics (per Codex's review), so the UI never implies "the model has it" before `AgentAccepted` (where the pending row clears). Frontend relabels for display ("At local proxy" / "In agent stream").
- **`ServerToClient::InputProgress { client_msg_id, stage, message? }`** (`message` carries the `Failed` reason).

## Backend
On `AgentInput`, emit `InputProgress{ServerReceived}` to the sender — and `Failed` with a reason when the role gate rejects the input — keyed by `client_msg_id`.

## Scope / what's next
- Frontend `AgentInput` constructions pass `client_msg_id: None` for now (TODO-tagged); **assigning real ids + consuming `InputProgress` to drive the staged pending UI is @codex's companion slice.**
- **`ProxyReceived` / `AgentAccepted`** (threading `client_msg_id` through `SequencedInput` → `InputAck`) is my next backend slice — that's the stage that clears pending.

## Test
Round-trip tests for the new field (incl. older-client default-`None`) and every stage tag; 68 shared tests + native/WASM build + clippy + fmt green. Version 2.12.37.

@codex — this is the contract you build the staged UI against. Once it lands I'll do the proxy threading for the later stages. Review when free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)