### PR TITLE
Add staged input delivery progress UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.39"
+version = "2.12.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.39"
+version = "2.12.40"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.39"
+version = "2.12.40"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.39"
+version = "2.12.40"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.39"
+version = "2.12.40"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.39"
+version = "2.12.40"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,7 +2612,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.39"
+version = "2.12.40"
 dependencies = [
  "anyhow",
  "colored",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.39"
+version = "2.12.40"
 dependencies = [
  "anyhow",
  "hex",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.39"
+version = "2.12.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.39"
+version = "2.12.40"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.39"
+version = "2.12.40"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -78,6 +78,7 @@ pub fn render_optimistic_user_message(
                 if msg.pending {
                     <span class="pending-indicator" title="Sending...">{ "\u{2022}" }</span>
                 }
+                { render_delivery_progress(msg.client_msg_id.is_some(), msg.delivery_stage, msg.delivery_message.as_deref()) }
                 <CopyButton text={msg.content.clone()} title="Copy message" />
             </div>
             <div class="message-body">{ render_optimistic_user_message_content(msg, session_id) }</div>
@@ -115,6 +116,7 @@ pub fn render_user_message(
                     if meta.pending {
                         <span class="pending-indicator" title="Sending...">{ "\u{2022}" }</span>
                     }
+                    { render_delivery_progress(meta.client_msg_id.is_some(), meta.delivery_stage, meta.delivery_message.as_deref()) }
                     <CopyButton text={text_content.clone()} title="Copy message" />
                 </div>
                 <div class="message-body">{ render_user_message_content(msg, session_id) }</div>
@@ -157,6 +159,65 @@ pub fn render_user_message_content(msg: &shared::UserMessage, session_id: Uuid) 
         html! {
             <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&text_content), session_id) }</div>
         }
+    }
+}
+
+fn render_delivery_progress(
+    tracked: bool,
+    stage: Option<shared::InputDeliveryStage>,
+    message: Option<&str>,
+) -> Html {
+    if !tracked && stage.is_none() {
+        return html! {};
+    };
+
+    let active_index = match stage {
+        None => 0,
+        Some(shared::InputDeliveryStage::ServerReceived) => 1,
+        Some(shared::InputDeliveryStage::ProxyReceived) => 2,
+        Some(shared::InputDeliveryStage::AgentAccepted) => 3,
+        Some(shared::InputDeliveryStage::Failed) => 0,
+    };
+    let failed = stage == Some(shared::InputDeliveryStage::Failed);
+    let title = match (stage, message) {
+        (None, _) => "Sent from browser",
+        (Some(shared::InputDeliveryStage::ServerReceived), _) => "Received by server",
+        (Some(shared::InputDeliveryStage::ProxyReceived), _) => "At local proxy",
+        (Some(shared::InputDeliveryStage::AgentAccepted), _) => "In agent stream",
+        (Some(shared::InputDeliveryStage::Failed), Some(msg)) => msg,
+        (Some(shared::InputDeliveryStage::Failed), None) => "Delivery failed",
+    };
+    let label = match stage {
+        None => "sent",
+        Some(shared::InputDeliveryStage::ServerReceived) => "server",
+        Some(shared::InputDeliveryStage::ProxyReceived) => "proxy",
+        Some(shared::InputDeliveryStage::AgentAccepted) => "stream",
+        Some(shared::InputDeliveryStage::Failed) => "failed",
+    };
+    let steps = ["sent", "server", "proxy", "stream"];
+
+    html! {
+        <span
+            class={classes!("input-delivery-progress", failed.then_some("failed"))}
+            title={title.to_string()}
+            aria-label={format!("Input delivery: {label}")}
+        >
+            <span class="input-delivery-label">{ label }</span>
+            <span class="input-delivery-steps" aria-hidden="true">
+                { for steps.iter().enumerate().map(|(idx, step)| {
+                    html! {
+                        <span
+                            class={classes!(
+                                "input-delivery-step",
+                                (!failed && idx <= active_index).then_some("active"),
+                                (failed && idx == 0).then_some("failed"),
+                            )}
+                            title={*step}
+                        />
+                    }
+                }) }
+            </span>
+        </span>
     }
 }
 

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -37,18 +37,30 @@ pub struct MessageSender {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct OptimisticUserMessage {
     pub content: String,
+    #[serde(default, rename = "_client_msg_id")]
+    pub client_msg_id: Option<uuid::Uuid>,
     #[serde(default, rename = "_sender")]
     pub sender: Option<MessageSender>,
     #[serde(default, rename = "_pending")]
     pub pending: bool,
+    #[serde(default, rename = "_delivery_stage")]
+    pub delivery_stage: Option<shared::InputDeliveryStage>,
+    #[serde(default, rename = "_delivery_message")]
+    pub delivery_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UserMessageMeta {
+    #[serde(default, rename = "_client_msg_id")]
+    pub client_msg_id: Option<uuid::Uuid>,
     #[serde(default, rename = "_sender")]
     pub sender: Option<MessageSender>,
     #[serde(default, rename = "_pending")]
     pub pending: bool,
+    #[serde(default, rename = "_delivery_stage")]
+    pub delivery_stage: Option<shared::InputDeliveryStage>,
+    #[serde(default, rename = "_delivery_message")]
+    pub delivery_message: Option<String>,
 }
 
 pub fn user_meta_from_json(json: &str) -> UserMessageMeta {

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -26,7 +26,8 @@ use yew::prelude::*;
 
 use super::helpers::{
     autoscroll_transition, classify_output_msg_type, inject_created_at_if_absent,
-    inject_message_metadata, is_claude_awaiting, reconcile_pending_sends, ActivityTag,
+    inject_message_metadata, is_claude_awaiting, reconcile_pending_sends,
+    update_pending_send_delivery, ActivityTag,
 };
 use super::input_bar::{InputBar, InputBarInbound};
 use super::permission_handler::{
@@ -63,6 +64,30 @@ pub struct SessionViewProps {
     pub current_user_id: Option<String>,
     #[prop_or(0)]
     pub interrupt_signal: u32,
+}
+
+fn optimistic_user_json(content: &str, created_at: &str, client_msg_id: &Uuid) -> String {
+    #[derive(serde::Serialize)]
+    struct OptimisticUserMessage<'a> {
+        #[serde(rename = "type")]
+        message_type: &'static str,
+        content: &'a str,
+        #[serde(rename = "_pending")]
+        pending: bool,
+        #[serde(rename = "_created_at")]
+        created_at: &'a str,
+        #[serde(rename = "_client_msg_id")]
+        client_msg_id: &'a Uuid,
+    }
+
+    serde_json::to_string(&OptimisticUserMessage {
+        message_type: "user",
+        content,
+        pending: true,
+        created_at,
+        client_msg_id,
+    })
+    .unwrap_or_default()
 }
 
 /// Messages for the SessionView component
@@ -391,10 +416,11 @@ impl Component for SessionView {
                 true
             }
             SessionViewMsg::SendFrame(frame) => {
+                let (frame, changed) = self.prepare_outbound_frame(frame);
                 if let Some(ref sender) = self.ws_sender {
                     send_message(sender, frame);
                 }
-                false
+                changed
             }
             SessionViewMsg::MessageSent => {
                 let session_id = ctx.props().session.id;
@@ -588,6 +614,16 @@ impl SessionView {
                     .send_message(SessionViewMsg::TurnMetricsReceived(metrics));
                 false
             }
+            WsEvent::InputProgress {
+                client_msg_id,
+                stage,
+                message,
+            } => update_pending_send_delivery(
+                &mut self.pending_sends,
+                client_msg_id,
+                stage,
+                message.as_deref(),
+            ),
             WsEvent::ContinuationStatus {
                 continuation_id,
                 status,
@@ -657,27 +693,9 @@ impl SessionView {
             .to_iso_string()
             .as_string()
             .unwrap_or_default();
-        // Local-only stub for the message list while the wire round-trips.
-        // Typed so the wire shape lives in source — the consumer renderer
-        // still parses `pending_sends` as JSON (cleanup tracked separately).
-        #[derive(serde::Serialize)]
-        struct OptimisticUserMessage<'a> {
-            #[serde(rename = "type")]
-            message_type: &'static str,
-            content: &'a str,
-            #[serde(rename = "_pending")]
-            pending: bool,
-            #[serde(rename = "_created_at")]
-            created_at: &'a str,
-        }
-        let optimistic_msg = serde_json::to_string(&OptimisticUserMessage {
-            message_type: "user",
-            content: &input,
-            pending: true,
-            created_at: &now_iso,
-        })
-        .unwrap_or_default();
-        self.pending_sends.push(optimistic_msg);
+        let client_msg_id = Uuid::new_v4();
+        self.pending_sends
+            .push(optimistic_user_json(&input, &now_iso, &client_msg_id));
 
         if let Some(ref sender) = self.ws_sender {
             let msg = ClientToServer::AgentInput {
@@ -687,12 +705,40 @@ impl SessionView {
                 } else {
                     Some(send_mode)
                 },
-                // TODO(delivery-progress): assign a real id + consume
-                // ServerToClient::InputProgress to drive the staged pending UI
-                // (Codex's slice). None keeps the legacy reconciliation path.
-                client_msg_id: None,
+                client_msg_id: Some(client_msg_id),
             };
             send_message(sender, msg);
+        }
+    }
+
+    fn prepare_outbound_frame(&mut self, frame: ClientToServer) -> (ClientToServer, bool) {
+        match frame {
+            ClientToServer::AgentInput {
+                content,
+                send_mode,
+                client_msg_id: _,
+            } => {
+                let client_msg_id = Uuid::new_v4();
+                let mut changed = false;
+                if let Some(text) = content.as_str() {
+                    let now_iso = js_sys::Date::new_0()
+                        .to_iso_string()
+                        .as_string()
+                        .unwrap_or_default();
+                    self.pending_sends
+                        .push(optimistic_user_json(text, &now_iso, &client_msg_id));
+                    changed = true;
+                }
+                (
+                    ClientToServer::AgentInput {
+                        content,
+                        send_mode,
+                        client_msg_id: Some(client_msg_id),
+                    },
+                    changed,
+                )
+            }
+            other => (other, false),
         }
     }
 

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -391,6 +391,9 @@ pub(super) fn reconcile_pending_sends(
                 .and_then(extract_user_text);
             if let Some(ref echo) = echo_text {
                 if let Some(pos) = pending_sends.iter().position(|pending| {
+                    if pending_has_client_msg_id(pending) {
+                        return false;
+                    }
                     ClaudeMessage::parse(pending)
                         .ok()
                         .as_ref()
@@ -403,10 +406,70 @@ pub(super) fn reconcile_pending_sends(
             }
         }
         ActivityTag::Assistant | ActivityTag::Result => {
-            pending_sends.clear();
+            pending_sends.retain(|pending| pending_has_client_msg_id(pending));
         }
         _ => {}
     }
+}
+
+pub(super) fn update_pending_send_delivery(
+    pending_sends: &mut Vec<String>,
+    client_msg_id: uuid::Uuid,
+    stage: shared::InputDeliveryStage,
+    message: Option<&str>,
+) -> bool {
+    let Some(pos) = pending_sends
+        .iter()
+        .position(|pending| pending_client_msg_id(pending) == Some(client_msg_id))
+    else {
+        return false;
+    };
+
+    if stage == shared::InputDeliveryStage::AgentAccepted {
+        pending_sends.remove(pos);
+        return true;
+    }
+
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&pending_sends[pos]) else {
+        return false;
+    };
+    let Some(obj) = value.as_object_mut() else {
+        return false;
+    };
+
+    obj.insert(
+        "_delivery_stage".to_string(),
+        serde_json::to_value(stage).unwrap_or(serde_json::Value::Null),
+    );
+    match message {
+        Some(message) => {
+            obj.insert(
+                "_delivery_message".to_string(),
+                serde_json::Value::String(message.to_string()),
+            );
+        }
+        None => {
+            obj.remove("_delivery_message");
+        }
+    }
+    if stage == shared::InputDeliveryStage::Failed {
+        obj.insert("_pending".to_string(), serde_json::Value::Bool(false));
+    }
+
+    pending_sends[pos] = value.to_string();
+    true
+}
+
+fn pending_has_client_msg_id(pending: &str) -> bool {
+    pending_client_msg_id(pending).is_some()
+}
+
+fn pending_client_msg_id(pending: &str) -> Option<uuid::Uuid> {
+    let value = serde_json::from_str::<serde_json::Value>(pending).ok()?;
+    value
+        .get("_client_msg_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| uuid::Uuid::parse_str(s).ok())
 }
 
 #[cfg(test)]
@@ -777,7 +840,8 @@ mod tests {
     fn reconcile_pending_sends_assistant_clears_all() {
         // Slash commands (/cost, /clear, /status) don't echo as "user",
         // so the assistant response is the only signal we get that input
-        // was received. Clear everything.
+        // was received. Clear legacy entries; id-tracked entries wait for
+        // InputProgress::AgentAccepted.
         let mut pending = vec![
             r#"{"type":"user","content":"a"}"#.to_string(),
             r#"{"type":"user","content":"b"}"#.to_string(),
@@ -787,6 +851,83 @@ mod tests {
             ActivityTag::Assistant,
             r#"{"type":"assistant","message":{"content":[]}}"#,
         );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn reconcile_pending_sends_preserves_id_tracked_rows() {
+        let id = uuid::Uuid::new_v4();
+        let mut pending = vec![
+            format!(r#"{{"type":"user","content":"hello","_client_msg_id":"{id}"}}"#),
+            r#"{"type":"user","content":"legacy"}"#.to_string(),
+        ];
+
+        reconcile_pending_sends(
+            &mut pending,
+            ActivityTag::User,
+            r#"{"type":"user","content":"hello"}"#,
+        );
+        assert_eq!(pending.len(), 2, "user echo must not clear id-tracked row");
+
+        reconcile_pending_sends(
+            &mut pending,
+            ActivityTag::Assistant,
+            r#"{"type":"assistant","message":{"content":[]}}"#,
+        );
+        assert_eq!(pending.len(), 1, "assistant clears only legacy rows");
+        assert!(pending[0].contains(&id.to_string()));
+    }
+
+    #[test]
+    fn update_pending_send_delivery_updates_stage() {
+        let id = uuid::Uuid::new_v4();
+        let mut pending = vec![format!(
+            r#"{{"type":"user","content":"hello","_pending":true,"_client_msg_id":"{id}"}}"#
+        )];
+
+        assert!(update_pending_send_delivery(
+            &mut pending,
+            id,
+            shared::InputDeliveryStage::ServerReceived,
+            None,
+        ));
+        let value: serde_json::Value = serde_json::from_str(&pending[0]).unwrap();
+        assert_eq!(value["_delivery_stage"], "server_received");
+        assert_eq!(value["_pending"], true);
+    }
+
+    #[test]
+    fn update_pending_send_delivery_failed_marks_not_pending() {
+        let id = uuid::Uuid::new_v4();
+        let mut pending = vec![format!(
+            r#"{{"type":"user","content":"hello","_pending":true,"_client_msg_id":"{id}"}}"#
+        )];
+
+        assert!(update_pending_send_delivery(
+            &mut pending,
+            id,
+            shared::InputDeliveryStage::Failed,
+            Some("permission denied"),
+        ));
+        let value: serde_json::Value = serde_json::from_str(&pending[0]).unwrap();
+        assert_eq!(value["_delivery_stage"], "failed");
+        assert_eq!(value["_delivery_message"], "permission denied");
+        assert_eq!(value["_pending"], false);
+    }
+
+    #[test]
+    fn update_pending_send_delivery_agent_accepted_removes_row() {
+        let id = uuid::Uuid::new_v4();
+        let mut pending = vec![format!(
+            r#"{{"type":"user","content":"hello","_pending":true,"_client_msg_id":"{id}"}}"#
+        )];
+
+        assert!(update_pending_send_delivery(
+            &mut pending,
+            id,
+            shared::InputDeliveryStage::AgentAccepted,
+            None,
+        ));
         assert!(pending.is_empty());
     }
 

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -3,7 +3,9 @@
 use crate::utils;
 use futures_util::StreamExt;
 use shared::api::ErrorMessage;
-use shared::{ClientEndpoint, ClientToServer, ServerToClient, TurnMetrics, WsEndpoint};
+use shared::{
+    ClientEndpoint, ClientToServer, InputDeliveryStage, ServerToClient, TurnMetrics, WsEndpoint,
+};
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use yew::Callback;
@@ -40,6 +42,11 @@ pub enum WsEvent {
     /// Boxed to keep `WsEvent` compact — `TurnMetrics` is the largest variant
     /// payload by a wide margin (~22 fields).
     TurnMetrics(Box<TurnMetrics>),
+    InputProgress {
+        client_msg_id: Uuid,
+        stage: InputDeliveryStage,
+        message: Option<String>,
+    },
 }
 
 /// Connect to WebSocket and start receiving messages.
@@ -223,6 +230,17 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
         // an explicit branch or land in `unhandled` below.
         ServerToClient::TurnMetrics(metrics) => {
             on_event.emit(WsEvent::TurnMetrics(metrics));
+        }
+        ServerToClient::InputProgress {
+            client_msg_id,
+            stage,
+            message,
+        } => {
+            on_event.emit(WsEvent::InputProgress {
+                client_msg_id,
+                stage,
+                message,
+            });
         }
         ServerToClient::ContinuationStatus {
             continuation_id,
@@ -544,6 +562,7 @@ mod tests {
             WsEvent::BranchChanged(_, _, _, _) => "BranchChanged",
             WsEvent::ContinuationStatus { .. } => "ContinuationStatus",
             WsEvent::TurnMetrics(_) => "TurnMetrics",
+            WsEvent::InputProgress { .. } => "InputProgress",
         }
     }
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1059,6 +1059,45 @@
     animation: pending-pulse 1.5s ease-in-out infinite;
 }
 
+.input-delivery-progress {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    line-height: 1;
+}
+
+.input-delivery-progress.failed {
+    color: var(--error);
+}
+
+.input-delivery-label {
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.input-delivery-steps {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.18rem;
+}
+
+.input-delivery-step {
+    width: 0.34rem;
+    height: 0.34rem;
+    border-radius: 999px;
+    background: rgba(192, 202, 245, 0.22);
+}
+
+.input-delivery-step.active {
+    background: var(--accent);
+}
+
+.input-delivery-step.failed {
+    background: var(--error);
+}
+
 @keyframes pending-pulse {
     0%, 100% { opacity: 0.3; }
     50% { opacity: 1; }


### PR DESCRIPTION
## Summary
- assign browser client_msg_id values to outgoing AgentInput frames
- render optimistic user messages with a compact sent/server/proxy/stream delivery marker
- consume ServerToClient::InputProgress to advance pending rows, show Failed, and clear on AgentAccepted
- keep legacy content reconciliation only for pending rows without client_msg_id

## Verification
- cargo check -p frontend
- cargo test -p frontend session_view::helpers
- cargo test -p frontend websocket
- cargo clippy -p frontend --all-targets -- -D warnings