### PR TITLE
Test coverage: delivery-progress, inter-agent, codex helpers (test-only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.40"
+version = "2.12.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.40"
+version = "2.12.41"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.40"
+version = "2.12.41"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.40"
+version = "2.12.41"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.40"
+version = "2.12.41"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.40"
+version = "2.12.41"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.40"
+version = "2.12.41"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.40"
+version = "2.12.41"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.40"
+version = "2.12.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.40"
+version = "2.12.41"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,7 @@ dependencies = [
  "shared",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.40"
+version = "2.12.41"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -582,4 +582,42 @@ mod tests {
         assert_eq!(normalized.content["content"][0]["type"], "text");
         assert_eq!(normalized.content["content"][0]["text"], "hello from peer");
     }
+
+    /// Anything that isn't a single, well-formed AgentMessage must pass through
+    /// untouched — no origin, no provenance, content byte-identical. A bug here
+    /// would either drop a normal message's body or fabricate bogus inter-agent
+    /// provenance on it.
+    fn assert_passthrough(content: serde_json::Value) {
+        let normalized = normalize_output_content(content.clone());
+        assert_eq!(normalized.content, content);
+        assert!(normalized.origin.is_none());
+        assert!(normalized.provenance_kind.is_none());
+        assert!(normalized.provenance_session_id.is_none());
+        assert!(normalized.provenance_agent_type.is_none());
+    }
+
+    #[test]
+    fn normalize_passthrough_for_non_portal_json() {
+        assert_passthrough(serde_json::json!({"type": "assistant", "text": "hi"}));
+        assert_passthrough(serde_json::json!("a bare string"));
+    }
+
+    #[test]
+    fn normalize_passthrough_for_non_agent_message_portal() {
+        assert_passthrough(PortalMessage::text("just text".to_string()).to_json());
+    }
+
+    #[test]
+    fn normalize_passthrough_when_session_id_is_not_a_uuid() {
+        // A malformed from_session_id must NOT be promoted to inter-agent
+        // provenance — fall back to passthrough rather than corrupting origin.
+        assert_passthrough(
+            PortalMessage::agent_message(
+                "codex".to_string(),
+                "not-a-uuid".to_string(),
+                "hello".to_string(),
+            )
+            .to_json(),
+        );
+    }
 }

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -510,3 +510,58 @@ async fn read_stderr(
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_limit_time_accepts_the_cli_time_formats() {
+        // The CLI renders reset times in a handful of am/pm shapes; each must
+        // parse so the continuation timer lands at the right hour.
+        // The CLI always emits a minute component ("resets 3:00pm"); these are
+        // the shapes parse_limit_time must handle.
+        let cases = [
+            ("3:00pm", NaiveTime::from_hms_opt(15, 0, 0)),
+            ("3:00 pm", NaiveTime::from_hms_opt(15, 0, 0)),
+            ("3:00 PM", NaiveTime::from_hms_opt(15, 0, 0)),
+            ("12:30am", NaiveTime::from_hms_opt(0, 30, 0)),
+            ("11:59pm", NaiveTime::from_hms_opt(23, 59, 0)),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(parse_limit_time(input), expected, "input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn parse_limit_time_rejects_garbage() {
+        assert!(parse_limit_time("").is_none());
+        assert!(parse_limit_time("noon").is_none());
+        assert!(parse_limit_time("25:00pm").is_none());
+    }
+
+    #[test]
+    fn parse_session_limit_reset_ignores_unrelated_text() {
+        assert!(parse_session_limit_reset("just a normal assistant reply").is_none());
+    }
+
+    #[test]
+    fn parse_session_limit_reset_returns_none_without_resets_clause() {
+        // Has the limit banner but no parseable "resets … (TZ)" clause.
+        let text = format!("{SESSION_LIMIT_TEXT}. Try again later.");
+        assert!(parse_session_limit_reset(&text).is_none());
+    }
+
+    #[test]
+    fn parse_session_limit_reset_yields_future_rfc3339() {
+        // A well-formed banner must produce a valid, future-dated UTC instant
+        // (the parser always rolls forward to the next occurrence of the time).
+        let text = format!("{SESSION_LIMIT_TEXT}. Your limit resets 3:00pm (America/New_York).");
+        let reset = parse_session_limit_reset(&text).expect("should parse a reset time");
+        let parsed = chrono::DateTime::parse_from_rfc3339(&reset).expect("valid rfc3339");
+        assert!(
+            parsed.with_timezone(&Utc) > Utc::now(),
+            "reset {reset} should be in the future"
+        );
+    }
+}

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -1471,3 +1471,159 @@ async fn read_download_file(
 // minute format is `"{}m {}s"` (with a space), matching the frontend
 // transcript — the old local copy here used `"{}m{}s"`.
 pub(crate) use shared::fmt::{format_duration, truncate_str as truncate};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn backoff_doubles_then_saturates_at_max() {
+        let mut b = Backoff::new();
+        assert_eq!(b.current_secs(), 1);
+        b.advance();
+        assert_eq!(b.current_secs(), 2);
+        b.advance();
+        assert_eq!(b.current_secs(), 4);
+        // Many advances must clamp at the protocol cap, never overflow past it.
+        for _ in 0..40 {
+            b.advance();
+        }
+        assert_eq!(
+            b.current_secs(),
+            shared::protocol::MAX_RECONNECT_BACKOFF_SECS
+        );
+    }
+
+    #[test]
+    fn backoff_reset_if_stable_only_resets_past_threshold() {
+        let mut b = Backoff::new();
+        b.advance();
+        b.advance();
+        // Below the 30s stability threshold: keep backing off.
+        b.reset_if_stable(Duration::from_secs(29));
+        assert_eq!(b.current_secs(), 4);
+        // At/over the threshold: a stable connection earns a reset to initial.
+        b.reset_if_stable(Duration::from_secs(30));
+        assert_eq!(b.current_secs(), 1);
+    }
+
+    #[test]
+    fn backoff_reset_is_unconditional() {
+        let mut b = Backoff::new();
+        b.advance();
+        b.advance();
+        b.reset();
+        assert_eq!(b.current_secs(), 1);
+    }
+
+    fn download_request(path: &str, max_bytes: u64) -> shared::FileDownloadRequestFields {
+        shared::FileDownloadRequestFields {
+            request_id: Uuid::nil(),
+            path: path.to_string(),
+            max_bytes,
+        }
+    }
+
+    #[tokio::test]
+    async fn read_download_file_returns_valid_file() {
+        use base64::Engine;
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(dir.path().join("hello.txt"), b"hi there")
+            .await
+            .unwrap();
+
+        let resp = read_download_file(
+            dir.path().to_str().unwrap(),
+            &download_request("hello.txt", 1024),
+        )
+        .await;
+
+        assert!(resp.success);
+        assert_eq!(resp.filename.as_deref(), Some("hello.txt"));
+        assert_eq!(resp.size, Some(8));
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(resp.data_base64.unwrap())
+            .unwrap();
+        assert_eq!(decoded, b"hi there");
+    }
+
+    #[tokio::test]
+    async fn read_download_file_rejects_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let resp = read_download_file(
+            dir.path().to_str().unwrap(),
+            &download_request("/etc/passwd", 1024),
+        )
+        .await;
+        assert!(!resp.success);
+        assert_eq!(resp.error.as_deref(), Some("invalid relative path"));
+    }
+
+    #[tokio::test]
+    async fn read_download_file_rejects_parent_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let resp = read_download_file(
+            dir.path().to_str().unwrap(),
+            &download_request("../secrets.txt", 1024),
+        )
+        .await;
+        assert!(!resp.success);
+        assert_eq!(resp.error.as_deref(), Some("invalid relative path"));
+    }
+
+    #[tokio::test]
+    async fn read_download_file_reports_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let resp = read_download_file(
+            dir.path().to_str().unwrap(),
+            &download_request("nope.txt", 1024),
+        )
+        .await;
+        assert!(!resp.success);
+        assert_eq!(resp.error.as_deref(), Some("file not found"));
+    }
+
+    #[tokio::test]
+    async fn read_download_file_enforces_size_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(dir.path().join("big.bin"), vec![0u8; 100])
+            .await
+            .unwrap();
+        let resp = read_download_file(
+            dir.path().to_str().unwrap(),
+            &download_request("big.bin", 10),
+        )
+        .await;
+        assert!(!resp.success);
+        assert_eq!(resp.error.as_deref(), Some("file exceeds size limit"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_download_file_rejects_symlink_escape() {
+        // A symlink whose name is a clean relative path but whose target
+        // canonicalizes outside the working directory must be refused.
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        tokio::fs::write(outside.path().join("secret.txt"), b"top secret")
+            .await
+            .unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("secret.txt"),
+            root.path().join("link.txt"),
+        )
+        .unwrap();
+
+        let resp = read_download_file(
+            root.path().to_str().unwrap(),
+            &download_request("link.txt", 1024),
+        )
+        .await;
+        assert!(!resp.success);
+        assert_eq!(
+            resp.error.as_deref(),
+            Some("path escapes working directory")
+        );
+    }
+}

--- a/claude-session-lib/src/proxy_session/ws_reader.rs
+++ b/claude-session-lib/src/proxy_session/ws_reader.rs
@@ -390,4 +390,52 @@ mod tests {
         assert_eq!(input.text, "hello");
         assert!(input.display_event.is_none());
     }
+
+    #[test]
+    fn classify_preserves_ack_and_client_msg_id_for_normal_input() {
+        // The delivery-progress pipeline (#939) depends on client_msg_id and the
+        // seq ack surviving classification — dropping either silently breaks the
+        // optimistic-row advance / pending-input replay.
+        let session_id = uuid::Uuid::nil();
+        let client_msg_id = uuid::Uuid::from_u128(7);
+        let ack = super::super::PortalInputAck {
+            session_id,
+            seq: 42,
+        };
+
+        let RoutedPortalInput::Input(input) = classify_portal_input(
+            serde_json::Value::String("hi".to_string()),
+            None,
+            Some(ack),
+            Some(client_msg_id),
+        ) else {
+            panic!("expected normal input");
+        };
+
+        assert_eq!(input.client_msg_id, Some(client_msg_id));
+        let ack = input.ack.expect("ack preserved");
+        assert_eq!(ack.seq, 42);
+        assert_eq!(ack.session_id, session_id);
+    }
+
+    #[test]
+    fn classify_wiggum_preserves_ack_and_client_msg_id() {
+        let client_msg_id = uuid::Uuid::from_u128(9);
+        let ack = super::super::PortalInputAck {
+            session_id: uuid::Uuid::nil(),
+            seq: 5,
+        };
+
+        let RoutedPortalInput::Wiggum(input) = classify_portal_input(
+            serde_json::Value::String("activate".to_string()),
+            Some(SendMode::Wiggum),
+            Some(ack),
+            Some(client_msg_id),
+        ) else {
+            panic!("expected wiggum activation");
+        };
+
+        assert_eq!(input.client_msg_id, Some(client_msg_id));
+        assert_eq!(input.ack.expect("ack preserved").seq, 5);
+    }
 }

--- a/codex-session-lib/Cargo.toml
+++ b/codex-session-lib/Cargo.toml
@@ -18,3 +18,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+uuid = { workspace = true }

--- a/codex-session-lib/src/helpers.rs
+++ b/codex-session-lib/src/helpers.rs
@@ -38,3 +38,60 @@ pub(crate) fn parse_request_id(s: &str) -> codex_codes::RequestId {
         codex_codes::RequestId::String(s.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claude_codes::io::{ContentBlock, TextBlock};
+    use codex_codes::RequestId;
+    use uuid::Uuid;
+
+    fn text_block(s: &str) -> ContentBlock {
+        ContentBlock::Text(TextBlock {
+            text: s.to_string(),
+            citations: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn extract_prompt_text_single_block() {
+        let input = ClaudeInput::user_message("hello world", Uuid::nil());
+        assert_eq!(extract_prompt_text(&input), "hello world");
+    }
+
+    #[test]
+    fn extract_prompt_text_joins_text_blocks_and_skips_non_text() {
+        // Non-text blocks (images, tool results, unknown) must be dropped, and
+        // the surviving text joined with newlines — a bug here silently sends
+        // a malformed or truncated prompt to the codex agent.
+        let input = ClaudeInput::user_message_blocks(
+            vec![
+                text_block("first"),
+                ContentBlock::Unknown(serde_json::json!({"type": "image"})),
+                text_block("second"),
+            ],
+            Uuid::nil(),
+        );
+        assert_eq!(extract_prompt_text(&input), "first\nsecond");
+    }
+
+    #[test]
+    fn extract_prompt_text_non_user_is_empty() {
+        let input = ClaudeInput::Raw(serde_json::json!({"type": "whatever"}));
+        assert_eq!(extract_prompt_text(&input), "");
+    }
+
+    #[test]
+    fn request_id_round_trips_both_variants() {
+        // Asymmetric parse/format silently breaks request↔result correlation,
+        // so exercise both directions for integer and string ids.
+        assert_eq!(format_request_id(&RequestId::Integer(42)), "42");
+        assert_eq!(format_request_id(&RequestId::String("abc".into())), "abc");
+        assert_eq!(parse_request_id("42"), RequestId::Integer(42));
+        assert_eq!(parse_request_id("abc"), RequestId::String("abc".into()));
+
+        for id in [RequestId::Integer(-7), RequestId::String("tool-9".into())] {
+            assert_eq!(parse_request_id(&format_request_id(&id)), id);
+        }
+    }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -584,6 +584,53 @@ mod tests {
     }
 
     #[test]
+    fn agent_message_round_trips_to_agent_facing_text() {
+        // This is the exact envelope→text conversion behind the inter-agent
+        // raw-JSON render bug (#1123/#1124): a single AgentMessage content
+        // becomes the bracketed "[message from …]" prefix the agent reads.
+        let msg = PortalMessage::agent_message(
+            "codex".to_string(),
+            "12345678-0000-0000-0000-000000000000".to_string(),
+            "hello there".to_string(),
+        );
+        assert_eq!(
+            msg.agent_facing_text().as_deref(),
+            Some("[message from codex 12345678-0000-0000-0000-000000000000]\nhello there")
+        );
+    }
+
+    #[test]
+    fn non_agent_message_has_no_agent_facing_text() {
+        // Plain text / image / reminder envelopes have no agent-facing form;
+        // returning None keeps them on the normal display path.
+        assert!(PortalMessage::text("just text".to_string())
+            .agent_facing_text()
+            .is_none());
+        assert!(
+            PortalMessage::reminder("title".to_string(), "body".to_string())
+                .agent_facing_text()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn multi_content_message_has_no_agent_facing_text() {
+        // The match requires *exactly one* AgentMessage content; a mixed or
+        // multi-block envelope must not be mistaken for an inter-agent message.
+        let msg = PortalMessage::with_content(vec![
+            PortalContent::AgentMessage {
+                from_agent_type: "codex".to_string(),
+                from_session_id: "id".to_string(),
+                text: "a".to_string(),
+            },
+            PortalContent::Text {
+                text: "trailing".to_string(),
+            },
+        ]);
+        assert!(msg.agent_facing_text().is_none());
+    }
+
+    #[test]
     fn message_role_as_str_matches_serde_encoding() {
         let roles = [
             MessageRole::System,


### PR DESCRIPTION
## What

Low-effort/high-value **test-only** coverage targeting the exact logic behind recent bugs, reconciled with Codex's sweep. All tests are pure or near-pure — no DB, no live WebSocket, no full async loop. This is the CLAUDE-PR half of the agreed split (Codex takes the frontend half).

## Coverage added

- **shared** — `PortalMessage::agent_facing_text`: the envelope→text fn behind the inter-agent raw-JSON render bug (#1123/#1124). Single `AgentMessage` maps to the bracketed prefix; text/reminder/multi-content return `None`.
- **backend** — `normalize_output_content` malformed matrix: non-portal JSON, bare string, non-`AgentMessage` portal, and **non-UUID `from_session_id`** all pass through without fabricating inter-agent provenance.
- **claude-session-lib**:
  - `Backoff` — doubling + saturation at the protocol cap, stable-threshold reset boundary, unconditional reset.
  - `read_download_file` path safety — valid file, absolute path, `..` traversal, missing file, size limit, and a unix **symlink-escape** rejection.
  - `classify_portal_input` — preserves `ack` + `client_msg_id` for normal **and** Wiggum routes (the #939 delivery pipeline).
- **codex-session-lib** — `extract_prompt_text` (join text blocks, skip non-text, non-user→empty) and `request_id` `parse`/`format` round-trip for integer and string ids. Adds a `uuid` dev-dependency for input construction.

## Testing

`cargo test --workspace` ✅ · `cargo clippy --workspace --all-targets` ✅ clean · `cargo fmt --all --check` ✅ · `cargo build --target wasm32-unknown-unknown -p shared` ✅

Version → 2.12.41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)