### PR TITLE
Launcher restart: inline two-step confirm (no browser popup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ screenlog.*
 /test-*.svg
 /*.patch
 parsing-dump/
+/image.png

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.41"
+version = "2.12.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.41"
+version = "2.12.42"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.41"
+version = "2.12.42"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.41"
+version = "2.12.42"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.41"
+version = "2.12.42"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.41"
+version = "2.12.42"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.41"
+version = "2.12.42"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.41"
+version = "2.12.42"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.41"
+version = "2.12.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.41"
+version = "2.12.42"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.41"
+version = "2.12.42"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -18,28 +18,53 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
     let on_update = props.on_update.clone();
     let launcher_id = l.launcher_id;
 
-    let (update_label, update_class) = if props.update_in_progress {
-        ("Restarting...", "update-button stage-3")
-    } else {
-        ("Update & Restart", "update-button stage-0")
+    // Inline two-step confirm instead of a browser `confirm()` popup, which
+    // doesn't render well on mobile. First click arms the confirmation; the
+    // row then shows explicit Confirm / Cancel buttons (normal DOM elements).
+    let confirming = use_state(|| false);
+
+    // A restart in progress takes precedence over the confirm state.
+    let arm = {
+        let confirming = confirming.clone();
+        Callback::from(move |_| confirming.set(true))
+    };
+    let cancel = {
+        let confirming = confirming.clone();
+        Callback::from(move |_| confirming.set(false))
+    };
+    let confirm = {
+        let on_update = on_update.clone();
+        let confirming = confirming.clone();
+        Callback::from(move |_| {
+            confirming.set(false);
+            on_update.emit(launcher_id);
+        })
     };
 
-    let on_update_click = {
-        let on_update = on_update.clone();
-        Callback::from(move |_| {
-            let confirmed = web_sys::window()
-                .and_then(|window| {
-                    window
-                        .confirm_with_message(
-                            "Update this launcher to the latest release and restart it?",
-                        )
-                        .ok()
-                })
-                .unwrap_or(false);
-            if confirmed {
-                on_update.emit(launcher_id);
-            }
-        })
+    let actions = if props.update_in_progress {
+        html! {
+            <button class="update-button stage-3" disabled=true>
+                { "Restarting..." }
+            </button>
+        }
+    } else if *confirming {
+        html! {
+            <div class="launcher-confirm-actions">
+                <span class="launcher-confirm-prompt">{ "Update & restart?" }</span>
+                <button class="confirm-button" onclick={confirm}>{ "Confirm" }</button>
+                <button class="cancel-button" onclick={cancel}>{ "Cancel" }</button>
+            </div>
+        }
+    } else {
+        html! {
+            <button
+                class="update-button stage-0"
+                onclick={arm}
+                title="Pull the latest agent-portal release and restart this launcher"
+            >
+                { "Update & Restart" }
+            </button>
+        }
     };
 
     html! {
@@ -48,16 +73,7 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
             <td>{ &l.hostname }</td>
             <td>{ format!("v{}", &l.version) }</td>
             <td>{ l.running_sessions }</td>
-            <td class="token-actions">
-                <button
-                    class={update_class}
-                    onclick={on_update_click}
-                    disabled={props.update_in_progress}
-                    title="Pull the latest agent-portal release and restart this launcher"
-                >
-                    { update_label }
-                </button>
-            </td>
+            <td class="token-actions">{ actions }</td>
         </tr>
     }
 }

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -406,6 +406,25 @@
     opacity: 0.85;
 }
 
+/* Inline two-step confirm for the launcher update/restart action (replaces a
+   browser confirm() popup, which is awkward on mobile). Wraps when narrow. */
+.launcher-confirm-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}
+.launcher-confirm-prompt {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+.launcher-confirm-actions .confirm-button,
+.launcher-confirm-actions .cancel-button {
+    padding: 0.4rem 0.9rem;
+    font-size: 0.85rem;
+}
+
 /* Token Created Success */
 .token-created-success {
     text-align: center;


### PR DESCRIPTION
## What

The launcher **Update & Restart** action used `window.confirm()` — a browser-native popup that renders poorly on mobile. This replaces it with an inline two-step confirm built from normal DOM elements:

- First click **arms** the action; the row swaps to a `Update & restart?` prompt with explicit **Confirm** / **Cancel** buttons
- Confirm fires the update; Cancel resets
- Reuses the existing `.confirm-button` / `.cancel-button` styles; flex layout wraps cleanly on narrow screens
- Restart-in-progress state still takes precedence ("Restarting...")

Local row state (`use_state`), keyed per launcher row — no global state, no popup.

## Testing

- `cargo build -p frontend --target wasm32-unknown-unknown` ✅
- `cargo clippy -p frontend --target wasm32-unknown-unknown --all-targets` ✅ clean
- `cargo fmt --all --check` ✅

Version → 2.12.42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)