### PR TITLE
Test live inter-agent origin injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.42"
+version = "2.12.43"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.42"
+version = "2.12.43"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.42"
+version = "2.12.43"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.42"
+version = "2.12.43"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.42"
+version = "2.12.43"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.42"
+version = "2.12.43"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.42"
+version = "2.12.43"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.42"
+version = "2.12.43"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.42"
+version = "2.12.43"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.42"
+version = "2.12.43"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.42"
+version = "2.12.43"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -451,6 +451,48 @@ mod tests {
         }
     }
 
+    /// Inter-agent attribution is carried on the live `AgentOutput.origin`
+    /// field, then injected as `_origin` into the JSON consumed by the portal
+    /// renderer. If this translation is dropped, a properly normalized
+    /// inter-agent message renders as a generic PORTAL card.
+    #[test]
+    fn agent_output_with_origin_injects_origin_metadata() {
+        let (cb, sink) = capture();
+        let from_session_id =
+            uuid::Uuid::parse_str("11111111-1111-1111-1111-111111111111").expect("uuid");
+        let msg = ServerToClient::AgentOutput {
+            content: serde_json::json!({
+                "type": "portal",
+                "content": [{"type": "text", "text": "hello from peer"}],
+            }),
+            sender_user_id: None,
+            sender_name: None,
+            agent_type: shared::AgentType::Codex,
+            created_at: None,
+            origin: Some(shared::MessageOrigin::InterAgent {
+                from_session_id,
+                from_agent_type: "codex".to_string(),
+            }),
+        };
+
+        handle_proxy_message(msg, &cb);
+
+        let events = sink.borrow();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            WsEvent::Output(content, _) => {
+                let parsed: serde_json::Value = serde_json::from_str(content).unwrap();
+                assert_eq!(parsed["_origin"]["kind"], "inter_agent");
+                assert_eq!(
+                    parsed["_origin"]["from_session_id"],
+                    "11111111-1111-1111-1111-111111111111"
+                );
+                assert_eq!(parsed["_origin"]["from_agent_type"], "codex");
+            }
+            other => panic!("expected Output, got {:?}", debug_event(other)),
+        }
+    }
+
     /// Backward-compat: a pre-#784 backend doesn't send `created_at`. The
     /// `WsEvent::Output` watermark is then `None`, and the component is
     /// expected to keep its prior watermark (never falling back to


### PR DESCRIPTION
## Summary
- add a frontend websocket regression test for live AgentOutput origin metadata
- assert MessageOrigin::InterAgent is injected into the renderer-facing JSON as _origin
- bump workspace version to 2.12.43

## Verification
- cargo test -p frontend websocket
- cargo fmt --check
- cargo clippy -p frontend --all-targets -- -D warnings

Note: #1129 owns 2.12.42 and should merge first. If it lands before this PR, this branch may need a version-line rebase but has no code overlap.