### PR TITLE
Portal metadata sidecar — slice 1: PortalMeta contract + design doc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.43"
+version = "2.12.44"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.43"
+version = "2.12.44"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.43"
+version = "2.12.44"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.43"
+version = "2.12.44"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.43"
+version = "2.12.44"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.43"
+version = "2.12.44"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.43"
+version = "2.12.44"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.43"
+version = "2.12.44"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.43"
+version = "2.12.44"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.43"
+version = "2.12.44"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.43"
+version = "2.12.44"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -118,6 +118,7 @@ pub fn handle_session_limit_reached(
                 agent_type: session.agent_type.parse().unwrap_or_default(),
                 created_at: row_created_at,
                 origin: None,
+                meta: None,
             },
         );
     }
@@ -287,6 +288,7 @@ fn update_terminal_status(
                             agent_type: session.agent_type.parse().unwrap_or_default(),
                             created_at: row_created_at,
                             origin: None,
+                            meta: None,
                         },
                     );
                 }

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -333,6 +333,10 @@ pub fn handle_claude_output(
                 agent_type,
                 created_at: row_created_at,
                 origin,
+                // Populated in slice 2 (backend meta population); None keeps
+                // slice 1 a pure additive contract change (see
+                // docs/PORTAL_META_SIDECAR.md).
+                meta: None,
             },
         );
     }

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -146,6 +146,9 @@ pub(super) fn replay_history(
 
     let _ = tx.send(ServerToClient::HistoryBatch {
         messages,
+        // Populated in slice 2 (backend meta population); empty keeps slice 1
+        // a pure additive contract change (see docs/PORTAL_META_SIDECAR.md).
+        message_meta: Vec::new(),
         last_created_at,
     });
 }
@@ -364,6 +367,7 @@ mod replay_tests {
             shared::ServerToClient::HistoryBatch {
                 messages,
                 last_created_at,
+                ..
             } => (messages, last_created_at),
             other => panic!("expected HistoryBatch, got {:?}", other),
         };
@@ -425,6 +429,7 @@ mod replay_tests {
             shared::ServerToClient::HistoryBatch {
                 messages,
                 last_created_at,
+                ..
             } => (messages, last_created_at),
             other => panic!("expected HistoryBatch, got {:?}", other),
         };

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -137,6 +137,7 @@ pub(super) mod test_support {
             agent_type: shared::AgentType::Claude,
             created_at: None,
             origin: None,
+            meta: None,
         }
     }
 }

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -430,6 +430,7 @@ fn handle_web_input(
                     agent_type,
                     created_at: row_created_at,
                     origin: None,
+                    meta: None,
                 },
             );
         }

--- a/docs/PORTAL_META_SIDECAR.md
+++ b/docs/PORTAL_META_SIDECAR.md
@@ -183,9 +183,9 @@ wrapper once no old bundles remain, or keep the parallel form if simpler.
 - **Stop mutating content.** `normalize_output_content` keeps deriving
   provenance for the columns but **leaves `content` as the raw
   `AgentMessage`** (no rewrite to `Text`). Display text is derived frontend-side
-  from the typed `PortalContent::AgentMessage` + `meta.origin`.
+  from the typed `PortalContent::AgentMessage` + `meta.source`.
   - ⚠️ Migration nuance: existing rows were already rewritten to `Text` with
-    provenance in columns — those still render correctly via `meta.origin`, so
+    provenance in columns — those still render correctly via `meta.source`, so
     no backfill needed. New rows keep the richer raw form.
 - During transition, **also** keep the `_`-injection (`replay.rs`) and the
   deprecated flat fields on `AgentOutput`, so an un-updated frontend bundle
@@ -195,8 +195,8 @@ wrapper once no old bundles remain, or keep the parallel form if simpler.
 
 - A single typed `RenderedMessage { content, meta }` (or thread `meta` next to
   the content string the message buffer already holds).
-- Renderer reads `meta.origin` / `meta.sender` / `meta.delivery_*` directly.
-  `agent_message_event` prefers `meta.origin`, then the existing typed-content
+- Renderer reads `meta.source` / `meta.delivery` directly.
+  `agent_message_event` prefers `meta.source` (the `Agent` variant), then the existing typed-content
   fallback (stale-proxy raw `AgentMessage`), and **drops all `_`-key reads**.
 - Delete `inject_message_metadata` and the `_`-injection in `websocket.rs`
   once reading from `meta`.
@@ -219,7 +219,7 @@ wrapper once no old bundles remain, or keep the parallel form if simpler.
 
 | # | Slice | Owner | Depends on |
 |---|-------|-------|-----------|
-| 1 | `shared`: add `PortalMeta`, `MessageSender`, `HistoryEntry`; add `meta` to `AgentOutput` (additive, defaults) | Claude | — |
+| 1 | `shared`: add `PortalMeta` + `MessageSource` + `DeliveryMeta`; add `meta` to `AgentOutput` and index-aligned `message_meta` to `HistoryBatch` (additive, defaults) | Claude | — |
 | 2 | Backend: `Message::portal_meta()`; populate `meta` on live + HTTP + WS-replay paths (keep flat fields + `_`-injection) | Claude | 1 |
 | 3 | Frontend: read from `meta` when present, fall back to `_`-keys; render unchanged | Codex | 1 |
 | 4 | Backend: stop rewriting `content` in `normalize_output_content` (keep columns) | Claude | 3 deployed |
@@ -236,11 +236,12 @@ contract. Land/agree it first; both sides build against it.
 - `shared`: round-trip `PortalMeta` (all-none default, full); `AgentOutput`
   with/without `meta` deserializes (old + new wire).
 - Backend: `Message::portal_meta()` maps each column combo; inter-agent row →
-  `meta.origin = InterAgent`; non-UUID `provenance_session_id` → `None` (not a
-  panic). `normalize` leaves content raw (slice 4).
-- Frontend (Codex): `AgentOutput { meta.origin: InterAgent }` renders the
+  `meta.source = Agent`; user row → `Human`; portal row → `Portal`; non-UUID
+  `provenance_session_id` → `None` (not a panic). `normalize` leaves content raw
+  (slice 4).
+- Frontend (Codex): `AgentOutput { meta.source: Agent }` renders the
   "Message from Codex" card; `meta` absent + legacy `_origin` still works
-  (transition); optimistic delivery stages drive off `meta`.
+  (transition); optimistic delivery stages drive off `meta.delivery`.
 
 ## 7. Rollout & back-compat invariants
 

--- a/docs/PORTAL_META_SIDECAR.md
+++ b/docs/PORTAL_META_SIDECAR.md
@@ -1,0 +1,205 @@
+# Portal metadata sidecar — design & plan
+
+**Status:** proposed (Claude + Codex co-design)
+**Owners:** backend/shared → Claude · frontend → Codex
+**Tracking versions:** TBD per slice (coordinate to avoid parallel-PR collisions)
+
+## 1. Problem
+
+Portal-specific message metadata (attribution, sender, server timestamp,
+delivery tracking) is **flattened into the agent's own JSON blob** as
+`_`-prefixed keys, on every delivery path, and read back on the frontend by
+`#[serde(rename = "_origin")]`-style string keys.
+
+The metadata already exists server-side as **typed `messages` columns**
+(`provenance_kind` / `provenance_session_id` / `provenance_agent_type`,
+`created_at`, `user_id`, `agent_type`, `role`). We then *re-flatten* those
+columns into the content blob in **four independent places**:
+
+| Path | Site | Injects |
+|------|------|---------|
+| Live broadcast | `frontend/.../session_view/websocket.rs:164/174/180` | `_sender`, `_created_at`, `_origin` |
+| WS history replay | `backend/.../websocket/replay.rs:119/133/138` | `_sender`, `_created_at`, `_origin` |
+| HTTP history load | `frontend/.../session_view/helpers.rs:320…` (`inject_message_metadata`) | `_sender`, `_created_at`, `_origin` |
+| Optimistic / delivery | frontend `component.rs`, `agent_frame.rs` | `_client_msg_id`, `_delivery_stage`, `_delivery_message`, `_pending` |
+
+The renderer (`frontend/src/components/message_renderer/types.rs`) then fishes
+these back out by string key.
+
+### Why this is the bug we keep hitting
+
+`_origin` is a **convention, not a type**. The four injection sites must stay
+byte-identical, forever, with no compiler enforcement. When one drifts — or a
+browser runs a cached bundle whose injection predates a field — attribution
+silently degrades to a generic "PORTAL" card (the inter-agent render gap, #1082
+→ #1130). The data was correct in the DB the whole time; it was lost in the
+flatten/re-parse round-trip.
+
+Additional smell: `normalize_output_content` (`message_handlers.rs:349`)
+**mutates the source-of-truth blob** — it rewrites a typed
+`PortalContent::AgentMessage` down to plain `Text` and moves the attribution to
+columns. The stored `content` is therefore no longer the raw agent message,
+which complicates replay and makes the frontend depend on the re-injected
+sidecar to reconstruct what it already had.
+
+## 2. Goal
+
+Bifurcate cleanly at the **wire + render boundary** (the DB is already a
+raw-blob + sidecar-columns split, so no migration is required):
+
+- `content` = the **raw agent JSON, untouched**.
+- A **typed `PortalMeta` sidecar** carried as a *sibling* field on the wire,
+  never merged into `content`.
+- The frontend renders from **typed `meta` fields**; zero `_`-key string reads.
+
+One mapping (columns → `PortalMeta`), one wire shape, one parse. Dropping a
+field becomes a **compile error**, not a silent render gap.
+
+## 3. Design
+
+### 3.1 Shared types (`shared/src/endpoints/` or `shared/src/lib.rs`)
+
+```rust
+/// Portal-side presentation/provenance metadata for a rendered message.
+/// Carried alongside the raw agent `content`, never merged into it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct PortalMeta {
+    /// Server-assigned persisted-row timestamp (ISO-8601 µs); reconnect watermark.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// Human sender attribution (user-role messages).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender: Option<MessageSender>,
+    /// Inter-agent provenance (the "Message from Codex (…)" card).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<MessageOrigin>,
+    /// Browser-assigned delivery-tracking id (optimistic row correlation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_msg_id: Option<Uuid>,
+    /// Live delivery stage for an optimistic send.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery_stage: Option<InputDeliveryStage>,
+    /// Failure detail (only when stage == Failed).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery_message: Option<String>,
+    /// True while an optimistic send hasn't reached AgentAccepted.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub pending: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageSender { pub user_id: String, pub name: String }
+```
+
+`MessageOrigin`, `InputDeliveryStage` already exist in `shared`.
+`MessageSender` is promoted from the frontend (currently
+`message_renderer::types::MessageSender`) into `shared`.
+
+### 3.2 Wire envelope changes (`shared/src/endpoints/client.rs`)
+
+Add a single optional, typed `meta` field next to the raw content on every
+message-bearing variant. All additive + `#[serde(default)]` → older clients and
+backends stay parseable.
+
+```rust
+ServerToClient::AgentOutput {
+    content: serde_json::Value,          // RAW agent JSON
+    agent_type: AgentType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    meta: Option<PortalMeta>,            // NEW typed sidecar
+    // DEPRECATED, kept during transition: sender_user_id, sender_name,
+    // created_at, origin — populated AND mirrored into `meta` until the
+    // frontend cuts over, then removed (slice 5).
+}
+```
+
+`HistoryBatch` is the harder one: today each entry is a bare
+`serde_json::Value` (raw content with `_`-keys baked in). Replace with a typed
+pair so history matches the live path:
+
+```rust
+#[derive(Serialize, Deserialize)]
+pub struct HistoryEntry {
+    pub content: serde_json::Value,      // RAW
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<PortalMeta>,
+}
+HistoryBatch { messages: Vec<HistoryEntry>, last_created_at: Option<String> }
+```
+
+Back-compat: keep accepting the old `Vec<Value>` shape during transition via an
+untagged enum or a transitional second field — see §5 slicing.
+
+### 3.3 Backend (`Claude`)
+
+- **`Message::portal_meta()`** on `models.rs` — single constructor mapping the
+  existing typed columns → `PortalMeta` (supersedes `Message::origin()`; keep
+  `origin()` as a thin shim until callers migrate).
+- Populate `meta` on all three emit paths from columns:
+  `message_handlers.rs` (live), `replay.rs` (WS history), `messages.rs` (HTTP).
+- **Stop mutating content.** `normalize_output_content` keeps deriving
+  provenance for the columns but **leaves `content` as the raw
+  `AgentMessage`** (no rewrite to `Text`). Display text is derived frontend-side
+  from the typed `PortalContent::AgentMessage` + `meta.origin`.
+  - ⚠️ Migration nuance: existing rows were already rewritten to `Text` with
+    provenance in columns — those still render correctly via `meta.origin`, so
+    no backfill needed. New rows keep the richer raw form.
+- During transition, **also** keep the `_`-injection (`replay.rs`) and the
+  deprecated flat fields on `AgentOutput`, so an un-updated frontend bundle
+  still works. Remove in slice 5.
+
+### 3.4 Frontend (`Codex`)
+
+- A single typed `RenderedMessage { content, meta }` (or thread `meta` next to
+  the content string the message buffer already holds).
+- Renderer reads `meta.origin` / `meta.sender` / `meta.delivery_*` directly.
+  `agent_message_event` prefers `meta.origin`, then the existing typed-content
+  fallback (stale-proxy raw `AgentMessage`), and **drops all `_`-key reads**.
+- Delete `inject_message_metadata` and the `_`-injection in `websocket.rs`
+  once reading from `meta`.
+- `message_renderer::types::PortalMessage` loses its `_origin` field; origin
+  comes from `meta`.
+
+## 4. Non-goals / explicitly out of scope
+
+- **No DB migration.** Columns already hold the metadata.
+- No change to the proxy ↔ backend protocol (`ProxyToServer`). The proxy still
+  forwards the typed `AgentMessage`; normalization stays backend-side.
+- No change to how the agent SDKs (`claude-codes` / `codex-codes`) are parsed.
+
+## 5. Slicing (thin, independently mergeable, parallel where possible)
+
+| # | Slice | Owner | Depends on |
+|---|-------|-------|-----------|
+| 1 | `shared`: add `PortalMeta`, `MessageSender`, `HistoryEntry`; add `meta` to `AgentOutput` (additive, defaults) | Claude | — |
+| 2 | Backend: `Message::portal_meta()`; populate `meta` on live + HTTP + WS-replay paths (keep flat fields + `_`-injection) | Claude | 1 |
+| 3 | Frontend: read from `meta` when present, fall back to `_`-keys; render unchanged | Codex | 1 |
+| 4 | Backend: stop rewriting `content` in `normalize_output_content` (keep columns) | Claude | 3 deployed |
+| 5 | Remove `_`-injection + deprecated flat fields once all clients read `meta` | Codex + Claude | 3, 4 |
+
+Slices 1–3 are the bulk and can run in parallel after slice 1's shape lands.
+Slices 4–5 are cleanup, gated on the frontend cutover being live.
+
+**Critical sync point:** slice 1 (the `PortalMeta` + envelope shape) is the
+contract. Land/agree it first; both sides build against it.
+
+## 6. Test plan
+
+- `shared`: round-trip `PortalMeta` (all-none default, full); `AgentOutput`
+  with/without `meta` deserializes (old + new wire).
+- Backend: `Message::portal_meta()` maps each column combo; inter-agent row →
+  `meta.origin = InterAgent`; non-UUID `provenance_session_id` → `None` (not a
+  panic). `normalize` leaves content raw (slice 4).
+- Frontend (Codex): `AgentOutput { meta.origin: InterAgent }` renders the
+  "Message from Codex" card; `meta` absent + legacy `_origin` still works
+  (transition); optimistic delivery stages drive off `meta`.
+
+## 7. Rollout & back-compat invariants
+
+1. Every new field is `#[serde(default)]` — old↔new in both directions parse.
+2. Transition keeps BOTH `meta` and the flat/`_`-injected fields populated, so
+   a cached old frontend bundle and a new backend coexist (this is the exact
+   failure we just debugged — make it impossible by construction).
+3. Flat fields + `_`-injection are removed only in slice 5, after the frontend
+   reads `meta` in production.
+4. Each PR bumps `[workspace.package] version`; coordinate numbers in chat.

--- a/docs/PORTAL_META_SIDECAR.md
+++ b/docs/PORTAL_META_SIDECAR.md
@@ -60,40 +60,75 @@ field becomes a **compile error**, not a silent render gap.
 ### 3.1 Shared types (`shared/src/endpoints/` or `shared/src/lib.rs`)
 
 ```rust
+/// Who produced a message — a single sum type (human XOR agent XOR portal)
+/// replacing the independent `sender` + `origin` optionals. `None` on
+/// PortalMeta = this session's own agent output (no attribution chip needed).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MessageSource {
+    Human { account_id: Uuid, name: String },
+    Agent { session_id: Uuid, agent_type: String },  // subsumes MessageOrigin::InterAgent
+    Portal,                                           // continuations, reminders, system notices
+}
+
 /// Portal-side presentation/provenance metadata for a rendered message.
 /// Carried alongside the raw agent `content`, never merged into it.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct PortalMeta {
     /// Server-assigned persisted-row timestamp (ISO-8601 µs); reconnect watermark.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
-    /// Human sender attribution (user-role messages).
+    /// Who produced the message (folds old sender + origin into one sum type).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sender: Option<MessageSender>,
-    /// Inter-agent provenance (the "Message from Codex (…)" card).
+    pub source: Option<MessageSource>,
+    /// Optimistic-send delivery tracking (frontend-owned; backend leaves None).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub origin: Option<MessageOrigin>,
-    /// Browser-assigned delivery-tracking id (optimistic row correlation).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub client_msg_id: Option<Uuid>,
-    /// Live delivery stage for an optimistic send.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub delivery_stage: Option<InputDeliveryStage>,
-    /// Failure detail (only when stage == Failed).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub delivery_message: Option<String>,
-    /// True while an optimistic send hasn't reached AgentAccepted.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub pending: bool,
+    pub delivery: Option<DeliveryMeta>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct MessageSender { pub user_id: String, pub name: String }
+/// Grouped so "a tracked send always has a client_msg_id" is structural, not
+/// four independently-Option fields that could drift into nonsense.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliveryMeta {
+    pub client_msg_id: Uuid,                       // non-optional: tracked ⇒ has id
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stage: Option<InputDeliveryStage>,         // None = submitted, awaiting first ack
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,                   // Failed-only detail
+}
+// pending() is DERIVED from stage, not stored — can never disagree with it.
 ```
 
-`MessageOrigin`, `InputDeliveryStage` already exist in `shared`.
-`MessageSender` is promoted from the frontend (currently
-`message_renderer::types::MessageSender`) into `shared`.
+**On tightness (reviewed per Matt's two notes):**
+
+- **`Option`-ness:** `created_at` and `source` stay `Option` — each is genuinely
+  absent for most messages, and a non-optional sentinel (client-clock timestamp,
+  a "no source" marker) would reintroduce exactly the is-this-real ambiguity
+  this refactor removes. The delivery cluster (was
+  `client_msg_id`/`delivery_stage`/`delivery_message`/`pending`) groups under one
+  `Option<DeliveryMeta>`: cuts top-level optionality, makes `client_msg_id`
+  non-optional inside, and **derives `pending` from the stage** (drops the bool).
+- **`MessageSource` sum type:** replaces two independent optionals
+  (`sender` human + `origin` inter-agent) — which could illegally both be set —
+  with one tagged enum. Backend maps existing columns → source:
+  `role=user` ⇒ `Human{user_id,name}`; `provenance_kind=inter_agent` ⇒
+  `Agent{session_id,agent_type}`; portal-generated rows ⇒ `Portal`. No DB
+  migration; `MessageOrigin` stays until slice 5 removes the deprecated path.
+
+`MessageOrigin`, `InputDeliveryStage` already exist in `shared`. `MessageSource`
+is new and supersedes both the frontend's `message_renderer::types::MessageSender`
+and `MessageOrigin` (the latter kept until slice 5).
+
+**Field ownership (important — `PortalMeta` is not "persisted delivery state"):**
+
+| Field | Set by | Notes |
+|-------|--------|-------|
+| `created_at`, `source` | **backend** | derived from `messages` columns (`created_at`; `role`/`user_id`/`provenance_*` → `source`); the durable, server-authoritative part |
+| `delivery` | **frontend** (local, for optimistic rows) | UI render state; the backend does **not** persist per-message delivery state. Live stage transitions arrive via `ServerToClient::InputProgress` and the frontend folds them into the matching optimistic row's `DeliveryMeta`. |
+
+So the *same* struct serves both wire-from-backend (attribution/timestamp) and
+local frontend optimistic state, but the backend only ever populates
+`created_at` + `source`. One render model, without implying the DB tracks delivery.
 
 ### 3.2 Wire envelope changes (`shared/src/endpoints/client.rs`)
 
@@ -113,22 +148,26 @@ ServerToClient::AgentOutput {
 }
 ```
 
-`HistoryBatch` is the harder one: today each entry is a bare
-`serde_json::Value` (raw content with `_`-keys baked in). Replace with a typed
-pair so history matches the live path:
+`HistoryBatch` needs care: today each entry is a bare `serde_json::Value` (raw
+content with `_`-keys baked in). **Replacing `messages` with a wrapper type is
+NOT additive** — a cached old frontend expects raw content values and would
+render the `{content, meta}` wrapper as the message body (the exact rollout
+failure §1/§7 warn about). Instead, **keep `messages` byte-compatible and add a
+parallel, index-aligned sidecar vector** (Codex's call, accepted):
 
 ```rust
-#[derive(Serialize, Deserialize)]
-pub struct HistoryEntry {
-    pub content: serde_json::Value,      // RAW
+HistoryBatch {
+    messages: Vec<serde_json::Value>,            // UNCHANGED (raw, still _-injected during transition)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    message_meta: Vec<Option<PortalMeta>>,       // index-aligned with messages; None per entry w/o meta
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub meta: Option<PortalMeta>,
+    last_created_at: Option<String>,
 }
-HistoryBatch { messages: Vec<HistoryEntry>, last_created_at: Option<String> }
 ```
 
-Back-compat: keep accepting the old `Vec<Value>` shape during transition via an
-untagged enum or a transitional second field — see §5 slicing.
+New frontends zip `messages` with `message_meta`; old frontends ignore the
+extra field and keep working. Slice 5 may collapse this into a `HistoryEntry`
+wrapper once no old bundles remain, or keep the parallel form if simpler.
 
 ### 3.3 Backend (`Claude`)
 
@@ -136,7 +175,11 @@ untagged enum or a transitional second field — see §5 slicing.
   existing typed columns → `PortalMeta` (supersedes `Message::origin()`; keep
   `origin()` as a thin shim until callers migrate).
 - Populate `meta` on all three emit paths from columns:
-  `message_handlers.rs` (live), `replay.rs` (WS history), `messages.rs` (HTTP).
+  `message_handlers.rs` (live `AgentOutput.meta`), `replay.rs` (WS history
+  `message_meta`), `messages.rs` (HTTP). For HTTP, add `meta: Option<PortalMeta>`
+  to the `MessageWithSender` response row **while keeping the existing top-level
+  `origin`/`sender_name` fields** during transition, so the frontend uses one
+  sidecar model across live WS, WS replay, and REST history.
 - **Stop mutating content.** `normalize_output_content` keeps deriving
   provenance for the columns but **leaves `content` as the raw
   `AgentMessage`** (no rewrite to `Text`). Display text is derived frontend-side
@@ -159,6 +202,11 @@ untagged enum or a transitional second field — see §5 slicing.
   once reading from `meta`.
 - `message_renderer::types::PortalMessage` loses its `_origin` field; origin
   comes from `meta`.
+- **Grouping simplification (Matt's note):** message grouping
+  (`message_renderer/grouping.rs`) can match on the typed `meta.source` variant
+  — group consecutive same-`source` runs, break on a `source` change — instead
+  of sniffing `_origin`/role/`_sender` out of the content blob. Fold this into
+  slice 3.
 
 ## 4. Non-goals / explicitly out of scope
 

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -143,6 +143,9 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
             agent_type: _,
             created_at,
             origin,
+            // Typed portal sidecar — consumed in slice 3 (frontend read-from-meta);
+            // ignored here so slice 1 stays a no-op contract change.
+            meta: _,
         } => {
             // Inject _sender into content for the renderer if sender info is
             // present. Also fold `created_at` into the content as
@@ -188,6 +191,9 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
         }
         ServerToClient::HistoryBatch {
             messages,
+            // Index-aligned typed sidecar — zipped in slice 3 (frontend
+            // read-from-meta); ignored here so slice 1 stays a no-op.
+            message_meta: _,
             last_created_at,
         } => {
             let strings: Vec<String> = messages.into_iter().map(|v| v.to_string()).collect();
@@ -425,6 +431,7 @@ mod tests {
             agent_type: shared::AgentType::Claude,
             created_at: Some(server_ts.clone()),
             origin: None,
+            meta: None,
         };
 
         handle_proxy_message(msg, &cb);
@@ -473,6 +480,7 @@ mod tests {
                 from_session_id,
                 from_agent_type: "codex".to_string(),
             }),
+            meta: None,
         };
 
         handle_proxy_message(msg, &cb);
@@ -509,6 +517,7 @@ mod tests {
             agent_type: shared::AgentType::Claude,
             created_at: None,
             origin: None,
+            meta: None,
         };
 
         handle_proxy_message(msg, &cb);
@@ -532,6 +541,7 @@ mod tests {
         let ts = "2026-05-18T00:00:00.000000".to_string();
         let msg = ServerToClient::HistoryBatch {
             messages: vec![serde_json::json!({"_created_at": ts.clone()})],
+            message_meta: Vec::new(),
             last_created_at: Some(ts.clone()),
         };
 
@@ -556,6 +566,7 @@ mod tests {
         let (cb, sink) = capture();
         let msg = ServerToClient::HistoryBatch {
             messages: vec![],
+            message_meta: Vec::new(),
             last_created_at: None,
         };
 

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -29,6 +29,86 @@ pub enum InputDeliveryStage {
     Failed,
 }
 
+/// Who produced a message. A single sum type — exactly one of human / agent /
+/// portal — rather than independent `sender` + `origin` optionals that could
+/// (illegally) both be set or disagree. `None` on [`PortalMeta`] means "this
+/// session's own agent output" (the common assistant-message case), which
+/// needs no attribution chip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MessageSource {
+    /// A human user via the web client. Drives the per-message sender label on
+    /// multi-member sessions.
+    Human { account_id: Uuid, name: String },
+    /// Another agent session (inter-agent message) — drives the
+    /// "Message from Codex (…)" card. Subsumes the old `MessageOrigin::InterAgent`.
+    Agent {
+        session_id: Uuid,
+        agent_type: String,
+    },
+    /// The portal itself: continuation prompts, reminders, system notices.
+    Portal,
+}
+
+/// Portal-side presentation/provenance metadata for a rendered message.
+///
+/// Carried as a typed **sibling** of the raw agent `content`, never merged into
+/// it. This is the structured replacement for the historical `_origin` /
+/// `_sender` / `_created_at` / `_delivery_*` keys that were flattened into the
+/// agent JSON blob on every delivery path and read back by string key — a
+/// convention with no compile-time enforcement that silently dropped
+/// attribution when any one injection site drifted (see
+/// `docs/PORTAL_META_SIDECAR.md`). Every field is optional + `serde(default)`
+/// so old↔new wire parses in both directions during the transition.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PortalMeta {
+    /// Server-assigned persisted-row timestamp (ISO-8601 µs); the frontend's
+    /// reconnect-replay watermark. `Option` because optimistic (pre-persist)
+    /// rows and non-DB broadcast paths have no server timestamp yet — a
+    /// client-clock sentinel would reintroduce the #784 skew bug.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// Who produced the message. `Option` (= this session's own agent output)
+    /// rather than per-source flags — the sum type makes "human XOR agent XOR
+    /// portal" structural. Folds the old `sender` + `origin` into one field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<MessageSource>,
+    /// Optimistic-send delivery tracking. `Option` because only browser-sent,
+    /// tracked inputs have it; once present the id + stage are guaranteed (see
+    /// [`DeliveryMeta`]). Frontend-owned — the backend leaves this `None` (it
+    /// does not persist per-message delivery state).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery: Option<DeliveryMeta>,
+}
+
+/// Frontend-owned optimistic-send delivery state for a tracked input. Grouped
+/// so the invariant "a tracked send always has a `client_msg_id`" is
+/// structural rather than four independently-`Option` fields that could drift
+/// into nonsensical combinations (a stage with no id, etc.).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliveryMeta {
+    /// Browser-assigned id correlating this row with its delivery stages.
+    pub client_msg_id: Uuid,
+    /// Latest stage reached. `None` ⇒ submitted locally, awaiting the first
+    /// server ack (`ServerReceived`). Non-`None` once stages start arriving.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stage: Option<InputDeliveryStage>,
+    /// Failure detail (only when `stage == Some(Failed)`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+impl DeliveryMeta {
+    /// Whether the optimistic row should still render as "pending" — derived
+    /// from the stage rather than stored, so it can never disagree with it.
+    pub fn pending(&self) -> bool {
+        !matches!(
+            self.stage,
+            Some(InputDeliveryStage::AgentAccepted) | Some(InputDeliveryStage::Failed)
+        )
+    }
+}
+
 pub struct ClientEndpoint;
 
 impl WsEndpoint for ClientEndpoint {
@@ -114,6 +194,15 @@ pub enum ServerToClient {
         created_at: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         origin: Option<MessageOrigin>,
+        /// Typed portal sidecar (attribution, sender, timestamp, delivery
+        /// stage). Carried alongside the raw `content`; the frontend renders
+        /// from this rather than from `_`-keys flattened into `content`. During
+        /// the transition the backend ALSO mirrors these values into the
+        /// deprecated flat fields above and the `_`-injection so an
+        /// un-updated frontend bundle keeps working; both are removed once the
+        /// frontend reads `meta` in production (see `docs/PORTAL_META_SIDECAR.md`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        meta: Option<PortalMeta>,
     },
 
     /// Batch of historical messages for replay.
@@ -127,6 +216,16 @@ pub enum ServerToClient {
     /// out of the last entry. Both default to absent on older backends.
     HistoryBatch {
         messages: Vec<serde_json::Value>,
+        /// Typed portal sidecar, **index-aligned** with `messages` (entry `i`
+        /// is the meta for `messages[i]`; `None` when a message has no portal
+        /// metadata). Kept as a parallel vector — rather than wrapping each
+        /// entry — so `messages` stays byte-compatible for cached old frontend
+        /// bundles, which simply ignore this field. New frontends zip the two.
+        /// `#[serde(default)]` ⇒ empty/absent on older backends. The `_`-keys
+        /// remain injected into `messages` during the transition; both are
+        /// removed in slice 5 (see `docs/PORTAL_META_SIDECAR.md`).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        message_meta: Vec<Option<PortalMeta>>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         last_created_at: Option<String>,
     },

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -104,6 +104,86 @@ mod tests {
     }
 
     #[test]
+    fn portal_meta_round_trips_and_omits_empty_fields() {
+        use crate::endpoints::client::{DeliveryMeta, MessageSource, PortalMeta};
+        use crate::InputDeliveryStage;
+
+        // Default (all-none) serializes to `{}` — no stray keys on the wire.
+        assert_eq!(serde_json::to_string(&PortalMeta::default()).unwrap(), "{}");
+
+        let meta = PortalMeta {
+            created_at: Some("2026-06-26T12:00:00.000000".to_string()),
+            source: Some(MessageSource::Agent {
+                session_id: Uuid::nil(),
+                agent_type: "codex".to_string(),
+            }),
+            delivery: Some(DeliveryMeta {
+                client_msg_id: Uuid::nil(),
+                stage: Some(InputDeliveryStage::ProxyReceived),
+                message: None,
+            }),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: PortalMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, meta);
+    }
+
+    #[test]
+    fn message_source_is_a_tagged_sum() {
+        use crate::endpoints::client::MessageSource;
+        let human = MessageSource::Human {
+            account_id: Uuid::nil(),
+            name: "Matt".to_string(),
+        };
+        let json = serde_json::to_string(&human).unwrap();
+        assert!(json.contains(r#""kind":"human""#));
+        assert_eq!(
+            serde_json::to_string(&MessageSource::Portal).unwrap(),
+            r#"{"kind":"portal"}"#
+        );
+        let back: MessageSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, human);
+    }
+
+    #[test]
+    fn delivery_meta_pending_is_derived_from_stage() {
+        use crate::endpoints::client::DeliveryMeta;
+        use crate::InputDeliveryStage;
+
+        let d = |stage| DeliveryMeta {
+            client_msg_id: Uuid::nil(),
+            stage,
+            message: None,
+        };
+        assert!(d(None).pending()); // submitted, no ack yet
+        assert!(d(Some(InputDeliveryStage::ServerReceived)).pending());
+        assert!(d(Some(InputDeliveryStage::ProxyReceived)).pending());
+        assert!(!d(Some(InputDeliveryStage::AgentAccepted)).pending());
+        assert!(!d(Some(InputDeliveryStage::Failed)).pending());
+    }
+
+    #[test]
+    fn agent_output_meta_is_back_compatible() {
+        use crate::endpoints::client::ServerToClient;
+
+        // An old-backend frame without `meta`/`message_meta` still parses.
+        // (The variant serializes with the legacy `ClaudeOutput` tag.)
+        let legacy = r#"{"type":"ClaudeOutput","content":{"type":"portal"}}"#;
+        let parsed: ServerToClient = serde_json::from_str(legacy).unwrap();
+        match parsed {
+            ServerToClient::AgentOutput { meta, .. } => assert!(meta.is_none()),
+            _ => panic!("Wrong variant"),
+        }
+
+        let legacy_history = r#"{"type":"HistoryBatch","messages":[{"type":"portal"}]}"#;
+        let parsed: ServerToClient = serde_json::from_str(legacy_history).unwrap();
+        match parsed {
+            ServerToClient::HistoryBatch { message_meta, .. } => assert!(message_meta.is_empty()),
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
     fn client_to_server_claude_input_roundtrip() {
         let id = uuid::Uuid::from_u128(7);
         let msg = ClientToServer::AgentInput {
@@ -180,6 +260,7 @@ mod tests {
             agent_type: AgentType::Codex,
             created_at: Some("2026-05-18T12:34:56.789012".to_string()),
             origin: None,
+            meta: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerToClient = serde_json::from_str(&json).unwrap();
@@ -220,6 +301,7 @@ mod tests {
             ServerToClient::HistoryBatch {
                 messages,
                 last_created_at,
+                ..
             } => {
                 assert!(messages.is_empty());
                 assert!(last_created_at.is_none());
@@ -236,6 +318,7 @@ mod tests {
     fn history_batch_roundtrip_with_last_created_at() {
         let msg = ServerToClient::HistoryBatch {
             messages: vec![serde_json::json!({"_created_at": "2026-05-18T00:00:00.000000"})],
+            message_meta: Vec::new(),
             last_created_at: Some("2026-05-18T00:00:00.000000".to_string()),
         };
         let json = serde_json::to_string(&msg).unwrap();
@@ -244,6 +327,7 @@ mod tests {
             ServerToClient::HistoryBatch {
                 messages,
                 last_created_at,
+                ..
             } => {
                 assert_eq!(messages.len(), 1);
                 assert_eq!(


### PR DESCRIPTION
## What

Slice 1 of the portal-metadata bifurcation (full design: `docs/PORTAL_META_SIDECAR.md`). Establishes the **typed sidecar contract** that replaces flattening `_origin`/`_sender`/`_created_at`/`_delivery_*` keys into the agent's content blob — the root-cause fix for the attribution bug class (an `_origin` injection site drifting / a stale bundle silently dropping attribution).

**This slice is purely additive — no behavior change.** All new fields default to absent; the `_`-injection and flat fields remain for transition.

## Contract (`shared/src/endpoints/client.rs`)

- `PortalMeta { created_at, source, delivery }` — carried as a typed **sibling** of raw `content`, never merged in.
- `MessageSource` sum type (`Human` / `Agent` / `Portal`) — folds the previously-independent `sender` + `origin` optionals into one "exactly one source" enum (subsumes `MessageOrigin::InterAgent`).
- `DeliveryMeta` — groups the optimistic-delivery fields so "tracked ⇒ has a `client_msg_id`" is structural; `pending()` is **derived** from stage, not stored.
- `ServerToClient::AgentOutput` gains `meta: Option<PortalMeta>`.
- `ServerToClient::HistoryBatch` gains an **index-aligned** `message_meta: Vec<Option<PortalMeta>>` — `messages` stays byte-compatible so cached old frontends keep working (Codex's compatibility call).

Design notes captured in the doc: `Option`-ness review (per-message attributes stay `Option`; delivery cluster grouped), `MessageSource` rationale, why `AgentOutput` stays `content: Value + agent_type` (forward-compat — type at the render edge, not the wire), and the grouping simplification.

## Slicing

1. **(this PR)** shared contract — Claude
2. backend `meta` population from columns — Claude
3. frontend render-from-`meta` (+ grouping by `source`) — Codex
4. backend stop rewriting content — Claude
5. remove `_`-injection + flat fields — both

## Testing

`cargo build --workspace --all-targets` ✅ · `cargo test` (shared/frontend/backend) ✅ · `cargo clippy --workspace --all-targets` ✅ · frontend WASM build + clippy ✅ · `cargo fmt --check` ✅. Round-trip + old-wire back-compat tests added.

Version → 2.12.44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)