### PR TITLE
Portal metadata sidecar — slice 2: backend populates PortalMeta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.44"
+version = "2.12.45"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.44"
+version = "2.12.45"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.44"
+version = "2.12.45"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.44"
+version = "2.12.45"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.44"
+version = "2.12.45"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.44"
+version = "2.12.45"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.44"
+version = "2.12.45"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.44"
+version = "2.12.45"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.44"
+version = "2.12.45"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.44"
+version = "2.12.45"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.44"
+version = "2.12.45"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -80,6 +80,11 @@ pub struct MessageWithSender {
     pub sender_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub origin: Option<shared::MessageOrigin>,
+    /// Typed portal sidecar (`created_at` + `source`); the frontend renders from
+    /// this. `origin`/`sender_name` above stay during the transition (see
+    /// docs/PORTAL_META_SIDECAR.md).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<shared::PortalMeta>,
 }
 
 /// Create a new message for a session
@@ -215,10 +220,12 @@ pub async fn list_messages(
                 None
             };
             let origin = msg.origin();
+            let meta = Some(msg.portal_meta(sender_name.clone()));
             MessageWithSender {
                 message: msg,
                 sender_name,
                 origin,
+                meta,
             }
         })
         .collect();

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -106,7 +106,9 @@ pub fn handle_session_limit_reached(
         continuation.status.clone(),
         continuation.source_message.clone().unwrap_or_default(),
     );
-    let row_created_at = insert_portal_message(&mut conn, &session, &portal);
+    let inserted = insert_portal_message(&mut conn, &session, &portal);
+    let row_created_at = inserted.as_ref().map(|m| m.created_at_iso());
+    let meta = inserted.map(|m| m.portal_meta(None));
 
     if let Some(key) = session_key {
         session_manager.broadcast_to_web_clients(
@@ -118,7 +120,7 @@ pub fn handle_session_limit_reached(
                 agent_type: session.agent_type.parse().unwrap_or_default(),
                 created_at: row_created_at,
                 origin: None,
-                meta: None,
+                meta,
             },
         );
     }
@@ -278,7 +280,9 @@ fn update_terminal_status(
                         "Continuation was not sent because the local Claude process was no longer running when the session limit reset."
                             .to_string(),
                     );
-                    let row_created_at = insert_portal_message(&mut conn, &session, &portal);
+                    let inserted = insert_portal_message(&mut conn, &session, &portal);
+                    let row_created_at = inserted.as_ref().map(|m| m.created_at_iso());
+                    let meta = inserted.map(|m| m.portal_meta(None));
                     app_state.session_manager.broadcast_to_web_clients(
                         &session_id.to_string(),
                         ServerToClient::AgentOutput {
@@ -288,7 +292,7 @@ fn update_terminal_status(
                             agent_type: session.agent_type.parse().unwrap_or_default(),
                             created_at: row_created_at,
                             origin: None,
-                            meta: None,
+                            meta,
                         },
                     );
                 }
@@ -344,11 +348,14 @@ pub fn load_scheduled_continuations(
         .collect()
 }
 
+/// Insert a portal-role message and return the persisted row, so callers can
+/// derive both the server `created_at` and the typed `PortalMeta` sidecar
+/// (`source = Portal`) for the live broadcast (#portal-meta).
 fn insert_portal_message(
     conn: &mut diesel::PgConnection,
     session: &Session,
     portal: &PortalMessage,
-) -> Option<String> {
+) -> Option<crate::models::Message> {
     use crate::schema::messages;
     let new_message = NewMessage {
         session_id: session.id,
@@ -364,12 +371,7 @@ fn insert_portal_message(
         .values(&new_message)
         .get_result::<crate::models::Message>(conn)
     {
-        Ok(inserted) => Some(
-            inserted
-                .created_at
-                .format("%Y-%m-%dT%H:%M:%S%.6f")
-                .to_string(),
-        ),
+        Ok(inserted) => Some(inserted),
         Err(e) => {
             error!("Failed to store continuation portal message: {}", e);
             None

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -233,6 +233,9 @@ pub fn handle_claude_output(
     // silently dropping the message (the frontend keeps its prior
     // watermark and a future message will heal it).
     let mut row_created_at: Option<String> = None;
+    // Typed portal sidecar for the live broadcast, derived from the persisted
+    // row's columns (#portal-meta). `None` when the insert didn't run/failed.
+    let mut broadcast_meta: Option<shared::PortalMeta> = None;
     if let (Some(session_id), Ok(mut conn)) = (db_session_id, db_pool.get()) {
         use crate::schema::{messages, sessions};
 
@@ -271,12 +274,9 @@ pub fn handle_claude_output(
                     // Format matches `replay_history`'s parser
                     // (`%Y-%m-%dT%H:%M:%S%.f`) and the frontend's
                     // `last_message_timestamp` watermark shape.
-                    row_created_at = Some(
-                        inserted
-                            .created_at
-                            .format("%Y-%m-%dT%H:%M:%S%.6f")
-                            .to_string(),
-                    );
+                    row_created_at = Some(inserted.created_at_iso());
+                    broadcast_meta =
+                        Some(inserted.portal_meta(sender_info.as_ref().map(|(_, n)| n.clone())));
                 }
                 Err(e) => {
                     error!("Failed to store message: {}", e);
@@ -333,10 +333,7 @@ pub fn handle_claude_output(
                 agent_type,
                 created_at: row_created_at,
                 origin,
-                // Populated in slice 2 (backend meta population); None keeps
-                // slice 1 a pure additive contract change (see
-                // docs/PORTAL_META_SIDECAR.md).
-                meta: None,
+                meta: broadcast_meta,
             },
         );
     }

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -85,70 +85,71 @@ pub(super) fn replay_history(
         .last()
         .map(|msg| msg.created_at.format("%Y-%m-%dT%H:%M:%S%.6f").to_string());
 
-    let messages: Vec<serde_json::Value> = history
-        .into_iter()
-        .map(|msg| {
-            let created_at_str = msg.created_at.format("%Y-%m-%dT%H:%M:%S%.6f").to_string();
-            // Fallback when the DB row content isn't valid JSON: wrap the raw
-            // string in a typed envelope so the frontend's `ClaudeMessage`
-            // dispatch still finds a `type` and `content`.
-            #[derive(serde::Serialize)]
-            struct FallbackMessageContent<'a> {
-                #[serde(rename = "type")]
-                message_type: &'a str,
-                content: &'a str,
-            }
-            let mut val =
-                serde_json::from_str::<serde_json::Value>(&msg.content).unwrap_or_else(|_| {
-                    serde_json::to_value(FallbackMessageContent {
-                        message_type: &msg.role,
-                        content: &msg.content,
-                    })
-                    .unwrap_or(serde_json::Value::Null)
-                });
-            if let Some(obj) = val.as_object_mut() {
-                // Reconstruct _sender for user messages from DB user_id
-                if msg.role == "user" {
-                    if let Some(name) = user_names.get(&msg.user_id) {
-                        #[derive(serde::Serialize)]
-                        struct SenderMeta<'a> {
-                            user_id: String,
-                            name: &'a str,
+    let (messages, message_meta): (Vec<serde_json::Value>, Vec<Option<shared::PortalMeta>>) =
+        history
+            .into_iter()
+            .map(|msg| {
+                // Typed sidecar, index-aligned with the message it accompanies.
+                let meta = Some(msg.portal_meta(user_names.get(&msg.user_id).cloned()));
+                let created_at_str = msg.created_at.format("%Y-%m-%dT%H:%M:%S%.6f").to_string();
+                // Fallback when the DB row content isn't valid JSON: wrap the raw
+                // string in a typed envelope so the frontend's `ClaudeMessage`
+                // dispatch still finds a `type` and `content`.
+                #[derive(serde::Serialize)]
+                struct FallbackMessageContent<'a> {
+                    #[serde(rename = "type")]
+                    message_type: &'a str,
+                    content: &'a str,
+                }
+                let mut val = serde_json::from_str::<serde_json::Value>(&msg.content)
+                    .unwrap_or_else(|_| {
+                        serde_json::to_value(FallbackMessageContent {
+                            message_type: &msg.role,
+                            content: &msg.content,
+                        })
+                        .unwrap_or(serde_json::Value::Null)
+                    });
+                if let Some(obj) = val.as_object_mut() {
+                    // Reconstruct _sender for user messages from DB user_id
+                    if msg.role == "user" {
+                        if let Some(name) = user_names.get(&msg.user_id) {
+                            #[derive(serde::Serialize)]
+                            struct SenderMeta<'a> {
+                                user_id: String,
+                                name: &'a str,
+                            }
+                            obj.insert(
+                                "_sender".to_string(),
+                                serde_json::to_value(SenderMeta {
+                                    user_id: msg.user_id.to_string(),
+                                    name,
+                                })
+                                .unwrap_or(serde_json::Value::Null),
+                            );
                         }
+                    }
+                    // Inject _created_at so renderers (and the watermark
+                    // recovery path on reload) see the server-assigned row
+                    // timestamp. Matches the REST list-messages path which
+                    // surfaces `created_at` on every `MessageWithSender`.
+                    obj.insert(
+                        "_created_at".to_string(),
+                        serde_json::Value::String(created_at_str),
+                    );
+                    if let Some(origin) = msg.origin() {
                         obj.insert(
-                            "_sender".to_string(),
-                            serde_json::to_value(SenderMeta {
-                                user_id: msg.user_id.to_string(),
-                                name,
-                            })
-                            .unwrap_or(serde_json::Value::Null),
+                            "_origin".to_string(),
+                            serde_json::to_value(origin).unwrap_or(serde_json::Value::Null),
                         );
                     }
                 }
-                // Inject _created_at so renderers (and the watermark
-                // recovery path on reload) see the server-assigned row
-                // timestamp. Matches the REST list-messages path which
-                // surfaces `created_at` on every `MessageWithSender`.
-                obj.insert(
-                    "_created_at".to_string(),
-                    serde_json::Value::String(created_at_str),
-                );
-                if let Some(origin) = msg.origin() {
-                    obj.insert(
-                        "_origin".to_string(),
-                        serde_json::to_value(origin).unwrap_or(serde_json::Value::Null),
-                    );
-                }
-            }
-            val
-        })
-        .collect();
+                (val, meta)
+            })
+            .unzip();
 
     let _ = tx.send(ServerToClient::HistoryBatch {
         messages,
-        // Populated in slice 2 (backend meta population); empty keeps slice 1
-        // a pure additive contract change (see docs/PORTAL_META_SIDECAR.md).
-        message_meta: Vec::new(),
+        message_meta,
         last_created_at,
     });
 }

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -391,6 +391,9 @@ fn handle_web_input(
             // Insert first so the broadcast carries the server-assigned
             // `created_at` (closes #784 — same fix as handle_claude_output).
             let mut row_created_at: Option<String> = None;
+            // Typed portal sidecar for the broadcast (source = Portal), so a
+            // meta-only frontend gets created_at + source (#portal-meta).
+            let mut broadcast_meta: Option<shared::PortalMeta> = None;
             if let (Some(session), Ok(mut conn)) = (session.as_ref(), db_pool.get()) {
                 use crate::schema::messages;
                 let new_message = crate::models::NewMessage {
@@ -408,12 +411,8 @@ fn handle_web_input(
                     .get_result::<crate::models::Message>(&mut conn)
                 {
                     Ok(inserted) => {
-                        row_created_at = Some(
-                            inserted
-                                .created_at
-                                .format("%Y-%m-%dT%H:%M:%S%.6f")
-                                .to_string(),
-                        );
+                        row_created_at = Some(inserted.created_at_iso());
+                        broadcast_meta = Some(inserted.portal_meta(None));
                     }
                     Err(e) => {
                         error!("Failed to store portal message: {}", e);
@@ -430,7 +429,7 @@ fn handle_web_input(
                     agent_type,
                     created_at: row_created_at,
                     origin: None,
-                    meta: None,
+                    meta: broadcast_meta,
                 },
             );
         }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -120,6 +120,49 @@ impl Message {
             _ => None,
         }
     }
+
+    /// Who produced this message, mapped from the durable columns to the typed
+    /// [`shared::MessageSource`] (portal-meta sidecar, see
+    /// `docs/PORTAL_META_SIDECAR.md`). Inter-agent provenance wins (it is itself
+    /// a `portal`-role row); otherwise the role decides. `sender_name` is the
+    /// resolved display name for user-role messages. Returns `None` for the
+    /// session's own agent output (assistant/system/result/error).
+    pub fn message_source(&self, sender_name: Option<String>) -> Option<shared::MessageSource> {
+        if let (Some("inter_agent"), Some(session_id), Some(agent_type)) = (
+            self.provenance_kind.as_deref(),
+            self.provenance_session_id,
+            self.provenance_agent_type.as_deref(),
+        ) {
+            return Some(shared::MessageSource::Agent {
+                session_id,
+                agent_type: agent_type.to_string(),
+            });
+        }
+        match self.role.as_str() {
+            "user" => Some(shared::MessageSource::Human {
+                account_id: self.user_id,
+                name: sender_name.unwrap_or_default(),
+            }),
+            "portal" => Some(shared::MessageSource::Portal),
+            _ => None,
+        }
+    }
+
+    /// ISO-8601 microsecond timestamp matching the wire format the frontend's
+    /// reconnect watermark + `replay_history` parser expect.
+    pub fn created_at_iso(&self) -> String {
+        self.created_at.format("%Y-%m-%dT%H:%M:%S%.6f").to_string()
+    }
+
+    /// Build the typed [`shared::PortalMeta`] sidecar for this row. The backend
+    /// only ever populates `created_at` + `source`; `delivery` is frontend-owned.
+    pub fn portal_meta(&self, sender_name: Option<String>) -> shared::PortalMeta {
+        shared::PortalMeta {
+            created_at: Some(self.created_at_iso()),
+            source: self.message_source(sender_name),
+            delivery: None,
+        }
+    }
 }
 
 #[derive(Debug, Insertable)]
@@ -463,4 +506,62 @@ pub struct NewTurnMetric {
     pub tool_call_count: i32,
     pub stream_restarts: i32,
     pub total_cost_usd: Option<f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(role: &str, provenance_kind: Option<&str>) -> Message {
+        Message {
+            id: Uuid::nil(),
+            session_id: Uuid::nil(),
+            role: role.to_string(),
+            content: "{}".to_string(),
+            created_at: NaiveDateTime::default(),
+            user_id: Uuid::from_u128(7),
+            agent_type: "claude".to_string(),
+            provenance_kind: provenance_kind.map(str::to_string),
+            provenance_session_id: provenance_kind.map(|_| Uuid::from_u128(9)),
+            provenance_agent_type: provenance_kind.map(|_| "codex".to_string()),
+        }
+    }
+
+    #[test]
+    fn message_source_maps_columns_to_typed_source() {
+        use shared::MessageSource;
+
+        // Inter-agent provenance wins, even though the row is portal-role.
+        assert_eq!(
+            msg("portal", Some("inter_agent")).message_source(None),
+            Some(MessageSource::Agent {
+                session_id: Uuid::from_u128(9),
+                agent_type: "codex".to_string(),
+            })
+        );
+        // User row → Human, carrying the resolved display name.
+        assert_eq!(
+            msg("user", None).message_source(Some("Matt".to_string())),
+            Some(MessageSource::Human {
+                account_id: Uuid::from_u128(7),
+                name: "Matt".to_string(),
+            })
+        );
+        // Plain portal row (no provenance) → Portal.
+        assert_eq!(
+            msg("portal", None).message_source(None),
+            Some(MessageSource::Portal)
+        );
+        // The session's own agent output carries no source.
+        assert!(msg("assistant", None).message_source(None).is_none());
+    }
+
+    #[test]
+    fn portal_meta_carries_created_at_and_source_only() {
+        let meta = msg("user", None).portal_meta(Some("Matt".to_string()));
+        assert!(meta.created_at.is_some());
+        assert!(meta.source.is_some());
+        // Delivery is frontend-owned — the backend never sets it.
+        assert!(meta.delivery.is_none());
+    }
 }


### PR DESCRIPTION
## What

Slice 2 of the portal-metadata bifurcation (design: `docs/PORTAL_META_SIDECAR.md`). The backend now **populates the typed `PortalMeta` sidecar on all three message paths**, mapped from the durable `messages` columns — **no DB migration**.

This is what lets Codex's frontend (slice 3) go **meta-only with no underscore-key fallback** (per Matt's "burn it"): `meta` is always complete, so the frontend never needs to read `_origin`/`_sender`/`_created_at`.

## Changes

- **`Message::message_source`** (`models.rs`): `provenance_kind=inter_agent` → `MessageSource::Agent`; `role=user` → `Human`; `role=portal` → `Portal`; own agent output (assistant/system/result/error) → `None`. `Message::portal_meta` wraps it with `created_at`. Backend only ever sets `created_at` + `source` — `delivery` is frontend-owned.
- **Live** (`message_handlers.rs`): `AgentOutput.meta` built from the inserted row.
- **WS replay** (`replay.rs`): `message_meta` built index-aligned with `messages` and unzipped into the batch.
- **HTTP** (`messages.rs`): `MessageWithSender` gains `meta`.

## Transition safety

The backend's `_`-injection (replay) and the deprecated flat `AgentOutput` fields **stay in place** — they're harmless to a meta-only frontend and keep every intermediate auto-deploy consistent. They're removed in a final cleanup slice once slice 3 is deployed.

## Testing

`cargo build --workspace` ✅ · `cargo test` (backend/shared) ✅ incl. new `message_source`/`portal_meta` mapping tests · `cargo clippy --workspace --all-targets` ✅ · `cargo fmt --check` ✅

Version → 2.12.45. Stacks on #1131 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)