### PR TITLE
Make code-uniqueness tests deterministic (closes #1133)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.45"
+version = "2.12.47"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.45"
+version = "2.12.47"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.45"
+version = "2.12.47"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.45"
+version = "2.12.47"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.45"
+version = "2.12.47"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.45"
+version = "2.12.47"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.45"
+version = "2.12.47"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.45"
+version = "2.12.47"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.45"
+version = "2.12.47"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.45"
+version = "2.12.47"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.45"
+version = "2.12.47"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -427,6 +427,7 @@ pub async fn complete_device_flow(
 
 #[cfg(test)]
 mod tests {
+    use super::state::{generate_device_code_with, generate_user_code_with};
     use super::*;
 
     #[test]
@@ -464,11 +465,17 @@ mod tests {
 
     #[test]
     fn test_user_code_uniqueness() {
+        use rand::{rngs::StdRng, SeedableRng};
+
+        // Drive generation from a fixed-seed RNG so this is deterministic: the
+        // 1000-code run either always passes or always fails for a given seed,
+        // making a collision a real, reproducible regression rather than a
+        // birthday-paradox dice roll on `thread_rng()` (see #1133).
+        let mut rng = StdRng::seed_from_u64(0xC0DE_1133);
         let mut codes = std::collections::HashSet::new();
 
-        // Generate 1000 codes and verify no collisions
         for _ in 0..1000 {
-            let code = generate_user_code();
+            let code = generate_user_code_with(&mut rng);
             assert!(
                 codes.insert(code.clone()),
                 "User code collision detected: {}",
@@ -505,11 +512,16 @@ mod tests {
 
     #[test]
     fn test_device_code_uniqueness() {
+        use rand::{rngs::StdRng, SeedableRng};
+
+        // Deterministic, like the user-code uniqueness test (#1133). The 32-char
+        // device-code space makes collisions astronomically unlikely regardless,
+        // but seeding keeps the test reproducible rather than chance-based.
+        let mut rng = StdRng::seed_from_u64(0xDEAD_1133);
         let mut codes = std::collections::HashSet::new();
 
-        // Generate 1000 codes and verify no collisions
         for _ in 0..1000 {
-            let code = generate_device_code();
+            let code = generate_device_code_with(&mut rng);
             assert!(
                 codes.insert(code.clone()),
                 "Device code collision detected: {}",

--- a/backend/src/handlers/device_flow/state.rs
+++ b/backend/src/handlers/device_flow/state.rs
@@ -37,7 +37,14 @@ pub struct VerifyQuery {
 }
 
 pub(super) fn generate_user_code() -> String {
-    let chars: String = rand::thread_rng()
+    generate_user_code_with(&mut rand::thread_rng())
+}
+
+/// Generate a user code from a caller-supplied RNG. Split out from
+/// [`generate_user_code`] so tests can drive it with a seeded RNG and stay
+/// deterministic (see #1133).
+pub(super) fn generate_user_code_with<R: Rng>(rng: &mut R) -> String {
+    let chars: String = rng
         .sample_iter(&Alphanumeric)
         .take(6)
         .map(|c| c as char)
@@ -49,8 +56,12 @@ pub(super) fn generate_user_code() -> String {
 }
 
 pub(super) fn generate_device_code() -> String {
-    rand::thread_rng()
-        .sample_iter(&Alphanumeric)
+    generate_device_code_with(&mut rand::thread_rng())
+}
+
+/// Generate a device code from a caller-supplied RNG (see [`generate_user_code_with`]).
+pub(super) fn generate_device_code_with<R: Rng>(rng: &mut R) -> String {
+    rng.sample_iter(&Alphanumeric)
         .take(32)
         .map(|c| c as char)
         .collect()


### PR DESCRIPTION
## What

`device_flow::test_user_code_uniqueness` (and its device-code sibling) generated 1000 codes from `thread_rng()` and asserted zero collisions — non-deterministic. User codes are ~36⁶, so ~0.02% of runs flaked on the birthday paradox; it failed once on #1132's CI (unrelated) and passed on rerun.

## Fix

- Split `generate_user_code` / `generate_device_code` into seedable `*_with(rng: &mut impl Rng)` variants; the public `generate_*()` wrappers still pass `thread_rng()` for production.
- The uniqueness tests now drive a fixed-seed `StdRng`, so each run is reproducible — a collision becomes a real regression to debug, not a dice roll.

Test-only behavior change; production code generation is unchanged.

Closes #1133.

## Testing
`cargo test -p backend device_flow` ✅ (18 pass) · clippy ✅ · fmt ✅. Version → 2.12.47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)