### PR TITLE
Use PortalMeta sidecar in frontend messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.47"
+version = "2.12.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.47"
+version = "2.12.48"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.47"
+version = "2.12.48"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.47"
+version = "2.12.48"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.47"
+version = "2.12.48"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.47"
+version = "2.12.48"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.47"
+version = "2.12.48"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.47"
+version = "2.12.48"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.47"
+version = "2.12.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.47"
+version = "2.12.48"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.47"
+version = "2.12.48"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -1,5 +1,5 @@
 use super::renderers;
-use super::types::{user_meta_from_json, ClaudeMessage};
+use super::types::{ClaudeMessage, RenderedMessage};
 use crate::components::agent_frame::{AgentFrame, AgentFrameRegistry, FrameRenderer};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use yew::prelude::*;
 
 pub(crate) struct FrameRenderContext<'a> {
-    pub json: &'a str,
+    pub message: &'a RenderedMessage,
     pub agent_type: shared::AgentType,
     pub session_id: Uuid,
     pub timestamp: Option<&'a str>,
@@ -19,7 +19,22 @@ pub(crate) struct FrameRenderContext<'a> {
 }
 
 pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
-    let frame = AgentFrameRegistry::parse(ctx.json, ctx.agent_type);
+    if let Some(shared::MessageSource::Agent {
+        session_id,
+        agent_type,
+    }) = ctx.message.source()
+    {
+        return renderers::render_agent_message_from_source(
+            session_id,
+            agent_type,
+            &message_text(ctx.message),
+            ctx.timestamp,
+            ctx.session_id,
+        );
+    }
+
+    let json = ctx.message.content.as_str();
+    let frame = AgentFrameRegistry::parse(json, ctx.agent_type);
 
     // Dispatch on the message shape, not the agent. `User` (the proxy's
     // synthetic echo) and `Portal` (the backend's portal-content envelope)
@@ -42,19 +57,17 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
             AgentFrame::Claude(ClaudeMessage::Result(msg)) => {
                 renderers::render_result_message(&msg, ctx.turn_metrics)
             }
-            AgentFrame::Claude(ClaudeMessage::User(msg)) => {
-                let meta = user_meta_from_json(ctx.json);
-                renderers::render_user_message(
-                    &msg,
-                    &meta,
-                    ctx.current_user_id,
-                    ctx.timestamp,
-                    ctx.session_id,
-                )
-            }
+            AgentFrame::Claude(ClaudeMessage::User(msg)) => renderers::render_user_message(
+                &msg,
+                ctx.message.meta.as_ref(),
+                ctx.current_user_id,
+                ctx.timestamp,
+                ctx.session_id,
+            ),
             AgentFrame::Claude(ClaudeMessage::OptimisticUser(msg)) => {
                 renderers::render_optimistic_user_message(
                     &msg,
+                    ctx.message.meta.as_ref(),
                     ctx.current_user_id,
                     ctx.timestamp,
                     ctx.session_id,
@@ -75,7 +88,7 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
             }
             AgentFrame::Claude(ClaudeMessage::Unknown)
             | AgentFrame::Codex(_)
-            | AgentFrame::RawJson => render_raw_json(ctx.json),
+            | AgentFrame::RawJson => render_raw_json(json),
         },
         FrameRenderer::Codex => match frame {
             AgentFrame::Codex(event) => crate::components::codex_renderer::render_codex_frame(
@@ -85,17 +98,22 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
             ),
             _ => html! {},
         },
-        FrameRenderer::RawJson => render_raw_json(ctx.json),
+        FrameRenderer::RawJson => render_raw_json(json),
     }
 }
 
 pub(crate) fn render_identity_group_part(
-    json: &str,
+    message: &RenderedMessage,
     agent_type: shared::AgentType,
     session_id: Uuid,
     continuation_statuses: &HashMap<Uuid, String>,
     on_schedule_continuation: Callback<Uuid>,
 ) -> Html {
+    if let Some(shared::MessageSource::Agent { .. }) = message.source() {
+        return renderers::render_agent_message_body(&message_text(message), session_id);
+    }
+
+    let json = message.content.as_str();
     let frame = AgentFrameRegistry::parse(json, agent_type);
     match frame {
         AgentFrame::Claude(ClaudeMessage::User(msg)) => {
@@ -118,6 +136,21 @@ pub(crate) fn render_identity_group_part(
         }
         _ => html! {},
     }
+}
+
+fn message_text(message: &RenderedMessage) -> String {
+    if let Ok(value) = serde_json::from_str::<Value>(&message.content) {
+        match value {
+            Value::String(text) => return text,
+            Value::Object(_) => {
+                if let Ok(portal) = serde_json::from_value::<super::types::PortalMessage>(value) {
+                    return renderers::portal_text(&portal);
+                }
+            }
+            _ => {}
+        }
+    }
+    message.content.clone()
 }
 
 fn render_raw_json(json: &str) -> Html {

--- a/frontend/src/components/message_renderer/group_renderer.rs
+++ b/frontend/src/components/message_renderer/group_renderer.rs
@@ -38,7 +38,7 @@ pub struct MessageGroupRendererProps {
 pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
     match &props.group {
         MessageGroup::Single(json) => {
-            html! { <super::MessageRenderer json={json.clone()} session_id={props.session_id} agent_type={props.agent_type} current_user_id={props.current_user_id.clone()} turn_metrics={props.turn_metrics.clone()} continuation_statuses={props.continuation_statuses.clone()} on_schedule_continuation={props.on_schedule_continuation.clone()} /> }
+            html! { <super::MessageRenderer message={json.clone()} session_id={props.session_id} agent_type={props.agent_type} current_user_id={props.current_user_id.clone()} turn_metrics={props.turn_metrics.clone()} continuation_statuses={props.continuation_statuses.clone()} on_schedule_continuation={props.on_schedule_continuation.clone()} /> }
         }
         MessageGroup::IdentityGroup {
             category,
@@ -48,7 +48,7 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
         } => {
             let ts = messages
                 .first()
-                .and_then(|json| extract_raw_iso(json))
+                .and_then(extract_raw_iso)
                 .and_then(|iso| local_timestamp(&iso));
 
             // A run of `thinking_tokens` markers collapses to a single compact
@@ -77,7 +77,7 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                 };
             }
 
-            let last_iso = messages.last().and_then(|json| extract_raw_iso(json));
+            let last_iso = messages.last().and_then(extract_raw_iso);
             let wrapper_class = match category {
                 GroupCategory::User => "user-message",
                 GroupCategory::Portal => "portal-message",
@@ -99,11 +99,11 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                     </div>
                     <div class="message-body grouped-message-body">
                         { for visible.iter().map(|&i| {
-                            let json = &messages[i];
-                            let key = extract_raw_iso(json)
+                            let message = &messages[i];
+                            let key = extract_raw_iso(message)
                                 .map(|iso| format!("m-{}", iso))
                                 .unwrap_or_else(|| format!("m{}", i));
-                            html! { <div {key} class="grouped-message-part">{ dispatch::render_identity_group_part(json, props.agent_type, props.session_id, &props.continuation_statuses, props.on_schedule_continuation.clone()) }</div> }
+                            html! { <div {key} class="grouped-message-part">{ dispatch::render_identity_group_part(message, props.agent_type, props.session_id, &props.continuation_statuses, props.on_schedule_continuation.clone()) }</div> }
                         })}
                     </div>
                     if let Some(iso) = last_iso {

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -1,15 +1,12 @@
-use serde_json::Value;
-
 use crate::components::agent_frame::{AgentFrame, AgentFrameKind, AgentFrameRegistry};
 
 use super::renderers::assistant_label;
-use super::types::{user_meta_from_json, ClaudeMessage};
+use super::types::{ClaudeMessage, RenderedMessage};
 
-/// Extract the raw `_created_at` ISO string from a message JSON, for use with
-/// the live-updating TimeAgo component (which parses it itself).
-pub(super) fn extract_raw_iso(json: &str) -> Option<String> {
-    let val: Value = serde_json::from_str(json).ok()?;
-    val.get("_created_at")?.as_str().map(|s| s.to_string())
+/// Extract the raw created-at ISO string from the typed message sidecar, for
+/// use with the live-updating TimeAgo component.
+pub(super) fn extract_raw_iso(message: &RenderedMessage) -> Option<String> {
+    message.raw_iso().map(str::to_string)
 }
 
 /// Category for a run of consecutive related messages — drives both the
@@ -57,13 +54,13 @@ pub enum MessageGroup {
     /// Kept as a distinct variant (rather than a one-element `Grouped`) so
     /// the most common case avoids the group-wrapper render path and keeps
     /// its Yew key stable independent of category.
-    Single(String),
+    Single(RenderedMessage),
     /// One or more consecutive messages with the same display identity.
     IdentityGroup {
         category: GroupCategory,
         label: String,
         badge_class: String,
-        messages: Vec<String>,
+        messages: Vec<RenderedMessage>,
     },
 }
 
@@ -78,11 +75,11 @@ impl MessageGroup {
     /// `index` is used only as a fallback when no timestamp is present.
     pub fn key(&self, index: usize) -> yew::virtual_dom::Key {
         let (prefix, first) = match self {
-            MessageGroup::Single(json) => ("s", json.as_str()),
+            MessageGroup::Single(message) => ("s", message),
             MessageGroup::IdentityGroup {
                 category, messages, ..
             } => match messages.first() {
-                Some(j) => (category.key_prefix(), j.as_str()),
+                Some(j) => (category.key_prefix(), j),
                 None => {
                     return yew::virtual_dom::Key::from(format!(
                         "{}{}",
@@ -104,6 +101,53 @@ pub(super) struct MessageIdentity {
     pub(super) category: GroupCategory,
     label: String,
     badge_class: String,
+}
+
+fn source_identity(
+    source: &shared::MessageSource,
+    current_user_id: Option<&str>,
+) -> MessageIdentity {
+    match source {
+        shared::MessageSource::Human { account_id, name } => {
+            let account_id = account_id.to_string();
+            let label = if current_user_id == Some(account_id.as_str()) {
+                "You".to_string()
+            } else {
+                name.clone()
+            };
+            MessageIdentity {
+                category: GroupCategory::User,
+                label,
+                badge_class: "user".to_string(),
+            }
+        }
+        shared::MessageSource::Agent {
+            session_id,
+            agent_type,
+        } => {
+            let short = session_id
+                .to_string()
+                .split('-')
+                .next()
+                .unwrap_or_default()
+                .to_string();
+            let label = match agent_type.to_ascii_lowercase().as_str() {
+                "claude" => format!("Message from Claude ({short})"),
+                "codex" => format!("Message from Codex ({short})"),
+                _ => format!("Message from agent ({short})"),
+            };
+            MessageIdentity {
+                category: GroupCategory::User,
+                label,
+                badge_class: "other-agent".to_string(),
+            }
+        }
+        shared::MessageSource::Portal => MessageIdentity {
+            category: GroupCategory::Portal,
+            label: "Portal".to_string(),
+            badge_class: "portal".to_string(),
+        },
+    }
 }
 
 /// True iff the parsed `UserMessage` carries only tool-result content blocks
@@ -168,10 +212,15 @@ fn user_is_plain_text(msg: &shared::UserMessage) -> bool {
 ///   5. **Codex** runs last — Codex events parse via a different enum and
 ///      only the messages that don't match any Claude shape get here.
 pub(super) fn classify(
-    json: &str,
+    message: &RenderedMessage,
     agent_type: shared::AgentType,
     current_user_id: Option<&str>,
 ) -> Option<MessageIdentity> {
+    let json = message.content.as_str();
+    if let Some(source) = message.source() {
+        return Some(source_identity(source, current_user_id));
+    }
+
     let assistant_identity_label = if agent_type == shared::AgentType::Codex {
         "Codex"
     } else {
@@ -195,30 +244,17 @@ pub(super) fn classify(
                 });
             }
             if user_is_plain_text(&msg) {
-                let meta = user_meta_from_json(json);
-                let label = match &meta.sender {
-                    Some(sender) if current_user_id != Some(sender.user_id.as_str()) => {
-                        sender.name.clone()
-                    }
-                    _ => "You".to_string(),
-                };
                 return Some(MessageIdentity {
                     category: GroupCategory::User,
-                    label,
+                    label: "You".to_string(),
                     badge_class: "user".to_string(),
                 });
             }
         }
-        AgentFrame::Claude(ClaudeMessage::OptimisticUser(msg)) => {
-            let label = match &msg.sender {
-                Some(sender) if current_user_id != Some(sender.user_id.as_str()) => {
-                    sender.name.clone()
-                }
-                _ => "You".to_string(),
-            };
+        AgentFrame::Claude(ClaudeMessage::OptimisticUser(_)) => {
             return Some(MessageIdentity {
                 category: GroupCategory::User,
-                label,
+                label: "You".to_string(),
                 badge_class: "user".to_string(),
             });
         }
@@ -264,24 +300,24 @@ pub(super) fn classify(
 /// (no typed fields). TODO(SDK): push a typed `thinking_tokens` system variant
 /// upstream to `rust-code-agent-sdks` so this reads a field instead of poking
 /// `data`.
-pub(super) fn thinking_tokens_estimate(messages: &[String]) -> i64 {
+pub(super) fn thinking_tokens_estimate(messages: &[RenderedMessage]) -> i64 {
     messages
         .iter()
-        .filter_map(
-            |json| match AgentFrameRegistry::parse(json, shared::AgentType::Claude) {
+        .filter_map(|message| {
+            match AgentFrameRegistry::parse(&message.content, shared::AgentType::Claude) {
                 AgentFrame::Claude(ClaudeMessage::System(msg)) => {
                     msg.data.get("estimated_tokens").and_then(|v| v.as_i64())
                 }
                 _ => None,
-            },
-        )
+            }
+        })
         .max()
         .unwrap_or(0)
 }
 
 fn group_label(
     identity: &MessageIdentity,
-    messages: &[String],
+    messages: &[RenderedMessage],
     agent_type: shared::AgentType,
 ) -> String {
     if identity.category != GroupCategory::Assistant || identity.label == "Codex" {
@@ -290,10 +326,12 @@ fn group_label(
 
     messages
         .iter()
-        .filter_map(|json| match AgentFrameRegistry::parse(json, agent_type) {
-            AgentFrame::Claude(message) => Some(message),
-            _ => None,
-        })
+        .filter_map(
+            |message| match AgentFrameRegistry::parse(&message.content, agent_type) {
+                AgentFrame::Claude(message) => Some(message),
+                _ => None,
+            },
+        )
         .find_map(|msg| match msg {
             ClaudeMessage::Assistant(msg) => Some(assistant_label(&msg.message.model)),
             _ => None,
@@ -310,9 +348,9 @@ fn group_label(
 /// pair-by-ordering join is the agreed PR 2 strategy — `user_message_id`
 /// stays `None` on the proxy-emit side until a future PR wires up the
 /// per-turn linkage, so a key-based join would fail on every row today.
-pub fn is_turn_terminator(json: &str) -> bool {
+pub fn is_turn_terminator(message: &RenderedMessage) -> bool {
     matches!(
-        AgentFrameRegistry::parse(json, shared::AgentType::Codex).kind(),
+        AgentFrameRegistry::parse(&message.content, shared::AgentType::Codex).kind(),
         AgentFrameKind::ClaudeResult
             | AgentFrameKind::CodexTurnCompleted
             | AgentFrameKind::CodexTurnFailed
@@ -373,16 +411,16 @@ pub fn thinking_chip_starts(groups: &[MessageGroup]) -> Vec<i64> {
 /// `MessageGroup::IdentityGroup`. Mixed / `None` messages become
 /// `MessageGroup::Single`.
 pub fn group_messages(
-    messages: &[String],
+    messages: &[RenderedMessage],
     agent_type: shared::AgentType,
     current_user_id: Option<&str>,
 ) -> Vec<MessageGroup> {
     let mut groups = Vec::new();
-    let mut current: Option<(MessageIdentity, Vec<String>)> = None;
+    let mut current: Option<(MessageIdentity, Vec<RenderedMessage>)> = None;
 
     fn flush(
         out: &mut Vec<MessageGroup>,
-        slot: &mut Option<(MessageIdentity, Vec<String>)>,
+        slot: &mut Option<(MessageIdentity, Vec<RenderedMessage>)>,
         agent_type: shared::AgentType,
     ) {
         if let Some((identity, messages)) = slot.take() {
@@ -396,7 +434,7 @@ pub fn group_messages(
         }
     }
 
-    for json in messages {
+    for message in messages {
         // Cumulative `turn/diff/updated` events are dropped entirely — Codex
         // re-sends the whole-turn diff on every edit tick, so they pile up
         // O(ticks) redundant cards (each the size of the full turn) on top of
@@ -404,22 +442,24 @@ pub fn group_messages(
         // rather than in `classify` keeps the surrounding Codex events in one
         // run instead of fragmenting the group around each dropped diff.
         if matches!(
-            AgentFrameRegistry::parse(json, agent_type).kind(),
+            AgentFrameRegistry::parse(&message.content, agent_type).kind(),
             AgentFrameKind::CodexTurnDiffUpdated
         ) {
             continue;
         }
-        match classify(json, agent_type, current_user_id) {
+        match classify(message, agent_type, current_user_id) {
             Some(identity) => match current.as_mut() {
-                Some((cur_identity, msgs)) if *cur_identity == identity => msgs.push(json.clone()),
+                Some((cur_identity, msgs)) if *cur_identity == identity => {
+                    msgs.push(message.clone())
+                }
                 _ => {
                     flush(&mut groups, &mut current, agent_type);
-                    current = Some((identity, vec![json.clone()]));
+                    current = Some((identity, vec![message.clone()]));
                 }
             },
             None => {
                 flush(&mut groups, &mut current, agent_type);
-                groups.push(MessageGroup::Single(json.clone()));
+                groups.push(MessageGroup::Single(message.clone()));
             }
         }
     }
@@ -439,7 +479,10 @@ pub fn group_messages(
 /// Events that don't carry an `item_id` (turn-level events, deltas, errors)
 /// always pass through — they're standalone signals, not lifecycle stages of
 /// a per-item card.
-pub(super) fn visible_group_indices(category: GroupCategory, messages: &[String]) -> Vec<usize> {
+pub(super) fn visible_group_indices(
+    category: GroupCategory,
+    messages: &[RenderedMessage],
+) -> Vec<usize> {
     if !matches!(category, GroupCategory::Codex) {
         return (0..messages.len()).collect();
     }
@@ -448,7 +491,10 @@ pub(super) fn visible_group_indices(category: GroupCategory, messages: &[String]
     // Parse each message's item_id once, then resolve the last index per id
     // from the cached vector — parsing twice per message doubled the JSON
     // work on the hot render path (#967).
-    let ids: Vec<Option<String>> = messages.iter().map(|j| codex_event_item_id(j)).collect();
+    let ids: Vec<Option<String>> = messages
+        .iter()
+        .map(|message| codex_event_item_id(&message.content))
+        .collect();
     let mut last_idx: HashMap<&str, usize> = HashMap::new();
     for (i, id) in ids.iter().enumerate() {
         if let Some(id) = id {

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -4,6 +4,7 @@ mod grouping;
 mod renderers;
 pub mod turn_metrics_footer;
 pub mod types;
+pub use types::RenderedMessage;
 
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -35,7 +36,7 @@ pub(super) fn local_timestamp(iso: &str) -> Option<String> {
 
 #[derive(Properties, PartialEq)]
 pub struct MessageRendererProps {
-    pub json: String,
+    pub message: RenderedMessage,
     pub session_id: Uuid,
     #[prop_or_default]
     pub agent_type: shared::AgentType,
@@ -59,10 +60,10 @@ pub struct MessageRendererProps {
 
 #[function_component(MessageRenderer)]
 pub fn message_renderer(props: &MessageRendererProps) -> Html {
-    let raw_iso = extract_raw_iso(&props.json);
+    let raw_iso = extract_raw_iso(&props.message);
     let ts = raw_iso.as_deref().and_then(local_timestamp);
     dispatch::render_frame(FrameRenderContext {
-        json: &props.json,
+        message: &props.message,
         agent_type: props.agent_type,
         session_id: props.session_id,
         timestamp: ts.as_deref(),
@@ -137,20 +138,28 @@ pub(crate) fn shorten_model_name(model: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    fn rendered(json: impl Into<String>) -> RenderedMessage {
+        RenderedMessage::new(json.into(), None)
+    }
+
+    fn rendered_vec(messages: &[String]) -> Vec<RenderedMessage> {
+        messages.iter().cloned().map(rendered).collect()
+    }
+
     fn classify_category(json: &str) -> Option<GroupCategory> {
-        classify(json, shared::AgentType::Claude, None).map(|identity| identity.category)
+        classify(&rendered(json), shared::AgentType::Claude, None).map(|identity| identity.category)
     }
 
     fn classify_codex_category(json: &str) -> Option<GroupCategory> {
-        classify(json, shared::AgentType::Codex, None).map(|identity| identity.category)
+        classify(&rendered(json), shared::AgentType::Codex, None).map(|identity| identity.category)
     }
 
     fn group_for_tests(messages: &[String]) -> Vec<MessageGroup> {
-        group_messages(messages, shared::AgentType::Claude, None)
+        group_messages(&rendered_vec(messages), shared::AgentType::Claude, None)
     }
 
     fn group_for_codex_tests(messages: &[String]) -> Vec<MessageGroup> {
-        group_messages(messages, shared::AgentType::Codex, None)
+        group_messages(&rendered_vec(messages), shared::AgentType::Codex, None)
     }
 
     /// A `system`/`thinking_tokens` marker — the bodyless per-reasoning-step
@@ -397,21 +406,27 @@ mod tests {
         .to_string()
     }
 
-    fn plain_user_text_from_sender(text: &str, user_id: &str, name: &str) -> String {
-        serde_json::json!({
+    fn plain_user_text_from_sender(text: &str, user_id: Uuid, name: &str) -> RenderedMessage {
+        let content = serde_json::json!({
             "type": "user",
             "message": {
                 "role": "user",
                 "content": [{"type": "text", "text": text}]
             },
-            "_sender": {
-                "user_id": user_id,
-                "name": name,
-            },
             "session_id": "01890000-0000-7000-8000-000000000001",
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
-        .to_string()
+        .to_string();
+        RenderedMessage::new(
+            content,
+            Some(shared::PortalMeta {
+                created_at: Some("2026-05-17T10:00:00.000Z".to_string()),
+                source: Some(shared::MessageSource::Human {
+                    account_id: user_id,
+                    name: name.to_string(),
+                }),
+                delivery: None,
+            }),
+        )
     }
 
     fn codex_item_started_agent_message(text: &str) -> String {
@@ -486,14 +501,17 @@ mod tests {
 
     #[test]
     fn user_grouping_splits_by_sender_identity() {
+        let user_a = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let user_b = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
         let messages = vec![
-            plain_user_text_from_sender("first from me", "user_a", "Matt"),
-            plain_user_text_from_sender("second from me", "user_a", "Matt"),
-            plain_user_text_from_sender("from someone else", "user_b", "Alex"),
-            plain_user_text_from_sender("back to me", "user_a", "Matt"),
+            plain_user_text_from_sender("first from me", user_a, "Matt"),
+            plain_user_text_from_sender("second from me", user_a, "Matt"),
+            plain_user_text_from_sender("from someone else", user_b, "Alex"),
+            plain_user_text_from_sender("back to me", user_a, "Matt"),
         ];
 
-        let groups = group_messages(&messages, shared::AgentType::Claude, Some("user_a"));
+        let current_user_id = user_a.to_string();
+        let groups = group_messages(&messages, shared::AgentType::Claude, Some(&current_user_id));
         assert_eq!(groups.len(), 3);
 
         let labels: Vec<_> = groups
@@ -555,18 +573,18 @@ mod tests {
 
         for json in [claude_result, codex_completed, codex_failed] {
             assert!(
-                group_is_turn_terminator(&MessageGroup::Single(json)),
+                group_is_turn_terminator(&MessageGroup::Single(rendered(json))),
                 "single terminator frame should be recognized"
             );
         }
-        assert!(!group_is_turn_terminator(&MessageGroup::Single(
+        assert!(!group_is_turn_terminator(&MessageGroup::Single(rendered(
             plain_user_text("hello")
-        )));
+        ))));
         assert!(!group_is_turn_terminator(&MessageGroup::IdentityGroup {
             category: GroupCategory::User,
             label: "You".to_string(),
             badge_class: "user".to_string(),
-            messages: vec![plain_user_text("hello")],
+            messages: vec![rendered(plain_user_text("hello"))],
         }));
     }
 
@@ -606,7 +624,10 @@ mod tests {
             thinking_tokens_message(150),
             thinking_tokens_message(250),
         ];
-        assert_eq!(grouping::thinking_tokens_estimate(&messages), 250);
+        assert_eq!(
+            grouping::thinking_tokens_estimate(&rendered_vec(&messages)),
+            250
+        );
         // No markers / unparseable input yields 0 (chip hides).
         assert_eq!(grouping::thinking_tokens_estimate(&[]), 0);
     }
@@ -812,7 +833,7 @@ mod tests {
         ];
 
         for (label, json, expected) in cases {
-            let got = classify(&json, shared::AgentType::Codex, None).map(|i| i.category);
+            let got = classify(&rendered(json), shared::AgentType::Codex, None).map(|i| i.category);
             assert_eq!(
                 got, expected,
                 "{label}: classifier returned {got:?}, expected {expected:?}"
@@ -831,7 +852,7 @@ mod tests {
             codex_command_event("item.started", "cmd_1", "in_progress"),
             codex_command_event("item.completed", "cmd_1", "completed"),
         ];
-        let visible = visible_group_indices(GroupCategory::Codex, &messages);
+        let visible = visible_group_indices(GroupCategory::Codex, &rendered_vec(&messages));
         assert_eq!(
             visible,
             vec![1],
@@ -850,7 +871,7 @@ mod tests {
             codex_command_event("item.updated", "cmd_1", "in_progress"),
             codex_command_event("item.completed", "cmd_1", "completed"),
         ];
-        let visible = visible_group_indices(GroupCategory::Codex, &messages);
+        let visible = visible_group_indices(GroupCategory::Codex, &rendered_vec(&messages));
         assert_eq!(visible, vec![2]);
     }
 
@@ -864,7 +885,7 @@ mod tests {
             codex_command_event("item.started", "cmd_b", "in_progress"),
             codex_command_event("item.completed", "cmd_b", "completed"),
         ];
-        let visible = visible_group_indices(GroupCategory::Codex, &messages);
+        let visible = visible_group_indices(GroupCategory::Codex, &rendered_vec(&messages));
         // Indices 1 (cmd_a completed) and 3 (cmd_b completed) remain.
         assert_eq!(visible, vec![1, 3]);
     }
@@ -885,7 +906,7 @@ mod tests {
             turn_completed.clone(),
             codex_command_event("item.completed", "cmd_1", "completed"),
         ];
-        let visible = visible_group_indices(GroupCategory::Codex, &messages);
+        let visible = visible_group_indices(GroupCategory::Codex, &rendered_vec(&messages));
         // turn.completed (index 1) is kept; the started (index 0) drops in
         // favor of the completed (index 2).
         assert_eq!(visible, vec![1, 2]);
@@ -906,7 +927,7 @@ mod tests {
             GroupCategory::Portal,
             GroupCategory::User,
         ] {
-            let visible = visible_group_indices(cat, &messages);
+            let visible = visible_group_indices(cat, &rendered_vec(&messages));
             assert_eq!(
                 visible,
                 vec![0, 1],
@@ -934,7 +955,8 @@ mod tests {
             "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string();
-        let visible = visible_group_indices(GroupCategory::Codex, &[no_id_a, no_id_b]);
+        let visible =
+            visible_group_indices(GroupCategory::Codex, &rendered_vec(&[no_id_a, no_id_b]));
         assert_eq!(visible, vec![0, 1]);
     }
 

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -6,7 +6,7 @@ mod system;
 mod tools;
 
 use super::shorten_model_name;
-use super::types::{OptimisticUserMessage, UserMessageMeta};
+use super::types::OptimisticUserMessage;
 use crate::components::copy_button::CopyButton;
 use crate::components::markdown::render_markdown_for_session;
 use crate::components::tool_renderers::{
@@ -22,7 +22,10 @@ pub(crate) use assistant::assistant_label;
 pub use assistant::{
     render_assistant_message, render_assistant_message_content, render_content_blocks,
 };
-pub use portal::{render_portal_message, render_portal_message_content};
+pub(crate) use portal::{
+    portal_text, render_agent_message_body, render_agent_message_from_source,
+    render_portal_message, render_portal_message_content,
+};
 pub use system::render_system_message;
 
 /// Convert single newlines to markdown hard breaks (trailing two spaces)
@@ -57,28 +60,27 @@ fn user_message_text_and_tool_results(msg: &shared::UserMessage) -> (String, boo
 
 pub fn render_optimistic_user_message(
     msg: &OptimisticUserMessage,
+    meta: Option<&shared::PortalMeta>,
     current_user_id: Option<&str>,
     timestamp: Option<&str>,
     session_id: Uuid,
 ) -> Html {
-    if let Some(event) = portal::agent_message_event_from_text(&msg.content) {
-        return portal::render_agent_message_event(&event, timestamp, session_id);
-    }
-
-    let label = match &msg.sender {
-        Some(sender) if current_user_id != Some(sender.user_id.as_str()) => sender.name.clone(),
-        _ => "You".to_string(),
+    let label = human_label(meta, current_user_id);
+    let delivery = meta.and_then(|m| m.delivery.as_ref());
+    let pending_class = if delivery.is_some_and(shared::DeliveryMeta::pending) {
+        " pending"
+    } else {
+        ""
     };
-    let pending_class = if msg.pending { " pending" } else { "" };
 
     html! {
         <div class={format!("claude-message user-message{}", pending_class)}>
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                 <span class="message-type-badge user">{ &label }</span>
-                if msg.pending {
+                if delivery.is_some_and(shared::DeliveryMeta::pending) {
                     <span class="pending-indicator" title="Sending...">{ "\u{2022}" }</span>
                 }
-                { render_delivery_progress(msg.client_msg_id.is_some(), msg.delivery_stage, msg.delivery_message.as_deref()) }
+                { render_delivery_progress(delivery) }
                 <CopyButton text={msg.content.clone()} title="Copy message" />
             </div>
             <div class="message-body">{ render_optimistic_user_message_content(msg, session_id) }</div>
@@ -88,16 +90,18 @@ pub fn render_optimistic_user_message(
 
 pub fn render_user_message(
     msg: &shared::UserMessage,
-    meta: &UserMessageMeta,
+    meta: Option<&shared::PortalMeta>,
     current_user_id: Option<&str>,
     timestamp: Option<&str>,
     session_id: Uuid,
 ) -> Html {
-    let label = match &meta.sender {
-        Some(sender) if current_user_id != Some(sender.user_id.as_str()) => sender.name.clone(),
-        _ => "You".to_string(),
+    let label = human_label(meta, current_user_id);
+    let delivery = meta.and_then(|m| m.delivery.as_ref());
+    let pending_class = if delivery.is_some_and(shared::DeliveryMeta::pending) {
+        " pending"
+    } else {
+        ""
     };
-    let pending_class = if meta.pending { " pending" } else { "" };
     let (text_content, has_tool_results) = user_message_text_and_tool_results(msg);
 
     if has_tool_results {
@@ -106,17 +110,15 @@ pub fn render_user_message(
                 <div class="message-body">{ render_user_message_content(msg, session_id) }</div>
             </div>
         }
-    } else if let Some(event) = portal::agent_message_event_from_text(&text_content) {
-        portal::render_agent_message_event(&event, timestamp, session_id)
     } else if !text_content.is_empty() {
         html! {
             <div class={format!("claude-message user-message{}", pending_class)}>
                 <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
                     <span class="message-type-badge user">{ &label }</span>
-                    if meta.pending {
+                    if delivery.is_some_and(shared::DeliveryMeta::pending) {
                         <span class="pending-indicator" title="Sending...">{ "\u{2022}" }</span>
                     }
-                    { render_delivery_progress(meta.client_msg_id.is_some(), meta.delivery_stage, meta.delivery_message.as_deref()) }
+                    { render_delivery_progress(delivery) }
                     <CopyButton text={text_content.clone()} title="Copy message" />
                 </div>
                 <div class="message-body">{ render_user_message_content(msg, session_id) }</div>
@@ -131,10 +133,6 @@ pub fn render_optimistic_user_message_content(
     msg: &OptimisticUserMessage,
     session_id: Uuid,
 ) -> Html {
-    if let Some(event) = portal::agent_message_event_from_text(&msg.content) {
-        return portal::render_agent_message_body(&event.text, session_id);
-    }
-
     html! {
         <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&msg.content), session_id) }</div>
     }
@@ -153,8 +151,6 @@ pub fn render_user_message_content(msg: &shared::UserMessage, session_id: Uuid) 
         render_content_blocks(&msg.message.content, session_id)
     } else if text_content.is_empty() {
         html! {}
-    } else if let Some(event) = portal::agent_message_event_from_text(&text_content) {
-        portal::render_agent_message_body(&event.text, session_id)
     } else {
         html! {
             <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&text_content), session_id) }</div>
@@ -162,14 +158,12 @@ pub fn render_user_message_content(msg: &shared::UserMessage, session_id: Uuid) 
     }
 }
 
-fn render_delivery_progress(
-    tracked: bool,
-    stage: Option<shared::InputDeliveryStage>,
-    message: Option<&str>,
-) -> Html {
-    if !tracked && stage.is_none() {
+fn render_delivery_progress(delivery: Option<&shared::DeliveryMeta>) -> Html {
+    let Some(delivery) = delivery else {
         return html! {};
     };
+    let stage = delivery.stage;
+    let message = delivery.message.as_deref();
 
     let active_index = match stage {
         None => 0,
@@ -218,6 +212,17 @@ fn render_delivery_progress(
                 }) }
             </span>
         </span>
+    }
+}
+
+fn human_label(meta: Option<&shared::PortalMeta>, current_user_id: Option<&str>) -> String {
+    match meta.and_then(|m| m.source.as_ref()) {
+        Some(shared::MessageSource::Human { account_id, name })
+            if current_user_id != Some(account_id.to_string().as_str()) =>
+        {
+            name.clone()
+        }
+        _ => "You".to_string(),
     }
 }
 

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -113,6 +113,21 @@ fn agent_label(agent_type: &str) -> &'static str {
     }
 }
 
+pub(crate) fn render_agent_message_from_source(
+    from_session_id: &Uuid,
+    from_agent_type: &str,
+    text: &str,
+    timestamp: Option<&str>,
+    session_id: Uuid,
+) -> Html {
+    let event = AgentMessageEvent {
+        from_agent_type: from_agent_type.to_string(),
+        from_session_id: from_session_id.to_string(),
+        text: text.to_string(),
+    };
+    render_agent_message_event_card(&event, timestamp, session_id)
+}
+
 fn render_agent_message_event_card(
     event: &AgentMessageEvent,
     timestamp: Option<&str>,
@@ -148,7 +163,7 @@ pub(crate) fn render_agent_message_body(text: &str, session_id: Uuid) -> Html {
     }
 }
 
-fn portal_text(msg: &PortalMessage) -> String {
+pub(crate) fn portal_text(msg: &PortalMessage) -> String {
     msg.content
         .iter()
         .filter_map(|content| match content {
@@ -167,22 +182,6 @@ pub(crate) struct AgentMessageEvent {
 }
 
 pub(crate) fn agent_message_event(msg: &PortalMessage) -> Option<AgentMessageEvent> {
-    if let Some(shared::MessageOrigin::InterAgent {
-        from_session_id,
-        from_agent_type,
-    }) = &msg.origin
-    {
-        return Some(AgentMessageEvent {
-            from_agent_type: from_agent_type.clone(),
-            from_session_id: from_session_id.to_string(),
-            text: portal_text(msg),
-        });
-    }
-
-    // Defensive mixed-version fallback: a stale proxy can echo the typed
-    // portal event before a new backend has normalized it into record-level
-    // provenance. This stays typed and does not revive body-text prefix
-    // parsing.
     let [shared::PortalContent::AgentMessage {
         from_agent_type,
         from_session_id,
@@ -197,11 +196,6 @@ pub(crate) fn agent_message_event(msg: &PortalMessage) -> Option<AgentMessageEve
         from_session_id: from_session_id.clone(),
         text: text.clone(),
     })
-}
-
-pub(crate) fn agent_message_event_from_text(text: &str) -> Option<AgentMessageEvent> {
-    let msg = serde_json::from_str::<PortalMessage>(text).ok()?;
-    agent_message_event(&msg)
 }
 
 pub(crate) fn render_agent_message_event(
@@ -343,34 +337,9 @@ mod tests {
     }
 
     #[test]
-    fn agent_message_event_prefers_record_origin() {
-        let from_session_id =
-            Uuid::parse_str("22222222-2222-2222-2222-222222222222").expect("uuid");
-        let msg = PortalMessage {
-            content: vec![shared::PortalContent::Text {
-                text: "hello from metadata".to_string(),
-            }],
-            origin: Some(shared::MessageOrigin::InterAgent {
-                from_session_id,
-                from_agent_type: "codex".to_string(),
-            }),
-        };
-
-        let event = agent_message_event(&msg).expect("event");
-
-        assert_eq!(event.from_agent_type, "codex");
-        assert_eq!(
-            event.from_session_id,
-            "22222222-2222-2222-2222-222222222222"
-        );
-        assert_eq!(event.text, "hello from metadata");
-    }
-
-    #[test]
-    fn agent_message_event_falls_back_to_typed_portal_event() {
+    fn agent_message_event_reads_typed_portal_event_content() {
         let msg = PortalMessage {
             content: agent_message_content(),
-            origin: None,
         };
 
         let event = agent_message_event(&msg).expect("event");
@@ -381,22 +350,6 @@ mod tests {
             "11111111-1111-1111-1111-111111111111"
         );
         assert_eq!(event.text, "hello from stale proxy");
-    }
-
-    #[test]
-    fn agent_message_event_parses_typed_portal_event_from_user_text() {
-        let msg = shared::PortalMessage::with_content(agent_message_content());
-        let text = serde_json::to_string(&msg).expect("portal json");
-
-        let event = agent_message_event_from_text(&text).expect("event");
-
-        assert_eq!(event.from_agent_type, "claude");
-        assert_eq!(
-            event.from_session_id,
-            "11111111-1111-1111-1111-111111111111"
-        );
-        assert_eq!(event.text, "hello from stale proxy");
-        assert!(agent_message_event_from_text("[message from claude 1111]\nbody").is_none());
     }
 
     #[test]
@@ -405,7 +358,6 @@ mod tests {
             content: vec![shared::PortalContent::Text {
                 text: "[message from claude 1111]\nbody".to_string(),
             }],
-            origin: None,
         };
 
         assert!(agent_message_event(&msg).is_none());

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -7,6 +7,30 @@
 
 use serde::{Deserialize, Deserializer, Serialize};
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct RenderedMessage {
+    pub content: String,
+    pub meta: Option<shared::PortalMeta>,
+}
+
+impl RenderedMessage {
+    pub fn new(content: String, meta: Option<shared::PortalMeta>) -> Self {
+        Self { content, meta }
+    }
+
+    pub fn raw_iso(&self) -> Option<&str> {
+        self.meta.as_ref()?.created_at.as_deref()
+    }
+
+    pub fn delivery(&self) -> Option<&shared::DeliveryMeta> {
+        self.meta.as_ref()?.delivery.as_ref()
+    }
+
+    pub fn source(&self) -> Option<&shared::MessageSource> {
+        self.meta.as_ref()?.source.as_ref()
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub enum ClaudeMessage {
     System(shared::SystemMessage),
@@ -24,47 +48,11 @@ pub enum ClaudeMessage {
 pub struct PortalMessage {
     #[serde(default)]
     pub content: Vec<shared::PortalContent>,
-    #[serde(default, rename = "_origin")]
-    pub origin: Option<shared::MessageOrigin>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MessageSender {
-    pub user_id: String,
-    pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct OptimisticUserMessage {
     pub content: String,
-    #[serde(default, rename = "_client_msg_id")]
-    pub client_msg_id: Option<uuid::Uuid>,
-    #[serde(default, rename = "_sender")]
-    pub sender: Option<MessageSender>,
-    #[serde(default, rename = "_pending")]
-    pub pending: bool,
-    #[serde(default, rename = "_delivery_stage")]
-    pub delivery_stage: Option<shared::InputDeliveryStage>,
-    #[serde(default, rename = "_delivery_message")]
-    pub delivery_message: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct UserMessageMeta {
-    #[serde(default, rename = "_client_msg_id")]
-    pub client_msg_id: Option<uuid::Uuid>,
-    #[serde(default, rename = "_sender")]
-    pub sender: Option<MessageSender>,
-    #[serde(default, rename = "_pending")]
-    pub pending: bool,
-    #[serde(default, rename = "_delivery_stage")]
-    pub delivery_stage: Option<shared::InputDeliveryStage>,
-    #[serde(default, rename = "_delivery_message")]
-    pub delivery_message: Option<String>,
-}
-
-pub fn user_meta_from_json(json: &str) -> UserMessageMeta {
-    serde_json::from_str(json).unwrap_or_default()
 }
 
 impl ClaudeMessage {

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -8,14 +8,14 @@
 //! `helpers.rs`; task-event derivation lives alongside its consumer in
 //! `tasks_panel.rs`.
 
-use crate::components::message_renderer::MessageRenderer;
+use crate::components::message_renderer::{MessageRenderer, RenderedMessage};
 use crate::components::{
     group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroupRenderer,
 };
 use crate::utils::{self, On401};
 use gloo::timers::callback::Timeout;
 use shared::api::{ErrorMessage, TurnMetricsResponse};
-use shared::{ClientToServer, SendMode, SessionInfo, TurnMetrics};
+use shared::{ClientToServer, DeliveryMeta, PortalMeta, SendMode, SessionInfo, TurnMetrics};
 use std::collections::HashMap;
 use uuid::Uuid;
 use wasm_bindgen::closure::Closure;
@@ -25,8 +25,7 @@ use web_sys::Element;
 use yew::prelude::*;
 
 use super::helpers::{
-    autoscroll_transition, classify_output_msg_type, inject_created_at_if_absent,
-    inject_message_metadata, is_claude_awaiting, reconcile_pending_sends,
+    autoscroll_transition, classify_output_msg_type, is_claude_awaiting, reconcile_pending_sends,
     update_pending_send_delivery, ActivityTag,
 };
 use super::input_bar::{InputBar, InputBarInbound};
@@ -66,34 +65,41 @@ pub struct SessionViewProps {
     pub interrupt_signal: u32,
 }
 
-fn optimistic_user_json(content: &str, created_at: &str, client_msg_id: &Uuid) -> String {
+fn optimistic_user_message(
+    content: &str,
+    created_at: &str,
+    client_msg_id: Uuid,
+) -> RenderedMessage {
     #[derive(serde::Serialize)]
     struct OptimisticUserMessage<'a> {
         #[serde(rename = "type")]
         message_type: &'static str,
         content: &'a str,
-        #[serde(rename = "_pending")]
-        pending: bool,
-        #[serde(rename = "_created_at")]
-        created_at: &'a str,
-        #[serde(rename = "_client_msg_id")]
-        client_msg_id: &'a Uuid,
     }
 
-    serde_json::to_string(&OptimisticUserMessage {
+    let content = serde_json::to_string(&OptimisticUserMessage {
         message_type: "user",
         content,
-        pending: true,
-        created_at,
-        client_msg_id,
     })
-    .unwrap_or_default()
+    .unwrap_or_default();
+    RenderedMessage::new(
+        content,
+        Some(PortalMeta {
+            created_at: Some(created_at.to_string()),
+            source: None,
+            delivery: Some(DeliveryMeta {
+                client_msg_id,
+                stage: None,
+                message: None,
+            }),
+        }),
+    )
 }
 
 /// Messages for the SessionView component
 pub enum SessionViewMsg {
     LoadHistory(Vec<MessageData>, Option<String>),
-    ReceivedOutput(String),
+    ReceivedOutput(RenderedMessage),
     WebSocketConnected(WsSender),
     WebSocketError(String),
     AttemptReconnect,
@@ -160,7 +166,7 @@ pub enum SessionViewMsg {
 
 /// SessionView - Main terminal view for a single session
 pub struct SessionView {
-    messages: Vec<String>,
+    messages: Vec<RenderedMessage>,
     ws_connected: bool,
     ws_sender: Option<WsSender>,
     messages_ref: NodeRef,
@@ -196,7 +202,7 @@ pub struct SessionView {
     /// component holds zero textarea / upload / send-mode state itself.
     input_bar_dispatcher: Option<Callback<InputBarInbound>>,
     /// Messages sent but not yet confirmed by the server echo
-    pending_sends: Vec<String>,
+    pending_sends: Vec<RenderedMessage>,
     /// Per-turn performance metrics, sorted by `started_at ASC` (PR 2 of N).
     /// Hydrated by `LoadTurnMetrics` on initial REST load and topped up by
     /// `TurnMetricsReceived` on every live WS frame. Joined to terminator
@@ -383,11 +389,11 @@ impl Component for SessionView {
                         .iter()
                         .rev()
                         .find_map(|msg| {
-                            crate::components::codex_renderer::is_codex_terminal_event(msg)
+                            crate::components::codex_renderer::is_codex_terminal_event(&msg.content)
                         })
                         .unwrap_or(false)
                 } else {
-                    is_claude_awaiting(self.messages.iter())
+                    is_claude_awaiting(self.messages.iter().map(|m| &m.content))
                 };
                 let is_awaiting = is_result_awaiting || self.has_pending_permission;
                 let session_id = ctx.props().session.id;
@@ -528,8 +534,8 @@ impl Component for SessionView {
                                 html! { <MessageGroupRenderer {key} group={group} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} {thinking_start} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
                             }).collect::<Html>()
                         }
-                        { for self.pending_sends.iter().enumerate().map(|(i, json)| {
-                            html! { <MessageRenderer key={format!("p{}", i)} json={json.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
+                        { for self.pending_sends.iter().enumerate().map(|(i, message)| {
+                            html! { <MessageRenderer key={format!("p{}", i)} message={message.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
                         })}
                     </div>
                     if !is_tailing {
@@ -564,7 +570,7 @@ impl SessionView {
                 ctx.link().send_message(SessionViewMsg::WebSocketError(err));
                 false
             }
-            WsEvent::Output(content, created_at) => {
+            WsEvent::Output(message) => {
                 // Update the reconnect-replay watermark from the
                 // server-assigned `created_at` (closes #784). Falling back to
                 // `Date.now()` here — the prior behavior — could miss
@@ -575,11 +581,11 @@ impl SessionView {
                 // a timestamp (pre-#784 server or an error envelope), keep
                 // the prior watermark — a future timestamped message will
                 // heal it.
-                if let Some(ts) = created_at {
+                if let Some(ts) = message.meta.as_ref().and_then(|m| m.created_at.clone()) {
                     self.last_message_timestamp = Some(ts);
                 }
                 ctx.link()
-                    .send_message(SessionViewMsg::ReceivedOutput(content));
+                    .send_message(SessionViewMsg::ReceivedOutput(message));
                 ctx.link().send_message(SessionViewMsg::CheckAwaiting);
                 false
             }
@@ -638,8 +644,7 @@ impl SessionView {
     /// Hydrate the message buffer + task panel from a REST history batch.
     /// Each message is classified once via [`classify_output_msg_type`],
     /// task events are forwarded to the panel via [`derive_task_events`],
-    /// and metadata (`_sender` for user messages, `_created_at` for every
-    /// row) is folded into the JSON via [`inject_message_metadata`].
+    /// and portal metadata stays in the typed sidecar carried by the API.
     fn handle_load_history(
         &mut self,
         ctx: &Context<Self>,
@@ -665,16 +670,7 @@ impl SessionView {
         }
         self.messages = messages
             .into_iter()
-            .map(|m| {
-                inject_message_metadata(
-                    &m.content,
-                    &m.created_at,
-                    m.role == "user",
-                    m.user_id.as_deref(),
-                    m.sender_name.as_deref(),
-                    m.origin.as_ref(),
-                )
-            })
+            .map(|m| RenderedMessage::new(m.content, m.meta))
             .collect();
         self.last_message_timestamp = last_timestamp;
         ctx.link().send_message(SessionViewMsg::CheckAwaiting);
@@ -695,7 +691,7 @@ impl SessionView {
             .unwrap_or_default();
         let client_msg_id = Uuid::new_v4();
         self.pending_sends
-            .push(optimistic_user_json(&input, &now_iso, &client_msg_id));
+            .push(optimistic_user_message(&input, &now_iso, client_msg_id));
 
         if let Some(ref sender) = self.ws_sender {
             let msg = ClientToServer::AgentInput {
@@ -726,7 +722,7 @@ impl SessionView {
                         .as_string()
                         .unwrap_or_default();
                     self.pending_sends
-                        .push(optimistic_user_json(text, &now_iso, &client_msg_id));
+                        .push(optimistic_user_message(text, &now_iso, client_msg_id));
                     changed = true;
                 }
                 (
@@ -742,9 +738,9 @@ impl SessionView {
         }
     }
 
-    fn handle_received_output(&mut self, ctx: &Context<Self>, output: String) -> bool {
-        let tag = classify_output_msg_type(&output);
-        if let Ok(claude_msg) = serde_json::from_str::<shared::ClaudeOutput>(&output) {
+    fn handle_received_output(&mut self, ctx: &Context<Self>, output: RenderedMessage) -> bool {
+        let tag = classify_output_msg_type(&output.content);
+        if let Ok(claude_msg) = serde_json::from_str::<shared::ClaudeOutput>(&output.content) {
             // Live task events: the `created_at` field isn't part of the
             // live wire envelope, so the panel falls back to `Date.now()`
             // — see `derive_task_events` for the two paths.
@@ -756,21 +752,7 @@ impl SessionView {
         ctx.props()
             .on_activity
             .emit((ctx.props().session.id, tag, js_sys::Date::now()));
-        // Inject _created_at for tooltip display only when the frame doesn't
-        // already carry one: `websocket.rs` folds the server-assigned
-        // `created_at` into the content before emitting `WsEvent::Output`,
-        // and that authoritative timestamp must win over the browser clock
-        // (#981). Frames without one (error envelopes, pre-#784 backends)
-        // fall back to `Date::now()`; the reconnect-replay watermark is set
-        // separately from the server `created_at` in `WsEvent::Output`
-        // (closes #784).
-        let now_iso = js_sys::Date::new_0()
-            .to_iso_string()
-            .as_string()
-            .unwrap_or_default();
-        let output = inject_created_at_if_absent(&output, &now_iso);
-
-        reconcile_pending_sends(&mut self.pending_sends, tag, &output);
+        reconcile_pending_sends(&mut self.pending_sends, tag, &output.content);
 
         push_message_with_limit(&mut self.messages, output, MAX_MESSAGES_PER_SESSION);
         true
@@ -799,8 +781,10 @@ impl SessionView {
             }));
         } else {
             let error_msg = ErrorMessage::new(format!("Connection lost: {}", err));
-            self.messages
-                .push(serde_json::to_string(&error_msg).unwrap_or_default());
+            self.messages.push(RenderedMessage::new(
+                serde_json::to_string(&error_msg).unwrap_or_default(),
+                None,
+            ));
         }
         true
     }

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -9,6 +9,7 @@
 //! was extracted from.
 
 use crate::components::message_renderer::types::ClaudeMessage;
+use crate::components::message_renderer::RenderedMessage;
 
 /// Cross-agent activity classification used by the session-rail sparkline and
 /// the pending-send reconciler. The same enum bridges Claude wire shapes
@@ -286,85 +287,6 @@ fn is_sed_print_read(command: &str) -> bool {
     command.contains('p')
 }
 
-/// Inject `_created_at` (and optionally `_sender`) metadata into a wire-JSON
-/// message string, returning a new JSON string. Used by both the REST
-/// `LoadHistory` path (where the row carries `user_id` / `sender_name`
-/// columns to fold into `_sender` for user messages) and the live
-/// `WsEvent::Output` path (where only `_created_at` matters; `role_user` is
-/// false so the `_sender` branch is skipped).
-///
-/// Returns the original `content` unchanged when the JSON parse fails — the
-/// caller still pushes the raw string so a malformed wire frame doesn't
-/// silently disappear from the message list.
-pub(super) fn inject_message_metadata(
-    content: &str,
-    created_at: &str,
-    role_user: bool,
-    user_id: Option<&str>,
-    sender_name: Option<&str>,
-    origin: Option<&shared::MessageOrigin>,
-) -> String {
-    let Ok(mut val) = serde_json::from_str::<serde_json::Value>(content) else {
-        return content.to_string();
-    };
-    let Some(obj) = val.as_object_mut() else {
-        return content.to_string();
-    };
-    if role_user && (user_id.is_some() || sender_name.is_some()) {
-        #[derive(serde::Serialize)]
-        struct SenderMeta<'a> {
-            user_id: &'a str,
-            name: &'a str,
-        }
-        obj.insert(
-            "_sender".to_string(),
-            serde_json::to_value(SenderMeta {
-                user_id: user_id.unwrap_or_default(),
-                name: sender_name.unwrap_or_default(),
-            })
-            .unwrap_or(serde_json::Value::Null),
-        );
-    }
-    obj.insert(
-        "_created_at".to_string(),
-        serde_json::Value::String(created_at.to_string()),
-    );
-    if let Some(origin) = origin {
-        obj.insert(
-            "_origin".to_string(),
-            serde_json::to_value(origin).unwrap_or(serde_json::Value::Null),
-        );
-    }
-    val.to_string()
-}
-
-/// Inject `_created_at` into a wire-JSON message string only when the key is
-/// absent, returning a new JSON string. Used by the live
-/// `handle_received_output` path: `websocket.rs` already folds the
-/// server-assigned `created_at` into `WsEvent::Output` content, and that
-/// authoritative timestamp must not be clobbered by the browser-clock
-/// fallback (#981). Frames that arrive without one (error envelopes, a
-/// pre-#784 backend) still get the `Date::now()` fallback for tooltips.
-///
-/// Returns the original `content` unchanged when the JSON parse fails or the
-/// value isn't an object — same contract as [`inject_message_metadata`].
-pub(super) fn inject_created_at_if_absent(content: &str, created_at: &str) -> String {
-    let Ok(mut val) = serde_json::from_str::<serde_json::Value>(content) else {
-        return content.to_string();
-    };
-    let Some(obj) = val.as_object_mut() else {
-        return content.to_string();
-    };
-    if obj.contains_key("_created_at") {
-        return content.to_string();
-    }
-    obj.insert(
-        "_created_at".to_string(),
-        serde_json::Value::String(created_at.to_string()),
-    );
-    val.to_string()
-}
-
 /// Drain pending optimistic-send entries when the server confirms our input.
 ///
 /// - [`ActivityTag::User`] echo: match by content (via [`extract_user_text`])
@@ -376,7 +298,7 @@ pub(super) fn inject_created_at_if_absent(content: &str, created_at: &str) -> St
 ///   the input was received and clears *all* pending entries.
 /// - Any other tag: no-op.
 pub(super) fn reconcile_pending_sends(
-    pending_sends: &mut Vec<String>,
+    pending_sends: &mut Vec<RenderedMessage>,
     tag: ActivityTag,
     output: &str,
 ) {
@@ -394,7 +316,7 @@ pub(super) fn reconcile_pending_sends(
                     if pending_has_client_msg_id(pending) {
                         return false;
                     }
-                    ClaudeMessage::parse(pending)
+                    ClaudeMessage::parse(&pending.content)
                         .ok()
                         .as_ref()
                         .and_then(extract_user_text)
@@ -406,14 +328,14 @@ pub(super) fn reconcile_pending_sends(
             }
         }
         ActivityTag::Assistant | ActivityTag::Result => {
-            pending_sends.retain(|pending| pending_has_client_msg_id(pending));
+            pending_sends.retain(pending_has_client_msg_id);
         }
         _ => {}
     }
 }
 
 pub(super) fn update_pending_send_delivery(
-    pending_sends: &mut Vec<String>,
+    pending_sends: &mut Vec<RenderedMessage>,
     client_msg_id: uuid::Uuid,
     stage: shared::InputDeliveryStage,
     message: Option<&str>,
@@ -430,51 +352,48 @@ pub(super) fn update_pending_send_delivery(
         return true;
     }
 
-    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&pending_sends[pos]) else {
+    let Some(meta) = pending_sends[pos].meta.as_mut() else {
         return false;
     };
-    let Some(obj) = value.as_object_mut() else {
+    let Some(delivery) = meta.delivery.as_mut() else {
         return false;
     };
 
-    obj.insert(
-        "_delivery_stage".to_string(),
-        serde_json::to_value(stage).unwrap_or(serde_json::Value::Null),
-    );
-    match message {
-        Some(message) => {
-            obj.insert(
-                "_delivery_message".to_string(),
-                serde_json::Value::String(message.to_string()),
-            );
-        }
-        None => {
-            obj.remove("_delivery_message");
-        }
-    }
-    if stage == shared::InputDeliveryStage::Failed {
-        obj.insert("_pending".to_string(), serde_json::Value::Bool(false));
-    }
-
-    pending_sends[pos] = value.to_string();
+    delivery.stage = Some(stage);
+    delivery.message = message.map(ToOwned::to_owned);
     true
 }
 
-fn pending_has_client_msg_id(pending: &str) -> bool {
+fn pending_has_client_msg_id(pending: &RenderedMessage) -> bool {
     pending_client_msg_id(pending).is_some()
 }
 
-fn pending_client_msg_id(pending: &str) -> Option<uuid::Uuid> {
-    let value = serde_json::from_str::<serde_json::Value>(pending).ok()?;
-    value
-        .get("_client_msg_id")
-        .and_then(|v| v.as_str())
-        .and_then(|s| uuid::Uuid::parse_str(s).ok())
+fn pending_client_msg_id(pending: &RenderedMessage) -> Option<uuid::Uuid> {
+    pending.delivery().map(|delivery| delivery.client_msg_id)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pending(content: &str) -> RenderedMessage {
+        RenderedMessage::new(format!(r#"{{"type":"user","content":"{content}"}}"#), None)
+    }
+
+    fn tracked_pending(content: &str, id: uuid::Uuid) -> RenderedMessage {
+        RenderedMessage::new(
+            format!(r#"{{"type":"user","content":"{content}"}}"#),
+            Some(shared::PortalMeta {
+                created_at: None,
+                source: None,
+                delivery: Some(shared::DeliveryMeta {
+                    client_msg_id: id,
+                    stage: None,
+                    message: None,
+                }),
+            }),
+        )
+    }
 
     // --- autoscroll_transition ---
 
@@ -661,144 +580,11 @@ mod tests {
         assert_eq!(classify_output_msg_type(json), ActivityTag::Unknown);
     }
 
-    // --- inject_message_metadata ---
-
-    #[test]
-    fn inject_message_metadata_adds_created_at_for_non_user_role() {
-        let out = inject_message_metadata(
-            r#"{"type":"assistant","content":"hi"}"#,
-            "2026-05-18T12:00:00Z",
-            false,
-            None,
-            None,
-            None,
-        );
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["_created_at"], "2026-05-18T12:00:00Z");
-        // Non-user role should never get _sender injected.
-        assert!(v.get("_sender").is_none());
-    }
-
-    #[test]
-    fn inject_message_metadata_adds_origin_when_present() {
-        let from_session_id =
-            uuid::Uuid::parse_str("11111111-1111-1111-1111-111111111111").expect("uuid");
-        let origin = shared::MessageOrigin::InterAgent {
-            from_session_id,
-            from_agent_type: "claude".to_string(),
-        };
-        let out = inject_message_metadata(
-            r#"{"type":"portal","content":[{"type":"text","text":"hello"}]}"#,
-            "2026-05-18T12:00:00Z",
-            false,
-            None,
-            None,
-            Some(&origin),
-        );
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["_origin"]["kind"], "inter_agent");
-        assert_eq!(
-            v["_origin"]["from_session_id"],
-            "11111111-1111-1111-1111-111111111111"
-        );
-        assert_eq!(v["_origin"]["from_agent_type"], "claude");
-    }
-
-    #[test]
-    fn inject_message_metadata_adds_sender_for_user_role_with_attribution() {
-        let out = inject_message_metadata(
-            r#"{"type":"user","content":"hi"}"#,
-            "2026-05-18T12:00:00Z",
-            true,
-            Some("uid-1"),
-            Some("Alice"),
-            None,
-        );
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["_created_at"], "2026-05-18T12:00:00Z");
-        assert_eq!(v["_sender"]["user_id"], "uid-1");
-        assert_eq!(v["_sender"]["name"], "Alice");
-    }
-
-    #[test]
-    fn inject_message_metadata_skips_sender_for_user_role_without_attribution() {
-        let out = inject_message_metadata(
-            r#"{"type":"user","content":"hi"}"#,
-            "2026-05-18T12:00:00Z",
-            true,
-            None,
-            None,
-            None,
-        );
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["_created_at"], "2026-05-18T12:00:00Z");
-        // User role with no attribution → no _sender either.
-        assert!(v.get("_sender").is_none());
-    }
-
-    #[test]
-    fn inject_message_metadata_returns_input_unchanged_for_invalid_json() {
-        // Malformed wire frame: the caller still pushes the raw string so
-        // the message doesn't silently disappear from the list.
-        let out = inject_message_metadata("not-json", "ts", false, None, None, None);
-        assert_eq!(out, "not-json");
-    }
-
-    #[test]
-    fn inject_message_metadata_returns_input_unchanged_for_non_object_json() {
-        // Valid JSON but not an object (e.g. a top-level string) — no
-        // _created_at slot to inject into, return as-is so callers don't
-        // re-serialize it into a quoted-string blob.
-        let out = inject_message_metadata("\"hello\"", "ts", false, None, None, None);
-        assert_eq!(out, "\"hello\"");
-    }
-
-    // --- inject_created_at_if_absent ---
-
-    #[test]
-    fn inject_created_at_if_absent_preserves_existing_server_timestamp() {
-        // The live path: websocket.rs already folded the server `created_at`
-        // into the frame — the browser-clock fallback must not clobber it
-        // (#981).
-        let server_ts = "2026-05-18T12:00:00Z";
-        let input = format!(r#"{{"type":"assistant","content":"hi","_created_at":"{server_ts}"}}"#);
-        let out = inject_created_at_if_absent(&input, "2026-05-18T12:34:56Z");
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(
-            v["_created_at"], server_ts,
-            "server timestamp must survive the component-side injection"
-        );
-    }
-
-    #[test]
-    fn inject_created_at_if_absent_adds_timestamp_when_missing() {
-        // Frames with no server timestamp (error envelopes, pre-#784
-        // backends) still get the browser-clock fallback for tooltips.
-        let out = inject_created_at_if_absent(
-            r#"{"type":"assistant","content":"hi"}"#,
-            "2026-05-18T12:34:56Z",
-        );
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["_created_at"], "2026-05-18T12:34:56Z");
-    }
-
-    #[test]
-    fn inject_created_at_if_absent_returns_input_unchanged_for_invalid_json() {
-        let out = inject_created_at_if_absent("not-json", "ts");
-        assert_eq!(out, "not-json");
-    }
-
-    #[test]
-    fn inject_created_at_if_absent_returns_input_unchanged_for_non_object_json() {
-        let out = inject_created_at_if_absent("\"hello\"", "ts");
-        assert_eq!(out, "\"hello\"");
-    }
-
     // --- reconcile_pending_sends ---
 
     #[test]
     fn reconcile_pending_sends_noop_when_empty() {
-        let mut pending: Vec<String> = vec![];
+        let mut pending: Vec<RenderedMessage> = vec![];
         reconcile_pending_sends(
             &mut pending,
             ActivityTag::User,
@@ -809,17 +595,14 @@ mod tests {
 
     #[test]
     fn reconcile_pending_sends_user_echo_removes_first_matching_entry() {
-        let mut pending = vec![
-            r#"{"type":"user","content":"hello"}"#.to_string(),
-            r#"{"type":"user","content":"world"}"#.to_string(),
-        ];
+        let mut pending = vec![pending("hello"), pending("world")];
         reconcile_pending_sends(
             &mut pending,
             ActivityTag::User,
             r#"{"type":"user","content":"hello"}"#,
         );
         assert_eq!(pending.len(), 1);
-        assert!(pending[0].contains("world"));
+        assert!(pending[0].content.contains("world"));
     }
 
     #[test]
@@ -827,7 +610,7 @@ mod tests {
         // A user echo for a message we didn't optimistically send must NOT
         // consume an unrelated pending entry — otherwise a multi-tab scenario
         // would drop legitimate pending sends.
-        let mut pending = vec![r#"{"type":"user","content":"hello"}"#.to_string()];
+        let mut pending = vec![pending("hello")];
         reconcile_pending_sends(
             &mut pending,
             ActivityTag::User,
@@ -842,10 +625,7 @@ mod tests {
         // so the assistant response is the only signal we get that input
         // was received. Clear legacy entries; id-tracked entries wait for
         // InputProgress::AgentAccepted.
-        let mut pending = vec![
-            r#"{"type":"user","content":"a"}"#.to_string(),
-            r#"{"type":"user","content":"b"}"#.to_string(),
-        ];
+        let mut pending = vec![pending("a"), pending("b")];
         reconcile_pending_sends(
             &mut pending,
             ActivityTag::Assistant,
@@ -857,10 +637,7 @@ mod tests {
     #[test]
     fn reconcile_pending_sends_preserves_id_tracked_rows() {
         let id = uuid::Uuid::new_v4();
-        let mut pending = vec![
-            format!(r#"{{"type":"user","content":"hello","_client_msg_id":"{id}"}}"#),
-            r#"{"type":"user","content":"legacy"}"#.to_string(),
-        ];
+        let mut pending = vec![tracked_pending("hello", id), pending("legacy")];
 
         reconcile_pending_sends(
             &mut pending,
@@ -875,15 +652,13 @@ mod tests {
             r#"{"type":"assistant","message":{"content":[]}}"#,
         );
         assert_eq!(pending.len(), 1, "assistant clears only legacy rows");
-        assert!(pending[0].contains(&id.to_string()));
+        assert_eq!(pending[0].delivery().map(|d| d.client_msg_id), Some(id));
     }
 
     #[test]
     fn update_pending_send_delivery_updates_stage() {
         let id = uuid::Uuid::new_v4();
-        let mut pending = vec![format!(
-            r#"{{"type":"user","content":"hello","_pending":true,"_client_msg_id":"{id}"}}"#
-        )];
+        let mut pending = vec![tracked_pending("hello", id)];
 
         assert!(update_pending_send_delivery(
             &mut pending,
@@ -891,17 +666,18 @@ mod tests {
             shared::InputDeliveryStage::ServerReceived,
             None,
         ));
-        let value: serde_json::Value = serde_json::from_str(&pending[0]).unwrap();
-        assert_eq!(value["_delivery_stage"], "server_received");
-        assert_eq!(value["_pending"], true);
+        let delivery = pending[0].delivery().expect("delivery");
+        assert_eq!(
+            delivery.stage,
+            Some(shared::InputDeliveryStage::ServerReceived)
+        );
+        assert!(delivery.pending());
     }
 
     #[test]
     fn update_pending_send_delivery_failed_marks_not_pending() {
         let id = uuid::Uuid::new_v4();
-        let mut pending = vec![format!(
-            r#"{{"type":"user","content":"hello","_pending":true,"_client_msg_id":"{id}"}}"#
-        )];
+        let mut pending = vec![tracked_pending("hello", id)];
 
         assert!(update_pending_send_delivery(
             &mut pending,
@@ -909,18 +685,16 @@ mod tests {
             shared::InputDeliveryStage::Failed,
             Some("permission denied"),
         ));
-        let value: serde_json::Value = serde_json::from_str(&pending[0]).unwrap();
-        assert_eq!(value["_delivery_stage"], "failed");
-        assert_eq!(value["_delivery_message"], "permission denied");
-        assert_eq!(value["_pending"], false);
+        let delivery = pending[0].delivery().expect("delivery");
+        assert_eq!(delivery.stage, Some(shared::InputDeliveryStage::Failed));
+        assert_eq!(delivery.message.as_deref(), Some("permission denied"));
+        assert!(!delivery.pending());
     }
 
     #[test]
     fn update_pending_send_delivery_agent_accepted_removes_row() {
         let id = uuid::Uuid::new_v4();
-        let mut pending = vec![format!(
-            r#"{{"type":"user","content":"hello","_pending":true,"_client_msg_id":"{id}"}}"#
-        )];
+        let mut pending = vec![tracked_pending("hello", id)];
 
         assert!(update_pending_send_delivery(
             &mut pending,
@@ -933,7 +707,7 @@ mod tests {
 
     #[test]
     fn reconcile_pending_sends_result_clears_all() {
-        let mut pending = vec![r#"{"type":"user","content":"a"}"#.to_string()];
+        let mut pending = vec![pending("a")];
         reconcile_pending_sends(
             &mut pending,
             ActivityTag::Result,
@@ -944,7 +718,7 @@ mod tests {
 
     #[test]
     fn reconcile_pending_sends_ignores_other_tags() {
-        let mut pending = vec![r#"{"type":"user","content":"a"}"#.to_string()];
+        let mut pending = vec![pending("a")];
         reconcile_pending_sends(&mut pending, ActivityTag::System, r#"{"type":"system"}"#);
         assert_eq!(pending.len(), 1);
     }

--- a/frontend/src/pages/dashboard/session_view/state.rs
+++ b/frontend/src/pages/dashboard/session_view/state.rs
@@ -19,7 +19,7 @@ pub(super) fn retain_newest_items<T>(items: &mut Vec<T>, max_len: usize) {
 
 /// Append one live message and apply the same retention rule as history
 /// hydration and replay batches.
-pub(super) fn push_message_with_limit(messages: &mut Vec<String>, message: String, max_len: usize) {
+pub(super) fn push_message_with_limit<T>(messages: &mut Vec<T>, message: T, max_len: usize) {
     messages.push(message);
     retain_newest_items(messages, max_len);
 }

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -4,11 +4,14 @@ use crate::utils;
 use futures_util::StreamExt;
 use shared::api::ErrorMessage;
 use shared::{
-    ClientEndpoint, ClientToServer, InputDeliveryStage, ServerToClient, TurnMetrics, WsEndpoint,
+    ClientEndpoint, ClientToServer, InputDeliveryStage, PortalMeta, ServerToClient, TurnMetrics,
+    WsEndpoint,
 };
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use yew::Callback;
+
+use crate::components::message_renderer::RenderedMessage;
 
 use super::types::{PendingPermission, WsSender};
 
@@ -21,12 +24,12 @@ pub enum WsEvent {
     /// pre-#784 wire shape and the rare error-envelope paths that don't go
     /// through a DB insert). The frontend uses it as the reconnect-replay
     /// watermark rather than `Date.now()` (closes #784).
-    Output(String, Option<String>),
+    Output(RenderedMessage),
     /// History replay batch. Second field is the server-assigned `created_at`
     /// of the latest message in the batch (`None` if the batch is empty or
     /// the backend is pre-#784). Used to set the reconnect watermark on
     /// initial load.
-    HistoryBatch(Vec<String>, Option<String>),
+    HistoryBatch(Vec<RenderedMessage>, Option<String>),
     Permission(PendingPermission),
     BranchChanged(
         Option<String>,
@@ -134,70 +137,42 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
     match msg {
         ServerToClient::AgentOutput {
             content,
-            sender_user_id,
-            sender_name,
+            sender_user_id: _,
+            sender_name: _,
             // agent_type is plumbed through the wire (per-message tag) and
             // available here for future multi-agent UI work — see #723.
             // The frontend renders off the session-level agent_type; both
             // the live and historical-read paths stay agent-agnostic.
             agent_type: _,
             created_at,
-            origin,
-            // Typed portal sidecar — consumed in slice 3 (frontend read-from-meta);
-            // ignored here so slice 1 stays a no-op contract change.
-            meta: _,
+            origin: _,
+            meta,
         } => {
-            // Inject _sender into content for the renderer if sender info is
-            // present. Also fold `created_at` into the content as
-            // `_created_at` so per-message renderers (TimeAgo footers, etc.)
-            // see the same shape the historical-read path produces — and so
-            // future replayers downstream of `Output` can read it without
-            // changing the event signature again.
-            let mut content_val = content;
-            let needs_sender = sender_user_id.is_some() || sender_name.is_some();
-            if needs_sender || created_at.is_some() || origin.is_some() {
-                if let Some(obj) = content_val.as_object_mut() {
-                    if needs_sender {
-                        #[derive(serde::Serialize)]
-                        struct SenderMeta<'a> {
-                            user_id: &'a str,
-                            name: &'a str,
-                        }
-                        obj.insert(
-                            "_sender".to_string(),
-                            serde_json::to_value(SenderMeta {
-                                user_id: sender_user_id.as_deref().unwrap_or_default(),
-                                name: sender_name.as_deref().unwrap_or_default(),
-                            })
-                            .unwrap_or(serde_json::Value::Null),
-                        );
-                    }
-                    if let Some(ref ts) = created_at {
-                        obj.insert(
-                            "_created_at".to_string(),
-                            serde_json::Value::String(ts.clone()),
-                        );
-                    }
-                    if let Some(origin) = origin {
-                        obj.insert(
-                            "_origin".to_string(),
-                            serde_json::to_value(origin).unwrap_or(serde_json::Value::Null),
-                        );
-                    }
-                }
-            }
-            let output = content_val.to_string();
-            on_event.emit(WsEvent::Output(output, created_at));
+            let meta = meta.or_else(|| {
+                created_at.map(|created_at| PortalMeta {
+                    created_at: Some(created_at),
+                    source: None,
+                    delivery: None,
+                })
+            });
+            on_event.emit(WsEvent::Output(RenderedMessage::new(
+                content.to_string(),
+                meta,
+            )));
         }
         ServerToClient::HistoryBatch {
             messages,
-            // Index-aligned typed sidecar — zipped in slice 3 (frontend
-            // read-from-meta); ignored here so slice 1 stays a no-op.
-            message_meta: _,
+            message_meta,
             last_created_at,
         } => {
-            let strings: Vec<String> = messages.into_iter().map(|v| v.to_string()).collect();
-            on_event.emit(WsEvent::HistoryBatch(strings, last_created_at));
+            let rendered: Vec<RenderedMessage> = messages
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    RenderedMessage::new(v.to_string(), message_meta.get(i).cloned().flatten())
+                })
+                .collect();
+            on_event.emit(WsEvent::HistoryBatch(rendered, last_created_at));
         }
         ServerToClient::PermissionRequest {
             request_id,
@@ -217,7 +192,7 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
             let error_json = serde_json::to_string(&error_msg).unwrap_or_default();
             // Error envelopes don't go through the DB so they have no
             // server-assigned `created_at` — leave the watermark unchanged.
-            on_event.emit(WsEvent::Output(error_json, None));
+            on_event.emit(WsEvent::Output(RenderedMessage::new(error_json, None)));
         }
         ServerToClient::SessionUpdate {
             session_id: _,
@@ -416,10 +391,10 @@ mod tests {
     }
 
     /// A `ServerToClient::ClaudeOutput` carrying a `created_at` must be
-    /// translated into a `WsEvent::Output(_, Some(ts))` with the exact
-    /// server-assigned timestamp string. This is the value the component
-    /// pipes into `last_message_timestamp` (#784); if it ever falls back
-    /// to `Date.now()` here the silent-data-loss regression returns.
+    /// translated into a `WsEvent::Output` whose `PortalMeta.created_at`
+    /// carries the exact server-assigned timestamp string. This is the value
+    /// the component pipes into `last_message_timestamp` (#784); if it ever
+    /// falls back to `Date.now()` here the silent-data-loss regression returns.
     #[test]
     fn claude_output_with_created_at_emits_server_timestamp() {
         let (cb, sink) = capture();
@@ -439,31 +414,28 @@ mod tests {
         let events = sink.borrow();
         assert_eq!(events.len(), 1);
         match &events[0] {
-            WsEvent::Output(content, ts) => {
+            WsEvent::Output(message) => {
                 assert_eq!(
-                    ts.as_deref(),
+                    message.meta.as_ref().and_then(|m| m.created_at.as_deref()),
                     Some(server_ts.as_str()),
                     "watermark must be the server's created_at, never Date.now()"
                 );
-                // _created_at must also be folded into the content JSON
-                // so per-message renderers see the same shape the
-                // historical-read path produces.
-                let parsed: serde_json::Value = serde_json::from_str(content).unwrap();
+                let parsed: serde_json::Value = serde_json::from_str(&message.content).unwrap();
                 assert_eq!(
-                    parsed.get("_created_at").and_then(|v| v.as_str()),
-                    Some(server_ts.as_str()),
+                    parsed.get("_created_at"),
+                    None,
+                    "content must not receive flattened portal metadata"
                 );
             }
             other => panic!("expected Output, got {:?}", debug_event(other)),
         }
     }
 
-    /// Inter-agent attribution is carried on the live `AgentOutput.origin`
-    /// field, then injected as `_origin` into the JSON consumed by the portal
-    /// renderer. If this translation is dropped, a properly normalized
-    /// inter-agent message renders as a generic PORTAL card.
+    /// Inter-agent attribution is carried on the live `AgentOutput.meta`
+    /// sidecar. It must stay out of the raw content JSON so renderers read a
+    /// typed source instead of `_origin` conventions.
     #[test]
-    fn agent_output_with_origin_injects_origin_metadata() {
+    fn agent_output_with_meta_keeps_origin_in_sidecar() {
         let (cb, sink) = capture();
         let from_session_id =
             uuid::Uuid::parse_str("11111111-1111-1111-1111-111111111111").expect("uuid");
@@ -476,11 +448,15 @@ mod tests {
             sender_name: None,
             agent_type: shared::AgentType::Codex,
             created_at: None,
-            origin: Some(shared::MessageOrigin::InterAgent {
-                from_session_id,
-                from_agent_type: "codex".to_string(),
+            origin: None,
+            meta: Some(shared::PortalMeta {
+                created_at: None,
+                source: Some(shared::MessageSource::Agent {
+                    session_id: from_session_id,
+                    agent_type: "codex".to_string(),
+                }),
+                delivery: None,
             }),
-            meta: None,
         };
 
         handle_proxy_message(msg, &cb);
@@ -488,14 +464,16 @@ mod tests {
         let events = sink.borrow();
         assert_eq!(events.len(), 1);
         match &events[0] {
-            WsEvent::Output(content, _) => {
-                let parsed: serde_json::Value = serde_json::from_str(content).unwrap();
-                assert_eq!(parsed["_origin"]["kind"], "inter_agent");
+            WsEvent::Output(message) => {
+                assert!(message.content.contains("hello from peer"));
+                assert!(!message.content.contains("_origin"));
                 assert_eq!(
-                    parsed["_origin"]["from_session_id"],
-                    "11111111-1111-1111-1111-111111111111"
+                    message.meta.as_ref().and_then(|m| m.source.as_ref()),
+                    Some(&shared::MessageSource::Agent {
+                        session_id: from_session_id,
+                        agent_type: "codex".to_string(),
+                    })
                 );
-                assert_eq!(parsed["_origin"]["from_agent_type"], "codex");
             }
             other => panic!("expected Output, got {:?}", debug_event(other)),
         }
@@ -525,7 +503,7 @@ mod tests {
         let events = sink.borrow();
         assert_eq!(events.len(), 1);
         match &events[0] {
-            WsEvent::Output(_, ts) => assert!(ts.is_none()),
+            WsEvent::Output(message) => assert!(message.meta.is_none()),
             other => panic!("expected Output, got {:?}", debug_event(other)),
         }
     }
@@ -540,8 +518,12 @@ mod tests {
         let (cb, sink) = capture();
         let ts = "2026-05-18T00:00:00.000000".to_string();
         let msg = ServerToClient::HistoryBatch {
-            messages: vec![serde_json::json!({"_created_at": ts.clone()})],
-            message_meta: Vec::new(),
+            messages: vec![serde_json::json!({"type": "assistant"})],
+            message_meta: vec![Some(shared::PortalMeta {
+                created_at: Some(ts.clone()),
+                source: None,
+                delivery: None,
+            })],
             last_created_at: Some(ts.clone()),
         };
 
@@ -553,6 +535,10 @@ mod tests {
             WsEvent::HistoryBatch(batch, last) => {
                 assert_eq!(batch.len(), 1);
                 assert_eq!(last.as_deref(), Some(ts.as_str()));
+                assert_eq!(
+                    batch[0].meta.as_ref().and_then(|m| m.created_at.as_deref()),
+                    Some(ts.as_str())
+                );
             }
             other => panic!("expected HistoryBatch, got {:?}", debug_event(other)),
         }
@@ -598,7 +584,7 @@ mod tests {
         let events = sink.borrow();
         assert_eq!(events.len(), 1);
         match &events[0] {
-            WsEvent::Output(_, ts) => assert!(ts.is_none()),
+            WsEvent::Output(message) => assert!(message.meta.is_none()),
             other => panic!("expected Output, got {:?}", debug_event(other)),
         }
     }
@@ -609,7 +595,7 @@ mod tests {
         match ev {
             WsEvent::Connected(_) => "Connected",
             WsEvent::Error(_) => "Error",
-            WsEvent::Output(_, _) => "Output",
+            WsEvent::Output(_) => "Output",
             WsEvent::HistoryBatch(_, _) => "HistoryBatch",
             WsEvent::Permission(_) => "Permission",
             WsEvent::BranchChanged(_, _, _, _) => "BranchChanged",

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -47,9 +47,9 @@ pub struct MessageData {
     /// Display name of the sender (looked up from users table)
     #[serde(default)]
     pub sender_name: Option<String>,
-    /// Typed provenance for records produced by another agent session.
+    /// Typed portal sidecar for attribution, timestamp, and delivery state.
     #[serde(default)]
-    pub origin: Option<shared::MessageOrigin>,
+    pub meta: Option<shared::PortalMeta>,
 }
 
 /// Response from the messages API endpoint — the shared envelope


### PR DESCRIPTION
## Summary
- Thread `PortalMeta` through frontend websocket/history/message rendering as a typed sidecar instead of flattening `_origin`/`_sender`/`_created_at`/delivery keys into message JSON.
- Render inter-agent cards from `MessageSource::Agent`; render human/portal grouping from `MessageSource`; keep raw agent content untouched.
- Move optimistic-send delivery state into `DeliveryMeta` and delete legacy metadata injection/text-parser helpers.

## Verification
- `cargo check -p frontend`
- `cargo test -p frontend`
- `cargo clippy -p frontend -- -D warnings`
- `git diff --check`

## Notes
- No underscore-key fallback is implemented; metadata comes from `PortalMeta`.
- Legacy `_created_at` strings remain only inside older realistic test fixtures and one assertion that content is not mutated.