### PR TITLE
Portal metadata sidecar — cleanup: remove _-injection + flat fields (refactor complete)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.48"
+version = "2.12.49"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -78,11 +78,8 @@ pub struct MessageWithSender {
     pub message: Message,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub origin: Option<shared::MessageOrigin>,
-    /// Typed portal sidecar (`created_at` + `source`); the frontend renders from
-    /// this. `origin`/`sender_name` above stay during the transition (see
-    /// docs/PORTAL_META_SIDECAR.md).
+    /// Typed portal sidecar (`created_at` + `source`); the frontend renders
+    /// entirely from this (see docs/PORTAL_META_SIDECAR.md).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<shared::PortalMeta>,
 }
@@ -219,12 +216,10 @@ pub async fn list_messages(
             } else {
                 None
             };
-            let origin = msg.origin();
             let meta = Some(msg.portal_meta(sender_name.clone()));
             MessageWithSender {
                 message: msg,
                 sender_name,
-                origin,
                 meta,
             }
         })

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -106,20 +106,14 @@ pub fn handle_session_limit_reached(
         continuation.status.clone(),
         continuation.source_message.clone().unwrap_or_default(),
     );
-    let inserted = insert_portal_message(&mut conn, &session, &portal);
-    let row_created_at = inserted.as_ref().map(|m| m.created_at_iso());
-    let meta = inserted.map(|m| m.portal_meta(None));
+    let meta = insert_portal_message(&mut conn, &session, &portal).map(|m| m.portal_meta(None));
 
     if let Some(key) = session_key {
         session_manager.broadcast_to_web_clients(
             key,
             ServerToClient::AgentOutput {
                 content: portal.to_json(),
-                sender_user_id: None,
-                sender_name: None,
                 agent_type: session.agent_type.parse().unwrap_or_default(),
-                created_at: row_created_at,
-                origin: None,
                 meta,
             },
         );
@@ -280,18 +274,13 @@ fn update_terminal_status(
                         "Continuation was not sent because the local Claude process was no longer running when the session limit reset."
                             .to_string(),
                     );
-                    let inserted = insert_portal_message(&mut conn, &session, &portal);
-                    let row_created_at = inserted.as_ref().map(|m| m.created_at_iso());
-                    let meta = inserted.map(|m| m.portal_meta(None));
+                    let meta = insert_portal_message(&mut conn, &session, &portal)
+                        .map(|m| m.portal_meta(None));
                     app_state.session_manager.broadcast_to_web_clients(
                         &session_id.to_string(),
                         ServerToClient::AgentOutput {
                             content: portal.to_json(),
-                            sender_user_id: None,
-                            sender_name: None,
                             agent_type: session.agent_type.parse().unwrap_or_default(),
-                            created_at: row_created_at,
-                            origin: None,
                             meta,
                         },
                     );

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -2,9 +2,7 @@ use super::{ProxySender, SessionManager};
 use crate::db::DbPool;
 use diesel::prelude::*;
 use serde::Deserialize;
-use shared::{
-    AgentType, MessageOrigin, PortalContent, PortalMessage, SendMode, ServerToClient, ServerToProxy,
-};
+use shared::{AgentType, PortalContent, PortalMessage, SendMode, ServerToClient, ServerToProxy};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -221,18 +219,13 @@ pub fn handle_claude_output(
     };
     let normalized = normalize_output_content(content);
     let content = normalized.content;
-    let origin = normalized.origin.clone();
 
-    // Insert the message FIRST and recover the server-assigned `created_at`
-    // so the live broadcast carries the same timestamp the historical-read
-    // path would surface (closes #784 — silent data-loss on reconnect when
-    // the frontend used `Date.now()` as the replay watermark). Doing the
-    // insert before the broadcast is the only way to make the persisted
-    // row's `created_at` available to the wire frame; if the insert fails
-    // we fall back to broadcasting without a timestamp rather than
-    // silently dropping the message (the frontend keeps its prior
-    // watermark and a future message will heal it).
-    let mut row_created_at: Option<String> = None;
+    // Insert the message FIRST so the live broadcast's `meta` carries the
+    // server-assigned `created_at` the historical-read path would surface
+    // (closes #784 — silent data-loss on reconnect when the frontend used
+    // `Date.now()` as the replay watermark). If the insert fails we broadcast
+    // without `meta` rather than dropping the message (the frontend keeps its
+    // prior watermark and a future message heals it).
     // Typed portal sidecar for the live broadcast, derived from the persisted
     // row's columns (#portal-meta). `None` when the insert didn't run/failed.
     let mut broadcast_meta: Option<shared::PortalMeta> = None;
@@ -271,10 +264,8 @@ pub fn handle_claude_output(
                 .get_result::<crate::models::Message>(&mut conn)
             {
                 Ok(inserted) => {
-                    // Format matches `replay_history`'s parser
-                    // (`%Y-%m-%dT%H:%M:%S%.f`) and the frontend's
-                    // `last_message_timestamp` watermark shape.
-                    row_created_at = Some(inserted.created_at_iso());
+                    // `meta.created_at` becomes the frontend's reconnect
+                    // watermark (matches `replay_history`'s `%Y-%m-%dT%H:%M:%S%.f`).
                     broadcast_meta =
                         Some(inserted.portal_meta(sender_info.as_ref().map(|(_, n)| n.clone())));
                 }
@@ -319,20 +310,15 @@ pub fn handle_claude_output(
         }
     }
 
-    // Broadcast output to all web clients with sender metadata + server
-    // timestamp alongside content. The `created_at` here is the same
-    // timestamp the message landed in the DB with; the frontend uses it
-    // as the watermark for reconnect replay (closes #784).
+    // Broadcast raw output to all web clients. Sender/attribution and the
+    // server `created_at` watermark (closes #784) ride in `meta`; the frontend
+    // renders entirely from it (see docs/PORTAL_META_SIDECAR.md).
     if let Some(ref key) = session_key {
         session_manager.broadcast_to_web_clients(
             key,
             ServerToClient::AgentOutput {
                 content,
-                sender_user_id: sender_info.as_ref().map(|(id, _)| id.to_string()),
-                sender_name: sender_info.as_ref().map(|(_, name)| name.clone()),
                 agent_type,
-                created_at: row_created_at,
-                origin,
                 meta: broadcast_meta,
             },
         );
@@ -341,7 +327,6 @@ pub fn handle_claude_output(
 
 struct NormalizedOutputContent {
     content: serde_json::Value,
-    origin: Option<MessageOrigin>,
     provenance_kind: Option<String>,
     provenance_session_id: Option<Uuid>,
     provenance_agent_type: Option<String>,
@@ -350,7 +335,6 @@ struct NormalizedOutputContent {
 fn normalize_output_content(content: serde_json::Value) -> NormalizedOutputContent {
     let base = NormalizedOutputContent {
         content,
-        origin: None,
         provenance_kind: None,
         provenance_session_id: None,
         provenance_agent_type: None,
@@ -371,13 +355,11 @@ fn normalize_output_content(content: serde_json::Value) -> NormalizedOutputConte
         return base;
     };
 
-    let origin = MessageOrigin::InterAgent {
-        from_session_id,
-        from_agent_type: from_agent_type.clone(),
-    };
+    // Move the inter-agent attribution into the provenance columns; the
+    // frontend renders the "Message from …" card from the typed `meta.source`
+    // derived from these (see docs/PORTAL_META_SIDECAR.md).
     NormalizedOutputContent {
         content: PortalMessage::text(text.clone()).to_json(),
-        origin: Some(origin),
         provenance_kind: Some("inter_agent".to_string()),
         provenance_session_id: Some(from_session_id),
         provenance_agent_type: Some(from_agent_type.clone()),
@@ -572,26 +554,18 @@ mod tests {
         assert_eq!(normalized.provenance_kind.as_deref(), Some("inter_agent"));
         assert_eq!(normalized.provenance_session_id, Some(sender));
         assert_eq!(normalized.provenance_agent_type.as_deref(), Some("claude"));
-        assert_eq!(
-            normalized.origin,
-            Some(MessageOrigin::InterAgent {
-                from_session_id: sender,
-                from_agent_type: "claude".to_string()
-            })
-        );
         assert_eq!(normalized.content["type"], "portal");
         assert_eq!(normalized.content["content"][0]["type"], "text");
         assert_eq!(normalized.content["content"][0]["text"], "hello from peer");
     }
 
     /// Anything that isn't a single, well-formed AgentMessage must pass through
-    /// untouched — no origin, no provenance, content byte-identical. A bug here
-    /// would either drop a normal message's body or fabricate bogus inter-agent
+    /// untouched — no provenance, content byte-identical. A bug here would
+    /// either drop a normal message's body or fabricate bogus inter-agent
     /// provenance on it.
     fn assert_passthrough(content: serde_json::Value) {
         let normalized = normalize_output_content(content.clone());
         assert_eq!(normalized.content, content);
-        assert!(normalized.origin.is_none());
         assert!(normalized.provenance_kind.is_none());
         assert!(normalized.provenance_session_id.is_none());
         assert!(normalized.provenance_agent_type.is_none());

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -89,9 +89,10 @@ pub(super) fn replay_history(
         history
             .into_iter()
             .map(|msg| {
-                // Typed sidecar, index-aligned with the message it accompanies.
+                // Typed sidecar, index-aligned with the message. All
+                // attribution/timestamp rides here — `content` stays raw (no
+                // more `_`-key injection; see docs/PORTAL_META_SIDECAR.md).
                 let meta = Some(msg.portal_meta(user_names.get(&msg.user_id).cloned()));
-                let created_at_str = msg.created_at.format("%Y-%m-%dT%H:%M:%S%.6f").to_string();
                 // Fallback when the DB row content isn't valid JSON: wrap the raw
                 // string in a typed envelope so the frontend's `ClaudeMessage`
                 // dispatch still finds a `type` and `content`.
@@ -101,48 +102,14 @@ pub(super) fn replay_history(
                     message_type: &'a str,
                     content: &'a str,
                 }
-                let mut val = serde_json::from_str::<serde_json::Value>(&msg.content)
-                    .unwrap_or_else(|_| {
+                let val =
+                    serde_json::from_str::<serde_json::Value>(&msg.content).unwrap_or_else(|_| {
                         serde_json::to_value(FallbackMessageContent {
                             message_type: &msg.role,
                             content: &msg.content,
                         })
                         .unwrap_or(serde_json::Value::Null)
                     });
-                if let Some(obj) = val.as_object_mut() {
-                    // Reconstruct _sender for user messages from DB user_id
-                    if msg.role == "user" {
-                        if let Some(name) = user_names.get(&msg.user_id) {
-                            #[derive(serde::Serialize)]
-                            struct SenderMeta<'a> {
-                                user_id: String,
-                                name: &'a str,
-                            }
-                            obj.insert(
-                                "_sender".to_string(),
-                                serde_json::to_value(SenderMeta {
-                                    user_id: msg.user_id.to_string(),
-                                    name,
-                                })
-                                .unwrap_or(serde_json::Value::Null),
-                            );
-                        }
-                    }
-                    // Inject _created_at so renderers (and the watermark
-                    // recovery path on reload) see the server-assigned row
-                    // timestamp. Matches the REST list-messages path which
-                    // surfaces `created_at` on every `MessageWithSender`.
-                    obj.insert(
-                        "_created_at".to_string(),
-                        serde_json::Value::String(created_at_str),
-                    );
-                    if let Some(origin) = msg.origin() {
-                        obj.insert(
-                            "_origin".to_string(),
-                            serde_json::to_value(origin).unwrap_or(serde_json::Value::Null),
-                        );
-                    }
-                }
                 (val, meta)
             })
             .unzip();
@@ -364,12 +331,12 @@ mod replay_tests {
         }
         let batch = got.expect("replay_history must send exactly one HistoryBatch");
 
-        let (messages, last_created_at) = match batch {
+        let (messages, message_meta, last_created_at) = match batch {
             shared::ServerToClient::HistoryBatch {
                 messages,
+                message_meta,
                 last_created_at,
-                ..
-            } => (messages, last_created_at),
+            } => (messages, message_meta, last_created_at),
             other => panic!("expected HistoryBatch, got {:?}", other),
         };
 
@@ -391,11 +358,13 @@ mod replay_tests {
             messages
         );
         assert_eq!(last_created_at.as_deref(), Some(expected_last.as_str()));
-        let injected = messages[0]
-            .get("_created_at")
-            .and_then(|v| v.as_str())
-            .expect("each replayed message must carry _created_at");
-        assert_eq!(injected, expected_last);
+        // Attribution/timestamp now ride in the typed sidecar, index-aligned
+        // with `messages` — content stays raw (no `_created_at` injection).
+        let meta_ts = message_meta[0]
+            .as_ref()
+            .and_then(|m| m.created_at.as_deref())
+            .expect("each replayed message must carry meta.created_at");
+        assert_eq!(meta_ts, expected_last);
     }
 
     /// A `None` `replay_after` (initial connect with no prior watermark)

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -132,11 +132,7 @@ pub(super) mod test_support {
     pub fn make_client_msg() -> ServerToClient {
         ServerToClient::AgentOutput {
             content: serde_json::json!({"text": "hello"}),
-            sender_user_id: None,
-            sender_name: None,
             agent_type: shared::AgentType::Claude,
-            created_at: None,
-            origin: None,
             meta: None,
         }
     }

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -388,10 +388,9 @@ fn handle_web_input(
                 .and_then(|s| s.agent_type.parse::<shared::AgentType>().ok())
                 .unwrap_or_default();
 
-            // Insert first so the broadcast carries the server-assigned
+            // Insert first so the broadcast's `meta` carries the server-assigned
             // `created_at` (closes #784 — same fix as handle_claude_output).
-            let mut row_created_at: Option<String> = None;
-            // Typed portal sidecar for the broadcast (source = Portal), so a
+            // Typed portal sidecar for the broadcast (source = Portal), so the
             // meta-only frontend gets created_at + source (#portal-meta).
             let mut broadcast_meta: Option<shared::PortalMeta> = None;
             if let (Some(session), Ok(mut conn)) = (session.as_ref(), db_pool.get()) {
@@ -411,7 +410,6 @@ fn handle_web_input(
                     .get_result::<crate::models::Message>(&mut conn)
                 {
                     Ok(inserted) => {
-                        row_created_at = Some(inserted.created_at_iso());
                         broadcast_meta = Some(inserted.portal_meta(None));
                     }
                     Err(e) => {
@@ -424,11 +422,7 @@ fn handle_web_input(
                 key,
                 ServerToClient::AgentOutput {
                     content: portal.to_json(),
-                    sender_user_id: None,
-                    sender_name: None,
                     agent_type,
-                    created_at: row_created_at,
-                    origin: None,
                     meta: broadcast_meta,
                 },
             );

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -105,22 +105,6 @@ pub struct Message {
 }
 
 impl Message {
-    pub fn origin(&self) -> Option<shared::MessageOrigin> {
-        match (
-            self.provenance_kind.as_deref(),
-            self.provenance_session_id,
-            self.provenance_agent_type.as_deref(),
-        ) {
-            (Some("inter_agent"), Some(from_session_id), Some(from_agent_type)) => {
-                Some(shared::MessageOrigin::InterAgent {
-                    from_session_id,
-                    from_agent_type: from_agent_type.to_string(),
-                })
-            }
-            _ => None,
-        }
-    }
-
     /// Who produced this message, mapped from the durable columns to the typed
     /// [`shared::MessageSource`] (portal-meta sidecar, see
     /// `docs/PORTAL_META_SIDECAR.md`). Inter-agent provenance wins (it is itself

--- a/docs/PORTAL_META_SIDECAR.md
+++ b/docs/PORTAL_META_SIDECAR.md
@@ -1,8 +1,8 @@
 # Portal metadata sidecar — design & plan
 
-**Status:** proposed (Claude + Codex co-design)
+**Status:** ✅ implemented — all slices landed; zero `_`-keys remain in production. Claude + Codex co-design.
 **Owners:** backend/shared → Claude · frontend → Codex
-**Tracking versions:** TBD per slice (coordinate to avoid parallel-PR collisions)
+**Shipped:** #1131 (contract) · #1132 (backend populate) · #1135 (frontend meta-only) · cleanup (this PR: strip `_`-injection + flat fields + `MessageOrigin`).
 
 ## 1. Problem
 
@@ -222,8 +222,7 @@ wrapper once no old bundles remain, or keep the parallel form if simpler.
 | 1 | `shared`: add `PortalMeta` + `MessageSource` + `DeliveryMeta`; add `meta` to `AgentOutput` and index-aligned `message_meta` to `HistoryBatch` (additive, defaults) | Claude | — |
 | 2 | Backend: `Message::portal_meta()`; populate `meta` on live + HTTP + WS-replay paths (keep flat fields + `_`-injection) | Claude | 1 |
 | 3 | Frontend: read from `meta` when present, fall back to `_`-keys; render unchanged | Codex | 1 |
-| 4 | Backend: stop rewriting `content` in `normalize_output_content` (keep columns) | Claude | 3 deployed |
-| 5 | Remove `_`-injection + deprecated flat fields once all clients read `meta` | Codex + Claude | 3, 4 |
+| 4+5 | ✅ Remove backend `_`-injection (`replay.rs`), the deprecated flat `AgentOutput`/`MessageWithSender` fields, `NormalizedOutputContent.origin`, `Message::origin()`, and the `MessageOrigin` type. `normalize_output_content` still moves inter-agent attribution to the provenance columns (frontend renders from `meta.source`); the content rewrite-to-text is retained (a no-op for the typed render path). | Claude | 3 merged |
 
 Slices 1–3 are the bulk and can run in parallel after slice 1's shape lands.
 Slices 4–5 are cleanup, gated on the frontend cutover being live.

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -4,8 +4,7 @@ use crate::utils;
 use futures_util::StreamExt;
 use shared::api::ErrorMessage;
 use shared::{
-    ClientEndpoint, ClientToServer, InputDeliveryStage, PortalMeta, ServerToClient, TurnMetrics,
-    WsEndpoint,
+    ClientEndpoint, ClientToServer, InputDeliveryStage, ServerToClient, TurnMetrics, WsEndpoint,
 };
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
@@ -137,24 +136,13 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
     match msg {
         ServerToClient::AgentOutput {
             content,
-            sender_user_id: _,
-            sender_name: _,
-            // agent_type is plumbed through the wire (per-message tag) and
-            // available here for future multi-agent UI work — see #723.
-            // The frontend renders off the session-level agent_type; both
-            // the live and historical-read paths stay agent-agnostic.
+            // agent_type is plumbed through the wire (per-message tag) for
+            // future multi-agent UI work (#723); the frontend renders off the
+            // session-level agent_type. All attribution/timestamp/delivery now
+            // rides in the typed `meta` sidecar (see docs/PORTAL_META_SIDECAR.md).
             agent_type: _,
-            created_at,
-            origin: _,
             meta,
         } => {
-            let meta = meta.or_else(|| {
-                created_at.map(|created_at| PortalMeta {
-                    created_at: Some(created_at),
-                    source: None,
-                    delivery: None,
-                })
-            });
             on_event.emit(WsEvent::Output(RenderedMessage::new(
                 content.to_string(),
                 meta,
@@ -401,12 +389,12 @@ mod tests {
         let server_ts = "2026-05-18T12:34:56.789012".to_string();
         let msg = ServerToClient::AgentOutput {
             content: serde_json::json!({"type": "assistant", "text": "hi"}),
-            sender_user_id: None,
-            sender_name: None,
             agent_type: shared::AgentType::Claude,
-            created_at: Some(server_ts.clone()),
-            origin: None,
-            meta: None,
+            meta: Some(shared::PortalMeta {
+                created_at: Some(server_ts.clone()),
+                source: None,
+                delivery: None,
+            }),
         };
 
         handle_proxy_message(msg, &cb);
@@ -444,11 +432,7 @@ mod tests {
                 "type": "portal",
                 "content": [{"type": "text", "text": "hello from peer"}],
             }),
-            sender_user_id: None,
-            sender_name: None,
             agent_type: shared::AgentType::Codex,
-            created_at: None,
-            origin: None,
             meta: Some(shared::PortalMeta {
                 created_at: None,
                 source: Some(shared::MessageSource::Agent {
@@ -490,11 +474,7 @@ mod tests {
         let (cb, sink) = capture();
         let msg = ServerToClient::AgentOutput {
             content: serde_json::json!({"type": "assistant"}),
-            sender_user_id: None,
-            sender_name: None,
             agent_type: shared::AgentType::Claude,
-            created_at: None,
-            origin: None,
             meta: None,
         };
 

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -5,10 +5,7 @@ use ws_bridge::WsEndpoint;
 use super::types::{
     FileUploadChunkFields, FileUploadStartFields, PermissionResponseFields, RegisterFields,
 };
-use crate::{
-    AgentType, MessageOrigin, PermissionSuggestion, SendMode, SessionCost, SessionStatus,
-    TurnMetrics,
-};
+use crate::{AgentType, PermissionSuggestion, SendMode, SessionCost, SessionStatus, TurnMetrics};
 
 /// Stages a user input passes through end to end, named by **transport fact**
 /// (not implied model semantics) so the UI never claims "the model has it"
@@ -41,7 +38,7 @@ pub enum MessageSource {
     /// multi-member sessions.
     Human { account_id: Uuid, name: String },
     /// Another agent session (inter-agent message) — drives the
-    /// "Message from Codex (…)" card. Subsumes the old `MessageOrigin::InterAgent`.
+    /// "Message from Codex (…)" card.
     Agent {
         session_id: Uuid,
         agent_type: String,
@@ -160,14 +157,11 @@ pub enum ClientToServer {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ServerToClient {
-    /// Output from Claude Code
+    /// Output from Claude Code.
     #[serde(rename = "ClaudeOutput")]
     AgentOutput {
+        /// Raw agent JSON, untouched — all portal metadata rides in `meta`.
         content: serde_json::Value,
-        #[serde(skip_serializing_if = "Option::is_none", default)]
-        sender_user_id: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none", default)]
-        sender_name: Option<String>,
         /// Which agent's wire format the `content` JSON came from.
         ///
         /// Mirrors the per-message `agent_type` tag on the proxy → backend
@@ -179,28 +173,12 @@ pub enum ServerToClient {
         /// (and any hand-rolled JSON) parseable; new code MUST set it.
         #[serde(default)]
         agent_type: AgentType,
-        /// Server-assigned `created_at` of the persisted `messages` row, in
-        /// the ISO-8601 microsecond format the backend's `replay_history`
-        /// parser accepts (`%Y-%m-%dT%H:%M:%S%.f`). Sourced from the DB row
-        /// (via `RETURNING created_at` on the insert) so the frontend can
-        /// remember the **server's** watermark for reconnect replay rather
-        /// than `Date.now()` (closes #784 — silent data-loss on reconnect
-        /// when client/server clocks were skewed). `Option<_>` + `#[serde(
-        /// default, skip_serializing_if = "Option::is_none")]` for the rare
-        /// broadcast paths that don't go through a DB insert (e.g. error
-        /// envelopes injected from in-memory state) and for wire compat
-        /// with older backends.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        created_at: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        origin: Option<MessageOrigin>,
-        /// Typed portal sidecar (attribution, sender, timestamp, delivery
-        /// stage). Carried alongside the raw `content`; the frontend renders
-        /// from this rather than from `_`-keys flattened into `content`. During
-        /// the transition the backend ALSO mirrors these values into the
-        /// deprecated flat fields above and the `_`-injection so an
-        /// un-updated frontend bundle keeps working; both are removed once the
-        /// frontend reads `meta` in production (see `docs/PORTAL_META_SIDECAR.md`).
+        /// Typed portal sidecar: attribution (`source`), server `created_at`
+        /// (the reconnect-replay watermark, closes #784), and frontend-owned
+        /// delivery state. Replaces the former flat `sender_*` / `created_at` /
+        /// `origin` fields and the `_`-key injection (see
+        /// `docs/PORTAL_META_SIDECAR.md`). `Option`/`default` keeps the rare
+        /// no-DB broadcast paths and old-wire frames parseable.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         meta: Option<PortalMeta>,
     },

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -255,12 +255,11 @@ mod tests {
     fn server_to_client_output_roundtrip() {
         let msg = ServerToClient::AgentOutput {
             content: serde_json::json!({"type": "assistant", "text": "hello"}),
-            sender_user_id: None,
-            sender_name: None,
             agent_type: AgentType::Codex,
-            created_at: Some("2026-05-18T12:34:56.789012".to_string()),
-            origin: None,
-            meta: None,
+            meta: Some(crate::PortalMeta {
+                created_at: Some("2026-05-18T12:34:56.789012".to_string()),
+                ..Default::default()
+            }),
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerToClient = serde_json::from_str(&json).unwrap();
@@ -268,28 +267,29 @@ mod tests {
             ServerToClient::AgentOutput {
                 content,
                 agent_type,
-                created_at,
-                ..
+                meta,
             } => {
                 assert_eq!(content["text"], "hello");
                 assert_eq!(agent_type, AgentType::Codex);
-                assert_eq!(created_at.as_deref(), Some("2026-05-18T12:34:56.789012"));
+                assert_eq!(
+                    meta.and_then(|m| m.created_at).as_deref(),
+                    Some("2026-05-18T12:34:56.789012")
+                );
             }
             _ => panic!("Wrong variant"),
         }
     }
 
-    /// Pre-#784 wire JSON for `ServerToClient::ClaudeOutput` (no `created_at`)
-    /// must still parse. The frontend's reconnect watermark just stays at the
-    /// last value it had (or `None` if it never received a timestamped
-    /// message) — same backward-compat slack we extend for `agent_type`.
+    /// Pre-#784 wire JSON for `ServerToClient::ClaudeOutput` (no `meta`) must
+    /// still parse — `meta` defaults to `None` and the frontend keeps its prior
+    /// reconnect watermark. Same backward-compat slack we extend for `agent_type`.
     #[test]
-    fn wire_compat_pre_784_omits_created_at() {
+    fn wire_compat_pre_784_omits_meta() {
         let json = r#"{"type":"ClaudeOutput","content":{"hello":"world"}}"#;
         let parsed: ServerToClient = serde_json::from_str(json).unwrap();
         match parsed {
-            ServerToClient::AgentOutput { created_at, .. } => {
-                assert!(created_at.is_none());
+            ServerToClient::AgentOutput { meta, .. } => {
+                assert!(meta.is_none());
             }
             _ => panic!("Wrong variant"),
         }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -285,15 +285,6 @@ pub enum MessageRole {
     Unknown,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum MessageOrigin {
-    InterAgent {
-        from_session_id: Uuid,
-        from_agent_type: String,
-    },
-}
-
 impl MessageRole {
     pub fn as_str(&self) -> &'static str {
         match self {


### PR DESCRIPTION
## What

The **final slice** of the portal-metadata bifurcation (design: `docs/PORTAL_META_SIDECAR.md`). With the frontend now meta-only (#1135), this strips every remaining `_`-key and deprecated flat field. **End state: zero `_`-keys in production** — attribution/timestamp/delivery is a typed compile-time contract, not a string-key convention.

## Changes

- **shared**: remove the flat `sender_user_id` / `sender_name` / `created_at` / `origin` from `ServerToClient::AgentOutput` (everything rides in `meta` now); delete the unused `MessageOrigin` type.
- **backend**:
  - `replay.rs`: remove the `_sender`/`_created_at`/`_origin` injection — history `content` is now raw, sidecar travels in `message_meta`.
  - `message_handlers.rs`: drop `NormalizedOutputContent.origin` (dead); broadcast `meta` only.
  - `models.rs`: remove `Message::origin()`; `messages.rs` `MessageWithSender` loses its deprecated `origin` field (frontend reads `meta`).
- **frontend**: the `AgentOutput` match reads `meta` directly — drop the dead `created_at` fallback and the ignored flat fields.
- tests updated to assert via `meta` / `message_meta`.

`normalize_output_content` still moves inter-agent attribution into the provenance columns (the frontend renders the card from the typed `meta.source` derived from them); the content rewrite-to-text is retained as a harmless no-op for the typed render path.

## Why it's safe now

#1135 (merged) made the frontend meta-only and slice 2 (#1132) populates `meta` on every path, so removing the flat fields/`_`-injection changes no rendered behavior — it just deletes the now-dead transition scaffolding.

## Testing

`cargo test` — shared 75 / backend 117 / frontend 349 ✅ · `cargo clippy --workspace --all-targets` ✅ · frontend WASM build + clippy ✅ · `cargo fmt --check` ✅. Confirmed `rg` shows no production `_`-key references (remaining hits are test fixtures).

Version → 2.12.49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)