### PR TITLE
cleanup: refresh stale HistoryBatch/PortalMeta docs (closes #1137)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.48"
+version = "2.12.50"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.48"
+version = "2.12.50"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.48"
+version = "2.12.50"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.48"
+version = "2.12.50"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.48"
+version = "2.12.50"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.48"
+version = "2.12.50"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.48"
+version = "2.12.50"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.48"
+version = "2.12.50"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.48"
+version = "2.12.50"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.48"
+version = "2.12.50"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.49"
+version = "2.12.50"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -55,8 +55,8 @@ pub enum MessageSource {
 /// agent JSON blob on every delivery path and read back by string key — a
 /// convention with no compile-time enforcement that silently dropped
 /// attribution when any one injection site drifted (see
-/// `docs/PORTAL_META_SIDECAR.md`). Every field is optional + `serde(default)`
-/// so old↔new wire parses in both directions during the transition.
+/// `docs/PORTAL_META_SIDECAR.md`). The `_`-key injection has been fully removed;
+/// every field is optional + `serde(default)` for wire-compat across versions.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PortalMeta {
     /// Server-assigned persisted-row timestamp (ISO-8601 µs); the frontend's
@@ -185,23 +185,20 @@ pub enum ServerToClient {
 
     /// Batch of historical messages for replay.
     ///
-    /// Each entry in `messages` is the raw stored content JSON with `_sender`
-    /// (for user-role messages) and `_created_at` (the server-assigned row
-    /// timestamp) injected by the backend's `replay_history`. The separate
-    /// `last_created_at` is the timestamp of the latest message in this batch
-    /// (or `None` for an empty batch); the frontend uses it directly as its
-    /// reconnect-replay watermark without having to re-parse `_created_at`
-    /// out of the last entry. Both default to absent on older backends.
+    /// Each entry in `messages` is the **raw** stored content JSON (no portal
+    /// metadata mixed in). All attribution/timestamp rides in the index-aligned
+    /// `message_meta`. `last_created_at` is the timestamp of the latest message
+    /// in this batch (or `None` for an empty batch); the frontend uses it
+    /// directly as its reconnect-replay watermark. Both `message_meta` and
+    /// `last_created_at` default to absent for wire-compat with older backends.
     HistoryBatch {
         messages: Vec<serde_json::Value>,
         /// Typed portal sidecar, **index-aligned** with `messages` (entry `i`
         /// is the meta for `messages[i]`; `None` when a message has no portal
-        /// metadata). Kept as a parallel vector — rather than wrapping each
-        /// entry — so `messages` stays byte-compatible for cached old frontend
-        /// bundles, which simply ignore this field. New frontends zip the two.
-        /// `#[serde(default)]` ⇒ empty/absent on older backends. The `_`-keys
-        /// remain injected into `messages` during the transition; both are
-        /// removed in slice 5 (see `docs/PORTAL_META_SIDECAR.md`).
+        /// metadata). A parallel vector rather than a `{content, meta}` wrapper
+        /// so `messages` stays a plain list of raw content; the frontend zips
+        /// the two. `#[serde(default)]` ⇒ empty/absent on older backends.
+        /// (Collapsing this into a typed `HistoryEntry` is tracked in #1139.)
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         message_meta: Vec<Option<PortalMeta>>,
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -310,14 +310,14 @@ mod tests {
         }
     }
 
-    /// New-shape `HistoryBatch` carries the latest server-assigned timestamp
-    /// alongside the messages so the frontend can update the reconnect
-    /// watermark without re-parsing `_created_at` out of the last entry
-    /// (closes #784).
+    /// `HistoryBatch` carries the latest server-assigned timestamp in
+    /// `last_created_at` so the frontend sets its reconnect watermark directly
+    /// (closes #784). `messages` is raw content; attribution rides in
+    /// `message_meta` (no `_`-key injection).
     #[test]
     fn history_batch_roundtrip_with_last_created_at() {
         let msg = ServerToClient::HistoryBatch {
-            messages: vec![serde_json::json!({"_created_at": "2026-05-18T00:00:00.000000"})],
+            messages: vec![serde_json::json!({"type": "assistant", "text": "hi"})],
             message_meta: Vec::new(),
             last_created_at: Some("2026-05-18T00:00:00.000000".to_string()),
         };


### PR DESCRIPTION
First slice of the post-portal-meta cleanup backlog (#1150).

#1136 removed the `_`-key injection, but stale references remained:
- `HistoryBatch` doc claimed `messages` carry `_sender`/`_created_at` "injected by `replay_history`" and "removed in slice 5" — now describes the typed `message_meta` reality.
- `PortalMeta` doc said fields exist "during the transition" — the transition is done; reworded to permanent wire-compat.
- A roundtrip test fixture used a meaningless `_created_at` content key — now plain content.

Docs/tests only, no behavior change. `cargo test -p shared` ✅ · clippy ✅ · fmt ✅. Version → 2.12.50. Closes #1137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)