### PR TITLE
Clean frontend PortalMeta transition leftovers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.52"
+version = "2.12.53"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.52"
+version = "2.12.53"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.52"
+version = "2.12.53"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.52"
+version = "2.12.53"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.52"
+version = "2.12.53"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.52"
+version = "2.12.53"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.52"
+version = "2.12.53"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.52"
+version = "2.12.53"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.52"
+version = "2.12.53"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.52"
+version = "2.12.53"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.52"
+version = "2.12.53"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -71,7 +71,8 @@ impl MessageGroup {
     /// or removed, causing Yew to throw away the group component and reset
     /// internal state of every expandable/collapsible inside it (bash
     /// command toggle, `ExpandableText`, image viewer, etc.). Using the
-    /// first message's `_created_at` keeps the key stable across reorderings.
+    /// first message's `PortalMeta.created_at` keeps the key stable across
+    /// reorderings.
     /// `index` is used only as a fallback when no timestamp is present.
     pub fn key(&self, index: usize) -> yew::virtual_dom::Key {
         let (prefix, first) = match self {

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -19,7 +19,7 @@ pub use grouping::{group_is_turn_terminator, group_messages, thinking_chip_start
 #[cfg(test)]
 use grouping::{visible_group_indices, GroupCategory, MessageGroup};
 
-/// Format an already-extracted `_created_at` ISO string as local time.
+/// Format an already-extracted `PortalMeta.created_at` ISO string as local time.
 /// Takes the `extract_raw_iso` result rather than the raw JSON so the
 /// message string is parsed once per render, not once per consumer.
 pub(super) fn local_timestamp(iso: &str) -> Option<String> {
@@ -172,7 +172,6 @@ mod tests {
             "estimated_tokens": estimated_tokens,
             "estimated_tokens_delta": estimated_tokens,
             "session_id": "01890000-0000-7000-8000-000000000001",
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string()
     }
@@ -180,8 +179,7 @@ mod tests {
     /// Realistic Claude wire shape for a user message containing a single
     /// `tool_result` content block (the kind Read / Bash / Edit etc. produce).
     /// Matches `claude-codes` 2.1.x `ClaudeOutput::User(UserMessage)`
-    /// serialization with the backend's wire envelope additions
-    /// (`_created_at` etc.).
+    /// serialization with portal metadata carried out-of-band in `PortalMeta`.
     fn read_tool_result_user_message(tool_use_id: &str) -> String {
         serde_json::json!({
             "type": "user",
@@ -194,7 +192,6 @@ mod tests {
                 }]
             },
             "session_id": "01890000-0000-7000-8000-000000000001",
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string()
     }
@@ -215,7 +212,6 @@ mod tests {
                 }]
             },
             "session_id": "01890000-0000-7000-8000-000000000001",
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string()
     }
@@ -284,7 +280,6 @@ mod tests {
                 }]
             },
             "session_id": "01890000-0000-7000-8000-000000000001",
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string();
         assert_eq!(
@@ -301,7 +296,6 @@ mod tests {
         serde_json::json!({
             "type": "portal",
             "content": [{"type": "text", "text": text}],
-            "_created_at": "2026-05-18T05:00:00.000Z",
         })
         .to_string()
     }
@@ -381,7 +375,6 @@ mod tests {
                 "content": [{"type": "text", "text": "hello agent"}]
             },
             "session_id": "01890000-0000-7000-8000-000000000001",
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string();
         assert_eq!(
@@ -401,7 +394,6 @@ mod tests {
                 "content": [{"type": "text", "text": text}]
             },
             "session_id": "01890000-0000-7000-8000-000000000001",
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string()
     }
@@ -437,7 +429,6 @@ mod tests {
                 "id": "item_abc",
                 "text": text,
             },
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string()
     }
@@ -459,7 +450,6 @@ mod tests {
                 "command": "echo hello",
                 "status": status,
             },
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string()
     }
@@ -555,19 +545,16 @@ mod tests {
             "num_turns": 1,
             "session_id": "01890000-0000-7000-8000-000000000001",
             "total_cost_usd": 0.0,
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string();
         let codex_completed = serde_json::json!({
             "type": "turn.completed",
             "usage": {"input_tokens": 1, "output_tokens": 2},
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string();
         let codex_failed = serde_json::json!({
             "type": "turn.failed",
             "error": {"message": "nope"},
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string();
 
@@ -647,7 +634,6 @@ mod tests {
             "num_turns": 1,
             "session_id": "01890000-0000-7000-8000-000000000001",
             "total_cost_usd": 0.0,
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string();
         let messages = vec![
@@ -791,7 +777,6 @@ mod tests {
                     "type": "system",
                     "subtype": "init",
                     "session_id": "01890000-0000-7000-8000-000000000001",
-                    "_created_at": "2026-05-17T10:00:00.000Z",
                 })
                 .to_string(),
                 None,
@@ -812,7 +797,6 @@ mod tests {
                     "num_turns": 1,
                     "session_id": "01890000-0000-7000-8000-000000000001",
                     "total_cost_usd": 0.0,
-                    "_created_at": "2026-05-17T10:00:00.000Z",
                 })
                 .to_string(),
                 None,
@@ -824,7 +808,6 @@ mod tests {
                 serde_json::json!({
                     "type": "error",
                     "message": "oops",
-                    "_created_at": "2026-05-17T10:00:00.000Z",
                 })
                 .to_string(),
                 Some(GroupCategory::Codex),
@@ -898,7 +881,6 @@ mod tests {
         let turn_completed = serde_json::json!({
             "type": "turn.completed",
             "usage": {"input_tokens": 1, "output_tokens": 2},
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string();
         let messages = vec![
@@ -946,13 +928,11 @@ mod tests {
         let no_id_a = serde_json::json!({
             "type": "item.started",
             "item": {"type": "agent_message", "text": "first"},
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string();
         let no_id_b = serde_json::json!({
             "type": "item.completed",
             "item": {"type": "agent_message", "text": "second"},
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string();
         let visible =
@@ -971,7 +951,6 @@ mod tests {
                 "content": [{"type": "text", "text": "hello"}],
             },
             "session_id": "01890000-0000-7000-8000-000000000001",
-            "_created_at": "2026-05-17T10:00:00.000Z",
         })
         .to_string()];
 

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -622,8 +622,8 @@ mod tests {
     #[test]
     fn reconcile_pending_sends_assistant_clears_all() {
         // Slash commands (/cost, /clear, /status) don't echo as "user",
-        // so the assistant response is the only signal we get that input
-        // was received. Clear legacy entries; id-tracked entries wait for
+        // so the assistant response is the only signal we get for
+        // pre-InputProgress pending rows. Id-tracked rows wait for
         // InputProgress::AgentAccepted.
         let mut pending = vec![pending("a"), pending("b")];
         reconcile_pending_sends(

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -584,8 +584,9 @@ impl InputBar {
             on_send_frame.emit(ClientToServer::AgentInput {
                 content: serde_json::Value::String(combined),
                 send_mode: None,
-                // TODO(delivery-progress): real id + InputProgress consumption
-                // lands in the staged-UI slice (Codex).
+                // `SessionView::prepare_outbound_frame` assigns the
+                // browser-side correlation id and optimistic row for every
+                // AgentInput frame, including file-upload summaries.
                 client_msg_id: None,
             });
 


### PR DESCRIPTION
## Summary
- remove stale delivery-progress comments now that SessionView assigns client_msg_id for AgentInput frames
- update PortalMeta-era comments around timestamps/group keys
- strip obsolete _created_at metadata from message-renderer test fixtures

## Verification
- cargo check -p frontend
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings
- git diff --check

Part of #1140 and #1141 under the #1150 cleanup backlog.