### PR TITLE
cleanup: remove dead session_id field + dedup codex thread-model fallback (closes #1148)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.50"
+version = "2.12.52"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.50"
+version = "2.12.52"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.50"
+version = "2.12.52"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.50"
+version = "2.12.52"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.50"
+version = "2.12.52"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.50"
+version = "2.12.52"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.50"
+version = "2.12.52"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.50"
+version = "2.12.52"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.50"
+version = "2.12.52"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.50"
+version = "2.12.52"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.50"
+version = "2.12.52"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -135,8 +135,7 @@ pub(crate) async fn codex_io_task(
             {
                 Ok(resp) => {
                     tracing::info!("Codex thread resumed: {}", prior);
-                    let model =
-                        non_empty_string(resp.model).or_else(|| configured_model_fallback.clone());
+                    let model = started_thread_model(resp.model, &configured_model_fallback);
                     resumed_thread = Some((prior.clone(), model));
                 }
                 Err(e) => {
@@ -171,8 +170,7 @@ pub(crate) async fn codex_io_task(
             let thread_params = empty_thread_start_params();
             match client.thread_start(&thread_params).await {
                 Ok(resp) => {
-                    let model =
-                        non_empty_string(resp.model).or_else(|| configured_model_fallback.clone());
+                    let model = started_thread_model(resp.model, &configured_model_fallback);
                     if model.is_none() {
                         tracing::warn!(
                             "Codex thread {} started without a detectable model; turn metrics will warn until model metadata is available",
@@ -732,6 +730,18 @@ fn non_empty_string(value: String) -> Option<String> {
     } else {
         Some(trimmed.to_string())
     }
+}
+
+/// Resolve the model a freshly resumed/started thread reports, falling back to
+/// the configured model when the server didn't surface one. Shared by the
+/// `thread_resume` and `thread_start` arms so the fallback policy stays in one
+/// place. (The per-turn current→thread→configured resolution is a distinct
+/// precedence and intentionally not folded in here.)
+fn started_thread_model(
+    resp_model: String,
+    configured_fallback: &Option<String>,
+) -> Option<String> {
+    non_empty_string(resp_model).or_else(|| configured_fallback.clone())
 }
 
 #[derive(Debug, Clone)]

--- a/session-lib/src/output_buffer.rs
+++ b/session-lib/src/output_buffer.rs
@@ -39,9 +39,6 @@ struct BufferState {
 
 /// Pending output buffer with persistence and acknowledgment tracking
 pub struct PendingOutputBuffer {
-    /// Session ID (kept for logging/debugging)
-    #[allow(dead_code)]
-    session_id: Uuid,
     /// Path to persistence file
     persist_path: PathBuf,
     /// In-memory buffer state
@@ -106,7 +103,6 @@ impl PendingOutputBuffer {
         };
 
         Ok(Self {
-            session_id,
             persist_path,
             state,
             dirty: false,
@@ -248,7 +244,6 @@ mod tests {
     fn test_push_and_acknowledge() {
         let session_id = Uuid::new_v4();
         let mut buffer = PendingOutputBuffer {
-            session_id,
             persist_path: PathBuf::from("/tmp/test_buffer.json"),
             state: BufferState {
                 session_id,
@@ -282,7 +277,6 @@ mod tests {
     fn test_duplicate_acknowledge() {
         let session_id = Uuid::new_v4();
         let mut buffer = PendingOutputBuffer {
-            session_id,
             persist_path: PathBuf::from("/tmp/test_buffer2.json"),
             state: BufferState {
                 session_id,
@@ -318,7 +312,6 @@ mod tests {
     fn test_overflow_protection() {
         let session_id = Uuid::new_v4();
         let mut buffer = PendingOutputBuffer {
-            session_id,
             persist_path: PathBuf::from("/tmp/test_buffer3.json"),
             state: BufferState {
                 session_id,


### PR DESCRIPTION
Part of the post-portal-meta cleanup backlog (#1150).

- **`session-lib/output_buffer.rs`** — delete the `#[allow(dead_code)]` `session_id` field on `PendingOutputBuffer`. It was never read (`BufferState.session_id` does the real mismatch check). CLAUDE.md: remove dead code, don't suppress.
- **`codex-session-lib/io_task.rs`** — extract `started_thread_model()` for the two *identical* thread-resume/thread-start model-fallback lines, so the fallback policy lives in one place and can't drift.

**Honesty note:** the sweep flagged this as "5× duplication," but only 2 sites are genuinely identical. The per-turn `current → thread → configured` resolution (and the in-place `to_model → current → thread` update) are distinct precedence chains and intentionally left alone — folding them in would be a worse abstraction.

No behavior change. `cargo test` (session-lib 25, codex-session-lib 34) ✅ · clippy ✅ · fmt ✅ · workspace build ✅. Version → 2.12.52. Closes #1148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)