### PR TITLE
cleanup: drop redundant sender_name/user_id; attribution via meta.source (closes #1138)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.53"
+version = "2.12.54"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.53"
+version = "2.12.54"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.53"
+version = "2.12.54"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.53"
+version = "2.12.54"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.53"
+version = "2.12.54"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.53"
+version = "2.12.54"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.53"
+version = "2.12.54"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.53"
+version = "2.12.54"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.53"
+version = "2.12.54"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.53"
+version = "2.12.54"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.53"
+version = "2.12.54"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -76,10 +76,10 @@ pub struct MessageResponse {
 pub struct MessageWithSender {
     #[serde(flatten)]
     pub message: Message,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sender_name: Option<String>,
     /// Typed portal sidecar (`created_at` + `source`); the frontend renders
-    /// entirely from this (see docs/PORTAL_META_SIDECAR.md).
+    /// attribution (incl. the human sender's name) entirely from this. The
+    /// former top-level `sender_name`/`origin` fields were redundant with
+    /// `meta.source` and have been removed (see docs/PORTAL_META_SIDECAR.md).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<shared::PortalMeta>,
 }
@@ -216,12 +216,8 @@ pub async fn list_messages(
             } else {
                 None
             };
-            let meta = Some(msg.portal_meta(sender_name.clone()));
-            MessageWithSender {
-                message: msg,
-                sender_name,
-                meta,
-            }
+            let meta = Some(msg.portal_meta(sender_name));
+            MessageWithSender { message: msg, meta }
         })
         .collect();
 

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -41,13 +41,9 @@ pub struct MessageData {
     pub content: String,
     /// ISO 8601 timestamp when message was created
     pub created_at: String,
-    /// User ID of who sent this message (for user-role messages)
-    #[serde(default)]
-    pub user_id: Option<String>,
-    /// Display name of the sender (looked up from users table)
-    #[serde(default)]
-    pub sender_name: Option<String>,
-    /// Typed portal sidecar for attribution, timestamp, and delivery state.
+    /// Typed portal sidecar for attribution (incl. the human sender name via
+    /// `meta.source`), timestamp, and delivery state. The former top-level
+    /// `user_id`/`sender_name` were redundant with this and have been removed.
     #[serde(default)]
     pub meta: Option<shared::PortalMeta>,
 }


### PR DESCRIPTION
Part of the post-portal-meta cleanup backlog (#1150).

`PortalMeta.source` (`Human`/`Agent`/`Portal`) carries attribution and the frontend renders from it (since #1135), so the parallel top-level sender fields were redundant:
- **backend** `MessageWithSender`: drop `sender_name` — the looked-up name still feeds `msg.portal_meta(...)` → `meta.source = Human{name}`, so attribution is unchanged.
- **frontend** `MessageData`: drop `user_id` + `sender_name` (vestigial — confirmed no display path reads them; sender renders from `meta.source`).

No behavior change. `cargo test` (backend 117, frontend 349) ✅ · clippy ✅ · fmt ✅ · WASM ✅. Version → 2.12.54. Closes #1138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)