### PR TITLE
cleanup: render compaction via SDK type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.54"
+version = "2.12.55"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.54"
+version = "2.12.55"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.54"
+version = "2.12.55"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.54"
+version = "2.12.55"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.54"
+version = "2.12.55"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.54"
+version = "2.12.55"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.54"
+version = "2.12.55"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.54"
+version = "2.12.55"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.54"
+version = "2.12.55"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.54"
+version = "2.12.55"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.54"
+version = "2.12.55"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers/system.rs
+++ b/frontend/src/components/message_renderer/renderers/system.rs
@@ -111,35 +111,10 @@ fn render_compaction_beginning() -> Html {
 }
 
 fn render_compaction_completed(msg: &shared::SystemMessage) -> Html {
-    // Typed dispatch over `extra` (closes #752). The SDK's
-    // `CompactBoundaryMessage` currently only exposes
-    // `compact_metadata { pre_tokens, trigger }` - not the `summary` /
-    // `leaf_message_count` / `duration_ms` fields the renderer needs.
-    // TODO(SDK rust-code-agent-sdks#141): drop the local `CompactionExtra`
-    // mirror once upstream adds these fields to `CompactBoundaryMessage`,
-    // and switch to `SystemMessage::as_compact_boundary()` here.
-    let compact_extra: shared::CompactionExtra = msg
-        .data
-        .as_object()
-        .and_then(|_| serde_json::from_value(msg.data.clone()).ok())
-        .unwrap_or_default();
-
-    let summary_text = msg
-        .data
-        .get("summary")
-        .and_then(|v| v.as_str())
-        .or_else(|| compact_extra.summary_text());
-    let leaf_count = msg
-        .data
-        .get("leaf_message_count")
-        .and_then(|v| v.as_u64())
-        .map(|v| v as u32)
-        .or_else(|| compact_extra.message_count());
-    let duration = msg
-        .data
-        .get("duration_ms")
-        .and_then(|v| v.as_u64())
-        .or(compact_extra.duration_ms);
+    let compact = msg.as_compact_boundary();
+    let summary_text = compact.as_ref().and_then(|c| c.summary.as_deref());
+    let leaf_count = compact.as_ref().and_then(|c| c.leaf_message_count);
+    let duration = compact.as_ref().and_then(|c| c.duration_ms);
 
     html! {
         <div class="claude-message compaction-message">

--- a/shared/src/api/system_extra.rs
+++ b/shared/src/api/system_extra.rs
@@ -20,68 +20,15 @@ pub struct SoundSettingsResponse {
 // views over the same JSON bytes.
 //
 // Where a subtype is already fully covered upstream by `claude-codes`, the
-// renderer uses the SDK type directly (`TaskNotificationMessage`,
-// `TaskStartedMessage`). The remaining structs below cover gaps not yet
-// represented in `claude-codes`:
+// renderer uses the SDK type directly (`CompactBoundaryMessage`,
+// `TaskNotificationMessage`, `TaskStartedMessage`). The remaining structs below
+// cover gaps not yet represented in `claude-codes`:
 //
-// - `CompactionExtra` — `summary`, `leaf_message_count`/`message_count`,
-//   `duration_ms`, `content`, `text`. Filed upstream as
-//   `rust-code-agent-sdks#141`; the SDK's `CompactBoundaryMessage` currently
-//   only exposes `compact_metadata { pre_tokens, trigger }`. Once upstream
-//   lands these, this struct can be deleted and the renderer can switch to
-//   `SystemMessage::as_compact_boundary()`.
 // - `InitExtra` — `fast_mode_state`. The SDK's `InitMessage::fast_mode_state`
 //   is already typed `Option<String>`; we keep a narrow local mirror because
 //   `InitMessage` has many required fields and a single-field shape is
 //   friendlier to partial frames the renderer encounters in practice.
 // =============================================================================
-
-/// Typed view of the `compact_boundary` subtype's `SystemMessage.extra`.
-///
-/// All fields are optional with `#[serde(default)]` so any wire shape that
-/// omits them still deserializes (yielding `None`). Read priority for the
-/// summary text is `summary` → `content` → `text` to match the historical
-/// renderer fallback chain.
-//
-// TODO(SDK rust-code-agent-sdks#141): drop this struct once
-// `claude_codes::CompactBoundaryMessage` exposes these fields directly and
-// switch `render_compaction_completed` to `SystemMessage::as_compact_boundary`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct CompactionExtra {
-    #[serde(default)]
-    pub summary: Option<String>,
-    /// Primary "messages summarized" count. CLI variants spell this
-    /// `leaf_message_count` (preferred) or `message_count` (legacy).
-    #[serde(default)]
-    pub leaf_message_count: Option<u32>,
-    #[serde(default)]
-    pub message_count: Option<u32>,
-    #[serde(default)]
-    pub duration_ms: Option<u64>,
-    /// Legacy aliases for the summary text — older CLI builds emitted under
-    /// `content` or `text` instead of `summary`.
-    #[serde(default)]
-    pub content: Option<String>,
-    #[serde(default)]
-    pub text: Option<String>,
-}
-
-impl CompactionExtra {
-    /// First-non-empty summary text, mirroring the historical renderer fallback
-    /// chain `summary` → `content` → `text`.
-    pub fn summary_text(&self) -> Option<&str> {
-        self.summary
-            .as_deref()
-            .or(self.content.as_deref())
-            .or(self.text.as_deref())
-    }
-
-    /// First-set message count, preferring `leaf_message_count` over the
-    /// legacy `message_count` spelling.
-    pub fn message_count(&self) -> Option<u32> {
-        self.leaf_message_count.or(self.message_count)
-    }
-}
 
 /// Typed view of the `init` subtype's `SystemMessage.extra` for fields the
 /// renderer needs that aren't already top-level on the local lenient

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -25,9 +25,9 @@ pub mod timezone;
 // API client types and trait
 pub mod api;
 pub use api::{
-    AgentSessionInfo, AgentSessionsResponse, CodexPermissionInput, CompactionExtra, InitExtra,
-    ModelUsage, ModelUsageEntry, SendAgentMessageRequest, SendAgentMessageResponse,
-    SoundSettingsResponse, TaskNotificationExtra, TurnMetrics, TurnMetricsResponse,
+    AgentSessionInfo, AgentSessionsResponse, CodexPermissionInput, InitExtra, ModelUsage,
+    ModelUsageEntry, SendAgentMessageRequest, SendAgentMessageResponse, SoundSettingsResponse,
+    TaskNotificationExtra, TurnMetrics, TurnMetricsResponse,
 };
 
 /// Default backend URL based on build profile.
@@ -682,5 +682,30 @@ mod tests {
                 "[message from codex 12345678-0000-0000-0000-000000000000]\nhello from another agent"
             )
         );
+    }
+
+    #[test]
+    fn compact_boundary_uses_sdk_summary_stats_aliases() {
+        let json = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "session_id": "session-1",
+            "compact_metadata": { "pre_tokens": 2000, "trigger": "auto" },
+            "content": "summarized earlier context",
+            "message_count": 7,
+            "duration_ms": 1234
+        });
+        let output: ClaudeOutput = serde_json::from_value(json).unwrap();
+        let ClaudeOutput::System(system) = output else {
+            panic!("expected system output");
+        };
+
+        let compact = system.as_compact_boundary().expect("compact boundary");
+        assert_eq!(
+            compact.summary.as_deref(),
+            Some("summarized earlier context")
+        );
+        assert_eq!(compact.leaf_message_count, Some(7));
+        assert_eq!(compact.duration_ms, Some(1234));
     }
 }


### PR DESCRIPTION
## Summary
- remove the local shared::CompactionExtra mirror now that claude-codes exposes CompactBoundaryMessage summary/count/duration fields
- render compaction stats from SystemMessage::as_compact_boundary()
- add a shared regression test for SDK alias handling (content/message_count)

Closes #1142.

## Verification
- cargo fmt --check
- cargo test -p shared
- cargo test -p frontend
- cargo check -p frontend
- cargo clippy -p shared -p frontend -- -D warnings
- git diff --check
- post-rebase: cargo test -p shared compact_boundary_uses_sdk_summary_stats_aliases && cargo check -p frontend && cargo clippy -p shared -p frontend -- -D warnings && git diff --check