### PR TITLE
cleanup: use SDK ModelUsageEntry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.55"
+version = "2.12.56"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.55"
+version = "2.12.56"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.55"
+version = "2.12.56"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.55"
+version = "2.12.56"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.55"
+version = "2.12.56"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.55"
+version = "2.12.56"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.55"
+version = "2.12.56"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.55"
+version = "2.12.56"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.55"
+version = "2.12.56"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.55"
+version = "2.12.56"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.55"
+version = "2.12.56"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/shared/src/api/metrics.rs
+++ b/shared/src/api/metrics.rs
@@ -5,45 +5,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use uuid::Uuid;
 
-/// Per-model usage / cost breakdown carried by Claude's `ResultMessage.modelUsage`
-/// field. Keyed by model name (e.g. `"claude-opus-4-7[1m]"`) in the parent map.
-///
-/// Wire shape from claude-codes' own `test_result_with_new_fields`:
-/// ```json
-/// "modelUsage": {
-///     "claude-opus-4-7[1m]": {
-///         "inputTokens": 3817,
-///         "outputTokens": 14,
-///         "costUSD": 0.06
-///     }
-/// }
-/// ```
-///
-/// TODO(SDK #140): `claude-codes::ResultMessage.model_usage` is currently
-/// `Option<serde_json::Value>` upstream. This local typed mirror exists so the
-/// frontend can iterate the per-model breakdown without poking JSON field
-/// names. When the SDK adopts a typed `BTreeMap<String, ModelUsageEntry>`
-/// itself, callers can `serde_json::from_value::<ModelUsage>(value)` directly
-/// against the upstream type instead, and this struct can be deleted.
-///
-/// All fields default so partial / older frames still parse.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ModelUsageEntry {
-    #[serde(default)]
-    pub input_tokens: u64,
-    #[serde(default)]
-    pub output_tokens: u64,
-    #[serde(default)]
-    pub cache_read_input_tokens: u64,
-    #[serde(default)]
-    pub cache_creation_input_tokens: u64,
-    /// Wire name is `costUSD`, not `costUsd`.
-    #[serde(default, rename = "costUSD")]
-    pub cost_usd: f64,
-    #[serde(default)]
-    pub web_search_requests: u32,
-}
+/// Per-model usage / cost breakdown carried by Claude's
+/// `ResultMessage.modelUsage` field.
+pub use claude_codes::io::ModelUsageEntry;
 
 /// Convenience alias for the full `modelUsage` map. The map key is the model
 /// name string as emitted by claude (e.g. `"claude-opus-4-7[1m]"`).

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -154,6 +154,7 @@ mod tests {
             "inputTokens": 3817,
             "outputTokens": 14,
             "costUSD": 0.06,
+            "futureField": 99,
         });
         let parsed: ModelUsageEntry = serde_json::from_value(json).unwrap();
         assert_eq!(parsed.input_tokens, 3817);
@@ -163,6 +164,7 @@ mod tests {
         assert_eq!(parsed.cache_read_input_tokens, 0);
         assert_eq!(parsed.cache_creation_input_tokens, 0);
         assert_eq!(parsed.web_search_requests, 0);
+        assert_eq!(parsed.extra["futureField"], 99);
     }
 
     /// The full `modelUsage` map: a `BTreeMap<String, ModelUsageEntry>` keyed


### PR DESCRIPTION
## Summary
- remove the local shared `ModelUsageEntry` mirror now that `claude-codes` 2.1.158 exposes the typed SDK model
- re-export `claude_codes::io::ModelUsageEntry` from shared so existing callers keep a stable import path
- keep `ModelUsage = BTreeMap<String, ModelUsageEntry>` and update the round-trip test to assert SDK `extra` preserves future fields

Closes #1145.

## Verification
- cargo fmt --check
- cargo test -p shared model_usage
- cargo check -p frontend
- cargo clippy -p shared -p frontend -- -D warnings
- git diff --check
- cargo test -p shared
- cargo test -p frontend