### PR TITLE
cleanup: collapse HistoryBatch into typed HistoryEntry{content,meta} (closes #1139)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.56"
+version = "2.12.57"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.56"
+version = "2.12.57"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.56"
+version = "2.12.57"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.56"
+version = "2.12.57"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.56"
+version = "2.12.57"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.56"
+version = "2.12.57"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.56"
+version = "2.12.57"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.56"
+version = "2.12.57"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.56"
+version = "2.12.57"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.56"
+version = "2.12.57"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.56"
+version = "2.12.57"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -85,38 +85,36 @@ pub(super) fn replay_history(
         .last()
         .map(|msg| msg.created_at.format("%Y-%m-%dT%H:%M:%S%.6f").to_string());
 
-    let (messages, message_meta): (Vec<serde_json::Value>, Vec<Option<shared::PortalMeta>>) =
-        history
-            .into_iter()
-            .map(|msg| {
-                // Typed sidecar, index-aligned with the message. All
-                // attribution/timestamp rides here — `content` stays raw (no
-                // more `_`-key injection; see docs/PORTAL_META_SIDECAR.md).
-                let meta = Some(msg.portal_meta(user_names.get(&msg.user_id).cloned()));
-                // Fallback when the DB row content isn't valid JSON: wrap the raw
-                // string in a typed envelope so the frontend's `ClaudeMessage`
-                // dispatch still finds a `type` and `content`.
-                #[derive(serde::Serialize)]
-                struct FallbackMessageContent<'a> {
-                    #[serde(rename = "type")]
-                    message_type: &'a str,
-                    content: &'a str,
-                }
-                let val =
-                    serde_json::from_str::<serde_json::Value>(&msg.content).unwrap_or_else(|_| {
-                        serde_json::to_value(FallbackMessageContent {
-                            message_type: &msg.role,
-                            content: &msg.content,
-                        })
-                        .unwrap_or(serde_json::Value::Null)
-                    });
-                (val, meta)
-            })
-            .unzip();
+    let entries: Vec<shared::HistoryEntry> = history
+        .into_iter()
+        .map(|msg| {
+            // Typed sidecar travels with its content. All attribution/timestamp
+            // rides here — `content` stays raw (no `_`-key injection; see
+            // docs/PORTAL_META_SIDECAR.md).
+            let meta = Some(msg.portal_meta(user_names.get(&msg.user_id).cloned()));
+            // Fallback when the DB row content isn't valid JSON: wrap the raw
+            // string in a typed envelope so the frontend's `ClaudeMessage`
+            // dispatch still finds a `type` and `content`.
+            #[derive(serde::Serialize)]
+            struct FallbackMessageContent<'a> {
+                #[serde(rename = "type")]
+                message_type: &'a str,
+                content: &'a str,
+            }
+            let content =
+                serde_json::from_str::<serde_json::Value>(&msg.content).unwrap_or_else(|_| {
+                    serde_json::to_value(FallbackMessageContent {
+                        message_type: &msg.role,
+                        content: &msg.content,
+                    })
+                    .unwrap_or(serde_json::Value::Null)
+                });
+            shared::HistoryEntry { content, meta }
+        })
+        .collect();
 
     let _ = tx.send(ServerToClient::HistoryBatch {
-        messages,
-        message_meta,
+        entries,
         last_created_at,
     });
 }
@@ -331,12 +329,11 @@ mod replay_tests {
         }
         let batch = got.expect("replay_history must send exactly one HistoryBatch");
 
-        let (messages, message_meta, last_created_at) = match batch {
+        let (entries, last_created_at) = match batch {
             shared::ServerToClient::HistoryBatch {
-                messages,
-                message_meta,
+                entries,
                 last_created_at,
-            } => (messages, message_meta, last_created_at),
+            } => (entries, last_created_at),
             other => panic!("expected HistoryBatch, got {:?}", other),
         };
 
@@ -351,19 +348,19 @@ mod replay_tests {
         cleanup(&mut conn, session.id, &[user.id]);
 
         assert_eq!(
-            messages.len(),
+            entries.len(),
             1,
-            "expected only the newest row to be replayed; got {} messages: {:?}",
-            messages.len(),
-            messages
+            "expected only the newest row to be replayed; got {} entries",
+            entries.len(),
         );
         assert_eq!(last_created_at.as_deref(), Some(expected_last.as_str()));
-        // Attribution/timestamp now ride in the typed sidecar, index-aligned
-        // with `messages` — content stays raw (no `_created_at` injection).
-        let meta_ts = message_meta[0]
+        // Attribution/timestamp ride in each entry's typed sidecar — content
+        // stays raw (no `_created_at` injection).
+        let meta_ts = entries[0]
+            .meta
             .as_ref()
             .and_then(|m| m.created_at.as_deref())
-            .expect("each replayed message must carry meta.created_at");
+            .expect("each replayed entry must carry meta.created_at");
         assert_eq!(meta_ts, expected_last);
     }
 
@@ -395,19 +392,18 @@ mod replay_tests {
         }
         let batch = batch.expect("replay_history must send HistoryBatch");
 
-        let (messages, last_created_at) = match batch {
+        let (entries, last_created_at) = match batch {
             shared::ServerToClient::HistoryBatch {
-                messages,
+                entries,
                 last_created_at,
-                ..
-            } => (messages, last_created_at),
+            } => (entries, last_created_at),
             other => panic!("expected HistoryBatch, got {:?}", other),
         };
 
         let mut conn = pool.get().expect("conn");
         cleanup(&mut conn, session.id, &[user.id]);
 
-        assert_eq!(messages.len(), 3, "expected all rows to be replayed");
+        assert_eq!(entries.len(), 3, "expected all rows to be replayed");
         let expected_last = stamps[2].format("%Y-%m-%dT%H:%M:%S%.6f").to_string();
         assert_eq!(last_created_at.as_deref(), Some(expected_last.as_str()));
     }

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -149,16 +149,12 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
             )));
         }
         ServerToClient::HistoryBatch {
-            messages,
-            message_meta,
+            entries,
             last_created_at,
         } => {
-            let rendered: Vec<RenderedMessage> = messages
+            let rendered: Vec<RenderedMessage> = entries
                 .into_iter()
-                .enumerate()
-                .map(|(i, v)| {
-                    RenderedMessage::new(v.to_string(), message_meta.get(i).cloned().flatten())
-                })
+                .map(|entry| RenderedMessage::new(entry.content.to_string(), entry.meta))
                 .collect();
             on_event.emit(WsEvent::HistoryBatch(rendered, last_created_at));
         }
@@ -498,12 +494,14 @@ mod tests {
         let (cb, sink) = capture();
         let ts = "2026-05-18T00:00:00.000000".to_string();
         let msg = ServerToClient::HistoryBatch {
-            messages: vec![serde_json::json!({"type": "assistant"})],
-            message_meta: vec![Some(shared::PortalMeta {
-                created_at: Some(ts.clone()),
-                source: None,
-                delivery: None,
-            })],
+            entries: vec![shared::HistoryEntry {
+                content: serde_json::json!({"type": "assistant"}),
+                meta: Some(shared::PortalMeta {
+                    created_at: Some(ts.clone()),
+                    source: None,
+                    delivery: None,
+                }),
+            }],
             last_created_at: Some(ts.clone()),
         };
 
@@ -531,8 +529,7 @@ mod tests {
     fn history_batch_without_last_created_at_emits_none() {
         let (cb, sink) = capture();
         let msg = ServerToClient::HistoryBatch {
-            messages: vec![],
-            message_meta: Vec::new(),
+            entries: vec![],
             last_created_at: None,
         };
 

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -106,6 +106,21 @@ impl DeliveryMeta {
     }
 }
 
+/// One historical message in a [`ServerToClient::HistoryBatch`]: the **raw**
+/// agent `content` plus its typed [`PortalMeta`] sidecar. Replaces the former
+/// parallel `messages` + `message_meta` vectors — index-aligned vectors can
+/// silently drift, whereas a wrapper makes "content carries its meta"
+/// structural (see #1139 / `docs/PORTAL_META_SIDECAR.md`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryEntry {
+    /// Raw stored content JSON (no portal metadata mixed in).
+    pub content: serde_json::Value,
+    /// Typed portal sidecar (attribution/timestamp); `None` when the row has no
+    /// portal metadata (e.g. the session's own agent output).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<PortalMeta>,
+}
+
 pub struct ClientEndpoint;
 
 impl WsEndpoint for ClientEndpoint {
@@ -192,15 +207,14 @@ pub enum ServerToClient {
     /// directly as its reconnect-replay watermark. Both `message_meta` and
     /// `last_created_at` default to absent for wire-compat with older backends.
     HistoryBatch {
-        messages: Vec<serde_json::Value>,
-        /// Typed portal sidecar, **index-aligned** with `messages` (entry `i`
-        /// is the meta for `messages[i]`; `None` when a message has no portal
-        /// metadata). A parallel vector rather than a `{content, meta}` wrapper
-        /// so `messages` stays a plain list of raw content; the frontend zips
-        /// the two. `#[serde(default)]` ⇒ empty/absent on older backends.
-        /// (Collapsing this into a typed `HistoryEntry` is tracked in #1139.)
+        /// Each entry is the raw content + its typed [`PortalMeta`] sidecar.
+        /// (Replaced the former parallel `messages`/`message_meta` vectors — see
+        /// [`HistoryEntry`]. A protocol bump, gated on the frontend reading the
+        /// new shape; old cached bundles need a refresh.) `#[serde(default)]` so
+        /// a pre-bump frame (which carried `messages`) degrades to an empty
+        /// batch rather than failing the whole frame to parse.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        message_meta: Vec<Option<PortalMeta>>,
+        entries: Vec<HistoryEntry>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         last_created_at: Option<String>,
     },

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -175,10 +175,13 @@ mod tests {
             _ => panic!("Wrong variant"),
         }
 
+        // A pre-#1139 HistoryBatch (carried `messages`, not `entries`) degrades
+        // to an empty batch rather than failing the whole frame (`entries` is
+        // serde(default)). The frontend recovers on the next batch / refresh.
         let legacy_history = r#"{"type":"HistoryBatch","messages":[{"type":"portal"}]}"#;
         let parsed: ServerToClient = serde_json::from_str(legacy_history).unwrap();
         match parsed {
-            ServerToClient::HistoryBatch { message_meta, .. } => assert!(message_meta.is_empty()),
+            ServerToClient::HistoryBatch { entries, .. } => assert!(entries.is_empty()),
             _ => panic!("Wrong variant"),
         }
     }
@@ -294,16 +297,15 @@ mod tests {
             _ => panic!("Wrong variant"),
         }
 
-        // Pre-#784 HistoryBatch without `last_created_at` must also parse.
-        let json = r#"{"type":"HistoryBatch","messages":[]}"#;
+        // Empty HistoryBatch without `last_created_at` must also parse.
+        let json = r#"{"type":"HistoryBatch"}"#;
         let parsed: ServerToClient = serde_json::from_str(json).unwrap();
         match parsed {
             ServerToClient::HistoryBatch {
-                messages,
+                entries,
                 last_created_at,
-                ..
             } => {
-                assert!(messages.is_empty());
+                assert!(entries.is_empty());
                 assert!(last_created_at.is_none());
             }
             _ => panic!("Wrong variant"),
@@ -312,24 +314,25 @@ mod tests {
 
     /// `HistoryBatch` carries the latest server-assigned timestamp in
     /// `last_created_at` so the frontend sets its reconnect watermark directly
-    /// (closes #784). `messages` is raw content; attribution rides in
-    /// `message_meta` (no `_`-key injection).
+    /// (closes #784). Each `entry` is raw content + its typed `meta` sidecar.
     #[test]
     fn history_batch_roundtrip_with_last_created_at() {
         let msg = ServerToClient::HistoryBatch {
-            messages: vec![serde_json::json!({"type": "assistant", "text": "hi"})],
-            message_meta: Vec::new(),
+            entries: vec![crate::endpoints::client::HistoryEntry {
+                content: serde_json::json!({"type": "assistant", "text": "hi"}),
+                meta: None,
+            }],
             last_created_at: Some("2026-05-18T00:00:00.000000".to_string()),
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerToClient = serde_json::from_str(&json).unwrap();
         match parsed {
             ServerToClient::HistoryBatch {
-                messages,
+                entries,
                 last_created_at,
-                ..
             } => {
-                assert_eq!(messages.len(), 1);
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].content["text"], "hi");
                 assert_eq!(
                     last_created_at.as_deref(),
                     Some("2026-05-18T00:00:00.000000")


### PR DESCRIPTION
Part of the post-portal-meta cleanup backlog (#1150). The last "bigger" item.

Replaces the parallel, index-aligned `messages: Vec<Value>` + `message_meta: Vec<Option<PortalMeta>>` with one `entries: Vec<HistoryEntry { content, meta }>`, so "content carries its meta" is structural — index-aligned vectors can silently drift.

- **shared**: new `HistoryEntry`; `HistoryBatch.entries` is `#[serde(default)]` so a pre-bump frame (which carried `messages`) degrades to an *empty* batch rather than failing the whole frame to parse.
- **backend** `replay.rs`: build `Vec<HistoryEntry>` directly (no unzip).
- **frontend** `websocket.rs`: map `entries → RenderedMessage` (no index zip).
- tests updated across shared/backend/frontend.

**Protocol bump:** the backend and the embedded frontend deploy atomically, so the only exposure is a cached old browser bundle during the deploy window — recovers on refresh, the same accepted trade-off as the rest of this work.

**@codex** — this touches your `websocket.rs` HistoryBatch consumer; please review that arm.

`cargo test` shared 76 / backend 117 / frontend 349 ✅ · clippy ✅ · fmt ✅ · WASM ✅. Version → 2.12.57. Closes #1139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)