### PR TITLE
cleanup: use SDK codex item variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.57"
+version = "2.12.58"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.57"
+version = "2.12.58"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -1,5 +1,8 @@
 use super::markdown::render_markdown_for_session;
-use codex_codes::io::items::{FileUpdateChange, ThreadItem};
+use codex_codes::{
+    io::items::{FileUpdateChange, ThreadItem},
+    protocol::ThreadItem as AppServerThreadItem,
+};
 use shared::fmt::format_duration;
 use uuid::Uuid;
 use yew::prelude::*;
@@ -113,8 +116,6 @@ fn render_item(item: Option<&CodexItem>, completed: bool, session_id: Uuid) -> H
         return html! {};
     };
     match item {
-        CodexItem::ContextCompaction(_) => render_context_compaction_item(completed),
-        CodexItem::CollabAgentToolCall(it) => render_collab_agent_tool_call(it, completed),
         CodexItem::Thread(item) => match item {
             ThreadItem::AgentMessage(it) => render_agent_message(&it.text, completed, session_id),
             ThreadItem::Reasoning(it) => render_reasoning(&it.text, completed),
@@ -130,6 +131,27 @@ fn render_item(item: Option<&CodexItem>, completed: bool, session_id: Uuid) -> H
             // here to avoid duplication.
             ThreadItem::UserMessage(_) => html! {},
         },
+        CodexItem::AppServer(AppServerThreadItem::ContextCompaction { .. }) => {
+            render_context_compaction_item(completed)
+        }
+        CodexItem::AppServer(AppServerThreadItem::CollabAgentToolCall {
+            agents_states,
+            model,
+            prompt,
+            reasoning_effort,
+            status,
+            tool,
+            ..
+        }) => render_collab_agent_tool_call(
+            tool,
+            model.as_deref(),
+            reasoning_effort.as_ref(),
+            status,
+            prompt.as_deref(),
+            agents_states,
+            completed,
+        ),
+        CodexItem::AppServer(_) => html! {},
     }
 }
 
@@ -622,9 +644,9 @@ mod tests {
     }
 
     /// #930 regression target — Codex emits compaction as an item lifecycle
-    /// event whose item type is not in codex-codes yet. It should parse as a
-    /// typed local item and render via the compaction card, not fall through
-    /// to the raw JSON renderer.
+    /// event whose item type is now typed in codex-codes' app-server model. It
+    /// should parse through the SDK item and render via the compaction card,
+    /// not fall through to the raw JSON renderer.
     #[test]
     fn event_item_started_context_compaction_no_longer_renders_raw() {
         let json = r#"{
@@ -638,12 +660,12 @@ mod tests {
 
         let event: CodexEvent = serde_json::from_str(json).unwrap();
         let CodexEvent::ItemStarted {
-            item: Some(CodexItem::ContextCompaction(item)),
+            item: Some(CodexItem::AppServer(AppServerThreadItem::ContextCompaction { ref id })),
         } = event
         else {
             panic!("expected ItemStarted{{ContextCompaction}}, got {:?}", event);
         };
-        assert_eq!(item.id, "9edb35c0-6b6b-407f-84e3-d03a03050a2a");
+        assert_eq!(id, "9edb35c0-6b6b-407f-84e3-d03a03050a2a");
         assert_eq!(
             codex_event_item_id(json).as_deref(),
             Some("9edb35c0-6b6b-407f-84e3-d03a03050a2a")
@@ -651,10 +673,9 @@ mod tests {
     }
 
     /// agent-portal#1049 — Codex emits multi-agent `collabAgentToolCall`
-    /// items (e.g. `spawnAgent`) that codex-codes does not model as a
-    /// `ThreadItem` variant. They must parse into the local
-    /// `CodexItem::CollabAgentToolCall` mirror and render through the spawn-agent
-    /// card, not fall through to the raw JSON renderer.
+    /// items (e.g. `spawnAgent`). They must parse through codex-codes'
+    /// app-server `ThreadItem` variant and render through the spawn-agent card,
+    /// not fall through to the raw JSON renderer.
     #[test]
     fn event_item_completed_collab_agent_tool_call() {
         let json = r#"{
@@ -676,7 +697,18 @@ mod tests {
         }"#;
         let event: CodexEvent = serde_json::from_str(json).unwrap();
         let CodexEvent::ItemCompleted {
-            item: Some(CodexItem::CollabAgentToolCall(item)),
+            item:
+                Some(CodexItem::AppServer(AppServerThreadItem::CollabAgentToolCall {
+                    agents_states,
+                    id,
+                    model,
+                    prompt,
+                    reasoning_effort,
+                    receiver_thread_ids,
+                    sender_thread_id,
+                    status,
+                    tool,
+                })),
         } = event
         else {
             panic!(
@@ -684,25 +716,25 @@ mod tests {
                 event
             );
         };
-        assert_eq!(item.id, "call_i1HC5jbTllWgsrMnJjqmRU05");
-        assert_eq!(item.tool.as_deref(), Some("spawnAgent"));
-        assert_eq!(item.model.as_deref(), Some("gpt-5.5"));
-        assert_eq!(item.reasoning_effort.as_deref(), Some("medium"));
-        assert_eq!(item.status.as_deref(), Some("completed"));
+        assert_eq!(id, "call_i1HC5jbTllWgsrMnJjqmRU05");
+        assert_eq!(tool, serde_json::Value::String("spawnAgent".to_string()));
+        assert_eq!(model.as_deref(), Some("gpt-5.5"));
         assert_eq!(
-            item.sender_thread_id.as_deref(),
-            Some("019ed195-44b1-77e0-a234-10307ce08eac")
+            reasoning_effort.as_ref().map(|effort| effort.0.as_str()),
+            Some("medium")
         );
+        assert_eq!(status, serde_json::Value::String("completed".to_string()));
+        assert_eq!(sender_thread_id, "019ed195-44b1-77e0-a234-10307ce08eac");
         assert_eq!(
-            item.receiver_thread_ids,
+            receiver_thread_ids,
             vec!["019ed247-768f-7603-8c71-911fd841766e".to_string()]
         );
-        assert_eq!(item.agents_states.len(), 1);
-        assert_eq!(
-            item.agents_states["019ed247-768f-7603-8c71-911fd841766e"].status,
-            "pendingInit"
-        );
-        assert!(item.prompt.as_deref().unwrap().contains("main branch"));
+        assert_eq!(agents_states.len(), 1);
+        assert!(matches!(
+            agents_states["019ed247-768f-7603-8c71-911fd841766e"].status,
+            codex_codes::protocol::CollabAgentStatus::PendingInit
+        ));
+        assert!(prompt.as_deref().unwrap().contains("main branch"));
 
         assert_eq!(
             codex_event_item_id(json).as_deref(),

--- a/frontend/src/components/codex_renderer/events.rs
+++ b/frontend/src/components/codex_renderer/events.rs
@@ -1,4 +1,7 @@
-use codex_codes::io::items::{FileUpdateChange, ThreadItem};
+use codex_codes::{
+    io::items::{FileUpdateChange, ThreadItem},
+    protocol::ThreadItem as AppServerThreadItem,
+};
 use serde::{Deserialize, Serialize};
 
 // Local outer-`CodexEvent` enum is the project-specific wire shape: a hybrid
@@ -93,69 +96,12 @@ pub enum CodexEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CodexItem {
-    // TODO(SDK #930): move this variant to codex-codes once the generated
-    // ThreadItem model includes `contextCompaction`.
-    ContextCompaction(ContextCompactionItem),
-    // TODO(SDK): codex-codes has no collabAgentToolCall ThreadItem variant; local mirror — see agent-portal#1049
-    CollabAgentToolCall(CollabAgentToolCallItem),
+    /// Exec-level item wrapper used by the stable codex renderer paths.
     Thread(ThreadItem),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ContextCompactionItem {
-    pub id: String,
-    #[serde(rename = "type")]
-    item_type: ContextCompactionItemType,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-enum ContextCompactionItemType {
-    #[serde(rename = "contextCompaction", alias = "context_compaction")]
-    ContextCompaction,
-}
-
-/// Local mirror of Codex's `collabAgentToolCall` item (multi-agent
-/// collaboration: `spawnAgent` and friends). codex-codes does not model this
-/// as a `ThreadItem` variant yet, so it would otherwise fall through to the
-/// raw-JSON renderer. See agent-portal#1049.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CollabAgentToolCallItem {
-    pub id: String,
-    /// Discriminant gate for the untagged `CodexItem` enum — without a typed
-    /// `type` field this struct (all-optional otherwise) would shadow every
-    /// upstream `ThreadItem` carrying an `id`.
-    #[serde(rename = "type")]
-    item_type: CollabAgentToolCallItemType,
-    /// The collaboration tool invoked, e.g. `"spawnAgent"`.
-    #[serde(default)]
-    pub tool: Option<String>,
-    #[serde(default)]
-    pub model: Option<String>,
-    #[serde(default, rename = "reasoningEffort", alias = "reasoning_effort")]
-    pub reasoning_effort: Option<String>,
-    #[serde(default)]
-    pub status: Option<String>,
-    #[serde(default, rename = "senderThreadId", alias = "sender_thread_id")]
-    pub sender_thread_id: Option<String>,
-    #[serde(default, rename = "receiverThreadIds", alias = "receiver_thread_ids")]
-    pub receiver_thread_ids: Vec<String>,
-    /// Child-agent thread id → its current state.
-    #[serde(default, rename = "agentsStates", alias = "agents_states")]
-    pub agents_states: std::collections::BTreeMap<String, AgentState>,
-    #[serde(default)]
-    pub prompt: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-enum CollabAgentToolCallItemType {
-    #[serde(rename = "collabAgentToolCall", alias = "collab_agent_tool_call")]
-    CollabAgentToolCall,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentState {
-    #[serde(default)]
-    pub status: String,
+    /// App-server item wrapper for item variants that the exec-level helper
+    /// model intentionally does not expose yet, such as `contextCompaction`
+    /// and `collabAgentToolCall`.
+    AppServer(AppServerThreadItem),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -335,11 +281,12 @@ pub fn thread_item_id(item: &ThreadItem) -> &str {
     }
 }
 
-pub fn codex_item_id(item: &CodexItem) -> &str {
+pub fn codex_item_id(item: &CodexItem) -> Option<&str> {
     match item {
-        CodexItem::ContextCompaction(it) => &it.id,
-        CodexItem::CollabAgentToolCall(it) => &it.id,
-        CodexItem::Thread(it) => thread_item_id(it),
+        CodexItem::Thread(it) => Some(thread_item_id(it)),
+        CodexItem::AppServer(AppServerThreadItem::ContextCompaction { id }) => Some(id),
+        CodexItem::AppServer(AppServerThreadItem::CollabAgentToolCall { id, .. }) => Some(id),
+        CodexItem::AppServer(_) => None,
     }
 }
 
@@ -353,7 +300,7 @@ pub fn codex_event_item_id(json: &str) -> Option<String> {
     match event {
         CodexEvent::ItemStarted { item }
         | CodexEvent::ItemUpdated { item }
-        | CodexEvent::ItemCompleted { item } => Some(codex_item_id(&item?).to_string()),
+        | CodexEvent::ItemCompleted { item } => codex_item_id(&item?).map(str::to_string),
         // Per-file patch updates (`item/fileChange/patchUpdated`) are cumulative
         // too — Codex re-sends the full file patch on every tick. Surfacing
         // their `item_id` here lets the group dedup keep only the final patch,

--- a/frontend/src/components/codex_renderer/tools.rs
+++ b/frontend/src/components/codex_renderer/tools.rs
@@ -1,4 +1,3 @@
-use super::events::CollabAgentToolCallItem;
 use super::item_card_classes;
 use crate::components::diff::{DiffCard, DiffSource};
 use crate::components::expandable::ExpandableText;
@@ -6,6 +5,9 @@ use codex_codes::io::items::{
     CommandExecutionItem, CommandExecutionStatus, FileChangeItem, FileUpdateChange,
     McpToolCallItem, McpToolCallStatus, PatchApplyStatus, PatchChangeKind, TodoItem,
 };
+use codex_codes::protocol::{CollabAgentState, ReasoningEffort};
+use serde_json::Value;
+use std::collections::BTreeMap;
 use yew::prelude::*;
 
 /// Wraps a per-variant body in the standard tool-style card chrome:
@@ -242,32 +244,41 @@ pub(super) fn render_todo_list(items: &[TodoItem], completed: bool) -> Html {
     tool_card("\u{2611}", "Todo List".into(), None, body, completed)
 }
 
-pub(super) fn render_collab_agent_tool_call(it: &CollabAgentToolCallItem, completed: bool) -> Html {
+pub(super) fn render_collab_agent_tool_call(
+    tool: &Value,
+    model: Option<&str>,
+    reasoning_effort: Option<&ReasoningEffort>,
+    status: &Value,
+    prompt: Option<&str>,
+    agents_states: &BTreeMap<String, CollabAgentState>,
+    completed: bool,
+) -> Html {
     // Card title: "Spawn Agent" for the common spawnAgent tool, otherwise
     // surface the raw tool name so unrecognized collaboration tools still read.
-    let name = match it.tool.as_deref() {
+    let tool_name = value_label(tool);
+    let name = match tool_name.as_deref() {
         Some("spawnAgent") | None => "Spawn Agent".to_string(),
         Some(other) => format!("Agent: {}", other),
     };
 
     // Status line mirrors render_command_execution's composition: the item
     // status plus model + reasoning-effort meta when present.
-    let mut status_text = it
-        .status
-        .clone()
-        .unwrap_or_else(|| "running...".to_string());
+    let mut status_text = value_label(status).unwrap_or_else(|| "running...".to_string());
     let mut meta_bits: Vec<String> = Vec::new();
-    if let Some(model) = it.model.as_deref().filter(|s| !s.is_empty()) {
+    if let Some(model) = model.filter(|s| !s.is_empty()) {
         meta_bits.push(model.to_string());
     }
-    if let Some(effort) = it.reasoning_effort.as_deref().filter(|s| !s.is_empty()) {
+    if let Some(effort) = reasoning_effort
+        .map(|effort| effort.0.as_str())
+        .filter(|s| !s.is_empty())
+    {
         meta_bits.push(format!("effort: {}", effort));
     }
     if !meta_bits.is_empty() {
         status_text = format!("{} \u{00b7} {}", status_text, meta_bits.join(" \u{00b7} "));
     }
 
-    let prompt = it.prompt.as_deref().unwrap_or("");
+    let prompt = prompt.unwrap_or("");
 
     let body = html! {
         <>
@@ -286,15 +297,19 @@ pub(super) fn render_collab_agent_tool_call(it: &CollabAgentToolCallItem, comple
                 }
             }
             {
-                if !it.agents_states.is_empty() {
+                if !agents_states.is_empty() {
                     html! {
                         <div class="codex-todo-list">
-                            { for it.agents_states.iter().map(|(thread_id, state)| {
+                            { for agents_states.iter().map(|(thread_id, state)| {
+                                let state_label = serde_json::to_value(&state.status)
+                                    .ok()
+                                    .and_then(|value| value_label(&value))
+                                    .unwrap_or_else(|| format!("{:?}", state.status));
                                 html! {
                                     <div class="codex-todo">
                                         <span class="codex-todo-marker">{ "\u{1F916}" }</span>
                                         <span class="codex-todo-text">
-                                            { format!("{} \u{2014} {}", thread_id, state.status) }
+                                            { format!("{} \u{2014} {}", thread_id, state_label) }
                                         </span>
                                     </div>
                                 }
@@ -315,4 +330,12 @@ pub(super) fn render_collab_agent_tool_call(it: &CollabAgentToolCallItem, comple
         body,
         completed,
     )
+}
+
+fn value_label(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) if !value.is_empty() => Some(value.clone()),
+        Value::Null => None,
+        value => Some(value.to_string()),
+    }
 }

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -227,14 +227,17 @@ pub(super) fn classify_output_msg_type(output: &str) -> ActivityTag {
 fn classify_codex_event(output: &str) -> Option<ActivityTag> {
     use crate::components::codex_renderer::{CodexEvent, CodexItem};
     use codex_codes::io::items::ThreadItem;
+    use codex_codes::protocol::ThreadItem as AppServerThreadItem;
     let event: CodexEvent = serde_json::from_str(output).ok()?;
     match event {
         CodexEvent::ItemStarted { item: Some(item) }
         | CodexEvent::ItemUpdated { item: Some(item) }
         | CodexEvent::ItemCompleted { item: Some(item) } => match item {
-            CodexItem::ContextCompaction(_) | CodexItem::CollabAgentToolCall(_) => {
-                Some(ActivityTag::Assistant)
-            }
+            CodexItem::AppServer(
+                AppServerThreadItem::ContextCompaction { .. }
+                | AppServerThreadItem::CollabAgentToolCall { .. },
+            ) => Some(ActivityTag::Assistant),
+            CodexItem::AppServer(_) => None,
             CodexItem::Thread(ThreadItem::Error(_)) => Some(ActivityTag::Error),
             CodexItem::Thread(ThreadItem::CommandExecution(ref it))
                 if command_execution_reads_file(&it.command) =>


### PR DESCRIPTION
## Summary
- remove the local frontend mirrors for Codex `contextCompaction` and `collabAgentToolCall` items
- parse those app-server-only items through `codex_codes::protocol::ThreadItem` while keeping the existing `io::ThreadItem` renderer path for standard Codex items
- update the renderer, sparkline classifier, and regression tests to assert the SDK variants

Part of #1146. The `codex-session-lib` MCP elicitation `server_name` fallback remains a real SDK gap: `McpServerElicitationRequestParams` still does not expose a server identifier in codex-codes 0.142.0.

## Verification
- cargo fmt --check
- cargo check -p frontend
- cargo test -p frontend codex_renderer
- cargo clippy -p frontend -- -D warnings
- git diff --check
- cargo test -p frontend