### PR TITLE
cleanup: use typed thinking token accessor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.58"
+version = "2.12.59"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.57"
+version = "2.12.59"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.57"
+version = "2.12.59"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.57"
+version = "2.12.59"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.57"
+version = "2.12.59"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.57"
+version = "2.12.59"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.57"
+version = "2.12.59"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.57"
+version = "2.12.59"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.57"
+version = "2.12.59"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.57"
+version = "2.12.59"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.58"
+version = "2.12.59"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -269,9 +269,7 @@ pub(super) fn classify(
         // The Claude CLI emits a bodyless `system`/`thinking_tokens` marker per
         // reasoning step; a long turn produces a wall of them. Fold a run into
         // one `Thinking` group so the renderer can show a single counted chip.
-        AgentFrame::Claude(ClaudeMessage::System(msg))
-            if msg.subtype.as_str() == "thinking_tokens" =>
-        {
+        AgentFrame::Claude(ClaudeMessage::System(msg)) if msg.is_thinking_tokens() => {
             return Some(MessageIdentity {
                 category: GroupCategory::Thinking,
                 label: "thinking".to_string(),
@@ -296,19 +294,16 @@ pub(super) fn classify(
 /// estimate so far (`50` → `150` → `250` …), so the maximum (last) value is the
 /// total for the run; returns `0` when none parse.
 ///
-/// `estimated_tokens` lives in the flattened `SystemMessage.data` because
-/// claude-codes 2.1.141 models `thinking_tokens` as `SystemSubtype::Unknown`
-/// (no typed fields). TODO(SDK): push a typed `thinking_tokens` system variant
-/// upstream to `rust-code-agent-sdks` so this reads a field instead of poking
-/// `data`.
+/// Reads through `claude-codes`' typed `ThinkingTokensMessage` accessor so the
+/// portal follows the SDK's schema instead of poking at flattened JSON fields.
 pub(super) fn thinking_tokens_estimate(messages: &[RenderedMessage]) -> i64 {
     messages
         .iter()
         .filter_map(|message| {
             match AgentFrameRegistry::parse(&message.content, shared::AgentType::Claude) {
-                AgentFrame::Claude(ClaudeMessage::System(msg)) => {
-                    msg.data.get("estimated_tokens").and_then(|v| v.as_i64())
-                }
+                AgentFrame::Claude(ClaudeMessage::System(msg)) => msg
+                    .as_thinking_tokens()
+                    .map(|tokens| tokens.estimated_tokens.min(i64::MAX as u64) as i64),
                 _ => None,
             }
         })

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -172,6 +172,7 @@ mod tests {
             "estimated_tokens": estimated_tokens,
             "estimated_tokens_delta": estimated_tokens,
             "session_id": "01890000-0000-7000-8000-000000000001",
+            "uuid": format!("01890000-0000-7000-8000-{estimated_tokens:012}"),
         })
         .to_string()
     }


### PR DESCRIPTION
## Summary
- classify Claude thinking-token system markers through claude-codes' typed `is_thinking_tokens()` accessor
- compute thinking-token chip estimates via `as_thinking_tokens()` instead of poking `SystemMessage.data`
- update the thinking-token test fixture to include the full typed SDK payload

Closes #1143.

## Verification
- cargo fmt --check
- cargo check -p frontend
- cargo test -p frontend thinking_tokens
- cargo clippy -p frontend -- -D warnings
- git diff --check
- cargo test -p frontend