### PR TITLE
cleanup: type Claude permission previews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.60"
+version = "2.12.61"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.60"
+version = "2.12.61"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.60"
+version = "2.12.61"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.60"
+version = "2.12.61"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.60"
+version = "2.12.61"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.60"
+version = "2.12.61"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.60"
+version = "2.12.61"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.60"
+version = "2.12.61"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.60"
+version = "2.12.61"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.60"
+version = "2.12.61"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.60"
+version = "2.12.61"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -2,6 +2,7 @@
 
 use crate::utils::{storage_get, storage_set};
 use serde::Deserialize;
+use shared::ToolInput;
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
@@ -209,32 +210,26 @@ pub fn calculate_backoff(attempt: u32) -> u32 {
 /// `input` is a `serde_json::Value` because the cross-agent
 /// `ServerToClient::PermissionRequest` wire envelope carries both
 /// claude-side tool inputs (whose typed shape lives in `claude-codes`)
-/// and codex-side typed `CodexPermissionInput` envelopes. The codex
-/// arms try to parse the value into the typed envelope first so the
-/// proxy → frontend contract is enforced by serde, falling back to the
-/// historical JSON-poke arms only if the parse fails (e.g. an in-flight
-/// frame from a proxy older than the rollout).
+/// and codex-side typed `CodexPermissionInput` envelopes. Both sides
+/// parse into typed SDK/shared shapes so field-name changes break at
+/// compile time instead of silently falling through display code.
 pub fn format_permission_input(tool_name: &str, input: &serde_json::Value) -> String {
     // Codex-side: try to round-trip the typed envelope first. Closes #731.
     if let Ok(codex_input) = serde_json::from_value::<shared::CodexPermissionInput>(input.clone()) {
         return format_codex_permission_input(&codex_input);
     }
 
-    // Claude-side tool inputs (Bash/Read/Edit/Write) follow the
-    // `claude-codes::tool_inputs::ToolInput` shape, which is a different
-    // IPC envelope than `CodexPermissionInput`. Keep the existing
-    // JSON-poke arms; typing this side is a separate refactor (#735/#736).
-    match tool_name {
-        "Bash" => input
-            .get("command")
-            .and_then(|v| v.as_str())
-            .map(|s| format!("$ {}", s))
-            .unwrap_or_else(|| serde_json::to_string_pretty(input).unwrap_or_default()),
-        "Read" | "Edit" | "Write" => input
-            .get("file_path")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| serde_json::to_string_pretty(input).unwrap_or_default()),
+    format_claude_permission_input(tool_name, input)
+}
+
+/// Render a Claude-side permission tool input from the SDK's named,
+/// typed `ToolInput` parser.
+fn format_claude_permission_input(tool_name: &str, input: &serde_json::Value) -> String {
+    match ToolInput::from_named_input(tool_name, input.clone()) {
+        ToolInput::Bash(bash) => format!("$ {}", bash.command),
+        ToolInput::Read(read) => read.file_path,
+        ToolInput::Edit(edit) => edit.file_path,
+        ToolInput::Write(write) => write.file_path,
         _ => serde_json::to_string_pretty(input).unwrap_or_else(|_| format!("{:?}", input)),
     }
 }
@@ -297,5 +292,56 @@ fn format_codex_permission_input(input: &shared::CodexPermissionInput) -> String
             // typed pretty-print.
             serde_json::to_string_pretty(input).unwrap_or_else(|_| format!("{:?}", input))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_permission_input;
+
+    #[test]
+    fn format_claude_bash_permission_uses_typed_tool_input() {
+        let input = serde_json::json!({ "command": "cargo test -p frontend" });
+        assert_eq!(
+            format_permission_input("Bash", &input),
+            "$ cargo test -p frontend"
+        );
+    }
+
+    #[test]
+    fn format_claude_file_permissions_use_typed_tool_input() {
+        let read = serde_json::json!({ "file_path": "/tmp/a.txt" });
+        let edit = serde_json::json!({
+            "file_path": "/tmp/b.txt",
+            "old_string": "old",
+            "new_string": "new"
+        });
+        let write = serde_json::json!({
+            "file_path": "/tmp/c.txt",
+            "content": "body"
+        });
+
+        assert_eq!(format_permission_input("Read", &read), "/tmp/a.txt");
+        assert_eq!(format_permission_input("Edit", &edit), "/tmp/b.txt");
+        assert_eq!(format_permission_input("Write", &write), "/tmp/c.txt");
+    }
+
+    #[test]
+    fn format_claude_permission_falls_back_for_malformed_named_input() {
+        let input = serde_json::json!({ "cmd": "not the Bash field" });
+        assert_eq!(
+            format_permission_input("Bash", &input),
+            serde_json::to_string_pretty(&input).unwrap()
+        );
+    }
+
+    #[test]
+    fn format_codex_permission_still_uses_typed_envelope_first() {
+        let input = serde_json::json!({
+            "tool": "bash",
+            "command": "ls",
+            "cwd": "/tmp"
+        });
+        assert_eq!(format_permission_input("Bash", &input), "$ ls");
     }
 }


### PR DESCRIPTION
## Summary
- render Claude permission previews through claude-codes' typed `ToolInput::from_named_input` parser
- remove the Bash/Read/Edit/Write JSON field pokes from `format_permission_input`
- add regression tests for typed Claude permission summaries and the existing typed Codex envelope priority

Closes #1147.

## Verification
- cargo check -p frontend
- cargo fmt --check
- cargo test -p frontend format_
- cargo clippy -p frontend -- -D warnings
- git diff --check
- cargo test -p frontend