### PR TITLE
feat: surface GitHub source/issues URL in --help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.61"
+version = "2.12.62"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.61"
+version = "2.12.62"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.61"
+version = "2.12.62"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.61"
+version = "2.12.62"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.61"
+version = "2.12.62"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.61"
+version = "2.12.62"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.61"
+version = "2.12.62"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.61"
+version = "2.12.62"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.61"
+version = "2.12.62"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.61"
+version = "2.12.62"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.61"
+version = "2.12.62"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -23,6 +23,10 @@ pub use crate::config::GoogleOAuthClient;
 #[derive(Parser, Debug, Clone)]
 #[command(name = "agent-portal-backend")]
 #[command(about = "Agent Portal backend server")]
+#[command(
+    after_help = "Source & issues: https://github.com/meawoppl/agent-portal\n  \
+                  Report bugs / file issues: https://github.com/meawoppl/agent-portal/issues"
+)]
 struct Args {
     /// Enable development mode (bypasses OAuth, creates test user)
     #[arg(long)]

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -14,6 +14,10 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 #[derive(Parser, Debug)]
 #[command(name = "agent-portal")]
 #[command(about = "Persistent daemon that launches claude-portal sessions as in-process tasks")]
+#[command(
+    after_help = "Source & issues: https://github.com/meawoppl/agent-portal\n  \
+                  Report bugs / file issues: https://github.com/meawoppl/agent-portal/issues"
+)]
 struct Args {
     /// Backend WebSocket URL (default: wss://txcl.io in release, ws://localhost:3000 in debug)
     #[arg(long)]

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -50,7 +50,9 @@ the backend URL and authentication tokens per working directory."
   # Pass arguments through to claude CLI\n  \
   claude-portal --model sonnet -- \"explain this code\"\n\n  \
   # Re-authenticate if token expired\n  \
-  claude-portal --reauth")]
+  claude-portal --reauth\n\n\
+  Source & issues: https://github.com/meawoppl/agent-portal\n  \
+  Report bugs / file issues: https://github.com/meawoppl/agent-portal/issues")]
 struct Args {
     /// Initialize proxy with a setup token from the web interface.
     ///


### PR DESCRIPTION
Adds an `after_help` line with the repo + issues URL to all three CLIs' `--help`, so anyone (or any agent) running `--help` can find where to file issues:

- `agent-portal` (launcher)
- `claude-portal` (proxy) — appended after the existing EXAMPLES block
- `agent-portal-backend` (backend)

```
Source & issues: https://github.com/meawoppl/agent-portal
  Report bugs / file issues: https://github.com/meawoppl/agent-portal/issues
```

Verified the line renders in all three `--help` outputs. `cargo fmt --check` ✅. Version → 2.12.62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)