### PR TITLE
Show launcher version in session view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.62"
+version = "2.12.63"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.62"
+version = "2.12.63"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.62"
+version = "2.12.63"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.62"
+version = "2.12.63"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.62"
+version = "2.12.63"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.62"
+version = "2.12.63"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.62"
+version = "2.12.63"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.62"
+version = "2.12.63"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.62"
+version = "2.12.63"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.62"
+version = "2.12.63"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.62"
+version = "2.12.63"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -34,6 +34,8 @@ pub struct SessionWithRole {
     #[serde(flatten)]
     pub session: Session,
     pub my_role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub launcher_version: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -60,6 +62,9 @@ pub async fn list_sessions(
     let sessions_with_role = results
         .into_iter()
         .map(|(session, role)| SessionWithRole {
+            launcher_version: app_state
+                .session_manager
+                .launcher_version(session.launcher_id),
             session,
             my_role: role,
         })

--- a/backend/src/handlers/websocket/session_manager/launcher_registry.rs
+++ b/backend/src/handlers/websocket/session_manager/launcher_registry.rs
@@ -90,6 +90,14 @@ impl SessionManager {
             .collect()
     }
 
+    pub fn launcher_version(&self, launcher_id: Option<Uuid>) -> Option<String> {
+        launcher_id.and_then(|id| {
+            self.launchers
+                .get(&id)
+                .map(|launcher| launcher.version.clone())
+        })
+    }
+
     pub fn send_to_launcher(&self, launcher_id: &Uuid, msg: ServerToLauncher) -> bool {
         if let Some(launcher) = self.launchers.get(launcher_id) {
             launcher.sender.send(msg).is_ok()
@@ -190,6 +198,23 @@ mod tests {
             .try_register_launcher(Uuid::new_v4(), make_launcher_connection(user_b, "host1"))
             .is_ok());
         assert_eq!(mgr.launchers.len(), 2);
+    }
+
+    #[test]
+    fn launcher_version_returns_connected_launcher_version() {
+        let mgr = SessionManager::new();
+        let user_id = Uuid::new_v4();
+        let launcher_id = Uuid::new_v4();
+
+        mgr.try_register_launcher(launcher_id, make_launcher_connection(user_id, "host1"))
+            .expect("register launcher");
+
+        assert_eq!(
+            mgr.launcher_version(Some(launcher_id)),
+            Some("test".to_string())
+        );
+        assert_eq!(mgr.launcher_version(Some(Uuid::new_v4())), None);
+        assert_eq!(mgr.launcher_version(None), None);
     }
 
     #[test]

--- a/frontend/src/pages/dashboard/session_order.rs
+++ b/frontend/src/pages/dashboard/session_order.rs
@@ -96,6 +96,7 @@ mod tests {
             my_role: "owner".to_string(),
             hostname: host.to_string(),
             launcher_id: None,
+            launcher_version: None,
             pr_url: None,
             repo_url: None,
             open_prs: Vec::new(),

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -521,9 +521,34 @@ impl Component for SessionView {
         // Seed each thinking chip's odometer with the prior burst's max in
         // its turn so tool-call splits don't re-race the count from 0.
         let thinking_starts = thinking_chip_starts(&groups);
+        let launcher_version = ctx
+            .props()
+            .session
+            .launcher_version
+            .as_deref()
+            .filter(|version| !version.is_empty());
+        let status_class = if ctx.props().session.status.as_str() == "active" {
+            "status connected"
+        } else {
+            "status disconnected"
+        };
 
         html! {
             <div class="session-view">
+                <div class="session-view-header">
+                    <span class="session-name">{ &ctx.props().session.session_name }</span>
+                    <span class="session-hostname">{ &ctx.props().session.hostname }</span>
+                    <span class="session-path">{ &ctx.props().session.working_directory }</span>
+                    if let Some(version) = launcher_version {
+                        <span
+                            class="session-launcher-version"
+                            title="Launcher version"
+                        >
+                            { format!("launcher v{}", version) }
+                        </span>
+                    }
+                    <span class={status_class}>{ ctx.props().session.status.as_str() }</span>
+                </div>
                 <div class="session-view-scroll-area">
                     <div class="session-view-messages" ref={self.messages_ref.clone()}>
                         {

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -140,6 +140,11 @@
         display: none;
     }
 
+    .session-view-header .session-launcher-version {
+        font-size: 0.7rem;
+        padding: 0.15rem 0.35rem;
+    }
+
     .session-view-header .status {
         font-size: 0.7rem;
         padding: 0.2rem 0.5rem;

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -78,6 +78,17 @@
     white-space: nowrap;
 }
 
+.session-view-header .session-launcher-version {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    font-family: monospace;
+    padding: 0.2rem 0.45rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: rgba(122, 162, 247, 0.08);
+    white-space: nowrap;
+}
+
 .session-view-header .status {
     font-size: 0.8rem;
     padding: 0.25rem 0.75rem;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -244,6 +244,13 @@ pub struct SessionInfo {
     /// Launcher ID if this session was started by a launcher
     #[serde(default)]
     pub launcher_id: Option<Uuid>,
+    /// Version of the connected launcher that owns this session, when known.
+    ///
+    /// This is a live connection property, not persisted session state, so it
+    /// is absent when the launcher is disconnected or the session did not
+    /// originate from a launcher.
+    #[serde(default)]
+    pub launcher_version: Option<String>,
     /// GitHub PR URL for the current branch
     #[serde(default)]
     pub pr_url: Option<String>,


### PR DESCRIPTION
## Summary
- add live launcher_version to SessionInfo from the connected launcher registry
- render launcher version in the session view header
- add launcher registry coverage for version lookup

## Verification
- cargo check -p shared
- cargo check -p frontend --target wasm32-unknown-unknown
- env -u NO_COLOR trunk build
- cargo check -p shared -p backend
- cargo test -p backend launcher_version_returns_connected_launcher_version
- cargo clippy -p shared -p frontend --target wasm32-unknown-unknown -- -D warnings
- cargo clippy -p backend -- -D warnings