### PR TITLE
feat: typed subagent token rollup on the Claude path (closes #1144 / SDK #169)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.63"
+version = "2.12.64"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.63"
+version = "2.12.64"
 dependencies = [
  "anyhow",
  "axum",
@@ -470,9 +470,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.158"
+version = "2.1.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49146a3a7520c891d450102363ba3347812e12fef1b6d9cf1b803c6c5843e56b"
+checksum = "24ec342792a75382f891a20b6898cdf297c8fed1b7d450b154ac762ba43bb58d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.63"
+version = "2.12.64"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.63"
+version = "2.12.64"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.63"
+version = "2.12.64"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.63"
+version = "2.12.64"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.63"
+version = "2.12.64"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.63"
+version = "2.12.64"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.63"
+version = "2.12.64"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.63"
+version = "2.12.64"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.63"
+version = "2.12.64"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -66,7 +66,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.158", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.159", default-features = false, features = ["types"] }
 
 # Codex CLI integration
 codex-codes = { version = "0.142.0", default-features = false, features = ["types"] }

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -72,6 +72,10 @@ pub(crate) async fn claude_io_task(
     // know either on its own.
     let mut current_model: Option<String> = None;
     let mut current_service_tier: Option<String> = None;
+    // Per-turn subagent (`Task`) token rollup: summed from each Task result's
+    // typed `SubagentResult.total_tokens` (claude-codes 2.1.159, #169), reset
+    // at every turn start so it matches the turn the metrics row represents.
+    let mut current_turn_subagent_tokens: i64 = 0;
 
     loop {
         tokio::select! {
@@ -90,6 +94,7 @@ pub(crate) async fn claude_io_task(
                         rate_limit_attempts = 0;
                         current_turn_was_rate_limited = false;
                         pending_session_limit = None;
+                        current_turn_subagent_tokens = 0;
                         // Begin per-turn metrics capture. Wall-clock UTC is
                         // chrono::Utc::now(); the monotonic instant is the
                         // anchor for TTFT / total / gap durations.
@@ -181,6 +186,16 @@ pub(crate) async fn claude_io_task(
                                 current_turn_was_rate_limited = false;
                                 pending_session_limit = None;
                             }
+                            ClaudeOutput::User(user) => {
+                                // A `Task` tool's result is echoed as a user
+                                // message carrying a typed `SubagentResult` in
+                                // `tool_use_result`. Sum its `total_tokens` into
+                                // the per-turn rollup (claude-codes 2.1.159, #169).
+                                if let Some(sub) = user.subagent_result() {
+                                    current_turn_subagent_tokens +=
+                                        sub.total_tokens.unwrap_or(0) as i64;
+                                }
+                            }
                             _ => {}
                         }
 
@@ -213,19 +228,12 @@ pub(crate) async fn claude_io_task(
                                     .map(|u| u.cache_read_input_tokens as i64)
                                     .unwrap_or(0),
                                 thinking_tokens: 0,
-                                // The Claude binary tracks subagent (`Task` /
-                                // sidechain) tokens and surfaces them as a
-                                // distinct `<subagent_tokens>` line in its
-                                // result `<usage>` envelope, but the
-                                // stream-json `usage` shape the proxy receives
-                                // exposes no subagent field (claude-codes
-                                // `UsageInfo` carries only input/output/cache/
-                                // service_tier). So we can't attribute
-                                // subagent tokens on the Claude path yet.
-                                // TODO(SDK #169): once claude-codes exposes
-                                // the result `<usage>` subagent rollup,
-                                // populate this instead of reporting 0.
-                                subagent_tokens: 0,
+                                // Subagent (`Task`) tokens summed across this
+                                // turn's Task results via the typed
+                                // `SubagentResult.total_tokens` (claude-codes
+                                // 2.1.159, #169) — the `<subagent_tokens>` line
+                                // the CLI renders in its terminal `<usage>`.
+                                subagent_tokens: current_turn_subagent_tokens,
                                 stop_reason: r.stop_reason.clone(),
                                 is_error: r.is_error,
                                 total_cost_usd: Some(r.total_cost_usd),
@@ -323,6 +331,7 @@ pub(crate) async fn claude_io_task(
                                 // turn from a metrics standpoint, but tag
                                 // the new turn with a stream-restart count
                                 // so the dashboard can spot retried turns.
+                                current_turn_subagent_tokens = 0;
                                 turn_tracker.start(Instant::now(), chrono::Utc::now());
                                 turn_tracker.record_stream_restart();
                                 if let Err(e) = client.send(&input).await {
@@ -343,6 +352,7 @@ pub(crate) async fn claude_io_task(
                                         // the budget for the new prompt.
                                         rate_limit_attempts = 0;
                                         pending_session_limit = None;
+                                        current_turn_subagent_tokens = 0;
                                         turn_tracker.start(Instant::now(), chrono::Utc::now());
                                         let r = client.send(&new_input).await;
                                         last_input = Some(new_input);
@@ -514,6 +524,31 @@ async fn read_stderr(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pins the wiring this module relies on: a `Task` tool's result is a
+    /// `ClaudeOutput::User` whose `tool_use_result` parses to a typed
+    /// `SubagentResult`, exposing the `total_tokens` we sum into the per-turn
+    /// subagent rollup (claude-codes 2.1.159, #169). If the SDK reshapes this,
+    /// the per-turn `subagent_tokens` would silently fall back to 0 — so lock it.
+    #[test]
+    fn subagent_result_total_tokens_is_readable_from_task_result_user_frame() {
+        let frame = serde_json::json!({
+            "type": "user",
+            "session_id": "00000000-0000-0000-0000-000000000000",
+            "message": { "role": "user", "content": [] },
+            "tool_use_result": {
+                "status": "completed",
+                "agentType": "general-purpose",
+                "totalTokens": 12345
+            }
+        });
+        let output: ClaudeOutput = serde_json::from_value(frame).expect("parses as ClaudeOutput");
+        let ClaudeOutput::User(user) = output else {
+            panic!("expected a user frame");
+        };
+        let sub = user.subagent_result().expect("typed SubagentResult");
+        assert_eq!(sub.total_tokens, Some(12345));
+    }
 
     #[test]
     fn parse_limit_time_accepts_the_cli_time_formats() {


### PR DESCRIPTION
The upstream gap is now closed: **claude-codes 2.1.159** landed typed subagent token accounting (#168/#169). This sweeps it into agent-portal.

## How it works now
A `Task` tool's result is a `ClaudeOutput::User` whose `tool_use_result` parses to the typed `SubagentResult { total_tokens, … }`. The proxy sums `total_tokens` across the turn's Task results and reports it as the per-turn `TurnMetrics.subagent_tokens`.

## Changes
- Bump `claude-codes` 2.1.158 → **2.1.159**.
- `claude-session-lib/io_task.rs`: accumulate `SubagentResult.total_tokens` into `current_turn_subagent_tokens` (reset at every turn start — input + both stream-restart sites), report it instead of the hardcoded `0`. Drops the `TODO(SDK #169)` stub.
- Test pinning the `User → subagent_result() → total_tokens` wiring (so a future SDK reshape can't silently fall back to 0).

Backend session-level accounting (the `task_notification` fold into `output_tokens`) is unchanged — this fills the **proxy per-turn metric** gap that was the actual #169 stub.

`cargo test` (claude-session-lib 29, shared, backend) ✅ · clippy ✅ · fmt ✅ · WASM ✅. Version → 2.12.64. Closes #1144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)