### PR TITLE
ci: decouple backend lanes from the frontend build (#1165 item 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,24 +73,19 @@ jobs:
       - name: Build frontend
         run: cd frontend && trunk build
 
-      - name: Upload frontend dist
-        uses: actions/upload-artifact@v4
-        with:
-          name: frontend-dist
-          path: frontend/dist
-
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    needs: build-frontend
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download frontend dist (required for backend embed)
-        uses: actions/download-artifact@v4
-        with:
-          name: frontend-dist
-          path: frontend/dist
+      - name: Stub frontend dist
+        # Backend embeds frontend/dist at build time, but memory_serve falls
+        # back to dynamic loading when it is empty. CI compile/test checks do
+        # not need the real bundle, so stub it instead of depending on (and
+        # waiting for) build-frontend. Keeps backend lanes independent of
+        # frontend/CSS failures (#1165 item 1).
+        run: mkdir -p frontend/dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -105,15 +100,16 @@ jobs:
   build-backend:
     name: Build Backend
     runs-on: ubuntu-latest
-    needs: build-frontend
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download frontend dist (required for backend embed)
-        uses: actions/download-artifact@v4
-        with:
-          name: frontend-dist
-          path: frontend/dist
+      - name: Stub frontend dist
+        # Backend embeds frontend/dist at build time, but memory_serve falls
+        # back to dynamic loading when it is empty. CI compile/test checks do
+        # not need the real bundle, so stub it instead of depending on (and
+        # waiting for) build-frontend. Keeps backend lanes independent of
+        # frontend/CSS failures (#1165 item 1).
+        run: mkdir -p frontend/dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -127,15 +123,16 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
-    needs: build-frontend
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download frontend dist (required for backend embed)
-        uses: actions/download-artifact@v4
-        with:
-          name: frontend-dist
-          path: frontend/dist
+      - name: Stub frontend dist
+        # Backend embeds frontend/dist at build time, but memory_serve falls
+        # back to dynamic loading when it is empty. CI compile/test checks do
+        # not need the real bundle, so stub it instead of depending on (and
+        # waiting for) build-frontend. Keeps backend lanes independent of
+        # frontend/CSS failures (#1165 item 1).
+        run: mkdir -p frontend/dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.64"
+version = "2.12.66"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
First slice of the maintainability roadmap (#1165, item 1 — build/CI ergonomics enabler).

## Problem
`clippy`, `build-backend`, and `test` all `needs: build-frontend` and download the `frontend-dist` artifact "for backend embed." So:
- a CSS-lint or `trunk build` failure blocks **every** backend check, and
- backend CI can't start until the WASM build finishes (serial, +minutes).

## Fix
The backend embeds `frontend/dist` via `memory_serve`, which **falls back to dynamic loading when the dir is empty** (verified locally: `cargo check -p backend` with an empty dist compiles, just warns). Compile/test checks don't need the real bundle.

- Drop `needs: build-frontend` + the artifact download from `clippy`/`build-backend`/`test`; replace with `mkdir -p frontend/dist`.
- `build-frontend` stays as an independent **WASM-validation lane** (its now-orphaned dist upload removed; `release.yml` is self-contained and unaffected).

Backend and frontend lanes now **fail independently and start in parallel** — directly removes the friction that stalled this whole effort.

Validated: ci.yml is valid YAML; backend compiles with an empty dist. CI on this PR is itself the proof (backend jobs no longer wait on/download the frontend artifact). Version → 2.12.66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)