### PR TITLE
chore: workspace unwrap/expect deny policy + ratchet scaffold (#1165 item 8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.65"
+version = "2.12.68"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.65"
+version = "2.12.68"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.65"
+version = "2.12.68"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.65"
+version = "2.12.68"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.65"
+version = "2.12.68"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.65"
+version = "2.12.68"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.65"
+version = "2.12.68"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.65"
+version = "2.12.68"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.65"
+version = "2.12.68"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.65"
+version = "2.12.68"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.67"
+version = "2.12.68"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -101,3 +101,15 @@ lto = true
 codegen-units = 1
 opt-level = "z"
 strip = true
+
+# Panic/error policy (#1165 item 8). `unwrap`/`expect` in production code hide
+# error context and, in background tasks, die silently. We deny them
+# workspace-wide and ratchet existing usage down per crate: crates that still
+# have unwraps carry a crate-root `#![allow(clippy::unwrap_used, expect_used)]`
+# (removed as each is cleaned); already-clean crates (portal-auth,
+# portal-update) are enforced today. Tests are exempt via clippy.toml
+# (allow-unwrap-in-tests / allow-expect-in-tests). Each member crate opts in
+# with `[lints] workspace = true`.
+[workspace.lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -80,3 +80,6 @@ base64 = "0.22.1"
 
 [build-dependencies]
 memory-serve = "2.1"
+
+[lints]
+workspace = true

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,3 +1,7 @@
+// Ratchet for the workspace unwrap/expect deny (#1165 item 8): this crate
+// still has production unwrap/expect; remove this allow as it is cleaned.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 mod auth;
 mod background;
 mod config;

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -26,3 +26,6 @@ dirs = "6.0.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"
+
+[lints]
+workspace = true

--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -1,3 +1,7 @@
+// Ratchet for the workspace unwrap/expect deny (#1165 item 8): this crate
+// still has production unwrap/expect; remove this allow as it is cleaned.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Claude Session Library
 //!
 //! Claude-specific backend for [`session_lib`]: defines [`ClaudeAgent`] (the

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+# Tests legitimately use unwrap/expect for brevity; the unwrap/expect-used
+# denials (see [workspace.lints.clippy] in Cargo.toml, #1165 item 8) apply to
+# production code only.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/codex-session-lib/Cargo.toml
+++ b/codex-session-lib/Cargo.toml
@@ -21,3 +21,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/codex-session-lib/src/lib.rs
+++ b/codex-session-lib/src/lib.rs
@@ -1,3 +1,7 @@
+// Ratchet for the workspace unwrap/expect deny (#1165 item 8): this crate
+// still has production unwrap/expect; remove this allow as it is cleaned.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Codex Session Library
 //!
 //! Codex-specific backend for [`session_lib`]: defines [`CodexAgent`] (the

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -81,3 +81,6 @@ js-sys = "0.3.83"
 pulldown-cmark = { version = "0.13.0", default-features = false }
 ws-bridge = { workspace = true, features = ["yew-client"] }
 base64 = "0.22"
+
+[lints]
+workspace = true

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -1,3 +1,7 @@
+// Ratchet for the workspace unwrap/expect deny (#1165 item 8): this crate
+// still has production unwrap/expect; remove this allow as it is cleaned.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 pub mod audio;
 mod components;
 mod hooks;

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -54,3 +54,6 @@ serde_json.workspace = true
 
 [dev-dependencies]
 tempfile = "3.27.0"
+
+[lints]
+workspace = true

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1,3 +1,7 @@
+// Ratchet for the workspace unwrap/expect deny (#1165 item 8): this crate
+// still has production unwrap/expect; remove this allow as it is cleaned.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 mod config;
 mod connection;
 mod message;

--- a/portal-auth/Cargo.toml
+++ b/portal-auth/Cargo.toml
@@ -16,3 +16,6 @@ serde_json = { workspace = true }
 shared = { path = "../shared" }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/portal-update/Cargo.toml
+++ b/portal-update/Cargo.toml
@@ -13,3 +13,6 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde = { workspace = true }
 sha2 = "0.10"
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -77,3 +77,6 @@ base64 = "0.22"
 # Unix system calls (for lock file process checking)
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[lints]
+workspace = true

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -1,3 +1,7 @@
+// Ratchet for the workspace unwrap/expect deny (#1165 item 8): this crate
+// still has production unwrap/expect; remove this allow as it is cleaned.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 mod auth;
 mod commands;
 mod config;

--- a/session-lib/Cargo.toml
+++ b/session-lib/Cargo.toml
@@ -27,3 +27,6 @@ which = "8.0.0"
 # process can't be orphaned when `kill_on_drop` doesn't fire (#927).
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[lints]
+workspace = true

--- a/session-lib/src/lib.rs
+++ b/session-lib/src/lib.rs
@@ -1,3 +1,7 @@
+// Ratchet for the workspace unwrap/expect deny (#1165 item 8): this crate
+// still has production unwrap/expect; remove this allow as it is cleaned.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Session Library (agent-agnostic core)
 //!
 //! Generic session-management primitives shared by all per-agent crates

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -21,3 +21,6 @@ claude-codes = { workspace = true }
 # Typed WebSocket endpoints (core traits only — WASM-safe, no features needed)
 ws-bridge = { workspace = true }
 base64 = "0.22"
+
+[lints]
+workspace = true

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,3 +1,7 @@
+// Ratchet for the workspace unwrap/expect deny (#1165 item 8): this crate
+// still has production unwrap/expect; remove this allow as it is cleaned.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 


### PR DESCRIPTION
Maintainability roadmap #1165, **item 8** (panic/error baseline) — the narrow policy/allowlist slice Codex and I agreed on; actual `unwrap` cleanup happens per touched area as other slices land.

## What
- `[workspace.lints.clippy]`: **deny `unwrap_used` + `expect_used`** workspace-wide.
- `clippy.toml`: `allow-unwrap-in-tests` / `allow-expect-in-tests` (tests stay terse).
- Each member crate: `[lints] workspace = true`.
- **Enforced today:** `portal-auth`, `portal-update` (0 production unwraps).
- **Ratchet:** the 8 crates that still carry production `unwrap`/`expect` get a crate-root `#![allow(clippy::unwrap_used, clippy::expect_used)]` with a comment — **removed as each crate is cleaned**.

## Why this shape
CI runs `RUSTFLAGS=-Dwarnings` and there are ~378 non-test `unwrap`/`expect` sites, so a plain `warn` would break CI everywhere at once. The deny + per-crate-allow ratchet keeps CI green now, **prevents regressions in the clean crates, makes new crates inherit the deny**, and leaves a documented path to enforce the rest area-by-area.

No behavior change. Verified `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets` passes. Version → 2.12.68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)