### PR TITLE
refactor: extract dashboard spend hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.69"
+version = "2.12.70"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.69"
+version = "2.12.70"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.69"
+version = "2.12.70"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.69"
+version = "2.12.70"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.69"
+version = "2.12.70"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.69"
+version = "2.12.70"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.69"
+version = "2.12.70"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.69"
+version = "2.12.70"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.69"
+version = "2.12.70"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.69"
+version = "2.12.70"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.69"
+version = "2.12.70"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/mod.rs
+++ b/frontend/src/pages/dashboard/mod.rs
@@ -8,6 +8,7 @@
 
 mod page;
 mod page_bootstrap;
+mod page_spend;
 mod page_state;
 mod permission_dialog;
 mod session_order;

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -1,6 +1,7 @@
 //! Dashboard page - Main session management interface
 
 use super::page_bootstrap::use_dashboard_bootstrap;
+use super::page_spend::use_spend_badge_animation;
 use super::page_state::{
     active_session_ids, DashboardSessionAction, DashboardSessionState, DashboardUiAction,
     DashboardUiState,
@@ -28,36 +29,6 @@ use yew::prelude::*;
 // =============================================================================
 // Dashboard Page - Main Orchestrating Component
 // =============================================================================
-
-/// Map total spend to its tier on the $1 / $10 / $100 / $1,000 / $10,000
-/// ladder (0 = below $1, 5 = at or above $10,000).
-fn spend_tier(spend: f64) -> u8 {
-    if spend >= 10000.0 {
-        5
-    } else if spend >= 1000.0 {
-        4
-    } else if spend >= 100.0 {
-        3
-    } else if spend >= 10.0 {
-        2
-    } else if spend >= 1.0 {
-        1
-    } else {
-        0
-    }
-}
-
-/// CSS class for the spend badge, derived from the spend tier.
-fn spend_tier_class(tier: u8) -> &'static str {
-    match tier {
-        5 => "spend-10000",
-        4 => "spend-1000",
-        3 => "spend-100",
-        2 => "spend-10",
-        1 => "spend-1",
-        _ => "",
-    }
-}
 
 #[function_component(DashboardPage)]
 pub fn dashboard_page() -> Html {
@@ -96,11 +67,6 @@ pub fn dashboard_page() -> Html {
         });
     }
 
-    // Track spend tier for timed animations
-    let prev_spend_tier = use_state(|| 0u8);
-    let spend_animating = use_state(|| false);
-    let spend_initialized = use_state(|| false);
-
     // UI state
     let ui_state = use_reducer_eq(|| {
         DashboardUiState::new(
@@ -117,40 +83,7 @@ pub fn dashboard_page() -> Html {
     // Activity buffer: mutations don't trigger page re-renders.
     // SessionRail reads this on its own 100 ms tick instead.
     let activity_timestamps = use_memo((), |_| ActivityRef::default());
-
-    // Detect spend tier changes and trigger timed animation
-    {
-        let spend_animating = spend_animating.clone();
-        let prev_spend_tier = prev_spend_tier.clone();
-        let spend_initialized = spend_initialized.clone();
-        let current_tier = spend_tier(total_user_spend);
-        use_effect_with(current_tier, move |tier| {
-            let tier = *tier;
-            if !*spend_initialized {
-                // First tier value from page load — record it, don't animate
-                spend_initialized.set(true);
-                prev_spend_tier.set(tier);
-            } else if tier > *prev_spend_tier {
-                spend_animating.set(true);
-                let duration_ms = match tier {
-                    1 => 500,
-                    2 => 2000,
-                    3 => 5000,
-                    4 => 10000,
-                    _ => 20000,
-                };
-                let spend_animating = spend_animating.clone();
-                let handle = gloo::timers::callback::Timeout::new(duration_ms, move || {
-                    spend_animating.set(false);
-                });
-                prev_spend_tier.set(tier);
-                handle.forget();
-            } else if tier != *prev_spend_tier {
-                prev_spend_tier.set(tier);
-            }
-            || ()
-        });
-    }
+    let spend_animation = use_spend_badge_animation(total_user_spend);
 
     // Get DB-authoritative sessions in a total, deterministic display order
     // (see `session_order`). A disconnected, unpaused session is
@@ -660,11 +593,10 @@ pub fn dashboard_page() -> Html {
                     <TurnMetricsHeaderPill metrics={ws_hook.recent_turn_metrics.clone()} />
                     {
                         if total_user_spend > 0.0 {
-                            let tier_class = spend_tier_class(spend_tier(total_user_spend));
                             let spend_class = classes!(
                                 "total-spend-badge",
-                                tier_class,
-                                if *spend_animating { Some("spend-animating") } else { None },
+                                spend_animation.tier_class,
+                                if spend_animation.animating { Some("spend-animating") } else { None },
                             );
                             html! {
                                 <>

--- a/frontend/src/pages/dashboard/page_spend.rs
+++ b/frontend/src/pages/dashboard/page_spend.rs
@@ -1,0 +1,119 @@
+use yew::prelude::*;
+
+pub struct SpendBadgeAnimation {
+    pub tier_class: &'static str,
+    pub animating: bool,
+}
+
+/// Map total spend to its tier on the $1 / $10 / $100 / $1,000 / $10,000
+/// ladder (0 = below $1, 5 = at or above $10,000).
+fn spend_tier(spend: f64) -> u8 {
+    if spend >= 10000.0 {
+        5
+    } else if spend >= 1000.0 {
+        4
+    } else if spend >= 100.0 {
+        3
+    } else if spend >= 10.0 {
+        2
+    } else if spend >= 1.0 {
+        1
+    } else {
+        0
+    }
+}
+
+/// CSS class for the spend badge, derived from the spend tier.
+fn spend_tier_class(tier: u8) -> &'static str {
+    match tier {
+        5 => "spend-10000",
+        4 => "spend-1000",
+        3 => "spend-100",
+        2 => "spend-10",
+        1 => "spend-1",
+        _ => "",
+    }
+}
+
+fn animation_duration_ms(tier: u8) -> u32 {
+    match tier {
+        1 => 500,
+        2 => 2000,
+        3 => 5000,
+        4 => 10000,
+        _ => 20000,
+    }
+}
+
+#[hook]
+pub fn use_spend_badge_animation(total_user_spend: f64) -> SpendBadgeAnimation {
+    let prev_spend_tier = use_state(|| 0u8);
+    let spend_animating = use_state(|| false);
+    let spend_initialized = use_state(|| false);
+    let current_tier = spend_tier(total_user_spend);
+
+    {
+        let spend_animating = spend_animating.clone();
+        let prev_spend_tier = prev_spend_tier.clone();
+        let spend_initialized = spend_initialized.clone();
+        use_effect_with(current_tier, move |tier| {
+            let tier = *tier;
+            if !*spend_initialized {
+                // First tier value from page load: record it, don't animate.
+                spend_initialized.set(true);
+                prev_spend_tier.set(tier);
+            } else if tier > *prev_spend_tier {
+                spend_animating.set(true);
+                let spend_animating = spend_animating.clone();
+                let handle =
+                    gloo::timers::callback::Timeout::new(animation_duration_ms(tier), move || {
+                        spend_animating.set(false);
+                    });
+                prev_spend_tier.set(tier);
+                handle.forget();
+            } else if tier != *prev_spend_tier {
+                prev_spend_tier.set(tier);
+            }
+            || ()
+        });
+    }
+
+    SpendBadgeAnimation {
+        tier_class: spend_tier_class(current_tier),
+        animating: *spend_animating,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{animation_duration_ms, spend_tier, spend_tier_class};
+
+    #[test]
+    fn spend_tier_uses_configured_thresholds() {
+        assert_eq!(spend_tier(0.99), 0);
+        assert_eq!(spend_tier(1.0), 1);
+        assert_eq!(spend_tier(10.0), 2);
+        assert_eq!(spend_tier(100.0), 3);
+        assert_eq!(spend_tier(1000.0), 4);
+        assert_eq!(spend_tier(10000.0), 5);
+    }
+
+    #[test]
+    fn spend_tier_class_maps_to_existing_css_classes() {
+        assert_eq!(spend_tier_class(0), "");
+        assert_eq!(spend_tier_class(1), "spend-1");
+        assert_eq!(spend_tier_class(2), "spend-10");
+        assert_eq!(spend_tier_class(3), "spend-100");
+        assert_eq!(spend_tier_class(4), "spend-1000");
+        assert_eq!(spend_tier_class(5), "spend-10000");
+    }
+
+    #[test]
+    fn animation_duration_grows_with_spend_tier() {
+        assert_eq!(animation_duration_ms(1), 500);
+        assert_eq!(animation_duration_ms(2), 2000);
+        assert_eq!(animation_duration_ms(3), 5000);
+        assert_eq!(animation_duration_ms(4), 10000);
+        assert_eq!(animation_duration_ms(5), 20000);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract dashboard total-spend tiering and timed animation state into `page_spend.rs` via `use_spend_badge_animation`
- Keep the header spend badge rendering and behavior unchanged
- Add focused unit tests for spend tier thresholds, CSS class mapping, and animation durations
- Bump workspace version to 2.12.70

## Verification
- `cargo fmt --check`
- `cargo check -p frontend`
- `cargo test -p frontend` (358 passed)
- `cargo clippy -p frontend -- -D warnings`