### PR TITLE
refactor: extract dashboard focus hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.70"
+version = "2.12.71"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.70"
+version = "2.12.71"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.70"
+version = "2.12.71"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.70"
+version = "2.12.71"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.70"
+version = "2.12.71"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.70"
+version = "2.12.71"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.70"
+version = "2.12.71"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.70"
+version = "2.12.71"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.70"
+version = "2.12.71"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.70"
+version = "2.12.71"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.70"
+version = "2.12.71"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/mod.rs
+++ b/frontend/src/pages/dashboard/mod.rs
@@ -8,6 +8,7 @@
 
 mod page;
 mod page_bootstrap;
+mod page_focus;
 mod page_spend;
 mod page_state;
 mod permission_dialog;

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -1,6 +1,7 @@
 //! Dashboard page - Main session management interface
 
 use super::page_bootstrap::use_dashboard_bootstrap;
+use super::page_focus::use_dashboard_focus;
 use super::page_spend::use_spend_badge_animation;
 use super::page_state::{
     active_session_ids, DashboardSessionAction, DashboardSessionState, DashboardUiAction,
@@ -106,112 +107,23 @@ pub fn dashboard_page() -> Html {
         hidden
     };
 
-    // Derive the focused display index from the focused session id against the
-    // current sorted order. Falls back to the first non-hidden session when the
-    // focused id is absent (nothing focused yet, or the focused session was
-    // deleted / left). The rail, keyboard nav, and focus render all consume
-    // this derived index.
-    let focused_index: usize = session_order::resolve_focus_index(
-        &active_sessions,
-        session_state.focused_id,
-        &effective_hidden_sessions,
+    let focus = use_dashboard_focus(
+        active_sessions.clone(),
+        effective_hidden_sessions.clone(),
+        loading,
+        session_state.clone(),
     );
-
-    // On initial load, focus first non-hidden session and activate all non-hidden sessions
-    {
-        let active_sessions = active_sessions.clone();
-        let effective_hidden_sessions = effective_hidden_sessions.clone();
-        let session_state = session_state.clone();
-
-        use_effect_with(
-            (
-                active_sessions.clone(),
-                effective_hidden_sessions.clone(),
-                loading,
-            ),
-            move |(sessions, hidden_sessions, is_loading)| {
-                if !*is_loading && !sessions.is_empty() {
-                    // Focus the first non-hidden session by id (falls through to
-                    // the first session if all are hidden).
-                    let first_focus = sessions
-                        .iter()
-                        .find(|s| !hidden_sessions.contains(&s.id))
-                        .or_else(|| sessions.first())
-                        .map(|s| s.id);
-
-                    // Activate all non-hidden sessions so they load in background
-                    let activate_ids = sessions
-                        .iter()
-                        .filter(|s| !hidden_sessions.contains(&s.id))
-                        .map(|s| s.id)
-                        .collect();
-
-                    session_state.dispatch(DashboardSessionAction::InitializeFocus {
-                        focus_id: first_focus,
-                        activate_ids,
-                    });
-                }
-                || ()
-            },
-        );
-    }
-
-    // Auto-focus newly launched session when it appears in the session list
-    {
-        let session_state = session_state.clone();
-
-        use_effect_with(active_session_ids(&active_sessions), move |session_ids| {
-            session_state.dispatch(DashboardSessionAction::FocusNewlyLaunched(
-                session_ids.clone(),
-            ));
-            || ()
-        });
-    }
-
-    // Session selection callback
-    let on_select_session = {
-        let session_state = session_state.clone();
-        let active_sessions = active_sessions.clone();
-        // The rail / keyboard nav emit a display index valid against the order
-        // that produced the current render; translate it to the session id so
-        // focus stays attached to that session across later reorders.
-        Callback::from(move |index: usize| {
-            crate::audio::ensure_audio_context();
-            crate::audio::play_sound(crate::audio::SoundEvent::SessionSwap);
-            if let Some(session) = active_sessions.get(index) {
-                session_state.dispatch(DashboardSessionAction::FocusAndActivate(session.id));
-            }
-        })
-    };
-
-    // Activation callback for keyboard nav
-    let on_activate = {
-        let session_state = session_state.clone();
-        Callback::from(move |session_id: Uuid| {
-            session_state.dispatch(DashboardSessionAction::Activate(session_id));
-        })
-    };
-
-    // Interrupt signal counter — incremented by triple-Escape, passed to focused SessionView
-    let interrupt_signal = use_state(|| 0u32);
-
-    let on_interrupt = {
-        let interrupt_signal = interrupt_signal.clone();
-        Callback::from(move |()| {
-            interrupt_signal.set(*interrupt_signal + 1);
-        })
-    };
 
     // Use the keyboard navigation hook
     let keyboard_nav = use_keyboard_nav(KeyboardNavConfig {
         sessions: active_sessions.clone(),
-        focused_index,
+        focused_index: focus.focused_index,
         hidden_sessions: effective_hidden_sessions.clone(),
         connected_sessions: session_state.connected_sessions.clone(),
         inactive_hidden: ui_state.inactive_hidden,
-        on_select: on_select_session.clone(),
-        on_activate,
-        on_interrupt,
+        on_select: focus.on_select_session.clone(),
+        on_activate: focus.on_activate.clone(),
+        on_interrupt: focus.on_interrupt.clone(),
     });
 
     // Modal open callbacks
@@ -692,7 +604,7 @@ pub fn dashboard_page() -> Html {
                     // Session Rail
                     <SessionRail
                         sessions={active_sessions.clone()}
-                        focused_index={focused_index}
+                        focused_index={focus.focused_index}
                         awaiting_sessions={session_state.awaiting_sessions.clone()}
                         hidden_sessions={effective_hidden_sessions.clone()}
                         inactive_hidden={ui_state.inactive_hidden}
@@ -700,7 +612,7 @@ pub fn dashboard_page() -> Html {
                         nav_mode={keyboard_nav.nav_mode}
                         activity_timestamps={(*activity_timestamps).clone()}
                         server_version={server_version.clone()}
-                        on_select={on_select_session.clone()}
+                        on_select={focus.on_select_session.clone()}
                         on_leave={on_leave.clone()}
                         on_delete={on_delete.clone()}
                         on_toggle_hidden={on_toggle_hidden.clone()}
@@ -713,7 +625,7 @@ pub fn dashboard_page() -> Html {
                     <div class={classes!("session-views-container", if keyboard_nav.nav_mode { Some("nav-mode") } else { None })}>
                         {
                             active_sessions.iter().enumerate().map(|(index, session)| {
-                                let is_focused = index == focused_index;
+                                let is_focused = index == focus.focused_index;
                                 let is_activated = session_state.activated_sessions.contains(&session.id);
                                 if is_activated {
                                     html! {
@@ -730,7 +642,7 @@ pub fn dashboard_page() -> Html {
                                                 on_branch_change={on_branch_change.clone()}
                                                 on_activity={on_activity.clone()}
                                                 current_user_id={current_user_id.map(|id| id.to_string())}
-                                                interrupt_signal={*interrupt_signal}
+                                                interrupt_signal={focus.interrupt_signal}
                                             />
                                         </div>
                                     }

--- a/frontend/src/pages/dashboard/page_focus.rs
+++ b/frontend/src/pages/dashboard/page_focus.rs
@@ -1,0 +1,124 @@
+use super::page_state::{active_session_ids, DashboardSessionAction, DashboardSessionState};
+use super::session_order;
+use shared::SessionInfo;
+use std::collections::HashSet;
+use uuid::Uuid;
+use yew::prelude::*;
+
+pub(super) struct DashboardFocus {
+    pub focused_index: usize,
+    pub on_select_session: Callback<usize>,
+    pub on_activate: Callback<Uuid>,
+    pub on_interrupt: Callback<()>,
+    pub interrupt_signal: u32,
+}
+
+#[hook]
+pub(super) fn use_dashboard_focus(
+    active_sessions: Vec<SessionInfo>,
+    effective_hidden_sessions: HashSet<Uuid>,
+    loading: bool,
+    session_state: UseReducerHandle<DashboardSessionState>,
+) -> DashboardFocus {
+    // Derive the focused display index from the focused session id against the
+    // current sorted order. Falls back to the first non-hidden session when the
+    // focused id is absent (nothing focused yet, or the focused session was
+    // deleted / left). The rail, keyboard nav, and focus render all consume
+    // this derived index.
+    let focused_index = session_order::resolve_focus_index(
+        &active_sessions,
+        session_state.focused_id,
+        &effective_hidden_sessions,
+    );
+
+    // On initial load, focus first non-hidden session and activate all non-hidden sessions.
+    {
+        let active_sessions = active_sessions.clone();
+        let effective_hidden_sessions = effective_hidden_sessions.clone();
+        let session_state = session_state.clone();
+
+        use_effect_with(
+            (
+                active_sessions.clone(),
+                effective_hidden_sessions.clone(),
+                loading,
+            ),
+            move |(sessions, hidden_sessions, is_loading)| {
+                if !*is_loading && !sessions.is_empty() {
+                    // Focus the first non-hidden session by id (falls through to
+                    // the first session if all are hidden).
+                    let first_focus = sessions
+                        .iter()
+                        .find(|s| !hidden_sessions.contains(&s.id))
+                        .or_else(|| sessions.first())
+                        .map(|s| s.id);
+
+                    // Activate all non-hidden sessions so they load in background.
+                    let activate_ids = sessions
+                        .iter()
+                        .filter(|s| !hidden_sessions.contains(&s.id))
+                        .map(|s| s.id)
+                        .collect();
+
+                    session_state.dispatch(DashboardSessionAction::InitializeFocus {
+                        focus_id: first_focus,
+                        activate_ids,
+                    });
+                }
+                || ()
+            },
+        );
+    }
+
+    // Auto-focus newly launched session when it appears in the session list.
+    {
+        let session_state = session_state.clone();
+
+        use_effect_with(active_session_ids(&active_sessions), move |session_ids| {
+            session_state.dispatch(DashboardSessionAction::FocusNewlyLaunched(
+                session_ids.clone(),
+            ));
+            || ()
+        });
+    }
+
+    let on_select_session = {
+        let session_state = session_state.clone();
+        let active_sessions = active_sessions.clone();
+        // The rail / keyboard nav emit a display index valid against the order
+        // that produced the current render; translate it to the session id so
+        // focus stays attached to that session across later reorders.
+        Callback::from(move |index: usize| {
+            crate::audio::ensure_audio_context();
+            crate::audio::play_sound(crate::audio::SoundEvent::SessionSwap);
+            if let Some(session) = active_sessions.get(index) {
+                session_state.dispatch(DashboardSessionAction::FocusAndActivate(session.id));
+            }
+        })
+    };
+
+    let on_activate = {
+        let session_state = session_state.clone();
+        Callback::from(move |session_id: Uuid| {
+            session_state.dispatch(DashboardSessionAction::Activate(session_id));
+        })
+    };
+
+    // Interrupt signal counter: incremented by triple-Escape, passed to focused SessionView.
+    let interrupt_signal = use_state(|| 0u32);
+
+    let on_interrupt = {
+        let interrupt_signal = interrupt_signal.clone();
+        Callback::from(move |()| {
+            interrupt_signal.set(*interrupt_signal + 1);
+        })
+    };
+
+    DashboardFocus {
+        focused_index,
+        on_select_session,
+        on_activate,
+        on_interrupt,
+        interrupt_signal: *interrupt_signal,
+    }
+}


### PR DESCRIPTION
## Summary
- Extract DashboardPage focus/activation orchestration into `page_focus.rs` via `use_dashboard_focus`
- Move focus index resolution, initial activation, newly-launched focus, selection/activation callbacks, and interrupt signal state out of `page.rs`
- Keep keyboard nav, rail, and session-view behavior unchanged
- Bump workspace version to 2.12.71

## Verification
- `cargo fmt --check`
- `cargo check -p frontend`
- `cargo test -p frontend` (358 passed)
- `cargo clippy -p frontend -- -D warnings`