### PR TITLE
refactor: encapsulate SessionManager per-session tracking state (#1165 item 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.71"
+version = "2.12.72"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.71"
+version = "2.12.72"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.71"
+version = "2.12.72"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.71"
+version = "2.12.72"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.71"
+version = "2.12.72"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.71"
+version = "2.12.72"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.71"
+version = "2.12.72"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.71"
+version = "2.12.72"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.71"
+version = "2.12.72"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.71"
+version = "2.12.72"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.71"
+version = "2.12.72"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -503,10 +503,11 @@ fn handle_launcher_message(
             let content_value = serde_json::Value::String(content);
 
             // Set sender attribution to "Scheduler"
-            app_state
-                .session_manager
-                .last_input_sender
-                .insert(session_id, (user_id, "Scheduler".to_string()));
+            app_state.session_manager.set_last_input_sender(
+                session_id,
+                user_id,
+                "Scheduler".to_string(),
+            );
 
             // Sequence and send (same pipeline as web client input)
             use crate::schema::{pending_inputs, sessions};

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -107,11 +107,7 @@ pub fn handle_claude_output(
 ) {
     // Deduplicate sequenced messages before broadcasting
     if let (Some(session_id), Some(seq_num)) = (db_session_id, seq) {
-        let last_ack = session_manager
-            .last_ack_seq
-            .get(&session_id)
-            .map(|v| *v)
-            .unwrap_or(0);
+        let last_ack = session_manager.last_ack_seq(session_id);
 
         if seq_num <= last_ack {
             info!(
@@ -132,12 +128,7 @@ pub fn handle_claude_output(
         .and_then(|t| t.as_str())
         .unwrap_or("assistant");
     let sender_info = if role_str == "user" {
-        db_session_id.and_then(|sid| {
-            session_manager
-                .last_input_sender
-                .remove(&sid)
-                .map(|(_, v)| v)
-        })
+        db_session_id.and_then(|sid| session_manager.take_last_input_sender(sid))
     } else {
         None
     };
@@ -169,11 +160,7 @@ pub fn handle_claude_output(
                             // fires once per task, so summing is exact.
                             if let (Some(sid), Some(usage)) = (db_session_id, notif.usage.as_ref())
                             {
-                                session_manager
-                                    .subagent_tokens
-                                    .entry(sid)
-                                    .and_modify(|v| *v += usage.total_tokens as i64)
-                                    .or_insert(usage.total_tokens as i64);
+                                session_manager.add_subagent_tokens(sid, usage.total_tokens as i64);
                             }
                         }
                         None => warn!(
@@ -275,11 +262,7 @@ pub fn handle_claude_output(
             }
 
             if role == shared::MessageRole::Result {
-                let subagent_tokens = session_manager
-                    .subagent_tokens
-                    .get(&session_id)
-                    .map(|v| *v)
-                    .unwrap_or(0);
+                let subagent_tokens = session_manager.subagent_tokens(session_id);
                 store_result_metadata(&mut conn, session_id, &content, subagent_tokens);
             }
 
@@ -293,15 +276,7 @@ pub fn handle_claude_output(
 
         // Update last_ack tracker and send acknowledgment
         if let Some(seq_num) = seq {
-            session_manager
-                .last_ack_seq
-                .entry(session_id)
-                .and_modify(|v| {
-                    if seq_num > *v {
-                        *v = seq_num;
-                    }
-                })
-                .or_insert(seq_num);
+            session_manager.record_ack_seq(session_id, seq_num);
 
             let _ = tx.send(ServerToProxy::OutputAck {
                 session_id,

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -26,6 +26,7 @@ mod input_queue;
 mod launcher_registry;
 mod pending_queue;
 mod proxy_lifecycle;
+mod session_tracking;
 
 pub use launcher_registry::LauncherConnection;
 use pending_queue::PendingMessage;
@@ -39,9 +40,9 @@ pub struct SessionManager {
     pub sessions: Arc<DashMap<SessionId, ProxySender>>,
     pub web_clients: Arc<DashMap<SessionId, Vec<WebClientSender>>>,
     pub user_clients: Arc<DashMap<Uuid, Vec<WebClientSender>>>,
-    pub last_ack_seq: Arc<DashMap<Uuid, u64>>,
+    last_ack_seq: Arc<DashMap<Uuid, u64>>,
     pending_messages: Arc<DashMap<SessionId, VecDeque<PendingMessage>>>,
-    pub pending_truncations: Arc<DashSet<Uuid>>,
+    pending_truncations: Arc<DashSet<Uuid>>,
     pub launchers: Arc<DashMap<Uuid, LauncherConnection>>,
     /// Dedup index: `(user_id, hostname)` → `launcher_id`. Used to atomically
     /// reject a second launcher connection from the same host for the same
@@ -53,7 +54,7 @@ pub struct SessionManager {
     pub pending_file_downloads: Arc<DashMap<Uuid, oneshot::Sender<FileDownloadResponseFields>>>,
     pub pending_launch_sessions: Arc<DashMap<Uuid, Uuid>>,
     /// Tracks who sent the last input for each session (session_id → (user_id, display_name))
-    pub last_input_sender: Arc<DashMap<Uuid, (Uuid, String)>>,
+    last_input_sender: Arc<DashMap<Uuid, (Uuid, String)>>,
     /// Running lifetime total of sub-agent (Task tool) tokens per session.
     /// Claude's `result.usage` reports only the parent conversation; sub-agents
     /// run as separate API conversations whose tokens arrive on `task_notification`
@@ -61,7 +62,7 @@ pub struct SessionManager {
     /// completion). We sum each completed task's total here and fold it into the
     /// session's `output_tokens` at result time so session totals (and the admin
     /// spend dashboard) don't under-count sub-agent usage.
-    pub subagent_tokens: Arc<DashMap<Uuid, i64>>,
+    subagent_tokens: Arc<DashMap<Uuid, i64>>,
     /// Monotonic counter for connection generations (prevents stale cleanup)
     gen_counter: Arc<AtomicU64>,
     /// Current connection generation per session
@@ -166,23 +167,43 @@ mod tests {
         let mgr = SessionManager::new();
         let session_id = Uuid::new_v4();
 
-        assert!(mgr.last_ack_seq.get(&session_id).is_none());
+        assert_eq!(mgr.last_ack_seq(session_id), 0);
 
-        mgr.last_ack_seq.insert(session_id, 5);
-        assert_eq!(*mgr.last_ack_seq.get(&session_id).unwrap(), 5);
+        mgr.record_ack_seq(session_id, 5);
+        assert_eq!(mgr.last_ack_seq(session_id), 5);
 
-        mgr.last_ack_seq.entry(session_id).and_modify(|v| {
-            if 10 > *v {
-                *v = 10;
-            }
-        });
-        assert_eq!(*mgr.last_ack_seq.get(&session_id).unwrap(), 10);
+        mgr.record_ack_seq(session_id, 10);
+        assert_eq!(mgr.last_ack_seq(session_id), 10);
 
-        mgr.last_ack_seq.entry(session_id).and_modify(|v| {
-            if 3 > *v {
-                *v = 3;
-            }
-        });
-        assert_eq!(*mgr.last_ack_seq.get(&session_id).unwrap(), 10);
+        // Older sequence must not regress the watermark.
+        mgr.record_ack_seq(session_id, 3);
+        assert_eq!(mgr.last_ack_seq(session_id), 10);
+    }
+
+    #[test]
+    fn last_input_sender_take_is_once() {
+        let mgr = SessionManager::new();
+        let session_id = Uuid::new_v4();
+        let user = Uuid::new_v4();
+
+        assert!(mgr.take_last_input_sender(session_id).is_none());
+        mgr.set_last_input_sender(session_id, user, "Matt".to_string());
+        assert_eq!(
+            mgr.take_last_input_sender(session_id),
+            Some((user, "Matt".to_string()))
+        );
+        // Consumed — a second take is empty.
+        assert!(mgr.take_last_input_sender(session_id).is_none());
+    }
+
+    #[test]
+    fn subagent_tokens_accumulate() {
+        let mgr = SessionManager::new();
+        let session_id = Uuid::new_v4();
+
+        assert_eq!(mgr.subagent_tokens(session_id), 0);
+        mgr.add_subagent_tokens(session_id, 100);
+        mgr.add_subagent_tokens(session_id, 50);
+        assert_eq!(mgr.subagent_tokens(session_id), 150);
     }
 }

--- a/backend/src/handlers/websocket/session_manager/session_tracking.rs
+++ b/backend/src/handlers/websocket/session_manager/session_tracking.rs
@@ -1,0 +1,60 @@
+//! Narrow accessors for per-session *tracking* state — the output-ack
+//! watermark, the last input sender, and the sub-agent token rollup.
+//!
+//! These were public `DashMap` fields that handlers poked directly; routing
+//! them through intent-named methods (and making the fields private) is part of
+//! the SessionManager de-god (#1165 item 4). Behavior is unchanged — each
+//! method is the exact storage operation its former call site performed.
+
+use uuid::Uuid;
+
+use super::SessionManager;
+
+impl SessionManager {
+    /// Highest output sequence number acked for `session_id` (0 if none yet).
+    /// Used to deduplicate already-broadcast sequenced output.
+    pub(crate) fn last_ack_seq(&self, session_id: Uuid) -> u64 {
+        self.last_ack_seq.get(&session_id).map(|v| *v).unwrap_or(0)
+    }
+
+    /// Advance the per-session ack watermark to `seq` when it is newer.
+    pub(crate) fn record_ack_seq(&self, session_id: Uuid, seq: u64) {
+        self.last_ack_seq
+            .entry(session_id)
+            .and_modify(|v| {
+                if seq > *v {
+                    *v = seq;
+                }
+            })
+            .or_insert(seq);
+    }
+
+    /// Record who sent the most recent input for `session_id` (for sender
+    /// attribution on the echoed user message).
+    pub(crate) fn set_last_input_sender(&self, session_id: Uuid, user_id: Uuid, name: String) {
+        self.last_input_sender.insert(session_id, (user_id, name));
+    }
+
+    /// Remove and return the last input sender for `session_id`, if any. The
+    /// echoed user message consumes it exactly once.
+    pub(crate) fn take_last_input_sender(&self, session_id: Uuid) -> Option<(Uuid, String)> {
+        self.last_input_sender.remove(&session_id).map(|(_, v)| v)
+    }
+
+    /// Add `tokens` to the running sub-agent (Task tool) token total for
+    /// `session_id`; folded into the session's `output_tokens` at result time.
+    pub(crate) fn add_subagent_tokens(&self, session_id: Uuid, tokens: i64) {
+        self.subagent_tokens
+            .entry(session_id)
+            .and_modify(|v| *v += tokens)
+            .or_insert(tokens);
+    }
+
+    /// The accumulated sub-agent token total for `session_id` (0 if none).
+    pub(crate) fn subagent_tokens(&self, session_id: Uuid) -> i64 {
+        self.subagent_tokens
+            .get(&session_id)
+            .map(|v| *v)
+            .unwrap_or(0)
+    }
+}

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -362,9 +362,7 @@ fn handle_web_input(
                     .ok()
             })
             .unwrap_or_else(|| "Unknown".to_string());
-        session_manager
-            .last_input_sender
-            .insert(session_id, (user_id, display_name));
+        session_manager.set_last_input_sender(session_id, user_id, display_name);
     }
 
     // For slash commands, broadcast a portal message so the user sees feedback


### PR DESCRIPTION
Maintainability roadmap #1165, **item 4** (SessionManager de-god) — first encapsulation slice.

`SessionManager`'s per-session *tracking* maps were public `DashMap`s that handlers poked directly (`.last_ack_seq.entry(...)`, `.subagent_tokens.get(...)`, `.last_input_sender.remove(...)`), coupling call sites to the storage shape.

## What
- Make `last_ack_seq`, `last_input_sender`, `subagent_tokens`, `pending_truncations` **private**.
- Add a `session_tracking` submodule with intent-named accessors: `record_ack_seq`/`last_ack_seq`, `set_`/`take_last_input_sender`, `add_subagent_tokens`/`subagent_tokens`.
- Route the ~7 external call sites (message_handlers, web_client_socket, launcher_socket) through them.

Behavior-preserving — each accessor is the exact storage op its former call site performed. Removes a chunk of the god-object's public surface; callers express intent now, not storage. Accessor tests added.

`cargo test -p backend` (120) ✅ · `RUSTFLAGS=-Dwarnings cargo clippy -p backend --all-targets` ✅ · fmt ✅. Version → 2.12.72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)