### PR TITLE
refactor: extract session rail pill component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.72"
+version = "2.12.73"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.72"
+version = "2.12.73"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.72"
+version = "2.12.73"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.72"
+version = "2.12.73"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.72"
+version = "2.12.73"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.72"
+version = "2.12.73"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.72"
+version = "2.12.73"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.72"
+version = "2.12.73"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.72"
+version = "2.12.73"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.72"
+version = "2.12.73"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.72"
+version = "2.12.73"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -16,8 +16,9 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::{Element, HtmlElement, WheelEvent};
 use yew::prelude::*;
 
+mod pill;
 mod sparkline;
-use sparkline::render_activity_sparkline;
+use pill::SessionPill;
 pub use sparkline::ActivityRef;
 
 #[cfg(test)]
@@ -596,204 +597,31 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         html! {}
     };
 
-    // Helper to render a single session pill
-    let render_pill = |index: usize,
-                       session: &SessionInfo,
-                       display_number: Option<usize>|
-     -> Html {
-        let is_focused = index == props.focused_index;
-        let is_awaiting = props.awaiting_sessions.contains(&session.id);
-        let is_hidden = props.hidden_sessions.contains(&session.id);
-        let is_connected = props.connected_sessions.contains(&session.id);
-
-        let on_click = {
-            let on_select = props.on_select.clone();
-            Callback::from(move |_| on_select.emit(index))
-        };
-
-        let on_toggle_menu = {
-            let menu_session = menu_session.clone();
-            let menu_pos = menu_pos.clone();
-            let stop_confirm = stop_confirm.clone();
-            let copied_id = copied_id.clone();
-            let session_id = session.id;
-            Callback::from(move |e: MouseEvent| {
-                e.stop_propagation();
-                stop_confirm.set(false);
-                copied_id.set(false);
-                if *menu_session == Some(session_id) {
-                    menu_session.set(None);
-                    return;
-                }
-                if let Some(el) = e.target_dyn_into::<HtmlElement>() {
-                    let rect = el.get_bounding_client_rect();
-                    let vw = web_sys::window()
-                        .and_then(|w| w.inner_width().ok())
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(800.0) as i32;
-                    let menu_width = 160; // min-width from CSS
-                    let left = (rect.left() as i32).min(vw - menu_width - 8);
-                    menu_pos.set((left, rect.bottom() as i32 + 4));
-                }
-                menu_session.set(Some(session_id));
-            })
-        };
-
-        let in_nav_mode = props.nav_mode;
-        let is_status_disconnected = session.status.as_str() != "active";
-        let pill_class = classes!(
-            "session-pill",
-            if is_focused { Some("focused") } else { None },
-            if is_awaiting { Some("awaiting") } else { None },
-            if is_hidden { Some("hidden") } else { None },
-            if in_nav_mode { Some("nav-mode") } else { None },
-            if is_status_disconnected {
-                Some("status-disconnected")
-            } else {
-                None
-            },
-        );
-
-        let hostname = &session.hostname;
-        let folder = utils::extract_folder(&session.working_directory);
-
-        let connection_class = if is_connected {
-            "pill-status connected"
-        } else {
-            "pill-status disconnected"
-        };
-
-        let number_annotation = if in_nav_mode {
-            display_number
-                .filter(|&n| n < 9)
-                .map(|n| format!("{}", n + 1))
-        } else {
-            None
-        };
-
-        // Build version badge (rendered inline with hostname).
-        let version_badge = if let Some(ref cv) = session.client_version {
-            if !props.server_version.is_empty() {
-                let staleness = version_staleness(cv, &props.server_version);
-                let (badge_class, tooltip) = match staleness {
-                    VersionStaleness::Current => {
-                        ("version-current", format!("v{} — up to date", cv))
-                    }
-                    VersionStaleness::PatchBehind => (
-                        "version-patch",
-                        format!(
-                            "v{} → v{} (patch update available)",
-                            cv, props.server_version
-                        ),
-                    ),
-                    VersionStaleness::MinorBehind => (
-                        "version-minor",
-                        format!(
-                            "v{} → v{} (minor update available)",
-                            cv, props.server_version
-                        ),
-                    ),
-                    VersionStaleness::MajorBehind => (
-                        "version-major",
-                        format!(
-                            "v{} → v{} (major update available)",
-                            cv, props.server_version
-                        ),
-                    ),
-                };
-                html! {
-                    <span class={classes!("pill-version-badge", badge_class)}
-                        title={tooltip}>
-                        { format!("v{}", cv) }
-                    </span>
-                }
-            } else {
-                html! {}
+    let on_toggle_pill_menu = {
+        let menu_session = menu_session.clone();
+        let menu_pos = menu_pos.clone();
+        let stop_confirm = stop_confirm.clone();
+        let copied_id = copied_id.clone();
+        Callback::from(move |(session_id, e): (Uuid, MouseEvent)| {
+            e.stop_propagation();
+            stop_confirm.set(false);
+            copied_id.set(false);
+            if *menu_session == Some(session_id) {
+                menu_session.set(None);
+                return;
             }
-        } else {
-            html! {}
-        };
-
-        let sparkline =
-            render_activity_sparkline(&props.activity_timestamps, session.id, *render_time);
-
-        let watermark_class = match session.agent_type {
-            shared::AgentType::Claude => "pill-watermark claude",
-            shared::AgentType::Codex => "pill-watermark codex",
-        };
-
-        html! {
-            <div class={pill_class} onclick={on_click} key={session.id.to_string()} data-index={index.to_string()}>
-                <span class={watermark_class} aria-hidden="true" />
-                {
-                    if let Some(num) = &number_annotation {
-                        html! { <span class="pill-number">{ num }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
-                <span class={connection_class}>
-                    { if is_connected { "●" } else { "○" } }
-                </span>
-                <span class="pill-name" title={session.session_name.clone()}>
-                    <span class="pill-folder">{ folder }</span>
-                    <span class="pill-hostname-row">
-                        <span class="pill-hostname">{ hostname }</span>
-                        { version_badge }
-                    </span>
-                    { {
-                        // Show open PR numbers (each with its branch as a hover
-                        // tooltip); fall back to the branch name, then "No VCS".
-                        let prs = sorted_prs(&session.open_prs);
-                        if !prs.is_empty() {
-                            html! {
-                                <span class="pill-branch pill-prs">
-                                    { for prs.iter().map(|pr| html! {
-                                        <span class="pill-pr-num" title={pr.branch.clone()}>
-                                            { format!("#{}", pr.number) }
-                                        </span>
-                                    }) }
-                                </span>
-                            }
-                        } else if let Some(ref branch) = session.git_branch {
-                            html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
-                        } else {
-                            html! { <span class="pill-branch pill-no-vcs">{ "No VCS" }</span> }
-                        }
-                    } }
-                </span>
-                // Codex text badge removed — the agent-type watermark behind the
-                // pill (anthropic-mark.svg / openai-mark.png) carries this signal.
-                {
-                    if session.scheduled_task_id.is_some() {
-                        html! { <span class="pill-agent-badge cron">{ "Cron" }</span> }
-                    } else if session.paused {
-                        html! { <span class="pill-agent-badge paused">{ "Paused" }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
-                {
-                    if is_hidden {
-                        html! { <span class="pill-hidden-badge">{ "ᴴ" }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
-                {
-                    if session.my_role != "owner" {
-                        let role_class = format!("pill-role-badge role-{}", session.my_role);
-                        html! { <span class={role_class}>{ &session.my_role }</span> }
-                    } else {
-                        html! {}
-                    }
-                }
-                <button type="button" class="pill-menu-toggle" onclick={on_toggle_menu}>
-                    { "▼" }
-                </button>
-                { sparkline }
-            </div>
-        }
+            if let Some(el) = e.target_dyn_into::<HtmlElement>() {
+                let rect = el.get_bounding_client_rect();
+                let vw = web_sys::window()
+                    .and_then(|w| w.inner_width().ok())
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(800.0) as i32;
+                let menu_width = 160; // min-width from CSS
+                let left = (rect.left() as i32).min(vw - menu_width - 8);
+                menu_pos.set((left, rect.bottom() as i32 + 4));
+            }
+            menu_session.set(Some(session_id));
+        })
     };
 
     // Split sessions into visible vs hidden.
@@ -827,7 +655,24 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         <div class="session-rail-container" onclick={on_container_click}>
             <div class="session-rail" ref={rail_ref} onwheel={on_wheel}>
                 { visible_indices.iter().enumerate().map(|(display_idx, (index, session))| {
-                    render_pill(*index, session, Some(display_idx))
+                    html! {
+                        <SessionPill
+                            key={session.id.to_string()}
+                            index={*index}
+                            display_number={Some(display_idx)}
+                            session={(*session).clone()}
+                            is_focused={*index == props.focused_index}
+                            is_awaiting={props.awaiting_sessions.contains(&session.id)}
+                            is_hidden={props.hidden_sessions.contains(&session.id)}
+                            is_connected={props.connected_sessions.contains(&session.id)}
+                            nav_mode={props.nav_mode}
+                            server_version={props.server_version.clone()}
+                            activity_timestamps={props.activity_timestamps.clone()}
+                            render_time={*render_time}
+                            on_select={props.on_select.clone()}
+                            on_toggle_menu={on_toggle_pill_menu.clone()}
+                        />
+                    }
                 }).collect::<Html>() }
 
                 {
@@ -856,7 +701,24 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 {
                     if !props.inactive_hidden {
                         hidden_indices.iter().enumerate().map(|(display_idx, (index, session))| {
-                            render_pill(*index, session, Some(visible_count + display_idx))
+                            html! {
+                                <SessionPill
+                                    key={session.id.to_string()}
+                                    index={*index}
+                                    display_number={Some(visible_count + display_idx)}
+                                    session={(*session).clone()}
+                                    is_focused={*index == props.focused_index}
+                                    is_awaiting={props.awaiting_sessions.contains(&session.id)}
+                                    is_hidden={props.hidden_sessions.contains(&session.id)}
+                                    is_connected={props.connected_sessions.contains(&session.id)}
+                                    nav_mode={props.nav_mode}
+                                    server_version={props.server_version.clone()}
+                                    activity_timestamps={props.activity_timestamps.clone()}
+                                    render_time={*render_time}
+                                    on_select={props.on_select.clone()}
+                                    on_toggle_menu={on_toggle_pill_menu.clone()}
+                                />
+                            }
                         }).collect::<Html>()
                     } else {
                         html! {}

--- a/frontend/src/pages/dashboard/session_rail/pill.rs
+++ b/frontend/src/pages/dashboard/session_rail/pill.rs
@@ -1,0 +1,296 @@
+use crate::utils;
+use shared::SessionInfo;
+use uuid::Uuid;
+use web_sys::MouseEvent;
+use yew::prelude::*;
+
+use super::sparkline::{render_activity_sparkline, ActivityRef};
+use super::{sorted_prs, version_staleness, VersionStaleness};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct VersionBadgeView {
+    class: &'static str,
+    tooltip: String,
+    label: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum VcsView {
+    PullRequests(Vec<(i64, String)>),
+    Branch(String),
+    None,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PillViewModel {
+    pill_classes: Vec<&'static str>,
+    watermark_class: &'static str,
+    connection_class: &'static str,
+    connection_symbol: &'static str,
+    number_annotation: Option<String>,
+    folder: String,
+    version_badge: Option<VersionBadgeView>,
+    vcs: VcsView,
+    agent_badge: Option<(&'static str, &'static str)>,
+    hidden_badge: bool,
+    role_badge_class: Option<String>,
+}
+
+#[derive(Properties, PartialEq)]
+pub(super) struct SessionPillProps {
+    pub index: usize,
+    pub display_number: Option<usize>,
+    pub session: SessionInfo,
+    pub is_focused: bool,
+    pub is_awaiting: bool,
+    pub is_hidden: bool,
+    pub is_connected: bool,
+    pub nav_mode: bool,
+    pub server_version: String,
+    pub activity_timestamps: ActivityRef,
+    pub render_time: f64,
+    pub on_select: Callback<usize>,
+    pub on_toggle_menu: Callback<(Uuid, MouseEvent)>,
+}
+
+#[function_component(SessionPill)]
+pub(super) fn session_pill(props: &SessionPillProps) -> Html {
+    let session = &props.session;
+    let view = PillViewModel::new(props);
+
+    let on_click = {
+        let on_select = props.on_select.clone();
+        let index = props.index;
+        Callback::from(move |_| on_select.emit(index))
+    };
+
+    let on_toggle_menu = {
+        let on_toggle_menu = props.on_toggle_menu.clone();
+        let session_id = session.id;
+        Callback::from(move |e: MouseEvent| on_toggle_menu.emit((session_id, e)))
+    };
+
+    let sparkline =
+        render_activity_sparkline(&props.activity_timestamps, session.id, props.render_time);
+
+    html! {
+        <div
+            class={classes!(view.pill_classes)}
+            onclick={on_click}
+            key={session.id.to_string()}
+            data-index={props.index.to_string()}
+        >
+            <span class={view.watermark_class} aria-hidden="true" />
+            {
+                if let Some(num) = &view.number_annotation {
+                    html! { <span class="pill-number">{ num }</span> }
+                } else {
+                    html! {}
+                }
+            }
+            <span class={view.connection_class}>
+                { view.connection_symbol }
+            </span>
+            <span class="pill-name" title={session.session_name.clone()}>
+                <span class="pill-folder">{ view.folder }</span>
+                <span class="pill-hostname-row">
+                    <span class="pill-hostname">{ &session.hostname }</span>
+                    { render_version_badge(view.version_badge.as_ref()) }
+                </span>
+                { render_vcs(&view.vcs) }
+            </span>
+            // Codex text badge removed: the agent-type watermark behind the
+            // pill (anthropic-mark.svg / openai-mark.png) carries this signal.
+            {
+                if let Some((class, label)) = view.agent_badge {
+                    html! { <span class={classes!("pill-agent-badge", class)}>{ label }</span> }
+                } else {
+                    html! {}
+                }
+            }
+            {
+                if view.hidden_badge {
+                    html! { <span class="pill-hidden-badge">{ "ᴴ" }</span> }
+                } else {
+                    html! {}
+                }
+            }
+            {
+                if let Some(role_class) = view.role_badge_class {
+                    html! { <span class={role_class}>{ &session.my_role }</span> }
+                } else {
+                    html! {}
+                }
+            }
+            <button type="button" class="pill-menu-toggle" onclick={on_toggle_menu}>
+                { "▼" }
+            </button>
+            { sparkline }
+        </div>
+    }
+}
+
+impl PillViewModel {
+    fn new(props: &SessionPillProps) -> Self {
+        let session = &props.session;
+        let is_status_disconnected = session.status.as_str() != "active";
+
+        let mut pill_classes = vec!["session-pill"];
+        if props.is_focused {
+            pill_classes.push("focused");
+        }
+        if props.is_awaiting {
+            pill_classes.push("awaiting");
+        }
+        if props.is_hidden {
+            pill_classes.push("hidden");
+        }
+        if props.nav_mode {
+            pill_classes.push("nav-mode");
+        }
+        if is_status_disconnected {
+            pill_classes.push("status-disconnected");
+        }
+
+        let number_annotation = if props.nav_mode {
+            props
+                .display_number
+                .filter(|&n| n < 9)
+                .map(|n| format!("{}", n + 1))
+        } else {
+            None
+        };
+
+        let version_badge = session
+            .client_version
+            .as_ref()
+            .filter(|_| !props.server_version.is_empty())
+            .map(|client_version| version_badge_view(client_version, &props.server_version));
+
+        let vcs = {
+            let prs = sorted_prs(&session.open_prs);
+            if !prs.is_empty() {
+                VcsView::PullRequests(
+                    prs.iter()
+                        .map(|pr| (pr.number, pr.branch.clone()))
+                        .collect(),
+                )
+            } else if let Some(branch) = &session.git_branch {
+                VcsView::Branch(branch.clone())
+            } else {
+                VcsView::None
+            }
+        };
+
+        let agent_badge = if session.scheduled_task_id.is_some() {
+            Some(("cron", "Cron"))
+        } else if session.paused {
+            Some(("paused", "Paused"))
+        } else {
+            None
+        };
+
+        let role_badge_class = (session.my_role != "owner")
+            .then(|| format!("pill-role-badge role-{}", session.my_role));
+
+        Self {
+            pill_classes,
+            watermark_class: match session.agent_type {
+                shared::AgentType::Claude => "pill-watermark claude",
+                shared::AgentType::Codex => "pill-watermark codex",
+            },
+            connection_class: if props.is_connected {
+                "pill-status connected"
+            } else {
+                "pill-status disconnected"
+            },
+            connection_symbol: if props.is_connected { "●" } else { "○" },
+            number_annotation,
+            folder: utils::extract_folder(&session.working_directory).to_string(),
+            version_badge,
+            vcs,
+            agent_badge,
+            hidden_badge: props.is_hidden,
+            role_badge_class,
+        }
+    }
+}
+
+fn render_version_badge(version_badge: Option<&VersionBadgeView>) -> Html {
+    if let Some(badge) = version_badge {
+        html! {
+            <span class={classes!("pill-version-badge", badge.class)}
+                title={badge.tooltip.clone()}>
+                { &badge.label }
+            </span>
+        }
+    } else {
+        html! {}
+    }
+}
+
+fn render_vcs(vcs: &VcsView) -> Html {
+    match vcs {
+        VcsView::PullRequests(prs) => html! {
+            <span class="pill-branch pill-prs">
+                { for prs.iter().map(|(number, branch)| html! {
+                    <span class="pill-pr-num" title={branch.clone()}>
+                        { format!("#{number}") }
+                    </span>
+                }) }
+            </span>
+        },
+        VcsView::Branch(branch) => {
+            html! { <span class="pill-branch" title={branch.clone()}>{ branch }</span> }
+        }
+        VcsView::None => html! { <span class="pill-branch pill-no-vcs">{ "No VCS" }</span> },
+    }
+}
+
+fn version_badge_view(client_version: &str, server_version: &str) -> VersionBadgeView {
+    let staleness = version_staleness(client_version, server_version);
+    let (class, tooltip) = match staleness {
+        VersionStaleness::Current => ("version-current", format!("v{client_version} — up to date")),
+        VersionStaleness::PatchBehind => (
+            "version-patch",
+            format!("v{client_version} → v{server_version} (patch update available)"),
+        ),
+        VersionStaleness::MinorBehind => (
+            "version-minor",
+            format!("v{client_version} → v{server_version} (minor update available)"),
+        ),
+        VersionStaleness::MajorBehind => (
+            "version-major",
+            format!("v{client_version} → v{server_version} (major update available)"),
+        ),
+    };
+    VersionBadgeView {
+        class,
+        tooltip,
+        label: format!("v{client_version}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_badge_view_reports_patch_update() {
+        let view = version_badge_view("2.12.70", "2.12.73");
+
+        assert_eq!(view.class, "version-patch");
+        assert_eq!(view.label, "v2.12.70");
+        assert!(view.tooltip.contains("patch update available"));
+    }
+
+    #[test]
+    fn render_vcs_prefers_pull_requests_over_branch() {
+        let prs = VcsView::PullRequests(vec![(12, "feature/a".to_string())]);
+        let branch = VcsView::Branch("main".to_string());
+        let none = VcsView::None;
+
+        assert_ne!(prs, branch);
+        assert_ne!(branch, none);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract SessionRail pill rendering into `session_rail/pill.rs` as `SessionPill`
- Introduce an initial pure `PillViewModel` for pill classes, badges, VCS summary, and version badge state
- Keep dropdown/menu positioning and menu content in `session_rail.rs` for the next Q2 slice
- Bump workspace version to 2.12.73

## Verification
- `cargo fmt --check`
- `cargo check -p frontend`
- `cargo test -p frontend` (360 passed)
- `cargo clippy -p frontend -- -D warnings`