### PR TITLE
refactor: encapsulate file-download RPC correlation (#1165 item 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.73"
+version = "2.12.74"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.73"
+version = "2.12.74"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.73"
+version = "2.12.74"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.73"
+version = "2.12.74"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.73"
+version = "2.12.74"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.73"
+version = "2.12.74"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.73"
+version = "2.12.74"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.73"
+version = "2.12.74"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.73"
+version = "2.12.74"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.73"
+version = "2.12.74"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.73"
+version = "2.12.74"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/files.rs
+++ b/backend/src/handlers/files.rs
@@ -12,7 +12,6 @@ use serde::Deserialize;
 use shared::{FileDownloadRequestFields, ServerToProxy};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::oneshot;
 use uuid::Uuid;
 
 const MAX_PULL_BYTES: u64 = 25 * 1024 * 1024;
@@ -36,11 +35,7 @@ pub async fn pull_session_file(
     verify_session_read_access(&app_state, session_id, current_user_id)?;
 
     let request_id = Uuid::new_v4();
-    let (tx, rx) = oneshot::channel();
-    app_state
-        .session_manager
-        .pending_file_downloads
-        .insert(request_id, tx);
+    let rx = app_state.session_manager.register_file_download(request_id);
 
     let sent = app_state.session_manager.send_to_connected_session(
         &session_id.to_string(),
@@ -52,10 +47,7 @@ pub async fn pull_session_file(
     );
 
     if !sent {
-        app_state
-            .session_manager
-            .pending_file_downloads
-            .remove(&request_id);
+        app_state.session_manager.cancel_file_download(request_id);
         return Err(AppError::ServiceUnavailable(
             "Session proxy is not connected",
         ));
@@ -65,10 +57,7 @@ pub async fn pull_session_file(
         Ok(Ok(response)) => response,
         Ok(Err(_)) => return Err(AppError::BadGateway("File download response was dropped")),
         Err(_) => {
-            app_state
-                .session_manager
-                .pending_file_downloads
-                .remove(&request_id);
+            app_state.session_manager.cancel_file_download(request_id);
             return Err(AppError::GatewayTimeout("File download timed out"));
         }
     };

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -322,15 +322,11 @@ fn handle_proxy_message(
             );
         }
         ProxyToServer::FileDownloadResponse(response) => {
-            if let Some((_, tx)) = session_manager
-                .pending_file_downloads
-                .remove(&response.request_id)
-            {
-                let _ = tx.send(response);
-            } else {
+            let request_id = response.request_id;
+            if !session_manager.complete_file_download(request_id, response) {
                 warn!(
                     "Received FileDownloadResponse for unknown request {}",
-                    response.request_id
+                    request_id
                 );
             }
         }

--- a/backend/src/handlers/websocket/session_manager/correlation.rs
+++ b/backend/src/handlers/websocket/session_manager/correlation.rs
@@ -2,7 +2,7 @@
 //! oneshot for a request id, the launcher socket completes it when the
 //! matching response frame arrives.
 
-use shared::LauncherToServer;
+use shared::{FileDownloadResponseFields, LauncherToServer};
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
@@ -30,6 +30,38 @@ impl SessionManager {
     pub fn complete_probe_request(&self, request_id: Uuid, msg: LauncherToServer) {
         if let Some((_, tx)) = self.pending_probe_requests.remove(&request_id) {
             let _ = tx.send(msg);
+        }
+    }
+
+    /// Register a pending file-download RPC; the returned receiver resolves when
+    /// the owning proxy replies (or is cancelled on send-failure/timeout).
+    pub fn register_file_download(
+        &self,
+        request_id: Uuid,
+    ) -> oneshot::Receiver<FileDownloadResponseFields> {
+        let (tx, rx) = oneshot::channel();
+        self.pending_file_downloads.insert(request_id, tx);
+        rx
+    }
+
+    /// Drop a pending file-download RPC without delivering (proxy not connected
+    /// or the wait timed out).
+    pub fn cancel_file_download(&self, request_id: Uuid) {
+        self.pending_file_downloads.remove(&request_id);
+    }
+
+    /// Deliver a proxy's file-download response to the waiting handler. Returns
+    /// `false` if no request was pending for `request_id` (already cancelled).
+    pub fn complete_file_download(
+        &self,
+        request_id: Uuid,
+        response: FileDownloadResponseFields,
+    ) -> bool {
+        if let Some((_, tx)) = self.pending_file_downloads.remove(&request_id) {
+            let _ = tx.send(response);
+            true
+        } else {
+            false
         }
     }
 }

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -51,7 +51,7 @@ pub struct SessionManager {
     launcher_dedup: Arc<DashMap<(Uuid, String), Uuid>>,
     pub pending_dir_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
     pub pending_probe_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
-    pub pending_file_downloads: Arc<DashMap<Uuid, oneshot::Sender<FileDownloadResponseFields>>>,
+    pending_file_downloads: Arc<DashMap<Uuid, oneshot::Sender<FileDownloadResponseFields>>>,
     pub pending_launch_sessions: Arc<DashMap<Uuid, Uuid>>,
     /// Tracks who sent the last input for each session (session_id → (user_id, display_name))
     last_input_sender: Arc<DashMap<Uuid, (Uuid, String)>>,


### PR DESCRIPTION
Maintainability roadmap #1165, **item 4** (SessionManager de-god) — second encapsulation slice.

`pending_file_downloads` was a public `DashMap` that `files.rs` and `proxy_socket.rs` poked directly (`.insert`/`.remove`/`tx.send`). Make it **private** and add `correlation`-module accessors:
- `register_file_download(request_id) -> Receiver<FileDownloadResponseFields>`
- `cancel_file_download(request_id)` — send-failure / timeout cleanup
- `complete_file_download(request_id, response) -> bool` — `false` when nothing was pending (drives the proxy_socket "unknown request" warn)

Behavior-preserving. Also dropped a now-unused `oneshot` import in `files.rs`.

**Follow-up noted:** `launchers.rs` still bypasses the existing `register/complete_dir_request` + `_probe_request` methods (same cluster) — next slice.

`cargo test -p backend` (120) ✅ · `RUSTFLAGS=-Dwarnings cargo clippy -p backend --all-targets` ✅ · fmt ✅. Version → 2.12.74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)