### PR TITLE
refactor: encapsulate launch-session RPC correlation (#1165 item 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.75"
+version = "2.12.76"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.75"
+version = "2.12.76"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.75"
+version = "2.12.76"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.75"
+version = "2.12.76"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.75"
+version = "2.12.76"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.75"
+version = "2.12.76"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.75"
+version = "2.12.76"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.75"
+version = "2.12.76"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.75"
+version = "2.12.76"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.75"
+version = "2.12.76"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.75"
+version = "2.12.76"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -67,8 +67,7 @@ pub async fn launch_session(
     )?;
     app_state
         .session_manager
-        .pending_launch_sessions
-        .insert(request_id, session_id);
+        .register_launch_session(request_id, session_id);
 
     let launch_msg = ServerToLauncher::LaunchSession {
         request_id,
@@ -86,10 +85,7 @@ pub async fn launch_session(
         .session_manager
         .send_to_launcher(&launcher_id, launch_msg)
     {
-        app_state
-            .session_manager
-            .pending_launch_sessions
-            .remove(&request_id);
+        app_state.session_manager.cancel_launch_session(request_id);
         let mut conn = app_state.conn()?;
         use crate::schema::sessions;
         let _ = diesel::delete(sessions::table.find(session_id)).execute(&mut conn);

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -297,11 +297,7 @@ fn handle_launcher_message(
             pid,
             ref error,
         } => {
-            let desired_session_id = app_state
-                .session_manager
-                .pending_launch_sessions
-                .remove(&request_id)
-                .map(|(_, id)| id);
+            let desired_session_id = app_state.session_manager.take_launch_session(request_id);
             if success {
                 info!(
                     "Launch succeeded: request={}, session={:?}, pid={:?}",
@@ -770,8 +766,7 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
         let request_id = Uuid::new_v4();
         app_state
             .session_manager
-            .pending_launch_sessions
-            .insert(request_id, session.id);
+            .register_launch_session(request_id, session.id);
 
         let claude_args =
             serde_json::from_value::<Vec<String>>(session.claude_args.clone()).unwrap_or_default();
@@ -806,10 +801,7 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
             .session_manager
             .send_to_launcher(&launcher_id, launch_msg)
         {
-            app_state
-                .session_manager
-                .pending_launch_sessions
-                .remove(&request_id);
+            app_state.session_manager.cancel_launch_session(request_id);
             warn!(
                 "Failed to send desired session {} to launcher {}",
                 session.id, launcher_id

--- a/backend/src/handlers/websocket/session_manager/correlation.rs
+++ b/backend/src/handlers/websocket/session_manager/correlation.rs
@@ -64,4 +64,24 @@ impl SessionManager {
             false
         }
     }
+
+    /// Record the session a `LaunchSession` request is expected to produce, so
+    /// the launcher's result frame can be correlated back to it.
+    pub fn register_launch_session(&self, request_id: Uuid, session_id: Uuid) {
+        self.pending_launch_sessions.insert(request_id, session_id);
+    }
+
+    /// Drop a pending launch correlation without resolving (the launch frame
+    /// failed to send).
+    pub fn cancel_launch_session(&self, request_id: Uuid) {
+        self.pending_launch_sessions.remove(&request_id);
+    }
+
+    /// Resolve a launch request to its expected session id, consuming the
+    /// correlation entry. `None` if the request id was unknown/already taken.
+    pub fn take_launch_session(&self, request_id: Uuid) -> Option<Uuid> {
+        self.pending_launch_sessions
+            .remove(&request_id)
+            .map(|(_, id)| id)
+    }
 }

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -52,7 +52,7 @@ pub struct SessionManager {
     pub pending_dir_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
     pub pending_probe_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
     pending_file_downloads: Arc<DashMap<Uuid, oneshot::Sender<FileDownloadResponseFields>>>,
-    pub pending_launch_sessions: Arc<DashMap<Uuid, Uuid>>,
+    pending_launch_sessions: Arc<DashMap<Uuid, Uuid>>,
     /// Tracks who sent the last input for each session (session_id → (user_id, display_name))
     last_input_sender: Arc<DashMap<Uuid, (Uuid, String)>>,
     /// Running lifetime total of sub-agent (Task tool) tokens per session.


### PR DESCRIPTION
Maintainability roadmap #1165, **item 4** (SessionManager de-god) — third encapsulation slice.

`pending_launch_sessions` was a public `DashMap` poked directly by `launchers.rs` and `launcher_socket.rs`. Make it **private** + add `correlation` accessors:
- `register_launch_session(request_id, session_id)`
- `cancel_launch_session(request_id)` — launch-send-failure cleanup
- `take_launch_session(request_id) -> Option<Uuid>` — resolve + consume on the launcher result frame

Behavior-preserving. Three of the four launcher-RPC correlation maps are now encapsulated; the last correlation follow-up is routing `launchers.rs` through the existing `register/complete_dir_request` + `_probe_request` methods it currently bypasses.

`cargo test -p backend` (120) ✅ · `RUSTFLAGS=-Dwarnings cargo clippy -p backend --all-targets` ✅ · fmt ✅. Version → 2.12.76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)