### PR TITLE
refactor: extract scheduled task blocker hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.76"
+version = "2.12.77"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.76"
+version = "2.12.77"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.76"
+version = "2.12.77"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.76"
+version = "2.12.77"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.76"
+version = "2.12.77"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.76"
+version = "2.12.77"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.76"
+version = "2.12.77"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.76"
+version = "2.12.77"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.76"
+version = "2.12.77"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.76"
+version = "2.12.77"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.76"
+version = "2.12.77"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -4,21 +4,20 @@
 //! parent page onclick closes it, toggle button uses stop_propagation.
 
 use crate::components::{ScheduleDialog, ShareDialog};
-use crate::utils::{self, On401};
 use gloo::events::EventListener;
 use gloo::timers::callback::Interval;
-use shared::api::ScheduledTaskListResponse;
 use shared::{PrRef, SessionInfo};
 use std::collections::HashSet;
 use uuid::Uuid;
 use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::spawn_local;
 use web_sys::{Element, HtmlElement, WheelEvent};
 use yew::prelude::*;
 
+mod hooks;
 mod menu;
 mod pill;
 mod sparkline;
+use hooks::use_scheduled_task_blocker;
 use menu::SessionRailMenu;
 use pill::SessionPill;
 pub use sparkline::ActivityRef;
@@ -155,39 +154,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     let copied_id = use_state(|| false);
     let share_session_id = use_state(|| None::<Uuid>);
     let schedule_session = use_state(|| None::<SessionInfo>);
-    let stop_has_tasks = use_state(|| false);
-
-    // Fetch scheduled task status when dropdown opens for a session
-    {
-        let stop_has_tasks = stop_has_tasks.clone();
-        let menu_id = *menu_session;
-        let sessions = props.sessions.clone();
-        use_effect_with(menu_id, move |menu_id| {
-            if let Some(sid) = menu_id {
-                if let Some(session) = sessions.iter().find(|s| s.id == *sid) {
-                    let wd = session.working_directory.clone();
-                    let stop_has_tasks = stop_has_tasks.clone();
-                    spawn_local(async move {
-                        if let Ok(data) = utils::fetch_json::<ScheduledTaskListResponse>(
-                            "/api/scheduled-tasks",
-                            On401::Ignore,
-                        )
-                        .await
-                        {
-                            let has = data
-                                .tasks
-                                .iter()
-                                .any(|t| t.fields.working_directory == wd && t.enabled);
-                            stop_has_tasks.set(has);
-                        }
-                    });
-                }
-            } else {
-                stop_has_tasks.set(false);
-            }
-            || ()
-        });
-    }
+    let stop_has_tasks = use_scheduled_task_blocker(*menu_session, props.sessions.clone());
 
     // Independent 100 ms tick that drives sparkline redraws.
     // Accumulation happens externally via ActivityRef mutations; this timer
@@ -447,7 +414,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 position={*menu_pos}
                 is_hidden={is_menu_session_hidden}
                 is_connected={is_menu_session_connected}
-                stop_has_tasks={*stop_has_tasks}
+                stop_has_tasks={stop_has_tasks}
                 confirming_stop={*stop_confirm}
                 copied_id={*copied_id}
                 on_close={close_menu}

--- a/frontend/src/pages/dashboard/session_rail/hooks.rs
+++ b/frontend/src/pages/dashboard/session_rail/hooks.rs
@@ -1,0 +1,45 @@
+use crate::utils::{self, On401};
+use shared::api::ScheduledTaskListResponse;
+use shared::SessionInfo;
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+#[hook]
+pub(super) fn use_scheduled_task_blocker(
+    menu_session: Option<Uuid>,
+    sessions: Vec<SessionInfo>,
+) -> bool {
+    let stop_has_tasks = use_state(|| false);
+
+    {
+        let stop_has_tasks = stop_has_tasks.clone();
+        use_effect_with((menu_session, sessions), move |(menu_session, sessions)| {
+            if let Some(session_id) = menu_session {
+                if let Some(session) = sessions.iter().find(|session| session.id == *session_id) {
+                    let working_directory = session.working_directory.clone();
+                    let stop_has_tasks = stop_has_tasks.clone();
+                    spawn_local(async move {
+                        if let Ok(data) = utils::fetch_json::<ScheduledTaskListResponse>(
+                            "/api/scheduled-tasks",
+                            On401::Ignore,
+                        )
+                        .await
+                        {
+                            let has_scheduled_task = data.tasks.iter().any(|task| {
+                                task.fields.working_directory == working_directory && task.enabled
+                            });
+                            stop_has_tasks.set(has_scheduled_task);
+                        }
+                    });
+                }
+            } else {
+                stop_has_tasks.set(false);
+            }
+
+            || ()
+        });
+    }
+
+    *stop_has_tasks
+}


### PR DESCRIPTION
## Summary
- extract the SessionRail scheduled-task stop blocker fetch into use_scheduled_task_blocker
- keep SessionRail focused on state wiring and rendering
- reserve version 2.12.77 behind Claude's open 2.12.76 slice

## Verification
- cargo fmt --check
- cargo check -p frontend
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings