### PR TITLE
refactor: close correlation de-god — route dir/probe cleanup, privatize fields (#1165 item 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.77"
+version = "2.12.78"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.77"
+version = "2.12.78"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.77"
+version = "2.12.78"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.77"
+version = "2.12.78"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.77"
+version = "2.12.78"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.77"
+version = "2.12.78"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.77"
+version = "2.12.78"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.77"
+version = "2.12.78"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.77"
+version = "2.12.78"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.77"
+version = "2.12.78"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.77"
+version = "2.12.78"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -229,10 +229,7 @@ pub async fn list_directories(
     );
 
     if !sent {
-        app_state
-            .session_manager
-            .pending_dir_requests
-            .remove(&request_id);
+        app_state.session_manager.cancel_dir_request(request_id);
         error!("Failed to send ListDirectories to launcher {}", launcher_id);
         return Err(AppError::BadGateway(
             "Failed to send directory listing request",
@@ -262,10 +259,7 @@ pub async fn list_directories(
             "Directory listing response channel closed".to_string(),
         )),
         Err(_) => {
-            app_state
-                .session_manager
-                .pending_dir_requests
-                .remove(&request_id);
+            app_state.session_manager.cancel_dir_request(request_id);
             warn!("Directory listing timed out for launcher {}", launcher_id);
             Err(AppError::GatewayTimeout("Directory listing timed out"))
         }
@@ -348,10 +342,7 @@ pub async fn probe_agents(
         .send(ServerToLauncher::ProbeAgents { request_id })
         .is_err()
     {
-        app_state
-            .session_manager
-            .pending_probe_requests
-            .remove(&request_id);
+        app_state.session_manager.cancel_probe_request(request_id);
         warn!("Launcher {} disconnected while probing agents", launcher_id);
         return Err(AppError::BadGateway("Failed to send agent probe request"));
     }
@@ -367,10 +358,7 @@ pub async fn probe_agents(
             "Agent probe response channel closed".to_string(),
         )),
         Err(_) => {
-            app_state
-                .session_manager
-                .pending_probe_requests
-                .remove(&request_id);
+            app_state.session_manager.cancel_probe_request(request_id);
             warn!("Probe agents timed out for launcher {}", launcher_id);
             Err(AppError::GatewayTimeout("Agent probe timed out"))
         }

--- a/backend/src/handlers/websocket/session_manager/correlation.rs
+++ b/backend/src/handlers/websocket/session_manager/correlation.rs
@@ -21,6 +21,12 @@ impl SessionManager {
         }
     }
 
+    /// Drop a pending directory-listing request without resolving (send
+    /// failure or timeout).
+    pub fn cancel_dir_request(&self, request_id: Uuid) {
+        self.pending_dir_requests.remove(&request_id);
+    }
+
     pub fn register_probe_request(&self, request_id: Uuid) -> oneshot::Receiver<LauncherToServer> {
         let (tx, rx) = oneshot::channel();
         self.pending_probe_requests.insert(request_id, tx);
@@ -31,6 +37,12 @@ impl SessionManager {
         if let Some((_, tx)) = self.pending_probe_requests.remove(&request_id) {
             let _ = tx.send(msg);
         }
+    }
+
+    /// Drop a pending agent-probe request without resolving (send failure or
+    /// timeout).
+    pub fn cancel_probe_request(&self, request_id: Uuid) {
+        self.pending_probe_requests.remove(&request_id);
     }
 
     /// Register a pending file-download RPC; the returned receiver resolves when

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -49,8 +49,8 @@ pub struct SessionManager {
     /// user. Entries here are kept in lockstep with `launchers`: inserted by
     /// `try_register_launcher`, removed by `unregister_launcher`.
     launcher_dedup: Arc<DashMap<(Uuid, String), Uuid>>,
-    pub pending_dir_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
-    pub pending_probe_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
+    pending_dir_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
+    pending_probe_requests: Arc<DashMap<Uuid, oneshot::Sender<LauncherToServer>>>,
     pending_file_downloads: Arc<DashMap<Uuid, oneshot::Sender<FileDownloadResponseFields>>>,
     pending_launch_sessions: Arc<DashMap<Uuid, Uuid>>,
     /// Tracks who sent the last input for each session (session_id → (user_id, display_name))


### PR DESCRIPTION
Maintainability roadmap #1165, **item 4** (SessionManager de-god) — closes the launcher-RPC correlation cluster.

`register_*`/`complete_*` for dir + probe already used the `correlation` methods, but the send-failure/timeout cleanup in `launchers.rs` still poked `.pending_dir_requests`/`.pending_probe_requests.remove(...)` directly. Add `cancel_dir_request`/`cancel_probe_request`, route those 4 sites through them, and make both fields **private**.

**All four launcher-RPC correlation maps** (dir, probe, file-download, launch-session) are now fully encapsulated — no external code touches the storage.

`cargo test -p backend` (120) ✅ · `RUSTFLAGS=-Dwarnings cargo clippy -p backend --all-targets` ✅ · fmt ✅. Version → 2.12.78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)