### PR TITLE
refactor: extract codex turn renderers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.78"
+version = "2.12.79"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.78"
+version = "2.12.79"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.78"
+version = "2.12.79"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.78"
+version = "2.12.79"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.78"
+version = "2.12.79"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.78"
+version = "2.12.79"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.78"
+version = "2.12.79"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.78"
+version = "2.12.79"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.78"
+version = "2.12.79"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.78"
+version = "2.12.79"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.78"
+version = "2.12.79"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -3,20 +3,23 @@ use codex_codes::{
     io::items::{FileUpdateChange, ThreadItem},
     protocol::ThreadItem as AppServerThreadItem,
 };
-use shared::fmt::format_duration;
 use uuid::Uuid;
 use yew::prelude::*;
 
 mod events;
 mod tools;
+mod turns;
 #[cfg(test)]
 use events::thread_item_id;
+#[cfg(test)]
+use events::CodexUsage;
 pub use events::{codex_event_item_id, is_codex_terminal_event, CodexEvent, CodexItem};
-use events::{CodexError, CodexUsage, ContextCompactedParams, TurnPlanStep};
+use events::{ContextCompactedParams, TurnPlanStep};
 use tools::{
     render_collab_agent_tool_call, render_command_execution, render_diff_card, render_file_change,
     render_mcp_tool_call, render_todo_list, render_web_search,
 };
+use turns::{render_turn_completed, render_turn_failed};
 
 /// Render a parsed Codex frame as a standalone message card.
 pub fn render_codex_frame(
@@ -191,144 +194,6 @@ fn render_reasoning(text: &str, completed: bool) -> Html {
                     <div class="thinking-content">{ text }</div>
                 </div>
             </div>
-        </div>
-    }
-}
-
-fn render_turn_completed(
-    usage: Option<&CodexUsage>,
-    duration_ms: Option<u64>,
-    turn_id: Option<&str>,
-    status: Option<&str>,
-    turn_metrics: Option<&shared::TurnMetrics>,
-) -> Html {
-    let input = usage.map(CodexUsage::input_tokens).unwrap_or(0);
-    let output = usage.map(CodexUsage::output_tokens).unwrap_or(0);
-    let cached = usage.map(CodexUsage::cached_input_tokens).unwrap_or(0);
-    let reasoning = usage.map(CodexUsage::reasoning_output_tokens).unwrap_or(0);
-    let total = usage.map(CodexUsage::total_tokens).unwrap_or(0);
-    let thread_total = usage.and_then(CodexUsage::thread_total_tokens);
-    let context_window = usage.and_then(|u| u.model_context_window);
-
-    let mut tooltip = format!(
-        "Input: {} | Output: {} | Cached: {} | Reasoning: {} | Total: {}",
-        input, output, cached, reasoning, total
-    );
-    if let Some(thread_total) = thread_total {
-        tooltip.push_str(&format!(" | Thread total: {}", thread_total));
-    }
-    if let Some(context_window) = context_window {
-        tooltip.push_str(&format!(" | Context window: {}", context_window));
-    }
-    let status_title = turn_id.unwrap_or("Codex turn").to_string();
-
-    // Per-turn metrics footer (PR 2 of N). Same shape as the Claude
-    // `result-message` footer — see
-    // `crate::components::message_renderer::turn_metrics_footer`. For Codex,
-    // the cost chip universally drops (no per-turn cost on the wire today)
-    // and the cache-hit-% chip universally drops (no cache breakdown on the
-    // wire today); the chips that do render are tok/s, TTFT, tokens-in/out
-    // (and max gap when > 1s).
-    let metrics_footer =
-        crate::components::message_renderer::turn_metrics_footer::render_turn_metrics_footer(
-            turn_metrics,
-        );
-
-    html! {
-        <div class="claude-message result-message success">
-            <div class="result-stats-bar">
-                <span class="result-status success">{ "\u{2713}" }</span>
-                <span class="result-done-label success">{ "completed" }</span>
-                {
-                    if let Some(ms) = duration_ms {
-                        html! {
-                            <span class="stat-item duration" title="Turn duration">
-                                { format_duration(ms) }
-                            </span>
-                        }
-                    } else {
-                        html! {}
-                    }
-                }
-                {
-                    if input > 0 || output > 0 || cached > 0 || reasoning > 0 {
-                        html! {
-                            <>
-                                <span class="stat-item tokens" title={tooltip}>
-                                    { format!("{}\u{2193} {}\u{2191}", input, output) }
-                                </span>
-                                if cached > 0 {
-                                    <span class="stat-item tokens" title="Cached input tokens">
-                                        { format!("{} cached", cached) }
-                                    </span>
-                                }
-                                if reasoning > 0 {
-                                    <span class="stat-item tokens" title="Reasoning output tokens">
-                                        { format!("{} reasoning", reasoning) }
-                                    </span>
-                                }
-                            </>
-                        }
-                    } else {
-                        html! {}
-                    }
-                }
-                {
-                    if let (Some(thread_total), Some(context_window)) = (thread_total, context_window) {
-                        html! {
-                            <span class="stat-item turns" title="Thread tokens / model context window">
-                                { format!("{} / {} ctx", thread_total, context_window) }
-                            </span>
-                        }
-                    } else {
-                        html! {}
-                    }
-                }
-                {
-                    // The `✓ completed` label already conveys a normal finish;
-                    // only surface the raw status when it says something else
-                    // (a non-"completed" stop reason), so it isn't shown twice.
-                    if let Some(status) = status.filter(|s| !s.eq_ignore_ascii_case("completed")) {
-                        html! {
-                            <span class="stat-item stop-reason" title={status_title.clone()}>
-                                { status }
-                            </span>
-                        }
-                    } else {
-                        html! {}
-                    }
-                }
-            </div>
-            { metrics_footer }
-        </div>
-    }
-}
-
-fn render_turn_failed(
-    error: Option<&CodexError>,
-    turn_metrics: Option<&shared::TurnMetrics>,
-) -> Html {
-    let message = error
-        .and_then(|e| e.message.as_deref())
-        .unwrap_or("Turn failed");
-
-    // Even a failed turn carries useful metrics (TTFT before the failure,
-    // tokens consumed, stream_restarts on retried-and-still-failed rate
-    // limits, etc.) — render the footer if we have a row for it.
-    let metrics_footer =
-        crate::components::message_renderer::turn_metrics_footer::render_turn_metrics_footer(
-            turn_metrics,
-        );
-
-    html! {
-        <div class="claude-message error-message-display">
-            <div class="message-header">
-                <span class="message-type-badge result error">{ "Turn Failed" }</span>
-            </div>
-            <div class="message-body">
-                <div class="error-text">{ message }</div>
-            </div>
-            { metrics_footer }
         </div>
     }
 }

--- a/frontend/src/components/codex_renderer/turns.rs
+++ b/frontend/src/components/codex_renderer/turns.rs
@@ -1,0 +1,141 @@
+use super::events::{CodexError, CodexUsage};
+use shared::fmt::format_duration;
+use yew::prelude::*;
+
+pub(super) fn render_turn_completed(
+    usage: Option<&CodexUsage>,
+    duration_ms: Option<u64>,
+    turn_id: Option<&str>,
+    status: Option<&str>,
+    turn_metrics: Option<&shared::TurnMetrics>,
+) -> Html {
+    let input = usage.map(CodexUsage::input_tokens).unwrap_or(0);
+    let output = usage.map(CodexUsage::output_tokens).unwrap_or(0);
+    let cached = usage.map(CodexUsage::cached_input_tokens).unwrap_or(0);
+    let reasoning = usage.map(CodexUsage::reasoning_output_tokens).unwrap_or(0);
+    let total = usage.map(CodexUsage::total_tokens).unwrap_or(0);
+    let thread_total = usage.and_then(CodexUsage::thread_total_tokens);
+    let context_window = usage.and_then(|u| u.model_context_window);
+
+    let mut tooltip = format!(
+        "Input: {} | Output: {} | Cached: {} | Reasoning: {} | Total: {}",
+        input, output, cached, reasoning, total
+    );
+    if let Some(thread_total) = thread_total {
+        tooltip.push_str(&format!(" | Thread total: {}", thread_total));
+    }
+    if let Some(context_window) = context_window {
+        tooltip.push_str(&format!(" | Context window: {}", context_window));
+    }
+    let status_title = turn_id.unwrap_or("Codex turn").to_string();
+
+    // Per-turn metrics footer (PR 2 of N). Same shape as the Claude
+    // `result-message` footer — see
+    // `crate::components::message_renderer::turn_metrics_footer`. For Codex,
+    // the cost chip universally drops (no per-turn cost on the wire today)
+    // and the cache-hit-% chip universally drops (no cache breakdown on the
+    // wire today); the chips that do render are tok/s, TTFT, tokens-in/out
+    // (and max gap when > 1s).
+    let metrics_footer =
+        crate::components::message_renderer::turn_metrics_footer::render_turn_metrics_footer(
+            turn_metrics,
+        );
+
+    html! {
+        <div class="claude-message result-message success">
+            <div class="result-stats-bar">
+                <span class="result-status success">{ "\u{2713}" }</span>
+                <span class="result-done-label success">{ "completed" }</span>
+                {
+                    if let Some(ms) = duration_ms {
+                        html! {
+                            <span class="stat-item duration" title="Turn duration">
+                                { format_duration(ms) }
+                            </span>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
+                    if input > 0 || output > 0 || cached > 0 || reasoning > 0 {
+                        html! {
+                            <>
+                                <span class="stat-item tokens" title={tooltip}>
+                                    { format!("{}\u{2193} {}\u{2191}", input, output) }
+                                </span>
+                                if cached > 0 {
+                                    <span class="stat-item tokens" title="Cached input tokens">
+                                        { format!("{} cached", cached) }
+                                    </span>
+                                }
+                                if reasoning > 0 {
+                                    <span class="stat-item tokens" title="Reasoning output tokens">
+                                        { format!("{} reasoning", reasoning) }
+                                    </span>
+                                }
+                            </>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
+                    if let (Some(thread_total), Some(context_window)) = (thread_total, context_window) {
+                        html! {
+                            <span class="stat-item turns" title="Thread tokens / model context window">
+                                { format!("{} / {} ctx", thread_total, context_window) }
+                            </span>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
+                {
+                    // The `✓ completed` label already conveys a normal finish;
+                    // only surface the raw status when it says something else
+                    // (a non-"completed" stop reason), so it isn't shown twice.
+                    if let Some(status) = status.filter(|s| !s.eq_ignore_ascii_case("completed")) {
+                        html! {
+                            <span class="stat-item stop-reason" title={status_title.clone()}>
+                                { status }
+                            </span>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
+            </div>
+            { metrics_footer }
+        </div>
+    }
+}
+
+pub(super) fn render_turn_failed(
+    error: Option<&CodexError>,
+    turn_metrics: Option<&shared::TurnMetrics>,
+) -> Html {
+    let message = error
+        .and_then(|e| e.message.as_deref())
+        .unwrap_or("Turn failed");
+
+    // Even a failed turn carries useful metrics (TTFT before the failure,
+    // tokens consumed, stream_restarts on retried-and-still-failed rate
+    // limits, etc.) — render the footer if we have a row for it.
+    let metrics_footer =
+        crate::components::message_renderer::turn_metrics_footer::render_turn_metrics_footer(
+            turn_metrics,
+        );
+
+    html! {
+        <div class="claude-message error-message-display">
+            <div class="message-header">
+                <span class="message-type-badge result error">{ "Turn Failed" }</span>
+            </div>
+            <div class="message-body">
+                <div class="error-text">{ message }</div>
+            </div>
+            { metrics_footer }
+        </div>
+    }
+}


### PR DESCRIPTION
## Summary
- extract Codex turn-completed and turn-failed renderers into codex_renderer/turns.rs
- keep CodexEvent dispatch and item rendering behavior unchanged
- bump workspace version to 2.12.79

## Verification
- cargo fmt --check
- cargo check -p frontend
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings