### PR TITLE
refactor: extract codex message renderers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.79"
+version = "2.12.80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.79"
+version = "2.12.80"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.79"
+version = "2.12.80"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.79"
+version = "2.12.80"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.79"
+version = "2.12.80"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.79"
+version = "2.12.80"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.79"
+version = "2.12.80"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.79"
+version = "2.12.80"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.79"
+version = "2.12.80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.79"
+version = "2.12.80"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.79"
+version = "2.12.80"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -1,4 +1,3 @@
-use super::markdown::render_markdown_for_session;
 use codex_codes::{
     io::items::{FileUpdateChange, ThreadItem},
     protocol::ThreadItem as AppServerThreadItem,
@@ -7,6 +6,7 @@ use uuid::Uuid;
 use yew::prelude::*;
 
 mod events;
+mod messages;
 mod tools;
 mod turns;
 #[cfg(test)]
@@ -15,6 +15,9 @@ use events::thread_item_id;
 use events::CodexUsage;
 pub use events::{codex_event_item_id, is_codex_terminal_event, CodexEvent, CodexItem};
 use events::{ContextCompactedParams, TurnPlanStep};
+use messages::{
+    render_agent_message, render_agent_message_content, render_error_block, render_reasoning,
+};
 use tools::{
     render_collab_agent_tool_call, render_command_execution, render_diff_card, render_file_change,
     render_mcp_tool_call, render_todo_list, render_web_search,
@@ -155,60 +158,6 @@ fn render_item(item: Option<&CodexItem>, completed: bool, session_id: Uuid) -> H
             completed,
         ),
         CodexItem::AppServer(_) => html! {},
-    }
-}
-
-fn render_agent_message(text: &str, completed: bool, session_id: Uuid) -> Html {
-    if text.is_empty() {
-        return html! {};
-    }
-    let class = item_card_classes(completed);
-    html! {
-        <div class={class}>
-            <div class="message-header">
-                <span class="message-type-badge assistant">{ "Codex" }</span>
-            </div>
-            <div class="message-body">{ render_agent_message_content(text, session_id) }</div>
-        </div>
-    }
-}
-
-fn render_agent_message_content(text: &str, session_id: Uuid) -> Html {
-    if text.is_empty() {
-        html! {}
-    } else {
-        html! { <div class="assistant-text">{ render_markdown_for_session(text, session_id) }</div> }
-    }
-}
-
-fn render_reasoning(text: &str, completed: bool) -> Html {
-    if text.is_empty() {
-        return html! {};
-    }
-    let class = item_card_classes(completed);
-    html! {
-        <div class={class}>
-            <div class="message-body">
-                <div class="thinking-block">
-                    <span class="thinking-label">{ "reasoning" }</span>
-                    <div class="thinking-content">{ text }</div>
-                </div>
-            </div>
-        </div>
-    }
-}
-
-fn render_error_block(message: Option<&str>) -> Html {
-    let message = message.unwrap_or("Unknown error");
-    html! {
-        <div class="claude-message error-message-display">
-            <div class="message-header">
-                <span class="message-type-badge result error">{ "Error" }</span>
-            </div>
-            <div class="message-body">
-                <div class="error-text">{ message }</div>
-            </div>
-        </div>
     }
 }
 

--- a/frontend/src/components/codex_renderer/messages.rs
+++ b/frontend/src/components/codex_renderer/messages.rs
@@ -1,0 +1,58 @@
+use super::item_card_classes;
+use crate::components::markdown::render_markdown_for_session;
+use uuid::Uuid;
+use yew::prelude::*;
+
+pub(super) fn render_agent_message(text: &str, completed: bool, session_id: Uuid) -> Html {
+    if text.is_empty() {
+        return html! {};
+    }
+    let class = item_card_classes(completed);
+    html! {
+        <div class={class}>
+            <div class="message-header">
+                <span class="message-type-badge assistant">{ "Codex" }</span>
+            </div>
+            <div class="message-body">{ render_agent_message_content(text, session_id) }</div>
+        </div>
+    }
+}
+
+pub(super) fn render_agent_message_content(text: &str, session_id: Uuid) -> Html {
+    if text.is_empty() {
+        html! {}
+    } else {
+        html! { <div class="assistant-text">{ render_markdown_for_session(text, session_id) }</div> }
+    }
+}
+
+pub(super) fn render_reasoning(text: &str, completed: bool) -> Html {
+    if text.is_empty() {
+        return html! {};
+    }
+    let class = item_card_classes(completed);
+    html! {
+        <div class={class}>
+            <div class="message-body">
+                <div class="thinking-block">
+                    <span class="thinking-label">{ "reasoning" }</span>
+                    <div class="thinking-content">{ text }</div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+pub(super) fn render_error_block(message: Option<&str>) -> Html {
+    let message = message.unwrap_or("Unknown error");
+    html! {
+        <div class="claude-message error-message-display">
+            <div class="message-header">
+                <span class="message-type-badge result error">{ "Error" }</span>
+            </div>
+            <div class="message-body">
+                <div class="error-text">{ message }</div>
+            </div>
+        </div>
+    }
+}


### PR DESCRIPTION
## Summary
- extract Codex agent-message, reasoning, and error-block renderers into codex_renderer/messages.rs
- keep CodexEvent dispatch and tool rendering unchanged
- bump workspace version to 2.12.80

## Verification
- cargo fmt --check
- cargo check -p frontend
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings