### PR TITLE
refactor: Session owns its AgentAdapter via Agent::adapter() (#1165 item 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.80"
+version = "2.12.81"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.80"
+version = "2.12.81"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.80"
+version = "2.12.81"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.80"
+version = "2.12.81"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.80"
+version = "2.12.81"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.80"
+version = "2.12.81"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.80"
+version = "2.12.81"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.80"
+version = "2.12.81"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.80"
+version = "2.12.81"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.80"
+version = "2.12.81"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.80"
+version = "2.12.81"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/agent.rs
+++ b/claude-session-lib/src/agent.rs
@@ -1,6 +1,7 @@
 //! `ClaudeAgent`: the [`session_lib::Agent`] implementation for the `claude`
 //! CLI. Construct `Session<ClaudeAgent>` to get a Claude-backed session.
 
+use session_lib::adapter::{AgentAdapter, ClaudeAdapter};
 use session_lib::agent::Agent;
 use session_lib::error::SessionError;
 use session_lib::io::{IoCommand, IoEvent};
@@ -38,5 +39,10 @@ impl Agent for ClaudeAgent {
             claude_io_task(session_id, client, command_rx, event_tx).await;
         });
         Ok(handle)
+    }
+
+    /// Claude classifies its stdout through the stateless [`ClaudeAdapter`].
+    fn adapter() -> Option<Box<dyn AgentAdapter>> {
+        Some(Box::new(ClaudeAdapter))
     }
 }

--- a/session-lib/src/adapter.rs
+++ b/session-lib/src/adapter.rs
@@ -65,7 +65,11 @@ pub struct PermissionDecision {
 /// The adapter owns all concrete-protocol knowledge. `Session` only ever sees
 /// neutral [`AgentOutput`] / [`PermissionDecision`] and opaque
 /// [`TransportPayload`]s.
-pub trait AgentAdapter: Send + 'static {
+// `Sync` so `Session<A>`, which stores `Box<dyn AgentAdapter>`, stays `Sync`
+// for consumers that share a session across threads (the launcher holds
+// sessions in shared state). Adapters are stateless today; any future stateful
+// adapter must use interior mutability that is itself `Sync`.
+pub trait AgentAdapter: Send + Sync + 'static {
     /// Parse + classify one unit of agent stdout into 0..n neutral decisions.
     ///
     /// `&mut self` so future stateful adapters (e.g. codex, which threads a

--- a/session-lib/src/agent.rs
+++ b/session-lib/src/agent.rs
@@ -9,6 +9,7 @@
 
 use tokio::sync::mpsc;
 
+use crate::adapter::AgentAdapter;
 use crate::error::SessionError;
 use crate::io::{IoCommand, IoEvent};
 use crate::snapshot::SessionConfig;
@@ -27,4 +28,17 @@ pub trait Agent: Send + Sync + 'static {
         command_rx: mpsc::UnboundedReceiver<IoCommand>,
         event_tx: mpsc::UnboundedSender<IoEvent>,
     ) -> Result<tokio::task::JoinHandle<()>, SessionError>;
+
+    /// The protocol adapter that classifies this agent's stdout into neutral
+    /// [`AgentOutput`](crate::adapter::AgentOutput) decisions. `Session::next_event`
+    /// calls it on each `IoEvent::Output` unit instead of hardcoding a concrete
+    /// adapter (#1165 item 2).
+    ///
+    /// Defaults to `None`: an agent that doesn't yet route through the adapter
+    /// (the Codex path still pre-classifies into `IoEvent::RawOutput` /
+    /// `IoEvent::CodexPermissionRequest` and never emits `IoEvent::Output`)
+    /// opts out, and `Session` forwards any stray `Output` verbatim.
+    fn adapter() -> Option<Box<dyn AgentAdapter>> {
+        None
+    }
 }

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -12,7 +12,7 @@ use claude_codes::ClaudeInput;
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
-use crate::adapter::{AgentAdapter, AgentOutput, ClaudeAdapter};
+use crate::adapter::{AgentAdapter, AgentOutput};
 use crate::agent::Agent;
 use crate::buffer::OutputBuffer;
 use crate::error::SessionError;
@@ -55,6 +55,10 @@ pub struct Session<A: Agent> {
     /// `kill_on_drop` doesn't fire when the SDK keeps the child alive in
     /// detached tasks (#927).
     agent_pid: Option<u32>,
+    /// Per-agent protocol adapter, supplied by `A::adapter()`. `next_event`
+    /// drives it to classify each `IoEvent::Output` unit. `None` for agents
+    /// that pre-classify their output (Codex today); see [`Agent::adapter`].
+    adapter: Option<Box<dyn AgentAdapter>>,
     _agent: PhantomData<A>,
 }
 
@@ -141,6 +145,7 @@ impl<A: Agent> Session<A> {
             event_rx: Some(event_rx),
             io_task: Some(handle),
             agent_pid: None,
+            adapter: A::adapter(),
             _agent: PhantomData,
         })
     }
@@ -182,6 +187,7 @@ impl<A: Agent> Session<A> {
             event_rx,
             io_task,
             agent_pid: None,
+            adapter: A::adapter(),
             _agent: PhantomData,
         })
     }
@@ -237,12 +243,20 @@ impl<A: Agent> Session<A> {
                     let output_value = serde_json::to_value(&output).unwrap_or_default();
                     self.buffer.push(output_value.clone());
 
-                    // Delegate protocol classification to the agent adapter. Claude
-                    // is 1:1 (one raw unit → one decision) but handle the Vec
-                    // generally so the loop matches the trait contract.
-                    let mut adapter = ClaudeAdapter;
+                    // Delegate protocol classification to the agent's adapter
+                    // (`A::adapter()`). Claude is 1:1 (one raw unit → one
+                    // decision) but handle the Vec generally so the loop matches
+                    // the trait contract. Collect first so the `&mut adapter`
+                    // borrow ends before the loop mutates other `self` fields.
+                    let decisions = match self.adapter.as_mut() {
+                        Some(adapter) => adapter.classify(output_value),
+                        // Agents without an adapter (Codex today) never emit
+                        // `IoEvent::Output` — they pre-classify upstream. Forward
+                        // any stray unit verbatim so output is never dropped.
+                        None => vec![AgentOutput::Visible(output_value)],
+                    };
                     let mut visible = false;
-                    for decision in adapter.classify(output_value) {
+                    for decision in decisions {
                         match decision {
                             AgentOutput::NotFound => {
                                 self.state = SessionState::Exited { code: 1 };


### PR DESCRIPTION
## #1165 item 2 — AgentAdapter campaign, slice 1 (backend/session-lib)

Removes the hardcoded `ClaudeAdapter` from `Session::next_event`. The generic `Session<A>` core was committing to a concrete protocol adapter (`let mut adapter = ClaudeAdapter;`), which is exactly the coupling that blocks the Codex side from routing through the same path.

### Change
- **`Agent` trait** gains a defaulted hook: `fn adapter() -> Option<Box<dyn AgentAdapter>> { None }`.
- **`Session<A>`** stores `A::adapter()` and drives it from the `IoEvent::Output` arm (decisions collected first so the `&mut` borrow ends before the loop mutates other `self` fields).
- **`ClaudeAgent`** returns `Some(Box::new(ClaudeAdapter))`.
- The `None` default covers agents that pre-classify upstream — the Codex path emits `IoEvent::RawOutput` / `IoEvent::CodexPermissionRequest` and never hits the classify arm; a stray `Output` is forwarded verbatim (never dropped).

### Why this slice
Behavior-preserving and Claude-only — classification logic is byte-for-byte unchanged, just sourced from the agent backend instead of a literal. This is the keystone that lets a future `CodexAdapter` (next slice) plug into the same generic loop instead of the bespoke `codex_io_task`/`handle_codex_server_message` path.

### Verification
- `cargo build -p session-lib -p claude-session-lib -p codex-session-lib -p backend` ✓
- `cargo test -p session-lib` (29) + `cargo test -p claude-session-lib` (34) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)