### PR TITLE
refactor: extract codex patch renderers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.81"
+version = "2.12.82"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.81"
+version = "2.12.82"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.81"
+version = "2.12.82"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.81"
+version = "2.12.82"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.81"
+version = "2.12.82"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.81"
+version = "2.12.82"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.81"
+version = "2.12.82"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.81"
+version = "2.12.82"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.81"
+version = "2.12.82"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.81"
+version = "2.12.82"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.81"
+version = "2.12.82"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -1,12 +1,10 @@
-use codex_codes::{
-    io::items::{FileUpdateChange, ThreadItem},
-    protocol::ThreadItem as AppServerThreadItem,
-};
+use codex_codes::{io::items::ThreadItem, protocol::ThreadItem as AppServerThreadItem};
 use uuid::Uuid;
 use yew::prelude::*;
 
 mod events;
 mod messages;
+mod patch;
 mod tools;
 mod turns;
 #[cfg(test)]
@@ -18,9 +16,10 @@ use events::{ContextCompactedParams, TurnPlanStep};
 use messages::{
     render_agent_message, render_agent_message_content, render_error_block, render_reasoning,
 };
+use patch::{render_file_change, render_file_change_patch};
 use tools::{
-    render_collab_agent_tool_call, render_command_execution, render_diff_card, render_file_change,
-    render_mcp_tool_call, render_todo_list, render_web_search,
+    render_collab_agent_tool_call, render_command_execution, render_mcp_tool_call,
+    render_todo_list, render_web_search,
 };
 use turns::{render_turn_completed, render_turn_failed};
 
@@ -158,25 +157,6 @@ fn render_item(item: Option<&CodexItem>, completed: bool, session_id: Uuid) -> H
             completed,
         ),
         CodexItem::AppServer(_) => html! {},
-    }
-}
-
-fn render_file_change_patch(changes: Option<&[FileUpdateChange]>) -> Html {
-    let changes = changes.unwrap_or(&[]);
-    let cards: Vec<Html> = changes
-        .iter()
-        .filter(|c| !c.diff.trim().is_empty())
-        .map(render_diff_card)
-        .collect();
-    if cards.is_empty() {
-        return html! {};
-    }
-    html! {
-        <div class="claude-message assistant-message">
-            <div class="message-body">
-                { for cards.into_iter() }
-            </div>
-        </div>
     }
 }
 

--- a/frontend/src/components/codex_renderer/patch.rs
+++ b/frontend/src/components/codex_renderer/patch.rs
@@ -1,0 +1,91 @@
+use super::tools::tool_card;
+use crate::components::diff::{DiffCard, DiffSource};
+use codex_codes::io::items::{FileChangeItem, FileUpdateChange, PatchApplyStatus, PatchChangeKind};
+use yew::prelude::*;
+
+fn patch_status_label(status: &PatchApplyStatus) -> &'static str {
+    match status {
+        PatchApplyStatus::InProgress => "in progress",
+        PatchApplyStatus::Completed => "completed",
+        PatchApplyStatus::Failed => "failed",
+        PatchApplyStatus::Declined => "declined",
+    }
+}
+
+/// Tagged-enum `PatchChangeKind` to a CSS suffix that pairs with the existing
+/// `.diff-card-kind.{add,update,delete}` styles from #823's unified DiffCard.
+fn patch_kind_css(kind: &PatchChangeKind) -> &'static str {
+    match kind {
+        PatchChangeKind::Add => "add",
+        PatchChangeKind::Delete => "delete",
+        PatchChangeKind::Update { .. } => "update",
+    }
+}
+
+pub(super) fn render_file_change(it: &FileChangeItem, completed: bool) -> Html {
+    if it.changes.is_empty() {
+        return html! {};
+    }
+    let status_label = patch_status_label(&it.status).to_string();
+    // Closes #827 part 2 — render the actual diff bodies through the unified
+    // `<DiffCard>` from #823 instead of just chip + path. Each per-file
+    // change becomes its own framed card with kind chip + path + diff body,
+    // matching the layout of `render_file_change_patch`.
+    let body = html! {
+        <>
+            { for it.changes.iter().map(render_diff_card) }
+        </>
+    };
+    tool_card(
+        "\u{1f4dd}",
+        "File Changes".into(),
+        Some(html! { { status_label } }),
+        body,
+        completed,
+    )
+}
+
+pub(super) fn render_file_change_patch(changes: Option<&[FileUpdateChange]>) -> Html {
+    let changes = changes.unwrap_or(&[]);
+    let cards: Vec<Html> = changes
+        .iter()
+        .filter(|c| !c.diff.trim().is_empty())
+        .map(render_diff_card)
+        .collect();
+    if cards.is_empty() {
+        return html! {};
+    }
+    html! {
+        <div class="claude-message assistant-message">
+            <div class="message-body">
+                { for cards.into_iter() }
+            </div>
+        </div>
+    }
+}
+
+/// Render one `FileUpdateChange` through the shared `<DiffCard>`. Returns
+/// the bare path + kind chip (without a diff body) for empty-diff entries
+/// — `item.started{file_change}` events typically carry the diff text
+/// already, but a defensive empty-diff path still shows the file path.
+fn render_diff_card(c: &FileUpdateChange) -> Html {
+    let kind_css = AttrValue::from(patch_kind_css(&c.kind));
+    let path = AttrValue::from(c.path.clone());
+    if c.diff.trim().is_empty() {
+        return html! {
+            <div class="diff-card">
+                <div class="diff-card-header">
+                    <span class="tool-icon">{ "\u{1f4dd}" }</span>
+                    <span class={classes!("diff-card-kind", kind_css.to_string())}>{ kind_css.clone() }</span>
+                    <span class="diff-card-path">{ path }</span>
+                </div>
+            </div>
+        };
+    }
+    let source = DiffSource::Unified {
+        text: c.diff.clone(),
+    };
+    html! {
+        <DiffCard {source} file_path={path} kind={kind_css} />
+    }
+}

--- a/frontend/src/components/codex_renderer/tools.rs
+++ b/frontend/src/components/codex_renderer/tools.rs
@@ -1,9 +1,7 @@
 use super::item_card_classes;
-use crate::components::diff::{DiffCard, DiffSource};
 use crate::components::expandable::ExpandableText;
 use codex_codes::io::items::{
-    CommandExecutionItem, CommandExecutionStatus, FileChangeItem, FileUpdateChange,
-    McpToolCallItem, McpToolCallStatus, PatchApplyStatus, PatchChangeKind, TodoItem,
+    CommandExecutionItem, CommandExecutionStatus, McpToolCallItem, McpToolCallStatus, TodoItem,
 };
 use codex_codes::protocol::{CollabAgentState, ReasoningEffort};
 use serde_json::Value;
@@ -15,7 +13,13 @@ use yew::prelude::*;
 /// and a tool-use-header with icon + name + optional `status` meta line.
 /// Returns `html! {}` when `body` is empty so callers can short-circuit
 /// empty-data cases by handing in a no-op body.
-fn tool_card(icon: &str, name: String, status: Option<Html>, body: Html, completed: bool) -> Html {
+pub(super) fn tool_card(
+    icon: &str,
+    name: String,
+    status: Option<Html>,
+    body: Html,
+    completed: bool,
+) -> Html {
     html! {
         <div class={item_card_classes(completed)}>
             <div class="message-body">
@@ -112,74 +116,6 @@ pub(super) fn render_command_execution(it: &CommandExecutionItem, completed: boo
 
     let status = command_status_meta(it, completed);
     tool_card("$", "Bash".into(), Some(status), body, completed)
-}
-
-fn patch_status_label(status: &PatchApplyStatus) -> &'static str {
-    match status {
-        PatchApplyStatus::InProgress => "in progress",
-        PatchApplyStatus::Completed => "completed",
-        PatchApplyStatus::Failed => "failed",
-        PatchApplyStatus::Declined => "declined",
-    }
-}
-
-/// Tagged-enum `PatchChangeKind` to a CSS suffix that pairs with the existing
-/// `.diff-card-kind.{add,update,delete}` styles from #823's unified DiffCard.
-fn patch_kind_css(kind: &PatchChangeKind) -> &'static str {
-    match kind {
-        PatchChangeKind::Add => "add",
-        PatchChangeKind::Delete => "delete",
-        PatchChangeKind::Update { .. } => "update",
-    }
-}
-
-pub(super) fn render_file_change(it: &FileChangeItem, completed: bool) -> Html {
-    if it.changes.is_empty() {
-        return html! {};
-    }
-    let status_label = patch_status_label(&it.status).to_string();
-    // Closes #827 part 2 — render the actual diff bodies through the unified
-    // `<DiffCard>` from #823 instead of just chip + path. Each per-file
-    // change becomes its own framed card with kind chip + path + diff body,
-    // matching the layout of `render_file_change_patch`.
-    let body = html! {
-        <>
-            { for it.changes.iter().map(render_diff_card) }
-        </>
-    };
-    tool_card(
-        "\u{1f4dd}",
-        "File Changes".into(),
-        Some(html! { { status_label } }),
-        body,
-        completed,
-    )
-}
-
-/// Render one `FileUpdateChange` through the shared `<DiffCard>`. Returns
-/// the bare path + kind chip (without a diff body) for empty-diff entries
-/// — `item.started{file_change}` events typically carry the diff text
-/// already, but a defensive empty-diff path still shows the file path.
-pub(super) fn render_diff_card(c: &FileUpdateChange) -> Html {
-    let kind_css = AttrValue::from(patch_kind_css(&c.kind));
-    let path = AttrValue::from(c.path.clone());
-    if c.diff.trim().is_empty() {
-        return html! {
-            <div class="diff-card">
-                <div class="diff-card-header">
-                    <span class="tool-icon">{ "\u{1f4dd}" }</span>
-                    <span class={classes!("diff-card-kind", kind_css.to_string())}>{ kind_css.clone() }</span>
-                    <span class="diff-card-path">{ path }</span>
-                </div>
-            </div>
-        };
-    }
-    let source = DiffSource::Unified {
-        text: c.diff.clone(),
-    };
-    html! {
-        <DiffCard {source} file_path={path} kind={kind_css} />
-    }
 }
 
 pub(super) fn render_mcp_tool_call(it: &McpToolCallItem, completed: bool) -> Html {


### PR DESCRIPTION
## Summary
- move Codex file-change and patch diff rendering into a dedicated codex_renderer/patch.rs module
- keep the root renderer as dispatch only for patch events and file-change items
- share the existing tool-card chrome from tools.rs without changing rendering behavior
- bump workspace version to 2.12.82

## Verification
- cargo fmt --check
- cargo check -p frontend
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings

Note: intended to merge after #1181 (2.12.81); this PR uses 2.12.82.