### PR TITLE
refactor: split codex tool renderers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.82"
+version = "2.12.83"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.82"
+version = "2.12.83"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.82"
+version = "2.12.83"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.82"
+version = "2.12.83"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.82"
+version = "2.12.83"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.82"
+version = "2.12.83"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.82"
+version = "2.12.83"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.82"
+version = "2.12.83"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.82"
+version = "2.12.83"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.82"
+version = "2.12.83"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.82"
+version = "2.12.83"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -5,7 +5,8 @@ use yew::prelude::*;
 mod events;
 mod messages;
 mod patch;
-mod tools;
+mod tool_calls;
+mod tool_card;
 mod turns;
 #[cfg(test)]
 use events::thread_item_id;
@@ -17,7 +18,7 @@ use messages::{
     render_agent_message, render_agent_message_content, render_error_block, render_reasoning,
 };
 use patch::{render_file_change, render_file_change_patch};
-use tools::{
+use tool_calls::{
     render_collab_agent_tool_call, render_command_execution, render_mcp_tool_call,
     render_todo_list, render_web_search,
 };

--- a/frontend/src/components/codex_renderer/patch.rs
+++ b/frontend/src/components/codex_renderer/patch.rs
@@ -1,4 +1,4 @@
-use super::tools::tool_card;
+use super::tool_card::tool_card;
 use crate::components::diff::{DiffCard, DiffSource};
 use codex_codes::io::items::{FileChangeItem, FileUpdateChange, PatchApplyStatus, PatchChangeKind};
 use yew::prelude::*;

--- a/frontend/src/components/codex_renderer/tool_calls.rs
+++ b/frontend/src/components/codex_renderer/tool_calls.rs
@@ -1,4 +1,4 @@
-use super::item_card_classes;
+use super::tool_card::tool_card;
 use crate::components::expandable::ExpandableText;
 use codex_codes::io::items::{
     CommandExecutionItem, CommandExecutionStatus, McpToolCallItem, McpToolCallStatus, TodoItem,
@@ -7,38 +7,6 @@ use codex_codes::protocol::{CollabAgentState, ReasoningEffort};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use yew::prelude::*;
-
-/// Wraps a per-variant body in the standard tool-style card chrome:
-/// card wrapper (with in-progress styling), message-body, tool-use-section,
-/// and a tool-use-header with icon + name + optional `status` meta line.
-/// Returns `html! {}` when `body` is empty so callers can short-circuit
-/// empty-data cases by handing in a no-op body.
-pub(super) fn tool_card(
-    icon: &str,
-    name: String,
-    status: Option<Html>,
-    body: Html,
-    completed: bool,
-) -> Html {
-    html! {
-        <div class={item_card_classes(completed)}>
-            <div class="message-body">
-                <div class="tool-use-section">
-                    <div class="tool-use-header">
-                        <span class="tool-icon">{ icon }</span>
-                        <span class="tool-name">{ name }</span>
-                        { if let Some(s) = status {
-                            html! { <span class="tool-meta">{ s }</span> }
-                        } else {
-                            html! {}
-                        } }
-                    </div>
-                    { body }
-                </div>
-            </div>
-        </div>
-    }
-}
 
 /// Build the command-execution status meta: an outcome-colored label
 /// (palette: `--success` / `--error` / `--warning`) with a ✓/✗ glyph that

--- a/frontend/src/components/codex_renderer/tool_card.rs
+++ b/frontend/src/components/codex_renderer/tool_card.rs
@@ -1,0 +1,34 @@
+use super::item_card_classes;
+use yew::prelude::*;
+
+/// Wraps a per-variant body in the standard tool-style card chrome:
+/// card wrapper (with in-progress styling), message-body, tool-use-section,
+/// and a tool-use-header with icon + name + optional `status` meta line.
+/// Returns `html! {}` when `body` is empty so callers can short-circuit
+/// empty-data cases by handing in a no-op body.
+pub(super) fn tool_card(
+    icon: &str,
+    name: String,
+    status: Option<Html>,
+    body: Html,
+    completed: bool,
+) -> Html {
+    html! {
+        <div class={item_card_classes(completed)}>
+            <div class="message-body">
+                <div class="tool-use-section">
+                    <div class="tool-use-header">
+                        <span class="tool-icon">{ icon }</span>
+                        <span class="tool-name">{ name }</span>
+                        { if let Some(s) = status {
+                            html! { <span class="tool-meta">{ s }</span> }
+                        } else {
+                            html! {}
+                        } }
+                    </div>
+                    { body }
+                </div>
+            </div>
+        </div>
+    }
+}


### PR DESCRIPTION
## Summary
- split Codex tool-call renderers into codex_renderer/tool_calls.rs
- move shared tool-card chrome into codex_renderer/tool_card.rs for patch + tool-call reuse
- keep render dispatch and behavior unchanged
- bump workspace version to 2.12.83

## Verification
- cargo fmt --check
- cargo check -p frontend
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings