### PR TITLE
refactor: extract codex lifecycle renderers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.83"
+version = "2.12.84"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.83"
+version = "2.12.84"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.83"
+version = "2.12.84"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.83"
+version = "2.12.84"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.83"
+version = "2.12.84"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.83"
+version = "2.12.84"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.83"
+version = "2.12.84"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.83"
+version = "2.12.84"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.83"
+version = "2.12.84"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.83"
+version = "2.12.84"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.83"
+version = "2.12.84"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -3,6 +3,7 @@ use uuid::Uuid;
 use yew::prelude::*;
 
 mod events;
+mod lifecycle;
 mod messages;
 mod patch;
 mod tool_calls;
@@ -13,7 +14,7 @@ use events::thread_item_id;
 #[cfg(test)]
 use events::CodexUsage;
 pub use events::{codex_event_item_id, is_codex_terminal_event, CodexEvent, CodexItem};
-use events::{ContextCompactedParams, TurnPlanStep};
+use lifecycle::{render_context_compacted, render_context_compaction_item, render_turn_plan};
 use messages::{
     render_agent_message, render_agent_message_content, render_error_block, render_reasoning,
 };
@@ -158,107 +159,6 @@ fn render_item(item: Option<&CodexItem>, completed: bool, session_id: Uuid) -> H
             completed,
         ),
         CodexItem::AppServer(_) => html! {},
-    }
-}
-
-fn render_turn_plan(plan: Option<&[TurnPlanStep]>, explanation: Option<&str>) -> Html {
-    let plan = plan.unwrap_or(&[]);
-    let explanation = explanation.unwrap_or("");
-    if plan.is_empty() && explanation.trim().is_empty() {
-        return html! {};
-    }
-    html! {
-        <div class="claude-message assistant-message">
-            <div class="message-body">
-                <div class="tool-use-section">
-                    <div class="tool-use-header">
-                        <span class="tool-icon">{ "\u{1f5d2}" }</span>
-                        <span class="tool-name">{ "Plan" }</span>
-                    </div>
-                    {
-                        if !explanation.trim().is_empty() {
-                            html! { <div class="assistant-text">{ explanation }</div> }
-                        } else {
-                            html! {}
-                        }
-                    }
-                    {
-                        if !plan.is_empty() {
-                            html! {
-                                <div class="codex-todo-list">
-                                    { for plan.iter().enumerate().map(|(i, step)| {
-                                        let status = step.status.as_deref().unwrap_or("pending");
-                                        let text = step.step.as_deref().unwrap_or("");
-                                        let (marker, class) = match status {
-                                            "completed" => ("\u{2611}", "codex-todo done"),
-                                            "inProgress" | "in_progress" => ("\u{25b6}", "codex-todo"),
-                                            _ => ("\u{2610}", "codex-todo"),
-                                        };
-                                        html! {
-                                            <div class={class}>
-                                                <span class="codex-todo-marker">{ marker }</span>
-                                                <span class="codex-todo-text">
-                                                    { format!("{}. {}", i + 1, text) }
-                                                </span>
-                                            </div>
-                                        }
-                                    })}
-                                </div>
-                            }
-                        } else {
-                            html! {}
-                        }
-                    }
-                </div>
-            </div>
-        </div>
-    }
-}
-
-fn render_context_compacted(params: Option<&ContextCompactedParams>) -> Html {
-    let title = params
-        .and_then(|p| p.turn_id.as_deref())
-        .map(|turn_id| format!("Codex compacted context for turn {}", turn_id))
-        .unwrap_or_else(|| "Codex compacted the conversation context".to_string());
-
-    html! {
-        <div class="claude-message compaction-message">
-            <div class="message-header">
-                <span class="message-type-badge compaction">{ "Context Compacted" }</span>
-            </div>
-            <div class="message-body">
-                <div class="compaction-content">
-                    <div class="compaction-icon">{ "\u{1f4e6}" }</div>
-                    <div class="compaction-text">
-                        <div class="compaction-description">{ title }</div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    }
-}
-
-fn render_context_compaction_item(completed: bool) -> Html {
-    let title = if completed {
-        "Codex compacted the conversation context"
-    } else {
-        "Codex is compacting the conversation context"
-    };
-
-    html! {
-        <div class="claude-message compaction-message">
-            <div class="message-header">
-                <span class="message-type-badge compaction">{ "Context Compaction" }</span>
-            </div>
-            <div class="message-body">
-                <div class="compaction-content">
-                    <div class="compaction-icon">{ "\u{1f4e6}" }</div>
-                    <div class="compaction-text">
-                        <div class="compaction-description">{ title }</div>
-                    </div>
-                </div>
-            </div>
-        </div>
     }
 }
 

--- a/frontend/src/components/codex_renderer/lifecycle.rs
+++ b/frontend/src/components/codex_renderer/lifecycle.rs
@@ -1,0 +1,103 @@
+use super::events::{ContextCompactedParams, TurnPlanStep};
+use yew::prelude::*;
+
+pub(super) fn render_turn_plan(plan: Option<&[TurnPlanStep]>, explanation: Option<&str>) -> Html {
+    let plan = plan.unwrap_or(&[]);
+    let explanation = explanation.unwrap_or("");
+    if plan.is_empty() && explanation.trim().is_empty() {
+        return html! {};
+    }
+    html! {
+        <div class="claude-message assistant-message">
+            <div class="message-body">
+                <div class="tool-use-section">
+                    <div class="tool-use-header">
+                        <span class="tool-icon">{ "\u{1f5d2}" }</span>
+                        <span class="tool-name">{ "Plan" }</span>
+                    </div>
+                    {
+                        if !explanation.trim().is_empty() {
+                            html! { <div class="assistant-text">{ explanation }</div> }
+                        } else {
+                            html! {}
+                        }
+                    }
+                    {
+                        if !plan.is_empty() {
+                            html! {
+                                <div class="codex-todo-list">
+                                    { for plan.iter().enumerate().map(|(i, step)| {
+                                        let status = step.status.as_deref().unwrap_or("pending");
+                                        let text = step.step.as_deref().unwrap_or("");
+                                        let (marker, class) = match status {
+                                            "completed" => ("\u{2611}", "codex-todo done"),
+                                            "inProgress" | "in_progress" => ("\u{25b6}", "codex-todo"),
+                                            _ => ("\u{2610}", "codex-todo"),
+                                        };
+                                        html! {
+                                            <div class={class}>
+                                                <span class="codex-todo-marker">{ marker }</span>
+                                                <span class="codex-todo-text">
+                                                    { format!("{}. {}", i + 1, text) }
+                                                </span>
+                                            </div>
+                                        }
+                                    })}
+                                </div>
+                            }
+                        } else {
+                            html! {}
+                        }
+                    }
+                </div>
+            </div>
+        </div>
+    }
+}
+
+pub(super) fn render_context_compacted(params: Option<&ContextCompactedParams>) -> Html {
+    let title = params
+        .and_then(|p| p.turn_id.as_deref())
+        .map(|turn_id| format!("Codex compacted context for turn {}", turn_id))
+        .unwrap_or_else(|| "Codex compacted the conversation context".to_string());
+
+    html! {
+        <div class="claude-message compaction-message">
+            <div class="message-header">
+                <span class="message-type-badge compaction">{ "Context Compacted" }</span>
+            </div>
+            <div class="message-body">
+                <div class="compaction-content">
+                    <div class="compaction-icon">{ "\u{1f4e6}" }</div>
+                    <div class="compaction-text">
+                        <div class="compaction-description">{ title }</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+pub(super) fn render_context_compaction_item(completed: bool) -> Html {
+    let title = if completed {
+        "Codex compacted the conversation context"
+    } else {
+        "Codex is compacting the conversation context"
+    };
+
+    html! {
+        <div class="claude-message compaction-message">
+            <div class="message-header">
+                <span class="message-type-badge compaction">{ "Context Compaction" }</span>
+            </div>
+            <div class="message-body">
+                <div class="compaction-content">
+                    <div class="compaction-icon">{ "\u{1f4e6}" }</div>
+                    <div class="compaction-text">
+                        <div class="compaction-description">{ title }</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+}


### PR DESCRIPTION
## Summary
- move Codex plan and context-compaction renderers into codex_renderer/lifecycle.rs
- keep codex_renderer.rs focused on dispatch and item routing
- preserve render behavior exactly
- bump workspace version to 2.12.84

## Verification
- cargo fmt --check
- cargo check -p frontend
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings