### PR TITLE
chore: ratchet frontend unwrap policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.84"
+version = "2.12.85"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.84"
+version = "2.12.85"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.84"
+version = "2.12.85"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.84"
+version = "2.12.85"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.84"
+version = "2.12.85"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.84"
+version = "2.12.85"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.84"
+version = "2.12.85"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.84"
+version = "2.12.85"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.84"
+version = "2.12.85"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.84"
+version = "2.12.85"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.84"
+version = "2.12.85"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 
@@ -104,12 +104,12 @@ strip = true
 
 # Panic/error policy (#1165 item 8). `unwrap`/`expect` in production code hide
 # error context and, in background tasks, die silently. We deny them
-# workspace-wide and ratchet existing usage down per crate: crates that still
-# have unwraps carry a crate-root `#![allow(clippy::unwrap_used, expect_used)]`
-# (removed as each is cleaned); already-clean crates (portal-auth,
-# portal-update) are enforced today. Tests are exempt via clippy.toml
-# (allow-unwrap-in-tests / allow-expect-in-tests). Each member crate opts in
-# with `[lints] workspace = true`.
+# workspace-wide and ratchet existing usage down per crate/module: crates or
+# files that still have production unwraps carry a local
+# `#![allow(clippy::unwrap_used, expect_used)]` (removed as each is cleaned);
+# already-clean crates (portal-auth, portal-update) are enforced today. Tests
+# are exempt via clippy.toml (allow-unwrap-in-tests / allow-expect-in-tests).
+# Each member crate opts in with `[lints] workspace = true`.
 [workspace.lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"

--- a/frontend/src/components/charts/stacked_area.rs
+++ b/frontend/src/components/charts/stacked_area.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Hand-rolled stacked-area chart, used by the Performance page's stop-reason
 //! mix plot.
 //!

--- a/frontend/src/components/cron_describe.rs
+++ b/frontend/src/components/cron_describe.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Cron expression to English description converter.
 //!
 //! Supports the standard 5-field UNIX cron format:

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use crate::components::skip_permissions::{skip_permissions_args, skip_permissions_label};
 use crate::components::ProxyTokenSetup;
 use crate::hooks::use_escape;

--- a/frontend/src/components/markdown/links.rs
+++ b/frontend/src/components/markdown/links.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use uuid::Uuid;
 use yew::prelude::*;
 

--- a/frontend/src/components/markdown/math.rs
+++ b/frontend/src/components/markdown/math.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use pulldown_cmark::Event;
 
 pub(super) const MATH_OPEN: char = '\u{E000}';

--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use crate::components::skip_permissions::{
     skip_permissions_args, skip_permissions_label, strip_skip_permissions_args,
 };

--- a/frontend/src/components/share_dialog.rs
+++ b/frontend/src/components/share_dialog.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use gloo::events::EventListener;
 use gloo_net::http::Request;
 use shared::api::{

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -1,7 +1,3 @@
-// Ratchet for the workspace unwrap/expect deny (#1165 item 8): this crate
-// still has production unwrap/expect; remove this allow as it is cleaned.
-#![allow(clippy::unwrap_used, clippy::expect_used)]
-
 pub mod audio;
 mod components;
 mod hooks;
@@ -39,7 +35,9 @@ pub enum Route {
 /// Wrapper for /admin route — provides back-navigation on_close callback
 #[function_component(AdminRoute)]
 fn admin_route() -> Html {
-    let navigator = use_navigator().unwrap();
+    let Some(navigator) = use_navigator() else {
+        return html! {};
+    };
     let on_close = Callback::from(move |_| navigator.push(&Route::Dashboard));
     html! { <AdminPage on_close={on_close} /> }
 }
@@ -47,7 +45,9 @@ fn admin_route() -> Html {
 /// Wrapper for /settings route — provides back-navigation on_close callback
 #[function_component(SettingsRoute)]
 fn settings_route() -> Html {
-    let navigator = use_navigator().unwrap();
+    let Some(navigator) = use_navigator() else {
+        return html! {};
+    };
     let on_close = Callback::from(move |_| navigator.push(&Route::Dashboard));
     html! { <SettingsPage on_close={on_close} /> }
 }

--- a/frontend/src/pages/admin/mod.rs
+++ b/frontend/src/pages/admin/mod.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Admin dashboard page
 //!
 //! Restricted to users with is_admin=true. Provides system overview,

--- a/frontend/src/pages/agent_messaging.rs
+++ b/frontend/src/pages/agent_messaging.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Agent Messaging page: list your sessions and send a message into one. The
 //! message is delivered to that session's agent as an input turn. Backed by
 //! `GET /api/agent/sessions` and `POST /api/agent/sessions/{id}/message`.

--- a/frontend/src/pages/dashboard/session_rail/menu.rs
+++ b/frontend/src/pages/dashboard/session_rail/menu.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use shared::SessionInfo;
 use uuid::Uuid;
 use wasm_bindgen_futures::JsFuture;

--- a/frontend/src/pages/dashboard/session_view/tasks_panel.rs
+++ b/frontend/src/pages/dashboard/session_view/tasks_panel.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! `TasksPanel` — sub-component owning sub-agent / background-task UI state.
 //!
 //! Pulled out of `SessionView` so the parent component no longer carries the

--- a/frontend/src/pages/settings/sounds_panel.rs
+++ b/frontend/src/pages/settings/sounds_panel.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use crate::audio::{self, EventSound, SoundConfig, SoundEvent, Waveform, STORAGE_KEY};
 use crate::utils::{self, On401};
 use gloo_net::http::Request;

--- a/frontend/src/pages/settings/tokens_panel.rs
+++ b/frontend/src/pages/settings/tokens_panel.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use crate::components::{ConfirmModal, ConfirmModalStyle};
 use crate::utils::{self, On401};
 use gloo_net::http::Request;

--- a/frontend/src/pages/splash.rs
+++ b/frontend/src/pages/splash.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use crate::utils::{self, On401};
 use crate::VERSION;
 use gloo::console;

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -1,3 +1,6 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use serde::de::DeserializeOwned;
 use web_sys::window;
 


### PR DESCRIPTION
## Summary\n- remove the frontend crate-root unwrap/expect allow\n- keep file-local #1165 ratchet allows only on production files Clippy currently flags\n- avoid two route-level navigator unwraps in frontend/src/lib.rs\n\n## Verification\n- cargo check -p frontend\n- cargo fmt --check\n- cargo test -p frontend\n- cargo clippy -p frontend -- -D warnings