### PR TITLE
refactor: split AgentOutputClassifier from AgentAdapter (#1165 item 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.85"
+version = "2.12.86"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.85"
+version = "2.12.86"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.85"
+version = "2.12.86"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.85"
+version = "2.12.86"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.85"
+version = "2.12.86"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.85"
+version = "2.12.86"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.85"
+version = "2.12.86"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.85"
+version = "2.12.86"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.85"
+version = "2.12.86"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.85"
+version = "2.12.86"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.85"
+version = "2.12.86"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/session-lib/src/adapter.rs
+++ b/session-lib/src/adapter.rs
@@ -60,23 +60,36 @@ pub struct PermissionDecision {
     pub reason: Option<String>,
 }
 
-/// Per-agent protocol parse/serialize boundary for the generic `Session<A>`.
+/// Output-classification boundary: parse one unit of agent output into neutral
+/// [`AgentOutput`] decisions. This is the *only* part of the adapter that fits
+/// every backend — both Claude (stdout JSON) and Codex (`ServerMessage`) can
+/// honestly map their output here.
 ///
-/// The adapter owns all concrete-protocol knowledge. `Session` only ever sees
-/// neutral [`AgentOutput`] / [`PermissionDecision`] and opaque
-/// [`TransportPayload`]s.
-// `Sync` so `Session<A>`, which stores `Box<dyn AgentAdapter>`, stays `Sync`
-// for consumers that share a session across threads (the launcher holds
-// sessions in shared state). Adapters are stateless today; any future stateful
-// adapter must use interior mutability that is itself `Sync`.
-pub trait AgentAdapter: Send + Sync + 'static {
-    /// Parse + classify one unit of agent stdout into 0..n neutral decisions.
+/// It is split out from [`AgentAdapter`] (its supertrait) because the rest of
+/// `AgentAdapter` — `user_input`/`permission_response` returning a sync
+/// `TransportPayload` for the I/O task to write — is Claude-transport-shaped
+/// and does *not* fit Codex, whose input/permission flow is an async
+/// `turn_start`/`respond` RPC owned by `codex_io_task`. A backend that only
+/// classifies output (Codex) implements this trait alone; full unification of
+/// the input side is a separate `AgentRuntime` design (see
+/// `docs/design/session-adapter.md`).
+///
+/// `Sync` so `Session<A>`, which stores `Box<dyn AgentAdapter>`, stays `Sync`
+/// for consumers that share a session across threads (the launcher holds
+/// sessions in shared state). Adapters are stateless today; any future stateful
+/// adapter must use interior mutability that is itself `Sync`.
+pub trait AgentOutputClassifier: Send + Sync + 'static {
+    /// Parse + classify one unit of agent output into 0..n neutral decisions.
     ///
-    /// `&mut self` so future stateful adapters (e.g. codex, which threads a
+    /// `&mut self` so future stateful classifiers (e.g. codex, which threads a
     /// request-id ↔ tool map) can update internal state. Claude is stateless
     /// and 1:1 (one `RawUnit` → exactly one `AgentOutput`).
     fn classify(&mut self, raw: RawUnit) -> Vec<AgentOutput>;
+}
 
+/// Per-agent protocol parse/serialize boundary for the generic `Session<A>`,
+/// for backends whose input side fits the sync stdin-payload model (Claude).
+pub trait AgentAdapter: AgentOutputClassifier {
     /// Build the transport payload for plain user text.
     fn user_input(&self, text: &str, session_id: Uuid) -> TransportPayload;
 
@@ -97,7 +110,7 @@ pub trait AgentAdapter: Send + Sync + 'static {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ClaudeAdapter;
 
-impl AgentAdapter for ClaudeAdapter {
+impl AgentOutputClassifier for ClaudeAdapter {
     fn classify(&mut self, raw: RawUnit) -> Vec<AgentOutput> {
         use claude_codes::io::ControlRequestPayload;
         use claude_codes::ClaudeOutput;
@@ -151,7 +164,9 @@ impl AgentAdapter for ClaudeAdapter {
             _ => vec![AgentOutput::Visible(raw)],
         }
     }
+}
 
+impl AgentAdapter for ClaudeAdapter {
     fn user_input(&self, text: &str, session_id: Uuid) -> TransportPayload {
         let input = claude_codes::ClaudeInput::user_message(text, session_id);
         serde_json::to_value(&input).unwrap_or(serde_json::Value::Null)

--- a/session-lib/src/lib.rs
+++ b/session-lib/src/lib.rs
@@ -32,7 +32,9 @@ pub mod session;
 pub mod snapshot;
 pub mod turn_tracker;
 
-pub use adapter::{AgentAdapter, AgentOutput, ClaudeAdapter, PermissionDecision};
+pub use adapter::{
+    AgentAdapter, AgentOutput, AgentOutputClassifier, ClaudeAdapter, PermissionDecision,
+};
 pub use agent::Agent;
 pub use buffer::{BufferedOutput, OutputBuffer};
 pub use error::SessionError;


### PR DESCRIPTION
## #1165 item 2 — the classification-boundary foundation (Claude+Codex consensus)

Establishes the honest output-classification boundary for the AgentAdapter campaign, so the next slice can add a Codex output classifier without forcing codex's async-RPC input model through a Claude-shaped sync trait.

### Change
- New narrower supertrait **`AgentOutputClassifier`** owns `classify(&mut self, raw) -> Vec<AgentOutput>`.
- **`AgentAdapter: AgentOutputClassifier`** retains the Claude-transport-shaped input methods (`user_input`/`permission_response`/`interrupt`, which return a sync `TransportPayload` for the I/O task to write to stdin).
- `ClaudeAdapter`'s `classify` impl is **unchanged**, just relocated into its `impl AgentOutputClassifier` block.

### Why
`user_input`/`permission_response` returning a sync `TransportPayload` fits Claude (write line to stdin) but **not Codex**, whose input/permission flow is an async `client.turn_start`/`client.respond` RPC owned by `codex_io_task` (needs `thread_id`, `turn_active`, prompt queueing, echo synthesis). Output classification is the one part every backend can implement honestly, so it gets its own trait. The forthcoming `CodexClassifier` implements `AgentOutputClassifier` **alone** — no pretending to satisfy the stdin-payload contract. Full input-side unification is a separate future `AgentRuntime` design (see `docs/design/session-adapter.md`).

### Behavior
Behavior-preserving. `Session` still calls `classify` through `dyn AgentAdapter` (inherited from the supertrait — **no `session.rs` change**).

### Verification
- `cargo build -p session-lib -p claude-session-lib -p agent-portal -p backend` ✓ (launcher built — `Session: Sync` preserved)
- `cargo test -p session-lib` (29) + `-p claude-session-lib` (34) ✓
- `cargo clippy` clean, `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)