### PR TITLE
refactor: extract performance metrics hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.87"
+version = "2.12.88"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.87"
+version = "2.12.88"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.87"
+version = "2.12.88"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.87"
+version = "2.12.88"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.87"
+version = "2.12.88"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.87"
+version = "2.12.88"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.87"
+version = "2.12.88"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.87"
+version = "2.12.88"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.87"
+version = "2.12.88"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.87"
+version = "2.12.88"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.87"
+version = "2.12.88"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -13,14 +13,15 @@
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
-use shared::api::{MetricBucket, MetricBucketsResponse};
-use wasm_bindgen_futures::spawn_local;
+use shared::api::MetricBucket;
 use yew::prelude::*;
 
 use crate::components::charts::{
     AxisScale, BucketKind, LinePlot, LineSeries, StackedArea, StackedSeries,
 };
-use crate::utils::{self, FetchError, On401};
+
+mod use_metrics;
+use use_metrics::use_performance_metrics;
 
 /// (agent_type, model, service_tier) tuple used as the group-by key. Codex
 /// currently reports no model or tier; keeping the agent in the key lets the
@@ -187,49 +188,9 @@ pub fn performance_panel() -> Html {
     let window = use_state(|| TimeWindow::Days30);
     let group_by = use_state(|| GroupBy::All);
     let axis_scale = use_state(|| AxisScale::Linear);
-    let buckets = use_state(Vec::<MetricBucket>::new);
-    let loading = use_state(|| true);
-    let error_msg = use_state(|| None::<String>);
+    let metrics = use_performance_metrics(*window);
 
-    // Refetch when the window selection changes.
-    {
-        let buckets = buckets.clone();
-        let loading = loading.clone();
-        let error_msg = error_msg.clone();
-        let window_val = *window;
-        use_effect_with(window_val, move |&window_val| {
-            loading.set(true);
-            error_msg.set(None);
-            let buckets = buckets.clone();
-            let loading = loading.clone();
-            let error_msg = error_msg.clone();
-            spawn_local(async move {
-                let path = format!(
-                    "/api/metrics/turns?bucket={}&window={}",
-                    bucket_param(window_val),
-                    window_val.label()
-                );
-                match utils::fetch_json::<MetricBucketsResponse>(&path, On401::Ignore).await {
-                    Ok(data) => {
-                        buckets.set(data.buckets);
-                    }
-                    Err(FetchError::Decode(e)) => {
-                        error_msg.set(Some(format!("Failed to parse response: {e}")));
-                    }
-                    Err(FetchError::Status(code)) => {
-                        error_msg.set(Some(format!("Request failed: HTTP {code}")));
-                    }
-                    Err(FetchError::Network(e)) => {
-                        error_msg.set(Some(format!("Network error: {e}")));
-                    }
-                }
-                loading.set(false);
-            });
-            || ()
-        });
-    }
-
-    let pairs = distinct_pairs(&buckets);
+    let pairs = distinct_pairs(&metrics.buckets);
 
     let on_window_change = {
         let window = window.clone();
@@ -255,22 +216,22 @@ pub fn performance_panel() -> Html {
         })
     };
 
-    let body = if *loading {
+    let body = if metrics.loading {
         html! {
             <div class="chart-empty">{ "Loading…" }</div>
         }
-    } else if let Some(msg) = (*error_msg).clone() {
+    } else if let Some(msg) = metrics.error_msg.clone() {
         html! {
             <div class="chart-empty">{ msg }</div>
         }
-    } else if buckets.is_empty() {
+    } else if metrics.buckets.is_empty() {
         html! {
             <div class="chart-empty">
                 { "No per-turn metrics in the selected window. Start a session to populate the dashboard." }
             </div>
         }
     } else {
-        render_charts(&buckets, &group_by, &pairs, *window, *axis_scale)
+        render_charts(&metrics.buckets, &group_by, &pairs, *window, *axis_scale)
     };
 
     html! {

--- a/frontend/src/pages/settings/performance_panel/use_metrics.rs
+++ b/frontend/src/pages/settings/performance_panel/use_metrics.rs
@@ -1,0 +1,64 @@
+//! Metrics fetch hook for the Performance settings panel.
+
+use shared::api::{MetricBucket, MetricBucketsResponse};
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+use super::{bucket_param, TimeWindow};
+use crate::utils::{self, FetchError, On401};
+
+pub(super) struct PerformanceMetrics {
+    pub buckets: Vec<MetricBucket>,
+    pub loading: bool,
+    pub error_msg: Option<String>,
+}
+
+/// Fetch per-turn metric buckets whenever the selected time window changes.
+#[hook]
+pub(super) fn use_performance_metrics(window: TimeWindow) -> PerformanceMetrics {
+    let buckets = use_state(Vec::<MetricBucket>::new);
+    let loading = use_state(|| true);
+    let error_msg = use_state(|| None::<String>);
+
+    {
+        let buckets = buckets.clone();
+        let loading = loading.clone();
+        let error_msg = error_msg.clone();
+        use_effect_with(window, move |&window| {
+            loading.set(true);
+            error_msg.set(None);
+            let buckets = buckets.clone();
+            let loading = loading.clone();
+            let error_msg = error_msg.clone();
+            spawn_local(async move {
+                let path = format!(
+                    "/api/metrics/turns?bucket={}&window={}",
+                    bucket_param(window),
+                    window.label()
+                );
+                match utils::fetch_json::<MetricBucketsResponse>(&path, On401::Ignore).await {
+                    Ok(data) => {
+                        buckets.set(data.buckets);
+                    }
+                    Err(FetchError::Decode(e)) => {
+                        error_msg.set(Some(format!("Failed to parse response: {e}")));
+                    }
+                    Err(FetchError::Status(code)) => {
+                        error_msg.set(Some(format!("Request failed: HTTP {code}")));
+                    }
+                    Err(FetchError::Network(e)) => {
+                        error_msg.set(Some(format!("Network error: {e}")));
+                    }
+                }
+                loading.set(false);
+            });
+            || ()
+        });
+    }
+
+    PerformanceMetrics {
+        buckets: (*buckets).clone(),
+        loading: *loading,
+        error_msg: (*error_msg).clone(),
+    }
+}


### PR DESCRIPTION
## Summary\n- extract PerformancePanel's metrics fetch/loading/error state into a dedicated use_performance_metrics hook\n- keep chart rendering and pure series helpers unchanged\n- bump workspace version to 2.12.88\n\n## Verification\n- cargo check -p frontend\n- cargo fmt --check\n- cargo test -p frontend\n- cargo clippy -p frontend -- -D warnings