### PR TITLE
refactor: extract performance chart composition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.91"
+version = "2.12.92"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.91"
+version = "2.12.92"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.91"
+version = "2.12.92"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.91"
+version = "2.12.92"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.91"
+version = "2.12.92"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.91"
+version = "2.12.92"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.91"
+version = "2.12.92"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.91"
+version = "2.12.92"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.91"
+version = "2.12.92"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.91"
+version = "2.12.92"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.91"
+version = "2.12.92"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -10,20 +10,16 @@
 //! A group-by dropdown filters to one `(agent_type, model, service_tier)`
 //! group, or "All" to render one line per group.
 
-use std::collections::BTreeMap;
-
 use chrono::{DateTime, Utc};
 use shared::api::MetricBucket;
 use yew::prelude::*;
 
-use crate::components::charts::{AxisScale, BucketKind, LinePlot, StackedArea};
+use crate::components::charts::AxisScale;
 
+mod charts;
 mod series;
 mod use_metrics;
-use series::{
-    build_auxiliary_token_series, build_cache_hit_series, build_cost_per_token_series,
-    build_p50_p95_series, build_stop_reason_series,
-};
+use charts::render_charts;
 use use_metrics::use_performance_metrics;
 
 /// (agent_type, model, service_tier) tuple used as the group-by key. Codex
@@ -322,121 +318,16 @@ pub fn performance_panel() -> Html {
     }
 }
 
-/// Render the five charts from a non-empty `buckets` slice.
-fn render_charts(
-    buckets: &[MetricBucket],
-    group_by: &GroupBy,
-    pairs: &[GroupKey],
-    window: TimeWindow,
-    axis_scale: AxisScale,
-) -> Html {
-    let bucket_axis = distinct_bucket_starts(buckets);
-    // Resolve the bucket-kind from the same wire param we sent on the request,
-    // so the time-axis label format stays in lockstep with the data. Defaults
-    // to `Day` if the param ever drifts to something `from_wire` doesn't know.
-    let bucket_kind = BucketKind::from_wire(bucket_param(window)).unwrap_or(BucketKind::Day);
-
-    // For per-pair plots: filter pairs by group-by.
-    let active_pairs: Vec<GroupKey> = match group_by {
-        GroupBy::All => pairs.to_vec(),
-        GroupBy::Pair(p) => vec![p.clone()],
-    };
-
-    // Bucketed by (pair, ts) for O(1) lookup.
-    let mut indexed: BTreeMap<(GroupKey, DateTime<Utc>), &MetricBucket> = BTreeMap::new();
-    for b in buckets {
-        indexed.insert((bucket_group_key(b), b.bucket_start), b);
-    }
-
-    // ------------ a) Throughput trend: p50 (solid) + p95 (dashed) ------------
-    let throughput_series = build_p50_p95_series(
-        &indexed,
-        &bucket_axis,
-        &active_pairs,
-        |r| r.throughput_p50_tps,
-        |r| r.throughput_p95_tps,
-    );
-
-    // ------------ b) TTFT trend: p50 (solid) + p95 (dashed) seconds ----------
-    let ttft_series = build_p50_p95_series(
-        &indexed,
-        &bucket_axis,
-        &active_pairs,
-        |r| r.ttft_p50_ms.map(|ms| ms as f64 / 1000.0),
-        |r| r.ttft_p95_ms.map(|ms| ms as f64 / 1000.0),
-    );
-
-    // ------------ c) Stop-reason stacked area ---------------------------------
-    let stop_reason_series = build_stop_reason_series(buckets, &bucket_axis, &active_pairs);
-
-    // ------------ d) Cache hit rate (Claude rows only) ------------------------
-    let cache_hit_series = build_cache_hit_series(&indexed, &bucket_axis, &active_pairs);
-
-    // ------------ e) Cost per output token (skips codex / no-cost rows) ------
-    let cost_series = build_cost_per_token_series(&indexed, &bucket_axis, &active_pairs);
-
-    // ------------ f) Auxiliary token volume (reasoning + subagents) ----------
-    let auxiliary_token_series =
-        build_auxiliary_token_series(&indexed, &bucket_axis, &active_pairs);
-
-    html! {
-        <div class="performance-charts">
-            <LinePlot
-                title="Throughput"
-                y_label="tok/s"
-                buckets={bucket_axis.clone()}
-                bucket_kind={bucket_kind}
-                series={throughput_series}
-                axis_scale={axis_scale}
-            />
-            <LinePlot
-                title="Time to first token"
-                y_label="seconds"
-                buckets={bucket_axis.clone()}
-                bucket_kind={bucket_kind}
-                series={ttft_series}
-                axis_scale={axis_scale}
-            />
-            <StackedArea
-                title="Stop-reason mix"
-                y_label="turns"
-                buckets={bucket_axis.clone()}
-                bucket_kind={bucket_kind}
-                series={stop_reason_series}
-                axis_scale={axis_scale}
-            />
-            <LinePlot
-                title="Cache hit rate"
-                y_label="%"
-                buckets={bucket_axis.clone()}
-                bucket_kind={bucket_kind}
-                series={cache_hit_series}
-                axis_scale={axis_scale}
-            />
-            <LinePlot
-                title="Cost per 1k output tokens"
-                y_label="USD"
-                buckets={bucket_axis.clone()}
-                bucket_kind={bucket_kind}
-                series={cost_series}
-                axis_scale={axis_scale}
-            />
-            <LinePlot
-                title="Auxiliary tokens"
-                y_label="tokens"
-                buckets={bucket_axis.clone()}
-                bucket_kind={bucket_kind}
-                series={auxiliary_token_series}
-                axis_scale={axis_scale}
-            />
-        </div>
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use std::collections::BTreeMap;
+
+    use super::series::{
+        build_auxiliary_token_series, build_cache_hit_series, build_cost_per_token_series,
+        build_stop_reason_series,
+    };
 
     fn mk_bucket(
         ts: DateTime<Utc>,

--- a/frontend/src/pages/settings/performance_panel/charts.rs
+++ b/frontend/src/pages/settings/performance_panel/charts.rs
@@ -1,0 +1,128 @@
+//! Chart composition for the Performance settings panel.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use shared::api::MetricBucket;
+use yew::prelude::*;
+
+use crate::components::charts::{AxisScale, BucketKind, LinePlot, StackedArea};
+
+use super::series::{
+    build_auxiliary_token_series, build_cache_hit_series, build_cost_per_token_series,
+    build_p50_p95_series, build_stop_reason_series,
+};
+use super::{
+    bucket_group_key, bucket_param, distinct_bucket_starts, GroupBy, GroupKey, TimeWindow,
+};
+
+/// Render the performance charts from a non-empty `buckets` slice.
+pub(super) fn render_charts(
+    buckets: &[MetricBucket],
+    group_by: &GroupBy,
+    pairs: &[GroupKey],
+    window: TimeWindow,
+    axis_scale: AxisScale,
+) -> Html {
+    let bucket_axis = distinct_bucket_starts(buckets);
+    // Resolve the bucket-kind from the same wire param we sent on the request,
+    // so the time-axis label format stays in lockstep with the data. Defaults
+    // to `Day` if the param ever drifts to something `from_wire` doesn't know.
+    let bucket_kind = BucketKind::from_wire(bucket_param(window)).unwrap_or(BucketKind::Day);
+
+    // For per-pair plots: filter pairs by group-by.
+    let active_pairs: Vec<GroupKey> = match group_by {
+        GroupBy::All => pairs.to_vec(),
+        GroupBy::Pair(p) => vec![p.clone()],
+    };
+
+    // Bucketed by (pair, ts) for O(1) lookup.
+    let mut indexed: BTreeMap<(GroupKey, DateTime<Utc>), &MetricBucket> = BTreeMap::new();
+    for b in buckets {
+        indexed.insert((bucket_group_key(b), b.bucket_start), b);
+    }
+
+    // ------------ a) Throughput trend: p50 (solid) + p95 (dashed) ------------
+    let throughput_series = build_p50_p95_series(
+        &indexed,
+        &bucket_axis,
+        &active_pairs,
+        |r| r.throughput_p50_tps,
+        |r| r.throughput_p95_tps,
+    );
+
+    // ------------ b) TTFT trend: p50 (solid) + p95 (dashed) seconds ----------
+    let ttft_series = build_p50_p95_series(
+        &indexed,
+        &bucket_axis,
+        &active_pairs,
+        |r| r.ttft_p50_ms.map(|ms| ms as f64 / 1000.0),
+        |r| r.ttft_p95_ms.map(|ms| ms as f64 / 1000.0),
+    );
+
+    // ------------ c) Stop-reason stacked area ---------------------------------
+    let stop_reason_series = build_stop_reason_series(buckets, &bucket_axis, &active_pairs);
+
+    // ------------ d) Cache hit rate (Claude rows only) ------------------------
+    let cache_hit_series = build_cache_hit_series(&indexed, &bucket_axis, &active_pairs);
+
+    // ------------ e) Cost per output token (skips codex / no-cost rows) ------
+    let cost_series = build_cost_per_token_series(&indexed, &bucket_axis, &active_pairs);
+
+    // ------------ f) Auxiliary token volume (reasoning + subagents) ----------
+    let auxiliary_token_series =
+        build_auxiliary_token_series(&indexed, &bucket_axis, &active_pairs);
+
+    html! {
+        <div class="performance-charts">
+            <LinePlot
+                title="Throughput"
+                y_label="tok/s"
+                buckets={bucket_axis.clone()}
+                bucket_kind={bucket_kind}
+                series={throughput_series}
+                axis_scale={axis_scale}
+            />
+            <LinePlot
+                title="Time to first token"
+                y_label="seconds"
+                buckets={bucket_axis.clone()}
+                bucket_kind={bucket_kind}
+                series={ttft_series}
+                axis_scale={axis_scale}
+            />
+            <StackedArea
+                title="Stop-reason mix"
+                y_label="turns"
+                buckets={bucket_axis.clone()}
+                bucket_kind={bucket_kind}
+                series={stop_reason_series}
+                axis_scale={axis_scale}
+            />
+            <LinePlot
+                title="Cache hit rate"
+                y_label="%"
+                buckets={bucket_axis.clone()}
+                bucket_kind={bucket_kind}
+                series={cache_hit_series}
+                axis_scale={axis_scale}
+            />
+            <LinePlot
+                title="Cost per 1k output tokens"
+                y_label="USD"
+                buckets={bucket_axis.clone()}
+                bucket_kind={bucket_kind}
+                series={cost_series}
+                axis_scale={axis_scale}
+            />
+            <LinePlot
+                title="Auxiliary tokens"
+                y_label="tokens"
+                buckets={bucket_axis}
+                bucket_kind={bucket_kind}
+                series={auxiliary_token_series}
+                axis_scale={axis_scale}
+            />
+        </div>
+    }
+}


### PR DESCRIPTION
## Summary
- move PerformancePanel chart composition into `performance_panel/charts.rs`
- leave UI controls, fetch hook usage, and series builders unchanged
- bump workspace version to 2.12.92

## Tests
- cargo check -p frontend
- cargo fmt --check
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings