### PR TITLE
refactor: extract performance panel controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.93"
+version = "2.12.94"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.93"
+version = "2.12.94"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.93"
+version = "2.12.94"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.93"
+version = "2.12.94"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.93"
+version = "2.12.94"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.93"
+version = "2.12.94"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.93"
+version = "2.12.94"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.93"
+version = "2.12.94"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.93"
+version = "2.12.94"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.93"
+version = "2.12.94"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.93"
+version = "2.12.94"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -17,9 +17,11 @@ use yew::prelude::*;
 use crate::components::charts::AxisScale;
 
 mod charts;
+mod controls;
 mod series;
 mod use_metrics;
 use charts::render_charts;
+use controls::{render_performance_controls, PerformanceControlsProps};
 use use_metrics::use_performance_metrics;
 
 /// (agent_type, model, service_tier) tuple used as the group-by key. Codex
@@ -243,75 +245,15 @@ pub fn performance_panel() -> Html {
                 </p>
             </div>
 
-            <div class="performance-controls">
-                <div class="performance-window-group" role="radiogroup">
-                    <span class="performance-control-label">{ "Window:" }</span>
-                    { for TimeWindow::all().iter().copied().map(|w| {
-                        let is_active = *window == w;
-                        let on_window_change = on_window_change.clone();
-                        let on_click = Callback::from(move |_| on_window_change.emit(w));
-                        html! {
-                            <button
-                                class={classes!(
-                                    "performance-window-button",
-                                    is_active.then_some("active"),
-                                )}
-                                onclick={on_click}
-                            >
-                                { w.label() }
-                            </button>
-                        }
-                    }) }
-                </div>
-
-                <div class="performance-group-by">
-                    <label class="performance-control-label" for="performance-group-by-select">
-                        { "Group:" }
-                    </label>
-                    <select
-                        id="performance-group-by-select"
-                        onchange={on_group_change}
-                        value={group_by.key()}
-                    >
-                        <option
-                            value="__ALL__"
-                            selected={matches!(*group_by, GroupBy::All)}
-                        >
-                            { "All groups" }
-                        </option>
-                        { for pairs.iter().map(|pair| {
-                            let gb = GroupBy::Pair(pair.clone());
-                            let selected = matches!(&*group_by, GroupBy::Pair(p) if p == pair);
-                            html! {
-                                <option value={gb.key()} selected={selected}>
-                                    { pair_label(pair) }
-                                </option>
-                            }
-                        }) }
-                    </select>
-                </div>
-
-                <div class="performance-scale-group" role="radiogroup">
-                    <span class="performance-control-label">{ "Y scale:" }</span>
-                    { for AxisScale::all().iter().copied().map(|scale| {
-                        let is_active = *axis_scale == scale;
-                        let on_axis_scale_change = on_axis_scale_change.clone();
-                        let on_click = Callback::from(move |_| on_axis_scale_change.emit(scale));
-                        html! {
-                            <button
-                                type="button"
-                                class={classes!(
-                                    "performance-window-button",
-                                    is_active.then_some("active"),
-                                )}
-                                onclick={on_click}
-                            >
-                                { scale.label() }
-                            </button>
-                        }
-                    }) }
-                </div>
-            </div>
+            { render_performance_controls(PerformanceControlsProps {
+                window: *window,
+                group_by: &group_by,
+                axis_scale: *axis_scale,
+                pairs: &pairs,
+                on_window_change,
+                on_group_change,
+                on_axis_scale_change,
+            }) }
 
             { body }
         </section>

--- a/frontend/src/pages/settings/performance_panel/controls.rs
+++ b/frontend/src/pages/settings/performance_panel/controls.rs
@@ -1,0 +1,91 @@
+//! Filter and scale controls for the Performance settings panel.
+
+use yew::prelude::*;
+
+use crate::components::charts::AxisScale;
+
+use super::{pair_label, GroupBy, GroupKey, TimeWindow};
+
+pub(super) struct PerformanceControlsProps<'a> {
+    pub window: TimeWindow,
+    pub group_by: &'a GroupBy,
+    pub axis_scale: AxisScale,
+    pub pairs: &'a [GroupKey],
+    pub on_window_change: Callback<TimeWindow>,
+    pub on_group_change: Callback<Event>,
+    pub on_axis_scale_change: Callback<AxisScale>,
+}
+
+pub(super) fn render_performance_controls(props: PerformanceControlsProps<'_>) -> Html {
+    html! {
+        <div class="performance-controls">
+            <div class="performance-window-group" role="radiogroup">
+                <span class="performance-control-label">{ "Window:" }</span>
+                { for TimeWindow::all().iter().copied().map(|w| {
+                    let is_active = props.window == w;
+                    let on_window_change = props.on_window_change.clone();
+                    let on_click = Callback::from(move |_| on_window_change.emit(w));
+                    html! {
+                        <button
+                            class={classes!(
+                                "performance-window-button",
+                                is_active.then_some("active"),
+                            )}
+                            onclick={on_click}
+                        >
+                            { w.label() }
+                        </button>
+                    }
+                }) }
+            </div>
+
+            <div class="performance-group-by">
+                <label class="performance-control-label" for="performance-group-by-select">
+                    { "Group:" }
+                </label>
+                <select
+                    id="performance-group-by-select"
+                    onchange={props.on_group_change}
+                    value={props.group_by.key()}
+                >
+                    <option
+                        value="__ALL__"
+                        selected={matches!(props.group_by, GroupBy::All)}
+                    >
+                        { "All groups" }
+                    </option>
+                    { for props.pairs.iter().map(|pair| {
+                        let gb = GroupBy::Pair(pair.clone());
+                        let selected = matches!(props.group_by, GroupBy::Pair(p) if p == pair);
+                        html! {
+                            <option value={gb.key()} selected={selected}>
+                                { pair_label(pair) }
+                            </option>
+                        }
+                    }) }
+                </select>
+            </div>
+
+            <div class="performance-scale-group" role="radiogroup">
+                <span class="performance-control-label">{ "Y scale:" }</span>
+                { for AxisScale::all().iter().copied().map(|scale| {
+                    let is_active = props.axis_scale == scale;
+                    let on_axis_scale_change = props.on_axis_scale_change.clone();
+                    let on_click = Callback::from(move |_| on_axis_scale_change.emit(scale));
+                    html! {
+                        <button
+                            type="button"
+                            class={classes!(
+                                "performance-window-button",
+                                is_active.then_some("active"),
+                            )}
+                            onclick={on_click}
+                        >
+                            { scale.label() }
+                        </button>
+                    }
+                }) }
+            </div>
+        </div>
+    }
+}


### PR DESCRIPTION
## Summary
- move the Performance settings window/group/scale controls into `performance_panel/controls.rs`
- keep state and callbacks owned by `PerformancePanel`
- bump workspace version to 2.12.94

## Tests
- cargo check -p frontend
- cargo fmt --check
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings