### PR TITLE
refactor: extract performance panel body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.94"
+version = "2.12.96"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.94"
+version = "2.12.96"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.94"
+version = "2.12.96"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.94"
+version = "2.12.96"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.94"
+version = "2.12.96"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.94"
+version = "2.12.96"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.94"
+version = "2.12.96"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.94"
+version = "2.12.96"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.94"
+version = "2.12.96"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.94"
+version = "2.12.96"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.94"
+version = "2.12.96"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -16,11 +16,12 @@ use yew::prelude::*;
 
 use crate::components::charts::AxisScale;
 
+mod body;
 mod charts;
 mod controls;
 mod series;
 mod use_metrics;
-use charts::render_charts;
+use body::render_performance_body;
 use controls::{render_performance_controls, PerformanceControlsProps};
 use use_metrics::use_performance_metrics;
 
@@ -217,24 +218,6 @@ pub fn performance_panel() -> Html {
         })
     };
 
-    let body = if metrics.loading {
-        html! {
-            <div class="chart-empty">{ "Loading…" }</div>
-        }
-    } else if let Some(msg) = metrics.error_msg.clone() {
-        html! {
-            <div class="chart-empty">{ msg }</div>
-        }
-    } else if metrics.buckets.is_empty() {
-        html! {
-            <div class="chart-empty">
-                { "No per-turn metrics in the selected window. Start a session to populate the dashboard." }
-            </div>
-        }
-    } else {
-        render_charts(&metrics.buckets, &group_by, &pairs, *window, *axis_scale)
-    };
-
     html! {
         <section class="performance-panel">
             <div class="section-header">
@@ -255,7 +238,7 @@ pub fn performance_panel() -> Html {
                 on_axis_scale_change,
             }) }
 
-            { body }
+            { render_performance_body(&metrics, &group_by, &pairs, *window, *axis_scale) }
         </section>
     }
 }

--- a/frontend/src/pages/settings/performance_panel/body.rs
+++ b/frontend/src/pages/settings/performance_panel/body.rs
@@ -1,0 +1,35 @@
+//! Body-state rendering for the Performance settings panel.
+
+use yew::prelude::*;
+
+use crate::components::charts::AxisScale;
+
+use super::charts::render_charts;
+use super::use_metrics::PerformanceMetrics;
+use super::{GroupBy, GroupKey, TimeWindow};
+
+pub(super) fn render_performance_body(
+    metrics: &PerformanceMetrics,
+    group_by: &GroupBy,
+    pairs: &[GroupKey],
+    window: TimeWindow,
+    axis_scale: AxisScale,
+) -> Html {
+    if metrics.loading {
+        html! {
+            <div class="chart-empty">{ "Loading…" }</div>
+        }
+    } else if let Some(msg) = metrics.error_msg.as_ref() {
+        html! {
+            <div class="chart-empty">{ msg }</div>
+        }
+    } else if metrics.buckets.is_empty() {
+        html! {
+            <div class="chart-empty">
+                { "No per-turn metrics in the selected window. Start a session to populate the dashboard." }
+            </div>
+        }
+    } else {
+        render_charts(&metrics.buckets, group_by, pairs, window, axis_scale)
+    }
+}


### PR DESCRIPTION
## Summary
- move PerformancePanel loading/error/empty/chart body selection into `performance_panel/body.rs`
- keep PerformancePanel focused on state, callbacks, and shell layout
- reserve workspace version 2.12.96 after Claude's 2.12.95 slice

## Tests
- cargo check -p frontend
- cargo fmt --check
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings