### PR TITLE
refactor: extract performance panel model helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.96"
+version = "2.12.98"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.96"
+version = "2.12.98"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.96"
+version = "2.12.98"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.96"
+version = "2.12.98"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.96"
+version = "2.12.98"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.96"
+version = "2.12.98"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.96"
+version = "2.12.98"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.96"
+version = "2.12.98"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.96"
+version = "2.12.98"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.96"
+version = "2.12.98"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.96"
+version = "2.12.98"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -10,8 +10,6 @@
 //! A group-by dropdown filters to one `(agent_type, model, service_tier)`
 //! group, or "All" to render one line per group.
 
-use chrono::{DateTime, Utc};
-use shared::api::MetricBucket;
 use yew::prelude::*;
 
 use crate::components::charts::AxisScale;
@@ -19,171 +17,13 @@ use crate::components::charts::AxisScale;
 mod body;
 mod charts;
 mod controls;
+mod model;
 mod series;
 mod use_metrics;
 use body::render_performance_body;
 use controls::{render_performance_controls, PerformanceControlsProps};
+use model::{distinct_pairs, GroupBy, TimeWindow};
 use use_metrics::use_performance_metrics;
-
-/// (agent_type, model, service_tier) tuple used as the group-by key. Codex
-/// currently reports no model or tier; keeping the agent in the key lets the
-/// UI label that shape explicitly without colliding with missing Claude
-/// metadata.
-type GroupKey = (String, Option<String>, Option<String>);
-
-/// Pure helper: list the distinct (agent, model, tier) groups present in the
-/// bucket list.
-fn distinct_pairs(buckets: &[MetricBucket]) -> Vec<GroupKey> {
-    let mut seen: std::collections::BTreeSet<GroupKey> = std::collections::BTreeSet::new();
-    for b in buckets {
-        seen.insert(bucket_group_key(b));
-    }
-    seen.into_iter().collect()
-}
-
-fn bucket_group_key(bucket: &MetricBucket) -> GroupKey {
-    (
-        bucket.agent_type.clone(),
-        bucket.model.clone(),
-        bucket.service_tier.clone(),
-    )
-}
-
-/// Format an (agent, model, tier) group as a human-readable label for the
-/// dropdown and legend.
-///
-/// Deliberately not `turn_metrics_pill::format_model_tier_label`: this page
-/// shows the full model id (no vendor-prefix shortening), keeps the tier's
-/// original case, and adds codex / agent-without-model handling.
-fn pair_label(pair: &GroupKey) -> String {
-    let base = match (pair.0.as_str(), pair.1.as_deref()) {
-        ("codex", None) => "Codex".to_string(),
-        (_, Some(model)) => model.to_string(),
-        (agent, None) if !agent.is_empty() => format!("{agent} unknown"),
-        _ => "unknown".to_string(),
-    };
-    match pair.2.as_deref() {
-        Some(t) if !t.is_empty() && !t.eq_ignore_ascii_case("standard") => {
-            format!("{base} {t}")
-        }
-        _ => base,
-    }
-}
-
-/// Pick a stable color from the Tokyo-Night palette. We cycle through a
-/// fixed palette by pair-index so the same pair always gets the same color
-/// across re-renders.
-fn pair_color(idx: usize) -> &'static str {
-    const PALETTE: &[&str] = &[
-        "#7aa2f7", // accent blue
-        "#bb9af7", // purple
-        "#9ece6a", // green
-        "#e0af68", // yellow
-        "#f7768e", // red (used by max_tokens band)
-        "#7dcfff", // cyan
-        "#ff9e64", // orange
-    ];
-    PALETTE[idx % PALETTE.len()]
-}
-
-/// Build distinct bucket-start timestamps (the x-axis) preserving order.
-fn distinct_bucket_starts(buckets: &[MetricBucket]) -> Vec<DateTime<Utc>> {
-    let mut seen: std::collections::BTreeSet<DateTime<Utc>> = std::collections::BTreeSet::new();
-    for b in buckets {
-        seen.insert(b.bucket_start);
-    }
-    seen.into_iter().collect()
-}
-
-/// Index a bucket-start timestamp to its position in the x-axis, returning
-/// `None` if missing.
-fn bucket_index(buckets: &[DateTime<Utc>], ts: DateTime<Utc>) -> Option<usize> {
-    buckets.iter().position(|b| *b == ts)
-}
-
-/// Build the bucket-granularity query string for the selected window.
-/// Pick high-fidelity buckets for the selected window. The charts only render
-/// a handful of x-axis labels, so dense buckets preserve real per-turn shape
-/// without cluttering the axis.
-fn bucket_param(window: TimeWindow) -> &'static str {
-    match window {
-        TimeWindow::Hours1 => "1m",
-        TimeWindow::Hours6 => "1m",
-        TimeWindow::Days1 => "5m",
-        TimeWindow::Days7 | TimeWindow::Days30 | TimeWindow::Days90 => "hour",
-    }
-}
-
-/// Selectable time window for the radio group.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TimeWindow {
-    Hours1,
-    Hours6,
-    Days1,
-    Days7,
-    Days30,
-    Days90,
-}
-
-impl TimeWindow {
-    /// Radio-button label, which doubles as the exact wire value sent to
-    /// `GET /api/metrics/turns?window=…` (the backend's window parser
-    /// accepts the same `Nh` / `Nd` suffix form).
-    fn label(self) -> &'static str {
-        match self {
-            Self::Hours1 => "1h",
-            Self::Hours6 => "6h",
-            Self::Days1 => "1d",
-            Self::Days7 => "7d",
-            Self::Days30 => "30d",
-            Self::Days90 => "90d",
-        }
-    }
-    fn all() -> &'static [TimeWindow] {
-        &[
-            TimeWindow::Hours1,
-            TimeWindow::Hours6,
-            TimeWindow::Days1,
-            TimeWindow::Days7,
-            TimeWindow::Days30,
-            TimeWindow::Days90,
-        ]
-    }
-}
-
-/// Group-by selection: either a specific (agent, model, tier) group or "All".
-#[derive(Debug, Clone, PartialEq)]
-enum GroupBy {
-    All,
-    Pair(GroupKey),
-}
-
-impl GroupBy {
-    /// Serialize to a stable string for the `<select>` `value` attribute.
-    fn key(&self) -> String {
-        match self {
-            Self::All => "__ALL__".to_string(),
-            Self::Pair((agent, m, t)) => format!(
-                "{}|{}|{}",
-                agent,
-                m.as_deref().unwrap_or(""),
-                t.as_deref().unwrap_or("")
-            ),
-        }
-    }
-    /// Inverse of [`key`]. Returns `GroupBy::All` for an unrecognized key.
-    fn from_key(key: &str, pairs: &[GroupKey]) -> Self {
-        if key == "__ALL__" {
-            return Self::All;
-        }
-        for p in pairs {
-            if Self::Pair(p.clone()).key() == key {
-                return Self::Pair(p.clone());
-            }
-        }
-        Self::All
-    }
-}
 
 #[function_component(PerformancePanel)]
 pub fn performance_panel() -> Html {
@@ -246,9 +86,13 @@ pub fn performance_panel() -> Html {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
+    use chrono::{DateTime, TimeZone, Utc};
+    use shared::api::MetricBucket;
     use std::collections::BTreeMap;
 
+    use super::model::{
+        bucket_group_key, bucket_param, distinct_bucket_starts, pair_color, pair_label, GroupKey,
+    };
     use super::series::{
         build_auxiliary_token_series, build_cache_hit_series, build_cost_per_token_series,
         build_stop_reason_series,

--- a/frontend/src/pages/settings/performance_panel/body.rs
+++ b/frontend/src/pages/settings/performance_panel/body.rs
@@ -5,8 +5,8 @@ use yew::prelude::*;
 use crate::components::charts::AxisScale;
 
 use super::charts::render_charts;
+use super::model::{GroupBy, GroupKey, TimeWindow};
 use super::use_metrics::PerformanceMetrics;
-use super::{GroupBy, GroupKey, TimeWindow};
 
 pub(super) fn render_performance_body(
     metrics: &PerformanceMetrics,

--- a/frontend/src/pages/settings/performance_panel/charts.rs
+++ b/frontend/src/pages/settings/performance_panel/charts.rs
@@ -8,12 +8,12 @@ use yew::prelude::*;
 
 use crate::components::charts::{AxisScale, BucketKind, LinePlot, StackedArea};
 
+use super::model::{
+    bucket_group_key, bucket_param, distinct_bucket_starts, GroupBy, GroupKey, TimeWindow,
+};
 use super::series::{
     build_auxiliary_token_series, build_cache_hit_series, build_cost_per_token_series,
     build_p50_p95_series, build_stop_reason_series,
-};
-use super::{
-    bucket_group_key, bucket_param, distinct_bucket_starts, GroupBy, GroupKey, TimeWindow,
 };
 
 /// Render the performance charts from a non-empty `buckets` slice.

--- a/frontend/src/pages/settings/performance_panel/controls.rs
+++ b/frontend/src/pages/settings/performance_panel/controls.rs
@@ -4,7 +4,7 @@ use yew::prelude::*;
 
 use crate::components::charts::AxisScale;
 
-use super::{pair_label, GroupBy, GroupKey, TimeWindow};
+use super::model::{pair_label, GroupBy, GroupKey, TimeWindow};
 
 pub(super) struct PerformanceControlsProps<'a> {
     pub window: TimeWindow,

--- a/frontend/src/pages/settings/performance_panel/model.rs
+++ b/frontend/src/pages/settings/performance_panel/model.rs
@@ -1,0 +1,166 @@
+//! View-model helpers for the Performance settings panel.
+
+use chrono::{DateTime, Utc};
+use shared::api::MetricBucket;
+
+/// (agent_type, model, service_tier) tuple used as the group-by key. Codex
+/// currently reports no model or tier; keeping the agent in the key lets the
+/// UI label that shape explicitly without colliding with missing Claude
+/// metadata.
+pub(super) type GroupKey = (String, Option<String>, Option<String>);
+
+/// Pure helper: list the distinct (agent, model, tier) groups present in the
+/// bucket list.
+pub(super) fn distinct_pairs(buckets: &[MetricBucket]) -> Vec<GroupKey> {
+    let mut seen: std::collections::BTreeSet<GroupKey> = std::collections::BTreeSet::new();
+    for b in buckets {
+        seen.insert(bucket_group_key(b));
+    }
+    seen.into_iter().collect()
+}
+
+pub(super) fn bucket_group_key(bucket: &MetricBucket) -> GroupKey {
+    (
+        bucket.agent_type.clone(),
+        bucket.model.clone(),
+        bucket.service_tier.clone(),
+    )
+}
+
+/// Format an (agent, model, tier) group as a human-readable label for the
+/// dropdown and legend.
+///
+/// Deliberately not `turn_metrics_pill::format_model_tier_label`: this page
+/// shows the full model id (no vendor-prefix shortening), keeps the tier's
+/// original case, and adds codex / agent-without-model handling.
+pub(super) fn pair_label(pair: &GroupKey) -> String {
+    let base = match (pair.0.as_str(), pair.1.as_deref()) {
+        ("codex", None) => "Codex".to_string(),
+        (_, Some(model)) => model.to_string(),
+        (agent, None) if !agent.is_empty() => format!("{agent} unknown"),
+        _ => "unknown".to_string(),
+    };
+    match pair.2.as_deref() {
+        Some(t) if !t.is_empty() && !t.eq_ignore_ascii_case("standard") => {
+            format!("{base} {t}")
+        }
+        _ => base,
+    }
+}
+
+/// Pick a stable color from the Tokyo-Night palette. We cycle through a
+/// fixed palette by pair-index so the same pair always gets the same color
+/// across re-renders.
+pub(super) fn pair_color(idx: usize) -> &'static str {
+    const PALETTE: &[&str] = &[
+        "#7aa2f7", // accent blue
+        "#bb9af7", // purple
+        "#9ece6a", // green
+        "#e0af68", // yellow
+        "#f7768e", // red (used by max_tokens band)
+        "#7dcfff", // cyan
+        "#ff9e64", // orange
+    ];
+    PALETTE[idx % PALETTE.len()]
+}
+
+/// Build distinct bucket-start timestamps (the x-axis) preserving order.
+pub(super) fn distinct_bucket_starts(buckets: &[MetricBucket]) -> Vec<DateTime<Utc>> {
+    let mut seen: std::collections::BTreeSet<DateTime<Utc>> = std::collections::BTreeSet::new();
+    for b in buckets {
+        seen.insert(b.bucket_start);
+    }
+    seen.into_iter().collect()
+}
+
+/// Index a bucket-start timestamp to its position in the x-axis, returning
+/// `None` if missing.
+pub(super) fn bucket_index(buckets: &[DateTime<Utc>], ts: DateTime<Utc>) -> Option<usize> {
+    buckets.iter().position(|b| *b == ts)
+}
+
+/// Build the bucket-granularity query string for the selected window.
+/// Pick high-fidelity buckets for the selected window. The charts only render
+/// a handful of x-axis labels, so dense buckets preserve real per-turn shape
+/// without cluttering the axis.
+pub(super) fn bucket_param(window: TimeWindow) -> &'static str {
+    match window {
+        TimeWindow::Hours1 => "1m",
+        TimeWindow::Hours6 => "1m",
+        TimeWindow::Days1 => "5m",
+        TimeWindow::Days7 | TimeWindow::Days30 | TimeWindow::Days90 => "hour",
+    }
+}
+
+/// Selectable time window for the radio group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TimeWindow {
+    Hours1,
+    Hours6,
+    Days1,
+    Days7,
+    Days30,
+    Days90,
+}
+
+impl TimeWindow {
+    /// Radio-button label, which doubles as the exact wire value sent to
+    /// `GET /api/metrics/turns?window=…` (the backend's window parser
+    /// accepts the same `Nh` / `Nd` suffix form).
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Hours1 => "1h",
+            Self::Hours6 => "6h",
+            Self::Days1 => "1d",
+            Self::Days7 => "7d",
+            Self::Days30 => "30d",
+            Self::Days90 => "90d",
+        }
+    }
+
+    pub(super) fn all() -> &'static [TimeWindow] {
+        &[
+            TimeWindow::Hours1,
+            TimeWindow::Hours6,
+            TimeWindow::Days1,
+            TimeWindow::Days7,
+            TimeWindow::Days30,
+            TimeWindow::Days90,
+        ]
+    }
+}
+
+/// Group-by selection: either a specific (agent, model, tier) group or "All".
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum GroupBy {
+    All,
+    Pair(GroupKey),
+}
+
+impl GroupBy {
+    /// Serialize to a stable string for the `<select>` `value` attribute.
+    pub(super) fn key(&self) -> String {
+        match self {
+            Self::All => "__ALL__".to_string(),
+            Self::Pair((agent, m, t)) => format!(
+                "{}|{}|{}",
+                agent,
+                m.as_deref().unwrap_or(""),
+                t.as_deref().unwrap_or("")
+            ),
+        }
+    }
+
+    /// Inverse of [`key`]. Returns `GroupBy::All` for an unrecognized key.
+    pub(super) fn from_key(key: &str, pairs: &[GroupKey]) -> Self {
+        if key == "__ALL__" {
+            return Self::All;
+        }
+        for p in pairs {
+            if Self::Pair(p.clone()).key() == key {
+                return Self::Pair(p.clone());
+            }
+        }
+        Self::All
+    }
+}

--- a/frontend/src/pages/settings/performance_panel/series.rs
+++ b/frontend/src/pages/settings/performance_panel/series.rs
@@ -7,7 +7,7 @@ use shared::api::MetricBucket;
 
 use crate::components::charts::{LineSeries, StackedSeries};
 
-use super::{bucket_group_key, bucket_index, pair_color, pair_label, GroupKey};
+use super::model::{bucket_group_key, bucket_index, pair_color, pair_label, GroupKey};
 
 /// Build paired p50 (solid) / p95 (dashed) line series per active pair,
 /// like the existing [`build_cache_hit_series`]. `p50` / `p95` extract the

--- a/frontend/src/pages/settings/performance_panel/use_metrics.rs
+++ b/frontend/src/pages/settings/performance_panel/use_metrics.rs
@@ -4,7 +4,7 @@ use shared::api::{MetricBucket, MetricBucketsResponse};
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
-use super::{bucket_param, TimeWindow};
+use super::model::{bucket_param, TimeWindow};
 use crate::utils::{self, FetchError, On401};
 
 pub(super) struct PerformanceMetrics {


### PR DESCRIPTION
## Summary
- move PerformancePanel grouping/window/bucket helper types into `performance_panel/model.rs`
- update body/charts/controls/series/use_metrics to import the model helpers directly
- reserve workspace version 2.12.98 after Claude's 2.12.97 slice

## Tests
- cargo check -p frontend
- cargo fmt --check
- cargo test -p frontend
- cargo clippy -p frontend -- -D warnings