### PR TITLE
refactor: neutralize Session output — IoEvent::Classified (#1165 item 2, phase A slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.98"
+version = "2.12.99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.98"
+version = "2.12.99"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.98"
+version = "2.12.99"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.98"
+version = "2.12.99"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.98"
+version = "2.12.99"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.98"
+version = "2.12.99"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.98"
+version = "2.12.99"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.98"
+version = "2.12.99"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.98"
+version = "2.12.99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.98"
+version = "2.12.99"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.98"
+version = "2.12.99"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/agent.rs
+++ b/claude-session-lib/src/agent.rs
@@ -1,7 +1,6 @@
 //! `ClaudeAgent`: the [`session_lib::Agent`] implementation for the `claude`
 //! CLI. Construct `Session<ClaudeAgent>` to get a Claude-backed session.
 
-use session_lib::adapter::{AgentAdapter, ClaudeAdapter};
 use session_lib::agent::Agent;
 use session_lib::error::SessionError;
 use session_lib::io::{IoCommand, IoEvent};
@@ -39,10 +38,5 @@ impl Agent for ClaudeAgent {
             claude_io_task(session_id, client, command_rx, event_tx).await;
         });
         Ok(handle)
-    }
-
-    /// Claude classifies its stdout through the stateless [`ClaudeAdapter`].
-    fn adapter() -> Option<Box<dyn AgentAdapter>> {
-        Some(Box::new(ClaudeAdapter))
     }
 }

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -15,7 +15,7 @@ use claude_codes::{AsyncClient as ClaudeAsyncClient, ClaudeInput, ClaudeOutput};
 use rand::Rng;
 use session_lib::error::SessionError;
 use session_lib::io::{IoCommand, IoEvent};
-use session_lib::{TurnOutcome, TurnTracker};
+use session_lib::{AgentOutputClassifier, ClaudeAdapter, TurnOutcome, TurnTracker};
 use shared::PortalMessage;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -264,8 +264,21 @@ pub(crate) async fn claude_io_task(
                             ClaudeOutput::Result(r) if r.is_error
                         ) && pending_session_limit.is_some();
 
-                        if event_tx.send(IoEvent::Output(Box::new(output))).is_err() {
-                            // Receiver dropped, session ended.
+                        // Classify the frame into neutral decisions here (the
+                        // boundary that keeps `Session` free of `ClaudeOutput`)
+                        // and forward each. `Session` buffers every `Visible`
+                        // value before emitting it, preserving ordering.
+                        let value = serde_json::to_value(&output).unwrap_or_default();
+                        let mut classifier = ClaudeAdapter;
+                        let mut send_failed = false;
+                        for decision in classifier.classify(value) {
+                            if event_tx.send(IoEvent::Classified(decision)).is_err() {
+                                // Receiver dropped, session ended.
+                                send_failed = true;
+                                break;
+                            }
+                        }
+                        if send_failed {
                             break;
                         }
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -326,8 +326,9 @@ struct ConnectionState {
     perm_rx: mpsc::UnboundedReceiver<PermissionResponseData>,
     /// Receiver for output acknowledgments from backend
     ack_rx: mpsc::UnboundedReceiver<u64>,
-    /// Sender for Claude outputs to the output forwarder
-    output_tx: mpsc::UnboundedSender<ClaudeOutput>,
+    /// Sender for Claude output (raw wire JSON) to the output forwarder, which
+    /// re-parses each frame to `ClaudeOutput` for its typed side-effects.
+    output_tx: mpsc::UnboundedSender<serde_json::Value>,
     /// WebSocket write handle for sending permission requests directly
     ws_write: SharedWsWrite,
     /// Receiver to detect WebSocket disconnection
@@ -736,7 +737,7 @@ async fn run_message_loop<A: Agent>(
     let (ws_write, ws_read) = conn.split();
 
     // Channel for Claude outputs
-    let (output_tx, output_rx) = mpsc::unbounded_channel::<ClaudeOutput>();
+    let (output_tx, output_rx) = mpsc::unbounded_channel::<serde_json::Value>();
 
     // Channel for permission responses from frontend
     let (perm_tx, perm_rx) = mpsc::unbounded_channel::<PermissionResponseData>();
@@ -1142,9 +1143,13 @@ async fn run_main_loop<A: Agent>(
             }
 
             event = claude_session.next_event() => {
-                // Handle raw output directly (Codex JSONL) — bypasses the
-                // ClaudeOutput-typed output forwarder
-                if let Some(SessionEvent::RawOutput(ref value)) = event {
+                // Both backends now deliver visible output as the neutral
+                // `SessionEvent::RawOutput(value)`. Route by agent at the proxy
+                // edge: Codex uses this simple inline path; Claude falls through
+                // to the wiggum/output-forwarder path, which re-parses the value
+                // to `ClaudeOutput` for its image/git/echo/wiggum side-effects.
+                if state.agent_type != shared::AgentType::Claude {
+                  if let Some(SessionEvent::RawOutput(ref value)) = event {
                     if state.git_refresh.should_check_before_message() {
                         check_and_send_branch_update(
                             &state.ws_write,
@@ -1177,6 +1182,7 @@ async fn run_main_loop<A: Agent>(
                         inject_portal_reminder(claude_session).await;
                     }
                     continue;
+                  }
                 }
 
                 // Per-turn metrics: forward as a typed `TurnMetricsReport`
@@ -1244,6 +1250,16 @@ async fn run_main_loop<A: Agent>(
             }
         }
     }
+}
+
+/// Re-parse a neutral `Visible` output value back to the typed `ClaudeOutput`
+/// at the Claude proxy edge. `Session` is now agent-neutral (it forwards raw
+/// `Value`s); the Claude-specific consumers — the `output_forwarder`'s
+/// image/git/echo handling and `wiggum`'s DONE detection — re-parse here.
+/// Returns `None` for malformed/non-Claude frames, which callers forward
+/// verbatim rather than drop (#1165 item 2, slice 1).
+pub(super) fn parse_visible_claude_output(value: &serde_json::Value) -> Option<ClaudeOutput> {
+    serde_json::from_value(value.clone()).ok()
 }
 
 fn is_codex_compaction_event(value: &serde_json::Value) -> bool {
@@ -1476,6 +1492,32 @@ pub(crate) use shared::fmt::{format_duration, truncate_str as truncate};
 mod tests {
     use super::*;
     use uuid::Uuid;
+
+    /// The Claude proxy-edge re-parse gate (#1165 item 2, slice 1). Valid Claude
+    /// frames parse to `Some`, so the typed side-effects (echo replacement,
+    /// wiggum DONE, image/git handling) run; malformed / non-Claude frames yield
+    /// `None`, so the caller forwards the original raw value verbatim — never
+    /// dropping or rewriting it, and never panicking.
+    #[test]
+    fn parse_visible_claude_output_gates_typed_side_effects() {
+        use serde_json::json;
+
+        // Valid Claude Result → Some (wiggum DONE detection can fire).
+        let result = json!({
+            "type": "result", "subtype": "success", "is_error": false,
+            "duration_ms": 1, "duration_api_ms": 1, "num_turns": 1,
+            "result": "DONE", "session_id": "s", "total_cost_usd": 0.0
+        });
+        assert!(matches!(
+            parse_visible_claude_output(&result),
+            Some(ClaudeOutput::Result(_))
+        ));
+
+        // Malformed / non-Claude frames → None (forward raw, no panic).
+        let garbage = json!({"totally": "unknown", "shape": [1, 2, 3]});
+        assert!(parse_visible_claude_output(&garbage).is_none());
+        assert!(parse_visible_claude_output(&json!(42)).is_none());
+    }
 
     #[test]
     fn backoff_doubles_then_saturates_at_max() {

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -31,7 +31,7 @@ const CHUNK_UPLOAD_THRESHOLD_BYTES: usize = 1024 * 1024;
 /// Forwards Claude outputs to WebSocket with sequence numbers for reliable delivery.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_output_forwarder(
-    mut output_rx: mpsc::UnboundedReceiver<ClaudeOutput>,
+    mut output_rx: mpsc::UnboundedReceiver<serde_json::Value>,
     ws_write: SharedWsWrite,
     session_id: Uuid,
     backend_url: String,
@@ -49,12 +49,17 @@ pub fn spawn_output_forwarder(
         // Track Read tool calls on image files: tool_use_id → file_path
         let mut image_read_map: HashMap<String, String> = HashMap::new();
 
-        while let Some(output) = output_rx.recv().await {
-            // Log detailed info about the message
-            log_claude_output(&output);
+        while let Some(value) = output_rx.recv().await {
+            // `Session` is now agent-neutral and forwards raw wire JSON. Re-parse
+            // it to `ClaudeOutput` here, ONCE, at the Claude proxy edge; all the
+            // typed side-effects (logging, git-signal, image extraction, echo
+            // replacement) hang off this `Option`. Malformed / non-Claude frames
+            // skip the typed work and are forwarded verbatim — never dropped or
+            // rewritten (#1165 item 2, slice 1).
+            let parsed = super::parse_visible_claude_output(&value);
 
-            // Check for branch/PR update from PREVIOUS git command (deferred so
-            // the command has finished executing before we query git/gh state)
+            // Branch/PR update from the PREVIOUS message's git command (deferred
+            // so the command has finished). Runs each frame regardless of parse.
             if git_refresh.should_check_before_message() {
                 check_and_send_branch_update(
                     &ws_write,
@@ -65,28 +70,35 @@ pub fn spawn_output_forwarder(
                 .await;
             }
 
-            // Check if THIS message is a git-related bash command (for next iteration)
-            if claude_output_has_git_signal(&output) {
-                git_refresh.mark_git_signal();
-            }
+            let (content, image_items) = if let Some(ref output) = parsed {
+                log_claude_output(output);
 
-            // Track Read tool calls on image files from assistant messages
-            track_image_reads(&output, &mut image_read_map);
+                // Is THIS message a git-related bash command (for next iteration)?
+                if claude_output_has_git_signal(output) {
+                    git_refresh.mark_git_signal();
+                }
 
-            // Collect any image work items from user-message tool results
-            // (raw bytes for large images, base64 strings for small ones).
-            let image_items = extract_image_work_items(&output, &mut image_read_map, max_bytes);
+                // Track Read tool calls on image files from assistant messages.
+                track_image_reads(output, &mut image_read_map);
 
-            // Serialize and buffer with sequence number. Typed portal inputs
-            // sent via `agent-portal message` are delivered to the agent as
-            // readable text, but their echoed user message should render as
-            // the original event envelope rather than a string-prefix parse.
-            let content = replacement_input_display_event(&output, &pending_input_display_events)
-                .await
-                .unwrap_or_else(|| {
-                    serde_json::to_value(&output)
-                        .unwrap_or(serde_json::Value::String(format!("{:?}", output)))
-                });
+                // Image work items from user-message tool results (raw bytes for
+                // large images, base64 for small ones).
+                let image_items = extract_image_work_items(output, &mut image_read_map, max_bytes);
+
+                // Echo-replacement swaps the rendered content for typed portal
+                // inputs (`agent-portal message`); otherwise persist + forward
+                // the EXACT raw value (invariant: exact raw Value is what gets
+                // persisted and sent).
+                let content =
+                    replacement_input_display_event(output, &pending_input_display_events)
+                        .await
+                        .unwrap_or_else(|| value.clone());
+
+                (content, image_items)
+            } else {
+                // Malformed / non-Claude frame: forward verbatim, no typed work.
+                (value.clone(), Vec::new())
+            };
 
             // Add to buffer and get sequence number
             let seq = {

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -44,7 +44,7 @@ pub struct WiggumState {
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
     event: Option<session_lib::SessionEvent>,
-    output_tx: &mpsc::UnboundedSender<ClaudeOutput>,
+    output_tx: &mpsc::UnboundedSender<serde_json::Value>,
     ws_write: &SharedWsWrite,
     connection_start: Instant,
     wiggum_state: &mut Option<WiggumState>,
@@ -55,9 +55,21 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
     use session_lib::SessionEvent;
 
     match event {
-        Some(SessionEvent::Output(ref output)) => {
+        Some(SessionEvent::RawOutput(ref value)) => {
+            // Claude visible output now arrives as neutral raw JSON. Re-parse to
+            // `ClaudeOutput` for the typed side-effects (wiggum DONE, compaction
+            // reminder, system-reminder echo drop); malformed/non-Claude frames
+            // skip those and are forwarded verbatim, never dropped.
+            let Some(output) = super::parse_visible_claude_output(value) else {
+                if output_tx.send(value.clone()).is_err() {
+                    error!("Failed to forward Claude output");
+                    return Some(ConnectionResult::Disconnected(connection_start.elapsed()));
+                }
+                return None;
+            };
+
             // Check for wiggum completion before forwarding
-            let should_continue_wiggum = if let ClaudeOutput::Result(ref result) = **output {
+            let should_continue_wiggum = if let ClaudeOutput::Result(ref result) = &output {
                 if let Some(ref state) = wiggum_state {
                     // Check if Claude responded with "DONE"
                     let is_done = check_wiggum_done(result);
@@ -79,7 +91,7 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
             // features reminder so the agent has it in the fresh context.
             // We check before forwarding so the reminder lands logically
             // after the compaction-completed notice in the user's transcript.
-            let is_compaction_boundary = match &**output {
+            let is_compaction_boundary = match &output {
                 ClaudeOutput::System(sys) => shared::is_compaction_boundary(sys),
                 _ => false,
             };
@@ -88,14 +100,14 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
             // <system-reminder> tags. Claude echoes that back as a User message
             // on its stdout — if we forward it, the wrapper text leaks into the
             // user's transcript as if they had typed it. Drop those echoes.
-            if is_system_reminder_echo(output) {
+            if is_system_reminder_echo(&output) {
                 debug!("Dropping system-reminder user echo from transcript");
                 // Skip forwarding and skip the rest of the handler.
                 return None;
             }
 
             // Forward the output
-            if output_tx.send(*output.clone()).is_err() {
+            if output_tx.send(value.clone()).is_err() {
                 error!("Failed to forward Claude output");
                 return Some(ConnectionResult::Disconnected(connection_start.elapsed()));
             }
@@ -162,7 +174,7 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
                         }
                     }
                 }
-            } else if matches!(&**output, ClaudeOutput::Result(_)) && wiggum_state.is_some() {
+            } else if matches!(&output, ClaudeOutput::Result(_)) && wiggum_state.is_some() {
                 // Send final completion portal message
                 if let Some(ref mut state) = wiggum_state {
                     let loop_duration = state.loop_start.elapsed();
@@ -197,7 +209,7 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
                 *wiggum_state = None;
             }
 
-            if matches!(&**output, ClaudeOutput::Result(_)) && wiggum_state.is_none() {
+            if matches!(&output, ClaudeOutput::Result(_)) && wiggum_state.is_none() {
                 debug!("--- ready for input ---");
             }
             None
@@ -229,12 +241,6 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
         Some(SessionEvent::Exited { code }) => {
             info!("Claude session exited with code {}", code);
             Some(ConnectionResult::ClaudeExited)
-        }
-        Some(SessionEvent::RawOutput(_)) => {
-            // Handled in run_main_loop before calling this function
-            unreachable!(
-                "RawOutput should be handled before calling handle_session_event_with_wiggum"
-            );
         }
         Some(SessionEvent::TurnMetricsReady(_)) => {
             // Handled in run_main_loop before calling this function

--- a/session-lib/src/adapter.rs
+++ b/session-lib/src/adapter.rs
@@ -1,16 +1,21 @@
-//! Agent-neutral adapter boundary (refactor item #1, slice 2a — additive).
+//! Agent-neutral protocol boundary (refactor #1165 item 2).
 //!
-//! An [`AgentAdapter`] owns all protocol parse/serialize for one agent backend
-//! and exposes only **neutral decisions** to the generic `Session<A>` core.
-//! Concrete protocol enums (`claude_codes::*`, `codex_codes::*`) stay *inside*
-//! the adapter and never surface into `session.rs`.
+//! Two traits split the per-agent protocol surface so the generic `Session<A>`
+//! core never touches `claude_codes` / `codex_codes` types:
 //!
-//! This slice introduces the trait, the neutral types, and a [`ClaudeAdapter`]
-//! whose [`classify`](AgentAdapter::classify) is a pure function mirroring
-//! exactly what `session.rs::next_event` currently decides for `ClaudeOutput`.
-//! It is **not** yet wired into `session.rs`; that happens in a later slice.
+//! - [`AgentOutputClassifier`] — parses one unit of agent output into neutral
+//!   [`AgentOutput`] decisions. This runs **inside each per-agent I/O task**
+//!   (Claude's `claude_io_task` via [`ClaudeAdapter`]; Codex's via
+//!   `CodexClassifier`), which then emits `IoEvent::Classified(AgentOutput)`.
+//!   `Session` only maps those neutral decisions to `SessionEvent`s.
+//! - [`AgentAdapter`] — the Claude stdin/permission *input* side
+//!   (`user_input` / `permission_response` / `interrupt` producing a
+//!   [`TransportPayload`]). This is Claude-transport-shaped and does not fit
+//!   Codex's async RPC input model; neutralizing the input side is phase-A
+//!   slice 2 (see `docs/design/agent-runtime.md`). [`ClaudeAdapter`] implements
+//!   both traits.
 //!
-//! See `docs/design/session-adapter.md` for the full design.
+//! See `docs/design/session-adapter.md` and `docs/design/agent-runtime.md`.
 
 use uuid::Uuid;
 

--- a/session-lib/src/agent.rs
+++ b/session-lib/src/agent.rs
@@ -9,7 +9,6 @@
 
 use tokio::sync::mpsc;
 
-use crate::adapter::AgentAdapter;
 use crate::error::SessionError;
 use crate::io::{IoCommand, IoEvent};
 use crate::snapshot::SessionConfig;
@@ -21,24 +20,12 @@ pub trait Agent: Send + Sync + 'static {
     /// The task is responsible for:
     /// - Starting whatever process(es) the agent needs.
     /// - Reading [`IoCommand`]s off `command_rx` and acting on them.
-    /// - Emitting [`IoEvent`]s on `event_tx`.
+    /// - Classifying the agent's output and emitting neutral
+    ///   [`IoEvent::Classified`] decisions (plus lifecycle/raw events).
     /// - Terminating cleanly when the process exits or `command_rx` closes.
     fn spawn_io_task(
         config: SessionConfig,
         command_rx: mpsc::UnboundedReceiver<IoCommand>,
         event_tx: mpsc::UnboundedSender<IoEvent>,
     ) -> Result<tokio::task::JoinHandle<()>, SessionError>;
-
-    /// The protocol adapter that classifies this agent's stdout into neutral
-    /// [`AgentOutput`](crate::adapter::AgentOutput) decisions. `Session::next_event`
-    /// calls it on each `IoEvent::Output` unit instead of hardcoding a concrete
-    /// adapter (#1165 item 2).
-    ///
-    /// Defaults to `None`: an agent that doesn't yet route through the adapter
-    /// (the Codex path still pre-classifies into `IoEvent::RawOutput` /
-    /// `IoEvent::CodexPermissionRequest` and never emits `IoEvent::Output`)
-    /// opts out, and `Session` forwards any stray `Output` verbatim.
-    fn adapter() -> Option<Box<dyn AgentAdapter>> {
-        None
-    }
 }

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -5,10 +5,11 @@
 //! `agent.rs` for the dispatch trait.
 
 use claude_codes::io::{ControlResponse, PermissionSuggestion};
-use claude_codes::{ClaudeInput, ClaudeOutput};
+use claude_codes::ClaudeInput;
 use shared::{CodexPermissionInput, TurnMetrics};
 use tokio::sync::oneshot;
 
+use crate::adapter::AgentOutput;
 use crate::error::SessionError;
 
 /// Commands sent from `Session<A>` to the per-agent I/O task.
@@ -48,12 +49,18 @@ pub enum IoEvent {
     AgentStarted {
         pid: Option<u32>,
     },
-    /// Typed output from a claude-protocol session.
-    Output(Box<ClaudeOutput>),
-    /// Raw JSON output from a non-claude agent (e.g. Codex JSONL).
+    /// A neutral, already-classified output decision from the agent's I/O task.
     ///
-    /// Bypasses claude-specific processing (permission extraction,
-    /// `ControlResponse` filtering) and is forwarded directly to the
+    /// The per-agent I/O task runs its `AgentOutputClassifier` (Claude:
+    /// `ClaudeAdapter`; Codex: `CodexClassifier`) and emits the resulting
+    /// neutral [`AgentOutput`]s here, so `Session` never sees a concrete
+    /// protocol type. `Session::next_event` maps each to a `SessionEvent`
+    /// (`Visible` → `RawOutput`, `PermissionRequest` → `PermissionRequest`,
+    /// `NotFound` → `SessionNotFound`, `Noop` → skip).
+    Classified(AgentOutput),
+    /// Raw JSON output forwarded directly (e.g. Codex JSONL frames the codex
+    /// I/O task emits outside the classifier, and portal-reminder messages).
+    /// Bypasses classification and is forwarded verbatim to the
     /// backend/frontend.
     RawOutput(serde_json::Value),
     /// Permission request from Codex's app-server approval flow.
@@ -98,15 +105,13 @@ pub enum IoEvent {
 /// Events emitted by a `Session<A>` to its consumer.
 #[derive(Debug)]
 pub enum SessionEvent {
-    /// Claude produced output (excluding permission requests, which have
-    /// their own event).
-    Output(Box<ClaudeOutput>),
-
-    /// Raw JSON output from a non-Claude agent (e.g. Codex JSONL).
+    /// User-visible agent output, as the original raw wire JSON.
     ///
-    /// This bypasses Claude-specific processing (permission extraction,
-    /// ControlResponse filtering) and is forwarded directly to the
-    /// backend/frontend.
+    /// Both backends now arrive here: the per-agent I/O task classifies its
+    /// native output and `Session` forwards each `AgentOutput::Visible` value
+    /// verbatim. Agent-specific consumers (e.g. the Claude proxy
+    /// `output_forwarder`, which re-parses for image/git/echo handling) live at
+    /// the proxy edge, keyed on `agent_type` — `Session` stays neutral.
     RawOutput(serde_json::Value),
 
     /// The agent is requesting permission for a tool.

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -12,7 +12,7 @@ use claude_codes::ClaudeInput;
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
-use crate::adapter::{AgentAdapter, AgentOutput};
+use crate::adapter::AgentOutput;
 use crate::agent::Agent;
 use crate::buffer::OutputBuffer;
 use crate::error::SessionError;
@@ -55,10 +55,6 @@ pub struct Session<A: Agent> {
     /// `kill_on_drop` doesn't fire when the SDK keeps the child alive in
     /// detached tasks (#927).
     agent_pid: Option<u32>,
-    /// Per-agent protocol adapter, supplied by `A::adapter()`. `next_event`
-    /// drives it to classify each `IoEvent::Output` unit. `None` for agents
-    /// that pre-classify their output (Codex today); see [`Agent::adapter`].
-    adapter: Option<Box<dyn AgentAdapter>>,
     _agent: PhantomData<A>,
 }
 
@@ -145,7 +141,6 @@ impl<A: Agent> Session<A> {
             event_rx: Some(event_rx),
             io_task: Some(handle),
             agent_pid: None,
-            adapter: A::adapter(),
             _agent: PhantomData,
         })
     }
@@ -187,7 +182,6 @@ impl<A: Agent> Session<A> {
             event_rx,
             io_task,
             agent_pid: None,
-            adapter: A::adapter(),
             _agent: PhantomData,
         })
     }
@@ -236,72 +230,54 @@ impl<A: Agent> Session<A> {
                     // not a consumer-facing event, so keep looping.
                     self.agent_pid = pid;
                 }
-                Some(IoEvent::Output(boxed_output)) => {
-                    let output = *boxed_output;
-
-                    // Buffer the raw output before classifying (preserve ordering).
-                    let output_value = serde_json::to_value(&output).unwrap_or_default();
-                    self.buffer.push(output_value.clone());
-
-                    // Delegate protocol classification to the agent's adapter
-                    // (`A::adapter()`). Claude is 1:1 (one raw unit → one
-                    // decision) but handle the Vec generally so the loop matches
-                    // the trait contract. Collect first so the `&mut adapter`
-                    // borrow ends before the loop mutates other `self` fields.
-                    let decisions = match self.adapter.as_mut() {
-                        Some(adapter) => adapter.classify(output_value),
-                        // Agents without an adapter (Codex today) never emit
-                        // `IoEvent::Output` — they pre-classify upstream. Forward
-                        // any stray unit verbatim so output is never dropped.
-                        None => vec![AgentOutput::Visible(output_value)],
-                    };
-                    let mut visible = false;
-                    for decision in decisions {
-                        match decision {
-                            AgentOutput::NotFound => {
-                                self.state = SessionState::Exited { code: 1 };
-                                self.command_tx = None;
-                                self.event_rx = None;
-                                return Some(SessionEvent::SessionNotFound);
-                            }
-                            AgentOutput::PermissionRequest {
+                Some(IoEvent::Classified(decision)) => {
+                    // The per-agent I/O task has already run its
+                    // `AgentOutputClassifier`; `Session` only maps the neutral
+                    // decision to a `SessionEvent`. Both backends converge here.
+                    match decision {
+                        AgentOutput::NotFound => {
+                            self.state = SessionState::Exited { code: 1 };
+                            self.command_tx = None;
+                            self.event_rx = None;
+                            return Some(SessionEvent::SessionNotFound);
+                        }
+                        AgentOutput::PermissionRequest {
+                            request_id,
+                            tool_name,
+                            input,
+                            suggestions,
+                        } => {
+                            // Recover the typed suggestions from the classifier's
+                            // opaque JSON round-trip (it serialized them).
+                            let permission_suggestions: Vec<PermissionSuggestion> = suggestions
+                                .into_iter()
+                                .filter_map(|s| serde_json::from_value(s).ok())
+                                .collect();
+                            self.pending_permission = Some(PendingPermission {
+                                request_id: request_id.clone(),
+                                tool_name: tool_name.clone(),
+                                input: input.clone(),
+                                requested_at: Utc::now(),
+                            });
+                            self.state = SessionState::WaitingForPermission;
+                            return Some(SessionEvent::PermissionRequest {
                                 request_id,
                                 tool_name,
                                 input,
-                                suggestions,
-                            } => {
-                                // Recover the typed suggestions from the adapter's
-                                // opaque JSON round-trip (it serialized them).
-                                let permission_suggestions: Vec<PermissionSuggestion> = suggestions
-                                    .into_iter()
-                                    .filter_map(|s| serde_json::from_value(s).ok())
-                                    .collect();
-                                self.pending_permission = Some(PendingPermission {
-                                    request_id: request_id.clone(),
-                                    tool_name: tool_name.clone(),
-                                    input: input.clone(),
-                                    requested_at: Utc::now(),
-                                });
-                                self.state = SessionState::WaitingForPermission;
-                                return Some(SessionEvent::PermissionRequest {
-                                    request_id,
-                                    tool_name,
-                                    input,
-                                    permission_suggestions,
-                                });
-                            }
-                            // Internal ack / nothing for the consumer — skip it and
-                            // let the outer loop pull the next event.
-                            AgentOutput::Noop => {}
-                            // User-visible output: forward the ORIGINAL typed value.
-                            AgentOutput::Visible(_) => visible = true,
+                                permission_suggestions,
+                            });
                         }
+                        // User-visible output: buffer the raw value and forward it
+                        // verbatim — the same path the codex `RawOutput` arm below
+                        // takes. Both agents now converge on this neutral channel.
+                        AgentOutput::Visible(value) => {
+                            self.buffer.push(value.clone());
+                            return Some(SessionEvent::RawOutput(value));
+                        }
+                        // Internal ack / nothing for the consumer — skip it and
+                        // let the outer loop pull the next event.
+                        AgentOutput::Noop => {}
                     }
-
-                    if visible {
-                        return Some(SessionEvent::Output(Box::new(output)));
-                    }
-                    continue;
                 }
                 Some(IoEvent::RawOutput(value)) => {
                     self.buffer.push(value.clone());


### PR DESCRIPTION
## #1165 item 2 — phase A, slice 1: output neutralization (Claude+Codex consensus)

Classification moves from `Session` into the per-agent I/O task, so `Session<A>` no longer touches `ClaudeOutput`. Both backends now deliver visible output on the same neutral channel.

### session-lib
- `IoEvent::Output(Box<ClaudeOutput>)` → **`IoEvent::Classified(AgentOutput)`**; `SessionEvent::Output` removed — visible Claude output now arrives on the existing neutral `SessionEvent::RawOutput(Value)` (the channel Codex already used).
- `Session::next_event` maps the neutral decision: `Visible`→buffer+`RawOutput`, `PermissionRequest`→`PermissionRequest`, `NotFound`→`SessionNotFound`, `Noop`→skip.
- The `Session` adapter field and `Agent::adapter()` are deleted — classification lives in the I/O task now.

### claude-session-lib
- `claude_io_task` runs `ClaudeAdapter::classify` and emits `Classified`, keeping its own typed turn-tracking / metrics / session-limit inspection.
- **Proxy edge** routes visible output by `agent_type`: Codex keeps the inline path; Claude flows to the output-forwarder / wiggum path. New `parse_visible_claude_output(&Value) -> Option<ClaudeOutput>` re-parses **once** at the forwarder loop top (and in wiggum for DONE/echo/compaction); all typed side-effects (image extraction, git-signal, echo replacement, wiggum DONE) hang off that `Option`. Malformed/non-Claude frames forward the exact raw `Value` verbatim — never dropped or rewritten, no panic.

### Invariants (Codex's acceptance criteria — all met)
1. Session never re-exposes `ClaudeOutput`; forwards raw `Value`. ✓
2. Forwarder takes `Value`, one parse at loop top, typed side-effects off the `Option`, parse-fail forwards raw, no panic. ✓
3. Codex `RawOutput` behavior unchanged (only shared routing shape). ✓
4. Exact raw `Value` persisted + sent as `SequencedOutput`. ✓

### Verification
- `cargo build --workspace` ✓ (launcher built — `Session: Sync` preserved)
- `cargo test -p session-lib` (30, incl. new parse-gate test) + `-p claude-session-lib` (34) ✓ — the existing echo-replacement + wiggum tests pass **unchanged** (the characterization net)
- clippy clean, `cargo fmt --check` clean

Codex side still emits `RawOutput`/`CodexPermissionRequest` directly (flips to `Classified` in a follow-up). Input-side neutralization is slice 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)