### PR TITLE
fix: stabilize launcher update action layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.99"
+version = "2.12.100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.99"
+version = "2.12.100"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.99"
+version = "2.12.100"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.99"
+version = "2.12.100"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.99"
+version = "2.12.100"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.99"
+version = "2.12.100"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.99"
+version = "2.12.100"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.99"
+version = "2.12.100"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.99"
+version = "2.12.100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.99"
+version = "2.12.100"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.99"
+version = "2.12.100"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -19,8 +19,8 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
     let launcher_id = l.launcher_id;
 
     // Inline two-step confirm instead of a browser `confirm()` popup, which
-    // doesn't render well on mobile. First click arms the confirmation; the
-    // row then shows explicit Confirm / Cancel buttons (normal DOM elements).
+    // doesn't render well on mobile. Keep the action slots stable so the
+    // primary click target doesn't move between the armed/unarmed states.
     let confirming = use_state(|| false);
 
     // A restart in progress takes precedence over the confirm state.
@@ -41,31 +41,35 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
         })
     };
 
-    let actions = if props.update_in_progress {
-        html! {
-            <button class="update-button stage-3" disabled=true>
-                { "Restarting..." }
-            </button>
-        }
+    let primary_label = if props.update_in_progress {
+        "Restarting..."
     } else if *confirming {
-        html! {
-            <div class="launcher-confirm-actions">
-                <span class="launcher-confirm-prompt">{ "Update & restart?" }</span>
-                <button class="confirm-button" onclick={confirm}>{ "Confirm" }</button>
-                <button class="cancel-button" onclick={cancel}>{ "Cancel" }</button>
-            </div>
-        }
+        "Confirm Restart"
     } else {
-        html! {
-            <button
-                class="update-button stage-0"
-                onclick={arm}
-                title="Pull the latest agent-portal release and restart this launcher"
-            >
-                { "Update & Restart" }
-            </button>
-        }
+        "Update & Restart"
     };
+    let primary_title = if *confirming {
+        "Confirm launcher update and restart"
+    } else {
+        "Pull the latest agent-portal release and restart this launcher"
+    };
+    let primary_class = classes!(
+        "update-button",
+        "launcher-update-primary",
+        if props.update_in_progress {
+            "stage-3"
+        } else if *confirming {
+            "confirming"
+        } else {
+            "stage-0"
+        }
+    );
+    let primary_onclick = if *confirming { confirm } else { arm };
+    let cancel_class = classes!(
+        "cancel-button",
+        "launcher-update-secondary",
+        (!*confirming || props.update_in_progress).then_some("is-placeholder")
+    );
 
     html! {
         <tr class="token-row">
@@ -73,7 +77,27 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
             <td>{ &l.hostname }</td>
             <td>{ format!("v{}", &l.version) }</td>
             <td>{ l.running_sessions }</td>
-            <td class="token-actions">{ actions }</td>
+            <td class="token-actions">
+                <div class="launcher-update-actions">
+                    <button
+                        class={primary_class}
+                        onclick={primary_onclick}
+                        title={primary_title}
+                        disabled={props.update_in_progress}
+                    >
+                        { primary_label }
+                    </button>
+                    <button
+                        class={cancel_class}
+                        onclick={cancel}
+                        disabled={!*confirming || props.update_in_progress}
+                        aria-hidden={(!*confirming || props.update_in_progress).to_string()}
+                        tabindex={if *confirming && !props.update_in_progress { "0" } else { "-1" }}
+                    >
+                        { "Cancel" }
+                    </button>
+                </div>
+            </td>
         </tr>
     }
 }

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -380,6 +380,14 @@
 }
 
 /* Update-and-restart button */
+.launcher-update-actions {
+    display: grid;
+    grid-template-columns: 11rem 5rem;
+    gap: 0.5rem;
+    justify-content: end;
+    align-items: center;
+}
+
 .update-button {
     border: none;
     color: white;
@@ -388,14 +396,25 @@
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 500;
-    margin-left: 0.5rem;
     transition: background 0.2s;
+}
+.launcher-update-primary,
+.launcher-update-secondary {
+    width: 100%;
+    min-height: 2.25rem;
+    white-space: nowrap;
 }
 .update-button.stage-0 {
     background: #7f849c;
 }
 .update-button.stage-0:hover {
     background: #565f89;
+}
+.update-button.confirming {
+    background: var(--error);
+}
+.update-button.confirming:hover {
+    background: #ff5a72;
 }
 .update-button.stage-3 {
     background: #565f89;
@@ -405,24 +424,12 @@
     cursor: not-allowed;
     opacity: 0.85;
 }
-
-/* Inline two-step confirm for the launcher update/restart action (replaces a
-   browser confirm() popup, which is awkward on mobile). Wraps when narrow. */
-.launcher-confirm-actions {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
-    justify-content: flex-end;
+.launcher-update-secondary {
+    padding: 0.5rem 0.75rem;
 }
-.launcher-confirm-prompt {
-    color: var(--text-secondary);
-    font-size: 0.85rem;
-}
-.launcher-confirm-actions .confirm-button,
-.launcher-confirm-actions .cancel-button {
-    padding: 0.4rem 0.9rem;
-    font-size: 0.85rem;
+.launcher-update-secondary.is-placeholder {
+    visibility: hidden;
+    pointer-events: none;
 }
 
 /* Token Created Success */


### PR DESCRIPTION
## Summary
- keep the launcher update/restart action in a fixed two-slot action rail
- reuse the primary button for the confirm step so the click target stays anchored
- hide the cancel slot when idle/restarting while preserving layout width

## Verification
- cargo check -p frontend
- cargo fmt --check
- cargo clippy -p frontend -- -D warnings
- cargo test -p frontend