### PR TITLE
refactor: neutralize Session input — IoCommand::{UserInput,Permission} (#1165 item 2, phase A slice 2)

### DIFF
--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -630,7 +630,7 @@ mod tests {
 
     #[test]
     fn control_response_deny_uses_reason_with_default() {
-        let explicit = serde_json::to_value(&claude_control_response(
+        let explicit = serde_json::to_value(claude_control_response(
             "req-3",
             PermissionDecision {
                 allow: false,
@@ -649,7 +649,7 @@ mod tests {
         );
 
         // Default reason mirrors the old respond_permission "User denied".
-        let defaulted = serde_json::to_value(&claude_control_response(
+        let defaulted = serde_json::to_value(claude_control_response(
             "req-4",
             PermissionDecision {
                 allow: false,

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -1,8 +1,9 @@
 //! Background task for Claude sessions.
 //!
-//! Owns the [`ClaudeAsyncClient`] exclusively, draining stdout into
-//! [`IoEvent`]s and writing [`IoCommand::Input`] / `PermissionResponse`
-//! back to claude's stdin. Also implements the upstream-429 rate-limit
+//! Owns the [`ClaudeAsyncClient`] exclusively, draining stdout into neutral
+//! [`IoEvent::Classified`] decisions and translating [`IoCommand::UserInput`] /
+//! [`IoCommand::Permission`] into claude's wire form on stdin. Also implements
+//! the upstream-429 rate-limit
 //! turn-retry state machine (see the `RATE_LIMIT_TEXT_PREFIX` comment
 //! below).
 
@@ -10,15 +11,42 @@ use std::time::{Duration, Instant};
 
 use chrono::{NaiveTime, TimeZone, Utc};
 use chrono_tz::Tz;
-use claude_codes::io::ContentBlock;
+use claude_codes::io::{ContentBlock, ControlResponse, PermissionResult};
 use claude_codes::{AsyncClient as ClaudeAsyncClient, ClaudeInput, ClaudeOutput};
 use rand::Rng;
 use session_lib::error::SessionError;
 use session_lib::io::{IoCommand, IoEvent};
-use session_lib::{AgentOutputClassifier, ClaudeAdapter, TurnOutcome, TurnTracker};
+use session_lib::{
+    AgentOutputClassifier, ClaudeAdapter, PermissionDecision, TurnOutcome, TurnTracker,
+};
 use shared::PortalMessage;
 use tokio::sync::mpsc;
 use uuid::Uuid;
+
+/// Build a Claude `ControlResponse` from a neutral [`PermissionDecision`].
+///
+/// Mirrors the allow/deny/remember mapping the generic `Session` used to do
+/// inline; it now lives at the Claude edge since the I/O task owns the typed
+/// client (#1165 item 2, phase A slice 2). `decision.remember` is opaque JSON
+/// (serialized `claude_codes::Permission`s) — the Value-based allow handles it.
+fn claude_control_response(request_id: &str, decision: PermissionDecision) -> ControlResponse {
+    if decision.allow {
+        let input_value = decision
+            .modified_input
+            .unwrap_or(serde_json::Value::Object(Default::default()));
+        if decision.remember.is_empty() {
+            ControlResponse::from_result(request_id, PermissionResult::allow(input_value))
+        } else {
+            ControlResponse::from_result(
+                request_id,
+                PermissionResult::allow_with_permissions(input_value, decision.remember),
+            )
+        }
+    } else {
+        let reason = decision.reason.unwrap_or_else(|| "User denied".to_string());
+        ControlResponse::from_result(request_id, PermissionResult::deny(reason))
+    }
+}
 
 const SESSION_LIMIT_TEXT: &str = "You've hit your session limit";
 const SESSION_LIMIT_CONTINUE_PROMPT: &str =
@@ -85,11 +113,13 @@ pub(crate) async fn claude_io_task(
                     // `display_event` is for agents that don't echo (Codex);
                     // claude echoes its input and the proxy swaps the typed
                     // event in via output_forwarder, so it's ignored here.
-                    IoCommand::Input {
-                        input,
+                    IoCommand::UserInput {
+                        text,
                         delivered,
                         display_event: _,
                     } => {
+                        // Build Claude's wire form from the neutral text.
+                        let input = ClaudeInput::user_message(text, session_id);
                         // Each fresh user input gets its own retry budget.
                         rate_limit_attempts = 0;
                         current_turn_was_rate_limited = false;
@@ -106,10 +136,13 @@ pub(crate) async fn claude_io_task(
                         }
                         r
                     }
-                    IoCommand::PermissionResponse(response) => {
+                    IoCommand::Permission {
+                        request_id,
+                        decision,
+                    } => {
+                        let response = claude_control_response(&request_id, decision);
                         client.send_control_response(response).await
                     }
-                    IoCommand::CodexApproval { .. } => continue,
                 };
                 if let Err(e) = result {
                     let _ = event_tx.send(IoEvent::Error(SessionError::Agent(e.to_string())));
@@ -355,14 +388,15 @@ pub(crate) async fn claude_io_task(
                             }
                             Some(cmd) = command_rx.recv() => {
                                 match cmd {
-                                    IoCommand::Input {
-                                        input: new_input,
+                                    IoCommand::UserInput {
+                                        text,
                                         delivered,
                                         display_event: _,
                                     } => {
                                         // User typed something while we were waiting
                                         // — honor that, abandon the retry, and reset
                                         // the budget for the new prompt.
+                                        let new_input = ClaudeInput::user_message(text, session_id);
                                         rate_limit_attempts = 0;
                                         pending_session_limit = None;
                                         current_turn_subagent_tokens = 0;
@@ -379,7 +413,12 @@ pub(crate) async fn claude_io_task(
                                             ));
                                         }
                                     }
-                                    IoCommand::PermissionResponse(response) => {
+                                    IoCommand::Permission {
+                                        request_id,
+                                        decision,
+                                    } => {
+                                        let response =
+                                            claude_control_response(&request_id, decision);
                                         if let Err(e) =
                                             client.send_control_response(response).await
                                         {
@@ -388,7 +427,6 @@ pub(crate) async fn claude_io_task(
                                             ));
                                         }
                                     }
-                                    IoCommand::CodexApproval { .. } => {}
                                 }
                             }
                         }
@@ -537,6 +575,93 @@ async fn read_stderr(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- claude_control_response: neutral PermissionDecision → ControlResponse.
+    // Ported from the deleted `ClaudeAdapter::permission_response` tests; this is
+    // permission hot-path code so the characterization net moves with the logic.
+
+    #[test]
+    fn control_response_allow_uses_empty_input_by_default() {
+        let resp = claude_control_response(
+            "req-1",
+            PermissionDecision {
+                allow: true,
+                ..Default::default()
+            },
+        );
+        let v = serde_json::to_value(&resp).unwrap();
+        let inner = &v["response"];
+        assert_eq!(inner["subtype"], serde_json::json!("success"));
+        assert_eq!(inner["request_id"], serde_json::json!("req-1"));
+        assert_eq!(inner["response"]["behavior"], serde_json::json!("allow"));
+        // input defaults to an empty object.
+        assert_eq!(inner["response"]["updatedInput"], serde_json::json!({}));
+        assert!(inner["response"].get("updatedPermissions").is_none());
+    }
+
+    #[test]
+    fn control_response_allow_with_modified_input_and_remember() {
+        let perm =
+            serde_json::to_value(claude_codes::Permission::allow_tool("Bash", "npm test")).unwrap();
+        let resp = claude_control_response(
+            "req-2",
+            PermissionDecision {
+                allow: true,
+                modified_input: Some(serde_json::json!({"command": "npm test"})),
+                remember: vec![perm],
+                reason: None,
+            },
+        );
+        let result = &serde_json::to_value(&resp).unwrap()["response"]["response"];
+        assert_eq!(result["behavior"], serde_json::json!("allow"));
+        assert_eq!(
+            result["updatedInput"],
+            serde_json::json!({"command": "npm test"})
+        );
+        assert_eq!(
+            result["updatedPermissions"][0]["type"],
+            serde_json::json!("addRules")
+        );
+        assert_eq!(
+            result["updatedPermissions"][0]["rules"][0]["toolName"],
+            serde_json::json!("Bash")
+        );
+    }
+
+    #[test]
+    fn control_response_deny_uses_reason_with_default() {
+        let explicit = serde_json::to_value(&claude_control_response(
+            "req-3",
+            PermissionDecision {
+                allow: false,
+                reason: Some("nope".to_string()),
+                ..Default::default()
+            },
+        ))
+        .unwrap();
+        assert_eq!(
+            explicit["response"]["response"]["behavior"],
+            serde_json::json!("deny")
+        );
+        assert_eq!(
+            explicit["response"]["response"]["message"],
+            serde_json::json!("nope")
+        );
+
+        // Default reason mirrors the old respond_permission "User denied".
+        let defaulted = serde_json::to_value(&claude_control_response(
+            "req-4",
+            PermissionDecision {
+                allow: false,
+                ..Default::default()
+            },
+        ))
+        .unwrap();
+        assert_eq!(
+            defaulted["response"]["response"]["message"],
+            serde_json::json!("User denied")
+        );
+    }
 
     /// Pins the wiring this module relies on: a `Task` tool's result is a
     /// `ClaudeOutput::User` whose `tool_use_result` parses to a typed

--- a/codex-session-lib/src/helpers.rs
+++ b/codex-session-lib/src/helpers.rs
@@ -1,27 +1,5 @@
 //! Small helpers shared by `io_task` and `handler`.
 
-use claude_codes::ClaudeInput;
-
-/// Extract prompt text from ClaudeInput.
-pub(crate) fn extract_prompt_text(input: &ClaudeInput) -> String {
-    match input {
-        ClaudeInput::User(msg) => msg
-            .message
-            .content
-            .iter()
-            .filter_map(|block| {
-                if let claude_codes::io::ContentBlock::Text(tb) = block {
-                    Some(tb.text.clone())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n"),
-        _ => String::new(),
-    }
-}
-
 /// Format a `codex_codes::RequestId` as a String.
 pub(crate) fn format_request_id(id: &codex_codes::RequestId) -> String {
     match id {
@@ -42,44 +20,7 @@ pub(crate) fn parse_request_id(s: &str) -> codex_codes::RequestId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use claude_codes::io::{ContentBlock, TextBlock};
     use codex_codes::RequestId;
-    use uuid::Uuid;
-
-    fn text_block(s: &str) -> ContentBlock {
-        ContentBlock::Text(TextBlock {
-            text: s.to_string(),
-            citations: Vec::new(),
-        })
-    }
-
-    #[test]
-    fn extract_prompt_text_single_block() {
-        let input = ClaudeInput::user_message("hello world", Uuid::nil());
-        assert_eq!(extract_prompt_text(&input), "hello world");
-    }
-
-    #[test]
-    fn extract_prompt_text_joins_text_blocks_and_skips_non_text() {
-        // Non-text blocks (images, tool results, unknown) must be dropped, and
-        // the surviving text joined with newlines — a bug here silently sends
-        // a malformed or truncated prompt to the codex agent.
-        let input = ClaudeInput::user_message_blocks(
-            vec![
-                text_block("first"),
-                ContentBlock::Unknown(serde_json::json!({"type": "image"})),
-                text_block("second"),
-            ],
-            Uuid::nil(),
-        );
-        assert_eq!(extract_prompt_text(&input), "first\nsecond");
-    }
-
-    #[test]
-    fn extract_prompt_text_non_user_is_empty() {
-        let input = ClaudeInput::Raw(serde_json::json!({"type": "whatever"}));
-        assert_eq!(extract_prompt_text(&input), "");
-    }
 
     #[test]
     fn request_id_round_trips_both_variants() {

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -15,14 +15,26 @@ use codex_codes::{
 use session_lib::error::SessionError;
 use session_lib::io::{IoCommand, IoEvent};
 use session_lib::snapshot::SessionConfig;
-use session_lib::{TurnOutcome, TurnTracker};
+use session_lib::{PermissionDecision, TurnOutcome, TurnTracker};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::events::{
     to_raw_output, CodexUsageEvent, ThreadStartedEvent, TurnFailedEvent, UserEchoEvent,
 };
 use crate::handler::handle_codex_server_message;
-use crate::helpers::{extract_prompt_text, parse_request_id};
+use crate::helpers::parse_request_id;
+
+/// Map a neutral [`PermissionDecision`] to Codex's approval JSON
+/// (`{"decision": "accept" | "decline"}`). Codex approval is a coarse
+/// allow/deny, so the decision's `modified_input` / `remember` are unused.
+fn codex_approval_result(decision: &PermissionDecision) -> serde_json::Value {
+    #[derive(serde::Serialize)]
+    struct CodexApprovalResult<'a> {
+        decision: &'a str,
+    }
+    let decision = if decision.allow { "accept" } else { "decline" };
+    serde_json::to_value(CodexApprovalResult { decision }).unwrap_or(serde_json::Value::Null)
+}
 
 type DeliveryAck = oneshot::Sender<Result<(), String>>;
 /// Queued user prompt: (agent-facing prompt text, delivery ack, optional typed
@@ -540,42 +552,43 @@ pub(crate) async fn codex_io_task(
                 }
                 Some(cmd) = command_rx.recv() => {
                     match cmd {
-                        IoCommand::CodexApproval { request_id, result } => {
+                        IoCommand::Permission {
+                            request_id,
+                            decision,
+                        } => {
                             let rid = parse_request_id(&request_id);
+                            let result = codex_approval_result(&decision);
                             if let Err(e) = client.respond(rid, &result).await {
                                 tracing::error!("Failed to send Codex approval: {}", e);
                             }
                         }
-                        IoCommand::Input {
-                            input,
+                        IoCommand::UserInput {
+                            text,
                             delivered,
                             display_event,
                         } => {
-                            let prompt = extract_prompt_text(&input);
-                            if !prompt.is_empty() {
+                            if !text.is_empty() {
                                 tracing::info!(
                                     "Queued Codex input received during active turn ({} pending)",
                                     queued_prompts.len() + 1
                                 );
-                                queued_prompts.push_back((prompt, delivered, display_event));
+                                queued_prompts.push_back((text, delivered, display_event));
                             } else if let Some(delivered) = delivered {
                                 let _ = delivered.send(Ok(()));
                             }
                         }
-                        IoCommand::PermissionResponse(_) => {}
                     }
                 }
             }
         } else {
             // No active turn: wait for user input.
             match command_rx.recv().await {
-                Some(IoCommand::Input {
-                    input,
+                Some(IoCommand::UserInput {
+                    text,
                     delivered,
                     display_event,
                 }) => {
-                    let prompt = extract_prompt_text(&input);
-                    if prompt.is_empty() {
+                    if text.is_empty() {
                         if let Some(delivered) = delivered {
                             let _ = delivered.send(Ok(()));
                         }
@@ -585,15 +598,14 @@ pub(crate) async fn codex_io_task(
                     turn_active = start_codex_turn(
                         &mut client,
                         &thread_id,
-                        prompt,
+                        text,
                         display_event,
                         delivered,
                         &event_tx,
                     )
                     .await;
                 }
-                Some(IoCommand::PermissionResponse(_)) => continue,
-                Some(IoCommand::CodexApproval { .. }) => {
+                Some(IoCommand::Permission { .. }) => {
                     tracing::warn!("Codex approval response with no active turn");
                 }
                 None => {
@@ -848,6 +860,25 @@ mod tests {
 
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Neutral `PermissionDecision` → Codex approval JSON. Ported from the
+    /// deleted `respond_permission` codex branch — approval is a coarse
+    /// accept/decline, so only `allow` matters.
+    #[test]
+    fn codex_approval_result_maps_allow_to_accept_decline() {
+        let accept = codex_approval_result(&PermissionDecision {
+            allow: true,
+            ..Default::default()
+        });
+        assert_eq!(accept["decision"], serde_json::json!("accept"));
+
+        let decline = codex_approval_result(&PermissionDecision {
+            allow: false,
+            reason: Some("nope".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(decline["decision"], serde_json::json!("decline"));
     }
 
     #[test]

--- a/session-lib/src/adapter.rs
+++ b/session-lib/src/adapter.rs
@@ -1,39 +1,33 @@
 //! Agent-neutral protocol boundary (refactor #1165 item 2).
 //!
-//! Two traits split the per-agent protocol surface so the generic `Session<A>`
-//! core never touches `claude_codes` / `codex_codes` types:
+//! The generic `Session<A>` core never touches `claude_codes` / `codex_codes`
+//! protocol types. The one trait here, [`AgentOutputClassifier`], parses a unit
+//! of agent output into neutral [`AgentOutput`] decisions. It runs **inside each
+//! per-agent I/O task** (Claude's `claude_io_task` via [`ClaudeAdapter`]; Codex's
+//! via `CodexClassifier`), which then emits `IoEvent::Classified(AgentOutput)`;
+//! `Session` only maps those neutral decisions to `SessionEvent`s.
 //!
-//! - [`AgentOutputClassifier`] — parses one unit of agent output into neutral
-//!   [`AgentOutput`] decisions. This runs **inside each per-agent I/O task**
-//!   (Claude's `claude_io_task` via [`ClaudeAdapter`]; Codex's via
-//!   `CodexClassifier`), which then emits `IoEvent::Classified(AgentOutput)`.
-//!   `Session` only maps those neutral decisions to `SessionEvent`s.
-//! - [`AgentAdapter`] — the Claude stdin/permission *input* side
-//!   (`user_input` / `permission_response` / `interrupt` producing a
-//!   [`TransportPayload`]). This is Claude-transport-shaped and does not fit
-//!   Codex's async RPC input model; neutralizing the input side is phase-A
-//!   slice 2 (see `docs/design/agent-runtime.md`). [`ClaudeAdapter`] implements
-//!   both traits.
+//! The **input** side (turning neutral [`crate::io::IoCommand`]s into the
+//! agent's wire form) is NOT a trait — there is no agent-neutral input
+//! abstraction. Each I/O task serializes input directly against its typed
+//! client (Claude: `ClaudeInput` / `ControlResponse` to stdin; Codex:
+//! `turn_start` / `respond` RPC). Phase-A slice 2 removed the old
+//! Claude-transport-shaped `AgentAdapter` input trait, which couldn't fit
+//! Codex's async RPC model. A future `AgentRuntime` may unify it.
 //!
 //! See `docs/design/session-adapter.md` and `docs/design/agent-runtime.md`.
 
-use uuid::Uuid;
-
-/// One unit of agent stdout, as opaque wire JSON. The adapter parses it.
+/// One unit of agent stdout, as opaque wire JSON. The classifier parses it.
 pub type RawUnit = serde_json::Value;
 
-/// Opaque payload the I/O task writes to the agent. The adapter produces it;
-/// `Session` never inspects it.
-pub type TransportPayload = serde_json::Value;
-
-/// A neutral decision produced by the adapter from one unit of agent output.
+/// A neutral decision produced by the classifier from one unit of agent output.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AgentOutput {
     /// User-visible output to forward/persist verbatim (opaque wire JSON).
     Visible(serde_json::Value),
     /// A permission/control request awaiting a response.
     PermissionRequest {
-        /// Neutral correlation id for the later [`AgentAdapter::permission_response`].
+        /// Neutral correlation id, echoed back in [`crate::io::IoCommand::Permission`].
         request_id: String,
         /// Stringly-typed tool name (the same key the claude path carries
         /// verbatim from `ToolUseRequest`).
@@ -66,8 +60,8 @@ pub struct PermissionDecision {
 }
 
 /// Output-classification boundary: parse one unit of agent output into neutral
-/// [`AgentOutput`] decisions. This is the *only* part of the adapter that fits
-/// every backend — both Claude and Codex can honestly map their output here.
+/// [`AgentOutput`] decisions — the part of the protocol surface every backend
+/// can honestly implement (both Claude and Codex map their output here).
 ///
 /// Generic over the input unit via [`Raw`](AgentOutputClassifier::Raw) because
 /// the backends' output units differ: Claude's I/O task yields opaque stdout
@@ -77,19 +71,17 @@ pub struct PermissionDecision {
 /// a single `Raw = Value` would lock Codex out; the associated type lets each
 /// backend classify its native unit while sharing the neutral [`AgentOutput`].
 ///
-/// It is split out from [`AgentAdapter`] (which pins `Raw = serde_json::Value`)
-/// because the rest of `AgentAdapter` — `user_input`/`permission_response`
-/// returning a sync `TransportPayload` for the I/O task to write — is
-/// Claude-transport-shaped and does *not* fit Codex, whose input/permission
-/// flow is an async `turn_start`/`respond` RPC owned by `codex_io_task`. A
-/// backend that only classifies output (Codex) implements this trait alone;
-/// full unification of the input side is a separate `AgentRuntime` design (see
-/// `docs/design/session-adapter.md`).
+/// The input side (turning neutral commands into wire form) is deliberately
+/// NOT part of this trait: it lives in each I/O task against its typed client,
+/// because the agents' input models diverge (Claude writes to stdin
+/// synchronously; Codex issues async `turn_start`/`respond` RPCs). See the
+/// module docs.
 ///
-/// `Sync` so `Session<A>`, which stores `Box<dyn AgentAdapter>`, stays `Sync`
-/// for consumers that share a session across threads (the launcher holds
-/// sessions in shared state). Adapters are stateless today; any future stateful
-/// adapter must use interior mutability that is itself `Sync`.
+/// `Send + Sync + 'static` so a boxed classifier can be held across threads if
+/// needed and `Session<A>` stays `Sync` for consumers that share a session (the
+/// launcher holds sessions in shared state). Classifiers are stateless today;
+/// any future stateful classifier must use interior mutability that is itself
+/// `Sync`.
 pub trait AgentOutputClassifier: Send + Sync + 'static {
     /// The native output unit this classifier parses (Claude: `serde_json::Value`
     /// stdout JSON; Codex: `codex_codes::ServerMessage`).
@@ -103,29 +95,12 @@ pub trait AgentOutputClassifier: Send + Sync + 'static {
     fn classify(&mut self, raw: Self::Raw) -> Vec<AgentOutput>;
 }
 
-/// Per-agent protocol parse/serialize boundary for the generic `Session<A>`,
-/// for backends whose input side fits the sync stdin-payload model (Claude).
+/// Claude-protocol output classifier. Stateless; a unit struct.
 ///
-/// Pins `Raw = serde_json::Value` so `Session`'s `dyn AgentAdapter` can call
-/// `classify` with the stdout JSON it already serializes.
-pub trait AgentAdapter: AgentOutputClassifier<Raw = RawUnit> {
-    /// Build the transport payload for plain user text.
-    fn user_input(&self, text: &str, session_id: Uuid) -> TransportPayload;
-
-    /// Build the transport payload responding to a prior `PermissionRequest`.
-    fn permission_response(
-        &self,
-        request_id: &str,
-        decision: PermissionDecision,
-    ) -> TransportPayload;
-
-    /// Optional control inputs (interrupt, etc.).
-    fn interrupt(&self) -> Option<TransportPayload> {
-        None
-    }
-}
-
-/// Claude-protocol adapter. Stateless for now; a unit struct.
+/// The input side (building `ClaudeInput` / `ControlResponse` from neutral
+/// commands) lives in `claude_io_task`, which owns the typed client — there is
+/// no agent-neutral input trait (phase A slice 2 removed the old
+/// `AgentAdapter`; see `docs/design/agent-runtime.md`).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ClaudeAdapter;
 
@@ -184,51 +159,6 @@ impl AgentOutputClassifier for ClaudeAdapter {
             // is user-visible.
             _ => vec![AgentOutput::Visible(raw)],
         }
-    }
-}
-
-impl AgentAdapter for ClaudeAdapter {
-    fn user_input(&self, text: &str, session_id: Uuid) -> TransportPayload {
-        let input = claude_codes::ClaudeInput::user_message(text, session_id);
-        serde_json::to_value(&input).unwrap_or(serde_json::Value::Null)
-    }
-
-    fn permission_response(
-        &self,
-        request_id: &str,
-        decision: PermissionDecision,
-    ) -> TransportPayload {
-        use claude_codes::io::{ControlResponse, PermissionResult};
-
-        // Mirrors `session.rs::respond_permission` (claude path):
-        // - input defaults to an empty object when not modified,
-        // - non-empty remembered permissions use the typed-permissions allow,
-        // - deny carries the reason, defaulting to "User denied".
-        let ctrl_response = if decision.allow {
-            let input_value = decision
-                .modified_input
-                .unwrap_or(serde_json::Value::Object(Default::default()));
-            if decision.remember.is_empty() {
-                ControlResponse::from_result(request_id, PermissionResult::allow(input_value))
-            } else {
-                ControlResponse::from_result(
-                    request_id,
-                    PermissionResult::allow_with_permissions(input_value, decision.remember),
-                )
-            }
-        } else {
-            let reason = decision.reason.unwrap_or_else(|| "User denied".to_string());
-            ControlResponse::from_result(request_id, PermissionResult::deny(reason))
-        };
-
-        serde_json::to_value(&ctrl_response).unwrap_or(serde_json::Value::Null)
-    }
-
-    fn interrupt(&self) -> Option<TransportPayload> {
-        Some(
-            serde_json::to_value(claude_codes::ClaudeInput::interrupt())
-                .unwrap_or(serde_json::Value::Null),
-        )
     }
 }
 
@@ -408,105 +338,5 @@ mod tests {
             adapter.classify(scalar.clone()),
             vec![AgentOutput::Visible(scalar)]
         );
-    }
-
-    // --- input / permission serialization tests ----------------------------
-
-    #[test]
-    fn user_input_builds_claude_user_message() {
-        let adapter = ClaudeAdapter;
-        let session_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-        let payload = adapter.user_input("Hello, Claude!", session_id);
-        assert_eq!(payload["type"], json!("user"));
-        assert_eq!(payload["message"]["role"], json!("user"));
-        assert_eq!(
-            payload["message"]["content"][0]["text"],
-            json!("Hello, Claude!")
-        );
-        assert_eq!(
-            payload["session_id"],
-            json!("550e8400-e29b-41d4-a716-446655440000")
-        );
-    }
-
-    #[test]
-    fn permission_response_allow_uses_empty_input_by_default() {
-        let adapter = ClaudeAdapter;
-        let payload = adapter.permission_response(
-            "req-1",
-            PermissionDecision {
-                allow: true,
-                ..Default::default()
-            },
-        );
-        let inner = &payload["response"];
-        assert_eq!(inner["subtype"], json!("success"));
-        assert_eq!(inner["request_id"], json!("req-1"));
-        assert_eq!(inner["response"]["behavior"], json!("allow"));
-        // input defaults to an empty object (mirrors respond_permission).
-        assert_eq!(inner["response"]["updatedInput"], json!({}));
-        assert!(inner["response"].get("updatedPermissions").is_none());
-    }
-
-    #[test]
-    fn permission_response_allow_with_modified_input_and_remember() {
-        let adapter = ClaudeAdapter;
-        let perm =
-            serde_json::to_value(claude_codes::Permission::allow_tool("Bash", "npm test")).unwrap();
-        let payload = adapter.permission_response(
-            "req-2",
-            PermissionDecision {
-                allow: true,
-                modified_input: Some(json!({"command": "npm test"})),
-                remember: vec![perm],
-                reason: None,
-            },
-        );
-        let result = &payload["response"]["response"];
-        assert_eq!(result["behavior"], json!("allow"));
-        assert_eq!(result["updatedInput"], json!({"command": "npm test"}));
-        assert_eq!(result["updatedPermissions"][0]["type"], json!("addRules"));
-        assert_eq!(
-            result["updatedPermissions"][0]["rules"][0]["toolName"],
-            json!("Bash")
-        );
-    }
-
-    #[test]
-    fn permission_response_deny_uses_reason_with_default() {
-        let adapter = ClaudeAdapter;
-
-        // Explicit reason.
-        let payload = adapter.permission_response(
-            "req-3",
-            PermissionDecision {
-                allow: false,
-                reason: Some("nope".to_string()),
-                ..Default::default()
-            },
-        );
-        let result = &payload["response"]["response"];
-        assert_eq!(result["behavior"], json!("deny"));
-        assert_eq!(result["message"], json!("nope"));
-
-        // Default reason mirrors respond_permission's "User denied".
-        let payload = adapter.permission_response(
-            "req-4",
-            PermissionDecision {
-                allow: false,
-                ..Default::default()
-            },
-        );
-        assert_eq!(
-            payload["response"]["response"]["message"],
-            json!("User denied")
-        );
-    }
-
-    #[test]
-    fn interrupt_builds_interrupt_payload() {
-        let adapter = ClaudeAdapter;
-        let payload = adapter.interrupt().expect("claude supports interrupt");
-        assert_eq!(payload["subtype"], json!("interrupt"));
     }
 }

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -4,23 +4,25 @@
 //! per-agent I/O tasks just ignore the variants they don't handle. See
 //! `agent.rs` for the dispatch trait.
 
-use claude_codes::io::{ControlResponse, PermissionSuggestion};
-use claude_codes::ClaudeInput;
+use claude_codes::io::PermissionSuggestion;
 use shared::{CodexPermissionInput, TurnMetrics};
 use tokio::sync::oneshot;
 
-use crate::adapter::AgentOutput;
+use crate::adapter::{AgentOutput, PermissionDecision};
 use crate::error::SessionError;
 
-/// Commands sent from `Session<A>` to the per-agent I/O task.
+/// Neutral commands sent from `Session<A>` to the per-agent I/O task.
 ///
-/// Per-agent tasks ignore variants they don't handle:
-/// - Claude io task ignores `CodexApproval`.
-/// - Codex io task ignores `PermissionResponse`.
+/// These carry no concrete-protocol types — each I/O task translates them into
+/// its own wire form (Claude: `ClaudeInput` / `ControlResponse` to stdin;
+/// Codex: `turn_start` / `respond` JSON-RPC). `Session` stays agent-neutral
+/// (#1165 item 2, phase A slice 2).
 pub enum IoCommand {
-    /// User input to forward to the agent.
-    Input {
-        input: ClaudeInput,
+    /// Plain user input to forward to the agent.
+    UserInput {
+        /// The user-facing text. The I/O task wraps it in its protocol's
+        /// user-message form.
+        text: String,
         delivered: Option<oneshot::Sender<Result<(), String>>>,
         /// Optional typed portal event to display in place of the agent's echo
         /// of this input (e.g. an inter-agent `PortalContent::AgentMessage`).
@@ -31,12 +33,12 @@ pub enum IoCommand {
         /// Boxed to keep this variant from dominating `IoCommand`'s size.
         display_event: Option<Box<serde_json::Value>>,
     },
-    /// Permission response for Claude's `can_use_tool` control flow.
-    PermissionResponse(ControlResponse),
-    /// Approval response for Codex's app-server JSON-RPC approval flow.
-    CodexApproval {
+    /// Response to a pending permission request. The I/O task serializes the
+    /// neutral decision into its protocol form (Claude `ControlResponse`,
+    /// Codex `accept`/`decline` approval).
+    Permission {
         request_id: String,
-        result: serde_json::Value,
+        decision: PermissionDecision,
     },
 }
 

--- a/session-lib/src/lib.rs
+++ b/session-lib/src/lib.rs
@@ -32,9 +32,7 @@ pub mod session;
 pub mod snapshot;
 pub mod turn_tracker;
 
-pub use adapter::{
-    AgentAdapter, AgentOutput, AgentOutputClassifier, ClaudeAdapter, PermissionDecision,
-};
+pub use adapter::{AgentOutput, AgentOutputClassifier, ClaudeAdapter, PermissionDecision};
 pub use agent::Agent;
 pub use buffer::{BufferedOutput, OutputBuffer};
 pub use error::SessionError;

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -7,12 +7,11 @@
 use std::marker::PhantomData;
 
 use chrono::Utc;
-use claude_codes::io::{ControlResponse, PermissionResult, PermissionSuggestion};
-use claude_codes::ClaudeInput;
+use claude_codes::io::PermissionSuggestion;
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
-use crate::adapter::AgentOutput;
+use crate::adapter::{AgentOutput, PermissionDecision};
 use crate::agent::Agent;
 use crate::buffer::OutputBuffer;
 use crate::error::SessionError;
@@ -358,7 +357,7 @@ impl<A: Agent> Session<A> {
 
     /// Like [`send_input`](Self::send_input), but carries an optional typed
     /// portal `display_event` to render in place of the agent's echo (see
-    /// [`IoCommand::Input::display_event`]). The proxy passes the inter-agent
+    /// [`IoCommand::UserInput::display_event`]). The proxy passes the inter-agent
     /// `PortalContent::AgentMessage` envelope here so the Codex path (which
     /// can't rely on echo-replacement) still renders the typed card.
     pub async fn send_input_with_display(
@@ -375,11 +374,10 @@ impl<A: Agent> Session<A> {
                 serde_json::Value::String(s) => s.clone(),
                 other => other.to_string(),
             };
-            let input = ClaudeInput::user_message(text, self.id);
             let (delivered_tx, delivered_rx) = oneshot::channel();
             command_tx
-                .send(IoCommand::Input {
-                    input,
+                .send(IoCommand::UserInput {
+                    text,
                     delivered: Some(delivered_tx),
                     display_event: display_event.map(Box::new),
                 })
@@ -399,9 +397,9 @@ impl<A: Agent> Session<A> {
 
     /// Respond to a pending permission request.
     ///
-    /// Codex sessions route this through `IoCommand::CodexApproval`; Claude
-    /// sessions route it through `IoCommand::PermissionResponse`. The per-
-    /// agent I/O task ignores whichever variant doesn't apply.
+    /// Builds a neutral [`PermissionDecision`] and hands it to the I/O task via
+    /// [`IoCommand::Permission`]; the per-agent task serializes it into its own
+    /// protocol form (Claude `ControlResponse`, Codex `accept`/`decline`).
     pub async fn respond_permission(
         &mut self,
         request_id: &str,
@@ -418,53 +416,25 @@ impl<A: Agent> Session<A> {
         }
 
         if let Some(ref command_tx) = self.command_tx {
-            if self.config.agent_type == shared::AgentType::Codex {
-                // Codex approval flow: map allow/deny to accept/decline.
-                // Typed wrapper so the wire shape lives in source rather than
-                // in a `json!` literal.
-                #[derive(serde::Serialize)]
-                struct CodexApprovalResult<'a> {
-                    decision: &'a str,
-                }
-                let decision = if response.allow { "accept" } else { "decline" };
-                let result = serde_json::to_value(CodexApprovalResult { decision })
-                    .unwrap_or(serde_json::Value::Null);
-                command_tx
-                    .send(IoCommand::CodexApproval {
-                        request_id: request_id.to_string(),
-                        result,
-                    })
-                    .map_err(|_| SessionError::CommunicationError("I/O task closed".to_string()))?;
-            } else {
-                // Claude permission flow.
-                let input_value = response
-                    .input
-                    .unwrap_or(serde_json::Value::Object(Default::default()));
-
-                let ctrl_response = if response.allow {
-                    if response.permissions.is_empty() {
-                        ControlResponse::from_result(
-                            request_id,
-                            PermissionResult::allow(input_value),
-                        )
-                    } else {
-                        ControlResponse::from_result(
-                            request_id,
-                            PermissionResult::allow_with_typed_permissions(
-                                input_value,
-                                response.permissions,
-                            ),
-                        )
-                    }
-                } else {
-                    let reason = response.reason.unwrap_or_else(|| "User denied".to_string());
-                    ControlResponse::from_result(request_id, PermissionResult::deny(reason))
-                };
-
-                command_tx
-                    .send(IoCommand::PermissionResponse(ctrl_response))
-                    .map_err(|_| SessionError::CommunicationError("I/O task closed".to_string()))?;
-            }
+            // Map the consumer-facing response to the neutral decision. The
+            // `remember` permissions are serialized to opaque JSON here so the
+            // neutral form carries no `claude_codes` types.
+            let decision = PermissionDecision {
+                allow: response.allow,
+                modified_input: response.input,
+                remember: response
+                    .permissions
+                    .iter()
+                    .map(|p| serde_json::to_value(p).unwrap_or(serde_json::Value::Null))
+                    .collect(),
+                reason: response.reason,
+            };
+            command_tx
+                .send(IoCommand::Permission {
+                    request_id: request_id.to_string(),
+                    decision,
+                })
+                .map_err(|_| SessionError::CommunicationError("I/O task closed".to_string()))?;
         }
 
         self.pending_permission = None;


### PR DESCRIPTION
## #1165 item 2 — phase A, slice 2: input neutralization (Claude+Codex consensus)

`Session<A>` is now **fully free of `claude_codes` / `codex_codes` types and the `agent_type` branch** (Codex's acceptance line for phase A).

### session-lib
- `IoCommand` is neutral: `UserInput { text, delivered, display_event }` and `Permission { request_id, decision: PermissionDecision }` — replacing the Claude-typed `Input{ClaudeInput}` + `PermissionResponse(ControlResponse)` + `CodexApproval`.
- `Session::send_input` sends `UserInput { text }`; `respond_permission` maps the consumer `PermissionResponse` → neutral `PermissionDecision` (remembered permissions serialized to opaque JSON) and sends `Permission`. **The `config.agent_type == Codex` branch is gone.**
- The **`AgentAdapter` trait + `ClaudeAdapter`'s impl are deleted**: `user_input`/`permission_response` returned `Value`, but the typed clients want `ClaudeInput`/`ControlResponse`, so input-building moves into the I/O tasks. `AgentOutputClassifier` / `AgentOutput` / `PermissionDecision` stay; the now-unused `TransportPayload` alias is removed.

### claude-session-lib
Both command sites build `ClaudeInput::user_message` and (via a local `claude_control_response` helper) the typed `ControlResponse`.

### codex-session-lib
Uses the neutral `text` directly for `turn_start`; maps `PermissionDecision` → `accept`/`decline` for `client.respond`. The now-dead `extract_prompt_text` helper + its tests are removed.

### No proxy changes
Public `Session::send_input(Value)` / `respond_permission(PermissionResponse)` signatures are unchanged.

### Verification
- `cargo build --workspace` ✓ (launcher built — `Session: Sync` preserved)
- `cargo test`: session-lib 30, claude-session-lib 31, codex-session-lib 29 ✓
- clippy clean, `cargo fmt --check` clean
- `grep agent_type session-lib/src/session.rs` → 0

Codex output still emits `RawOutput`/`CodexPermissionRequest` directly (the `Classified` flip is a separate follow-up); that doesn't affect this input-side slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)