### PR TITLE
refactor: codex emits IoEvent::Classified; drop CodexPermissionRequest (#1165 item 2, A1b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.101"
+version = "2.12.102"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.101"
+version = "2.12.102"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.101"
+version = "2.12.102"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.101"
+version = "2.12.102"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.101"
+version = "2.12.102"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.101"
+version = "2.12.102"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.101"
+version = "2.12.102"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.101"
+version = "2.12.102"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.101"
+version = "2.12.102"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.101"
+version = "2.12.102"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.101"
+version = "2.12.102"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/codex-session-lib/src/classifier.rs
+++ b/codex-session-lib/src/classifier.rs
@@ -257,7 +257,7 @@ fn classify_request(request_id: String, request: ServerRequest) -> Vec<AgentOutp
 }
 
 /// Build a neutral `PermissionRequest` from a typed Codex permission input,
-/// matching what `session.rs`'s `CodexPermissionRequest` arm produces today:
+/// matching what `Session`'s neutral `PermissionRequest` handling expects:
 /// `tool_name` from the typed variant, `input` re-serialized to JSON, no
 /// suggestions (codex carries none).
 fn permission(request_id: String, input: CodexPermissionInput) -> Vec<AgentOutput> {

--- a/codex-session-lib/src/handler.rs
+++ b/codex-session-lib/src/handler.rs
@@ -1,29 +1,30 @@
-//! Translate Codex app-server `ServerMessage` frames into [`IoEvent`]s.
+//! Drive [`CodexClassifier`] from `codex_io_task` and emit the resulting
+//! neutral [`IoEvent::Classified`] decisions.
 //!
-//! The `ServerMessage` → neutral-output mapping now lives in
+//! The `ServerMessage` → neutral-output mapping lives in
 //! [`CodexClassifier`](crate::classifier::CodexClassifier) (the single source
 //! of Codex output classification, #1165 item 2). This module is the thin
-//! adapter that drives the classifier from `codex_io_task` and translates its
-//! neutral [`AgentOutput`]s back into the [`IoEvent`]s the I/O task forwards
-//! (`Visible` → `RawOutput`, `PermissionRequest` → `CodexPermissionRequest`).
+//! adapter that runs it and forwards each [`AgentOutput`] verbatim as
+//! `IoEvent::Classified` — the same neutral channel Claude uses, so `Session`
+//! has no codex-specific output/permission arms.
 //!
 //! It also owns the one carve-out the classifier deliberately skips:
 //! `TurnCompleted`. That frame carries token usage and drives per-turn metrics
 //! finalization — turn/token orchestration owned by `codex_io_task` — so the
-//! `turn.completed` event (with usage) is shaped here, and `turn_ended` is
-//! returned to the I/O task's turn-lifecycle loop.
+//! `turn.completed` event (with usage) is shaped here (as a `Visible`
+//! decision), and `turn_ended` is returned to the I/O task's turn-lifecycle
+//! loop.
 
 use codex_codes::{Notification, ServerMessage};
 use session_lib::io::IoEvent;
 use session_lib::{AgentOutput, AgentOutputClassifier};
-use shared::CodexPermissionInput;
 use tokio::sync::mpsc;
 
 use crate::classifier::CodexClassifier;
 use crate::events::{to_raw_output, CodexUsageEvent, TurnCompletedEvent};
 
-/// Convert a Codex app-server ServerMessage into exec-format JSONL events.
-/// Returns (event_sent_ok, turn_ended).
+/// Classify a Codex app-server ServerMessage and emit neutral
+/// [`IoEvent::Classified`] decisions. Returns (event_sent_ok, turn_ended).
 pub(crate) fn handle_codex_server_message(
     msg: ServerMessage,
     event_tx: &mpsc::UnboundedSender<IoEvent>,
@@ -31,7 +32,8 @@ pub(crate) fn handle_codex_server_message(
 ) -> (bool, bool) {
     // Turn completion stays here: it carries token usage + drives per-turn
     // metrics, which is turn/token orchestration owned by the I/O task.
-    // `CodexClassifier` deliberately returns `Noop` for it.
+    // `CodexClassifier` deliberately returns `Noop` for it, so shape the
+    // user-visible `turn.completed` event here and emit it as `Visible`.
     if let ServerMessage::Notification(Notification::TurnCompleted(p)) = &msg {
         let event = TurnCompletedEvent::new(
             p.turn.id.clone(),
@@ -40,36 +42,20 @@ pub(crate) fn handle_codex_server_message(
             latest_token_usage.cloned(),
         );
         let ok = event_tx
-            .send(IoEvent::RawOutput(to_raw_output(&event)))
+            .send(IoEvent::Classified(AgentOutput::Visible(to_raw_output(
+                &event,
+            ))))
             .is_ok();
         return (ok, true);
     }
 
-    // Everything else: the classifier is the single mapping source. Translate
-    // its neutral decisions back into the I/O task's transport events.
+    // Everything else: the classifier is the single mapping source; forward its
+    // neutral decisions straight through (`Session` maps Visible→RawOutput,
+    // PermissionRequest→PermissionRequest, Noop→skip — same as Claude).
     let mut classifier = CodexClassifier;
     let mut ok = true;
     for output in classifier.classify(msg) {
-        let event = match output {
-            AgentOutput::Visible(value) => IoEvent::RawOutput(value),
-            AgentOutput::PermissionRequest {
-                request_id, input, ..
-            } => {
-                // Recover the typed Codex permission envelope the classifier
-                // serialized (`CodexPermissionInput` round-trips through its
-                // wire form). The I/O task / `Session` consume the typed event.
-                match serde_json::from_value::<CodexPermissionInput>(input) {
-                    Ok(input) => IoEvent::CodexPermissionRequest { request_id, input },
-                    Err(e) => {
-                        tracing::error!("Codex permission input round-trip failed: {}", e);
-                        continue;
-                    }
-                }
-            }
-            // Codex never produces `NotFound`; `Noop` is an internal skip.
-            AgentOutput::Noop | AgentOutput::NotFound => continue,
-        };
-        if event_tx.send(event).is_err() {
+        if event_tx.send(IoEvent::Classified(output)).is_err() {
             ok = false;
         }
     }
@@ -87,69 +73,38 @@ fn turn_status_label(status: &codex_codes::TurnStatus) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    //! Verify that the typed dispatch produces the same JSON shape the frontend
-    //! expects (preserves `IoEvent::CodexPermissionRequest::input` field names).
-    //! Construct typed param structs from JSON via `serde_json::from_value` so
-    //! the tests don't have to chase per-field defaults.
+    //! Handler-level behavior: the `TurnCompleted` carve-out (with usage) and
+    //! that every frame is forwarded as a neutral `IoEvent::Classified`. The
+    //! per-variant `ServerMessage` → `AgentOutput` mapping is characterized in
+    //! `classifier.rs`; these tests only cover what the handler adds.
     use super::*;
     use codex_codes::{Notification, RequestId, ServerMessage, ServerRequest};
     use serde_json::json;
 
-    fn drain(rx: &mut mpsc::UnboundedReceiver<IoEvent>) -> Vec<IoEvent> {
+    /// Collect the `AgentOutput`s the handler emits (each wrapped in
+    /// `IoEvent::Classified`); panics if it ever emits a non-Classified event.
+    fn classified(
+        msg: ServerMessage,
+        usage: Option<&CodexUsageEvent>,
+    ) -> (Vec<AgentOutput>, bool, bool) {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (sent, ended) = handle_codex_server_message(msg, &tx, usage);
+        drop(tx);
         let mut out = Vec::new();
         while let Ok(ev) = rx.try_recv() {
-            out.push(ev);
-        }
-        out
-    }
-
-    fn handle_with_usage(
-        msg: ServerMessage,
-        latest_token_usage: Option<&CodexUsageEvent>,
-    ) -> (Vec<IoEvent>, bool, bool) {
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let (sent, ended) = handle_codex_server_message(msg, &tx, latest_token_usage);
-        drop(tx);
-        (drain(&mut rx), sent, ended)
-    }
-
-    fn handle(msg: ServerMessage) -> (Vec<IoEvent>, bool, bool) {
-        handle_with_usage(msg, None)
-    }
-
-    #[test]
-    fn context_compacted_emits_renderable_event() {
-        let notif: codex_codes::ContextCompactedNotification = serde_json::from_value(json!({
-            "threadId": "thread-1",
-            "turnId": "turn-1"
-        }))
-        .unwrap();
-        let msg = ServerMessage::Notification(Notification::ContextCompacted(notif));
-        let (events, sent, ended) = handle(msg);
-
-        assert!(sent);
-        assert!(!ended);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::RawOutput(value) => {
-                assert_eq!(value["type"], "thread/compacted");
-                assert_eq!(value["params"]["threadId"], "thread-1");
-                assert_eq!(value["params"]["turnId"], "turn-1");
+            match ev {
+                IoEvent::Classified(ao) => out.push(ao),
+                _ => panic!("expected IoEvent::Classified"),
             }
-            _ => panic!("expected RawOutput"),
         }
+        (out, sent, ended)
     }
 
     #[test]
-    fn turn_completed_emits_duration_status_and_latest_usage() {
+    fn turn_completed_emits_visible_with_usage_and_ends_turn() {
         let notif: codex_codes::TurnCompletedNotification = serde_json::from_value(json!({
             "threadId": "thread-1",
-            "turn": {
-                "id": "turn-1",
-                "status": "completed",
-                "durationMs": 4200,
-                "items": []
-            }
+            "turn": { "id": "turn-1", "status": "completed", "durationMs": 4200, "items": [] }
         }))
         .unwrap();
         let usage = CodexUsageEvent {
@@ -170,13 +125,13 @@ mod tests {
             model_context_window: Some(200000),
         };
         let msg = ServerMessage::Notification(Notification::TurnCompleted(notif));
-        let (events, sent, ended) = handle_with_usage(msg, Some(&usage));
+        let (outputs, sent, ended) = classified(msg, Some(&usage));
 
         assert!(sent);
-        assert!(ended);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::RawOutput(value) => {
+        assert!(ended, "TurnCompleted must signal turn_ended=true");
+        assert_eq!(outputs.len(), 1);
+        match &outputs[0] {
+            AgentOutput::Visible(value) => {
                 assert_eq!(value["type"], "turn.completed");
                 assert_eq!(value["turn_id"], "turn-1");
                 assert_eq!(value["status"], "completed");
@@ -184,14 +139,12 @@ mod tests {
                 assert_eq!(value["usage"]["last"]["inputTokens"], 100);
                 assert_eq!(value["usage"]["model_context_window"], 200000);
             }
-            _ => panic!("expected RawOutput"),
+            other => panic!("expected Visible, got {other:?}"),
         }
     }
 
-    /// `FileChangeApproval` should now expose the typed `itemId`/`reason`/`grantRoot`
-    /// fields rather than a stale `changes: null` (the issue #723 / PR #721 bug).
     #[test]
-    fn file_change_approval_emits_typed_fields() {
+    fn permission_request_forwarded_as_classified() {
         let req: codex_codes::FileChangeRequestApprovalParams = serde_json::from_value(json!({
             "itemId": "item-1",
             "reason": "writes /etc/passwd",
@@ -204,285 +157,40 @@ mod tests {
             id: RequestId::Integer(7),
             request: ServerRequest::FileChangeApproval(req),
         };
-        let (events, _, ended) = handle(msg);
+        let (outputs, _, ended) = classified(msg, None);
         assert!(!ended);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::CodexPermissionRequest { request_id, input } => {
+        assert_eq!(outputs.len(), 1);
+        match &outputs[0] {
+            AgentOutput::PermissionRequest {
+                request_id,
+                tool_name,
+                input,
+                ..
+            } => {
                 assert_eq!(request_id, "7");
-                assert_eq!(input.tool_name(), "FileChange");
-                match input {
-                    CodexPermissionInput::FileChange {
-                        item_id,
-                        reason,
-                        grant_root,
-                    } => {
-                        assert_eq!(item_id, "item-1");
-                        assert_eq!(reason.as_deref(), Some("writes /etc/passwd"));
-                        // grantRoot omitted in source JSON → None
-                        assert!(grant_root.is_none());
-                    }
-                    _ => panic!("expected FileChange variant"),
-                }
+                assert_eq!(tool_name, "FileChange");
+                assert_eq!(input["tool"], "fileChange");
+                assert_eq!(input["itemId"], "item-1");
             }
-            _ => panic!("expected CodexPermissionRequest"),
+            other => panic!("expected PermissionRequest, got {other:?}"),
         }
     }
 
-    /// `ExecCommandApproval` joins the argv `Vec<String>` into a single string
-    /// for the frontend, and preserves `cwd` + `parsedCmd`.
     #[test]
-    fn exec_command_approval_joins_argv() {
-        let req: codex_codes::ExecCommandApprovalParams = serde_json::from_value(json!({
-            "callId": "call-1",
-            "conversationId": "conv-1",
-            "command": ["ls", "-la", "/tmp"],
-            "cwd": "/home/user",
-            "parsedCmd": []
+    fn visible_notification_forwarded_as_classified() {
+        let notif: codex_codes::ContextCompactedNotification = serde_json::from_value(json!({
+            "threadId": "thread-1",
+            "turnId": "turn-1"
         }))
         .unwrap();
-        let msg = ServerMessage::Request {
-            id: RequestId::String("abc".to_string()),
-            request: ServerRequest::ExecCommandApproval(req),
-        };
-        let (events, _, _) = handle(msg);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::CodexPermissionRequest { request_id, input } => {
-                assert_eq!(request_id, "abc");
-                assert_eq!(input.tool_name(), "ExecCommand");
-                match input {
-                    CodexPermissionInput::ExecCommand {
-                        command,
-                        cwd,
-                        parsed_cmd,
-                    } => {
-                        assert_eq!(command, "ls -la /tmp");
-                        assert_eq!(cwd, "/home/user");
-                        // empty parsed_cmd in source → None (skipped on serialize)
-                        assert!(parsed_cmd.is_none());
-                    }
-                    _ => panic!("expected ExecCommand variant"),
-                }
-            }
-            _ => panic!("expected CodexPermissionRequest"),
-        }
-    }
-
-    /// `CmdExecApproval` unwraps `Option<String>` command / `Option<AbsolutePathBuf>` cwd.
-    #[test]
-    fn cmd_exec_approval_unwraps_options() {
-        let req: codex_codes::CommandExecutionRequestApprovalParams =
-            serde_json::from_value(json!({
-                "itemId": "item-2",
-                "command": "echo hello",
-                "cwd": "/work",
-                "startedAtMs": 0,
-                "threadId": "t",
-                "turnId": "tu"
-            }))
-            .unwrap();
-        let msg = ServerMessage::Request {
-            id: RequestId::Integer(1),
-            request: ServerRequest::CmdExecApproval(req),
-        };
-        let (events, _, _) = handle(msg);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::CodexPermissionRequest { input, .. } => {
-                assert_eq!(input.tool_name(), "Bash");
-                match input {
-                    CodexPermissionInput::Bash { command, cwd, .. } => {
-                        assert_eq!(command, "echo hello");
-                        assert_eq!(cwd, "/work");
-                    }
-                    _ => panic!("expected Bash variant"),
-                }
-            }
-            _ => panic!("expected CodexPermissionRequest"),
-        }
-    }
-
-    /// `ApplyPatchApproval` should preserve the `fileChanges` map keyed by path
-    /// (the frontend's `format_permission_input` reads these keys).
-    #[test]
-    fn apply_patch_approval_preserves_file_changes_map() {
-        let req: codex_codes::ApplyPatchApprovalParams = serde_json::from_value(json!({
-            "callId": "c",
-            "conversationId": "cv",
-            "fileChanges": {
-                "/tmp/a.rs": { "type": "add", "content": "fn a() {}" },
-                "/tmp/b.rs": { "type": "delete", "content": "old contents" }
-            },
-            "reason": "tidy up"
-        }))
-        .unwrap();
-        let msg = ServerMessage::Request {
-            id: RequestId::Integer(2),
-            request: ServerRequest::ApplyPatchApproval(req),
-        };
-        let (events, _, _) = handle(msg);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::CodexPermissionRequest { input, .. } => {
-                assert_eq!(input.tool_name(), "ApplyPatch");
-                match input {
-                    CodexPermissionInput::ApplyPatch {
-                        file_changes,
-                        reason,
-                        ..
-                    } => {
-                        let keys: Vec<&str> = file_changes
-                            .as_object()
-                            .map(|m| m.keys().map(String::as_str).collect())
-                            .unwrap_or_default();
-                        assert!(keys.contains(&"/tmp/a.rs"));
-                        assert!(keys.contains(&"/tmp/b.rs"));
-                        assert_eq!(reason.as_deref(), Some("tidy up"));
-                    }
-                    _ => panic!("expected ApplyPatch variant"),
-                }
-            }
-            _ => panic!("expected CodexPermissionRequest"),
-        }
-    }
-
-    /// `TurnCompleted` signals turn end and emits a `turn.completed` raw event.
-    #[test]
-    fn turn_completed_ends_turn() {
-        let notif: codex_codes::TurnCompletedNotification = serde_json::from_value(json!({
-            "threadId": "t",
-            "turn": {
-                "id": "tu1",
-                "items": [],
-                "status": "completed"
-            }
-        }))
-        .unwrap();
-        let msg = ServerMessage::Notification(Notification::TurnCompleted(notif));
-        let (events, _, ended) = handle(msg);
-        assert!(ended, "TurnCompleted must signal turn_ended=true");
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::RawOutput(v) => {
-                assert_eq!(
-                    v.get("type").and_then(|t| t.as_str()),
-                    Some("turn.completed")
-                );
-            }
-            _ => panic!("expected RawOutput"),
-        }
-    }
-
-    /// `Error` notification extracts `error.message` from the typed `TurnError`.
-    #[test]
-    fn error_notification_uses_typed_message() {
-        let notif: codex_codes::ErrorNotification = serde_json::from_value(json!({
-            "error": { "message": "model unavailable" },
-            "threadId": "t",
-            "turnId": "tu",
-            "willRetry": false
-        }))
-        .unwrap();
-        let msg = ServerMessage::Notification(Notification::Error(notif));
-        let (events, _, _) = handle(msg);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::RawOutput(v) => {
-                assert_eq!(v.get("type").and_then(|t| t.as_str()), Some("error"));
-                assert_eq!(
-                    v.get("message").and_then(|m| m.as_str()),
-                    Some("model unavailable")
-                );
-            }
-            _ => panic!("expected RawOutput"),
-        }
-    }
-
-    /// `ItemStarted` re-serializes the typed `ThreadItem` back into the raw event.
-    #[test]
-    fn item_started_emits_item() {
-        let notif: codex_codes::ItemStartedNotification = serde_json::from_value(json!({
-            "item": { "type": "userMessage", "id": "i1", "content": [] },
-            "startedAtMs": 0,
-            "threadId": "t",
-            "turnId": "tu"
-        }))
-        .unwrap();
-        let msg = ServerMessage::Notification(Notification::ItemStarted(notif));
-        let (events, _, _) = handle(msg);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::RawOutput(v) => {
-                assert_eq!(v.get("type").and_then(|t| t.as_str()), Some("item.started"));
-                assert!(v.get("item").is_some());
-            }
-            _ => panic!("expected RawOutput"),
-        }
-    }
-
-    /// Pre-refactor handler hard-defaulted `serverName` to `"(unknown)"` for
-    /// MCP elicitation requests because the field never existed on the wire.
-    /// Preserve that frontend-facing string so `format_permission_input`'s
-    /// "MCP server `(unknown)` is asking …" rendering is unchanged.
-    #[test]
-    fn mcp_elicitation_preserves_unknown_default() {
-        let req: codex_codes::McpServerElicitationRequestParams = serde_json::from_value(json!({
-            "mode": "url",
-            "elicitationId": "e1",
-            "message": "please auth",
-            "url": "https://example.com/auth"
-        }))
-        .unwrap();
-        let msg = ServerMessage::Request {
-            id: RequestId::Integer(3),
-            request: ServerRequest::McpServerElicitationRequest(req),
-        };
-        let (events, _, _) = handle(msg);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::CodexPermissionRequest { input, .. } => {
-                assert_eq!(input.tool_name(), "McpElicitation");
-                match input {
-                    CodexPermissionInput::McpElicitation { server_name } => {
-                        assert_eq!(server_name, "(unknown)");
-                    }
-                    _ => panic!("expected McpElicitation variant"),
-                }
-            }
-            _ => panic!("expected CodexPermissionRequest"),
-        }
-    }
-
-    /// The wire envelope serialized from a `CodexPermissionInput` must include
-    /// the `tool` discriminant so the frontend's typed round-trip works (#731).
-    /// Closes the proxy → frontend type contract end-to-end.
-    #[test]
-    fn permission_input_serializes_with_tool_discriminant() {
-        let req: codex_codes::FileChangeRequestApprovalParams = serde_json::from_value(json!({
-            "itemId": "item-x",
-            "threadId": "t",
-            "turnId": "tu",
-            "startedAtMs": 0
-        }))
-        .unwrap();
-        let msg = ServerMessage::Request {
-            id: RequestId::Integer(9),
-            request: ServerRequest::FileChangeApproval(req),
-        };
-        let (events, _, _) = handle(msg);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            IoEvent::CodexPermissionRequest { input, .. } => {
-                let wire = serde_json::to_value(input).unwrap();
-                assert_eq!(wire["tool"], "fileChange");
-                assert_eq!(wire["itemId"], "item-x");
-                // Round-trip via wire → typed parse must succeed (this is the
-                // frontend's consumption path).
-                let parsed: CodexPermissionInput = serde_json::from_value(wire).unwrap();
-                assert_eq!(parsed.tool_name(), "FileChange");
-            }
-            _ => panic!("expected CodexPermissionRequest"),
+        let msg = ServerMessage::Notification(Notification::ContextCompacted(notif));
+        let (outputs, sent, ended) = classified(msg, None);
+        assert!(sent);
+        assert!(!ended);
+        assert_eq!(outputs.len(), 1);
+        match &outputs[0] {
+            AgentOutput::Visible(value) => assert_eq!(value["type"], "thread/compacted"),
+            other => panic!("expected Visible, got {other:?}"),
         }
     }
 }

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -5,7 +5,7 @@
 //! `agent.rs` for the dispatch trait.
 
 use claude_codes::io::PermissionSuggestion;
-use shared::{CodexPermissionInput, TurnMetrics};
+use shared::TurnMetrics;
 use tokio::sync::oneshot;
 
 use crate::adapter::{AgentOutput, PermissionDecision};
@@ -60,25 +60,11 @@ pub enum IoEvent {
     /// (`Visible` → `RawOutput`, `PermissionRequest` → `PermissionRequest`,
     /// `NotFound` → `SessionNotFound`, `Noop` → skip).
     Classified(AgentOutput),
-    /// Raw JSON output forwarded directly (e.g. Codex JSONL frames the codex
-    /// I/O task emits outside the classifier, and portal-reminder messages).
-    /// Bypasses classification and is forwarded verbatim to the
-    /// backend/frontend.
+    /// Raw JSON output forwarded directly — portal-reminder messages and the
+    /// codex decode-failure / turn-failed frames the I/O task emits outside the
+    /// classifier. Bypasses classification and is forwarded verbatim. (Normal
+    /// agent output now flows through [`IoEvent::Classified`] for both backends.)
     RawOutput(serde_json::Value),
-    /// Permission request from Codex's app-server approval flow.
-    ///
-    /// Claude permission requests come up the typed `Output` channel
-    /// (`ClaudeOutput::ControlRequest`) and `Session::next_event` handles
-    /// the extraction.
-    ///
-    /// The `tool_name` discriminant lives on the `CodexPermissionInput`
-    /// variant — call `input.tool_name()` if a stringly-typed key is
-    /// needed (e.g. for the `SessionEvent::PermissionRequest` envelope
-    /// which still carries one for the cross-agent claude path).
-    CodexPermissionRequest {
-        request_id: String,
-        input: CodexPermissionInput,
-    },
     /// A completed-turn performance metrics payload, ready for the proxy to
     /// ship to the backend as `ProxyToServer::TurnMetricsReport`. Emitted
     /// once per finalize by the agent-specific I/O task.

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -282,33 +282,6 @@ impl<A: Agent> Session<A> {
                     self.buffer.push(value.clone());
                     return Some(SessionEvent::RawOutput(value));
                 }
-                Some(IoEvent::CodexPermissionRequest { request_id, input }) => {
-                    // Derive the stringly-typed `tool_name` from the typed
-                    // variant so the cross-agent `SessionEvent::PermissionRequest`
-                    // and the persisted `PendingPermission` keep the same key
-                    // the claude path provides verbatim from `ToolUseRequest`.
-                    let tool_name = input.tool_name().to_string();
-                    // Re-serialize the typed envelope to JSON for the
-                    // cross-agent boundary (the claude path emits a raw
-                    // `serde_json::Value` from `ToolUseRequest::input` and
-                    // the wire stays `Value` for both). Infallible for a
-                    // serde-derived enum, but fall back to Null defensively.
-                    let input_value =
-                        serde_json::to_value(&input).unwrap_or(serde_json::Value::Null);
-                    self.pending_permission = Some(PendingPermission {
-                        request_id: request_id.clone(),
-                        tool_name: tool_name.clone(),
-                        input: input_value.clone(),
-                        requested_at: Utc::now(),
-                    });
-                    self.state = SessionState::WaitingForPermission;
-                    return Some(SessionEvent::PermissionRequest {
-                        request_id,
-                        tool_name,
-                        input: input_value,
-                        permission_suggestions: vec![],
-                    });
-                }
                 Some(IoEvent::TurnMetricsReady(metrics)) => {
                     return Some(SessionEvent::TurnMetricsReady(metrics));
                 }


### PR DESCRIPTION
## #1165 item 2 — follow-up 1b: finish output unification

Both backends now deliver agent output through the single neutral `IoEvent::Classified(AgentOutput)` channel, so `Session` has **no codex-specific output/permission arms**.

- `handle_codex_server_message` forwards each `CodexClassifier` decision as `IoEvent::Classified` (Visible / PermissionRequest / Noop), and shapes the `TurnCompleted` carve-out (usage/metrics) as `Classified(Visible(turn.completed))`. The `CodexPermissionInput` round-trip is gone — the classifier's neutral `PermissionRequest` flows straight through.
- **`IoEvent::CodexPermissionRequest` + its `Session::next_event` arm are deleted.** Codex permission requests now use the generic `Classified(PermissionRequest)` path, identical to Claude. Downstream `SessionEvent` is unchanged (Visible → `RawOutput`; PermissionRequest → `PermissionRequest`).
- Handler tests trimmed to the handler's unique behavior (TurnCompleted carve-out + Classified wrapping); the per-variant `ServerMessage`→`AgentOutput` mapping stays characterized in `classifier.rs`.

`IoEvent::RawOutput` remains for the verbatim portal / decode-failure frames both backends still emit directly.

### Verification
- `cargo build --workspace` ✓ (launcher built — `Session: Sync` preserved)
- `cargo test` session-lib / claude-session-lib / codex-session-lib ✓
- **`cargo clippy --workspace --all-targets -- -D warnings`** ✓ (the gate that bit #1198)
- `cargo fmt --check` ✓

Behavior-preserving; no proxy changes. With this, codex no longer bypasses the classify path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)