### PR TITLE
refactor: neutralize SessionEvent permission suggestions — Session now claude_codes-free (#1165 item 2, A1c)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.102"
+version = "2.12.103"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.102"
+version = "2.12.103"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.102"
+version = "2.12.103"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.102"
+version = "2.12.103"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.102"
+version = "2.12.103"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.102"
+version = "2.12.103"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.102"
+version = "2.12.103"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.102"
+version = "2.12.103"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.102"
+version = "2.12.103"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.102"
+version = "2.12.103"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.102"
+version = "2.12.103"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -220,6 +220,15 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
             input,
             permission_suggestions,
         }) => {
+            // `Session` hands these as opaque wire JSON (it's protocol-neutral);
+            // re-parse into the typed `ProxyToServer` wire form at the proxy
+            // edge. Unparseable entries are dropped rather than failing the
+            // request (claude emits well-formed suggestions; codex emits none).
+            let permission_suggestions: Vec<claude_codes::io::PermissionSuggestion> =
+                permission_suggestions
+                    .into_iter()
+                    .filter_map(|s| serde_json::from_value(s).ok())
+                    .collect();
             // Send permission request directly to WebSocket
             let msg = ProxyToServer::PermissionRequest {
                 request_id,

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -4,7 +4,6 @@
 //! per-agent I/O tasks just ignore the variants they don't handle. See
 //! `agent.rs` for the dispatch trait.
 
-use claude_codes::io::PermissionSuggestion;
 use shared::TurnMetrics;
 use tokio::sync::oneshot;
 
@@ -103,11 +102,15 @@ pub enum SessionEvent {
     RawOutput(serde_json::Value),
 
     /// The agent is requesting permission for a tool.
+    ///
+    /// `permission_suggestions` are opaque wire JSON (the classifier serialized
+    /// the agent's typed suggestions); the proxy edge re-parses them into its
+    /// typed wire form. Keeps `Session` free of concrete protocol types.
     PermissionRequest {
         request_id: String,
         tool_name: String,
         input: serde_json::Value,
-        permission_suggestions: Vec<PermissionSuggestion>,
+        permission_suggestions: Vec<serde_json::Value>,
     },
 
     /// Session not found locally (e.g., when resuming an expired session).

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -7,7 +7,6 @@
 use std::marker::PhantomData;
 
 use chrono::Utc;
-use claude_codes::io::PermissionSuggestion;
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
@@ -246,12 +245,9 @@ impl<A: Agent> Session<A> {
                             input,
                             suggestions,
                         } => {
-                            // Recover the typed suggestions from the classifier's
-                            // opaque JSON round-trip (it serialized them).
-                            let permission_suggestions: Vec<PermissionSuggestion> = suggestions
-                                .into_iter()
-                                .filter_map(|s| serde_json::from_value(s).ok())
-                                .collect();
+                            // `suggestions` is already opaque wire JSON; forward
+                            // it as-is. The proxy edge re-parses into its typed
+                            // wire form, keeping `Session` protocol-neutral.
                             self.pending_permission = Some(PendingPermission {
                                 request_id: request_id.clone(),
                                 tool_name: tool_name.clone(),
@@ -263,7 +259,7 @@ impl<A: Agent> Session<A> {
                                 request_id,
                                 tool_name,
                                 input,
-                                permission_suggestions,
+                                permission_suggestions: suggestions,
                             });
                         }
                         // User-visible output: buffer the raw value and forward it


### PR DESCRIPTION
## #1165 item 2 — final cleanup (1c): `Session` is now fully protocol-neutral

`SessionEvent::PermissionRequest.permission_suggestions` becomes `Vec<serde_json::Value>` instead of typed `Vec<claude_codes::io::PermissionSuggestion>` — **the last `claude_codes` type reference in `Session` is gone** (only a doc comment remains, correctly noting Session carries no such types).

- The classifier already produces suggestions as `Vec<Value>`; `Session` now forwards them untouched (no deserialize).
- The proxy edge (`wiggum.rs`) re-parses `Vec<Value>` → typed `Vec<PermissionSuggestion>` when building `ProxyToServer::PermissionRequest`, so the **wire protocol (`shared`) and frontend stay typed and unchanged** — the same re-parse-at-the-edge pattern as `parse_visible_claude_output`.

### Scope
Contained to `session-lib` + the `claude-session-lib` proxy edge. No `shared`/frontend/proxy-protocol changes. Behavior-preserving.

### Verification
- `cargo build --workspace` ✓
- `cargo test` session-lib (33) + claude-session-lib (29) ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo fmt --check` ✓
- `grep -E 'claude_codes|codex_codes' session-lib/src/session.rs` → only 1 doc comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)