### PR TITLE
refactor: render compaction status via typed system message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.103"
+version = "2.12.104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.103"
+version = "2.12.104"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.103"
+version = "2.12.104"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.103"
+version = "2.12.104"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.103"
+version = "2.12.104"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.103"
+version = "2.12.104"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.103"
+version = "2.12.104"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.103"
+version = "2.12.104"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.103"
+version = "2.12.104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.103"
+version = "2.12.104"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.103"
+version = "2.12.104"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers/system.rs
+++ b/frontend/src/components/message_renderer/renderers/system.rs
@@ -6,14 +6,7 @@ use yew::prelude::*;
 pub fn render_system_message(msg: &shared::SystemMessage, timestamp: Option<&str>) -> Html {
     let subtype = msg.subtype.as_str();
 
-    // Check if this is a compaction-related message via subtype or status field
-    let status_value = msg
-        .data
-        .get("status")
-        .and_then(|s| s.as_str())
-        .unwrap_or("");
-
-    if status_value == "compacting" {
+    if is_compaction_beginning(msg) {
         return render_compaction_beginning();
     }
 
@@ -58,6 +51,12 @@ pub fn render_system_message(msg: &shared::SystemMessage, timestamp: Option<&str
             <span class="message-type-badge system">{ subtype }</span>
         </div>
     }
+}
+
+fn is_compaction_beginning(msg: &shared::SystemMessage) -> bool {
+    msg.as_status()
+        .and_then(|status| status.status)
+        .is_some_and(|status| status.as_str() == "compacting")
 }
 
 fn render_init_bar(msg: &shared::SystemMessage, timestamp: Option<&str>) -> Html {
@@ -255,5 +254,53 @@ fn render_task_notification(msg: &shared::SystemMessage, timestamp: Option<&str>
                 } else { html! {} }
             }
         </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn system_message(json: serde_json::Value) -> shared::SystemMessage {
+        serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn compaction_beginning_uses_typed_status_accessor() {
+        let msg = system_message(serde_json::json!({
+            "type": "system",
+            "subtype": "status",
+            "status": "compacting",
+            "session_id": "s-1"
+        }));
+
+        assert!(is_compaction_beginning(&msg));
+    }
+
+    #[test]
+    fn non_compacting_status_is_not_compaction_beginning() {
+        let msg = system_message(serde_json::json!({
+            "type": "system",
+            "subtype": "status",
+            "status": null,
+            "session_id": "s-1"
+        }));
+
+        assert!(!is_compaction_beginning(&msg));
+    }
+
+    #[test]
+    fn compact_boundary_is_not_compaction_beginning() {
+        let msg = system_message(serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "summary": "trimmed",
+            "compact_metadata": {
+                "trigger": "auto",
+                "pre_tokens": 123
+            }
+        }));
+
+        assert!(!is_compaction_beginning(&msg));
     }
 }


### PR DESCRIPTION
## Summary
- replace system renderer status-field JSON poking with SystemMessage::as_status()
- keep compaction-beginning behavior the same
- add focused tests for compacting, null status, and compact-boundary cases

## Tests
- cargo test -p frontend renderers::system -- --nocapture
- cargo clippy -p frontend --all-targets -- -D warnings
- cargo fmt --check
- cargo test -p frontend