### PR TITLE
refactor: extract input-delivery from the proxy connection loop (#1165 item 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.104"
+version = "2.12.105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.104"
+version = "2.12.105"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.104"
+version = "2.12.105"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.104"
+version = "2.12.105"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.104"
+version = "2.12.105"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.104"
+version = "2.12.105"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.104"
+version = "2.12.105"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.104"
+version = "2.12.105"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.104"
+version = "2.12.105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.104"
+version = "2.12.105"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.104"
+version = "2.12.105"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/input_delivery.rs
+++ b/claude-session-lib/src/proxy_session/input_delivery.rs
@@ -1,0 +1,97 @@
+//! Input-delivery arm of the proxy connection loop (#1165 item 3).
+//!
+//! Extracted from the `run_main_loop` `select!` so the god-loop reads as thin
+//! dispatch. Hands a [`PortalInput`] to the agent: refreshes git metadata,
+//! emits the [`InputDeliveryStage`](shared::InputDeliveryStage) progress
+//! events (#939), stashes the typed display-event echo for Claude's
+//! `output_forwarder` to swap in (#1124), and acks the portal input.
+
+use tracing::{debug, error};
+use uuid::Uuid;
+
+use session_lib::agent::Agent;
+use session_lib::session::Session;
+
+use super::git_metadata::{check_and_send_branch_update_if_branch_changed, GitMetadataState};
+use super::{
+    ack_portal_input, emit_input_progress, truncate, ConnectionResult, PendingInputDisplayEvent,
+    PendingInputDisplayEvents, PortalInput, SharedWsWrite,
+};
+
+/// Deliver one user input to the agent. Returns `Some(ConnectionResult)` to end
+/// the connection (delivery failure), or `None` to continue the loop.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn handle_input<A: Agent>(
+    ws_write: &SharedWsWrite,
+    session_id: Uuid,
+    working_directory: &str,
+    git_metadata: &GitMetadataState,
+    agent_type: shared::AgentType,
+    pending_input_display_events: &PendingInputDisplayEvents,
+    claude_session: &mut Session<A>,
+    input: PortalInput,
+) -> Option<ConnectionResult> {
+    check_and_send_branch_update_if_branch_changed(
+        ws_write,
+        session_id,
+        working_directory,
+        git_metadata,
+    )
+    .await;
+
+    debug!("sending to claude process: {}", truncate(&input.text, 100));
+
+    // Delivery stage: the proxy has the input and is about to hand it to the
+    // agent (#939).
+    emit_input_progress(
+        ws_write,
+        session_id,
+        input.client_msg_id,
+        shared::InputDeliveryStage::ProxyReceived,
+    )
+    .await;
+
+    // Two mechanisms deliver the typed display event, exactly one per agent —
+    // never both:
+    //  - Claude echoes its input, so we stash the event here for the
+    //    output_forwarder to swap in on the matching ClaudeOutput::User.
+    //  - Codex doesn't echo, so its io-task emits the event itself (handed in
+    //    via send_input_with_display below).
+    // Gate the stash on Claude: pushing for Codex would leak the VecDeque entry
+    // forever, since nothing consumes it there (#1124).
+    if agent_type == shared::AgentType::Claude {
+        if let Some(display_event) = input.display_event.clone() {
+            let mut pending = pending_input_display_events.lock().await;
+            pending.push_back(PendingInputDisplayEvent {
+                echoed_text: input.text.clone(),
+                content: display_event,
+            });
+        }
+    }
+
+    if let Err(e) = claude_session
+        .send_input_with_display(serde_json::Value::String(input.text), input.display_event)
+        .await
+    {
+        error!("Failed to send to Claude: {}", e);
+        emit_input_progress(
+            ws_write,
+            session_id,
+            input.client_msg_id,
+            shared::InputDeliveryStage::Failed,
+        )
+        .await;
+        return Some(ConnectionResult::ClaudeExited);
+    }
+    // Delivery stage: the input is now in the agent's stream — the optimistic
+    // row clears here (#939).
+    emit_input_progress(
+        ws_write,
+        session_id,
+        input.client_msg_id,
+        shared::InputDeliveryStage::AgentAccepted,
+    )
+    .await;
+    ack_portal_input(ws_write, input.ack).await;
+    None
+}

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -2,6 +2,7 @@
 
 mod git_metadata;
 mod image_uploader;
+mod input_delivery;
 mod output_forwarder;
 mod portal_reminder;
 mod wiggum;
@@ -862,7 +863,7 @@ async fn recv_option(rx: &mut tokio::sync::oneshot::Receiver<()>) -> Option<()> 
 
 /// Emit an `InputProgressAck` delivery-stage signal for a tracked input, if it
 /// carried a `client_msg_id` (#939). The backend relays it to web clients.
-async fn emit_input_progress(
+pub(super) async fn emit_input_progress(
     ws_write: &SharedWsWrite,
     session_id: Uuid,
     client_msg_id: Option<Uuid>,
@@ -982,71 +983,20 @@ async fn run_main_loop<A: Agent>(
             }
 
             Some(input) = input_rx.recv() => {
-                check_and_send_branch_update_if_branch_changed(
+                if let Some(result) = input_delivery::handle_input(
                     &state.ws_write,
                     state.session_id,
                     &state.working_directory,
                     &state.git_metadata,
+                    state.agent_type,
+                    &state.pending_input_display_events,
+                    claude_session,
+                    input,
                 )
-                .await;
-
-                debug!("sending to claude process: {}", truncate(&input.text, 100));
-
-                // Delivery stage: the proxy has the input and is about to hand
-                // it to the agent (#939).
-                emit_input_progress(
-                    &state.ws_write,
-                    state.session_id,
-                    input.client_msg_id,
-                    shared::InputDeliveryStage::ProxyReceived,
-                )
-                .await;
-
-                // Two mechanisms deliver the typed display event, exactly one
-                // per agent — never both:
-                //  - Claude echoes its input, so we stash the event here for the
-                //    output_forwarder to swap in on the matching ClaudeOutput::User.
-                //  - Codex doesn't echo, so its io-task emits the event itself
-                //    (handed in via send_input_with_display below).
-                // Gate the stash on Claude: pushing for Codex would leak the
-                // VecDeque entry forever, since nothing consumes it there (#1124).
-                if state.agent_type == shared::AgentType::Claude {
-                    if let Some(display_event) = input.display_event.clone() {
-                        let mut pending = state.pending_input_display_events.lock().await;
-                        pending.push_back(PendingInputDisplayEvent {
-                            echoed_text: input.text.clone(),
-                            content: display_event,
-                        });
-                    }
-                }
-
-                if let Err(e) = claude_session
-                    .send_input_with_display(
-                        serde_json::Value::String(input.text),
-                        input.display_event,
-                    )
-                    .await
+                .await
                 {
-                    error!("Failed to send to Claude: {}", e);
-                    emit_input_progress(
-                        &state.ws_write,
-                        state.session_id,
-                        input.client_msg_id,
-                        shared::InputDeliveryStage::Failed,
-                    )
-                    .await;
-                    return ConnectionResult::ClaudeExited;
+                    return result;
                 }
-                // Delivery stage: the input is now in the agent's stream — the
-                // optimistic row clears here (#939).
-                emit_input_progress(
-                    &state.ws_write,
-                    state.session_id,
-                    input.client_msg_id,
-                    shared::InputDeliveryStage::AgentAccepted,
-                )
-                .await;
-                ack_portal_input(&state.ws_write, input.ack).await;
             }
 
             // Wiggum mode activation — set state and send prompt atomically


### PR DESCRIPTION
## #1165 item 3 — split the proxy connection god-loop (slice 1)

`proxy_session/mod.rs` (~1670 lines) runs reconnect + heartbeat + input-delivery + wiggum + permissions + uploads/downloads + git-metadata in one giant `select!`. This starts decomposing it: the `input_rx` arm body moves into `input_delivery::handle_input`, so the loop arm becomes thin dispatch — the same pattern as the existing `wiggum` extraction.

### Behavior-preserving
The arm now calls `handle_input(...)` and returns its `Option<ConnectionResult>` (`Some` → end the connection on delivery failure, `None` → continue). Git-metadata refresh, the #939 delivery-progress stages, the #1124 Claude-only display-event stash, and the portal-input ack are byte-for-byte unchanged — just relocated. `emit_input_progress` becomes `pub(super)`.

### Verification
- `cargo build --workspace` ✓
- `cargo test -p claude-session-lib` (33) ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo fmt --check` ✓

More arms (heartbeat, permission bridge, file transfer) follow in subsequent slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)