### PR TITLE
refactor: extract permission-bridge from the proxy connection loop (#1165 item 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.105"
+version = "2.12.106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.105"
+version = "2.12.106"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.105"
+version = "2.12.106"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.105"
+version = "2.12.106"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.105"
+version = "2.12.106"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.105"
+version = "2.12.106"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.105"
+version = "2.12.106"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.105"
+version = "2.12.106"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.105"
+version = "2.12.106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.105"
+version = "2.12.106"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.105"
+version = "2.12.106"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -4,6 +4,7 @@ mod git_metadata;
 mod image_uploader;
 mod input_delivery;
 mod output_forwarder;
+mod permission_bridge;
 mod portal_reminder;
 mod wiggum;
 mod ws_reader;
@@ -908,9 +909,6 @@ async fn run_main_loop<A: Agent>(
     input_rx: &mut mpsc::UnboundedReceiver<PortalInput>,
     state: &mut ConnectionState,
 ) -> ConnectionResult {
-    use crate::Permission;
-    use session_lib::io::PermissionResponse as LibPermissionResponse;
-
     let mut heartbeat_interval = tokio::time::interval(session_lib::heartbeat::HEARTBEAT_INTERVAL);
 
     loop {
@@ -1056,30 +1054,7 @@ async fn run_main_loop<A: Agent>(
             }
 
             Some(perm_response) = state.perm_rx.recv() => {
-                debug!("sending permission response to claude: {:?}", perm_response);
-
-                // Build the library's PermissionResponse
-                let lib_response = if perm_response.allow {
-                    let input = perm_response.input.unwrap_or(serde_json::Value::Object(Default::default()));
-                    let permissions: Vec<Permission> = perm_response
-                        .permissions
-                        .iter()
-                        .map(Permission::from_suggestion)
-                        .collect();
-
-                    if permissions.is_empty() {
-                        LibPermissionResponse::allow_with_input(input)
-                    } else {
-                        LibPermissionResponse::allow_with_input_and_remember(input, permissions)
-                    }
-                } else {
-                    let reason = perm_response.reason.unwrap_or_else(|| "User denied".to_string());
-                    LibPermissionResponse::deny_with_reason(reason)
-                };
-
-                if let Err(e) = claude_session.respond_permission(&perm_response.request_id, lib_response).await {
-                    warn!("Permission response failed (stale request?): {}", e);
-                }
+                permission_bridge::handle_permission_response(claude_session, perm_response).await;
             }
 
             Some(ack_seq) = state.ack_rx.recv() => {

--- a/claude-session-lib/src/proxy_session/permission_bridge.rs
+++ b/claude-session-lib/src/proxy_session/permission_bridge.rs
@@ -1,0 +1,54 @@
+//! Permission-response arm of the proxy connection loop (#1165 item 3).
+//!
+//! Extracted from the `run_main_loop` `select!` so the god-loop reads as thin
+//! dispatch. Translates a frontend [`PermissionResponseData`] into the library's
+//! neutral [`PermissionResponse`](session_lib::io::PermissionResponse) and hands
+//! it to the agent; a stale/failed response is logged, not fatal.
+
+use tracing::{debug, warn};
+
+use session_lib::agent::Agent;
+use session_lib::io::PermissionResponse as LibPermissionResponse;
+use session_lib::session::Session;
+
+use crate::Permission;
+
+use super::PermissionResponseData;
+
+/// Forward a frontend permission response to the agent.
+pub(super) async fn handle_permission_response<A: Agent>(
+    claude_session: &mut Session<A>,
+    perm_response: PermissionResponseData,
+) {
+    debug!("sending permission response to claude: {:?}", perm_response);
+
+    // Build the library's neutral PermissionResponse.
+    let lib_response = if perm_response.allow {
+        let input = perm_response
+            .input
+            .unwrap_or(serde_json::Value::Object(Default::default()));
+        let permissions: Vec<Permission> = perm_response
+            .permissions
+            .iter()
+            .map(Permission::from_suggestion)
+            .collect();
+
+        if permissions.is_empty() {
+            LibPermissionResponse::allow_with_input(input)
+        } else {
+            LibPermissionResponse::allow_with_input_and_remember(input, permissions)
+        }
+    } else {
+        let reason = perm_response
+            .reason
+            .unwrap_or_else(|| "User denied".to_string());
+        LibPermissionResponse::deny_with_reason(reason)
+    };
+
+    if let Err(e) = claude_session
+        .respond_permission(&perm_response.request_id, lib_response)
+        .await
+    {
+        warn!("Permission response failed (stale request?): {}", e);
+    }
+}


### PR DESCRIPTION
## #1165 item 3 — split the proxy connection god-loop (slice 2)

Moves the `perm_rx` `select!` arm into `permission_bridge::handle_permission_response` — builds the library's neutral `PermissionResponse` from the frontend `PermissionResponseData` and forwards it to the agent (stale/failed responses are logged, not fatal). Removes the now-orphaned function-local `Permission` / `LibPermissionResponse` imports from `run_main_loop`.

Behavior-preserving; same pattern as the `input_delivery` / `wiggum` extractions. The god-loop continues to shrink (1621 → 1596 lines).

### Verification
- `cargo build --workspace` ✓
- `cargo test -p claude-session-lib` (33) ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo fmt --check` ✓

Next slices: file-transfer (upload/download) → `FileTransferBridge`, heartbeat → `HeartbeatWatchdog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)