### PR TITLE
refactor: extract heartbeat-watchdog from the proxy connection loop (#1165 item 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.106"
+version = "2.12.107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.106"
+version = "2.12.107"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.106"
+version = "2.12.107"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.106"
+version = "2.12.107"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.106"
+version = "2.12.107"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.106"
+version = "2.12.107"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.106"
+version = "2.12.107"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.106"
+version = "2.12.107"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.106"
+version = "2.12.107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.106"
+version = "2.12.107"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.106"
+version = "2.12.107"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/heartbeat_watchdog.rs
+++ b/claude-session-lib/src/proxy_session/heartbeat_watchdog.rs
@@ -1,0 +1,56 @@
+//! Heartbeat-watchdog arm of the proxy connection loop (#1165 item 3).
+//!
+//! Extracted from the `run_main_loop` `select!`. On each interval tick: force a
+//! reconnect if no heartbeat response has arrived within the window, otherwise
+//! send a `Heartbeat` — with the lock+send bounded by a timeout so a wedged
+//! `ws_write` on a half-dead socket can't starve the `select!` and strand the
+//! session "shown but not connected" (#926).
+
+use session_lib::heartbeat::HeartbeatTracker;
+use shared::ProxyToServer;
+use tracing::warn;
+
+use super::{ConnectionResult, SharedWsWrite};
+
+/// Run one heartbeat tick. Returns `Some(ConnectionResult::Disconnected)` to
+/// force a reconnect (expired, send failed, or send wedged), or `None` to
+/// continue the loop.
+pub(super) async fn tick(
+    heartbeat: &HeartbeatTracker,
+    ws_write: &SharedWsWrite,
+    connection_start: std::time::Instant,
+) -> Option<ConnectionResult> {
+    if heartbeat.is_expired() {
+        warn!(
+            "No heartbeat response in {}s, forcing reconnect",
+            heartbeat.elapsed_secs()
+        );
+        return Some(ConnectionResult::Disconnected(connection_start.elapsed()));
+    }
+    // Bound the heartbeat lock+send. On a half-dead socket (e.g. after a backend
+    // restart) the send can block forever; that starves this `select!` so the
+    // disconnect / graceful-shutdown arms never fire and the data plane never
+    // reconnects — the session is "shown but not connected" until the launcher
+    // is restarted (#926). Timing out the lock acquisition *and* the send makes
+    // this a true watchdog: even if another ws_write send is wedged holding the
+    // lock, this fires and returns `Disconnected`, letting the reconnect/backoff
+    // in `run_connection_loop` recover.
+    let send = async {
+        let mut ws = ws_write.lock().await;
+        ws.send(ProxyToServer::Heartbeat).await
+    };
+    match tokio::time::timeout(session_lib::heartbeat::HEARTBEAT_TIMEOUT, send).await {
+        Ok(Ok(())) => None,
+        Ok(Err(e)) => {
+            warn!("Heartbeat send failed ({e}), forcing reconnect");
+            Some(ConnectionResult::Disconnected(connection_start.elapsed()))
+        }
+        Err(_) => {
+            warn!(
+                "Heartbeat send blocked >{}s (dead socket), forcing reconnect",
+                session_lib::heartbeat::HEARTBEAT_TIMEOUT.as_secs()
+            );
+            Some(ConnectionResult::Disconnected(connection_start.elapsed()))
+        }
+    }
+}

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -1,6 +1,7 @@
 //! Proxy session management and WebSocket connection handling.
 
 mod git_metadata;
+mod heartbeat_watchdog;
 mod image_uploader;
 mod input_delivery;
 mod output_forwarder;
@@ -914,49 +915,14 @@ async fn run_main_loop<A: Agent>(
     loop {
         tokio::select! {
             _ = heartbeat_interval.tick() => {
-                if state.heartbeat.is_expired() {
-                    warn!(
-                        "No heartbeat response in {}s, forcing reconnect",
-                        state.heartbeat.elapsed_secs()
-                    );
-                    return ConnectionResult::Disconnected(state.connection_start.elapsed());
-                }
-                // Bound the heartbeat lock+send. On a half-dead socket (e.g.
-                // after a backend restart) the send can block forever; that
-                // starves this `select!` so the disconnect / graceful-shutdown
-                // arms never fire and the data plane reconnects never — the
-                // session is "shown but not connected" until the launcher is
-                // restarted (#926). Timing out the lock acquisition *and* the
-                // send makes this heartbeat a true watchdog: even if another
-                // ws_write send is wedged holding the lock, this fires and
-                // returns `Disconnected`, letting `run_connection_loop`'s
-                // reconnect/backoff recover the connection.
-                let send = async {
-                    let mut ws = state.ws_write.lock().await;
-                    ws.send(ProxyToServer::Heartbeat).await
-                };
-                match tokio::time::timeout(
-                    session_lib::heartbeat::HEARTBEAT_TIMEOUT,
-                    send,
+                if let Some(result) = heartbeat_watchdog::tick(
+                    &state.heartbeat,
+                    &state.ws_write,
+                    state.connection_start,
                 )
                 .await
                 {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => {
-                        warn!("Heartbeat send failed ({e}), forcing reconnect");
-                        return ConnectionResult::Disconnected(
-                            state.connection_start.elapsed(),
-                        );
-                    }
-                    Err(_) => {
-                        warn!(
-                            "Heartbeat send blocked >{}s (dead socket), forcing reconnect",
-                            session_lib::heartbeat::HEARTBEAT_TIMEOUT.as_secs()
-                        );
-                        return ConnectionResult::Disconnected(
-                            state.connection_start.elapsed(),
-                        );
-                    }
+                    return result;
                 }
             }
 


### PR DESCRIPTION
## #1165 item 3 — split the proxy connection god-loop (slice 3)

Moves the heartbeat `select!` arm into `heartbeat_watchdog::tick` — forces a reconnect on an expired or wedged heartbeat (the #926 timeout-bounded lock+send watchdog) and otherwise sends the `Heartbeat`. The arm is now thin dispatch returning the handler's `Option<ConnectionResult>`.

Behavior-preserving; same pattern as `input_delivery` / `permission_bridge`. The god-loop is now **1562 lines** (down from 1671 at the start of item 3).

### Verification
- `cargo build --workspace` ✓
- `cargo test -p claude-session-lib` (33) ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo fmt --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)