### PR TITLE
refactor: remove utils unwrap ratchet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.107"
+version = "2.12.108"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.107"
+version = "2.12.108"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.107"
+version = "2.12.108"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.107"
+version = "2.12.108"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.107"
+version = "2.12.108"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.107"
+version = "2.12.108"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.107"
+version = "2.12.108"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.107"
+version = "2.12.108"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.107"
+version = "2.12.108"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.107"
+version = "2.12.108"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.107"
+version = "2.12.108"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -1,6 +1,3 @@
-// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
-#![allow(clippy::unwrap_used, clippy::expect_used)]
-
 use serde::de::DeserializeOwned;
 use web_sys::window;
 
@@ -65,7 +62,9 @@ pub async fn fetch_json<T: DeserializeOwned>(path: &str, on_401: On401) -> Resul
 
 /// Get the base HTTP URL (e.g., "http://localhost:3000" or "https://myapp.com")
 pub fn get_base_url() -> String {
-    let window = window().expect("no global window");
+    let Some(window) = window() else {
+        return "http://localhost:3000".to_string();
+    };
     let location = window.location();
 
     let protocol = location.protocol().unwrap_or_else(|_| "http:".to_string());
@@ -78,7 +77,9 @@ pub fn get_base_url() -> String {
 
 /// Get the WebSocket URL (e.g., "ws://localhost:3000" or "wss://myapp.com")
 pub fn get_ws_url() -> String {
-    let window = window().expect("no global window");
+    let Some(window) = window() else {
+        return "ws://localhost:3000".to_string();
+    };
     let location = window.location();
 
     let protocol = location.protocol().unwrap_or_else(|_| "http:".to_string());
@@ -103,14 +104,21 @@ pub fn ws_url(path: &str) -> String {
 /// Format a dollar amount with commas (e.g., 1234.56 -> "$1,234.56")
 pub fn format_dollars(amount: f64) -> String {
     let formatted = format!("{:.2}", amount);
-    let (integer, decimal) = formatted.split_once('.').unwrap();
-    let with_commas: String = integer
+    let Some((integer, decimal)) = formatted.split_once('.') else {
+        return format!("${formatted}");
+    };
+    let negative = integer.starts_with('-');
+    let digits = integer.strip_prefix('-').unwrap_or(integer);
+    let mut with_commas = digits
         .as_bytes()
         .rchunks(3)
         .rev()
-        .map(|chunk| std::str::from_utf8(chunk).unwrap())
+        .map(|chunk| chunk.iter().map(|byte| *byte as char).collect::<String>())
         .collect::<Vec<_>>()
         .join(",");
+    if negative {
+        with_commas.insert(0, '-');
+    }
     format!("${}.{}", with_commas, decimal)
 }
 
@@ -212,6 +220,19 @@ mod tests {
     }
 
     // --- format_token_count ---
+
+    #[test]
+    fn format_dollars_adds_commas_and_keeps_two_decimals() {
+        assert_eq!(format_dollars(0.0), "$0.00");
+        assert_eq!(format_dollars(12.3), "$12.30");
+        assert_eq!(format_dollars(1_234.56), "$1,234.56");
+        assert_eq!(format_dollars(1_234_567.89), "$1,234,567.89");
+    }
+
+    #[test]
+    fn format_dollars_handles_negative_amounts() {
+        assert_eq!(format_dollars(-1_234.5), "$-1,234.50");
+    }
 
     #[test]
     fn format_token_count_magnitudes() {


### PR DESCRIPTION
## Summary
- remove the frontend `utils.rs` file-local unwrap/expect clippy ratchet
- make URL helpers gracefully fall back when no browser window is available
- make dollar formatting avoid unwraps and cover comma insertion/negative values

## Local checks
- cargo test -p frontend utils::tests -- --nocapture
- cargo clippy -p frontend --all-targets -- -D warnings
- cargo fmt --check
- cargo test -p frontend