### PR TITLE
ci: cache trunk tool installation

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Install trunk via cargo
     required: false
     default: "false"
+  trunk-version:
+    description: Trunk version to install when trunk is enabled
+    required: false
+    default: "0.21.14"
 
 runs:
   using: composite
@@ -64,7 +68,22 @@ runs:
       with:
         shared-key: ${{ inputs.cache-key }}
 
+    - name: Cache trunk binary
+      if: inputs.trunk == 'true'
+      id: cache-trunk
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/trunk
+          ~/.cache/trunk
+        key: ${{ runner.os }}-trunk-${{ inputs.trunk-version }}
+
     - name: Install trunk
+      if: inputs.trunk == 'true' && steps.cache-trunk.outputs.cache-hit != 'true'
+      shell: bash
+      run: cargo install trunk --locked --version "${{ inputs.trunk-version }}"
+
+    - name: Verify trunk
       if: inputs.trunk == 'true'
       shell: bash
-      run: cargo install trunk --locked
+      run: trunk --version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.112"
+version = "2.12.114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.112"
+version = "2.12.114"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.112"
+version = "2.12.114"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.112"
+version = "2.12.114"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.112"
+version = "2.12.114"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.112"
+version = "2.12.114"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.112"
+version = "2.12.114"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.112"
+version = "2.12.114"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.112"
+version = "2.12.114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.112"
+version = "2.12.114"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.112"
+version = "2.12.114"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## Summary
- pin trunk installation in the shared setup-rust action to 0.21.14
- cache the trunk binary and trunk tool cache for jobs that build the frontend
- verify trunk after restore/install so cache hits still fail clearly if the tool is unusable

## Local checks
- python3 YAML parse for .github/actions/setup-rust/action.yml, .github/workflows/ci.yml, and .github/workflows/container.yml
- git diff --check

This is a #1209 item 10 CI-speed slice. It targets the repeated cargo install trunk cost in the frontend and container lanes without changing the build commands themselves.