### PR TITLE
ci: run the E2E harness in a dedicated Postgres-backed job (#1209 item 1, 1c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,43 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    # Dedicated job for DB-backed integration tests (#1209 item 1). Kept
+    # separate from `Tests` so only the harness — which self-migrates a fresh
+    # Postgres — runs against a DB; the main test lane stays DB-free.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: claude_portal
+          POSTGRES_USER: claude_portal
+          POSTGRES_PASSWORD: dev_password_change_in_production
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U claude_portal"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stub frontend dist
+        run: mkdir -p frontend/dist
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key: "e2e"
+          protoc: "true"
+
+      - name: Run E2E harness
+        env:
+          DATABASE_URL: postgresql://claude_portal:dev_password_change_in_production@localhost:5432/claude_portal
+        run: cargo test -p backend --test harness
+
   build-binaries:
     name: ${{ matrix.job-name }}
     runs-on: ${{ matrix.runner }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.117"
+version = "2.12.118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.117"
+version = "2.12.118"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.117"
+version = "2.12.118"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.117"
+version = "2.12.118"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.117"
+version = "2.12.118"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.117"
+version = "2.12.118"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.117"
+version = "2.12.118"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.117"
+version = "2.12.118"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.117"
+version = "2.12.118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.117"
+version = "2.12.118"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.117"
+version = "2.12.118"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## #1209 item 1 — slice 1c: the harness now runs in CI

Adds an **`E2E Tests`** CI job with a health-checked `postgres:16-alpine` service + `DATABASE_URL`, running only `cargo test -p backend --test harness`. The harness self-migrates the fresh CI Postgres (embedded migrations) and asserts the proxy `Register → RegisterAck` handshake — so the cross-crate E2E test runs in CI, not just locally.

### Why a separate job (not `DATABASE_URL` on the main `Tests` lane)
Setting `DATABASE_URL` on the main lane would also un-gate the pre-existing `handlers::messages::db_tests` / `replay_tests`, which **fail independently of the harness** on a timestamp-precision assertion — Postgres stores microseconds (`…619150`) while the in-memory `chrono` value carries nanoseconds (`…619150574`). That's a pre-existing test bug, orthogonal to the harness; fixing it is a separate cleanup. This job keeps the main test lane **DB-free and unchanged** while giving the harness real CI coverage.

### Verification (local, exact CI command)
- `python3 -c "import yaml; yaml.safe_load(...)"` on ci.yml ✓
- Fresh DB (`docker compose -f docker-compose.test.yml down -v && up -d db`) → `DATABASE_URL=… cargo test -p backend --test harness` **passes** (self-migrates) ✓
- Without `DATABASE_URL` → harness **skips** (main lane unaffected) ✓
- `cargo fmt --check` ✓ (no Rust changes — ci.yml + version bump only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)