### PR TITLE
ci: combine binary build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,52 +195,32 @@ jobs:
         include:
           - job-name: Build Proxy (Linux x86_64)
             runner: ubuntu-latest
-            package: claude-portal
-            binary: claude-portal
-            cache-key: proxy-linux
-            artifact: proxy-linux-x86_64
-          - job-name: Build Proxy (Linux aarch64)
+            cache-key: binaries-linux
+            proxy-binary: claude-portal
+            proxy-artifact: proxy-linux-x86_64
+            launcher-binary: agent-portal
+            launcher-artifact: launcher-linux-x86_64
+          - job-name: Build Binaries (Linux aarch64)
             runner: ubuntu-24.04-arm
-            package: claude-portal
-            binary: claude-portal
-            cache-key: proxy-linux-aarch64
-            artifact: proxy-linux-aarch64
-          - job-name: Build Proxy (macOS ARM64)
+            cache-key: binaries-linux-aarch64
+            proxy-binary: claude-portal
+            proxy-artifact: proxy-linux-aarch64
+            launcher-binary: agent-portal
+            launcher-artifact: launcher-linux-aarch64
+          - job-name: Build Binaries (macOS ARM64)
             runner: macos-14
-            package: claude-portal
-            binary: claude-portal
-            cache-key: proxy-macos-arm64
-            artifact: proxy-darwin-aarch64
-          - job-name: Build Proxy (Windows x86_64)
+            cache-key: binaries-macos-arm64
+            proxy-binary: claude-portal
+            proxy-artifact: proxy-darwin-aarch64
+            launcher-binary: agent-portal
+            launcher-artifact: launcher-darwin-aarch64
+          - job-name: Build Binaries (Windows x86_64)
             runner: windows-latest
-            package: claude-portal
-            binary: claude-portal.exe
-            cache-key: proxy-windows
-            artifact: proxy-windows-x86_64
-          - job-name: Build Launcher (Linux x86_64)
-            runner: ubuntu-latest
-            package: agent-portal
-            binary: agent-portal
-            cache-key: launcher-linux
-            artifact: launcher-linux-x86_64
-          - job-name: Build Launcher (Linux aarch64)
-            runner: ubuntu-24.04-arm
-            package: agent-portal
-            binary: agent-portal
-            cache-key: launcher-linux-aarch64
-            artifact: launcher-linux-aarch64
-          - job-name: Build Launcher (macOS ARM64)
-            runner: macos-14
-            package: agent-portal
-            binary: agent-portal
-            cache-key: launcher-macos-arm64
-            artifact: launcher-darwin-aarch64
-          - job-name: Build Launcher (Windows x86_64)
-            runner: windows-latest
-            package: agent-portal
-            binary: agent-portal.exe
-            cache-key: launcher-windows
-            artifact: launcher-windows-x86_64
+            cache-key: binaries-windows
+            proxy-binary: claude-portal.exe
+            proxy-artifact: proxy-windows-x86_64
+            launcher-binary: agent-portal.exe
+            launcher-artifact: launcher-windows-x86_64
     steps:
       - uses: actions/checkout@v4
 
@@ -249,16 +229,24 @@ jobs:
         with:
           cache-key: ${{ matrix.cache-key }}
 
-      - name: Build ${{ matrix.package }}
+      - name: Build binaries
         shell: bash
-        run: cargo build -p ${{ matrix.package }} --release
+        run: cargo build -p claude-portal -p agent-portal --release
 
       - name: Ad-hoc code sign
         if: runner.os == 'macOS'
-        run: codesign -s - target/release/${{ matrix.binary }}
+        run: |
+          codesign -s - target/release/${{ matrix.proxy-binary }}
+          codesign -s - target/release/${{ matrix.launcher-binary }}
 
-      - name: Upload artifact
+      - name: Upload proxy artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
-          path: target/release/${{ matrix.binary }}
+          name: ${{ matrix.proxy-artifact }}
+          path: target/release/${{ matrix.proxy-binary }}
+
+      - name: Upload launcher artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.launcher-artifact }}
+          path: target/release/${{ matrix.launcher-binary }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.118"
+version = "2.12.119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.118"
+version = "2.12.119"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.118"
+version = "2.12.119"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.118"
+version = "2.12.119"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.118"
+version = "2.12.119"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.118"
+version = "2.12.119"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.118"
+version = "2.12.119"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.118"
+version = "2.12.119"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.118"
+version = "2.12.119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.118"
+version = "2.12.119"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.118"
+version = "2.12.119"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## Summary
- collapse CI release-binary checks from separate proxy/launcher jobs into one job per platform
- build claude-portal and agent-portal in the same cargo invocation per runner
- keep the existing artifact names and binary paths for proxy and launcher outputs

## Local checks
- python3 YAML parse for .github/workflows/ci.yml
- git diff --check

This is a #1209 item 10 CI-speed slice. It cuts binary-build runner fan-out from 8 jobs to 4 and reuses the same build graph per platform instead of restoring/setup twice for proxy and launcher.