### PR TITLE
feat: add inter-agent reply reminder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.119"
+version = "2.12.120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.119"
+version = "2.12.120"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.119"
+version = "2.12.120"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.119"
+version = "2.12.120"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.119"
+version = "2.12.120"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.119"
+version = "2.12.120"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.119"
+version = "2.12.120"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.119"
+version = "2.12.120"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.119"
+version = "2.12.120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.119"
+version = "2.12.120"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.119"
+version = "2.12.120"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/ws_reader.rs
+++ b/claude-session-lib/src/proxy_session/ws_reader.rs
@@ -369,10 +369,12 @@ mod tests {
             panic!("expected normal input");
         };
 
-        assert_eq!(
-            input.text,
-            "[message from codex 12345678-0000-0000-0000-000000000000]\nhello"
-        );
+        assert!(input
+            .text
+            .starts_with("[message from codex 12345678-0000-0000-0000-000000000000]\nhello"));
+        assert!(input.text.contains(
+            "agent-portal message send 12345678-0000-0000-0000-000000000000 \"your reply\""
+        ));
         assert_eq!(input.display_event, Some(content));
     }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -424,7 +424,13 @@ impl PortalMessage {
             return None;
         };
         Some(format!(
-            "[message from {from_agent_type} {from_session_id}]\n{text}"
+            "[message from {from_agent_type} {from_session_id}]\n{text}\n\n\
+<system-reminder>\n\
+This message came from another agent. Reply to that agent, not the user.\n\
+Sender session id: {from_session_id}\n\
+Reply with:\n\
+agent-portal message send {from_session_id} \"your reply\"\n\
+</system-reminder>"
         ))
     }
 
@@ -595,10 +601,13 @@ mod tests {
             "12345678-0000-0000-0000-000000000000".to_string(),
             "hello there".to_string(),
         );
-        assert_eq!(
-            msg.agent_facing_text().as_deref(),
-            Some("[message from codex 12345678-0000-0000-0000-000000000000]\nhello there")
-        );
+        let text = msg.agent_facing_text().expect("agent-facing text");
+        assert!(text
+            .starts_with("[message from codex 12345678-0000-0000-0000-000000000000]\nhello there"));
+        assert!(text.contains("Reply to that agent, not the user."));
+        assert!(text.contains(
+            "agent-portal message send 12345678-0000-0000-0000-000000000000 \"your reply\""
+        ));
     }
 
     #[test]
@@ -687,12 +696,13 @@ mod tests {
         assert_eq!(json["content"][0]["type"], "agent_message");
         assert_eq!(json["content"][0]["from_agent_type"], "codex");
         assert_eq!(json["content"][0]["text"], "hello from another agent");
-        assert_eq!(
-            msg.agent_facing_text().as_deref(),
-            Some(
-                "[message from codex 12345678-0000-0000-0000-000000000000]\nhello from another agent"
-            )
-        );
+        let text = msg.agent_facing_text().expect("agent-facing text");
+        assert!(text.starts_with(
+            "[message from codex 12345678-0000-0000-0000-000000000000]\nhello from another agent"
+        ));
+        assert!(text.contains(
+            "agent-portal message send 12345678-0000-0000-0000-000000000000 \"your reply\""
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1200.\n\n## Summary\n- append a compact reply reminder to agent-facing inter-agent messages\n- include the sender session id and a ready-to-run agent-portal message command\n- update shared tests for the new agent-facing text\n\n## Tests\n- cargo test -p shared agent_message --lib\n- cargo fmt --check