### PR TITLE
feat: de-peak the performance charts — coarser buckets + trend smoothing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.120"
+version = "2.12.121"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -372,12 +372,15 @@ mod tests {
     /// itself is already subsampled to a few readable labels.
     #[test]
     fn bucket_param_dispatches_on_window_length() {
-        assert_eq!(bucket_param(TimeWindow::Hours1), "1m");
-        assert_eq!(bucket_param(TimeWindow::Hours6), "1m");
-        assert_eq!(bucket_param(TimeWindow::Days1), "5m");
+        // Widths are picked so each bucket holds enough turns for stable
+        // percentiles/rates (trend-readable, not per-minute spiky) — see
+        // `bucket_param`'s doc.
+        assert_eq!(bucket_param(TimeWindow::Hours1), "5m");
+        assert_eq!(bucket_param(TimeWindow::Hours6), "15m");
+        assert_eq!(bucket_param(TimeWindow::Days1), "15m");
         assert_eq!(bucket_param(TimeWindow::Days7), "hour");
-        assert_eq!(bucket_param(TimeWindow::Days30), "hour");
-        assert_eq!(bucket_param(TimeWindow::Days90), "hour");
+        assert_eq!(bucket_param(TimeWindow::Days30), "day");
+        assert_eq!(bucket_param(TimeWindow::Days90), "day");
     }
 
     #[test]

--- a/frontend/src/pages/settings/performance_panel/model.rs
+++ b/frontend/src/pages/settings/performance_panel/model.rs
@@ -80,15 +80,22 @@ pub(super) fn bucket_index(buckets: &[DateTime<Utc>], ts: DateTime<Utc>) -> Opti
 }
 
 /// Build the bucket-granularity query string for the selected window.
-/// Pick high-fidelity buckets for the selected window. The charts only render
-/// a handful of x-axis labels, so dense buckets preserve real per-turn shape
-/// without cluttering the axis.
+///
+/// Bucket width is chosen so each bucket holds *enough turns* for its
+/// percentile/rate aggregates to be stable — the dashboard is for spotting
+/// trends, not per-minute shape. The old very-fine widths (1m over 6h = 360
+/// buckets, hourly over 90d = 2160) put 1-2 turns in most buckets, so each
+/// "p50/p95" was effectively a single turn's value and the lines were pure
+/// spike noise. These coarser widths trade temporal resolution for readable
+/// trends; the moving average in `series.rs` smooths whatever remains.
 pub(super) fn bucket_param(window: TimeWindow) -> &'static str {
     match window {
-        TimeWindow::Hours1 => "1m",
-        TimeWindow::Hours6 => "1m",
-        TimeWindow::Days1 => "5m",
-        TimeWindow::Days7 | TimeWindow::Days30 | TimeWindow::Days90 => "hour",
+        TimeWindow::Hours1 => "5m",  // 12 buckets
+        TimeWindow::Hours6 => "15m", // 24 buckets
+        TimeWindow::Days1 => "15m",  // 96 buckets
+        TimeWindow::Days7 => "hour", // 168 buckets
+        TimeWindow::Days30 => "day", // 30 buckets
+        TimeWindow::Days90 => "day", // 90 buckets
     }
 }
 

--- a/frontend/src/pages/settings/performance_panel/series.rs
+++ b/frontend/src/pages/settings/performance_panel/series.rs
@@ -30,6 +30,8 @@ pub(super) fn build_p50_p95_series(
             p50_vals.push(row.and_then(|r| p50(r)));
             p95_vals.push(row.and_then(|r| p95(r)));
         }
+        let p50_vals = smoothed(&p50_vals);
+        let p95_vals = smoothed(&p95_vals);
         if p50_vals.iter().any(Option::is_some) {
             out.push(LineSeries {
                 label: format!("{label} p50"),
@@ -145,6 +147,7 @@ pub(super) fn build_cache_hit_series(
             });
             vals.push(v);
         }
+        let vals = smoothed(&vals);
         if vals.iter().any(Option::is_some) {
             out.push(LineSeries {
                 label,
@@ -180,6 +183,7 @@ pub(super) fn build_cost_per_token_series(
             });
             vals.push(v);
         }
+        let vals = smoothed(&vals);
         if vals.iter().any(Option::is_some) {
             out.push(LineSeries {
                 label,
@@ -211,6 +215,8 @@ pub(super) fn build_auxiliary_token_series(
             thinking_vals.push(row.and_then(|r| positive_i64(r.thinking_tokens_sum)));
             subagent_vals.push(row.and_then(|r| positive_i64(r.subagent_tokens_sum)));
         }
+        let thinking_vals = smoothed(&thinking_vals);
+        let subagent_vals = smoothed(&subagent_vals);
         if thinking_vals.iter().any(Option::is_some) {
             out.push(LineSeries {
                 label: format!("{label} thinking"),
@@ -233,4 +239,53 @@ pub(super) fn build_auxiliary_token_series(
 
 fn positive_i64(value: i64) -> Option<f64> {
     (value > 0).then_some(value as f64)
+}
+
+/// Half-window for the trend moving average: each present point is averaged
+/// with up to this many present neighbors on each side (a 3-point window).
+/// Gentle on purpose — coarser buckets already do most of the de-noising; this
+/// just smooths the residual per-bucket jitter so trends read cleanly.
+const SMOOTH_HALF_WINDOW: usize = 1;
+
+/// Centered moving-average smoothing for a per-bucket line series (#1209 item 4).
+///
+/// Gaps are preserved: a `None` slot (the group had no turns in that bucket)
+/// stays `None` — we never invent data across a gap. A present point is
+/// replaced by the mean of the present values within `±SMOOTH_HALF_WINDOW`
+/// indices, so an isolated slow/fast turn no longer reads as a full spike.
+fn smoothed(values: &[Option<f64>]) -> Vec<Option<f64>> {
+    (0..values.len())
+        .map(|i| {
+            values[i]?; // keep gaps as gaps — don't smooth across missing buckets
+            let lo = i.saturating_sub(SMOOTH_HALF_WINDOW);
+            let hi = (i + SMOOTH_HALF_WINDOW + 1).min(values.len());
+            let present: Vec<f64> = values[lo..hi].iter().filter_map(|v| *v).collect();
+            (!present.is_empty()).then(|| present.iter().sum::<f64>() / present.len() as f64)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::smoothed;
+
+    #[test]
+    fn smoothing_averages_present_neighbors_and_preserves_gaps() {
+        // A spike at index 2 (10.0) is pulled down toward its neighbors;
+        // the `None` gap at index 4 stays a gap.
+        let input = vec![Some(0.0), Some(0.0), Some(10.0), Some(0.0), None, Some(6.0)];
+        let out = smoothed(&input);
+
+        assert_eq!(out[0], Some(0.0)); // (0+0)/2
+        assert!((out[2].unwrap() - (10.0 / 3.0)).abs() < 1e-9); // (0+10+0)/3 — spike flattened
+        assert_eq!(out[4], None, "missing bucket must stay missing");
+        // index 5: neighbor 4 is None, so only the present value 6.0 averages.
+        assert_eq!(out[5], Some(6.0));
+    }
+
+    #[test]
+    fn smoothing_all_none_stays_all_none() {
+        let input = vec![None, None, None];
+        assert_eq!(smoothed(&input), vec![None, None, None]);
+    }
 }


### PR DESCRIPTION
## Why
The Settings → Performance line charts read as spiky noise, hard to use for trend identification (user report). **Root cause:** very fine fixed buckets — 1m over a 6h window = 360 buckets, hourly over 90d = 2160 — put **1–2 turns in most buckets**, so each per-bucket `p50/p95` was effectively a single turn's value, and the SUM/rate lines spiked on any single bursty turn. No smoothing, and bin width was tied to the window, not data density.

## Fix (frontend perf panel only — no backend/API change)
1. **`model.rs bucket_param`** — coarsen so each bucket holds enough turns for stable percentiles/rates: 1h `1m→5m`, 6h `1m→15m`, 1d `5m→15m`, 30d `hour→day`, 90d `hour→day`. Trades temporal resolution for readable trends (the right tradeoff for a trends dashboard).
2. **`series.rs`** — a gentle **gap-preserving centered moving average** (`smoothed`, 3-point) on the continuous line metrics (latency p50/p95, cache-hit %, cost/1k-tok, thinking/subagent tokens). Missing buckets stay `None` (we never invent data across a gap). Stop-reason **bars** are left as raw counts.

## Tests
- New unit tests for `smoothed`: spike-flattening, gap preservation, all-None.
- Updated the `bucket_param` characterization test to the new widths.
- 367 frontend tests pass; `cargo clippy -p frontend --all-targets -- -D warnings` + `cargo fmt --check` clean.

Future option (not here): true sliding-window percentiles in the backend SQL for resolution + smoothness together; this contained frontend change already removes the spikiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)