### PR TITLE
feat: support short agent message ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.120"
+version = "2.12.121"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.120"
+version = "2.12.121"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/ws_reader.rs
+++ b/claude-session-lib/src/proxy_session/ws_reader.rs
@@ -372,9 +372,9 @@ mod tests {
         assert!(input
             .text
             .starts_with("[message from codex 12345678-0000-0000-0000-000000000000]\nhello"));
-        assert!(input.text.contains(
-            "agent-portal message send 12345678-0000-0000-0000-000000000000 \"your reply\""
-        ));
+        assert!(input
+            .text
+            .contains("agent-portal message send 12345678 \"your reply\""));
         assert_eq!(input.display_event, Some(content));
     }
 

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -9,6 +9,8 @@ use anyhow::{anyhow, Context, Result};
 
 use shared::api::{AgentSessionsResponse, SendAgentMessageRequest, SendAgentMessageResponse};
 
+const SHORT_SESSION_ID_LEN: usize = 8;
+
 /// The calling agent's own portal session id, read from whatever the agent
 /// already exposes — no portal-side injection needed:
 ///
@@ -53,16 +55,8 @@ fn api_base() -> Result<(String, String)> {
 /// `agent-portal message list` — print the caller's sessions (agents).
 pub async fn list() -> Result<()> {
     let (base, token) = api_base()?;
-    let resp = reqwest::Client::new()
-        .get(format!("{base}/api/agent/sessions"))
-        .bearer_auth(&token)
-        .send()
-        .await
-        .context("request to backend failed")?;
-    if !resp.status().is_success() {
-        return Err(anyhow!("backend returned {}", resp.status()));
-    }
-    let data: AgentSessionsResponse = resp.json().await.context("malformed response")?;
+    let client = reqwest::Client::new();
+    let data = fetch_sessions(&client, &base, &token).await?;
     if data.sessions.is_empty() {
         println!("No sessions found.");
         return Ok(());
@@ -76,20 +70,47 @@ pub async fn list() -> Result<()> {
         };
         println!(
             "{}  {}  [{}/{}]  {}{}",
-            s.id, s.session_name, s.agent_type, s.status, s.working_directory, marker
+            display_session_id(s, &data.sessions),
+            s.session_name,
+            s.agent_type,
+            s.status,
+            s.working_directory,
+            marker
         );
     }
     Ok(())
+}
+
+async fn fetch_sessions(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+) -> Result<AgentSessionsResponse> {
+    let resp = client
+        .get(format!("{base}/api/agent/sessions"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .context("request to backend failed")?;
+    if !resp.status().is_success() {
+        return Err(anyhow!("backend returned {}", resp.status()));
+    }
+    resp.json().await.context("malformed response")
 }
 
 /// `agent-portal message send <agent-id> <message>` — deliver a message into a
 /// session as an input turn.
 pub async fn send(agent_id: &str, message: &str) -> Result<()> {
     let (base, token) = api_base()?;
+    let client = reqwest::Client::new();
+    let sessions = fetch_sessions(&client, &base, &token).await?;
+    let resolved_agent_id = resolve_session_id(agent_id, &sessions.sessions)?;
     let from = sender_session_id();
-    let resp = reqwest::Client::new()
-        .post(format!("{base}/api/agent/sessions/{agent_id}/message"))
-        .bearer_auth(&token)
+    let resp = client
+        .post(format!(
+            "{base}/api/agent/sessions/{resolved_agent_id}/message"
+        ))
+        .bearer_auth(token)
         .json(&SendAgentMessageRequest {
             message: message.to_string(),
             from,
@@ -109,4 +130,151 @@ pub async fn send(agent_id: &str, message: &str) -> Result<()> {
         println!("Queued for the session's reconnect (seq {}).", data.seq);
     }
     Ok(())
+}
+
+fn short_session_id(id: &uuid::Uuid) -> String {
+    id.simple()
+        .to_string()
+        .chars()
+        .take(SHORT_SESSION_ID_LEN)
+        .collect()
+}
+
+fn display_session_id(
+    session: &shared::api::AgentSessionInfo,
+    sessions: &[shared::api::AgentSessionInfo],
+) -> String {
+    let short = short_session_id(&session.id);
+    let collision = sessions
+        .iter()
+        .filter(|candidate| short_session_id(&candidate.id) == short)
+        .count()
+        > 1;
+    if collision {
+        session.id.to_string()
+    } else {
+        short
+    }
+}
+
+fn resolve_session_id(
+    input: &str,
+    sessions: &[shared::api::AgentSessionInfo],
+) -> Result<uuid::Uuid> {
+    let prefix = normalize_session_id_prefix(input)?;
+    let matches = sessions
+        .iter()
+        .filter(|session| session.id.simple().to_string().starts_with(&prefix))
+        .collect::<Vec<_>>();
+
+    match matches.as_slice() {
+        [session] => Ok(session.id),
+        [] => Err(anyhow!("no session id matches `{}`", input.trim())),
+        matches => {
+            let ids = matches
+                .iter()
+                .map(|session| session.id.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(anyhow!(
+                "session id prefix `{}` is ambiguous; use more characters or a full id (matches: {})",
+                input.trim(),
+                ids
+            ))
+        }
+    }
+}
+
+fn normalize_session_id_prefix(input: &str) -> Result<String> {
+    let prefix = input.trim().replace('-', "").to_ascii_lowercase();
+    if prefix.is_empty() {
+        return Err(anyhow!("session id prefix cannot be empty"));
+    }
+    if !prefix.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(anyhow!(
+            "session id prefix `{}` must contain only hex digits",
+            input.trim()
+        ));
+    }
+    Ok(prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::api::AgentSessionInfo;
+    use uuid::Uuid;
+
+    fn session(id: &str) -> AgentSessionInfo {
+        AgentSessionInfo {
+            id: Uuid::parse_str(id).expect("valid uuid"),
+            session_name: "session".to_string(),
+            working_directory: "/repo".to_string(),
+            agent_type: "codex".to_string(),
+            status: "active".to_string(),
+            hostname: "host".to_string(),
+        }
+    }
+
+    #[test]
+    fn display_session_id_uses_short_prefix_without_collision() {
+        let sessions = vec![
+            session("12345678-0000-0000-0000-000000000000"),
+            session("abcdef12-0000-0000-0000-000000000000"),
+        ];
+
+        assert_eq!(display_session_id(&sessions[0], &sessions), "12345678");
+    }
+
+    #[test]
+    fn display_session_id_uses_full_uuid_for_short_prefix_collision() {
+        let sessions = vec![
+            session("12345678-0000-0000-0000-000000000000"),
+            session("12345678-ffff-0000-0000-000000000000"),
+        ];
+
+        assert_eq!(
+            display_session_id(&sessions[0], &sessions),
+            "12345678-0000-0000-0000-000000000000"
+        );
+    }
+
+    #[test]
+    fn resolve_session_id_accepts_unique_short_prefix() {
+        let sessions = vec![
+            session("12345678-0000-0000-0000-000000000000"),
+            session("abcdef12-0000-0000-0000-000000000000"),
+        ];
+
+        assert_eq!(
+            resolve_session_id("12345678", &sessions).expect("resolved"),
+            sessions[0].id
+        );
+    }
+
+    #[test]
+    fn resolve_session_id_accepts_full_uuid() {
+        let sessions = vec![session("12345678-0000-0000-0000-000000000000")];
+
+        assert_eq!(
+            resolve_session_id("12345678-0000-0000-0000-000000000000", &sessions)
+                .expect("resolved"),
+            sessions[0].id
+        );
+    }
+
+    #[test]
+    fn resolve_session_id_rejects_ambiguous_prefix() {
+        let sessions = vec![
+            session("12345678-0000-0000-0000-000000000000"),
+            session("12345678-ffff-0000-0000-000000000000"),
+        ];
+
+        let err = resolve_session_id("12345678", &sessions)
+            .expect_err("ambiguous prefix should fail")
+            .to_string();
+        assert!(err.contains("ambiguous"));
+        assert!(err.contains("12345678-0000-0000-0000-000000000000"));
+        assert!(err.contains("12345678-ffff-0000-0000-000000000000"));
+    }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -423,19 +423,29 @@ impl PortalMessage {
         else {
             return None;
         };
+        let reply_session_id = short_reply_session_id(from_session_id);
         Some(format!(
             "[message from {from_agent_type} {from_session_id}]\n{text}\n\n\
 <system-reminder>\n\
 This message came from another agent. Reply to that agent, not the user.\n\
 Sender session id: {from_session_id}\n\
 Reply with:\n\
-agent-portal message send {from_session_id} \"your reply\"\n\
+agent-portal message send {reply_session_id} \"your reply\"\n\
 </system-reminder>"
         ))
     }
 
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or_default()
+    }
+}
+
+fn short_reply_session_id(session_id: &str) -> String {
+    let compact = session_id.replace('-', "");
+    if compact.len() >= 8 && compact.chars().all(|c| c.is_ascii_hexdigit()) {
+        compact.chars().take(8).collect()
+    } else {
+        session_id.to_string()
     }
 }
 
@@ -605,9 +615,7 @@ mod tests {
         assert!(text
             .starts_with("[message from codex 12345678-0000-0000-0000-000000000000]\nhello there"));
         assert!(text.contains("Reply to that agent, not the user."));
-        assert!(text.contains(
-            "agent-portal message send 12345678-0000-0000-0000-000000000000 \"your reply\""
-        ));
+        assert!(text.contains("agent-portal message send 12345678 \"your reply\""));
     }
 
     #[test]
@@ -700,9 +708,7 @@ mod tests {
         assert!(text.starts_with(
             "[message from codex 12345678-0000-0000-0000-000000000000]\nhello from another agent"
         ));
-        assert!(text.contains(
-            "agent-portal message send 12345678-0000-0000-0000-000000000000 \"your reply\""
-        ));
+        assert!(text.contains("agent-portal message send 12345678 \"your reply\""));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1199.\n\n## Summary\n- resolve `agent-portal message send` ids by unique hex prefix before posting to the existing full-UUID backend route\n- render 8-character session ids in `agent-portal message list`, falling back to full UUIDs only when the short prefix collides\n- update the inter-agent reply reminder to use the short id in its ready-to-run command\n- add launcher unit coverage for short display, full-id fallback, unique-prefix resolution, and ambiguity errors\n\n## Tests\n- cargo test -p shared agent_message --lib\n- cargo test -p claude-session-lib classify_agent_message_portal_input_keeps_display_event --lib\n- cargo test -p agent-portal message::tests --bin agent-portal\n- cargo clippy -p agent-portal --bin agent-portal --all-targets -- -D warnings