### PR TITLE
fix: µs-truncate seed timestamps in DB tests (timestamp-precision bug)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.121"
+version = "2.12.123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.121"
+version = "2.12.123"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.121"
+version = "2.12.123"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.121"
+version = "2.12.123"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.121"
+version = "2.12.123"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.121"
+version = "2.12.123"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.121"
+version = "2.12.123"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.121"
+version = "2.12.123"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.121"
+version = "2.12.123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.121"
+version = "2.12.123"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.121"
+version = "2.12.123"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -349,8 +349,17 @@ mod db_tests {
         user_id: uuid::Uuid,
         count: usize,
     ) -> Vec<chrono::NaiveDateTime> {
+        use chrono::Timelike;
         use diesel::sql_query;
-        let base = Utc::now().naive_utc();
+        // Postgres `timestamp` stores microsecond precision, but
+        // `Utc::now()` carries sub-microsecond nanoseconds that the DB drops on
+        // insert. Truncate the base to µs so the stamps we return match the
+        // values read back — otherwise exact `created_at` equality assertions
+        // compare an ns-precision in-memory value against a µs-precision DB one.
+        let now = Utc::now().naive_utc();
+        let base = now
+            .with_nanosecond(now.nanosecond() / 1_000 * 1_000)
+            .unwrap_or(now);
         let mut stamps = Vec::with_capacity(count);
         for i in 0..count {
             // Microsecond-step keeps the order strict and avoids fractional

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -187,8 +187,15 @@ mod replay_tests {
         user_id: uuid::Uuid,
         count: usize,
     ) -> Vec<chrono::NaiveDateTime> {
+        use chrono::Timelike;
         use diesel::sql_query;
-        let base = Utc::now().naive_utc();
+        // Truncate to µs so the returned stamps match the DB read-back —
+        // Postgres `timestamp` drops the sub-µs nanoseconds in `Utc::now()`,
+        // which otherwise breaks exact `created_at` equality assertions.
+        let now = Utc::now().naive_utc();
+        let base = now
+            .with_nanosecond(now.nanosecond() / 1_000 * 1_000)
+            .unwrap_or(now);
         let mut stamps = Vec::with_capacity(count);
         for i in 0..count {
             let ts = base + chrono::Duration::microseconds((i as i64 + 1) * 1000);


### PR DESCRIPTION
## The bug
The DB-backed message/replay tests assert exact `created_at` equality but **fail against Postgres**: `Utc::now().naive_utc()` carries sub-microsecond nanoseconds (`…619150574`) that the `timestamp` column drops on insert (`…619150`), so the in-memory `stamps` the seed helpers return never equal the read-back values. (Surfaced while wiring the E2E Postgres job in #1216 — these 4 were gated/skipped without a DB, so they'd been silently failing-when-run.)

## Fix
Truncate the base to microseconds in both `seed_messages` helpers (`handlers::messages::db_tests` and `handlers::websocket::replay::replay_tests`) so the seeded stamps match what Postgres stores. The "microsecond-bumped" stepping was already correct; only the base needed truncating.

## Verification (against a real local Postgres)
- `DATABASE_URL=… cargo test -p backend` → **120 lib tests pass** (the 4 previously-failing: default/after/before-cursor pagination + replay retention-cap, now green), parallel.
- `cargo clippy -p backend --all-targets -- -D warnings` + `cargo fmt --check` clean.

## Follow-up enabled
With the DB tests green, the `E2E Tests` CI job (#1216) could now run the full backend suite (not just `--test harness`) — a natural next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)