### PR TITLE
fix: restore vertical scrolling of the session rail (left/right layout)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.123"
+version = "2.12.124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.123"
+version = "2.12.124"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.123"
+version = "2.12.124"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.123"
+version = "2.12.124"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.123"
+version = "2.12.124"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.123"
+version = "2.12.124"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.123"
+version = "2.12.124"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.123"
+version = "2.12.124"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.123"
+version = "2.12.124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.123"
+version = "2.12.124"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.123"
+version = "2.12.124"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -196,6 +196,17 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         let rail_ref = rail_ref.clone();
         Callback::from(move |e: WheelEvent| {
             if let Some(rail) = rail_ref.cast::<HtmlElement>() {
+                // This handler maps the wheel onto the rail's HORIZONTAL scroll,
+                // so a plain vertical scroll-wheel drives the top/bottom rail.
+                // The left/right rail scrolls *vertically* (`overflow-y: auto`)
+                // and has no horizontal overflow — there we must NOT intercept,
+                // or `prevent_default` kills the native vertical scroll while we
+                // only nudge `scroll_left` (a no-op), leaving the pills unscroll-
+                // able. The component doesn't know its orientation, so gate on
+                // the axis that actually overflows.
+                if rail.scroll_width() <= rail.client_width() {
+                    return; // vertical rail (or nothing to scroll) — let native scroll run
+                }
                 let dx = e.delta_x();
                 let dy = e.delta_y();
                 // Use whichever axis has the larger delta — this lets both


### PR DESCRIPTION
## Symptom
The session-pill rail's scrollbar was "busted" — but **only in the up-down (left/right) rail layouts** (user report).

## Cause
`session_rail.rs`'s `on_wheel` handler unconditionally `prevent_default()`s the wheel and maps the delta onto **horizontal** `scroll_left` — by design, so a vertical scroll-wheel drives the **horizontal** (top/bottom) rail. But the **vertical** (left/right) rail scrolls on the Y axis (`overflow-y: auto`) and has no horizontal overflow, so the handler **killed the native vertical scroll** while only nudging `scroll_left` (a no-op) → the pills couldn't scroll.

## Fix
Gate the hijack on the axis that actually overflows: if there's no horizontal overflow (`scroll_width <= client_width`), bail early and let native scrolling run. The component doesn't know its orientation (set by the parent's `.rail-*` class), so the overflow check is the robust, orientation-agnostic gate. **Horizontal-rail behavior is unchanged** (it overflows X, so it still hijacks the wheel as before).

## Verification
- `cargo build -p frontend` (wasm) ✓, `cargo clippy -p frontend --all-targets -- -D warnings` ✓, `cargo fmt --check` ✓.
- Logic verified by inspection; worth a quick manual check in both left/right (vertical scroll works) and top/bottom (wheel still scrolls horizontally) layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)