### PR TITLE
fix: avoid blocking proxy loop on queued Codex input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.124"
+version = "2.12.125"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.124"
+version = "2.12.125"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.124"
+version = "2.12.125"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.124"
+version = "2.12.125"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.124"
+version = "2.12.125"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.124"
+version = "2.12.125"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.124"
+version = "2.12.125"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.124"
+version = "2.12.125"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.124"
+version = "2.12.125"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.124"
+version = "2.12.125"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.124"
+version = "2.12.125"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/input_delivery.rs
+++ b/claude-session-lib/src/proxy_session/input_delivery.rs
@@ -4,8 +4,10 @@
 //! dispatch. Hands a [`PortalInput`] to the agent: refreshes git metadata,
 //! emits the [`InputDeliveryStage`](shared::InputDeliveryStage) progress
 //! events (#939), stashes the typed display-event echo for Claude's
-//! `output_forwarder` to swap in (#1124), and acks the portal input.
+//! `output_forwarder` to swap in (#1124), and schedules the final
+//! `AgentAccepted`/input ack without blocking the connection loop.
 
+use tokio::sync::oneshot;
 use tracing::{debug, error};
 use uuid::Uuid;
 
@@ -15,7 +17,7 @@ use session_lib::session::Session;
 use super::git_metadata::{check_and_send_branch_update_if_branch_changed, GitMetadataState};
 use super::{
     ack_portal_input, emit_input_progress, truncate, ConnectionResult, PendingInputDisplayEvent,
-    PendingInputDisplayEvents, PortalInput, SharedWsWrite,
+    PendingInputDisplayEvents, PortalInput, PortalInputAck, SharedWsWrite,
 };
 
 /// Deliver one user input to the agent. Returns `Some(ConnectionResult)` to end
@@ -39,7 +41,7 @@ pub(super) async fn handle_input<A: Agent>(
     )
     .await;
 
-    debug!("sending to claude process: {}", truncate(&input.text, 100));
+    debug!("sending to agent process: {}", truncate(&input.text, 100));
 
     // Delivery stage: the proxy has the input and is about to hand it to the
     // agent (#939).
@@ -69,29 +71,73 @@ pub(super) async fn handle_input<A: Agent>(
         }
     }
 
-    if let Err(e) = claude_session
-        .send_input_with_display(serde_json::Value::String(input.text), input.display_event)
-        .await
+    let delivered = match claude_session
+        .enqueue_input_with_display(serde_json::Value::String(input.text), input.display_event)
     {
-        error!("Failed to send to Claude: {}", e);
-        emit_input_progress(
-            ws_write,
-            session_id,
-            input.client_msg_id,
-            shared::InputDeliveryStage::Failed,
-        )
-        .await;
-        return Some(ConnectionResult::ClaudeExited);
-    }
-    // Delivery stage: the input is now in the agent's stream — the optimistic
-    // row clears here (#939).
-    emit_input_progress(
-        ws_write,
+        Ok(delivered) => delivered,
+        Err(e) => {
+            error!("Failed to send to Claude: {}", e);
+            emit_input_progress(
+                ws_write,
+                session_id,
+                input.client_msg_id,
+                shared::InputDeliveryStage::Failed,
+            )
+            .await;
+            return Some(ConnectionResult::ClaudeExited);
+        }
+    };
+    spawn_delivery_completion(
+        ws_write.clone(),
         session_id,
         input.client_msg_id,
-        shared::InputDeliveryStage::AgentAccepted,
-    )
-    .await;
-    ack_portal_input(ws_write, input.ack).await;
+        input.ack,
+        delivered,
+    );
     None
+}
+
+fn spawn_delivery_completion(
+    ws_write: SharedWsWrite,
+    session_id: Uuid,
+    client_msg_id: Option<Uuid>,
+    ack: Option<PortalInputAck>,
+    delivered: oneshot::Receiver<Result<(), String>>,
+) {
+    tokio::spawn(async move {
+        match delivered.await {
+            Ok(Ok(())) => {
+                // Delivery stage: the input is now in the agent's stream — the
+                // optimistic row clears here (#939).
+                emit_input_progress(
+                    &ws_write,
+                    session_id,
+                    client_msg_id,
+                    shared::InputDeliveryStage::AgentAccepted,
+                )
+                .await;
+                ack_portal_input(&ws_write, ack).await;
+            }
+            Ok(Err(message)) => {
+                error!("Agent rejected input: {}", message);
+                emit_input_progress(
+                    &ws_write,
+                    session_id,
+                    client_msg_id,
+                    shared::InputDeliveryStage::Failed,
+                )
+                .await;
+            }
+            Err(_) => {
+                error!("I/O task closed before accepting input");
+                emit_input_progress(
+                    &ws_write,
+                    session_id,
+                    client_msg_id,
+                    shared::InputDeliveryStage::Failed,
+                )
+                .await;
+            }
+        }
+    });
 }

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -334,34 +334,51 @@ impl<A: Agent> Session<A> {
         content: serde_json::Value,
         display_event: Option<serde_json::Value>,
     ) -> Result<(), SessionError> {
+        let delivered_rx = self.enqueue_input_with_display(content, display_event)?;
+        delivered_rx
+            .await
+            .map_err(|_| {
+                SessionError::CommunicationError(
+                    "I/O task closed before accepting input".to_string(),
+                )
+            })?
+            .map_err(SessionError::Agent)
+    }
+
+    /// Queue user input to the agent and return a receiver that resolves when
+    /// the agent has accepted it into its stream.
+    ///
+    /// This lets proxy connection loops keep processing output, reconnects, and
+    /// heartbeats while Codex queues input behind an active turn. Callers that
+    /// need the old blocking behavior can await the returned receiver; see
+    /// [`send_input_with_display`](Self::send_input_with_display).
+    pub fn enqueue_input_with_display(
+        &mut self,
+        content: serde_json::Value,
+        display_event: Option<serde_json::Value>,
+    ) -> Result<oneshot::Receiver<Result<(), String>>, SessionError> {
         if let SessionState::Exited { code } = self.state {
             return Err(SessionError::AlreadyExited(code));
         }
 
-        if let Some(ref command_tx) = self.command_tx {
-            let text = match &content {
-                serde_json::Value::String(s) => s.clone(),
-                other => other.to_string(),
-            };
-            let (delivered_tx, delivered_rx) = oneshot::channel();
-            command_tx
-                .send(IoCommand::UserInput {
-                    text,
-                    delivered: Some(delivered_tx),
-                    display_event: display_event.map(Box::new),
-                })
-                .map_err(|_| SessionError::CommunicationError("I/O task closed".to_string()))?;
-            delivered_rx
-                .await
-                .map_err(|_| {
-                    SessionError::CommunicationError(
-                        "I/O task closed before accepting input".to_string(),
-                    )
-                })?
-                .map_err(SessionError::Agent)?;
-        }
+        let command_tx = self
+            .command_tx
+            .as_ref()
+            .ok_or_else(|| SessionError::CommunicationError("I/O task closed".to_string()))?;
+        let text = match &content {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        let (delivered_tx, delivered_rx) = oneshot::channel();
+        command_tx
+            .send(IoCommand::UserInput {
+                text,
+                delivered: Some(delivered_tx),
+                display_event: display_event.map(Box::new),
+            })
+            .map_err(|_| SessionError::CommunicationError("I/O task closed".to_string()))?;
 
-        Ok(())
+        Ok(delivered_rx)
     }
 
     /// Respond to a pending permission request.
@@ -492,12 +509,14 @@ impl<A: Agent> Session<A> {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
 
     // `STARTED` flips once the mock io-task is actually running (so we don't
     // abort it before it begins); `GUARD_DROPPED` flips when it's dropped, which
     // proves `stop` aborted it.
     static STARTED: AtomicBool = AtomicBool::new(false);
     static GUARD_DROPPED: AtomicBool = AtomicBool::new(false);
+    static COMMAND_RECEIVED: AtomicBool = AtomicBool::new(false);
 
     struct DropFlag;
     impl Drop for DropFlag {
@@ -519,6 +538,26 @@ mod tests {
                 let _guard = DropFlag;
                 STARTED.store(true, Ordering::SeqCst);
                 std::future::pending::<()>().await;
+            }))
+        }
+    }
+
+    /// An agent that accepts the command from the session channel but never
+    /// resolves the per-input delivery signal, matching a Codex prompt queued
+    /// behind an active turn.
+    struct HangingDeliveryAgent;
+    impl Agent for HangingDeliveryAgent {
+        fn spawn_io_task(
+            _config: SessionConfig,
+            mut command_rx: mpsc::UnboundedReceiver<IoCommand>,
+            _event_tx: mpsc::UnboundedSender<IoEvent>,
+        ) -> Result<tokio::task::JoinHandle<()>, SessionError> {
+            Ok(tokio::spawn(async move {
+                if let Some(IoCommand::UserInput { delivered, .. }) = command_rx.recv().await {
+                    let _delivered = delivered;
+                    COMMAND_RECEIVED.store(true, Ordering::SeqCst);
+                    std::future::pending::<()>().await;
+                }
             }))
         }
     }
@@ -546,5 +585,30 @@ mod tests {
             GUARD_DROPPED.load(Ordering::SeqCst),
             "stop() should abort the io task and reap it"
         );
+    }
+
+    #[tokio::test]
+    async fn enqueue_input_returns_before_delivery_ack() {
+        COMMAND_RECEIVED.store(false, Ordering::SeqCst);
+        let mut session = Session::<HangingDeliveryAgent>::new(SessionConfig::default())
+            .await
+            .unwrap();
+
+        let delivered = session
+            .enqueue_input_with_display(serde_json::Value::String("queued".to_string()), None)
+            .unwrap();
+
+        while !COMMAND_RECEIVED.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), delivered)
+                .await
+                .is_err(),
+            "enqueue should return without waiting for the agent delivery ack"
+        );
+
+        session.stop().await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- split Session input send into enqueue + delivery-wait phases
- make proxy input delivery enqueue immediately and complete AgentAccepted/InputAck from a spawned delivery waiter
- add a regression test for queued input whose delivery ack stays pending

## Why
Codex queues input behind an active turn and only resolves the delivery ack when the queued turn actually starts. Awaiting that ack inline in the proxy connection loop can stop output/reconnect/heartbeat processing, which looks like a hung session when messages arrive out of sequence.

## Tests
- cargo test -p session-lib enqueue_input_returns_before_delivery_ack --lib
- cargo test -p session-lib --lib
- cargo test -p claude-session-lib --lib
- cargo clippy -p session-lib -p claude-session-lib --all-targets -- -D warnings