### PR TITLE
ci: run the DB-backed backend unit tests in the E2E job (#1209 item 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,13 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    # Dedicated job for DB-backed integration tests (#1209 item 1). Kept
-    # separate from `Tests` so only the harness — which self-migrates a fresh
-    # Postgres — runs against a DB; the main test lane stays DB-free.
+    # Dedicated job for DB-backed tests (#1209 item 1): the E2E harness plus the
+    # backend unit tests that need a real Postgres (messages/replay pagination,
+    # session-access). Kept separate from `Tests` so the main lane stays
+    # DB-free. The harness step runs first because it self-migrates the fresh
+    # Postgres; the `--lib` step then runs the DB-backed unit tests against the
+    # migrated schema (cargo runs lib tests before integration tests within a
+    # single invocation, so they must be split to get migration ordering right).
     services:
       postgres:
         image: postgres:16-alpine
@@ -181,10 +185,15 @@ jobs:
           cache-key: "e2e"
           protoc: "true"
 
-      - name: Run E2E harness
+      - name: Run E2E harness (migrates the fresh Postgres)
         env:
           DATABASE_URL: postgresql://claude_portal:dev_password_change_in_production@localhost:5432/claude_portal
         run: cargo test -p backend --test harness
+
+      - name: Run DB-backed backend unit tests
+        env:
+          DATABASE_URL: postgresql://claude_portal:dev_password_change_in_production@localhost:5432/claude_portal
+        run: cargo test -p backend --lib
 
   build-binaries:
     name: ${{ matrix.job-name }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.125"
+version = "2.12.126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.125"
+version = "2.12.126"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.125"
+version = "2.12.126"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.125"
+version = "2.12.126"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.125"
+version = "2.12.126"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.125"
+version = "2.12.126"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.125"
+version = "2.12.126"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.125"
+version = "2.12.126"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.125"
+version = "2.12.126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.125"
+version = "2.12.126"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.125"
+version = "2.12.126"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## What
The backend's DB-backed unit tests (messages/replay pagination + retention, session-access) are gated on `DATABASE_URL` and so **never ran in CI** — they only ran locally. Now that #1221 fixed their timestamp-precision bug, they pass against a real Postgres. This adds a second step to the `E2E Tests` job (`cargo test -p backend --lib` with `DATABASE_URL`) to give them real-DB coverage in CI for the first time.

## Migration ordering (why two steps)
cargo runs lib tests *before* integration tests within a single invocation, so a single `cargo test -p backend` would hit the db_tests on an **unmigrated** fresh DB. So: the **harness step runs first** (it self-migrates the fresh Postgres), then **`--lib`** runs against the migrated schema.

## Verified (fresh DB, exact CI sequence)
```
docker compose -f docker-compose.test.yml down -v && up -d db
cargo test -p backend --test harness   # migrates → 1 passed
cargo test -p backend --lib            # 120 passed (db_tests now covered)
```
YAML validated; no Rust changes (ci.yml + version bump only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)