### PR TITLE
refactor: extract Wiggum-activation select! arm into handle_wiggum_activation (#1165 item 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.127"
+version = "2.12.128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.127"
+version = "2.12.128"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.127"
+version = "2.12.128"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.127"
+version = "2.12.128"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.127"
+version = "2.12.128"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.127"
+version = "2.12.128"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.127"
+version = "2.12.128"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.127"
+version = "2.12.128"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.127"
+version = "2.12.128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.127"
+version = "2.12.128"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.127"
+version = "2.12.128"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -33,8 +33,8 @@ use uuid::Uuid;
 pub use git_metadata::{get_git_branch, get_repo_url};
 
 use git_metadata::{
-    check_and_send_branch_update, check_and_send_branch_update_if_branch_changed,
-    codex_output_has_git_signal, get_open_prs, get_pr_url, GitMetadataState, GitRefreshTrigger,
+    check_and_send_branch_update, codex_output_has_git_signal, get_open_prs, get_pr_url,
+    GitMetadataState, GitRefreshTrigger,
 };
 use output_forwarder::spawn_output_forwarder;
 use wiggum::{handle_session_event_with_wiggum, WiggumState};
@@ -965,50 +965,19 @@ async fn run_main_loop<A: Agent>(
 
             // Wiggum mode activation — set state and send prompt atomically
             Some(wiggum_input) = state.wiggum_rx.recv() => {
-                info!(
-                    "Wiggum mode activated with prompt: {}",
-                    truncate(&wiggum_input.text, 60)
-                );
-                check_and_send_branch_update_if_branch_changed(
+                if let Some(result) = wiggum::handle_wiggum_activation(
                     &state.ws_write,
                     state.session_id,
                     &state.working_directory,
                     &state.git_metadata,
+                    &mut state.wiggum_state,
+                    claude_session,
+                    wiggum_input,
                 )
-                .await;
-                emit_input_progress(
-                    &state.ws_write,
-                    state.session_id,
-                    wiggum_input.client_msg_id,
-                    shared::InputDeliveryStage::ProxyReceived,
-                )
-                .await;
-                let prompt = wiggum_prompt(&wiggum_input.text);
-                state.wiggum_state = Some(WiggumState {
-                    original_prompt: wiggum_input.text,
-                    iteration: 1,
-                    loop_start: Instant::now(),
-                    loop_durations: Vec::new(),
-                });
-                if let Err(e) = claude_session.send_input(serde_json::Value::String(prompt)).await {
-                    error!("Failed to send wiggum prompt to Claude: {}", e);
-                    emit_input_progress(
-                        &state.ws_write,
-                        state.session_id,
-                        wiggum_input.client_msg_id,
-                        shared::InputDeliveryStage::Failed,
-                    )
-                    .await;
-                    return ConnectionResult::ClaudeExited;
+                .await
+                {
+                    return result;
                 }
-                emit_input_progress(
-                    &state.ws_write,
-                    state.session_id,
-                    wiggum_input.client_msg_id,
-                    shared::InputDeliveryStage::AgentAccepted,
-                )
-                .await;
-                ack_portal_input(&state.ws_write, wiggum_input.ack).await;
             }
 
             Some(upload_event) = state.file_upload_rx.recv() => {

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -16,8 +16,8 @@ use session_lib::session::Session;
 
 use super::git_metadata::{check_and_send_branch_update_if_branch_changed, GitMetadataState};
 use super::{
-    ack_portal_input, emit_input_progress, format_duration, truncate, ConnectionResult, PortalInput,
-    SharedWsWrite,
+    ack_portal_input, emit_input_progress, format_duration, truncate, ConnectionResult,
+    PortalInput, SharedWsWrite,
 };
 
 /// Maximum iterations for wiggum mode before auto-stopping

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -8,12 +8,17 @@ use claude_codes::ClaudeOutput;
 use shared::{AgentType, ProxyToServer};
 use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, error, info, warn};
+use uuid::Uuid;
 
 use session_lib::agent::Agent;
 use session_lib::output_buffer::PendingOutputBuffer;
 use session_lib::session::Session;
 
-use super::{format_duration, ConnectionResult, SharedWsWrite};
+use super::git_metadata::{check_and_send_branch_update_if_branch_changed, GitMetadataState};
+use super::{
+    ack_portal_input, emit_input_progress, format_duration, truncate, ConnectionResult, PortalInput,
+    SharedWsWrite,
+};
 
 /// Maximum iterations for wiggum mode before auto-stopping
 const WIGGUM_MAX_ITERATIONS: u32 = 50;
@@ -38,6 +43,74 @@ pub struct WiggumState {
     pub loop_start: Instant,
     /// Durations of the last N loop iterations (most recent last)
     pub loop_durations: Vec<Duration>,
+}
+
+/// Wiggum-activation arm of the proxy connection loop (#1165 item 3).
+///
+/// Extracted from the `run_main_loop` `select!` so the god-loop reads as thin
+/// dispatch (parallels [`input_delivery::handle_input`](super::input_delivery)).
+/// Sets [`WiggumState`] atomically with sending the first iteration's prompt,
+/// emitting the [`InputDeliveryStage`](shared::InputDeliveryStage) progress
+/// events (#939) along the way. Returns `Some(ConnectionResult)` to end the
+/// connection (agent exited), or `None` to continue the loop.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn handle_wiggum_activation<A: Agent>(
+    ws_write: &SharedWsWrite,
+    session_id: Uuid,
+    working_directory: &str,
+    git_metadata: &GitMetadataState,
+    wiggum_state: &mut Option<WiggumState>,
+    claude_session: &mut Session<A>,
+    wiggum_input: PortalInput,
+) -> Option<ConnectionResult> {
+    info!(
+        "Wiggum mode activated with prompt: {}",
+        truncate(&wiggum_input.text, 60)
+    );
+    check_and_send_branch_update_if_branch_changed(
+        ws_write,
+        session_id,
+        working_directory,
+        git_metadata,
+    )
+    .await;
+    emit_input_progress(
+        ws_write,
+        session_id,
+        wiggum_input.client_msg_id,
+        shared::InputDeliveryStage::ProxyReceived,
+    )
+    .await;
+    let prompt = wiggum_prompt(&wiggum_input.text);
+    *wiggum_state = Some(WiggumState {
+        original_prompt: wiggum_input.text,
+        iteration: 1,
+        loop_start: Instant::now(),
+        loop_durations: Vec::new(),
+    });
+    if let Err(e) = claude_session
+        .send_input(serde_json::Value::String(prompt))
+        .await
+    {
+        error!("Failed to send wiggum prompt to Claude: {}", e);
+        emit_input_progress(
+            ws_write,
+            session_id,
+            wiggum_input.client_msg_id,
+            shared::InputDeliveryStage::Failed,
+        )
+        .await;
+        return Some(ConnectionResult::ClaudeExited);
+    }
+    emit_input_progress(
+        ws_write,
+        session_id,
+        wiggum_input.client_msg_id,
+        shared::InputDeliveryStage::AgentAccepted,
+    )
+    .await;
+    ack_portal_input(ws_write, wiggum_input.ack).await;
+    None
 }
 
 /// Handle a session event from session-lib, with wiggum loop support


### PR DESCRIPTION
## What
Extracts the proxy connection god-loop's ~45-line inline Wiggum-activation `select!` arm into `wiggum::handle_wiggum_activation`, mirroring the already-extracted `input_delivery::handle_input`. The `select!` now reads as thin dispatch.

## Why
Continues #1165 item 3 (proxy god-loop → thin dispatch). The remaining large inline blocks were the Wiggum arm and the `next_event` arm; this takes the Wiggum one.

## Behavior
Unchanged: sets `WiggumState` atomically with sending the first iteration's prompt, emitting the #939 `InputDeliveryStage` progress events (`ProxyReceived` → `AgentAccepted`/`Failed`) along the way, then acks. Returns `Some(ConnectionResult::ClaudeExited)` on send failure to end the connection.

## Notes
- Rebased onto main after #1226 (strict-DONE Wiggum fix); `check_wiggum_done` and its regression tests are untouched — the extraction only adds a function near the top of `wiggum.rs`.
- `cargo build -p claude-portal -p agent-portal` + `cargo clippy -p claude-session-lib --all-targets` clean. v2.12.128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)