### PR TITLE
refactor: extract next_event select! arm into session_event::handle_next_event (#1165 item 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.129"
+version = "2.12.130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.129"
+version = "2.12.130"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.129"
+version = "2.12.130"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.129"
+version = "2.12.130"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.129"
+version = "2.12.130"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.129"
+version = "2.12.130"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.129"
+version = "2.12.130"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.129"
+version = "2.12.130"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.129"
+version = "2.12.130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.129"
+version = "2.12.130"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.129"
+version = "2.12.130"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -7,6 +7,7 @@ mod input_delivery;
 mod output_forwarder;
 mod permission_bridge;
 mod portal_reminder;
+mod session_event;
 mod wiggum;
 mod ws_reader;
 
@@ -24,7 +25,6 @@ use claude_codes::ClaudeOutput;
 use session_lib::agent::Agent;
 use session_lib::output_buffer::PendingOutputBuffer;
 use session_lib::session::Session;
-use session_lib::SessionEvent;
 use shared::{ProxyToServer, ServerToProxy, SessionEndpoint};
 use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, error, info, warn};
@@ -32,12 +32,9 @@ use uuid::Uuid;
 
 pub use git_metadata::{get_git_branch, get_repo_url};
 
-use git_metadata::{
-    check_and_send_branch_update, codex_output_has_git_signal, get_open_prs, get_pr_url,
-    GitMetadataState, GitRefreshTrigger,
-};
+use git_metadata::{get_open_prs, get_pr_url, GitMetadataState, GitRefreshTrigger};
 use output_forwarder::spawn_output_forwarder;
-use wiggum::{handle_session_event_with_wiggum, WiggumState};
+use wiggum::WiggumState;
 use ws_reader::{
     spawn_ws_reader, FileDownloadEvent, FileReceiveState, FileUploadEvent, WsReaderChannels,
 };
@@ -1003,109 +1000,10 @@ async fn run_main_loop<A: Agent>(
             }
 
             event = claude_session.next_event() => {
-                // Both backends now deliver visible output as the neutral
-                // `SessionEvent::RawOutput(value)`. Route by agent at the proxy
-                // edge: Codex uses this simple inline path; Claude falls through
-                // to the wiggum/output-forwarder path, which re-parses the value
-                // to `ClaudeOutput` for its image/git/echo/wiggum side-effects.
-                if state.agent_type != shared::AgentType::Claude {
-                  if let Some(SessionEvent::RawOutput(ref value)) = event {
-                    if state.git_refresh.should_check_before_message() {
-                        check_and_send_branch_update(
-                            &state.ws_write,
-                            state.session_id,
-                            &state.working_directory,
-                            &state.git_metadata,
-                        )
-                        .await;
-                    }
-                    if codex_output_has_git_signal(value) {
-                        state.git_refresh.mark_git_signal();
-                    }
-
-                    let is_codex_compaction = is_codex_compaction_event(value);
-                    let seq = {
-                        let mut buf = state.output_buffer.lock().await;
-                        buf.push(value.clone())
-                    };
-                    let msg = ProxyToServer::SequencedOutput {
-                        seq,
-                        content: value.clone(),
-                        agent_type: state.agent_type,
-                    };
-                    let mut ws = state.ws_write.lock().await;
-                    if ws.send(msg).await.is_err() {
-                        error!("Failed to send raw output");
-                        return ConnectionResult::Disconnected(state.connection_start.elapsed());
-                    }
-                    if is_codex_compaction {
-                        inject_portal_reminder(claude_session).await;
-                    }
-                    continue;
-                  }
-                }
-
-                // Per-turn metrics: forward as a typed `TurnMetricsReport`
-                // envelope. Doesn't go through the output buffer because
-                // it's not part of the message-replay path — a missed
-                // metrics row is acceptable (next turn replaces it on the
-                // dashboard) but we still want low-latency delivery.
-                if let Some(SessionEvent::TurnMetricsReady(metrics)) = event {
-                    let msg = ProxyToServer::TurnMetricsReport(metrics);
-                    let mut ws = state.ws_write.lock().await;
-                    if ws.send(msg).await.is_err() {
-                        error!("Failed to send turn metrics report");
-                        return ConnectionResult::Disconnected(state.connection_start.elapsed());
-                    }
-                    continue;
-                }
-
-                // Codex app-server thread id: hand it to the persistence
-                // sink (the proxy's ProxyConfig writer) so the next resume
-                // of this session can call `thread/resume` with it.
-                // Emitted once per spawn by codex-session-lib. No-op for
-                // claude sessions (claude doesn't emit it).
-                if let Some(SessionEvent::CodexThreadId(thread_id)) = event {
-                    if let Some(sink) = state.codex_thread_id_sink.as_ref() {
-                        sink(thread_id);
-                    }
-                    continue;
-                }
-
-                if let Some(SessionEvent::SessionLimitReached {
-                    session_id,
-                    reset_at,
-                    source_message,
-                    prompt,
-                }) = event
+                if let Some(result) =
+                    session_event::handle_next_event(state, claude_session, event).await
                 {
-                    let msg =
-                        ProxyToServer::SessionLimitReached(shared::SessionLimitContinuationFields {
-                            session_id,
-                            reset_at,
-                            source_message,
-                            prompt,
-                        });
-                    let mut ws = state.ws_write.lock().await;
-                    if ws.send(msg).await.is_err() {
-                        error!("Failed to send session-limit continuation candidate");
-                        return ConnectionResult::Disconnected(state.connection_start.elapsed());
-                    }
-                    continue;
-                }
-
-                match handle_session_event_with_wiggum(
-                    event,
-                    &state.output_tx,
-                    &state.ws_write,
-                    state.connection_start,
-                    &mut state.wiggum_state,
-                    &state.output_buffer,
-                    claude_session,
-                    state.agent_type,
-                ).await {
-                    Some(result) => return result,
-                    None => continue,
+                    return result;
                 }
             }
         }

--- a/claude-session-lib/src/proxy_session/session_event.rs
+++ b/claude-session-lib/src/proxy_session/session_event.rs
@@ -1,0 +1,144 @@
+//! Session-event arm of the proxy connection loop (#1165 item 3).
+//!
+//! Extracted from the `run_main_loop` `select!` so the god-loop reads as thin
+//! dispatch (parallels [`input_delivery::handle_input`](super::input_delivery)
+//! and [`wiggum::handle_wiggum_activation`](super::wiggum)). Dispatches one
+//! [`SessionEvent`] from `claude_session.next_event()`:
+//!
+//! - Non-Claude `RawOutput`: the simple codex path (git refresh, buffer, send,
+//!   compaction reminder) — Claude `RawOutput` falls through to the
+//!   wiggum/output-forwarder path that re-parses to `ClaudeOutput`.
+//! - `TurnMetricsReady`, `CodexThreadId`, `SessionLimitReached`: typed
+//!   side-channel forwards.
+//! - Everything else: delegated to
+//!   [`wiggum::handle_session_event_with_wiggum`](super::wiggum).
+//!
+//! Returns `Some(ConnectionResult)` to end the connection, or `None` to
+//! continue the loop (the inline `continue`s become `None`).
+
+use session_lib::agent::Agent;
+use session_lib::session::Session;
+use session_lib::SessionEvent;
+use shared::ProxyToServer;
+use tracing::error;
+
+use super::git_metadata::{check_and_send_branch_update, codex_output_has_git_signal};
+use super::wiggum::handle_session_event_with_wiggum;
+use super::{inject_portal_reminder, is_codex_compaction_event, ConnectionResult, ConnectionState};
+
+pub(super) async fn handle_next_event<A: Agent>(
+    state: &mut ConnectionState,
+    claude_session: &mut Session<A>,
+    event: Option<SessionEvent>,
+) -> Option<ConnectionResult> {
+    // Both backends now deliver visible output as the neutral
+    // `SessionEvent::RawOutput(value)`. Route by agent at the proxy edge: Codex
+    // uses this simple inline path; Claude falls through to the
+    // wiggum/output-forwarder path, which re-parses the value to `ClaudeOutput`
+    // for its image/git/echo/wiggum side-effects.
+    if state.agent_type != shared::AgentType::Claude {
+        if let Some(SessionEvent::RawOutput(ref value)) = event {
+            if state.git_refresh.should_check_before_message() {
+                check_and_send_branch_update(
+                    &state.ws_write,
+                    state.session_id,
+                    &state.working_directory,
+                    &state.git_metadata,
+                )
+                .await;
+            }
+            if codex_output_has_git_signal(value) {
+                state.git_refresh.mark_git_signal();
+            }
+
+            let is_codex_compaction = is_codex_compaction_event(value);
+            let seq = {
+                let mut buf = state.output_buffer.lock().await;
+                buf.push(value.clone())
+            };
+            let msg = ProxyToServer::SequencedOutput {
+                seq,
+                content: value.clone(),
+                agent_type: state.agent_type,
+            };
+            // NB: the `ws` write guard is intentionally held across the
+            // `inject_portal_reminder` await below, matching the pre-extraction
+            // inline behavior (the guard's scope was the whole arm). The
+            // reminder injects input to the agent and never touches `ws_write`,
+            // so this is a plain serialization point, not a deadlock.
+            let mut ws = state.ws_write.lock().await;
+            if ws.send(msg).await.is_err() {
+                error!("Failed to send raw output");
+                return Some(ConnectionResult::Disconnected(
+                    state.connection_start.elapsed(),
+                ));
+            }
+            if is_codex_compaction {
+                inject_portal_reminder(claude_session).await;
+            }
+            return None;
+        }
+    }
+
+    // Per-turn metrics: forward as a typed `TurnMetricsReport` envelope. Doesn't
+    // go through the output buffer because it's not part of the message-replay
+    // path — a missed metrics row is acceptable (next turn replaces it on the
+    // dashboard) but we still want low-latency delivery.
+    if let Some(SessionEvent::TurnMetricsReady(metrics)) = event {
+        let msg = ProxyToServer::TurnMetricsReport(metrics);
+        let mut ws = state.ws_write.lock().await;
+        if ws.send(msg).await.is_err() {
+            error!("Failed to send turn metrics report");
+            return Some(ConnectionResult::Disconnected(
+                state.connection_start.elapsed(),
+            ));
+        }
+        return None;
+    }
+
+    // Codex app-server thread id: hand it to the persistence sink (the proxy's
+    // ProxyConfig writer) so the next resume of this session can call
+    // `thread/resume` with it. Emitted once per spawn by codex-session-lib.
+    // No-op for claude sessions (claude doesn't emit it).
+    if let Some(SessionEvent::CodexThreadId(thread_id)) = event {
+        if let Some(sink) = state.codex_thread_id_sink.as_ref() {
+            sink(thread_id);
+        }
+        return None;
+    }
+
+    if let Some(SessionEvent::SessionLimitReached {
+        session_id,
+        reset_at,
+        source_message,
+        prompt,
+    }) = event
+    {
+        let msg = ProxyToServer::SessionLimitReached(shared::SessionLimitContinuationFields {
+            session_id,
+            reset_at,
+            source_message,
+            prompt,
+        });
+        let mut ws = state.ws_write.lock().await;
+        if ws.send(msg).await.is_err() {
+            error!("Failed to send session-limit continuation candidate");
+            return Some(ConnectionResult::Disconnected(
+                state.connection_start.elapsed(),
+            ));
+        }
+        return None;
+    }
+
+    handle_session_event_with_wiggum(
+        event,
+        &state.output_tx,
+        &state.ws_write,
+        state.connection_start,
+        &mut state.wiggum_state,
+        &state.output_buffer,
+        claude_session,
+        state.agent_type,
+    )
+    .await
+}


### PR DESCRIPTION
## What
Extracts the proxy connection god-loop's largest remaining inline `select!` arm — the ~105-line `claude_session.next_event()` block — into a new `session_event::handle_next_event(&mut state, session, event) -> Option<ConnectionResult>`. The arm is now a 5-line dispatch, matching `input_delivery::handle_input` (#1227) and `wiggum::handle_wiggum_activation`.

## Why
Completes the big-block extractions for #1165 item 3 (proxy god-loop → thin dispatch). The `select!` now reads as a list of one-line delegations.

## Behavior
Unchanged. Mechanical transform: inline `continue` → `return None`, `return ConnectionResult::X` → `return Some(ConnectionResult::X)`, final wiggum fall-through returned directly. All five event branches (codex `RawOutput`, `TurnMetricsReady`, `CodexThreadId`, `SessionLimitReached`, wiggum) preserved verbatim.

One spot called out in a comment: the codex `RawOutput` path **intentionally** still holds the `ws` write guard across `inject_portal_reminder` (the guard's scope was the whole arm pre-extraction; the reminder injects agent input and never touches `ws_write`, so it's a serialization point, not a deadlock).

## Checks
`cargo build -p claude-portal -p agent-portal`, `cargo clippy -p claude-session-lib --all-targets`, `cargo fmt --all --check`, `cargo test -p claude-session-lib --lib` (36 passed) — all clean. v2.12.130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)