### PR TITLE
feat: harden auth routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.128"
+version = "2.12.129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.128"
+version = "2.12.129"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.128"
+version = "2.12.129"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.128"
+version = "2.12.129"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.128"
+version = "2.12.129"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.128"
+version = "2.12.129"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.128"
+version = "2.12.129"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.128"
+version = "2.12.129"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.128"
+version = "2.12.129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.128"
+version = "2.12.129"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.128"
+version = "2.12.129"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use shared::api::MeResponse;
 use std::sync::Arc;
 use tower_cookies::{cookie::SameSite, Cookie, Cookies};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     errors::AppError,
@@ -23,9 +23,20 @@ mod oauth;
 
 /// Regular web login - redirects to Google OAuth
 pub async fn login(State(app_state): State<Arc<AppState>>, cookies: Cookies) -> impl IntoResponse {
+    info!(
+        target: "auth_audit",
+        event = "web_login_start",
+        oauth_configured = app_state.oauth_basic_client.is_some(),
+    );
     let client = match &app_state.oauth_basic_client {
         Some(c) => c,
-        None => return Redirect::temporary(routes::AUTH_DEV_LOGIN).into_response(),
+        None => {
+            info!(
+                target: "auth_audit",
+                event = "web_login_dev_redirect",
+            );
+            return Redirect::temporary(routes::AUTH_DEV_LOGIN).into_response();
+        }
     };
 
     oauth::regular_authorization_redirect(client, &cookies, &app_state).into_response()
@@ -43,6 +54,12 @@ pub async fn device_login(
     cookies: Cookies,
     Query(query): Query<DeviceLoginQuery>,
 ) -> Result<impl IntoResponse, AppError> {
+    info!(
+        target: "auth_audit",
+        event = "device_login_start",
+        user_code = %query.device_user_code,
+        oauth_configured = app_state.oauth_basic_client.is_some(),
+    );
     // In dev mode, auto-login and redirect to device approval page
     if app_state.oauth_basic_client.is_none() {
         let mut conn = app_state.conn()?;
@@ -51,10 +68,26 @@ pub async fn device_login(
 
         if user.disabled {
             info!("Banned user {} attempted dev device login", user.email);
+            warn!(
+                target: "auth_audit",
+                event = "device_login_denied",
+                reason = "disabled_user",
+                user_id = %user.id,
+                user_email = %user.email,
+                user_code = %query.device_user_code,
+            );
             return Ok(Redirect::temporary(routes::BANNED).into_response());
         }
 
         info!("Dev mode: auto-logged in for device flow");
+        info!(
+            target: "auth_audit",
+            event = "device_login_success",
+            mode = "dev",
+            user_id = %user.id,
+            user_email = %user.email,
+            user_code = %query.device_user_code,
+        );
 
         add_session_cookie(&cookies, &app_state, &user);
 
@@ -88,6 +121,22 @@ pub async fn callback(
     cookies: Cookies,
     Query(query): Query<AuthCallbackQuery>,
 ) -> Result<impl IntoResponse, AppError> {
+    let callback_kind = if query
+        .state
+        .as_deref()
+        .is_some_and(|state| state.starts_with("device:"))
+    {
+        "device"
+    } else {
+        "web"
+    };
+    info!(
+        target: "auth_audit",
+        event = "oauth_callback_start",
+        flow = callback_kind,
+        state_present = query.state.is_some(),
+    );
+
     let client = app_state
         .oauth_basic_client
         .as_ref()
@@ -97,8 +146,15 @@ pub async fn callback(
         .build()
         .map_err(|e| AppError::Internal(format!("Failed to build OAuth HTTP client: {e}")))?;
 
-    let device_state =
-        oauth::validate_callback_state(&cookies, &app_state, query.state.as_deref())?;
+    let device_state = oauth::validate_callback_state(&cookies, &app_state, query.state.as_deref())
+        .inspect_err(|_| {
+            warn!(
+                target: "auth_audit",
+                event = "oauth_callback_denied",
+                flow = callback_kind,
+                reason = "invalid_state",
+            );
+        })?;
 
     // Exchange code for token
     let token: oauth2::StandardTokenResponse<
@@ -108,7 +164,15 @@ pub async fn callback(
         .exchange_code(AuthorizationCode::new(query.code))
         .request_async(&http_client)
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to exchange OAuth code: {e}")))?;
+        .map_err(|e| {
+            warn!(
+                target: "auth_audit",
+                event = "oauth_callback_failed",
+                flow = callback_kind,
+                stage = "token_exchange",
+            );
+            AppError::Internal(format!("Failed to exchange OAuth code: {e}"))
+        })?;
 
     // Fetch user info from Google
     let client = reqwest::Client::new();
@@ -117,15 +181,38 @@ pub async fn callback(
         .bearer_auth(token.access_token().secret())
         .send()
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to fetch Google user info: {e}")))?
+        .map_err(|e| {
+            warn!(
+                target: "auth_audit",
+                event = "oauth_callback_failed",
+                flow = callback_kind,
+                stage = "userinfo_fetch",
+            );
+            AppError::Internal(format!("Failed to fetch Google user info: {e}"))
+        })?
         .json()
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to parse Google user info: {e}")))?;
+        .map_err(|e| {
+            warn!(
+                target: "auth_audit",
+                event = "oauth_callback_failed",
+                flow = callback_kind,
+                stage = "userinfo_parse",
+            );
+            AppError::Internal(format!("Failed to parse Google user info: {e}"))
+        })?;
 
     info!("User authenticated: {}", user_info.email);
 
     // Check email access control
     if let Err(redirect) = check_email_allowed(&app_state, &user_info.email) {
+        warn!(
+            target: "auth_audit",
+            event = "oauth_callback_denied",
+            flow = callback_kind,
+            reason = "email_not_allowed",
+            user_email = %user_info.email,
+        );
         return Ok(redirect);
     }
 
@@ -161,6 +248,14 @@ pub async fn callback(
     if user.disabled {
         let reason = user.ban_reason.as_deref().unwrap_or("No reason provided");
         info!("Banned user {} attempted login", user.email);
+        warn!(
+            target: "auth_audit",
+            event = "oauth_callback_denied",
+            flow = callback_kind,
+            reason = "disabled_user",
+            user_id = %user.id,
+            user_email = %user.email,
+        );
         return Ok(banned_redirect(reason));
     }
 
@@ -172,10 +267,25 @@ pub async fn callback(
             "OAuth complete for device flow, redirecting to approval page for user: {}",
             user.email
         );
+        info!(
+            target: "auth_audit",
+            event = "oauth_callback_success",
+            flow = "device",
+            user_id = %user.id,
+            user_email = %user.email,
+            user_code = %device_state.user_code,
+        );
         return Ok(device_approval_redirect(&device_state.user_code));
     }
 
     add_session_cookie(&cookies, &app_state, &user);
+    info!(
+        target: "auth_audit",
+        event = "oauth_callback_success",
+        flow = "web",
+        user_id = %user.id,
+        user_email = %user.email,
+    );
 
     Ok(Redirect::temporary(routes::DASHBOARD))
 }
@@ -217,12 +327,25 @@ pub async fn dev_login(
     if user.disabled {
         let reason = user.ban_reason.as_deref().unwrap_or("No reason provided");
         info!("Banned user {} attempted dev login", user.email);
+        warn!(
+            target: "auth_audit",
+            event = "dev_login_denied",
+            reason = "disabled_user",
+            user_id = %user.id,
+            user_email = %user.email,
+        );
         return Ok(banned_redirect(reason));
     }
 
     info!(
         "Dev mode: auto-logged in as {}",
         crate::auth::DEV_USER_EMAIL
+    );
+    info!(
+        target: "auth_audit",
+        event = "dev_login_success",
+        user_id = %user.id,
+        user_email = %user.email,
     );
 
     add_session_cookie(&cookies, &app_state, &user);

--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -11,7 +11,7 @@ use shared::api::{
 use shared::DevicePollResponse;
 use std::sync::Arc;
 use tower_cookies::Cookies;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -38,12 +38,15 @@ pub async fn device_code(
     State(app_state): State<Arc<AppState>>,
     body: Option<Json<DeviceCodeRequest>>,
 ) -> Result<Json<DeviceCodeResponse>, DeviceFlowApiError> {
+    info!(target: "auth_audit", event = "device_code_request");
     let store = app_state
         .device_flow_store
         .as_ref()
         .ok_or_else(DeviceFlowApiError::service_unavailable)?;
 
     let req = body.map(|b| b.0).unwrap_or_default();
+    let hostname = req.hostname;
+    let working_directory = req.working_directory;
     let device_code = generate_device_code();
     let user_code = generate_user_code();
 
@@ -57,14 +60,21 @@ pub async fn device_code(
         access_token: None,
         expires_at,
         status: DeviceFlowStatus::Pending,
-        hostname: req.hostname,
-        working_directory: req.working_directory,
+        hostname: hostname.clone(),
+        working_directory: working_directory.clone(),
     };
 
     let mut store_lock = store.write().await;
     store_lock.insert(device_code.clone(), state);
 
     let verification_uri = format!("{}/api/auth/device", app_state.public_url);
+    info!(
+        target: "auth_audit",
+        event = "device_code_created",
+        user_code = %user_code,
+        hostname = ?hostname,
+        working_directory = ?working_directory,
+    );
 
     Ok(Json(DeviceCodeResponse {
         device_code,
@@ -80,15 +90,21 @@ pub async fn device_poll(
     State(app_state): State<Arc<AppState>>,
     Json(req): Json<DeviceFlowPollRequest>,
 ) -> Result<Json<DevicePollResponse>, DeviceFlowApiError> {
+    info!(target: "auth_audit", event = "device_poll_request");
     let store = app_state
         .device_flow_store
         .as_ref()
         .ok_or_else(DeviceFlowApiError::service_unavailable)?;
     let mut store_lock = store.write().await;
 
-    let state = store_lock
-        .get_mut(&req.device_code)
-        .ok_or_else(|| DeviceFlowApiError::not_found("Device code not found or expired"))?;
+    let state = store_lock.get_mut(&req.device_code).ok_or_else(|| {
+        warn!(
+            target: "auth_audit",
+            event = "device_poll_denied",
+            reason = "not_found",
+        );
+        DeviceFlowApiError::not_found("Device code not found or expired")
+    })?;
 
     // Check expiration
     if std::time::SystemTime::now() > state.expires_at {
@@ -96,7 +112,14 @@ pub async fn device_poll(
     }
 
     match &state.status {
-        DeviceFlowStatus::Pending => Ok(Json(DevicePollResponse::Pending)),
+        DeviceFlowStatus::Pending => {
+            info!(
+                target: "auth_audit",
+                event = "device_poll_pending",
+                user_code = %state.user_code,
+            );
+            Ok(Json(DevicePollResponse::Pending))
+        }
         DeviceFlowStatus::Complete => {
             let user_id = state
                 .user_id
@@ -118,14 +141,36 @@ pub async fn device_poll(
                 .first::<crate::models::User>(&mut conn)
                 .map_err(|_| DeviceFlowApiError::internal_error("User not found"))?;
 
+            info!(
+                target: "auth_audit",
+                event = "device_poll_complete",
+                user_code = %state.user_code,
+                user_id = %user_id,
+                user_email = %user.email,
+            );
             Ok(Json(DevicePollResponse::Complete {
                 access_token,
                 user_id: user_id.to_string(),
                 user_email: user.email,
             }))
         }
-        DeviceFlowStatus::Expired => Ok(Json(DevicePollResponse::Expired)),
-        DeviceFlowStatus::Denied => Ok(Json(DevicePollResponse::Denied)),
+        DeviceFlowStatus::Expired => {
+            info!(
+                target: "auth_audit",
+                event = "device_poll_expired",
+                user_code = %state.user_code,
+            );
+            Ok(Json(DevicePollResponse::Expired))
+        }
+        DeviceFlowStatus::Denied => {
+            info!(
+                target: "auth_audit",
+                event = "device_poll_denied",
+                user_code = %state.user_code,
+                reason = "user_denied",
+            );
+            Ok(Json(DevicePollResponse::Denied))
+        }
     }
 }
 
@@ -201,8 +246,20 @@ pub async fn device_approve(
     cookies: Cookies,
     Json(req): Json<ApproveRequest>,
 ) -> Result<Json<DeviceFlowActionResponse>, DeviceFlowApiError> {
-    let user_id = auth::extract_user_id(&app_state, &cookies)
-        .map_err(|e| auth_error_to_device_flow(e, "approve"))?;
+    info!(
+        target: "auth_audit",
+        event = "device_approve_request",
+        user_code = %req.user_code,
+    );
+    let user_id = auth::extract_user_id(&app_state, &cookies).map_err(|e| {
+        warn!(
+            target: "auth_audit",
+            event = "device_approve_denied",
+            user_code = %req.user_code,
+            reason = "unauthorized",
+        );
+        auth_error_to_device_flow(e, "approve")
+    })?;
 
     let store = app_state
         .device_flow_store
@@ -212,11 +269,26 @@ pub async fn device_approve(
     // Complete the device flow
     complete_device_flow(&app_state, store, &req.user_code, user_id)
         .await
-        .map_err(|_| DeviceFlowApiError::not_found("Device code not found or already used"))?;
+        .map_err(|_| {
+            warn!(
+                target: "auth_audit",
+                event = "device_approve_denied",
+                user_code = %req.user_code,
+                user_id = %user_id,
+                reason = "not_found_or_used",
+            );
+            DeviceFlowApiError::not_found("Device code not found or already used")
+        })?;
 
     info!(
         "Device flow approved for user_code: {}, user: {}",
         req.user_code, user_id
+    );
+    info!(
+        target: "auth_audit",
+        event = "device_approve_success",
+        user_code = %req.user_code,
+        user_id = %user_id,
     );
 
     Ok(Json(DeviceFlowActionResponse {
@@ -231,8 +303,20 @@ pub async fn device_deny(
     cookies: Cookies,
     Json(req): Json<ApproveRequest>,
 ) -> Result<Json<DeviceFlowActionResponse>, DeviceFlowApiError> {
-    auth::extract_user_id(&app_state, &cookies)
-        .map_err(|e| auth_error_to_device_flow(e, "deny"))?;
+    info!(
+        target: "auth_audit",
+        event = "device_deny_request",
+        user_code = %req.user_code,
+    );
+    let user_id = auth::extract_user_id(&app_state, &cookies).map_err(|e| {
+        warn!(
+            target: "auth_audit",
+            event = "device_deny_denied",
+            user_code = %req.user_code,
+            reason = "unauthorized",
+        );
+        auth_error_to_device_flow(e, "deny")
+    })?;
 
     let store = app_state
         .device_flow_store
@@ -247,6 +331,19 @@ pub async fn device_deny(
     {
         state.status = DeviceFlowStatus::Denied;
         info!("Device flow denied for user_code: {}", req.user_code);
+        info!(
+            target: "auth_audit",
+            event = "device_deny_success",
+            user_code = %req.user_code,
+            user_id = %user_id,
+        );
+    } else {
+        warn!(
+            target: "auth_audit",
+            event = "device_deny_missing",
+            user_code = %req.user_code,
+            user_id = %user_id,
+        );
     }
 
     Ok(Json(DeviceFlowActionResponse {
@@ -417,6 +514,13 @@ pub async fn complete_device_flow(
         info!(
             "Device flow completed for user_code: {}, user: {}",
             user_code, issued.user_email
+        );
+        info!(
+            target: "auth_audit",
+            event = "device_token_issued",
+            user_code = %user_code,
+            user_id = %user_id,
+            user_email = %issued.user_email,
         );
         Ok(())
     } else {

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -64,6 +64,29 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
         .layer(rate_limit(6, 10))
         .with_state(app_state.clone());
 
+    // Rate-limited browser auth routes. These endpoints either initiate OAuth
+    // or consume OAuth callback codes, so keep them separate from ordinary
+    // authenticated API traffic.
+    let auth_login_routes = Router::new()
+        .route(AUTH_GOOGLE, get(handlers::auth::login))
+        .route(AUTH_GOOGLE_CALLBACK, get(handlers::auth::callback))
+        .route(AUTH_DEV_LOGIN, get(handlers::auth::dev_login))
+        .route(AUTH_DEVICE_LOGIN, get(handlers::auth::device_login))
+        .layer(rate_limit(2, 20))
+        .with_state(app_state.clone());
+
+    // Rate-limited device approval actions. The verify page remains unthrottled
+    // enough for normal browser refreshes, while mutating approve/deny submits
+    // get explicit abuse protection.
+    let auth_device_action_routes = Router::new()
+        .route(
+            AUTH_DEVICE_APPROVE,
+            post(handlers::device_flow::device_approve),
+        )
+        .route(AUTH_DEVICE_DENY, post(handlers::device_flow::device_deny))
+        .layer(rate_limit(2, 20))
+        .with_state(app_state.clone());
+
     // Rate-limited download routes
     let download_routes = Router::new()
         .route(
@@ -184,21 +207,10 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             get(handlers::sound_settings::get_sound_settings)
                 .put(handlers::sound_settings::save_sound_settings),
         )
-        // Auth routes (under /api/auth)
-        .route(AUTH_GOOGLE, get(handlers::auth::login))
-        .route(AUTH_GOOGLE_CALLBACK, get(handlers::auth::callback))
         .route(AUTH_ME, get(handlers::auth::me))
         .route(AUTH_LOGOUT, get(handlers::auth::logout))
-        .route(AUTH_DEV_LOGIN, get(handlers::auth::dev_login))
-        // Device-specific login endpoint (separate from regular web login)
-        .route(AUTH_DEVICE_LOGIN, get(handlers::auth::device_login))
-        // Non-rate-limited device flow endpoints (verify page, approve, deny are user-facing)
+        // Non-rate-limited device flow verify page (form + browser refreshes)
         .route(AUTH_DEVICE, get(handlers::device_flow::device_verify_page))
-        .route(
-            AUTH_DEVICE_APPROVE,
-            post(handlers::device_flow::device_approve),
-        )
-        .route(AUTH_DEVICE_DENY, post(handlers::device_flow::device_deny))
         // WebSocket routes (paths from ws-bridge endpoint definitions)
         .route(
             shared::SessionEndpoint::PATH,
@@ -247,6 +259,8 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
         .with_state(app_state)
         // Merge rate-limited route groups
         .merge(auth_device_routes)
+        .merge(auth_login_routes)
+        .merge(auth_device_action_routes)
         .merge(download_routes)
         // Serve embedded frontend assets with SPA fallback
         .merge(


### PR DESCRIPTION
## Summary
- add rate limits to browser auth entry/callback routes and device approve/deny actions
- add structured auth_audit tracing for web OAuth, dev login, device code, polling, approval, denial, and token issuance outcomes
- bump workspace to 2.12.129

## Tests
- cargo test -p backend auth --lib
- cargo test -p backend device_flow --lib
- cargo clippy -p backend --all-targets -- -D warnings