### PR TITLE
ci: narrow e2e db-backed test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,8 @@ jobs:
     # backend unit tests that need a real Postgres (messages/replay pagination,
     # session-access). Kept separate from `Tests` so the main lane stays
     # DB-free. The harness step runs first because it self-migrates the fresh
-    # Postgres; the `--lib` step then runs the DB-backed unit tests against the
-    # migrated schema (cargo runs lib tests before integration tests within a
-    # single invocation, so they must be split to get migration ordering right).
+    # Postgres; then run only the DB-gated lib test modules instead of the full
+    # backend lib suite, which already runs in the main `Tests` job.
     services:
       postgres:
         image: postgres:16-alpine
@@ -193,7 +192,10 @@ jobs:
       - name: Run DB-backed backend unit tests
         env:
           DATABASE_URL: postgresql://claude_portal:dev_password_change_in_production@localhost:5432/claude_portal
-        run: cargo test -p backend --lib
+        run: |
+          cargo test -p backend --lib handlers::messages::db_tests
+          cargo test -p backend --lib handlers::session_access::db_tests
+          cargo test -p backend --lib handlers::websocket::replay::replay_tests
 
   build-binaries:
     name: ${{ matrix.job-name }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.131"
+version = "2.12.132"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.131"
+version = "2.12.132"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.131"
+version = "2.12.132"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.131"
+version = "2.12.132"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.131"
+version = "2.12.132"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.131"
+version = "2.12.132"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.131"
+version = "2.12.132"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.131"
+version = "2.12.132"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.131"
+version = "2.12.132"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.131"
+version = "2.12.132"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.131"
+version = "2.12.132"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 


### PR DESCRIPTION
## Summary
- keep the E2E harness and Postgres job intact
- replace the broad `cargo test -p backend --lib` rerun with only the DB-gated backend modules
- bump workspace to 2.12.132

## Why
The main `Tests` job already runs the full backend lib suite without DATABASE_URL. The E2E job only needs to re-run the DB-gated modules after the harness migrates Postgres, so this removes redundant non-DB backend test work from the E2E lane.

## Tests
- cargo check -p shared
- cargo test -p backend --lib handlers::messages::db_tests
- cargo test -p backend --lib handlers::session_access::db_tests
- cargo test -p backend --lib handlers::websocket::replay::replay_tests