### PR TITLE
fix: clamp session pill menu to viewport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.132"
+version = "2.12.133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.132"
+version = "2.12.133"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.132"
+version = "2.12.133"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.132"
+version = "2.12.133"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.132"
+version = "2.12.133"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.132"
+version = "2.12.133"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.132"
+version = "2.12.133"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.132"
+version = "2.12.133"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.132"
+version = "2.12.133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.132"
+version = "2.12.133"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.132"
+version = "2.12.133"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -22,6 +22,27 @@ use menu::SessionRailMenu;
 use pill::SessionPill;
 pub use sparkline::ActivityRef;
 
+const PILL_MENU_MIN_WIDTH_PX: i32 = 160;
+const PILL_MENU_ESTIMATED_HEIGHT_PX: i32 = 420;
+const PILL_MENU_VIEWPORT_MARGIN_PX: i32 = 8;
+const PILL_MENU_TOGGLE_GAP_PX: i32 = 4;
+
+fn clamped_pill_menu_position(
+    anchor_left: i32,
+    anchor_bottom: i32,
+    viewport_width: i32,
+    viewport_height: i32,
+) -> (i32, i32) {
+    let left = anchor_left
+        .min(viewport_width - PILL_MENU_MIN_WIDTH_PX - PILL_MENU_VIEWPORT_MARGIN_PX)
+        .max(PILL_MENU_VIEWPORT_MARGIN_PX);
+    let preferred_top = anchor_bottom + PILL_MENU_TOGGLE_GAP_PX;
+    let top = preferred_top
+        .min(viewport_height - PILL_MENU_ESTIMATED_HEIGHT_PX - PILL_MENU_VIEWPORT_MARGIN_PX)
+        .max(PILL_MENU_VIEWPORT_MARGIN_PX);
+    (left, top)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -62,6 +83,29 @@ mod tests {
         );
         assert_eq!(repo_pr_menu_hint(None, 1), "1 PR");
         assert_eq!(repo_pr_menu_hint(None, 4), "PRs");
+    }
+
+    #[test]
+    fn pill_menu_position_keeps_menu_inside_right_edge() {
+        let (left, top) = clamped_pill_menu_position(760, 100, 800, 900);
+
+        assert_eq!(left, 632);
+        assert_eq!(top, 104);
+    }
+
+    #[test]
+    fn pill_menu_position_opens_upward_near_bottom_edge() {
+        let (left, top) = clamped_pill_menu_position(80, 860, 1000, 900);
+
+        assert_eq!(left, 80);
+        assert_eq!(top, 472);
+    }
+
+    #[test]
+    fn pill_menu_position_keeps_minimum_viewport_margin() {
+        let (left, top) = clamped_pill_menu_position(-20, -10, 300, 300);
+
+        assert_eq!((left, top), (8, 8));
     }
 }
 
@@ -307,13 +351,27 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
             }
             if let Some(el) = e.target_dyn_into::<HtmlElement>() {
                 let rect = el.get_bounding_client_rect();
-                let vw = web_sys::window()
-                    .and_then(|w| w.inner_width().ok())
-                    .and_then(|v| v.as_f64())
-                    .unwrap_or(800.0) as i32;
-                let menu_width = 160; // min-width from CSS
-                let left = (rect.left() as i32).min(vw - menu_width - 8);
-                menu_pos.set((left, rect.bottom() as i32 + 4));
+                let (viewport_width, viewport_height) = web_sys::window()
+                    .map(|window| {
+                        let width = window
+                            .inner_width()
+                            .ok()
+                            .and_then(|v| v.as_f64())
+                            .unwrap_or(800.0) as i32;
+                        let height = window
+                            .inner_height()
+                            .ok()
+                            .and_then(|v| v.as_f64())
+                            .unwrap_or(600.0) as i32;
+                        (width, height)
+                    })
+                    .unwrap_or((800, 600));
+                menu_pos.set(clamped_pill_menu_position(
+                    rect.left() as i32,
+                    rect.bottom() as i32,
+                    viewport_width,
+                    viewport_height,
+                ));
             }
             menu_session.set(Some(session_id));
         })


### PR DESCRIPTION
## Summary
- clamp session pill dropdown X/Y position to viewport margins
- open pill menus upward when the toggle is near the viewport bottom, fixing vertical rail modes
- add unit coverage for right-edge, bottom-edge, and minimum-margin positioning
- bump workspace to 2.12.133

## Tests
- cargo test -p frontend pill_menu_position --lib
- cargo check -p shared
- cargo clippy -p frontend --all-targets -- -D warnings