### PR TITLE
fix: classify tool results before human source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.133"
+version = "2.12.134"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.133"
+version = "2.12.134"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.133"
+version = "2.12.134"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.133"
+version = "2.12.134"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.133"
+version = "2.12.134"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.133"
+version = "2.12.134"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.133"
+version = "2.12.134"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.133"
+version = "2.12.134"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.133"
+version = "2.12.134"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.133"
+version = "2.12.134"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.133"
+version = "2.12.134"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -218,7 +218,10 @@ pub(super) fn classify(
     current_user_id: Option<&str>,
 ) -> Option<MessageIdentity> {
     let json = message.content.as_str();
-    if let Some(source) = message.source() {
+    let source = message.source();
+    if let Some(source @ (shared::MessageSource::Agent { .. } | shared::MessageSource::Portal)) =
+        source
+    {
         return Some(source_identity(source, current_user_id));
     }
 
@@ -245,19 +248,25 @@ pub(super) fn classify(
                 });
             }
             if user_is_plain_text(&msg) {
-                return Some(MessageIdentity {
-                    category: GroupCategory::User,
-                    label: "You".to_string(),
-                    badge_class: "user".to_string(),
-                });
+                return Some(source.map_or_else(
+                    || MessageIdentity {
+                        category: GroupCategory::User,
+                        label: "You".to_string(),
+                        badge_class: "user".to_string(),
+                    },
+                    |source| source_identity(source, current_user_id),
+                ));
             }
         }
         AgentFrame::Claude(ClaudeMessage::OptimisticUser(_)) => {
-            return Some(MessageIdentity {
-                category: GroupCategory::User,
-                label: "You".to_string(),
-                badge_class: "user".to_string(),
-            });
+            return Some(source.map_or_else(
+                || MessageIdentity {
+                    category: GroupCategory::User,
+                    label: "You".to_string(),
+                    badge_class: "user".to_string(),
+                },
+                |source| source_identity(source, current_user_id),
+            ));
         }
         AgentFrame::Claude(ClaudeMessage::Portal(_)) => {
             return Some(MessageIdentity {
@@ -284,6 +293,10 @@ pub(super) fn classify(
             });
         }
         _ => {}
+    }
+
+    if let Some(source) = source {
+        return Some(source_identity(source, current_user_id));
     }
 
     None

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -422,6 +422,20 @@ mod tests {
         )
     }
 
+    fn tool_result_from_sender(tool_use_id: &str, user_id: Uuid, name: &str) -> RenderedMessage {
+        RenderedMessage::new(
+            read_tool_result_user_message(tool_use_id),
+            Some(shared::PortalMeta {
+                created_at: Some("2026-05-17T10:00:00.000Z".to_string()),
+                source: Some(shared::MessageSource::Human {
+                    account_id: user_id,
+                    name: name.to_string(),
+                }),
+                delivery: None,
+            }),
+        )
+    }
+
     fn codex_item_started_agent_message(text: &str) -> String {
         serde_json::json!({
             "type": "item.started",
@@ -469,6 +483,47 @@ mod tests {
     fn tool_result_user_envelope_stays_in_assistant_group() {
         let msg = read_tool_result_user_message("toolu_01");
         assert_eq!(classify_category(&msg), Some(GroupCategory::Assistant));
+    }
+
+    #[test]
+    fn tool_result_user_envelope_with_human_source_stays_in_assistant_group() {
+        let user_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let msg = tool_result_from_sender("toolu_01", user_id, "Matt");
+
+        assert_eq!(
+            classify(&msg, shared::AgentType::Claude, Some(&user_id.to_string()))
+                .map(|identity| identity.category),
+            Some(GroupCategory::Assistant)
+        );
+    }
+
+    #[test]
+    fn tool_result_user_envelope_with_human_source_renders_in_assistant_group() {
+        let user_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let messages = vec![
+            rendered(assistant_with_tool_use("toolu_01", "Read")),
+            tool_result_from_sender("toolu_01", user_id, "Matt"),
+        ];
+
+        let groups = group_messages(
+            &messages,
+            shared::AgentType::Claude,
+            Some(&user_id.to_string()),
+        );
+
+        assert_eq!(groups.len(), 1);
+        match &groups[0] {
+            MessageGroup::IdentityGroup {
+                category: GroupCategory::Assistant,
+                label,
+                messages,
+                ..
+            } => {
+                assert!(label.starts_with("Claude"));
+                assert_eq!(messages.len(), 2);
+            }
+            other => panic!("expected Assistant identity group, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- classify Claude user-shaped tool-result envelopes before applying Human PortalMeta source labels
- preserve Agent/Portal source short-circuiting and Human source labels for plain user text
- add regressions for tool-result envelopes with Human source metadata staying in the Assistant group
- bump workspace to 2.12.134

## Root Cause
After PortalMeta, tool-result rows can carry source=Human because their protocol role is user. The grouping classifier trusted source metadata before parsing the Claude frame, so Read/Bash/etc. tool_result envelopes could render under the user bubble path.

## Tests
- cargo test -p frontend tool_result_user_envelope --lib
- cargo check -p shared
- cargo clippy -p frontend --all-targets -- -D warnings