### PR TITLE
fix: outlier-robust y-axis for performance line charts (#1209 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.134"
+version = "2.12.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.134"
+version = "2.12.135"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.134"
+version = "2.12.135"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.134"
+version = "2.12.135"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.134"
+version = "2.12.135"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.134"
+version = "2.12.135"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.134"
+version = "2.12.135"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.134"
+version = "2.12.135"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.134"
+version = "2.12.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.134"
+version = "2.12.135"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.134"
+version = "2.12.135"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/charts/line_plot.rs
+++ b/frontend/src/components/charts/line_plot.rs
@@ -13,8 +13,8 @@ use chrono::{DateTime, Utc};
 use yew::prelude::*;
 
 use super::scale::{
-    series_points_with_axis, time_axis_ticks, y_axis_for_values, y_axis_tick_labels, AxisScale,
-    BucketKind,
+    series_points_with_axis, time_axis_ticks, y_axis_for_values_robust, y_axis_tick_labels,
+    AxisScale, BucketKind,
 };
 use super::{
     chart_empty, chart_frame, render_gridlines, render_legend, render_x_labels, PAD_L, PAD_T,
@@ -72,7 +72,7 @@ pub fn line_plot(props: &LinePlotProps) -> Html {
     if all_y.is_empty() {
         return chart_empty(&props.title);
     }
-    let y_axis = y_axis_for_values(&all_y, props.axis_scale);
+    let y_axis = y_axis_for_values_robust(&all_y, props.axis_scale);
 
     let x_ticks = time_axis_ticks(&props.buckets, props.bucket_kind, 6);
     let y_ticks = y_axis_tick_labels(&y_axis);

--- a/frontend/src/components/charts/scale.rs
+++ b/frontend/src/components/charts/scale.rs
@@ -111,9 +111,31 @@ pub fn nice_y_axis(min: f64, max: f64) -> (f64, f64, f64) {
 /// maps positive values by base-10 decades. That keeps sparse zero buckets
 /// visible without pretending that `log(0)` exists.
 pub fn y_axis_for_values(values: &[f64], scale: AxisScale) -> YAxis {
+    y_axis_impl(values, scale, false)
+}
+
+/// Like [`y_axis_for_values`], but the linear lower/upper bounds exclude
+/// *far-out* outliers (Tukey fence, k = 3) so a single absurd value can't blow
+/// the axis up and flatten every real series into a baseline line.
+///
+/// Used by the line charts, whose rate metrics (throughput tok/s, cost/token)
+/// can spike to garbage when a turn's denominator is near zero. The clipped
+/// outliers clamp to the axis edge in [`value_frac`], so they stay visible as a
+/// pegged point rather than dragging the whole scale. With no outliers (or
+/// fewer than 4 points) this is identical to [`y_axis_for_values`].
+pub fn y_axis_for_values_robust(values: &[f64], scale: AxisScale) -> YAxis {
+    y_axis_impl(values, scale, true)
+}
+
+fn y_axis_impl(values: &[f64], scale: AxisScale, robust: bool) -> YAxis {
     match scale {
         AxisScale::Linear => {
-            let (min_v, max_v) = finite_min_max(values).unwrap_or((0.0, 1.0));
+            let bounds = if robust {
+                robust_min_max(values)
+            } else {
+                finite_min_max(values)
+            };
+            let (min_v, max_v) = bounds.unwrap_or((0.0, 1.0));
             let (min, max, step) = nice_y_axis(min_v, max_v);
             YAxis::Linear { min, max, step }
         }
@@ -149,6 +171,53 @@ fn finite_min_max(values: &[f64]) -> Option<(f64, f64)> {
                 None => (v, v),
             })
         })
+}
+
+/// Linear-interpolated percentile of an ascending-sorted slice. `p` in `[0, 1]`.
+fn percentile_sorted(sorted: &[f64], p: f64) -> f64 {
+    match sorted {
+        [] => 0.0,
+        [only] => *only,
+        _ => {
+            let rank = p * (sorted.len() as f64 - 1.0);
+            let lo = rank.floor() as usize;
+            let hi = rank.ceil() as usize;
+            let frac = rank - lo as f64;
+            sorted[lo] + (sorted[hi] - sorted[lo]) * frac
+        }
+    }
+}
+
+/// `(min, max)` of `values` with *far-out* outliers excluded via a Tukey fence
+/// (k = 3 × IQR). This is the robustness behind [`y_axis_for_values_robust`].
+///
+/// Returns exactly the same `(min, max)` as [`finite_min_max`] when there are
+/// fewer than 4 finite values (IQR is unreliable), when the data has no spread
+/// (IQR == 0), or when nothing falls outside the fence. Only genuinely absurd
+/// points (e.g. a 1.5M tok/s throughput from a near-zero-duration turn next to
+/// real ~50 tok/s data) are dropped from the bound.
+fn robust_min_max(values: &[f64]) -> Option<(f64, f64)> {
+    let mut finite: Vec<f64> = values.iter().copied().filter(|v| v.is_finite()).collect();
+    if finite.len() < 4 {
+        return finite_min_max(values);
+    }
+    finite.sort_by(f64::total_cmp);
+    let q1 = percentile_sorted(&finite, 0.25);
+    let q3 = percentile_sorted(&finite, 0.75);
+    let iqr = q3 - q1;
+    if iqr <= 0.0 {
+        return finite_min_max(values);
+    }
+    let lo_fence = q1 - 3.0 * iqr;
+    let hi_fence = q3 + 3.0 * iqr;
+    // `finite` is sorted ascending: first within the lower fence is the robust
+    // min; last within the upper fence is the robust max.
+    let lo = finite.iter().copied().find(|v| *v >= lo_fence);
+    let hi = finite.iter().rev().copied().find(|v| *v <= hi_fence);
+    match (lo, hi) {
+        (Some(lo), Some(hi)) if hi >= lo => Some((lo, hi)),
+        _ => finite_min_max(values),
+    }
 }
 
 /// Round `raw` up to the nearest "nice" value (1, 2, or 5 times a power of ten).
@@ -564,6 +633,49 @@ mod tests {
     fn log_y_axis_without_positive_values_falls_back_to_linear() {
         let axis = y_axis_for_values(&[0.0, 0.0], AxisScale::Log);
         assert!(matches!(axis, YAxis::Linear { .. }));
+    }
+
+    #[test]
+    fn robust_axis_caps_at_bulk_and_ignores_far_out_outlier() {
+        // Real throughput ~40-55 tok/s with one garbage 1.5M spike (the bug in
+        // the screenshot). The exact-max axis would run to 1.5M and flatten
+        // every real point; the robust axis must hug the ~40-55 bulk.
+        let mut vals = vec![40.0, 45.0, 48.0, 50.0, 52.0, 55.0, 47.0, 49.0];
+        vals.push(1_500_000.0);
+        let YAxis::Linear { max, .. } = y_axis_for_values_robust(&vals, AxisScale::Linear) else {
+            panic!("expected linear axis");
+        };
+        assert!(
+            max < 100.0,
+            "robust axis max should hug the ~55 bulk, got {max}"
+        );
+        // The non-robust axis, by contrast, is dragged to the outlier.
+        let YAxis::Linear { max: raw_max, .. } = y_axis_for_values(&vals, AxisScale::Linear) else {
+            panic!("expected linear axis");
+        };
+        assert!(raw_max >= 1_500_000.0, "exact axis includes the outlier");
+    }
+
+    #[test]
+    fn robust_axis_no_outliers_matches_exact_bounds() {
+        // Without outliers, robust and exact axes must be identical (no
+        // surprise clipping of normal variation).
+        let vals = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0];
+        assert_eq!(
+            y_axis_for_values_robust(&vals, AxisScale::Linear),
+            y_axis_for_values(&vals, AxisScale::Linear),
+        );
+    }
+
+    #[test]
+    fn robust_axis_small_sample_keeps_exact_bounds() {
+        // Fewer than 4 points: IQR is unreliable, so fall back to exact bounds
+        // even if one value looks extreme.
+        let vals = [5.0, 7.0, 900.0];
+        assert_eq!(
+            y_axis_for_values_robust(&vals, AxisScale::Linear),
+            y_axis_for_values(&vals, AxisScale::Linear),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Symptom
The Settings → Performance **Throughput** chart renders every series as a flat line pinned to the baseline — the y-axis runs **0–1500k tok/s** while real throughput is ~40–55 tok/s.

![flat throughput chart](does-not-need-image)

## Root cause
A single garbage data point — a throughput of **~1.5M tok/s** (a near-zero-duration turn dividing tokens by ~0 ms) — drags the **exact-max** y-axis up to 1.5M, so all real data collapses into a sliver at the bottom. The charts auto-scale correctly to their data; the problem is the exact max isn't *robust* to outliers. (This is what made #1219's de-peaking look like it "shrank" the data — the smoothed bulk is tiny next to the raw outlier.)

## Fix
`components/charts/scale.rs` + `line_plot.rs` (frontend only):
- Add a **Tukey-fence robust min/max** (k = 3 × IQR — the classic "far out" threshold). It drops only genuinely absurd points; with no outliers / <4 points / no spread it returns the *exact* same bounds as before.
- `LinePlot` now uses `y_axis_for_values_robust` — its rate metrics (throughput, cost/token) are the ones prone to divide-by-tiny spikes. Outliers clamp to the axis edge in `value_frac` (already clamping), so a spike shows as a pegged point instead of flattening the scale.
- `StackedArea` (Stop-reason mix) keeps **exact** bounds — turn counts have no impossible outliers and a busy bucket is real data.

## Tests
`scale.rs`: outlier-cap (1.5M spike → axis hugs the ~55 bulk), no-outlier no-op (robust == exact), small-sample fallback. `cargo clippy -p frontend --all-targets` + all 26 scale tests green. v2.12.135.

Note: the upstream throughput metric producing ~1.5M tok/s is itself suspect (likely a near-zero-duration turn) — worth a separate backend look, but the chart should be robust regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)