### PR TITLE
feat: client-side send outbox for reliable web-client input delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.12.135"
+version = "2.12.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.12.135"
+version = "2.12.136"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.12.135"
+version = "2.12.136"
 dependencies = [
  "anyhow",
  "base64",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.12.135"
+version = "2.12.136"
 dependencies = [
  "anyhow",
  "base64",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.12.135"
+version = "2.12.136"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.12.135"
+version = "2.12.136"
 dependencies = [
  "base64",
  "chrono",
@@ -2613,7 +2613,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.12.135"
+version = "2.12.136"
 dependencies = [
  "anyhow",
  "colored",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.12.135"
+version = "2.12.136"
 dependencies = [
  "anyhow",
  "hex",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.12.135"
+version = "2.12.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.12.135"
+version = "2.12.136"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.12.135"
+version = "2.12.136"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -29,6 +29,7 @@ use super::helpers::{
     update_pending_send_delivery, ActivityTag,
 };
 use super::input_bar::{InputBar, InputBarInbound};
+use super::outbox::Outbox;
 use super::permission_handler::{
     build_permission_response, PermissionHandler, PermissionResponseKind,
 };
@@ -169,6 +170,9 @@ pub struct SessionView {
     messages: Vec<RenderedMessage>,
     ws_connected: bool,
     ws_sender: Option<WsSender>,
+    /// Unacked `AgentInput` frames, resent on reconnect so inputs typed while
+    /// the socket is down aren't silently dropped. See [`Outbox`].
+    outbox: Outbox,
     messages_ref: NodeRef,
     should_autoscroll: bool,
     #[allow(dead_code)]
@@ -272,6 +276,7 @@ impl Component for SessionView {
             messages: vec![],
             ws_connected: false,
             ws_sender: None,
+            outbox: Outbox::default(),
             messages_ref: NodeRef::default(),
             should_autoscroll: true,
             scroll_listener: None,
@@ -371,6 +376,10 @@ impl Component for SessionView {
                 self.ws_sender = Some(sender);
                 self.reconnect_attempt = 0;
                 self.reconnect_timer = None;
+                // Flush inputs typed while the socket was down. Only frames
+                // never handed to the transport are resent, so this can't
+                // duplicate anything the backend already received.
+                self.flush_outbox();
                 let session_id = ctx.props().session.id;
                 ctx.props().on_connected_change.emit((session_id, true));
                 true
@@ -421,13 +430,23 @@ impl Component for SessionView {
                 self.send_text_input(input, mode);
                 true
             }
-            SessionViewMsg::SendFrame(frame) => {
-                let (frame, changed) = self.prepare_outbound_frame(frame);
-                if let Some(ref sender) = self.ws_sender {
-                    send_message(sender, frame);
+            SessionViewMsg::SendFrame(frame) => match frame {
+                // User input goes through the outbox so it survives a
+                // reconnect; other frames (interrupts, permission responses)
+                // are transient and fire-and-forget.
+                ClientToServer::AgentInput {
+                    content, send_mode, ..
+                } => {
+                    self.dispatch_agent_input(content, send_mode);
+                    true
                 }
-                changed
-            }
+                other => {
+                    if let Some(ref sender) = self.ws_sender {
+                        send_message(sender, other);
+                    }
+                    false
+                }
+            },
             SessionViewMsg::MessageSent => {
                 let session_id = ctx.props().session.id;
                 ctx.props().on_message_sent.emit(session_id);
@@ -649,12 +668,23 @@ impl SessionView {
                 client_msg_id,
                 stage,
                 message,
-            } => update_pending_send_delivery(
-                &mut self.pending_sends,
-                client_msg_id,
-                stage,
-                message.as_deref(),
-            ),
+            } => {
+                // Terminal outcome — the backend has taken responsibility
+                // (accepted) or given up (failed); either way stop tracking it
+                // for resend so a later reconnect won't re-deliver.
+                if matches!(
+                    stage,
+                    shared::InputDeliveryStage::AgentAccepted | shared::InputDeliveryStage::Failed
+                ) {
+                    self.outbox.resolve(client_msg_id);
+                }
+                update_pending_send_delivery(
+                    &mut self.pending_sends,
+                    client_msg_id,
+                    stage,
+                    message.as_deref(),
+                )
+            }
             WsEvent::ContinuationStatus {
                 continuation_id,
                 status,
@@ -701,65 +731,71 @@ impl SessionView {
         ctx.link().send_message(SessionViewMsg::CheckAwaiting);
     }
 
-    /// Translate a plain-text submission from `InputBar` into the optimistic
-    /// local echo + the `ClientToServer::ClaudeInput` WS frame. The bar has
-    /// already trimmed and cleared its textarea, and already emitted
-    /// `MessageSent` (which we forward to `on_message_sent` separately);
-    /// we just package the wire frame and local echo.
+    /// Translate a plain-text submission from `InputBar` into an outbox-tracked
+    /// `AgentInput`. The bar has already trimmed and cleared its textarea and
+    /// emitted `MessageSent` separately; we just dispatch the input.
     fn send_text_input(&mut self, input: String, send_mode: SendMode) {
         if input.is_empty() {
             return;
         }
-        let now_iso = js_sys::Date::new_0()
-            .to_iso_string()
-            .as_string()
-            .unwrap_or_default();
-        let client_msg_id = Uuid::new_v4();
-        self.pending_sends
-            .push(optimistic_user_message(&input, &now_iso, client_msg_id));
+        let send_mode = (send_mode != SendMode::Normal).then_some(send_mode);
+        self.dispatch_agent_input(serde_json::Value::String(input), send_mode);
+    }
 
-        if let Some(ref sender) = self.ws_sender {
-            let msg = ClientToServer::AgentInput {
-                content: serde_json::Value::String(input),
-                send_mode: if send_mode == SendMode::Normal {
-                    None
-                } else {
-                    Some(send_mode)
-                },
-                client_msg_id: Some(client_msg_id),
-            };
-            send_message(sender, msg);
+    /// Optimistically echo an `AgentInput`, record it in the outbox (assigning a
+    /// fresh `client_msg_id`), and try to transmit. If the socket is down — or
+    /// the send fails — the entry stays queued and is flushed on the next
+    /// reconnect, so the input is never silently lost.
+    fn dispatch_agent_input(&mut self, content: serde_json::Value, send_mode: Option<SendMode>) {
+        let client_msg_id = Uuid::new_v4();
+        if let Some(text) = content.as_str() {
+            let now_iso = js_sys::Date::new_0()
+                .to_iso_string()
+                .as_string()
+                .unwrap_or_default();
+            self.pending_sends
+                .push(optimistic_user_message(text, &now_iso, client_msg_id));
+        }
+        let frame = ClientToServer::AgentInput {
+            content,
+            send_mode,
+            client_msg_id: Some(client_msg_id),
+        };
+        for dropped in self.outbox.record(client_msg_id, frame.clone()) {
+            // Evicted from a full outbox — surface as failed rather than leave
+            // it displaying as forever-pending.
+            update_pending_send_delivery(
+                &mut self.pending_sends,
+                dropped,
+                shared::InputDeliveryStage::Failed,
+                Some("send backlog full"),
+            );
+        }
+        self.transmit_input(client_msg_id, frame);
+    }
+
+    /// Hand a recorded frame to the transport, marking it transmitted on
+    /// success. A failure (no socket / closing channel) leaves it queued for
+    /// the reconnect flush.
+    fn transmit_input(&mut self, client_msg_id: Uuid, frame: ClientToServer) {
+        if let Some(sender) = self.ws_sender.clone() {
+            if send_message(&sender, frame) {
+                self.outbox.mark_transmitted(client_msg_id);
+            }
         }
     }
 
-    fn prepare_outbound_frame(&mut self, frame: ClientToServer) -> (ClientToServer, bool) {
-        match frame {
-            ClientToServer::AgentInput {
-                content,
-                send_mode,
-                client_msg_id: _,
-            } => {
-                let client_msg_id = Uuid::new_v4();
-                let mut changed = false;
-                if let Some(text) = content.as_str() {
-                    let now_iso = js_sys::Date::new_0()
-                        .to_iso_string()
-                        .as_string()
-                        .unwrap_or_default();
-                    self.pending_sends
-                        .push(optimistic_user_message(text, &now_iso, client_msg_id));
-                    changed = true;
-                }
-                (
-                    ClientToServer::AgentInput {
-                        content,
-                        send_mode,
-                        client_msg_id: Some(client_msg_id),
-                    },
-                    changed,
-                )
+    /// Resend every outbox frame not yet handed to the transport. Called on
+    /// reconnect. Dup-free: already-transmitted frames are skipped, so a frame
+    /// the backend already received is never sent twice.
+    fn flush_outbox(&mut self) {
+        let Some(sender) = self.ws_sender.clone() else {
+            return;
+        };
+        for (client_msg_id, frame) in self.outbox.untransmitted() {
+            if send_message(&sender, frame) {
+                self.outbox.mark_transmitted(client_msg_id);
             }
-            other => (other, false),
         }
     }
 

--- a/frontend/src/pages/dashboard/session_view/mod.rs
+++ b/frontend/src/pages/dashboard/session_view/mod.rs
@@ -16,6 +16,7 @@ mod component;
 pub(super) mod helpers;
 mod history;
 mod input_bar;
+mod outbox;
 mod permission_handler;
 mod state;
 mod tasks_panel;

--- a/frontend/src/pages/dashboard/session_view/outbox.rs
+++ b/frontend/src/pages/dashboard/session_view/outbox.rs
@@ -1,0 +1,165 @@
+//! Client-side send outbox for reliable web-client input delivery.
+//!
+//! `AgentInput` frames are sent fire-and-forget over the WebSocket. When the
+//! socket is down — `ws_sender` is cleared to `None` in `handle_ws_error`, and
+//! a send can also fail if the transport channel is closing — the frame is
+//! silently dropped: the optimistic echo renders but nothing reaches the
+//! backend and nothing ever resends it. That is the "messages deliver somewhat
+//! unreliably" bug.
+//!
+//! The outbox closes that hole:
+//! - Every `AgentInput` is recorded here, keyed by its `client_msg_id`, with a
+//!   `transmitted` flag: was the frame actually handed to the transport?
+//! - On reconnect the caller flushes only the **un-transmitted** frames.
+//!   Because those provably never reached the backend, resending them cannot
+//!   duplicate — so no backend dedupe is required.
+//! - An entry is removed once the backend resolves it: `AgentAccepted`
+//!   (delivered) or `Failed` (terminal).
+//! - The outbox is bounded; the oldest entry is evicted past the cap so a
+//!   perpetually-unacked backlog can't grow without limit.
+//!
+//! NOT covered here (would require backend idempotency keyed on
+//! `client_msg_id`, tracked as a follow-up): a frame handed to a socket that
+//! dies before it transmits. Such a frame is marked `transmitted` and
+//! deliberately not resent, keeping the outbox strictly dup-free.
+
+use shared::ClientToServer;
+use uuid::Uuid;
+
+/// Max entries retained before the oldest is evicted.
+pub(super) const MAX_OUTBOX_ENTRIES: usize = 50;
+
+struct OutboxEntry {
+    client_msg_id: Uuid,
+    frame: ClientToServer,
+    transmitted: bool,
+}
+
+/// FIFO of in-flight `AgentInput` frames awaiting backend confirmation.
+#[derive(Default)]
+pub(super) struct Outbox {
+    entries: Vec<OutboxEntry>,
+}
+
+impl Outbox {
+    /// Record a freshly-built input frame (not yet transmitted). Returns the
+    /// `client_msg_id`s of any entries evicted to stay within the cap, so the
+    /// caller can surface them as failed.
+    pub(super) fn record(&mut self, client_msg_id: Uuid, frame: ClientToServer) -> Vec<Uuid> {
+        self.entries.push(OutboxEntry {
+            client_msg_id,
+            frame,
+            transmitted: false,
+        });
+        let mut dropped = Vec::new();
+        while self.entries.len() > MAX_OUTBOX_ENTRIES {
+            dropped.push(self.entries.remove(0).client_msg_id);
+        }
+        dropped
+    }
+
+    /// Mark an entry as handed to the transport (a successful WS send).
+    pub(super) fn mark_transmitted(&mut self, client_msg_id: Uuid) {
+        if let Some(entry) = self
+            .entries
+            .iter_mut()
+            .find(|e| e.client_msg_id == client_msg_id)
+        {
+            entry.transmitted = true;
+        }
+    }
+
+    /// Remove an entry once its delivery is resolved (accepted or failed).
+    /// Returns whether an entry was actually present.
+    pub(super) fn resolve(&mut self, client_msg_id: Uuid) -> bool {
+        let before = self.entries.len();
+        self.entries.retain(|e| e.client_msg_id != client_msg_id);
+        self.entries.len() != before
+    }
+
+    /// `(client_msg_id, frame)` clones for every entry never handed to the
+    /// transport, in send order. The caller sends each and calls
+    /// [`mark_transmitted`](Self::mark_transmitted) on success — so a flush
+    /// that itself fails leaves the entry queued for the next reconnect.
+    pub(super) fn untransmitted(&self) -> Vec<(Uuid, ClientToServer)> {
+        self.entries
+            .iter()
+            .filter(|e| !e.transmitted)
+            .map(|e| (e.client_msg_id, e.frame.clone()))
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(tag: &str) -> ClientToServer {
+        ClientToServer::AgentInput {
+            content: serde_json::Value::String(tag.to_string()),
+            send_mode: None,
+            client_msg_id: None,
+        }
+    }
+
+    #[test]
+    fn untransmitted_lists_only_unsent_in_order() {
+        let mut ob = Outbox::default();
+        let a = Uuid::from_u128(1);
+        let b = Uuid::from_u128(2);
+        ob.record(a, input("a"));
+        ob.record(b, input("b"));
+        ob.mark_transmitted(a);
+
+        let pending: Vec<Uuid> = ob.untransmitted().into_iter().map(|(id, _)| id).collect();
+        assert_eq!(pending, vec![b], "only the un-transmitted frame flushes");
+    }
+
+    #[test]
+    fn flush_is_dup_free_after_marking_transmitted() {
+        // The reconnect flush must not re-send a frame it already sent — this
+        // is what keeps resends free of duplicates without backend dedupe.
+        let mut ob = Outbox::default();
+        let a = Uuid::from_u128(1);
+        ob.record(a, input("a"));
+
+        // First flush: send + mark.
+        for (id, _frame) in ob.untransmitted() {
+            ob.mark_transmitted(id);
+        }
+        // Second flush (e.g. a later reconnect) returns nothing.
+        assert!(
+            ob.untransmitted().is_empty(),
+            "a transmitted frame is never re-sent"
+        );
+    }
+
+    #[test]
+    fn resolve_removes_entry() {
+        let mut ob = Outbox::default();
+        let a = Uuid::from_u128(1);
+        ob.record(a, input("a"));
+        assert_eq!(ob.len(), 1);
+        assert!(ob.resolve(a), "known id resolves");
+        assert_eq!(ob.len(), 0);
+        assert!(!ob.resolve(a), "unknown id is a no-op");
+    }
+
+    #[test]
+    fn cap_evicts_oldest_and_reports_it() {
+        let mut ob = Outbox::default();
+        for i in 0..MAX_OUTBOX_ENTRIES {
+            let dropped = ob.record(Uuid::from_u128(i as u128), input("x"));
+            assert!(dropped.is_empty());
+        }
+        // One past the cap evicts the oldest (id 0).
+        let dropped = ob.record(Uuid::from_u128(999), input("overflow"));
+        assert_eq!(dropped, vec![Uuid::from_u128(0)]);
+        assert_eq!(ob.len(), MAX_OUTBOX_ENTRIES);
+    }
+}

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -228,17 +228,18 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
     }
 }
 
-/// Send a message over WebSocket.
+/// Send a message over WebSocket. Returns whether the frame was accepted.
 ///
 /// Pushes onto an unbounded mpsc queue drained by a single owner task — see
 /// the `connect_websocket` drain loop. This means concurrent callers (e.g.
 /// the file-upload chunk loop in `component.rs`) can never race each other
 /// into a "sink temporarily missing, drop the message" hole (closes #783).
-/// A failure here only means the WebSocket task already exited (e.g. the
-/// connection closed); the caller doesn't have anywhere useful to surface
-/// that, so we swallow it to match the prior non-erroring signature.
-pub fn send_message(sender: &WsSender, msg: ClientToServer) {
-    let _ = sender.unbounded_send(msg);
+/// A `false` return means the WebSocket task already exited (the connection is
+/// closing); the input outbox uses this to keep the frame queued for resend on
+/// reconnect instead of dropping it. Callers with nowhere to surface it can
+/// ignore the result.
+pub fn send_message(sender: &WsSender, msg: ClientToServer) -> bool {
+    sender.unbounded_send(msg).is_ok()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem
Messages typed into the frontend deliver unreliably. Root cause (traced with Matt): `send_text_input` only sends `if ws_sender.is_some()`, and `handle_ws_error` clears `ws_sender = None` on disconnect — so **anything typed during a reconnect window is silently dropped** (the optimistic echo renders with nothing behind it) and nothing ever resends it. Delivery was fire-and-forget with only one-way `InputDeliveryStage` progress feedback — no retry.

## Fix: a client-side outbox
New pure module `session_view/outbox.rs`, keyed by `client_msg_id`:
- Every `AgentInput` is recorded with a `transmitted` flag (was it handed to the transport?).
- On reconnect (`WebSocketConnected`), only the **un-transmitted** frames flush. Because those provably never reached the backend, resending them **cannot duplicate** — so no backend dedupe / protocol change is needed.
- An entry clears on the backend's terminal `AgentAccepted` / `Failed`.
- Bounded (50); oldest evicted past the cap and surfaced as failed rather than forever-pending.

`send_message` now returns whether the frame was accepted, so a send onto a closing channel keeps the frame queued instead of losing it. Both input paths (`SendText`, `SendFrame(AgentInput)`) funnel through one `dispatch_agent_input`.

## Dup-free by construction
The outbox only resends frames it never successfully handed to the transport. A frame handed to a socket that then dies before transmitting is marked transmitted and **deliberately not resent** — closing that rarer in-flight-loss case needs backend idempotency keyed on `client_msg_id`, which I've scoped as a **follow-up** (it's the web-client twin of the #939 reconnect-ack durability gap).

## Tests
`outbox.rs` unit tests: order-preserving flush, **dup-free re-flush** (a transmitted frame is never re-sent), resolve-removes-entry, cap-evicts-oldest. `cargo clippy -p frontend --all-targets`, `cargo fmt --check`, WASM build, all green. v2.12.136.

/cc @codex — requesting review/signoff per Matt before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)