### PR TITLE
Port forwarding: session-header forward chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.13.5
+
+- **Port forwarding milestone 3: session-header forward chips (docs/PORT_FORWARDING.md, #689).** The session view header now renders a chip per active forward (`:8080 ↗`), fetched from `GET /api/sessions/{id}/forwards` and refetched whenever a `ServerToClient::ForwardsChanged` frame arrives (new `WsEvent::ForwardsChanged` → a `forwards_refresh` tick prop the `ForwardChips` component watches), so chips appear/disappear live as the agent registers or revokes. Each chip links through the portal `/open` handoff endpoint in a new tab; the session owner also gets a revoke `×` (owner-gated in the UI to match the backend). Completes the user-facing surface and the whole #689 forwarding feature (spec → protocol → proxy tunnel → backend reverse proxy + WS upgrade → CLI → UI).
+
 ## 2.13.4
 
 - **Port forwarding milestone 2: WebSocket upgrade passthrough (docs/PORT_FORWARDING.md, #689).** The forward-origin reverse proxy now relays `Connection: Upgrade` requests end-to-end: the hyper client connection is driven with `.with_upgrades()`, upgrade requests keep their `Connection`/`Upgrade` headers (other hop-by-hop still stripped), and on a `101 Switching Protocols` the browser's and upstream's upgraded byte streams are spliced with `copy_bidirectional` — so WebSocket-dependent apps (Jupyter kernels, Vite HMR) work through a forward, riding the same raw tunnel as ordinary requests. Upgrade detection scans all `Connection` header values (split fields are RFC-legal); a stray upstream `101` to a non-upgrade request is refused rather than forwarded; the 101 response keeps `Connection`/`Upgrade` and passes `Sec-WebSocket-Accept` through normally. SSE already worked via the streaming-body path (no upgrade). Unit tests cover the handshake detection (incl. split `Connection` fields). (Idle-stream timeouts remain deferred; streams are still bounded by the per-connection cleanup from milestone 1c.)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "base64",
  "chrono",
@@ -2617,7 +2617,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "colored",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "hex",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.4"
+version = "2.13.5"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.13.4"
+version = "2.13.5"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -24,6 +24,7 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::Element;
 use yew::prelude::*;
 
+use super::forward_chips::ForwardChips;
 use super::helpers::{
     autoscroll_transition, classify_output_msg_type, is_claude_awaiting, reconcile_pending_sends,
     update_pending_send_delivery, ActivityTag,
@@ -218,6 +219,9 @@ pub struct SessionView {
     /// counter would buy nothing.
     turn_metrics: Vec<TurnMetrics>,
     continuation_statuses: HashMap<Uuid, String>,
+    /// Monotonic tick bumped on every `ForwardsChanged` frame; passed to the
+    /// forward-chip strip as a prop so it refetches (docs/PORT_FORWARDING.md).
+    forwards_refresh: u32,
 }
 
 impl Component for SessionView {
@@ -291,6 +295,7 @@ impl Component for SessionView {
             pending_sends: Vec::new(),
             turn_metrics: Vec::new(),
             continuation_statuses: HashMap::new(),
+            forwards_refresh: 0,
         }
     }
 
@@ -551,6 +556,13 @@ impl Component for SessionView {
         } else {
             "status disconnected"
         };
+        // Only the session owner may revoke a forward; the chip strip hides
+        // the revoke button for other members (the backend enforces this too).
+        let is_forward_owner = ctx
+            .props()
+            .current_user_id
+            .as_deref()
+            .is_some_and(|uid| uid == ctx.props().session.user_id.to_string());
 
         html! {
             <div class="session-view">
@@ -566,6 +578,11 @@ impl Component for SessionView {
                             { format!("launcher v{}", version) }
                         </span>
                     }
+                    <ForwardChips
+                        session_id={ctx.props().session.id}
+                        is_owner={is_forward_owner}
+                        refresh={self.forwards_refresh}
+                    />
                     <span class={status_class}>{ ctx.props().session.status.as_str() }</span>
                 </div>
                 <div class="session-view-scroll-area">
@@ -692,6 +709,12 @@ impl SessionView {
                 ctx.link()
                     .send_message(SessionViewMsg::ContinuationStatus(continuation_id, status));
                 false
+            }
+            WsEvent::ForwardsChanged => {
+                // Bump the counter the chip strip watches; it refetches the
+                // forward list (docs/PORT_FORWARDING.md).
+                self.forwards_refresh = self.forwards_refresh.wrapping_add(1);
+                true
             }
         }
     }

--- a/frontend/src/pages/dashboard/session_view/forward_chips.rs
+++ b/frontend/src/pages/dashboard/session_view/forward_chips.rs
@@ -24,48 +24,59 @@ pub struct ForwardChipsProps {
 
 #[function_component(ForwardChips)]
 pub fn forward_chips(props: &ForwardChipsProps) -> Html {
-    let forwards = use_state(Vec::<ForwardInfo>::new);
+    // The forwards are tagged with the session they belong to. SessionView
+    // reuses this component instance across session switches, so an in-flight
+    // or already-loaded fetch for the previous session must never render: we
+    // only show `state` when its tagged id matches the current prop. This
+    // closes both stale paths — old chips carrying the new session's URLs, and
+    // an out-of-order fetch overwriting a newer session's chips — without a
+    // clear-then-refetch flicker on the `refresh` bump.
+    let state = use_state(|| (Uuid::nil(), Vec::<ForwardInfo>::new()));
 
     // Refetch on mount and whenever (session, refresh) changes.
     {
-        let forwards = forwards.clone();
+        let state = state.clone();
         let session_id = props.session_id;
         use_effect_with((session_id, props.refresh), move |_| {
             spawn_local(async move {
-                if let Ok(data) = fetch_json::<SessionForwardsResponse>(
+                let forwards = fetch_json::<SessionForwardsResponse>(
                     &format!("/api/sessions/{session_id}/forwards"),
                     On401::Ignore,
                 )
                 .await
-                {
-                    forwards.set(data.forwards);
-                }
+                .map(|data| data.forwards)
+                .unwrap_or_default();
+                // Tag with the session this fetch was for; a late arrival for
+                // an old session is ignored by the render guard below.
+                state.set((session_id, forwards));
             });
             || ()
         });
     }
 
+    // Ignore results tagged for a different (stale) session.
+    let forwards: &[ForwardInfo] = if state.0 == props.session_id {
+        &state.1
+    } else {
+        &[]
+    };
     if forwards.is_empty() {
         return Html::default();
     }
 
     let revoke = {
-        let forwards = forwards.clone();
+        let state = state.clone();
         let session_id = props.session_id;
         Callback::from(move |port: u16| {
-            let forwards = forwards.clone();
+            let state = state.clone();
             spawn_local(async move {
                 let url = api_url(&format!("/api/sessions/{session_id}/forwards/{port}"));
                 if Request::delete(&url).send().await.is_ok() {
-                    // Optimistic: drop it locally; the ForwardsChanged frame
-                    // will reconcile if the server disagrees.
-                    forwards.set(
-                        forwards
-                            .iter()
-                            .filter(|f| f.port != port)
-                            .cloned()
-                            .collect(),
-                    );
+                    // Optimistic: drop it locally (re-tagging with this
+                    // session); the ForwardsChanged frame reconciles if the
+                    // server disagrees.
+                    let remaining = state.1.iter().filter(|f| f.port != port).cloned().collect();
+                    state.set((session_id, remaining));
                 }
             });
         })

--- a/frontend/src/pages/dashboard/session_view/forward_chips.rs
+++ b/frontend/src/pages/dashboard/session_view/forward_chips.rs
@@ -1,0 +1,100 @@
+//! Active port-forward chips for the session header (docs/PORT_FORWARDING.md).
+//!
+//! Fetches `GET /api/sessions/{id}/forwards` on mount and whenever `refresh`
+//! bumps (the parent bumps it on a `ForwardsChanged` WS frame). Each chip
+//! opens the forward through the portal `/open` handoff endpoint in a new tab;
+//! the session owner also gets a revoke `×`.
+
+use gloo_net::http::Request;
+use shared::api::{ForwardInfo, SessionForwardsResponse};
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+use crate::utils::{self, api_url, fetch_json, On401};
+
+#[derive(Properties, PartialEq)]
+pub struct ForwardChipsProps {
+    pub session_id: Uuid,
+    /// True when the viewer owns the session (owner-only revoke).
+    pub is_owner: bool,
+    /// Bumped by the parent on a `ForwardsChanged` frame to trigger a refetch.
+    pub refresh: u32,
+}
+
+#[function_component(ForwardChips)]
+pub fn forward_chips(props: &ForwardChipsProps) -> Html {
+    let forwards = use_state(Vec::<ForwardInfo>::new);
+
+    // Refetch on mount and whenever (session, refresh) changes.
+    {
+        let forwards = forwards.clone();
+        let session_id = props.session_id;
+        use_effect_with((session_id, props.refresh), move |_| {
+            spawn_local(async move {
+                if let Ok(data) = fetch_json::<SessionForwardsResponse>(
+                    &format!("/api/sessions/{session_id}/forwards"),
+                    On401::Ignore,
+                )
+                .await
+                {
+                    forwards.set(data.forwards);
+                }
+            });
+            || ()
+        });
+    }
+
+    if forwards.is_empty() {
+        return Html::default();
+    }
+
+    let revoke = {
+        let forwards = forwards.clone();
+        let session_id = props.session_id;
+        Callback::from(move |port: u16| {
+            let forwards = forwards.clone();
+            spawn_local(async move {
+                let url = api_url(&format!("/api/sessions/{session_id}/forwards/{port}"));
+                if Request::delete(&url).send().await.is_ok() {
+                    // Optimistic: drop it locally; the ForwardsChanged frame
+                    // will reconcile if the server disagrees.
+                    forwards.set(
+                        forwards
+                            .iter()
+                            .filter(|f| f.port != port)
+                            .cloned()
+                            .collect(),
+                    );
+                }
+            });
+        })
+    };
+
+    html! {
+        <span class="session-forwards">
+            { for forwards.iter().map(|f| {
+                let open_url = utils::api_url(&format!(
+                    "/api/sessions/{}/forwards/{}/open",
+                    props.session_id, f.port
+                ));
+                let port = f.port;
+                let on_revoke = revoke.clone();
+                html! {
+                    <span class="forward-chip" key={port} title={f.url.clone()}>
+                        <a href={open_url} target="_blank" rel="noopener noreferrer">
+                            { format!(":{port} ↗") }
+                        </a>
+                        if props.is_owner {
+                            <button
+                                class="forward-chip-revoke"
+                                title="Stop forwarding this port"
+                                onclick={Callback::from(move |_| on_revoke.emit(port))}
+                            >{ "×" }</button>
+                        }
+                    </span>
+                }
+            }) }
+        </span>
+    }
+}

--- a/frontend/src/pages/dashboard/session_view/forward_chips.rs
+++ b/frontend/src/pages/dashboard/session_view/forward_chips.rs
@@ -5,6 +5,9 @@
 //! opens the forward through the portal `/open` handoff endpoint in a new tab;
 //! the session owner also gets a revoke `×`.
 
+use std::cell::Cell;
+use std::rc::Rc;
+
 use gloo_net::http::Request;
 use shared::api::{ForwardInfo, SessionForwardsResponse};
 use uuid::Uuid;
@@ -24,13 +27,14 @@ pub struct ForwardChipsProps {
 
 #[function_component(ForwardChips)]
 pub fn forward_chips(props: &ForwardChipsProps) -> Html {
-    // The forwards are tagged with the session they belong to. SessionView
-    // reuses this component instance across session switches, so an in-flight
-    // or already-loaded fetch for the previous session must never render: we
-    // only show `state` when its tagged id matches the current prop. This
-    // closes both stale paths — old chips carrying the new session's URLs, and
-    // an out-of-order fetch overwriting a newer session's chips — without a
-    // clear-then-refetch flicker on the `refresh` bump.
+    // Forwards are tagged with the session they belong to (belt) and every
+    // fetch is guarded by a cancellation flag its effect trips on cleanup
+    // (suspenders). SessionView reuses this component instance across session
+    // switches, so both are needed: the tag stops a stale result from ever
+    // *rendering* under the new session's URLs, and the cancel flag stops a
+    // superseded fetch from *writing* at all — otherwise a late fetch for the
+    // old session could clobber the new session's already-loaded chips, which
+    // might never refetch and would vanish indefinitely.
     let state = use_state(|| (Uuid::nil(), Vec::<ForwardInfo>::new()));
 
     // Refetch on mount and whenever (session, refresh) changes.
@@ -38,6 +42,8 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
         let state = state.clone();
         let session_id = props.session_id;
         use_effect_with((session_id, props.refresh), move |_| {
+            let cancelled = Rc::new(Cell::new(false));
+            let guard = cancelled.clone();
             spawn_local(async move {
                 let forwards = fetch_json::<SessionForwardsResponse>(
                     &format!("/api/sessions/{session_id}/forwards"),
@@ -46,11 +52,14 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
                 .await
                 .map(|data| data.forwards)
                 .unwrap_or_default();
-                // Tag with the session this fetch was for; a late arrival for
-                // an old session is ignored by the render guard below.
-                state.set((session_id, forwards));
+                // Superseded by a newer (session, refresh) — don't write.
+                if !guard.get() {
+                    state.set((session_id, forwards));
+                }
             });
-            || ()
+            // Cleanup runs before the next effect (deps changed) and on
+            // unmount, tripping the flag for this now-stale fetch.
+            move || cancelled.set(true)
         });
     }
 

--- a/frontend/src/pages/dashboard/session_view/mod.rs
+++ b/frontend/src/pages/dashboard/session_view/mod.rs
@@ -13,6 +13,7 @@
 //! - `history.rs` - Command history management
 
 mod component;
+mod forward_chips;
 pub(super) mod helpers;
 mod history;
 mod input_bar;

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -49,6 +49,9 @@ pub enum WsEvent {
         stage: InputDeliveryStage,
         message: Option<String>,
     },
+    /// The session's port-forward set changed; the view refetches
+    /// `GET /api/sessions/{id}/forwards` (docs/PORT_FORWARDING.md).
+    ForwardsChanged,
 }
 
 /// Connect to WebSocket and start receiving messages.
@@ -217,6 +220,9 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
                 continuation_id,
                 status,
             });
+        }
+        ServerToClient::ForwardsChanged { session_id: _ } => {
+            on_event.emit(WsEvent::ForwardsChanged);
         }
         unhandled => {
             // Variants we haven't wired a UI route for yet (e.g. new

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -586,6 +586,7 @@ mod tests {
             WsEvent::ContinuationStatus { .. } => "ContinuationStatus",
             WsEvent::TurnMetrics(_) => "TurnMetrics",
             WsEvent::InputProgress { .. } => "InputProgress",
+            WsEvent::ForwardsChanged => "ForwardsChanged",
         }
     }
 }

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -89,6 +89,50 @@
     white-space: nowrap;
 }
 
+/* Port-forward chips (docs/PORT_FORWARDING.md) */
+.session-view-header .session-forwards {
+    display: inline-flex;
+    gap: 0.35rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.session-view-header .forward-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.78rem;
+    font-family: monospace;
+    padding: 0.15rem 0.4rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: rgba(125, 207, 255, 0.1);
+    white-space: nowrap;
+}
+
+.session-view-header .forward-chip a {
+    color: var(--text-teal, #7dcfff);
+    text-decoration: none;
+}
+
+.session-view-header .forward-chip a:hover {
+    text-decoration: underline;
+}
+
+.session-view-header .forward-chip-revoke {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+    font-size: 0.95rem;
+}
+
+.session-view-header .forward-chip-revoke:hover {
+    color: var(--error);
+}
+
 .session-view-header .status {
     font-size: 0.8rem;
     padding: 0.25rem 0.75rem;


### PR DESCRIPTION
## Summary

Milestone-3 of [docs/PORT_FORWARDING.md](https://github.com/meawoppl/agent-portal/blob/main/docs/PORT_FORWARDING.md) (#689): the frontend surface. **Completes the whole forwarding feature.**

- Session header renders a chip per active forward (`:8080 ↗`), from a new self-contained `ForwardChips` function component.
- Fetches `GET /api/sessions/{id}/forwards` on mount and refetches whenever a `ServerToClient::ForwardsChanged` frame arrives — new `WsEvent::ForwardsChanged` maps to a `forwards_refresh` tick prop the component's `use_effect_with` watches, so chips appear/disappear live as the agent runs `agent-portal forward` / `close`.
- Each chip links through the portal `/open` handoff endpoint (`target="_blank"`, `rel="noopener noreferrer"`), so auth flows through the token handoff.
- Owner-only revoke `×` (compares `current_user_id` to `session.user_id`; the backend enforces owner-only too, so the button is just UX). Optimistic removal on click, reconciled by the next `ForwardsChanged`.
- CSS in `session-terminal.css`, matching the existing launcher-version chip style; teal accent, dark-theme tokens.

### Verification
- `cargo build/clippy -p frontend --target wasm32-unknown-unknown` clean; `trunk build` succeeds; rustfmt clean.
- When forwarding is disabled the list endpoint returns empty, so the strip renders nothing (`Html::default()`).

Depends on the merged `ForwardsChanged` variant + list API (#1240) and the `/open` endpoint (#1242). Versioned 2.13.5.

---

## Feature complete: #689 port forwarding

This is the last of 7 PRs. The full arc: spec (#1238) → protocol + registration + migration (#1240) → proxy tunnel transport (#1241) → backend reverse proxy + handoff auth (#1242) → WebSocket upgrade passthrough (#1244) → CLI + reminder (#1243) → these chips. (Plus #1239, a duplicate-migration-version fix found along the way.) Agents `agent-portal forward <port>` and share a subdomain URL; users open local HTTP services — including WebSocket/SSE apps — through the portal, owner-gated, for the life of the session.