### PR TITLE
Port forwarding: inline preview overlay with portal-scoped framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.13.15
+
+- **Port forwarding: inline preview overlay (docs/PORT_FORWARDING.md, #689).** Clicking the session-header forward chip now opens a collapsible overlay that renders the forwarded app in an `<iframe>` (via the `/open` handoff, so auth rides the normal `portal_fwd` cookie flow), with a **Visit site ↗** link to the full page in a new tab, a collapse toggle that hides the frame *without unmounting it* (the embedded app keeps running), and a close `×`. The overlay closes on session switch and disappears with the forward. To make embedding work, the reverse proxy now **re-scopes upstream framing policy**: `X-Frame-Options` and any upstream `frame-ancestors` CSP directive are stripped (all other CSP directives pass through untouched; directive names parsed per CSP whitespace incl. HTAB) and `Content-Security-Policy: frame-ancestors 'self' {portal origin}` is appended — apps like Jupyter ship `frame-ancestors 'self'` which would otherwise block the overlay, while apps that shipped no policy get *narrowed* from any-site-may-frame to portal-or-self. Unit tests cover the CSP directive stripping (only-frame-ancestors → header dropped; mixed policies preserved; HTAB whitespace; lookalike directive names untouched). Dev caveat: on `*.localhost` domains browsers treat the forward origin as cross-site so the iframe's `SameSite=Lax` cookie isn't sent — private-forward previews need production (same eTLD+1) domains; public forwards preview anywhere.
+
 ## 2.13.14
 
 - **Limit continuations: wait two minutes after the reset time.** The continuation scheduler now uses a two-minute post-reset grace period before injecting or relaunching a session, and the continuation card copy reflects that timing. This gives the upstream limit window a wider margin before automatic resume.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,11 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
+<<<<<<< HEAD
 version = "2.13.14"
+=======
+version = "2.13.11"
+>>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +223,11 @@ dependencies = [
 
 [[package]]
 name = "backend"
+<<<<<<< HEAD
 version = "2.13.14"
+=======
+version = "2.13.11"
+>>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
 dependencies = [
  "anyhow",
  "axum",
@@ -491,7 +499,11 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
+<<<<<<< HEAD
 version = "2.13.14"
+=======
+version = "2.13.11"
+>>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +534,11 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
+<<<<<<< HEAD
 version = "2.13.14"
+=======
+version = "2.13.11"
+>>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
 dependencies = [
  "anyhow",
  "base64",
@@ -560,7 +576,11 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
+<<<<<<< HEAD
 version = "2.13.14"
+=======
+version = "2.13.11"
+>>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1100,7 +1120,11 @@ dependencies = [
 
 [[package]]
 name = "frontend"
+<<<<<<< HEAD
 version = "2.13.14"
+=======
+version = "2.13.11"
+>>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
 dependencies = [
  "base64",
  "chrono",
@@ -2617,7 +2641,11 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
+<<<<<<< HEAD
 version = "2.13.14"
+=======
+version = "2.13.11"
+>>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
 dependencies = [
  "anyhow",
  "colored",
@@ -2632,7 +2660,11 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
+<<<<<<< HEAD
 version = "2.13.14"
+=======
+version = "2.13.11"
+>>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
 dependencies = [
  "anyhow",
  "hex",
@@ -3295,7 +3327,11 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
+<<<<<<< HEAD
 version = "2.13.14"
+=======
+version = "2.13.11"
+>>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
 dependencies = [
  "anyhow",
  "base64",
@@ -3360,7 +3396,11 @@ dependencies = [
 
 [[package]]
 name = "shared"
+<<<<<<< HEAD
 version = "2.13.14"
+=======
+version = "2.13.11"
+>>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,11 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-<<<<<<< HEAD
-version = "2.13.14"
-=======
-version = "2.13.11"
->>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
+version = "2.13.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -223,11 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-<<<<<<< HEAD
-version = "2.13.14"
-=======
-version = "2.13.11"
->>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
+version = "2.13.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -499,11 +491,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-<<<<<<< HEAD
-version = "2.13.14"
-=======
-version = "2.13.11"
->>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
+version = "2.13.15"
 dependencies = [
  "anyhow",
  "base64",
@@ -534,11 +522,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-<<<<<<< HEAD
-version = "2.13.14"
-=======
-version = "2.13.11"
->>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
+version = "2.13.15"
 dependencies = [
  "anyhow",
  "base64",
@@ -576,11 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-<<<<<<< HEAD
-version = "2.13.14"
-=======
-version = "2.13.11"
->>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
+version = "2.13.15"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1120,11 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-<<<<<<< HEAD
-version = "2.13.14"
-=======
-version = "2.13.11"
->>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
+version = "2.13.15"
 dependencies = [
  "base64",
  "chrono",
@@ -2641,11 +2617,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-<<<<<<< HEAD
-version = "2.13.14"
-=======
-version = "2.13.11"
->>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
+version = "2.13.15"
 dependencies = [
  "anyhow",
  "colored",
@@ -2660,11 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-<<<<<<< HEAD
-version = "2.13.14"
-=======
-version = "2.13.11"
->>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
+version = "2.13.15"
 dependencies = [
  "anyhow",
  "hex",
@@ -3327,11 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-<<<<<<< HEAD
-version = "2.13.14"
-=======
-version = "2.13.11"
->>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
+version = "2.13.15"
 dependencies = [
  "anyhow",
  "base64",
@@ -3396,11 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-<<<<<<< HEAD
-version = "2.13.14"
-=======
-version = "2.13.11"
->>>>>>> ceb4c97 (Add inline forward preview overlay with portal-scoped framing)
+version = "2.13.15"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.13.14"
+version = "2.13.15"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/forward_proxy.rs
+++ b/backend/src/handlers/forward_proxy.rs
@@ -704,15 +704,17 @@ fn build_downstream_response(
 }
 
 /// Remove any `frame-ancestors` directive from a CSP header value, keeping
-/// every other directive intact. `None` when nothing remains.
+/// every other directive intact. `None` when nothing remains. The directive
+/// name is the first whitespace-separated token (CSP whitespace includes
+/// HTAB, not just space), compared case-insensitively.
 pub fn strip_frame_ancestors(csp: &str) -> Option<String> {
     let kept: Vec<&str> = csp
         .split(';')
         .map(str::trim)
         .filter(|d| !d.is_empty())
         .filter(|d| {
-            let dl = d.to_ascii_lowercase();
-            !(dl == "frame-ancestors" || dl.starts_with("frame-ancestors "))
+            let name = d.split_ascii_whitespace().next().unwrap_or("");
+            !name.eq_ignore_ascii_case("frame-ancestors")
         })
         .collect();
     if kept.is_empty() {
@@ -809,6 +811,8 @@ mod tests {
         // Jupyter-style: only frame-ancestors → drop the whole header.
         assert_eq!(strip_frame_ancestors("frame-ancestors 'self'"), None);
         assert_eq!(strip_frame_ancestors("FRAME-ANCESTORS 'none'"), None);
+        // CSP whitespace includes HTAB (codex review nit on #1251).
+        assert_eq!(strip_frame_ancestors("frame-ancestors\t'none'"), None);
         // Mixed policy: everything else survives verbatim.
         assert_eq!(
             strip_frame_ancestors("default-src 'self'; frame-ancestors 'none'; img-src data:")

--- a/backend/src/handlers/forward_proxy.rs
+++ b/backend/src/handlers/forward_proxy.rs
@@ -651,6 +651,27 @@ fn build_downstream_response(
         if HOP_BY_HOP.contains(&lower) && !keep_for_upgrade {
             continue;
         }
+        // Framing policy is rewritten below: drop the upstream's
+        // X-Frame-Options and any `frame-ancestors` CSP directive (the rest
+        // of its CSP passes through). Multiple CSP headers intersect
+        // (most-restrictive wins), so appending ours without stripping the
+        // upstream's could never *allow* the portal to embed.
+        if lower == "x-frame-options" {
+            continue;
+        }
+        if lower == "content-security-policy" {
+            if let Ok(csp) = value.to_str() {
+                match strip_frame_ancestors(csp) {
+                    Some(rest) => {
+                        if let Ok(v) = HeaderValue::from_str(&rest) {
+                            headers.append(name.clone(), v);
+                        }
+                    }
+                    None => {} // policy was only frame-ancestors — drop it
+                }
+                continue;
+            }
+        }
         if (lower == "location" || lower == "content-location") && origin.is_some() {
             if let Ok(loc) = value.to_str() {
                 let rewritten = rewrite_upstream_location(loc, port, origin.as_deref().unwrap());
@@ -663,9 +684,41 @@ fn build_downstream_response(
         headers.append(name.clone(), value.clone());
     }
 
+    // Allow the portal (and the forward origin itself) to embed the response —
+    // the session-view preview overlay renders forwards in an iframe
+    // (docs/PORT_FORWARDING.md). This *narrows* framing for apps that shipped
+    // no policy (previously any site could frame them) and re-scopes apps
+    // that shipped `frame-ancestors 'self'`/`X-Frame-Options` (e.g. Jupyter)
+    // to portal-or-self instead of blocking the overlay.
+    if !is_upgrade {
+        let portal_origin = app_state.public_url.trim_end_matches('/');
+        if let Ok(v) = HeaderValue::from_str(&format!("frame-ancestors 'self' {portal_origin}")) {
+            headers.append(header::CONTENT_SECURITY_POLICY, v);
+        }
+    }
+
     match response.body(Body::new(body)) {
         Ok(r) => r,
         Err(_) => plain_status(StatusCode::BAD_GATEWAY, "bad upstream response"),
+    }
+}
+
+/// Remove any `frame-ancestors` directive from a CSP header value, keeping
+/// every other directive intact. `None` when nothing remains.
+pub fn strip_frame_ancestors(csp: &str) -> Option<String> {
+    let kept: Vec<&str> = csp
+        .split(';')
+        .map(str::trim)
+        .filter(|d| !d.is_empty())
+        .filter(|d| {
+            let dl = d.to_ascii_lowercase();
+            !(dl == "frame-ancestors" || dl.starts_with("frame-ancestors "))
+        })
+        .collect();
+    if kept.is_empty() {
+        None
+    } else {
+        Some(kept.join("; "))
     }
 }
 
@@ -749,6 +802,29 @@ mod tests {
                 "reserved label {label} should fall through"
             );
         }
+    }
+
+    #[test]
+    fn strip_frame_ancestors_preserves_other_directives() {
+        // Jupyter-style: only frame-ancestors → drop the whole header.
+        assert_eq!(strip_frame_ancestors("frame-ancestors 'self'"), None);
+        assert_eq!(strip_frame_ancestors("FRAME-ANCESTORS 'none'"), None);
+        // Mixed policy: everything else survives verbatim.
+        assert_eq!(
+            strip_frame_ancestors("default-src 'self'; frame-ancestors 'none'; img-src data:")
+                .as_deref(),
+            Some("default-src 'self'; img-src data:")
+        );
+        // No frame-ancestors: unchanged (modulo whitespace normalization).
+        assert_eq!(
+            strip_frame_ancestors("default-src 'self'").as_deref(),
+            Some("default-src 'self'")
+        );
+        // A directive that merely starts with the same bytes is not stripped.
+        assert_eq!(
+            strip_frame_ancestors("frame-ancestors-custom 'x'").as_deref(),
+            Some("frame-ancestors-custom 'x'")
+        );
     }
 
     #[test]

--- a/backend/src/handlers/forward_proxy.rs
+++ b/backend/src/handlers/forward_proxy.rs
@@ -661,13 +661,11 @@ fn build_downstream_response(
         }
         if lower == "content-security-policy" {
             if let Ok(csp) = value.to_str() {
-                match strip_frame_ancestors(csp) {
-                    Some(rest) => {
-                        if let Ok(v) = HeaderValue::from_str(&rest) {
-                            headers.append(name.clone(), v);
-                        }
+                // `None` = the policy was only frame-ancestors — drop it.
+                if let Some(rest) = strip_frame_ancestors(csp) {
+                    if let Ok(v) = HeaderValue::from_str(&rest) {
+                        headers.append(name.clone(), v);
                     }
-                    None => {} // policy was only frame-ancestors — drop it
                 }
                 continue;
             }

--- a/docs/PORT_FORWARDING.md
+++ b/docs/PORT_FORWARDING.md
@@ -327,6 +327,15 @@ Response rewriting is limited to headers:
   `localhost:{port}`, `127.0.0.1:{port}`, or `[::1]:{port}` back to the
   forward origin — apps that saw `Host: localhost:{port}` emit absolute
   redirects there, which would otherwise send the browser off-origin.
+- **Framing policy is re-scoped to the portal.** The upstream's
+  `X-Frame-Options` and any `frame-ancestors` CSP directive are stripped
+  (every other CSP directive passes through), and the proxy appends
+  `Content-Security-Policy: frame-ancestors 'self' {portal origin}` — the
+  session view's preview overlay embeds forwards in an iframe, and apps like
+  Jupyter ship `frame-ancestors 'self'` which would block it. This *narrows*
+  policy for apps that shipped none (previously any site could frame them),
+  and stripping-then-replacing is required because multiple CSP headers
+  intersect (appending alone can never loosen an upstream `'none'`).
 - `Set-Cookie` passes through untouched; a `Domain=localhost` attribute is
   the app's own (mis)behavior and scoping it is not our job.
 
@@ -364,10 +373,20 @@ No HTML/URL body rewriting, ever — origin isolation makes it unnecessary.
 ## Frontend
 
 - Session view renders a chip for the session's forward (`:8080 ↗`), sourced
-  from `GET /api/sessions/{id}/forwards`; click opens the `open` endpoint in a
-  new tab; owners get a revoke `×`. A
+  from `GET /api/sessions/{id}/forwards`; owners get a revoke `×`. A
   `ServerToClient::ForwardsChanged { session_id }` event triggers a refetch so
   the chip appears/updates the moment the agent registers or re-points.
+- **Clicking the chip opens an inline preview overlay**: a fixed collapsible
+  panel containing an `<iframe>` pointed at the `open` handoff endpoint, with
+  a "Visit site ↗" link that opens the full page in a new tab and a collapse
+  toggle that hides the frame without unmounting it (the embedded app keeps
+  running). Auth inside the iframe rides the normal handoff → `portal_fwd`
+  cookie flow; that cookie is `SameSite=Lax`, which is sent because the
+  forward origin and the portal are same-*site* (same eTLD+1) in production.
+  On `*.localhost` dev domains browsers treat the two as cross-site, so the
+  overlay's iframe can't authenticate there — public forwards still preview,
+  private ones need "Visit site". The reverse proxy re-scopes upstream
+  framing policy so the portal may embed (see Response rewriting).
 - **Settings ▸ Forwarding** lists the caller's active forwards across their
   sessions (`GET /api/forwards`, owner-scoped) with a per-forward public/private
   toggle (`PATCH …/forwards/public`), so the owner can opt a forward into

--- a/frontend/src/pages/dashboard/session_view/forward_chips.rs
+++ b/frontend/src/pages/dashboard/session_view/forward_chips.rs
@@ -63,6 +63,19 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
         });
     }
 
+    // Preview overlay: open/collapsed are independent so collapsing keeps the
+    // iframe mounted (the embedded app keeps running; expand restores it
+    // where it was). Closed on session switch below.
+    let preview_open = use_state(|| false);
+    let preview_collapsed = use_state(|| false);
+    {
+        let preview_open = preview_open.clone();
+        use_effect_with(props.session_id, move |_| {
+            preview_open.set(false);
+            || ()
+        });
+    }
+
     // Ignore results tagged for a different (stale) session.
     let forwards: &[ForwardInfo] = if state.0 == props.session_id {
         &state.1
@@ -93,13 +106,39 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
 
     let open_url = utils::api_url(&format!("/api/sessions/{}/forwards/open", props.session_id));
 
+    let toggle_preview = {
+        let preview_open = preview_open.clone();
+        let preview_collapsed = preview_collapsed.clone();
+        Callback::from(move |e: MouseEvent| {
+            e.prevent_default();
+            if *preview_open {
+                preview_open.set(false);
+            } else {
+                preview_open.set(true);
+                preview_collapsed.set(false);
+            }
+        })
+    };
+    let toggle_collapse = {
+        let preview_collapsed = preview_collapsed.clone();
+        Callback::from(move |_: MouseEvent| preview_collapsed.set(!*preview_collapsed))
+    };
+    let close_preview = {
+        let preview_open = preview_open.clone();
+        Callback::from(move |_: MouseEvent| preview_open.set(false))
+    };
+
+    let forward = &forwards[0];
     html! {
+        <>
         <span class="session-forwards">
             { for forwards.iter().map(|f| {
                 let on_revoke = revoke.clone();
                 html! {
                     <span class="forward-chip" key={f.port} title={f.url.clone()}>
-                        <a href={open_url.clone()} target="_blank" rel="noopener noreferrer">
+                        // Click opens the inline preview overlay; "Visit site"
+                        // inside it goes to the full page.
+                        <a href={open_url.clone()} onclick={toggle_preview.clone()}>
                             { format!(":{} ↗", f.port) }
                         </a>
                         if props.is_owner {
@@ -113,5 +152,43 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
                 }
             }) }
         </span>
+        if *preview_open {
+            <div class="forward-preview">
+                <div class="forward-preview-bar">
+                    <button
+                        class="forward-preview-btn"
+                        title={ if *preview_collapsed { "Expand" } else { "Collapse" } }
+                        onclick={toggle_collapse}
+                    >
+                        { if *preview_collapsed { "▸" } else { "▾" } }
+                    </button>
+                    <span class="forward-preview-title">
+                        { format!(":{} — {}", forward.port, forward.url) }
+                    </span>
+                    <a
+                        class="forward-preview-visit"
+                        href={open_url.clone()}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >{ "Visit site ↗" }</a>
+                    <button
+                        class="forward-preview-btn forward-preview-close"
+                        title="Close preview"
+                        onclick={close_preview}
+                    >{ "×" }</button>
+                </div>
+                // Kept mounted while collapsed so the embedded app keeps its
+                // state; only the height changes.
+                <iframe
+                    class={classes!(
+                        "forward-preview-frame",
+                        preview_collapsed.then_some("collapsed"),
+                    )}
+                    src={open_url}
+                    title="Forwarded app preview"
+                />
+            </div>
+        }
+        </>
     }
 }

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -133,6 +133,78 @@
     color: var(--error);
 }
 
+/* Inline preview overlay for the session's forward (opened from the chip) */
+.forward-preview {
+    position: fixed;
+    top: 3.25rem;
+    left: 0.75rem;
+    z-index: 900;
+    width: min(760px, calc(100vw - 1.5rem));
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+    overflow: hidden;
+}
+
+.forward-preview-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.6rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.forward-preview-title {
+    flex: 1;
+    font-family: monospace;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.forward-preview-visit {
+    color: var(--text-teal, #7dcfff);
+    font-size: 0.8rem;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.forward-preview-visit:hover {
+    text-decoration: underline;
+}
+
+.forward-preview-btn {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.95rem;
+    padding: 0 0.2rem;
+    line-height: 1;
+}
+
+.forward-preview-close:hover {
+    color: var(--error);
+}
+
+/* Kept mounted while collapsed (height 0) so the embedded app keeps state. */
+.forward-preview-frame {
+    display: block;
+    width: 100%;
+    height: min(65vh, 640px);
+    border: 0;
+    background: #fff;
+}
+
+.forward-preview-frame.collapsed {
+    height: 0;
+}
+
 .session-view-header .status {
     font-size: 0.8rem;
     padding: 0.25rem 0.75rem;


### PR DESCRIPTION
## Summary

Clicking the session-header forward chip now opens a **collapsible inline preview overlay** rendering the forwarded app in an iframe, with a **Visit site ↗** link to the full page (#689 follow-up, per user request).

### Frontend (`forward_chips.rs` + CSS)
- Chip click toggles a fixed overlay panel (top-left, under the header): title bar with `:{port} — {url}`, collapse toggle, Visit site (new tab, `noopener noreferrer`), close `×`.
- The iframe points at the `/open` handoff endpoint, so auth rides the normal token→`portal_fwd`-cookie flow.
- **Collapse hides without unmounting** — the embedded app keeps running (state preserved); only the frame's height changes.
- Overlay closes on session switch and disappears with the forward.

### Backend (`forward_proxy.rs`)
Embedding needs a framing-policy rewrite — apps like Jupyter ship `CSP: frame-ancestors 'self'`, which blocks cross-origin iframes:
- Strip upstream `X-Frame-Options`.
- Strip only the `frame-ancestors` directive from upstream `Content-Security-Policy` (all other directives pass through; header dropped if nothing remains).
- Append `Content-Security-Policy: frame-ancestors 'self' {portal origin}`.

Security analysis: this **narrows** policy for apps that shipped none (any-site-may-frame → portal-or-self) and re-scopes apps that shipped `'self'`/XFO to portal-or-self. Stripping-then-replacing is required because multiple CSP headers intersect — appending alone can never loosen an upstream `'none'`. Skipped on 101 upgrades.

### Known caveat (documented in the spec)
`portal_fwd` is `SameSite=Lax`; in production the forward origin and portal share an eTLD+1 (same-site) so the iframe authenticates normally. On `*.localhost` dev domains browsers treat them as cross-site — private-forward previews don't authenticate there (public forwards preview fine; Visit site always works).

### Verification
- Unit tests for `strip_frame_ancestors` (only-frame-ancestors → dropped, mixed policy preserved verbatim, case-insensitive, lookalike directive names untouched) — 9 forward_proxy tests pass.
- Backend + WASM builds, workspace clippy (both targets), trunk build, rustfmt clean.
- The browser-side overlay UX needs a human click after deploy (iframe + cookie flow isn't curl-able); the pieces it composes (handoff, tunnel, chip) are all previously live-verified.

Versioned 2.13.11.