### PR TITLE
Clarify continuation resumes one minute after limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.13.12
+
+- **Continuation cards: make the one-minute post-limit restart explicit.** The launcher already waits one minute after Claude's reported reset time before injecting a scheduled limit continuation; the card now says the continuation runs one minute after reset and the button reads "Continue 1 min after limit lifts." Added launcher scheduler regression tests that prove continuations are not ready before `reset_at + 60s` and are ready after that skew.
+
 ## 2.13.10
 
 - **Launcher: park on fatal auth rejection instead of crash-looping (#1237 part 1).** A fatal registration rejection (expired/revoked/missing token, launcher limit, duplicate host) used to make the launcher exit 1, which under systemd `Restart=on-failure`/5s became an indefinite crash loop — one expired token racked up 76k restarts, each a full TLS+WS+registration cycle. The launcher now **parks**: it logs one prominent, actionable instruction (`run \`agent-portal login\` to re-authenticate` for auth; disconnect/stop guidance for limit/duplicate) and retries slowly (60s doubling to a 10-minute cap — distinct from the 30s network backoff). It is **self-healing**: the auth token is re-resolved from `launcher.json` on *every* connection attempt (a CLI `--auth-token` still pins), so running `agent-portal login` while parked recovers the launcher on its next retry with no service restart. `LauncherRegisterAck` gains an additive machine-readable `reject_reason` (`AuthFailed`/`TooManyLaunchers`/`DuplicateLauncher`); old backends omit it and the launcher falls back to sniffing the error text, old launchers ignore it. `save_config` is now write-temp+rename so a login concurrent with the per-attempt re-read can never observe a torn `launcher.json`. Verified live against prod with a bogus token: one instruction line, process parked (no exit). Part 2 (token rotation over the live websocket) is a follow-up.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.13.10"
+version = "2.13.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.10"
+version = "2.13.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.10"
+version = "2.13.12"
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.10"
+version = "2.13.12"
 dependencies = [
  "anyhow",
  "base64",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.10"
+version = "2.13.12"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.10"
+version = "2.13.12"
 dependencies = [
  "base64",
  "chrono",
@@ -2617,7 +2617,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.10"
+version = "2.13.12"
 dependencies = [
  "anyhow",
  "colored",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.10"
+version = "2.13.12"
 dependencies = [
  "anyhow",
  "hex",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.10"
+version = "2.13.12"
 dependencies = [
  "anyhow",
  "base64",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.10"
+version = "2.13.12"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.13.10"
+version = "2.13.12"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -213,7 +213,7 @@ fn render_continuation_prompt(
     source_message: &str,
     on_schedule_continuation: Callback<Uuid>,
 ) -> Html {
-    let reset_label = format_reset_label(reset_at);
+    let continuation_label = format_continuation_label(reset_at);
     let terminal = matches!(
         status,
         "scheduled" | "scheduling" | "fired" | "dropped" | "failed"
@@ -225,7 +225,7 @@ fn render_continuation_prompt(
         "fired" => "Continued",
         "dropped" => "Dropped",
         "failed" => "Failed",
-        _ => "Continue when limit lifted",
+        _ => "Continue 1 min after limit lifts",
     };
     let onclick = {
         let on_schedule_continuation = on_schedule_continuation.clone();
@@ -238,7 +238,7 @@ fn render_continuation_prompt(
         <div class="continuation-card">
             <div class="continuation-copy">
                 <div class="continuation-title">{ "Claude session limit reached" }</div>
-                <div class="continuation-detail">{ reset_label }</div>
+                <div class="continuation-detail">{ continuation_label }</div>
                 if !source_message.is_empty() {
                     <div class="continuation-source">{ source_message }</div>
                 }
@@ -255,17 +255,28 @@ fn render_continuation_prompt(
     }
 }
 
-fn format_reset_label(reset_at: &str) -> String {
+fn format_continuation_label(reset_at: &str) -> String {
     let ms = js_sys::Date::parse(reset_at);
     if ms.is_nan() {
-        return format!("Resets at {}", reset_at);
+        return format!(
+            "Limit resets at {}; continuation runs 1 minute later",
+            reset_at
+        );
     }
-    let date = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ms));
-    let local = date
+    let reset_date = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ms));
+    let reset_local = reset_date
         .to_locale_string("default", &js_sys::Object::new())
         .as_string()
         .unwrap_or_else(|| reset_at.to_string());
-    format!("Resets at {}", local)
+    let continue_date = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ms + 60_000.0));
+    let continue_local = continue_date
+        .to_locale_string("default", &js_sys::Object::new())
+        .as_string()
+        .unwrap_or_else(|| "1 minute later".to_string());
+    format!(
+        "Limit resets at {}; continuation runs at {}",
+        reset_local, continue_local
+    )
 }
 
 #[derive(Properties, PartialEq)]

--- a/launcher/src/scheduler.rs
+++ b/launcher/src/scheduler.rs
@@ -483,6 +483,43 @@ mod tests {
         assert_eq!(scheduler.running[&session_id].task_id, task_id);
     }
 
+    fn continuation(reset_at: DateTime<Utc>) -> ContinuationConfig {
+        ContinuationConfig {
+            id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            reset_at: reset_at.to_rfc3339(),
+            prompt: "continue".to_string(),
+        }
+    }
+
+    #[test]
+    fn continuation_waits_one_minute_after_reset() {
+        let mut scheduler = Scheduler::new();
+        scheduler.update_continuations(vec![continuation(
+            Utc::now() - chrono::Duration::seconds(CONTINUATION_RESET_SKEW_SECS - 1),
+        )]);
+
+        assert!(scheduler.ready_continuations().is_empty());
+        assert!(
+            scheduler.next_continuation_duration() > Some(Duration::ZERO),
+            "continuation should not be due until one minute after reset_at"
+        );
+    }
+
+    #[test]
+    fn continuation_is_ready_after_one_minute_skew() {
+        let mut scheduler = Scheduler::new();
+        let due =
+            continuation(Utc::now() - chrono::Duration::seconds(CONTINUATION_RESET_SKEW_SECS + 1));
+        let continuation_id = due.id;
+        scheduler.update_continuations(vec![due]);
+
+        let ready = scheduler.ready_continuations();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].id, continuation_id);
+        assert!(scheduler.next_continuation_duration().is_none());
+    }
+
     #[test]
     fn session_exit_clears_running_state() {
         let mut scheduler = Scheduler::new();


### PR DESCRIPTION
## Summary
- Update the session-limit continuation card so the button says it resumes 1 minute after the limit lifts
- Show both the reset time and the continuation run time in the card detail
- Add launcher scheduler regression tests for the reset_at + 60s continuation skew

## Tests
- cargo test -p agent-portal scheduler::tests::continuation --all-targets
- cargo check -p frontend --target wasm32-unknown-unknown
- git diff --check