### PR TITLE
Relaunch exited sessions for limit continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.13.13
+
+- **Limit continuations: relaunch exited sessions when the continuation is due.** Clicking the continuation card after the reset window can now resume the original session if the local agent process already exited, then queue the continuation prompt against that resumed session. Still-running sessions keep the existing direct-inject path; older continuation syncs without launch metadata fall back to a clear dropped status.
+
+
 ## 2.13.12
 
 - **Continuation cards: make the one-minute post-limit restart explicit.** The launcher already waits one minute after Claude's reported reset time before injecting a scheduled limit continuation; the card now says the continuation runs one minute after reset and the button reads "Continue 1 min after limit lifts." Added launcher scheduler regression tests that prove continuations are not ready before `reset_at + 60s` and are ready after that skew.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "base64",
  "chrono",
@@ -2617,7 +2617,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "anyhow",
  "colored",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "anyhow",
  "hex",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.13.12"
+version = "2.13.13"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -319,20 +319,31 @@ pub fn load_scheduled_continuations(
         return Vec::new();
     };
 
-    use crate::schema::session_continuations;
+    use crate::schema::{session_continuations, sessions};
     session_continuations::table
+        .inner_join(sessions::table.on(sessions::id.eq(session_continuations::session_id)))
         .filter(session_continuations::launcher_id.eq(launcher_id))
         .filter(session_continuations::user_id.eq(user_id))
         .filter(session_continuations::status.eq(STATUS_SCHEDULED))
         .order(session_continuations::reset_at.asc())
-        .load::<SessionContinuation>(&mut conn)
+        .select((SessionContinuation::as_select(), Session::as_select()))
+        .load::<(SessionContinuation, Session)>(&mut conn)
         .unwrap_or_default()
         .into_iter()
-        .map(|row| ContinuationConfig {
-            id: row.id,
-            session_id: row.session_id,
-            reset_at: row.reset_at.to_rfc3339(),
-            prompt: row.prompt,
+        .map(|(row, session)| {
+            let claude_args =
+                serde_json::from_value::<Vec<String>>(session.claude_args).unwrap_or_default();
+            let agent_type = session.agent_type.parse().unwrap_or_default();
+            ContinuationConfig {
+                id: row.id,
+                session_id: row.session_id,
+                reset_at: row.reset_at.to_rfc3339(),
+                prompt: row.prompt,
+                working_directory: Some(session.working_directory),
+                session_name: Some(session.session_name),
+                claude_args,
+                agent_type,
+            }
         })
         .collect()
 }

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -420,6 +420,7 @@ fn handle_launcher_message(
             agent_type,
             scheduled_task_id,
             last_session_id,
+            continuation_id,
         } => {
             info!(
                 "Launcher requested launch: dir={}, name={:?}",
@@ -434,6 +435,16 @@ fn handle_launcher_message(
                                 "Skipping launcher auto-resume for paused session {}",
                                 session_id
                             );
+                            if let Some(continuation_id) = continuation_id {
+                                super::continuations::mark_continuation_dropped(
+                                    app_state,
+                                    launcher_id,
+                                    user_id,
+                                    continuation_id,
+                                    session_id,
+                                    "session was paused before continuation relaunch".to_string(),
+                                );
+                            }
                             return;
                         }
                         Ok(Some(false)) => {}
@@ -442,6 +453,16 @@ fn handle_launcher_message(
                                 "Skipping launcher auto-resume for deleted session {}",
                                 session_id
                             );
+                            if let Some(continuation_id) = continuation_id {
+                                super::continuations::mark_continuation_dropped(
+                                    app_state,
+                                    launcher_id,
+                                    user_id,
+                                    continuation_id,
+                                    session_id,
+                                    "session was deleted before continuation relaunch".to_string(),
+                                );
+                            }
                             return;
                         }
                         Err(e) => {

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -1,6 +1,6 @@
 use crate::path_policy;
 use crate::process_manager::{ProcessManager, SessionExited, SpawnParams};
-use crate::scheduler::Scheduler;
+use crate::scheduler::{PendingLaunchKind, Scheduler};
 use shared::{LauncherEndpoint, LauncherRejectReason, LauncherToServer, ServerToLauncher};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
@@ -279,6 +279,7 @@ pub async fn run_launcher_loop(
                                     agent_type: task_to_fire.config.fields.agent_type,
                                     scheduled_task_id: Some(task_to_fire.config.id),
                                     last_session_id: task_to_fire.config.last_session_id,
+                                    continuation_id: None,
                                 };
                                 if ws_sender.send(msg).await.is_err() {
                                     warn!("Failed to send RequestLaunch for scheduled task");
@@ -339,8 +340,32 @@ pub async fn run_launcher_loop(
                                         warn!("Failed to send ContinuationFired");
                                         break;
                                     }
+                                } else if let Some(working_directory) =
+                                    continuation.working_directory.clone()
+                                {
+                                    info!(
+                                        "Relaunching session {} for continuation {}",
+                                        continuation.session_id, continuation.id
+                                    );
+                                    let request_id =
+                                        scheduler.register_continuation_launch(&continuation);
+                                    let relaunch = LauncherToServer::RequestLaunch {
+                                        request_id,
+                                        working_directory,
+                                        session_name: continuation.session_name.clone(),
+                                        claude_args: continuation.claude_args.clone(),
+                                        agent_type: continuation.agent_type,
+                                        scheduled_task_id: None,
+                                        last_session_id: Some(continuation.session_id),
+                                        continuation_id: Some(continuation.id),
+                                    };
+                                    if ws_sender.send(relaunch).await.is_err() {
+                                        warn!("Failed to send continuation RequestLaunch");
+                                        scheduler.clear_pending_launch(&request_id);
+                                        break;
+                                    }
                                 } else {
-                                    let reason = "local Claude process was no longer running at reset time".to_string();
+                                    let reason = "local agent process was no longer running and this launcher did not receive resume metadata".to_string();
                                     warn!(
                                         "Dropping continuation {} for session {}: {}",
                                         continuation.id, continuation.session_id, reason
@@ -514,21 +539,22 @@ async fn handle_message(
             resume_session_id,
             ..
         } => {
-            // Check if this is a scheduled launch
-            let (resume_session_id, scheduled_task_id, is_scheduled) = if let Some((
-                resume_id,
-                task_id,
-            )) =
-                scheduler.get_pending_launch_info(&request_id)
-            {
-                (resume_id, Some(task_id), true)
-            } else {
-                (resume_session_id, None, false)
-            };
+            // Check if this is a scheduler-owned launch.
+            let pending_launch = scheduler.get_pending_launch_info(&request_id);
+            let (resume_session_id, scheduled_task_id, scheduler_owned) =
+                if let Some(info) = pending_launch.as_ref() {
+                    let scheduled_task_id = match info.kind {
+                        PendingLaunchKind::ScheduledTask { task_id } => Some(task_id),
+                        PendingLaunchKind::Continuation { .. } => None,
+                    };
+                    (info.last_session_id, scheduled_task_id, true)
+                } else {
+                    (resume_session_id, None, false)
+                };
 
             info!(
-                "Launch request: dir={}, name={:?}, agent={}, scheduled={}",
-                working_directory, session_name, agent_type, is_scheduled
+                "Launch request: dir={}, name={:?}, agent={}, scheduler_owned={}",
+                working_directory, session_name, agent_type, scheduler_owned
             );
 
             let result = process_manager
@@ -545,8 +571,32 @@ async fn handle_message(
 
             let response = match result {
                 Ok(session_id) => {
-                    if is_scheduled {
-                        scheduler.on_session_spawned(request_id, session_id);
+                    let launch_kind = if scheduler_owned {
+                        scheduler.on_session_spawned(request_id, session_id)
+                    } else {
+                        None
+                    };
+                    if let Some(PendingLaunchKind::Continuation {
+                        continuation_id,
+                        session_id,
+                        prompt,
+                    }) = launch_kind
+                    {
+                        let inject = LauncherToServer::InjectInput {
+                            session_id,
+                            content: prompt,
+                        };
+                        if ws_sender.send(inject).await.is_err() {
+                            warn!("Failed to send relaunched continuation InjectInput");
+                        } else {
+                            let fired = LauncherToServer::ContinuationFired {
+                                continuation_id,
+                                session_id,
+                            };
+                            if ws_sender.send(fired).await.is_err() {
+                                warn!("Failed to send relaunched ContinuationFired");
+                            }
+                        }
                     }
                     LauncherToServer::LaunchSessionResult {
                         request_id,
@@ -558,7 +608,7 @@ async fn handle_message(
                 }
                 Err(e) => {
                     error!("Failed to spawn: {}", e);
-                    if is_scheduled {
+                    if scheduler_owned {
                         scheduler.clear_pending_launch(&request_id);
                     }
                     LauncherToServer::LaunchSessionResult {

--- a/launcher/src/scheduler.rs
+++ b/launcher/src/scheduler.rs
@@ -16,8 +16,26 @@ struct ActiveTask {
     next_fire: Option<DateTime<Utc>>,
 }
 
-pub struct PendingLaunch {
-    pub task_id: Uuid,
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PendingLaunchKind {
+    ScheduledTask {
+        task_id: Uuid,
+    },
+    Continuation {
+        continuation_id: Uuid,
+        session_id: Uuid,
+        prompt: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingLaunchInfo {
+    pub last_session_id: Option<Uuid>,
+    pub kind: PendingLaunchKind,
+}
+
+struct PendingLaunch {
+    kind: PendingLaunchKind,
     pub last_session_id: Option<Uuid>,
     prompt: String,
 }
@@ -34,6 +52,10 @@ pub struct ReadyContinuation {
     pub id: Uuid,
     pub session_id: Uuid,
     pub prompt: String,
+    pub working_directory: Option<String>,
+    pub session_name: Option<String>,
+    pub claude_args: Vec<String>,
+    pub agent_type: shared::AgentType,
 }
 
 pub struct RunningInfo {
@@ -156,6 +178,10 @@ impl Scheduler {
                     id: c.id,
                     session_id: c.session_id,
                     prompt: c.prompt.clone(),
+                    working_directory: c.working_directory.clone(),
+                    session_name: c.session_name.clone(),
+                    claude_args: c.claude_args.clone(),
+                    agent_type: c.agent_type,
                 });
                 false
             } else {
@@ -197,7 +223,9 @@ impl Scheduler {
             new_pending.push((
                 request_id,
                 PendingLaunch {
-                    task_id: task.config.id,
+                    kind: PendingLaunchKind::ScheduledTask {
+                        task_id: task.config.id,
+                    },
                     last_session_id: task.config.last_session_id,
                     prompt: task.config.fields.prompt.clone(),
                 },
@@ -227,20 +255,47 @@ impl Scheduler {
         to_fire
     }
 
-    /// Check if a request_id corresponds to a scheduled launch.
-    /// Returns (last_session_id, task_id) if so.
-    pub fn get_pending_launch_info(&self, request_id: &Uuid) -> Option<(Option<Uuid>, Uuid)> {
-        self.pending_launches
-            .get(request_id)
-            .map(|p| (p.last_session_id, p.task_id))
+    pub fn register_continuation_launch(&mut self, continuation: &ReadyContinuation) -> Uuid {
+        let request_id = Uuid::new_v4();
+        self.pending_launches.insert(
+            request_id,
+            PendingLaunch {
+                kind: PendingLaunchKind::Continuation {
+                    continuation_id: continuation.id,
+                    session_id: continuation.session_id,
+                    prompt: continuation.prompt.clone(),
+                },
+                last_session_id: Some(continuation.session_id),
+                prompt: continuation.prompt.clone(),
+            },
+        );
+        request_id
     }
 
-    /// Called after a scheduled session is spawned successfully.
-    pub fn on_session_spawned(&mut self, request_id: Uuid, session_id: Uuid) {
+    /// Check if a request_id corresponds to a scheduler-owned launch.
+    pub fn get_pending_launch_info(&self, request_id: &Uuid) -> Option<PendingLaunchInfo> {
+        self.pending_launches
+            .get(request_id)
+            .map(|p| PendingLaunchInfo {
+                last_session_id: p.last_session_id,
+                kind: p.kind.clone(),
+            })
+    }
+
+    /// Called after a scheduler-owned session is spawned successfully.
+    pub fn on_session_spawned(
+        &mut self,
+        request_id: Uuid,
+        session_id: Uuid,
+    ) -> Option<PendingLaunchKind> {
         if let Some(pending) = self.pending_launches.remove(&request_id) {
+            let kind = pending.kind;
+            let PendingLaunchKind::ScheduledTask { task_id } = kind else {
+                return Some(kind);
+            };
             self.pending_prompts.push(PendingPrompt {
                 session_id,
-                task_id: pending.task_id,
+                task_id,
                 prompt: pending.prompt,
                 send_at: Instant::now() + PROMPT_DELAY,
             });
@@ -248,18 +303,21 @@ impl Scheduler {
             let max_minutes = self
                 .tasks
                 .iter()
-                .find(|t| t.config.id == pending.task_id)
+                .find(|t| t.config.id == task_id)
                 .map(|t| t.config.fields.max_runtime_minutes)
                 .unwrap_or(30);
 
             self.running.insert(
                 session_id,
                 RunningInfo {
-                    task_id: pending.task_id,
+                    task_id,
                     started_at: Instant::now(),
                     max_runtime: Duration::from_secs(max_minutes as u64 * 60),
                 },
             );
+            Some(PendingLaunchKind::ScheduledTask { task_id })
+        } else {
+            None
         }
     }
 
@@ -489,6 +547,10 @@ mod tests {
             session_id: Uuid::new_v4(),
             reset_at: reset_at.to_rfc3339(),
             prompt: "continue".to_string(),
+            working_directory: Some("/home/test/project".to_string()),
+            session_name: Some("project".to_string()),
+            claude_args: vec!["--model".to_string(), "sonnet".to_string()],
+            agent_type: shared::AgentType::Claude,
         }
     }
 
@@ -518,6 +580,43 @@ mod tests {
         assert_eq!(ready.len(), 1);
         assert_eq!(ready[0].id, continuation_id);
         assert!(scheduler.next_continuation_duration().is_none());
+    }
+
+    #[test]
+    fn continuation_relaunch_tracks_prompt_for_same_session() {
+        let mut scheduler = Scheduler::new();
+        let due =
+            continuation(Utc::now() - chrono::Duration::seconds(CONTINUATION_RESET_SKEW_SECS + 1));
+        let continuation_id = due.id;
+        let session_id = due.session_id;
+        scheduler.update_continuations(vec![due]);
+
+        let ready = scheduler.ready_continuations();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(
+            ready[0].working_directory.as_deref(),
+            Some("/home/test/project")
+        );
+        let request_id = scheduler.register_continuation_launch(&ready[0]);
+
+        let launch = scheduler.get_pending_launch_info(&request_id).unwrap();
+        assert_eq!(launch.last_session_id, Some(session_id));
+        assert_eq!(
+            launch.kind,
+            PendingLaunchKind::Continuation {
+                continuation_id,
+                session_id,
+                prompt: "continue".to_string(),
+            }
+        );
+        assert_eq!(
+            scheduler.on_session_spawned(request_id, session_id),
+            Some(PendingLaunchKind::Continuation {
+                continuation_id,
+                session_id,
+                prompt: "continue".to_string(),
+            })
+        );
     }
 
     #[test]

--- a/shared/src/endpoints/launcher.rs
+++ b/shared/src/endpoints/launcher.rs
@@ -127,6 +127,11 @@ pub enum LauncherToServer {
         /// auto-resume when the session is paused server-side.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         last_session_id: Option<Uuid>,
+        /// One-shot limit continuation this launch should satisfy. Only set
+        /// when the launcher is relaunching an exited session to deliver a
+        /// scheduled continuation prompt.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        continuation_id: Option<Uuid>,
     },
 
     /// Inject input into a session on behalf of the scheduler

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -451,6 +451,7 @@ mod tests {
             agent_type: AgentType::Claude,
             scheduled_task_id: None,
             last_session_id: None,
+            continuation_id: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"RequestLaunch""#));
@@ -460,11 +461,13 @@ mod tests {
                 working_directory,
                 session_name,
                 claude_args,
+                continuation_id,
                 ..
             } => {
                 assert_eq!(working_directory, "/home/user/project");
                 assert_eq!(session_name.as_deref(), Some("my-project"));
                 assert_eq!(claude_args, vec!["--verbose"]);
+                assert_eq!(continuation_id, None);
             }
             _ => panic!("Wrong variant"),
         }

--- a/shared/src/endpoints/types.rs
+++ b/shared/src/endpoints/types.rs
@@ -77,6 +77,16 @@ pub struct ContinuationConfig {
     pub session_id: Uuid,
     pub reset_at: String,
     pub prompt: String,
+    /// Launch metadata for resuming the same session if the original local
+    /// process has already exited by the time the continuation is due.
+    #[serde(default)]
+    pub working_directory: Option<String>,
+    #[serde(default)]
+    pub session_name: Option<String>,
+    #[serde(default)]
+    pub claude_args: Vec<String>,
+    #[serde(default)]
+    pub agent_type: AgentType,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- include session launch metadata in scheduled limit continuation syncs
- relaunch/resume the original session when a due continuation finds no local process running
- mark continuation relaunches dropped if the backend denies resume because the session was paused/deleted

## Tests
- cargo test -p agent-portal scheduler::tests::continuation --all-targets
- cargo test -p shared launcher_request_launch_roundtrip
- cargo check -p backend
- cargo check -p agent-portal
- git diff --check