### PR TITLE
Use two minute grace for limit continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.13.14
+
+- **Limit continuations: wait two minutes after the reset time.** The continuation scheduler now uses a two-minute post-reset grace period before injecting or relaunching a session, and the continuation card copy reflects that timing. This gives the upstream limit window a wider margin before automatic resume.
+
+
 ## 2.13.13
 
 - **Limit continuations: relaunch exited sessions when the continuation is due.** Clicking the continuation card after the reset window can now resume the original session if the local agent process already exited, then queue the continuation prompt against that resumed session. Still-running sessions keep the existing direct-inject path; older continuation syncs without launch metadata fall back to a clear dropped status.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.13.13"
+version = "2.13.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.13"
+version = "2.13.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.13"
+version = "2.13.14"
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.13"
+version = "2.13.14"
 dependencies = [
  "anyhow",
  "base64",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.13"
+version = "2.13.14"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.13"
+version = "2.13.14"
 dependencies = [
  "base64",
  "chrono",
@@ -2617,7 +2617,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.13"
+version = "2.13.14"
 dependencies = [
  "anyhow",
  "colored",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.13"
+version = "2.13.14"
 dependencies = [
  "anyhow",
  "hex",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.13"
+version = "2.13.14"
 dependencies = [
  "anyhow",
  "base64",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.13"
+version = "2.13.14"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.13.13"
+version = "2.13.14"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -225,7 +225,7 @@ fn render_continuation_prompt(
         "fired" => "Continued",
         "dropped" => "Dropped",
         "failed" => "Failed",
-        _ => "Continue 1 min after limit lifts",
+        _ => "Continue 2 min after limit lifts",
     };
     let onclick = {
         let on_schedule_continuation = on_schedule_continuation.clone();
@@ -259,7 +259,7 @@ fn format_continuation_label(reset_at: &str) -> String {
     let ms = js_sys::Date::parse(reset_at);
     if ms.is_nan() {
         return format!(
-            "Limit resets at {}; continuation runs 1 minute later",
+            "Limit resets at {}; continuation runs 2 minutes later",
             reset_at
         );
     }
@@ -268,11 +268,11 @@ fn format_continuation_label(reset_at: &str) -> String {
         .to_locale_string("default", &js_sys::Object::new())
         .as_string()
         .unwrap_or_else(|| reset_at.to_string());
-    let continue_date = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ms + 60_000.0));
+    let continue_date = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ms + 120_000.0));
     let continue_local = continue_date
         .to_locale_string("default", &js_sys::Object::new())
         .as_string()
-        .unwrap_or_else(|| "1 minute later".to_string());
+        .unwrap_or_else(|| "2 minutes later".to_string());
     format!(
         "Limit resets at {}; continuation runs at {}",
         reset_local, continue_local

--- a/launcher/src/scheduler.rs
+++ b/launcher/src/scheduler.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 /// Delay before sending the prompt after session spawn.
 /// Gives the proxy time to connect and register the session row.
 const PROMPT_DELAY: Duration = Duration::from_secs(5);
-const CONTINUATION_RESET_SKEW_SECS: i64 = 60;
+const CONTINUATION_RESET_SKEW_SECS: i64 = 120;
 
 struct ActiveTask {
     config: ScheduledTaskConfig,
@@ -555,7 +555,7 @@ mod tests {
     }
 
     #[test]
-    fn continuation_waits_one_minute_after_reset() {
+    fn continuation_waits_two_minutes_after_reset() {
         let mut scheduler = Scheduler::new();
         scheduler.update_continuations(vec![continuation(
             Utc::now() - chrono::Duration::seconds(CONTINUATION_RESET_SKEW_SECS - 1),
@@ -564,12 +564,12 @@ mod tests {
         assert!(scheduler.ready_continuations().is_empty());
         assert!(
             scheduler.next_continuation_duration() > Some(Duration::ZERO),
-            "continuation should not be due until one minute after reset_at"
+            "continuation should not be due until two minutes after reset_at"
         );
     }
 
     #[test]
-    fn continuation_is_ready_after_one_minute_skew() {
+    fn continuation_is_ready_after_two_minute_skew() {
         let mut scheduler = Scheduler::new();
         let due =
             continuation(Utc::now() - chrono::Duration::seconds(CONTINUATION_RESET_SKEW_SECS + 1));


### PR DESCRIPTION
## Summary
- change the continuation scheduler grace from 60s to 120s after the reported reset time
- update the continuation card button/detail text to say 2 minutes and compute the displayed continuation time accordingly
- rename/update continuation scheduler tests for the two-minute skew

## Tests
- cargo test -p agent-portal scheduler::tests::continuation --all-targets
- cargo check -p frontend --target wasm32-unknown-unknown
- git diff --check