### PR TITLE
Tint forward chip by live port health from periodic probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.13.17
+
+- **Forward chip: live green/red port health (docs/PORT_FORWARDING.md, #689).** The session-header forward chip now shows whether anything is actually listening on the forwarded port: green = the proxy's last probe connected, red = connection refused, neutral = no verdict yet (proxy offline / pre-probe / mixed fleet). The proxy's `TunnelManager` background-probes every allowlisted port on a 10s cadence (a loopback TCP dial — microseconds of work) and sends the existing `ForwardStatus` frame **only when a port's verdict changes**, so steady state costs zero WS frames; the registration-time probe seeds the state. The backend caches the latest verdict in memory on the `SessionManager`, exposes it as `ForwardInfo.listening` (`Option<bool>`, additive), and broadcasts `ForwardsChanged` on transitions so chips re-tint within one probe interval of a server starting or dying. No protocol change — old proxies simply never report (chips stay neutral), old backends ignore unsolicited statuses as before. Prober is `Weak`-held and aborted on connection shutdown.
+
 ## 2.13.16
 
 - **Forward preview overlay: draggable + resizable.** The inline preview panel can now be moved by dragging its title bar and resized from a corner grip (min 320×160, clamped to the viewport so the bar can't be lost off-screen; geometry survives collapse/expand). Both interactions use pointer capture — `setPointerCapture` on the handle keeps the `pointermove` stream flowing even when the cursor crosses the embedded iframe — with `pointer-events: none` applied to the iframe during an interaction as belt-and-suspenders. `touch-action: none` + `user-select: none` on the handles keep touch scrolling and text selection from hijacking the gesture, so it works on mobile too. Position/size moved from CSS to state-driven inline styles; collapse still keeps the iframe mounted (height 0).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.13.16"
+version = "2.13.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.16"
+version = "2.13.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.16"
+version = "2.13.17"
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.16"
+version = "2.13.17"
 dependencies = [
  "anyhow",
  "base64",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.16"
+version = "2.13.17"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.16"
+version = "2.13.17"
 dependencies = [
  "base64",
  "chrono",
@@ -2617,7 +2617,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.16"
+version = "2.13.17"
 dependencies = [
  "anyhow",
  "colored",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.16"
+version = "2.13.17"
 dependencies = [
  "anyhow",
  "hex",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.16"
+version = "2.13.17"
 dependencies = [
  "anyhow",
  "base64",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.16"
+version = "2.13.17"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.13.16"
+version = "2.13.17"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/forwards.rs
+++ b/backend/src/handlers/forwards.rs
@@ -69,6 +69,11 @@ fn to_forward_info(
         url: forward_url(app_state, label)?,
         created_at: DateTime::<Utc>::from_naive_utc_and_offset(row.created_at, Utc).to_rfc3339(),
         public: row.public,
+        // Latest probe verdict from the proxy's background health check;
+        // `None` until a probe has reported (drives the chip tint).
+        listening: app_state
+            .session_manager
+            .forward_health(row.session_id, row.port as u16),
     })
 }
 

--- a/backend/src/handlers/forwards.rs
+++ b/backend/src/handlers/forwards.rs
@@ -306,8 +306,12 @@ pub async fn create_forward(
         Ok((session, row, label, replaced_port))
     })?;
 
-    // Drop the replaced port from the proxy's allowlist (and its live streams).
+    // Drop the replaced port from the proxy's allowlist (and its live
+    // streams), plus its cached health verdict.
     if let Some(old) = replaced_port {
+        app_state
+            .session_manager
+            .forget_forward_health(session_id, old);
         app_state.session_manager.send_to_connected_session(
             &session.session_key,
             ServerToProxy::ForwardClose(ForwardPortFields { port: old }),
@@ -412,6 +416,9 @@ pub async fn delete_forward(
     })?;
 
     // Best effort — a disconnected proxy re-syncs from the DB on reconnect.
+    app_state
+        .session_manager
+        .forget_forward_health(session_id, port);
     app_state.session_manager.send_to_connected_session(
         &session.session_key,
         ServerToProxy::ForwardClose(ForwardPortFields { port }),

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -9,7 +9,7 @@ use super::{ProxySender, SessionId, SessionManager};
 use crate::AppState;
 use axum::extract::ws::WebSocket;
 use diesel::prelude::*;
-use shared::{ProxyToServer, ServerToProxy, SessionEndpoint, SessionStatus};
+use shared::{ProxyToServer, ServerToClient, ServerToProxy, SessionEndpoint, SessionStatus};
 use std::ops::ControlFlow;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -346,6 +346,21 @@ fn handle_proxy_message(
         ProxyToServer::SessionStatus { .. } => {}
         ProxyToServer::ForwardStatus(status) => {
             if let Some(session_id) = *db_session_id {
+                // Record port health first (drives the chip's green/red tint)
+                // and nudge web clients to refetch when it changed.
+                let changed = session_manager.update_forward_health(
+                    session_id,
+                    status.port,
+                    status.listening,
+                );
+                if changed {
+                    if let Some(key) = session_key.as_ref() {
+                        session_manager.broadcast_to_web_clients(
+                            key,
+                            ServerToClient::ForwardsChanged { session_id },
+                        );
+                    }
+                }
                 // `false` = nothing waiting: the unsolicited reply to a
                 // reconnect-replayed `ForwardOpen`. Expected, not an error.
                 session_manager.complete_forward_status(session_id, status);

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -98,6 +98,19 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
                     );
                 }
             }
+
+            // With the proxy gone there is no tunnel path, so any cached
+            // port-health verdict is meaningless — drop it and nudge chips
+            // back to neutral. The reconnect's replayed `ForwardOpen` probe
+            // re-seeds a fresh verdict (None → Some broadcasts again).
+            if session_manager.forget_forward_health_for_session(session_id) > 0 {
+                if let Some(key) = session_key.as_ref() {
+                    session_manager.broadcast_to_web_clients(
+                        key,
+                        ServerToClient::ForwardsChanged { session_id },
+                    );
+                }
+            }
         }
 
         if let Some(key) = session_key {

--- a/backend/src/handlers/websocket/session_manager/correlation.rs
+++ b/backend/src/handlers/websocket/session_manager/correlation.rs
@@ -97,20 +97,25 @@ impl SessionManager {
         self.pending_forward_status.remove(&(session_id, port));
     }
 
-    /// Record a probe verdict for the session's forward. Returns `true` when
-    /// the stored health *changed* — the caller broadcasts `ForwardsChanged`
-    /// so chips refetch and re-tint.
+    /// Record a probe verdict for `(session, port)`. Returns `true` when the
+    /// stored health *changed* — the caller broadcasts `ForwardsChanged` so
+    /// chips refetch and re-tint.
     pub fn update_forward_health(&self, session_id: Uuid, port: u16, listening: bool) -> bool {
-        self.forward_health.insert(session_id, (port, listening)) != Some((port, listening))
+        self.forward_health.insert((session_id, port), listening) != Some(listening)
     }
 
-    /// The last reported health for the session's forward, if the proxy has
-    /// probed `port` since it (re)connected.
+    /// The last reported health for `(session, port)`, if the proxy has
+    /// probed it since it (re)connected.
     pub fn forward_health(&self, session_id: Uuid, port: u16) -> Option<bool> {
         self.forward_health
-            .get(&session_id)
-            .filter(|entry| entry.0 == port)
-            .map(|entry| entry.1)
+            .get(&(session_id, port))
+            .map(|entry| *entry)
+    }
+
+    /// Drop a cached verdict — called when a forward is revoked or re-pointed
+    /// so the abandoned port's entry doesn't linger.
+    pub fn forget_forward_health(&self, session_id: Uuid, port: u16) {
+        self.forward_health.remove(&(session_id, port));
     }
 
     /// Deliver a proxy's `ForwardStatus` to the waiting handler. Returns
@@ -146,5 +151,36 @@ impl SessionManager {
         self.pending_launch_sessions
             .remove(&request_id)
             .map(|(_, id)| id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::handlers::websocket::SessionManager;
+    use uuid::Uuid;
+
+    #[test]
+    fn stale_old_port_status_cannot_clobber_current_port_health() {
+        // Regression (codex review on #1257): health is keyed by
+        // (session, port), so a late status for a just-replaced port must
+        // not erase the live port's verdict.
+        let mgr = SessionManager::default();
+        let session = Uuid::new_v4();
+
+        assert!(mgr.update_forward_health(session, 9000, true));
+        // Stale frame for the old port arrives late.
+        assert!(mgr.update_forward_health(session, 8000, false));
+        // The live port's verdict is untouched.
+        assert_eq!(mgr.forward_health(session, 9000), Some(true));
+        assert_eq!(mgr.forward_health(session, 8000), Some(false));
+
+        // Change-detection: same verdict again is not a change.
+        assert!(!mgr.update_forward_health(session, 9000, true));
+        assert!(mgr.update_forward_health(session, 9000, false));
+
+        // Forgetting drops only the named pair.
+        mgr.forget_forward_health(session, 8000);
+        assert_eq!(mgr.forward_health(session, 8000), None);
+        assert_eq!(mgr.forward_health(session, 9000), Some(false));
     }
 }

--- a/backend/src/handlers/websocket/session_manager/correlation.rs
+++ b/backend/src/handlers/websocket/session_manager/correlation.rs
@@ -97,6 +97,22 @@ impl SessionManager {
         self.pending_forward_status.remove(&(session_id, port));
     }
 
+    /// Record a probe verdict for the session's forward. Returns `true` when
+    /// the stored health *changed* — the caller broadcasts `ForwardsChanged`
+    /// so chips refetch and re-tint.
+    pub fn update_forward_health(&self, session_id: Uuid, port: u16, listening: bool) -> bool {
+        self.forward_health.insert(session_id, (port, listening)) != Some((port, listening))
+    }
+
+    /// The last reported health for the session's forward, if the proxy has
+    /// probed `port` since it (re)connected.
+    pub fn forward_health(&self, session_id: Uuid, port: u16) -> Option<bool> {
+        self.forward_health
+            .get(&session_id)
+            .filter(|entry| entry.0 == port)
+            .map(|entry| entry.1)
+    }
+
     /// Deliver a proxy's `ForwardStatus` to the waiting handler. Returns
     /// `false` if nothing was waiting (replayed `ForwardOpen`s after a
     /// reconnect get unsolicited replies — that's fine).

--- a/backend/src/handlers/websocket/session_manager/correlation.rs
+++ b/backend/src/handlers/websocket/session_manager/correlation.rs
@@ -118,6 +118,17 @@ impl SessionManager {
         self.forward_health.remove(&(session_id, port));
     }
 
+    /// Drop every cached verdict for `session_id` — called on proxy
+    /// disconnect, when no tunnel path exists and any verdict is stale (the
+    /// chip must fall back to neutral). Returns how many entries were removed
+    /// so the caller can broadcast `ForwardsChanged` only when something
+    /// actually changed.
+    pub fn forget_forward_health_for_session(&self, session_id: Uuid) -> usize {
+        let before = self.forward_health.len();
+        self.forward_health.retain(|(sid, _), _| *sid != session_id);
+        before - self.forward_health.len()
+    }
+
     /// Deliver a proxy's `ForwardStatus` to the waiting handler. Returns
     /// `false` if nothing was waiting (replayed `ForwardOpen`s after a
     /// reconnect get unsolicited replies — that's fine).
@@ -182,5 +193,25 @@ mod tests {
         mgr.forget_forward_health(session, 8000);
         assert_eq!(mgr.forward_health(session, 8000), None);
         assert_eq!(mgr.forward_health(session, 9000), Some(false));
+    }
+
+    #[test]
+    fn proxy_disconnect_clears_only_that_sessions_health() {
+        // Regression (codex re-review on #1257): a disconnected proxy has no
+        // tunnel path, so its cached verdicts must clear (chip → neutral)
+        // without touching other sessions'.
+        let mgr = SessionManager::default();
+        let (a, b) = (Uuid::new_v4(), Uuid::new_v4());
+
+        mgr.update_forward_health(a, 8000, true);
+        mgr.update_forward_health(a, 9000, true);
+        mgr.update_forward_health(b, 8000, true);
+
+        assert_eq!(mgr.forget_forward_health_for_session(a), 2);
+        assert_eq!(mgr.forward_health(a, 8000), None);
+        assert_eq!(mgr.forward_health(a, 9000), None);
+        assert_eq!(mgr.forward_health(b, 8000), Some(true));
+        // Nothing left for `a` → nothing removed → caller skips the broadcast.
+        assert_eq!(mgr.forget_forward_health_for_session(a), 0);
     }
 }

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -61,11 +61,13 @@ pub struct SessionManager {
     /// Pending `ForwardOpen` → `ForwardStatus` round-trips, keyed by
     /// `(session_id, port)` — the reply frame carries no request id.
     pending_forward_status: Arc<DashMap<(Uuid, u16), oneshot::Sender<ForwardStatusFields>>>,
-    /// Last reported forward-port health per session (`(port, listening)`),
-    /// fed by the proxy's background probe; drives the forward chip's
+    /// Last reported forward-port health, keyed by `(session, port)` — NOT
+    /// per-session, so a stale in-flight status for a just-replaced port can
+    /// never clobber the current port's verdict (codex review on #1257).
+    /// Fed by the proxy's background probe; drives the forward chip's
     /// green/red tint (docs/PORT_FORWARDING.md). In-memory only — unknown
     /// after a backend restart until the next probe report.
-    forward_health: Arc<DashMap<Uuid, (u16, bool)>>,
+    forward_health: Arc<DashMap<(Uuid, u16), bool>>,
     /// Live backend tunnel streams (docs/PORT_FORWARDING.md), keyed by
     /// stream id; the reverse proxy opens them, proxy sockets feed them.
     tunnel_streams: TunnelStreamMap,

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -61,6 +61,11 @@ pub struct SessionManager {
     /// Pending `ForwardOpen` → `ForwardStatus` round-trips, keyed by
     /// `(session_id, port)` — the reply frame carries no request id.
     pending_forward_status: Arc<DashMap<(Uuid, u16), oneshot::Sender<ForwardStatusFields>>>,
+    /// Last reported forward-port health per session (`(port, listening)`),
+    /// fed by the proxy's background probe; drives the forward chip's
+    /// green/red tint (docs/PORT_FORWARDING.md). In-memory only — unknown
+    /// after a backend restart until the next probe report.
+    forward_health: Arc<DashMap<Uuid, (u16, bool)>>,
     /// Live backend tunnel streams (docs/PORT_FORWARDING.md), keyed by
     /// stream id; the reverse proxy opens them, proxy sockets feed them.
     tunnel_streams: TunnelStreamMap,
@@ -96,6 +101,7 @@ impl Default for SessionManager {
             pending_probe_requests: Arc::new(DashMap::new()),
             pending_file_downloads: Arc::new(DashMap::new()),
             pending_forward_status: Arc::new(DashMap::new()),
+            forward_health: Arc::new(DashMap::new()),
             tunnel_streams: Arc::new(DashMap::new()),
             pending_launch_sessions: Arc::new(DashMap::new()),
             last_input_sender: Arc::new(DashMap::new()),

--- a/docs/PORT_FORWARDING.md
+++ b/docs/PORT_FORWARDING.md
@@ -376,6 +376,13 @@ No HTML/URL body rewriting, ever — origin isolation makes it unnecessary.
   from `GET /api/sessions/{id}/forwards`; owners get a revoke `×`. A
   `ServerToClient::ForwardsChanged { session_id }` event triggers a refetch so
   the chip appears/updates the moment the agent registers or re-points.
+- **The chip is tinted by live port health**: green = a listener answered the
+  proxy's last probe, red = connection refused, neutral = no verdict (proxy
+  offline / pre-probe). The proxy's `TunnelManager` background-probes every
+  allowlisted port each 10s (a loopback dial — microseconds) and sends
+  `ForwardStatus` only when a port's verdict *changes*; the backend caches
+  the verdict in memory (`ForwardInfo.listening`) and broadcasts
+  `ForwardsChanged` so chips refetch. Steady state costs zero frames.
 - **Clicking the chip opens an inline preview overlay**: a fixed collapsible
   panel containing an `<iframe>` pointed at the `open` handoff endpoint, with
   a "Visit site ↗" link that opens the full page in a new tab and a collapse

--- a/frontend/src/pages/dashboard/session_view/forward_chips.rs
+++ b/frontend/src/pages/dashboard/session_view/forward_chips.rs
@@ -233,8 +233,25 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
         <span class="session-forwards">
             { for forwards.iter().map(|f| {
                 let on_revoke = revoke.clone();
+                // Green = last probe saw a listener on the port, red = probe
+                // got connection-refused, neutral = no verdict yet (proxy
+                // offline or pre-probe). Updates ride ForwardsChanged.
+                let health_class = match f.listening {
+                    Some(true) => Some("is-up"),
+                    Some(false) => Some("is-down"),
+                    None => None,
+                };
+                let health_title = match f.listening {
+                    Some(true) => format!("{} — port is live", f.url),
+                    Some(false) => format!("{} — nothing listening on the port", f.url),
+                    None => f.url.clone(),
+                };
                 html! {
-                    <span class="forward-chip" key={f.port} title={f.url.clone()}>
+                    <span
+                        class={classes!("forward-chip", health_class)}
+                        key={f.port}
+                        title={health_title}
+                    >
                         // Click opens the inline preview overlay; "Visit site"
                         // inside it goes to the full page.
                         <a href={open_url.clone()} onclick={toggle_preview.clone()}>

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -119,6 +119,25 @@
     text-decoration: underline;
 }
 
+/* Live port health from the proxy's background probe. */
+.session-view-header .forward-chip.is-up {
+    border-color: rgba(158, 206, 106, 0.6);
+    background: rgba(158, 206, 106, 0.12);
+}
+
+.session-view-header .forward-chip.is-up a {
+    color: var(--success, #9ece6a);
+}
+
+.session-view-header .forward-chip.is-down {
+    border-color: rgba(247, 118, 142, 0.6);
+    background: rgba(247, 118, 142, 0.12);
+}
+
+.session-view-header .forward-chip.is-down a {
+    color: var(--error, #f7768e);
+}
+
 .session-view-header .forward-chip-revoke {
     background: none;
     border: none;

--- a/session-lib/src/tunnel.rs
+++ b/session-lib/src/tunnel.rs
@@ -48,6 +48,10 @@ pub const INITIAL_WINDOW: u32 = 256 * 1024;
 pub const MAX_STREAMS: usize = 64;
 /// How long a probe/stream dial to loopback may take before it is refused.
 const DIAL_TIMEOUT: Duration = Duration::from_secs(2);
+/// Cadence of the background port-health probe. A loopback dial is
+/// microseconds of work, so this can be frequent — it drives the green/red
+/// liveness tint on the frontend's forward chip.
+const PROBE_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Frames the manager's per-stream downlink loop consumes.
 enum StreamMsg {
@@ -76,15 +80,69 @@ pub struct TunnelManager {
     ws: TunnelWsWrite,
     allowed: Mutex<HashSet<u16>>,
     streams: Mutex<HashMap<Uuid, StreamHandle>>,
+    /// Last probe verdict per allowlisted port; the background prober reports
+    /// a `ForwardStatus` only when a port's verdict *changes* (the
+    /// registration-time probe seeds it), so steady state costs no frames.
+    last_health: Mutex<HashMap<u16, bool>>,
+    prober: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl TunnelManager {
     pub fn new(ws: TunnelWsWrite) -> Arc<Self> {
-        Arc::new(Self {
+        let mgr = Arc::new(Self {
             ws,
             allowed: Mutex::new(HashSet::new()),
             streams: Mutex::new(HashMap::new()),
-        })
+            last_health: Mutex::new(HashMap::new()),
+            prober: std::sync::Mutex::new(None),
+        });
+        // Background health probe: holds only a Weak so a dropped manager
+        // (connection gone) ends the loop; `shutdown` aborts it eagerly.
+        let weak = Arc::downgrade(&mgr);
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(PROBE_INTERVAL).await;
+                let Some(mgr) = weak.upgrade() else { return };
+                mgr.probe_tick().await;
+            }
+        });
+        *mgr.prober.lock().unwrap_or_else(|e| e.into_inner()) = Some(handle);
+        mgr
+    }
+
+    /// One pass of the background prober: dial every allowlisted port and
+    /// report the ports whose verdict changed since the last pass.
+    async fn probe_tick(self: &Arc<Self>) {
+        let ports: Vec<u16> = self.allowed.lock().await.iter().copied().collect();
+        // Drop verdicts for ports no longer forwarded.
+        self.last_health
+            .lock()
+            .await
+            .retain(|port, _| ports.contains(port));
+        for port in ports {
+            let (listening, error) =
+                match tokio::time::timeout(DIAL_TIMEOUT, dial_loopback(port)).await {
+                    Ok(Ok(_)) => (true, None),
+                    Ok(Err(e)) => (false, Some(e.to_string())),
+                    Err(_) => (false, Some("probe dial timed out".to_string())),
+                };
+            let changed = {
+                let mut health = self.last_health.lock().await;
+                health.insert(port, listening) != Some(listening)
+            };
+            if changed {
+                info!(
+                    "Forward port {} health changed: listening={}",
+                    port, listening
+                );
+                self.send(ProxyToServer::ForwardStatus(ForwardStatusFields {
+                    port,
+                    listening,
+                    error,
+                }))
+                .await;
+            }
+        }
     }
 
     /// Returns `true` if `msg` was a forward/tunnel frame (and was handled).
@@ -105,6 +163,8 @@ impl TunnelManager {
                             Ok(Err(e)) => (false, Some(e.to_string())),
                             Err(_) => (false, Some("probe dial timed out".to_string())),
                         };
+                    // Seed the background prober so it only reports changes.
+                    mgr.last_health.lock().await.insert(port, listening);
                     mgr.send(ProxyToServer::ForwardStatus(ForwardStatusFields {
                         port,
                         listening,
@@ -116,6 +176,7 @@ impl TunnelManager {
             }
             ServerToProxy::ForwardClose(f) => {
                 self.allowed.lock().await.remove(&f.port);
+                self.last_health.lock().await.remove(&f.port);
                 let streams = self.streams.lock().await;
                 for handle in streams.values().filter(|h| h.port == f.port) {
                     let _ = handle.inbox.send(StreamMsg::Close);
@@ -193,6 +254,9 @@ impl TunnelManager {
     /// connection; a reconnect builds a fresh one and the backend replays
     /// `ForwardOpen`s to rebuild the allowlist.
     pub async fn shutdown(&self) {
+        if let Some(prober) = self.prober.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            prober.abort();
+        }
         let streams = self.streams.lock().await;
         for handle in streams.values() {
             let _ = handle.inbox.send(StreamMsg::Close);

--- a/session-lib/src/tunnel.rs
+++ b/session-lib/src/tunnel.rs
@@ -126,6 +126,13 @@ impl TunnelManager {
                     Ok(Err(e)) => (false, Some(e.to_string())),
                     Err(_) => (false, Some("probe dial timed out".to_string())),
                 };
+            // Re-check the allowlist after the dial: a `ForwardClose` that
+            // raced this tick must not resurrect the port with a stale
+            // status (codex review on #1257).
+            if !self.allowed.lock().await.contains(&port) {
+                self.last_health.lock().await.remove(&port);
+                continue;
+            }
             let changed = {
                 let mut health = self.last_health.lock().await;
                 health.insert(port, listening) != Some(listening)
@@ -163,6 +170,11 @@ impl TunnelManager {
                             Ok(Err(e)) => (false, Some(e.to_string())),
                             Err(_) => (false, Some("probe dial timed out".to_string())),
                         };
+                    // A `ForwardClose` may have raced the dial — don't emit a
+                    // stale status for a port that's no longer forwarded.
+                    if !mgr.allowed.lock().await.contains(&port) {
+                        return;
+                    }
                     // Seed the background prober so it only reports changes.
                     mgr.last_health.lock().await.insert(port, listening);
                     mgr.send(ProxyToServer::ForwardStatus(ForwardStatusFields {

--- a/shared/src/api/forwards.rs
+++ b/shared/src/api/forwards.rs
@@ -19,6 +19,11 @@ pub struct ForwardInfo {
     /// When true, the URL serves without a portal login (owner opt-in).
     #[serde(default)]
     pub public: bool,
+    /// Latest probe verdict for the forwarded port: `Some(true)` = something
+    /// is listening, `Some(false)` = nothing there, `None` = unknown (proxy
+    /// disconnected, pre-probe, or pre-2.13.17). Drives the chip tint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub listening: Option<bool>,
 }
 
 /// One of the caller's active forwards, for the Settings ▸ Forwarding tab.


### PR DESCRIPTION
## Summary

The session-header forward chip now shows **live port health**: green = something is listening on the forwarded port, red = connection refused, neutral = unknown (per user request — "active" next to the chip is session status and says nothing about the port).

### How (no protocol change)
- **Proxy** (`session-lib/tunnel.rs`): `TunnelManager` gains a background prober — every **10s** it loopback-dials each allowlisted port (microseconds of work) and sends the existing `ForwardStatus` frame **only when a port's verdict changes**; the registration-time probe seeds the state so there's no duplicate initial report. Steady state = zero extra WS frames. The prober holds a `Weak<TunnelManager>` (exits when the connection's manager drops) and is aborted eagerly in `shutdown()`. Verdicts for closed ports are dropped.
- **Backend**: `ForwardStatus` frames now also update an in-memory health cache on the `SessionManager` (`session → (port, listening)`); on a *change*, the backend broadcasts `ForwardsChanged`, riding the chips' existing refetch plumbing. The one-shot registration waiter behavior is unchanged.
- **API**: `ForwardInfo` gains additive `listening: Option<bool>` (serde-defaulted); populated from the cache in the session forwards list.
- **Frontend**: chip gets `is-up` / `is-down` classes (green/red border+text per theme palette) and a health-aware tooltip; neutral (teal) when no verdict.

### Mixed-fleet behavior
Old proxies never send periodic statuses → chips stay neutral (exactly today's look). Old backends treat unsolicited `ForwardStatus` as the existing replayed-`ForwardOpen` case → ignored. Old frontends ignore the new field.

### Verification
- All native crates + WASM build; **fresh non-incremental clippy** on workspace + wasm target; backend (135) + session-lib (33) tests; rustfmt; **local stylelint** on the touched CSS (the #1255 lesson).
- End-to-end tint needs a deployed fleet (proxy probe → backend cache → chip); every hop reuses machinery that's been live-verified (`ForwardStatus` at registration, `ForwardsChanged` refetch).

Versioned 2.13.17.