### PR TITLE
Preview panel: accent edge + genie open/close animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.13.19
+
+- **Forward preview overlay: accent edge + genie open/close.** The floating preview panel gets a contrasting accent-blue border (plus a faint outer ring in the shadow stack) so it reads as a distinct surface instead of blending into the dark page. Opening now **expands the panel out of the chip that launched it** and closing **collapses it back into the chip** — the chip's screen position is captured at click time and becomes the animation's `transform-origin` (0.18s out / 0.16s in, scale+fade). Unmount waits for `animationend` on the out-animation, with an effect-armed 250ms timer fallback for `prefers-reduced-motion` (where the animations are disabled entirely) — armed via `use_effect_with` so the closure holds fresh state handles, and cancelled if the panel reopens mid-close. The `▾` collapse-to-titlebar behavior is unchanged.
+
 ## 2.13.18
 
 - **Forward chip: bound-app name + color-only health (docs/PORT_FORWARDING.md, #689).** When the proxy's health probe finds a listener it now also resolves the owning process (the [`listeners`](https://crates.io/crates/listeners) crate — same-user `/proc`/libproc lookup, run in `spawn_blocking`) and ships it in `ForwardStatus.process` (additive). The name is part of the probe verdict, so an app swap on the same port re-reports; it surfaces as `ForwardInfo.process`, in the chip tooltip (`python3 — {url}`) and the preview overlay's title bar (`python3 :8899 — {url}`). Health is now conveyed by **color alone** — the "port is live"/"nothing listening" tooltip text is gone: the chip **breathes a subtle green** while live (2.8s ease, disabled under `prefers-reduced-motion`) and sits **flat red** when the last probe was refused; neutral when no verdict. New deterministic test binds a listener in-process and asserts the resolver names our own binary; health-cache tests extended for the (listening, process) verdict tuple.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.13.18"
+version = "2.13.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.18"
+version = "2.13.19"
 dependencies = [
  "anyhow",
  "axum",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.18"
+version = "2.13.19"
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.18"
+version = "2.13.19"
 dependencies = [
  "anyhow",
  "base64",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.18"
+version = "2.13.19"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.18"
+version = "2.13.19"
 dependencies = [
  "base64",
  "chrono",
@@ -2630,7 +2630,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.18"
+version = "2.13.19"
 dependencies = [
  "anyhow",
  "colored",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.18"
+version = "2.13.19"
 dependencies = [
  "anyhow",
  "hex",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.18"
+version = "2.13.19"
 dependencies = [
  "anyhow",
  "base64",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.18"
+version = "2.13.19"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.13.18"
+version = "2.13.19"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_view/forward_chips.rs
+++ b/frontend/src/pages/dashboard/session_view/forward_chips.rs
@@ -11,6 +11,7 @@ use std::rc::Rc;
 use gloo_net::http::Request;
 use shared::api::{ForwardInfo, SessionForwardsResponse};
 use uuid::Uuid;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use yew::events::{AnimationEvent, PointerEvent};
 use yew::prelude::*;
@@ -181,13 +182,21 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
                 preview_closing.set(true);
             } else {
                 // Anchor the genie animation at the chip that launched it.
-                let rect = e
-                    .target_unchecked_into::<web_sys::Element>()
-                    .get_bounding_client_rect();
-                anchor.set((
-                    rect.left() + rect.width() / 2.0,
-                    rect.top() + rect.height() / 2.0,
-                ));
+                // `current_target` (the element this handler is bound to),
+                // NOT `target`: a click can land on a text node or future
+                // child markup inside the anchor, whose rect (or unchecked
+                // Element cast) would be wrong. Missing cast keeps the
+                // previous/default anchor.
+                if let Some(el) = e
+                    .current_target()
+                    .and_then(|t| t.dyn_into::<web_sys::Element>().ok())
+                {
+                    let rect = el.get_bounding_client_rect();
+                    anchor.set((
+                        rect.left() + rect.width() / 2.0,
+                        rect.top() + rect.height() / 2.0,
+                    ));
+                }
                 preview_open.set(true);
                 preview_closing.set(false);
                 preview_collapsed.set(false);

--- a/frontend/src/pages/dashboard/session_view/forward_chips.rs
+++ b/frontend/src/pages/dashboard/session_view/forward_chips.rs
@@ -12,7 +12,7 @@ use gloo_net::http::Request;
 use shared::api::{ForwardInfo, SessionForwardsResponse};
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
-use yew::events::PointerEvent;
+use yew::events::{AnimationEvent, PointerEvent};
 use yew::prelude::*;
 
 use crate::utils::{self, api_url, fetch_json, On401};
@@ -102,9 +102,30 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
 
     // Preview overlay: open/collapsed are independent so collapsing keeps the
     // iframe mounted (the embedded app keeps running; expand restores it
-    // where it was). Closed on session switch below.
+    // where it was). Closed on session switch below. `closing` keeps the
+    // panel mounted while the collapse-into-the-chip animation plays;
+    // `anchor` is the chip's screen position, the animation's origin.
     let preview_open = use_state(|| false);
     let preview_collapsed = use_state(|| false);
+    let preview_closing = use_state(|| false);
+    let anchor = use_state(|| (24.0f64, 48.0f64));
+    // Fallback for the close animation's `animationend`: it never fires under
+    // `prefers-reduced-motion` (the animation is disabled), so a timer
+    // finalizes the close regardless. Armed by the effect so its closure gets
+    // fresh state handles, and dropped (cancelled) if `closing` flips back.
+    {
+        let preview_open = preview_open.clone();
+        let closing_handle = preview_closing.clone();
+        use_effect_with(*preview_closing, move |closing| {
+            let timer = closing.then(|| {
+                gloo::timers::callback::Timeout::new(250, move || {
+                    preview_open.set(false);
+                    closing_handle.set(false);
+                })
+            });
+            move || drop(timer)
+        });
+    }
     // Panel geometry (left, top, width, iframe height) in px — dragged by the
     // title bar, resized by the corner grip. Survives collapse/expand.
     let geom = use_state(|| (12.0f64, 52.0f64, 760.0f64, 480.0f64));
@@ -150,12 +171,25 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
     let toggle_preview = {
         let preview_open = preview_open.clone();
         let preview_collapsed = preview_collapsed.clone();
+        let preview_closing = preview_closing.clone();
+        let anchor = anchor.clone();
         Callback::from(move |e: MouseEvent| {
             e.prevent_default();
-            if *preview_open {
-                preview_open.set(false);
+            if *preview_open && !*preview_closing {
+                // Play the collapse-into-the-chip animation; unmount happens
+                // on animationend (with a timer fallback).
+                preview_closing.set(true);
             } else {
+                // Anchor the genie animation at the chip that launched it.
+                let rect = e
+                    .target_unchecked_into::<web_sys::Element>()
+                    .get_bounding_client_rect();
+                anchor.set((
+                    rect.left() + rect.width() / 2.0,
+                    rect.top() + rect.height() / 2.0,
+                ));
                 preview_open.set(true);
+                preview_closing.set(false);
                 preview_collapsed.set(false);
             }
         })
@@ -165,8 +199,21 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
         Callback::from(move |_: MouseEvent| preview_collapsed.set(!*preview_collapsed))
     };
     let close_preview = {
+        let preview_closing = preview_closing.clone();
+        Callback::from(move |_: MouseEvent| preview_closing.set(true))
+    };
+    // Unmount as soon as the collapse animation lands on the chip. The name
+    // check gates on the out-animation, which only plays while `.closing` is
+    // applied, so no state guard is needed here.
+    let on_panel_animation_end = {
         let preview_open = preview_open.clone();
-        Callback::from(move |_: MouseEvent| preview_open.set(false))
+        let preview_closing = preview_closing.clone();
+        Callback::from(move |e: AnimationEvent| {
+            if e.animation_name() == "forward-preview-out" {
+                preview_open.set(false);
+                preview_closing.set(false);
+            }
+        })
     };
 
     // Drag (title bar) and resize (corner grip) share the pointer-capture
@@ -271,8 +318,21 @@ pub fn forward_chips(props: &ForwardChipsProps) -> Html {
         </span>
         if *preview_open {
             <div
-                class="forward-preview"
-                style={format!("left:{}px; top:{}px; width:{}px;", geom.0, geom.1, geom.2)}
+                class={classes!(
+                    "forward-preview",
+                    preview_closing.then_some("closing"),
+                )}
+                // transform-origin puts the genie animation's focal point on
+                // the chip that launched the panel.
+                style={format!(
+                    "left:{}px; top:{}px; width:{}px; transform-origin: {}px {}px;",
+                    geom.0,
+                    geom.1,
+                    geom.2,
+                    anchor.0 - geom.0,
+                    anchor.1 - geom.1,
+                )}
+                onanimationend={on_panel_animation_end}
             >
                 <div class="forward-preview-bar">
                     <button

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -184,10 +184,58 @@
     display: flex;
     flex-direction: column;
     background: var(--bg-darker);
-    border: 1px solid var(--border);
+
+    /* Accent edge: the default --border blends into the dark page behind a
+       floating window; the accent line keeps the panel readable as a
+       distinct surface. */
+    border: 1px solid rgba(122, 162, 247, 0.55);
     border-radius: 10px;
-    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+    box-shadow:
+        0 0 0 1px rgba(122, 162, 247, 0.15),
+        0 12px 32px rgba(0, 0, 0, 0.55);
     overflow: hidden;
+
+    /* Genie in: expand out of the launching chip (transform-origin is set
+       inline to the chip's position). */
+    animation: forward-preview-in 0.18s ease-out;
+}
+
+/* Genie out: collapse back into the chip; unmount happens on animationend
+   (with a timer fallback for reduced-motion, where this never plays). */
+.forward-preview.closing {
+    animation: forward-preview-out 0.16s ease-in forwards;
+    pointer-events: none;
+}
+
+@keyframes forward-preview-in {
+    from {
+        transform: scale(0.05);
+        opacity: 0.25;
+    }
+
+    to {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+@keyframes forward-preview-out {
+    from {
+        transform: scale(1);
+        opacity: 1;
+    }
+
+    to {
+        transform: scale(0.05);
+        opacity: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .forward-preview,
+    .forward-preview.closing {
+        animation: none;
+    }
 }
 
 .forward-preview-bar {


### PR DESCRIPTION
## Summary

Two visual refinements to the forward preview window (per user request):

1. **Contrasting edge** — the panel border was `var(--border)`, which blends into the dark page. Now an accent-blue 1px border plus a faint outer ring in the shadow stack, so the floating window reads as a distinct surface.
2. **Genie open/close** — opening expands the panel *out of the chip that launched it*; closing (via `×` or clicking the chip again) collapses it *back into the chip*. The chip's screen position is captured from the click target's bounding rect and applied as the panel's `transform-origin`, so the scale+fade (0.18s out / 0.16s in) converges exactly on the chip wherever the panel has been dragged.

### Lifecycle correctness
- Unmount is deferred until `animationend` of the out-animation (name-gated so the in-animation's end can't trigger it).
- `prefers-reduced-motion` disables both animations — so `animationend` never fires there. A 250ms fallback timer finalizes the close; it's armed by `use_effect_with(*preview_closing)` so the closure gets **fresh state handles** (a plain callback-captured handle would read a stale snapshot and no-op), and the effect cleanup cancels the timer if the panel reopens mid-close.
- `.closing` also sets `pointer-events: none` so a shrinking panel can't eat clicks.
- Collapse-to-titlebar (`▾`) is untouched.

### Verification
- WASM build, CI-style clippy (`-Dwarnings --all-targets` + frontend/dist shim), frontend-target clippy, stylelint, rustfmt — all clean.
- Animation feel needs eyes after deploy; the state machine (open → closing → unmount, reopen-cancels-close) is the reviewable part.

Versioned 2.13.19.