### PR TITLE
Report server version from health endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.13.21
+
+- **Health endpoint reports server version (#1048).** `/api/health` now returns a typed JSON response with the existing `status` plus the backend package `version`, so clients and operators can confirm which server build answered a health check.
+
 ## 2.13.19
 
 - **Forward preview overlay: accent edge + genie open/close.** The floating preview panel gets a contrasting accent-blue border (plus a faint outer ring in the shadow stack) so it reads as a distinct surface instead of blending into the dark page. Opening now **expands the panel out of the chip that launched it** and closing **collapses it back into the chip** — the chip's screen position is captured at click time and becomes the animation's `transform-origin` (0.18s out / 0.16s in, scale+fade). Unmount waits for `animationend` on the out-animation, with an effect-armed 250ms timer fallback for `prefers-reduced-motion` (where the animations are disabled entirely) — armed via `use_effect_with` so the closure holds fresh state handles, and cancelled if the panel reopens mid-close. The `▾` collapse-to-titlebar behavior is unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.13.19"
+version = "2.13.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.19"
+version = "2.13.21"
 dependencies = [
  "anyhow",
  "axum",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.19"
+version = "2.13.21"
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.19"
+version = "2.13.21"
 dependencies = [
  "anyhow",
  "base64",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.19"
+version = "2.13.21"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.19"
+version = "2.13.21"
 dependencies = [
  "base64",
  "chrono",
@@ -2630,7 +2630,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.19"
+version = "2.13.21"
 dependencies = [
  "anyhow",
  "colored",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.19"
+version = "2.13.21"
 dependencies = [
  "anyhow",
  "hex",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.19"
+version = "2.13.21"
 dependencies = [
  "anyhow",
  "base64",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.19"
+version = "2.13.21"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.13.19"
+version = "2.13.21"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,10 +1,10 @@
 use axum::{
     routing::{get, post},
-    Router,
+    Json, Router,
 };
 use governor::clock::QuantaInstant;
 use governor::middleware::NoOpMiddleware;
-use shared::WsEndpoint;
+use shared::{api::HealthResponse, WsEndpoint};
 use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_governor::governor::GovernorConfigBuilder;
@@ -106,7 +106,15 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
 
     Router::new()
         // Health check endpoint
-        .route("/api/health", get(|| async { "OK" }))
+        .route(
+            "/api/health",
+            get(|| async {
+                Json(HealthResponse {
+                    status: "OK".to_string(),
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                })
+            }),
+        )
         // App configuration (public, no auth required)
         .route("/api/config", get(handlers::config::get_config))
         // Session API routes

--- a/shared/src/api/health.rs
+++ b/shared/src/api/health.rs
@@ -1,0 +1,10 @@
+//! Health-check endpoint response types.
+
+use serde::{Deserialize, Serialize};
+
+/// Response from GET /api/health.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthResponse {
+    pub status: String,
+    pub version: String,
+}

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -3,6 +3,7 @@
 mod device_flow;
 mod error;
 mod forwards;
+mod health;
 mod launch;
 mod metrics;
 mod permissions;
@@ -14,6 +15,7 @@ mod users;
 pub use device_flow::*;
 pub use error::*;
 pub use forwards::*;
+pub use health::*;
 pub use launch::*;
 pub use metrics::*;
 pub use permissions::*;


### PR DESCRIPTION
Closes #1048.

## Summary
- add shared::api::HealthResponse for the health endpoint
- return JSON from /api/health with status and CARGO_PKG_VERSION
- bump workspace version to 2.13.21

## Verification
- cargo test -p shared
- mkdir -p frontend/dist && RUSTFLAGS=-Dwarnings cargo clippy -p backend -p shared --all-targets
- cargo fmt --check