### PR TITLE
Derive version patch from git commit count (#1096)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Check migration naming convention
         run: ./scripts/check-migration-names.sh
@@ -35,6 +37,8 @@ jobs:
         working-directory: frontend/lint
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -54,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.92.0
@@ -68,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -84,6 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
         # Backend embeds frontend/dist at build time, but memory_serve falls
@@ -108,6 +118,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
         # Backend embeds frontend/dist at build time, but memory_serve falls
@@ -131,6 +143,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
         # Backend embeds frontend/dist at build time, but memory_serve falls
@@ -174,6 +188,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
         run: mkdir -p frontend/dist
@@ -234,6 +250,8 @@ jobs:
             launcher-artifact: launcher-windows-x86_64
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
             target-dir: target/release
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -93,6 +95,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+- **Versioning: patch is now the git commit count (issue #1096).** The reported version is `major.minor.{git rev-list --count HEAD}`, derived at build time by `shared/build.rs` and read everywhere as `shared::VERSION`. PRs no longer bump a version line — so parallel PRs can't collide on a hand-picked number, and the patch advances by exactly one per squash-merge. `major.minor` in `Cargo.toml` is the only human knob (its patch is a placeholder). This changelog is maintained by a periodic sweep rather than in lockstep per-PR; add notable changes under this `[Unreleased]` heading.
+
 ## 2.13.21
 
-- **Health endpoint reports server version (#1048).** `/api/health` now returns a typed JSON response with the existing `status` plus the backend package `version`, so clients and operators can confirm which server build answered a health check.
+- **Health endpoint reports server version (#1048).** `/api/health` now returns a typed JSON response with the existing `status` plus the backend package `version` (now `shared::VERSION`), so clients and operators can confirm which server build answered a health check.
 
 ## 2.13.19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -628,11 +628,23 @@ If code is unused, delete it. It can be recovered from git history if needed lat
 
 ### Versioning
 
-The workspace version lives in `Cargo.toml` under `[workspace.package]`. When shipping changes:
-- **Patch bump** (e.g. 1.1.2 → 1.1.3): bug fixes, dependency updates, minor tweaks
-- **Minor bump** (e.g. 1.1.3 → 1.2.0): new features, new crates, protocol changes
+The reported version is `major.minor.{git commit count}` — the **patch is
+derived at build time** from `git rev-list --count HEAD` by `shared/build.rs`,
+and read everywhere as `shared::VERSION` (issue #1096). This means:
 
-**Every PR must include at least a patch version bump.** Bump the version in the same commit/PR as the code change — do not ship a PR without incrementing the version.
+- **PRs do NOT touch the version.** There is no version line to bump and no
+  version collisions between parallel PRs. The patch advances by exactly one
+  per squash-merge, automatically.
+- **`major.minor` is the only human knob**, in `Cargo.toml` under
+  `[workspace.package] version` (the patch there is a placeholder). Bump it by
+  hand only for a **feature** (`2.13 → 2.14`) or **breaking** (`2 → 3`) release.
+- **Do not reintroduce `env!("CARGO_PKG_VERSION")` for display** — it's the
+  static placeholder, not the real version. Use `shared::VERSION`.
+
+The CHANGELOG is no longer kept in lockstep per-PR (you can't know the commit
+count in advance); it's maintained by a periodic sweep. Add notable
+user-facing changes under the `## [Unreleased]` heading if you like, but it's
+not a merge gate.
 
 ### No `serde_json::json!`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-portal"
-version = "2.13.21"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.21"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.21"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.21"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.21"
+version = "2.13.0"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.21"
+version = "2.13.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2630,7 +2630,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.21"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.21"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.21"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.21"
+version = "2.13.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.13.21"
+# Only `major.minor` here is meaningful — bump it by hand for a feature/breaking
+# release. The patch is a placeholder: the reported version is
+# `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
+# so no PR ever edits a version line (issue #1096). Runtime version =
+# `shared::VERSION`.
+version = "2.13.0"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 pub async fn get_config(State(app_state): State<Arc<AppState>>) -> Json<AppConfig> {
     Json(AppConfig {
         app_title: app_state.app_title.clone(),
-        server_version: env!("CARGO_PKG_VERSION").to_string(),
+        server_version: shared::VERSION.to_string(),
         splash_text: app_state.splash_text.clone(),
     })
 }

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -111,7 +111,7 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             get(|| async {
                 Json(HealthResponse {
                     status: "OK".to_string(),
-                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    version: shared::VERSION.to_string(),
                 })
             }),
         )

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -662,7 +662,7 @@ pub async fn register_session(
         resuming: config.resume,
         git_branch: config.git_branch.clone(),
         replay_after: None, // Proxy doesn't need history replay
-        client_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        client_version: Some(shared::VERSION.to_string()),
         replaces_session_id: config.replaces_session_id,
         hostname: Some(hostname),
         launcher_id: config.launcher_id,

--- a/claude-session-lib/src/proxy_session/portal_reminder.rs
+++ b/claude-session-lib/src/proxy_session/portal_reminder.rs
@@ -25,7 +25,7 @@ const DEFAULT_BODY: &str = include_str!("../../portal_reminder.md");
 /// Running portal version, captured at compile time from the workspace
 /// `Cargo.toml`. Surfaced in the system-reminder envelope so the agent
 /// knows which portal features and fixes are in scope.
-const PORTAL_VERSION: &str = env!("CARGO_PKG_VERSION");
+const PORTAL_VERSION: &str = shared::VERSION;
 
 /// Resolve the reminder body. Honors `PORTAL_REMINDER_FILE` at call time so
 /// operators can hot-edit the file and have the next compaction pick it up

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -4,8 +4,9 @@ mod hooks;
 mod pages;
 pub mod utils;
 
-/// Application version from Cargo.toml (set at compile time)
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Application version — derived at build time from the git commit count
+/// (see `shared::VERSION` / `shared/build.rs`, issue #1096).
+pub const VERSION: &str = shared::VERSION;
 
 use pages::{
     access_denied::AccessDeniedPage, admin::AdminPage, agent_messaging::AgentMessagingPage,

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -92,7 +92,7 @@ pub async fn run_launcher_loop(
                     launcher_name: launcher_name.to_string(),
                     auth_token: auth_token.clone(),
                     hostname: claude_session_lib::hostname_or_unknown(),
-                    version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                    version: Some(shared::VERSION.to_string()),
                     working_directory: std::env::current_dir()
                         .ok()
                         .map(|p| p.to_string_lossy().to_string()),

--- a/launcher/src/pastebin.rs
+++ b/launcher/src/pastebin.rs
@@ -30,7 +30,7 @@ fn write_section(buf: &mut String, title: &str, content: &str) {
 }
 
 fn build_info() -> String {
-    let version = env!("CARGO_PKG_VERSION");
+    let version = shared::VERSION;
     let binary = std::env::current_exe()
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| "<unknown>".into());

--- a/shared/build.rs
+++ b/shared/build.rs
@@ -1,0 +1,39 @@
+//! Derives the portal version at build time so PRs never edit a version line
+//! (issue #1096): `major.minor` come from the workspace `[workspace.package]
+//! version`, the patch is the git commit count.
+//!
+//! The count is monotonic on `main` — with squash-merge it increases by
+//! exactly one per merged PR — so deployed versions stay tidy and sequential
+//! while parallel PRs can't collide on a hand-picked number. Feature branches
+//! naturally show a higher count (their own unmerged commits), i.e. a dev
+//! build reads "ahead" of what `main` will be after squash, which is useful
+//! signal. Falls back to the Cargo.toml patch when git is unavailable (a
+//! source tarball or vendored build with no history).
+
+use std::process::Command;
+
+fn git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    (!s.is_empty()).then_some(s)
+}
+
+fn main() {
+    let major = std::env::var("CARGO_PKG_VERSION_MAJOR").unwrap_or_else(|_| "0".into());
+    let minor = std::env::var("CARGO_PKG_VERSION_MINOR").unwrap_or_else(|_| "0".into());
+    let fallback_patch = std::env::var("CARGO_PKG_VERSION_PATCH").unwrap_or_else(|_| "0".into());
+
+    let patch = git(&["rev-list", "--count", "HEAD"]).unwrap_or(fallback_patch);
+    println!("cargo:rustc-env=PORTAL_VERSION={major}.{minor}.{patch}");
+
+    // Recompute only when the commit count could have changed: HEAD moving
+    // (branch switch / detached commit) or the reflog appending (any
+    // commit/reset/checkout). Without git, fall through to Cargo's default.
+    if let Some(git_dir) = git(&["rev-parse", "--absolute-git-dir"]) {
+        println!("cargo:rerun-if-changed={git_dir}/HEAD");
+        println!("cargo:rerun-if-changed={git_dir}/logs/HEAD");
+    }
+}

--- a/shared/build.rs
+++ b/shared/build.rs
@@ -26,7 +26,16 @@ fn main() {
     let minor = std::env::var("CARGO_PKG_VERSION_MINOR").unwrap_or_else(|_| "0".into());
     let fallback_patch = std::env::var("CARGO_PKG_VERSION_PATCH").unwrap_or_else(|_| "0".into());
 
-    let patch = git(&["rev-list", "--count", "HEAD"]).unwrap_or(fallback_patch);
+    // In a shallow checkout (`actions/checkout` default fetch-depth) the count
+    // is truncated — usually 1 — which would ship a wrong low version. The CI
+    // workflows set `fetch-depth: 0`, but guard here too so a forgotten
+    // setting degrades to the Cargo.toml placeholder, never a bogus `2.13.1`.
+    let shallow = git(&["rev-parse", "--is-shallow-repository"]).as_deref() == Some("true");
+    let patch = if shallow {
+        fallback_patch
+    } else {
+        git(&["rev-list", "--count", "HEAD"]).unwrap_or(fallback_patch)
+    };
     println!("cargo:rustc-env=PORTAL_VERSION={major}.{minor}.{patch}");
 
     // Recompute only when the commit count could have changed: HEAD moving

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,6 +5,24 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// The portal version, `major.minor.{git commit count}` — derived at build
+/// time by `build.rs` (issue #1096) so no PR ever edits a version line. Every
+/// crate reports this single value (`server_version`, launcher `version`, the
+/// frontend footer, the `agent-portal` client version). The Cargo.toml
+/// `[workspace.package] version` supplies only `major.minor`; its patch is a
+/// placeholder.
+pub const VERSION: &str = env!("PORTAL_VERSION");
+
+/// Split [`VERSION`] into `(major, minor, patch)` numeric components.
+/// `None` on the (impossible-by-construction) malformed string.
+pub fn version_parts() -> Option<(u64, u64, u64)> {
+    let mut it = VERSION.split('.');
+    let major = it.next()?.parse().ok()?;
+    let minor = it.next()?.parse().ok()?;
+    let patch = it.next()?.parse().ok()?;
+    Some((major, minor, patch))
+}
+
 // Proxy token types in separate module
 pub mod proxy_tokens;
 pub use proxy_tokens::*;
@@ -586,6 +604,18 @@ pub struct AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn version_is_well_formed() {
+        // Derived by build.rs; must always be `major.minor.patch`, all numeric
+        // (issue #1096). A parse failure means the derivation broke.
+        let (major, minor, _patch) = version_parts().expect("VERSION is major.minor.patch");
+        // major.minor track the workspace Cargo.toml; patch is the commit
+        // count (fallback to the Cargo patch when git is absent).
+        assert!(major >= 2, "unexpected major in {VERSION}");
+        let _ = minor;
+        assert_eq!(VERSION.split('.').count(), 3, "VERSION = {VERSION}");
+    }
 
     #[test]
     fn session_status_serialization() {


### PR DESCRIPTION
## Summary

Fixes #1096: **PRs no longer touch a version line**, so parallel PRs can't collide on a hand-picked patch number and there's no rebase/rebump/force-push tax.

The reported version is now `major.minor.{git rev-list --count HEAD}`, derived at build time:

- **`shared/build.rs`** computes the patch from the commit count and emits `PORTAL_VERSION` via `cargo:rustc-env` (re-runs when `.git/HEAD` or the reflog moves; falls back to the Cargo.toml patch when git is absent — source tarball / vendored build).
- **`shared::VERSION`** (`env!("PORTAL_VERSION")`) is the single value every crate reports: `server_version`, launcher `version`, the frontend footer, and the `agent-portal` client version. All six `env!("CARGO_PKG_VERSION")` display sites now read `shared::VERSION`.
- **`Cargo.toml` `[workspace.package] version`** keeps only `major.minor` as the human knob (patch is a documented placeholder). Set to `2.13.0`; bump `major.minor` by hand only for feature/breaking releases.

### Behavior
- Commit count is monotonic on `main`; with squash-merge the patch advances by exactly **+1 per merged PR**, so deployed versions stay tidy and sequential (currently derives `2.13.949`).
- Feature branches read a higher count (their own unmerged commits) — a dev build shows "ahead" of what `main` will be post-squash. Useful signal, and harmless: the auto-updater compares by **binary hash**, not version, so nothing depends on the number.

### Changelog
Per Matt: no longer kept in lockstep per-PR (you can't know the commit count in advance). Switched to a rolling `## [Unreleased]` heading, maintained by a periodic sweep. `CLAUDE.md` versioning section rewritten to match (no more "every PR must bump").

### Verification
- Native + WASM builds; CI-style clippy (`-Dwarnings --all-targets` + frontend/dist); fmt; `shared` tests incl. a new `version_is_well_formed`. Confirmed `PORTAL_VERSION=2.13.949` from the build output and the no-git fallback path.

This is, fittingly, the last PR that has to think about a version number at all.