### PR TITLE
Fix device-flow poll limits

### DIFF
--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -61,11 +61,19 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
     // binding is consumed by `.with_state` below.
     let app_state_for_forward_gate = app_state.clone();
 
-    // Rate-limited device flow auth routes
-    let auth_device_routes = Router::new()
+    // Rate-limited device-code creation. Keep this strict: creating a code is
+    // user-visible work and should not be spammed.
+    let auth_device_code_routes = Router::new()
         .route(AUTH_DEVICE_CODE, post(handlers::device_flow::device_code))
-        .route(AUTH_DEVICE_POLL, post(handlers::device_flow::device_poll))
         .layer(rate_limit(6, 10))
+        .with_state(app_state.clone());
+
+    // Rate-limited device polling. The CLI polls every 5s, and this limiter is
+    // per-IP, so it must sustain normal polling plus a few machines behind one
+    // NAT without draining the burst during a slow browser approval (#1047).
+    let auth_device_poll_routes = Router::new()
+        .route(AUTH_DEVICE_POLL, post(handlers::device_flow::device_poll))
+        .layer(rate_limit(2, 30))
         .with_state(app_state.clone());
 
     // Rate-limited browser auth routes. These endpoints either initiate OAuth
@@ -309,7 +317,8 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
         // Add single unified state
         .with_state(app_state)
         // Merge rate-limited route groups
-        .merge(auth_device_routes)
+        .merge(auth_device_code_routes)
+        .merge(auth_device_poll_routes)
         .merge(auth_login_routes)
         .merge(auth_device_action_routes)
         .merge(download_routes)

--- a/portal-auth/src/lib.rs
+++ b/portal-auth/src/lib.rs
@@ -1,5 +1,9 @@
 use anyhow::{Context, Result};
 use colored::Colorize;
+use reqwest::{
+    header::{HeaderMap, RETRY_AFTER},
+    StatusCode,
+};
 use shared::api::{DeviceCodeRequest, DeviceCodeResponse, DeviceFlowPollRequest};
 use shared::DevicePollResponse;
 use std::time::Duration;
@@ -17,6 +21,24 @@ pub struct DeviceFlowResult {
 pub fn ws_to_http(url: &str) -> String {
     url.replace("ws://", "http://")
         .replace("wss://", "https://")
+}
+
+fn retry_after_delay(headers: &HeaderMap, interval: Duration) -> Duration {
+    headers
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(interval)
+        .max(interval)
+}
+
+fn poll_retry_delay(
+    status: StatusCode,
+    headers: &HeaderMap,
+    interval: Duration,
+) -> Option<Duration> {
+    (status == StatusCode::TOO_MANY_REQUESTS).then(|| retry_after_delay(headers, interval))
 }
 
 /// Run the OAuth device flow against a portal backend.
@@ -132,6 +154,10 @@ pub async fn device_flow_login(
 
         if !poll_http_response.status().is_success() {
             let status = poll_http_response.status();
+            if let Some(delay) = poll_retry_delay(status, poll_http_response.headers(), interval) {
+                sleep(delay).await;
+                continue;
+            }
             let body = poll_http_response.text().await.unwrap_or_default();
             anyhow::bail!("Poll request failed with status {}: {}", status, body);
         }
@@ -165,5 +191,71 @@ pub async fn device_flow_login(
                 anyhow::bail!("Authentication was denied");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::HeaderValue;
+
+    #[test]
+    fn poll_retry_delay_retries_429_for_poll_interval() {
+        let headers = HeaderMap::new();
+        assert_eq!(
+            poll_retry_delay(
+                StatusCode::TOO_MANY_REQUESTS,
+                &headers,
+                Duration::from_secs(5)
+            ),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    #[test]
+    fn poll_retry_delay_honors_longer_retry_after() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("17"));
+        assert_eq!(
+            poll_retry_delay(
+                StatusCode::TOO_MANY_REQUESTS,
+                &headers,
+                Duration::from_secs(5)
+            ),
+            Some(Duration::from_secs(17))
+        );
+    }
+
+    #[test]
+    fn poll_retry_delay_rejects_short_or_invalid_retry_after() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("0"));
+        assert_eq!(
+            poll_retry_delay(
+                StatusCode::TOO_MANY_REQUESTS,
+                &headers,
+                Duration::from_secs(5)
+            ),
+            Some(Duration::from_secs(5))
+        );
+
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("not-seconds"));
+        assert_eq!(
+            poll_retry_delay(
+                StatusCode::TOO_MANY_REQUESTS,
+                &headers,
+                Duration::from_secs(5)
+            ),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    #[test]
+    fn poll_retry_delay_does_not_retry_other_statuses() {
+        let headers = HeaderMap::new();
+        assert_eq!(
+            poll_retry_delay(StatusCode::BAD_GATEWAY, &headers, Duration::from_secs(5)),
+            None
+        );
     }
 }


### PR DESCRIPTION
Closes #1047.

## Summary
- split device-code creation and device polling onto separate route limiters
- keep device-code creation strict at the existing 6s/10 burst bucket
- let device polling sustain the CLI 5s cadence with NAT headroom via 2s/30 burst
- make portal-auth retry HTTP 429 poll responses until the device code expires
- add retry-decision tests for Retry-After handling and non-429 failures

## Review focus
- route grouping in backend/src/routes.rs preserves auth behavior while splitting limiter state
- 429 retry path in portal-auth/src/lib.rs never retries non-429 poll failures
- Retry-After parsing is deliberately delta-seconds only, falling back to the poll interval

## Verification
- cargo test -p portal-auth
- mkdir -p frontend/dist && RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets
- cargo fmt --check