### PR TITLE
Distinguish retryable registration failures from fatal auth rejection

### DIFF
--- a/backend/src/handlers/proxy_tokens.rs
+++ b/backend/src/handlers/proxy_tokens.rs
@@ -270,14 +270,27 @@ pub fn verify_and_get_user(
             AppError::Unauthorized
         })?;
 
-    // Then check database for revocation
+    // Then check database for revocation.
+    //
+    // Only `NotFound` means the token is bad. Any other Diesel error is a
+    // transient infrastructure failure (connection reset, pool timeout,
+    // statement timeout — common during deploys), and MUST NOT be reported
+    // as Unauthorized: clients treat auth rejection as fatal (launchers
+    // park, proxies stop reconnecting), so conflating the two turns a DB
+    // blip into a fleet-wide manual-restart event. See #1264.
     let token_hash = hash_token(token);
     let db_token: ProxyAuthToken = proxy_auth_tokens::table
         .filter(proxy_auth_tokens::token_hash.eq(&token_hash))
         .first(conn)
-        .map_err(|_| {
-            error!("Token not found in database");
-            AppError::Unauthorized
+        .map_err(|e| match e {
+            diesel::result::Error::NotFound => {
+                error!("Token not found in database");
+                AppError::Unauthorized
+            }
+            other => {
+                error!("Transient DB error verifying token: {}", other);
+                AppError::ServiceUnavailable("token verification unavailable")
+            }
         })?;
 
     // Check if revoked
@@ -299,10 +312,20 @@ pub fn verify_and_get_user(
 
     // Check if user is banned
     use crate::schema::users;
-    let user: crate::models::User = users::table.find(claims.sub).first(conn).map_err(|_| {
-        error!("User not found for token");
-        AppError::Unauthorized
-    })?;
+    let user: crate::models::User =
+        users::table
+            .find(claims.sub)
+            .first(conn)
+            .map_err(|e| match e {
+                diesel::result::Error::NotFound => {
+                    error!("User not found for token");
+                    AppError::Unauthorized
+                }
+                other => {
+                    error!("Transient DB error loading token user: {}", other);
+                    AppError::ServiceUnavailable("token verification unavailable")
+                }
+            })?;
 
     if user.disabled {
         error!("Token belongs to banned user: {}", user.email);

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -39,6 +39,27 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                                     info!("Launcher authenticated as {} ({})", email, uid);
                                     uid
                                 }
+                                Err(crate::errors::AppError::ServiceUnavailable(_)) => {
+                                    // Transient DB failure while checking the
+                                    // token — the token was never evaluated.
+                                    // Must not be fatal: a fatal AuthFailed
+                                    // parks the launcher for a deploy blip
+                                    // (#1264). Non-fatal → normal reconnect
+                                    // backoff.
+                                    let _ = ws_sender
+                                        .send(ServerToLauncher::LauncherRegisterAck {
+                                            success: false,
+                                            fatal: false,
+                                            launcher_id,
+                                            error: Some(
+                                                "Server temporarily unavailable - retrying"
+                                                    .to_string(),
+                                            ),
+                                            reject_reason: None,
+                                        })
+                                        .await;
+                                    return;
+                                }
                                 Err(_) => {
                                     if app_state.dev_mode {
                                         get_dev_user_id(&app_state)

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -203,6 +203,7 @@ fn handle_proxy_message(
                 session_id: claude_session_id,
                 error: result.error,
                 max_image_mb: app_state.max_image_mb,
+                retryable: result.retryable,
             });
 
             info!(

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -12,11 +12,24 @@ use uuid::Uuid;
 /// UUIDs by guessing.
 const SESSION_NOT_FOUND_ERROR: &str = "Session not found or not authorized";
 
+/// Error string for transient infrastructure failures during registration.
+/// Paired with `retryable: true` — clients reconnect with backoff instead of
+/// treating it as fatal. Deliberately does not mention authentication.
+const TRANSIENT_REGISTRATION_ERROR: &str = "Server temporarily unavailable - retrying";
+
 /// Result of a session registration attempt
 pub struct RegistrationResult {
     pub success: bool,
     pub session_id: Option<Uuid>,
     pub error: Option<String>,
+    /// Whether a failed registration is worth retrying with backoff.
+    ///
+    /// `true` for transient infrastructure failures (DB pool exhausted,
+    /// connection reset mid-deploy); `false` for definitive rejections
+    /// (bad token, unauthorized session). Clients treat non-retryable
+    /// failures as fatal — proxies stop reconnecting, launchers park — so
+    /// only provably-permanent conditions may set this to `false`. #1264.
+    pub retryable: bool,
 }
 
 /// Parameters for registering a session
@@ -57,7 +70,8 @@ pub fn register_or_update_session(
             return RegistrationResult {
                 success: false,
                 session_id: None,
-                error: Some("Database connection failed".to_string()),
+                error: Some(TRANSIENT_REGISTRATION_ERROR.to_string()),
+                retryable: true,
             };
         }
     };
@@ -65,17 +79,32 @@ pub fn register_or_update_session(
     // Resolve auth_token → user_id up front. Required for *both* new and
     // existing sessions so an attacker can't reactivate someone else's
     // session by knowing its UUID.
-    let Some(requesting_user_id) = get_user_id_from_token(app_state, &mut conn, params.auth_token)
-    else {
-        warn!(
-            "Session registration without valid auth_token: session_id={}",
-            params.claude_session_id
-        );
-        return RegistrationResult {
-            success: false,
-            session_id: None,
-            error: Some("Authentication failed - please re-authenticate".to_string()),
-        };
+    let requesting_user_id = match get_user_id_from_token(app_state, &mut conn, params.auth_token) {
+        TokenAuth::User(id) => id,
+        TokenAuth::Unavailable => {
+            warn!(
+                "Deferring session registration, token verification unavailable: session_id={}",
+                params.claude_session_id
+            );
+            return RegistrationResult {
+                success: false,
+                session_id: None,
+                error: Some(TRANSIENT_REGISTRATION_ERROR.to_string()),
+                retryable: true,
+            };
+        }
+        TokenAuth::Rejected => {
+            warn!(
+                "Session registration without valid auth_token: session_id={}",
+                params.claude_session_id
+            );
+            return RegistrationResult {
+                success: false,
+                session_id: None,
+                error: Some("Authentication failed - please re-authenticate".to_string()),
+                retryable: false,
+            };
+        }
     };
 
     use crate::schema::sessions;
@@ -128,6 +157,7 @@ pub fn register_or_update_session(
                 success: false,
                 session_id: None,
                 error: Some(SESSION_NOT_FOUND_ERROR.to_string()),
+                retryable: false,
             };
         }
 
@@ -167,6 +197,7 @@ pub fn register_or_update_session(
                     success: true,
                     session_id: Some(existing_session.id),
                     error: None,
+                    retryable: false,
                 }
             }
             Err(e) => {
@@ -175,6 +206,7 @@ pub fn register_or_update_session(
                     success: false,
                     session_id: None,
                     error: Some("Failed to reactivate session".to_string()),
+                    retryable: true,
                 }
             }
         }
@@ -286,6 +318,7 @@ fn create_new_session(
                 success: true,
                 session_id: Some(session.id),
                 error: None,
+                retryable: false,
             }
         }
         Err(e) => {
@@ -294,9 +327,22 @@ fn create_new_session(
                 success: false,
                 session_id: None,
                 error: Some("Failed to persist session".to_string()),
+                retryable: true,
             }
         }
     }
+}
+
+/// Outcome of resolving an auth token to a user during registration.
+///
+/// `Rejected` is definitive (bad/revoked/expired token — safe for clients to
+/// treat as fatal); `Unavailable` is a transient infrastructure failure that
+/// clients must retry with backoff. Collapsing the two is what turned deploy
+/// blips into parked launchers (#1264).
+enum TokenAuth {
+    User(Uuid),
+    Rejected,
+    Unavailable,
 }
 
 /// Get user_id from auth token using JWT verification, with dev-mode fallback.
@@ -304,12 +350,18 @@ fn get_user_id_from_token(
     app_state: &AppState,
     conn: &mut diesel::PgConnection,
     auth_token: Option<&str>,
-) -> Option<Uuid> {
+) -> TokenAuth {
     if let Some(token) = auth_token {
         match super::super::proxy_tokens::verify_and_get_user(app_state, conn, token) {
             Ok((user_id, email)) => {
                 info!("JWT token verified for user: {}", email);
-                return Some(user_id);
+                return TokenAuth::User(user_id);
+            }
+            Err(crate::errors::AppError::ServiceUnavailable(_)) => {
+                // The token was never evaluated — don't let a DB blip
+                // masquerade as an auth rejection (or fall through to a
+                // dev-mode lookup on the same struggling DB).
+                return TokenAuth::Unavailable;
             }
             Err(e) => {
                 warn!("JWT verification failed: {:?}, falling back to dev mode", e);
@@ -318,9 +370,12 @@ fn get_user_id_from_token(
     }
 
     if app_state.dev_mode {
-        crate::auth::dev_user(conn).map(|user| user.id).ok()
+        match crate::auth::dev_user(conn).map(|user| user.id) {
+            Ok(id) => TokenAuth::User(id),
+            Err(_) => TokenAuth::Rejected,
+        }
     } else {
-        None
+        TokenAuth::Rejected
     }
 }
 
@@ -335,6 +390,7 @@ mod tests {
             success: false,
             session_id: None,
             error: Some(SESSION_NOT_FOUND_ERROR.to_string()),
+            retryable: false,
         }
     }
 
@@ -352,6 +408,7 @@ mod tests {
             success: false,
             session_id: None,
             error: Some(SESSION_NOT_FOUND_ERROR.to_string()),
+            retryable: false,
         }
     }
 
@@ -389,10 +446,32 @@ mod tests {
             success: true,
             session_id: Some(session_id),
             error: None,
+            retryable: false,
         };
         assert!(r.success);
         assert_eq!(r.session_id, Some(session_id));
         assert!(r.error.is_none());
+    }
+
+    /// Retryability contract (#1264): definitive rejections (bad token,
+    /// unauthorized session) must be non-retryable so clients can safely
+    /// park/stop; transient failures must be retryable AND must not read as
+    /// auth-shaped — a proxy string-matching "auth" in an error (old
+    /// launchers do, as a pre-reject_reason fallback) would otherwise park
+    /// on a DB blip.
+    #[test]
+    fn transient_error_is_retryable_and_not_auth_shaped() {
+        let unauthorized = unauthorized_reattach_result();
+        assert!(!unauthorized.retryable);
+
+        let s = TRANSIENT_REGISTRATION_ERROR.to_lowercase();
+        for forbidden in ["auth", "token", "credential", "login", "denied"] {
+            assert!(
+                !s.contains(forbidden),
+                "TRANSIENT_REGISTRATION_ERROR (`{TRANSIENT_REGISTRATION_ERROR}`) \
+                 reads as auth-shaped via substring `{forbidden}`"
+            );
+        }
     }
 
     /// The unauthorized-reattach error must be wire-identical to the

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -686,8 +686,9 @@ pub async fn register_session(
                     session_id: _,
                     error,
                     max_image_mb,
+                    retryable,
                 }) => {
-                    return Some((success, error, max_image_mb));
+                    return Some((success, error, max_image_mb, retryable));
                 }
                 Ok(_) => continue,
                 Err(_) => return None,
@@ -698,14 +699,23 @@ pub async fn register_session(
     .await;
 
     match ack_timeout {
-        Ok(Some((true, _, max_image_mb))) => {
+        Ok(Some((true, _, max_image_mb, _))) => {
             info!("Session registered (max_image_mb: {})", max_image_mb);
             Ok(max_image_mb)
         }
-        Ok(Some((false, error, _))) => {
+        Ok(Some((false, error, _, retryable))) => {
             let err_msg = error.as_deref().unwrap_or("Unknown error");
-            error!("Registration rejected by server: {}", err_msg);
-            Err(RegisterError::Rejected)
+            if retryable {
+                // Transient infrastructure failure (DB blip mid-deploy) —
+                // the backend explicitly asked us to retry. Keep the agent
+                // process alive and reconnect with backoff instead of
+                // exiting for relaunch. #1264.
+                warn!("Registration deferred by server (retryable): {}", err_msg);
+                Err(RegisterError::Transient(Duration::ZERO))
+            } else {
+                error!("Registration rejected by server: {}", err_msg);
+                Err(RegisterError::Rejected)
+            }
         }
         Ok(None) => {
             // The socket closed before any RegisterAck arrived — a transient
@@ -714,11 +724,13 @@ pub async fn register_session(
             Err(RegisterError::Transient(Duration::ZERO))
         }
         Err(_) => {
-            // Timeout - assume success for backwards compatibility with older backends
-            info!(
-                "No RegisterAck received (timeout), assuming success for backwards compatibility"
-            );
-            Ok(10)
+            // No ack within the window. Every deployed backend acks
+            // registration, so silence means the connection is wedged (or
+            // the backend is mid-restart) — not an old server. Reconnect
+            // with backoff rather than assuming success and running with a
+            // half-open socket. #1264.
+            warn!("No RegisterAck received within timeout; reconnecting");
+            Err(RegisterError::Transient(Duration::ZERO))
         }
     }
 }

--- a/shared/src/endpoints/session.rs
+++ b/shared/src/endpoints/session.rs
@@ -164,6 +164,12 @@ pub enum ServerToProxy {
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
         max_image_mb: u32,
+        /// On failure: whether the proxy should reconnect with backoff
+        /// (transient infrastructure error) instead of treating the
+        /// rejection as fatal. Defaults to `false` so acks from older
+        /// backends keep today's fatal semantics. #1264.
+        #[serde(default)]
+        retryable: bool,
     },
 
     /// Keepalive heartbeat


### PR DESCRIPTION
Fixes #1264.

A transient DB error during token verification (connection reset, pool timeout — routine during deploys) was reported as `Authentication failed - please re-authenticate`, which clients rightly treat as fatal: proxies stop reconnecting and exit for relaunch; launchers park. One DB blip during the 2026-07-09 deploy did exactly this to a live session (#1264 has the forensics).

## Changes

**Root cause** — `verify_and_get_user` now maps only `diesel NotFound` to `Unauthorized`; every other DB error becomes `ServiceUnavailable` (token row lookup, user lookup).

**Registration layer** — `get_user_id_from_token` returns a three-way `TokenAuth` (`User` / `Rejected` / `Unavailable`); `RegistrationResult` gains `retryable`. Transient failures return `"Server temporarily unavailable - retrying"` + `retryable: true` (string deliberately not auth-shaped — old launchers string-match `"auth"`/`"token"` as a fatal-classification fallback). Pool-checkout failure ("Database connection failed") is now also marked retryable.

**Wire** — `ServerToProxy::RegisterAck` gains `#[serde(default)] retryable: bool`. Old backend → new proxy: field absent → `false` → today's fatal semantics preserved. New backend → old proxy: extra field ignored. Launcher path needed no wire change (`fatal: false` already existed); transient token-verification failures now take that branch instead of `fatal: true, AuthFailed`.

**Proxy client** — `success:false && retryable` → reconnect with backoff, keeping the agent process and output buffer alive, instead of exiting for relaunch. Also: registration-ack **timeout** no longer "assumes success" — every deployed backend acks registration, so silence means a wedged connection or mid-restart backend; we now reconnect instead of running on a half-open socket (behavior change, flagged for review).

## Tests
- New: transient error string is retryable and not auth-shaped (pins the old-launcher string-match hazard).
- Existing #780 anti-enumeration shape tests extended with the new field.
- `cargo test` (backend 138, claude-session-lib 36, shared 77), clippy `-Dwarnings` both targets, fmt clean.