### PR TITLE
Unify connection identity with generation guards and dead-connection eviction

### DIFF
--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -381,6 +381,8 @@ mod tests {
             running_sessions: Vec::new(),
             working_directory: None,
             version: "test".to_string(),
+            cancel: tokio_util::sync::CancellationToken::new(),
+            gen: 0,
         }
     }
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -160,6 +160,11 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
     let (tx, mut rx) = mpsc::unbounded_channel::<ServerToLauncher>();
     let tx_for_sync = tx.clone();
 
+    // Server-side kill switch: fired by the SessionManager if it evicts this
+    // connection (channel dead / half-open socket, #1256) so the select loop
+    // below exits and the launcher's reconnect logic takes over.
+    let cancel = tokio_util::sync::CancellationToken::new();
+
     // Atomically check for duplicate (user_id, hostname) and register. See
     // `SessionManager::try_register_launcher` — the check + claim happen under
     // a single DashMap shard lock to close the TOCTOU window that existed
@@ -175,29 +180,34 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
             running_sessions: Vec::new(),
             working_directory,
             version: version.unwrap_or_default(),
+            cancel: cancel.clone(),
+            gen: 0, // stamped by try_register_launcher
         },
     );
 
-    if let Err(existing_name) = register_result {
-        warn!(
-            "Rejecting duplicate launcher '{}' from {} (user {}) — '{}' already connected",
-            launcher_name, hostname, user_id, existing_name
-        );
-        let _ = ws_sender
-            .send(ServerToLauncher::LauncherRegisterAck {
-                success: false,
-                launcher_id,
-                fatal: true,
-                error: Some(format!(
-                    "A launcher named '{}' is already connected from this host. \
+    let connection_gen = match register_result {
+        Ok(gen) => gen,
+        Err(existing_name) => {
+            warn!(
+                "Rejecting duplicate launcher '{}' from {} (user {}) — '{}' already connected",
+                launcher_name, hostname, user_id, existing_name
+            );
+            let _ = ws_sender
+                .send(ServerToLauncher::LauncherRegisterAck {
+                    success: false,
+                    launcher_id,
+                    fatal: true,
+                    error: Some(format!(
+                        "A launcher named '{}' is already connected from this host. \
                      Stop the existing instance before starting a new one.",
-                    existing_name
-                )),
-                reject_reason: Some(LauncherRejectReason::DuplicateLauncher),
-            })
-            .await;
-        return;
-    }
+                        existing_name
+                    )),
+                    reject_reason: Some(LauncherRejectReason::DuplicateLauncher),
+                })
+                .await;
+            return;
+        }
+    };
 
     // Send RegisterAck
     let _ = ws_sender
@@ -261,10 +271,25 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                     break;
                 }
             }
+
+            // Evicted by the SessionManager (dead channel / half-open
+            // socket, #1256): close the transport so the launcher's
+            // reconnect logic takes over.
+            _ = cancel.cancelled() => {
+                warn!(
+                    "Launcher '{}' connection force-closed by server (evicted)",
+                    launcher_name
+                );
+                break;
+            }
         }
     }
 
-    app_state.session_manager.unregister_launcher(&launcher_id);
+    // Generation-guarded: a reconnect reuses the same launcher_id, so this
+    // stale socket's cleanup must not remove the successor's registration.
+    app_state
+        .session_manager
+        .unregister_launcher(&launcher_id, Some(connection_gen));
 }
 
 /// Verify that this launcher is authorized to mutate `session_id`. A

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -27,6 +27,12 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
     let mut db_session_id: Option<Uuid> = None;
     let mut connection_gen: Option<u64> = None;
 
+    // Server-side kill switch for this connection. Registered with the
+    // SessionManager; fired when the manager evicts this connection (e.g.
+    // its channel died while the socket lingered half-open, #1256) so the
+    // recv loop below exits and normal cleanup runs.
+    let cancel = tokio_util::sync::CancellationToken::new();
+
     let send_task = tokio::spawn(async move {
         while let Some(msg) = rx.recv().await {
             if ws_sender.send(msg).await.is_err() {
@@ -35,7 +41,20 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
         }
     });
 
-    while let Some(result) = ws_receiver.recv().await {
+    loop {
+        let result = tokio::select! {
+            result = ws_receiver.recv() => match result {
+                Some(result) => result,
+                None => break,
+            },
+            _ = cancel.cancelled() => {
+                warn!(
+                    "Proxy connection for session {:?} force-closed by server (evicted)",
+                    session_key
+                );
+                break;
+            }
+        };
         match result {
             Ok(proxy_msg) => {
                 let flow = handle_proxy_message(
@@ -44,6 +63,7 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
                     &session_manager,
                     &db_pool,
                     &tx,
+                    &cancel,
                     &mut session_key,
                     &mut db_session_id,
                     &mut connection_gen,
@@ -133,6 +153,7 @@ fn handle_proxy_message(
     session_manager: &SessionManager,
     db_pool: &crate::db::DbPool,
     tx: &ProxySender,
+    cancel: &tokio_util::sync::CancellationToken,
     session_key: &mut Option<SessionId>,
     db_session_id: &mut Option<Uuid>,
     connection_gen: &mut Option<u64>,
@@ -192,7 +213,7 @@ fn handle_proxy_message(
                 // below) flow through `tx` regardless of session-manager
                 // registration, so the proxy still gets a response on
                 // failure even though we never registered the socket.
-                let gen = session_manager.register_session(key.clone(), tx.clone());
+                let gen = session_manager.register_session(key.clone(), tx.clone(), cancel.clone());
                 *session_key = Some(key);
                 *connection_gen = Some(gen);
                 *db_session_id = result.session_id;

--- a/backend/src/handlers/websocket/session_manager/client_fanout.rs
+++ b/backend/src/handlers/websocket/session_manager/client_fanout.rs
@@ -65,7 +65,7 @@ impl SessionManager {
             reconnect_delay_ms,
         };
         for entry in self.sessions.iter() {
-            let _ = entry.value().send(proxy_msg.clone());
+            let _ = entry.value().sender.send(proxy_msg.clone());
         }
 
         let client_msg = ServerToClient::ServerShutdown {
@@ -190,7 +190,11 @@ mod tests {
         let (web_tx, mut web_rx) = mpsc::unbounded_channel();
         let (user_tx, mut user_rx) = mpsc::unbounded_channel();
 
-        mgr.register_session("s1".into(), session_tx);
+        mgr.register_session(
+            "s1".into(),
+            session_tx,
+            tokio_util::sync::CancellationToken::new(),
+        );
         mgr.add_web_client("s1".into(), web_tx);
         mgr.add_user_client(Uuid::new_v4(), user_tx);
 

--- a/backend/src/handlers/websocket/session_manager/launcher_registry.rs
+++ b/backend/src/handlers/websocket/session_manager/launcher_registry.rs
@@ -1,13 +1,21 @@
 use shared::ServerToLauncher;
+use std::sync::atomic::Ordering;
 use tokio::sync::mpsc;
-use tracing::info;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use super::SessionManager;
 
 pub type LauncherSender = mpsc::UnboundedSender<ServerToLauncher>;
 
-/// A connected launcher daemon
+/// A connected launcher daemon.
+///
+/// `gen` identifies THIS socket: a launcher that reconnects reuses its
+/// stable `launcher_id`, so without a generation the old socket's cleanup
+/// would remove the new socket's entry (the launcher half of #1256 — the
+/// proxy half was fixed earlier with `ProxyConnection.gen`). `cancel`
+/// force-closes the socket task when the entry is evicted.
 pub struct LauncherConnection {
     pub sender: LauncherSender,
     pub launcher_name: String,
@@ -16,6 +24,9 @@ pub struct LauncherConnection {
     pub running_sessions: Vec<Uuid>,
     pub working_directory: Option<String>,
     pub version: String,
+    pub cancel: CancellationToken,
+    /// Stamped by `try_register_launcher`; caller-supplied values are ignored.
+    pub gen: u64,
 }
 
 impl SessionManager {
@@ -26,14 +37,17 @@ impl SessionManager {
     /// lock on the dedup index, so two concurrent connections from the same
     /// `(user_id, hostname)` cannot both pass the check and both insert.
     ///
-    /// On success, returns `Ok(())` and inserts the connection into
-    /// `launchers`. On a duplicate, returns `Err(existing_launcher_name)` and
-    /// does not touch `launchers`.
+    /// On success, inserts the connection into `launchers` and returns the
+    /// stamped connection generation, which must be passed to
+    /// `unregister_launcher` so a stale socket's cleanup can't remove a
+    /// newer same-id registration. On a duplicate, returns
+    /// `Err(existing_launcher_name)` and does not touch `launchers`.
     pub fn try_register_launcher(
         &self,
         launcher_id: Uuid,
-        connection: LauncherConnection,
-    ) -> Result<(), String> {
+        mut connection: LauncherConnection,
+    ) -> Result<u64, String> {
+        connection.gen = self.gen_counter.fetch_add(1, Ordering::Relaxed);
         let dedup_key = (connection.user_id, connection.hostname.clone());
 
         // Use `entry().or_insert_with` so the duplicate check and the
@@ -54,23 +68,45 @@ impl SessionManager {
         // `launchers` so other lookups on this shard aren't blocked.
         drop(entry);
 
+        let gen = connection.gen;
         info!(
-            "Registering launcher: {} ({})",
-            connection.launcher_name, launcher_id
+            "Registering launcher: {} ({}) (gen={})",
+            connection.launcher_name, launcher_id, gen
         );
         self.launchers.insert(launcher_id, connection);
-        Ok(())
+        Ok(gen)
     }
 
-    pub fn unregister_launcher(&self, launcher_id: &Uuid) {
-        info!("Unregistering launcher: {}", launcher_id);
-        if let Some((_, connection)) = self.launchers.remove(launcher_id) {
-            // Only release the dedup slot if it still points at us — a
-            // newer-generation registration for the same (user_id, hostname)
-            // would have replaced this entry's value and must not be evicted.
-            let dedup_key = (connection.user_id, connection.hostname);
-            self.launcher_dedup
-                .remove_if(&dedup_key, |_, claimed_by| claimed_by == launcher_id);
+    /// Unregister a launcher. If `gen` is provided, only removes the entry
+    /// when it matches — a reconnect reuses the same `launcher_id`, so the
+    /// old socket's cleanup must not remove the new socket's registration.
+    /// Pass `None` to force removal.
+    pub fn unregister_launcher(&self, launcher_id: &Uuid, gen: Option<u64>) {
+        let removed = match gen {
+            Some(expected) => self
+                .launchers
+                .remove_if(launcher_id, |_, conn| conn.gen == expected)
+                .map(|(_, conn)| conn),
+            None => self.launchers.remove(launcher_id).map(|(_, conn)| conn),
+        };
+        match removed {
+            Some(connection) => {
+                info!("Unregistering launcher: {}", launcher_id);
+                // Only release the dedup slot if it still points at us — a
+                // different launcher_id may have claimed (user_id, hostname)
+                // since, and must not be evicted.
+                let dedup_key = (connection.user_id, connection.hostname);
+                self.launcher_dedup
+                    .remove_if(&dedup_key, |_, claimed_by| claimed_by == launcher_id);
+            }
+            None => {
+                if gen.is_some() {
+                    info!(
+                        "Skipping stale unregister for launcher {} (superseded or already gone)",
+                        launcher_id
+                    );
+                }
+            }
         }
     }
 
@@ -99,10 +135,28 @@ impl SessionManager {
     }
 
     pub fn send_to_launcher(&self, launcher_id: &Uuid, msg: ServerToLauncher) -> bool {
-        if let Some(launcher) = self.launchers.get(launcher_id) {
-            launcher.sender.send(msg).is_ok()
-        } else {
-            false
+        match self.launchers.get(launcher_id) {
+            Some(launcher) => match launcher.sender.send(msg) {
+                Ok(()) => true,
+                Err(_) => {
+                    // Channel closed while still registered: the socket task
+                    // is dead or half-open. Evict (gen-guarded, releases the
+                    // dedup slot) and cancel so the transport closes and the
+                    // launcher reconnects, instead of every reconcile send
+                    // failing silently forever (#1256).
+                    let gen = launcher.gen;
+                    let cancel = launcher.cancel.clone();
+                    drop(launcher);
+                    warn!(
+                        "Launcher {} channel closed; evicting and closing its socket",
+                        launcher_id
+                    );
+                    self.unregister_launcher(launcher_id, Some(gen));
+                    cancel.cancel();
+                    false
+                }
+            },
+            None => false,
         }
     }
 
@@ -161,6 +215,8 @@ mod tests {
             running_sessions: Vec::new(),
             working_directory: None,
             version: "test".to_string(),
+            cancel: CancellationToken::new(),
+            gen: 0,
         }
     }
 
@@ -217,6 +273,81 @@ mod tests {
         assert_eq!(mgr.launcher_version(None), None);
     }
 
+    /// The launcher half of #1256: a launcher reconnect reuses the same
+    /// `launcher_id`, so the OLD socket's cleanup (running late, after the
+    /// new socket registered) must not remove the NEW registration.
+    #[test]
+    fn stale_launcher_unregister_is_noop() {
+        let mgr = SessionManager::new();
+        let user_id = Uuid::new_v4();
+        let id = Uuid::new_v4();
+
+        let old_gen = mgr
+            .try_register_launcher(id, make_launcher_connection(user_id, "host1"))
+            .expect("first registration");
+
+        // Same launcher_id reconnects (registry entry replaced, new gen).
+        let new_gen = mgr
+            .try_register_launcher(id, make_launcher_connection(user_id, "host1"))
+            .expect("same-id reconnect must succeed");
+        assert_ne!(old_gen, new_gen);
+
+        // Old socket's late cleanup: must be a no-op.
+        mgr.unregister_launcher(&id, Some(old_gen));
+        assert!(mgr.launchers.contains_key(&id));
+        assert_eq!(mgr.launchers.get(&id).unwrap().gen, new_gen);
+
+        // The dedup slot must still be claimed (a different launcher_id
+        // for the same (user, host) is still rejected).
+        assert!(mgr
+            .try_register_launcher(Uuid::new_v4(), make_launcher_connection(user_id, "host1"))
+            .is_err());
+
+        // New socket's own cleanup still works.
+        mgr.unregister_launcher(&id, Some(new_gen));
+        assert!(!mgr.launchers.contains_key(&id));
+    }
+
+    /// A send to a registered launcher whose channel has died must evict the
+    /// entry (releasing the dedup slot) and fire its cancel token.
+    #[test]
+    fn launcher_send_failure_evicts_and_cancels() {
+        let mgr = SessionManager::new();
+        let user_id = Uuid::new_v4();
+        let id = Uuid::new_v4();
+
+        let (sender, rx) = mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
+        let conn = LauncherConnection {
+            sender,
+            launcher_name: "l".to_string(),
+            hostname: "host1".to_string(),
+            user_id,
+            running_sessions: Vec::new(),
+            working_directory: None,
+            version: "test".to_string(),
+            cancel: cancel.clone(),
+            gen: 0,
+        };
+        mgr.try_register_launcher(id, conn).expect("register");
+        drop(rx);
+
+        assert!(!mgr.send_to_launcher(
+            &id,
+            ServerToLauncher::ServerShutdown {
+                reason: "test".to_string(),
+                reconnect_delay_ms: 0,
+            }
+        ));
+        assert!(!mgr.launchers.contains_key(&id));
+        assert!(cancel.is_cancelled());
+
+        // Dedup slot released: same (user, host) can register again.
+        assert!(mgr
+            .try_register_launcher(Uuid::new_v4(), make_launcher_connection(user_id, "host1"))
+            .is_ok());
+    }
+
     #[test]
     fn unregister_launcher_releases_dedup_slot() {
         let mgr = SessionManager::new();
@@ -227,7 +358,7 @@ mod tests {
         assert!(mgr
             .try_register_launcher(id_a, make_launcher_connection(user_id, "host1"))
             .is_ok());
-        mgr.unregister_launcher(&id_a);
+        mgr.unregister_launcher(&id_a, None);
 
         // After unregister the same (user, host) should be claimable again.
         assert!(mgr
@@ -265,6 +396,8 @@ mod tests {
                         running_sessions: Vec::new(),
                         working_directory: None,
                         version: "test".to_string(),
+                        cancel: CancellationToken::new(),
+                        gen: 0,
                     }
                 };
                 mgr_clone

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -41,6 +41,17 @@ pub type SessionId = String;
 pub type ProxySender = mpsc::UnboundedSender<ServerToProxy>;
 pub type WebClientSender = mpsc::UnboundedSender<ServerToClient>;
 
+/// A live proxy connection. `gen` identifies THIS socket (as opposed to a
+/// reconnect for the same session) — every registry mutation is guarded on
+/// it. `cancel` force-closes the socket task, so a connection whose channel
+/// is dead can be torn down server-side instead of lingering half-open
+/// (#1256: inbound-alive/outbound-dead sockets wedged delivery for 9h).
+pub struct ProxyConnection {
+    pub sender: ProxySender,
+    pub gen: u64,
+    pub cancel: tokio_util::sync::CancellationToken,
+}
+
 /// Latest probe verdict for a forwarded port, as reported by the proxy's
 /// background health check (docs/PORT_FORWARDING.md).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,7 +64,7 @@ pub struct ForwardHealth {
 
 #[derive(Clone)]
 pub struct SessionManager {
-    pub sessions: Arc<DashMap<SessionId, ProxySender>>,
+    pub sessions: Arc<DashMap<SessionId, ProxyConnection>>,
     pub web_clients: Arc<DashMap<SessionId, Vec<WebClientSender>>>,
     pub user_clients: Arc<DashMap<Uuid, Vec<WebClientSender>>>,
     last_ack_seq: Arc<DashMap<Uuid, u64>>,
@@ -93,10 +104,10 @@ pub struct SessionManager {
     /// session's `output_tokens` at result time so session totals (and the admin
     /// spend dashboard) don't under-count sub-agent usage.
     subagent_tokens: Arc<DashMap<Uuid, i64>>,
-    /// Monotonic counter for connection generations (prevents stale cleanup)
+    /// Monotonic counter for connection generations (prevents stale cleanup).
+    /// Shared by proxy and launcher registrations — uniqueness is all that
+    /// matters, not contiguity per registry.
     gen_counter: Arc<AtomicU64>,
-    /// Current connection generation per session
-    connection_gen: Arc<DashMap<SessionId, u64>>,
 }
 
 impl Default for SessionManager {
@@ -120,7 +131,6 @@ impl Default for SessionManager {
             last_input_sender: Arc::new(DashMap::new()),
             subagent_tokens: Arc::new(DashMap::new()),
             gen_counter: Arc::new(AtomicU64::new(1)),
-            connection_gen: Arc::new(DashMap::new()),
         }
     }
 }

--- a/backend/src/handlers/websocket/session_manager/pending_queue.rs
+++ b/backend/src/handlers/websocket/session_manager/pending_queue.rs
@@ -24,11 +24,18 @@ pub(super) struct PendingMessage {
 impl SessionManager {
     pub fn send_to_session(&self, session_key: &SessionId, msg: ServerToProxy) -> bool {
         let msg = match self.sessions.get(session_key) {
-            Some(sender) => match sender.send(msg) {
+            Some(conn) => match conn.sender.send(msg) {
                 Ok(()) => return true,
                 // A closed channel hands the message back in the error, so
                 // there's no need to clone up front just in case.
-                Err(mpsc::error::SendError(msg)) => msg,
+                Err(mpsc::error::SendError(msg)) => {
+                    let gen = conn.gen;
+                    let cancel = conn.cancel.clone();
+                    // Release the shard guard before mutating the map.
+                    drop(conn);
+                    self.evict_dead_connection(session_key, gen, &cancel);
+                    msg
+                }
             },
             None => msg,
         };
@@ -37,9 +44,19 @@ impl SessionManager {
     }
 
     pub fn send_to_connected_session(&self, session_key: &SessionId, msg: ServerToProxy) -> bool {
-        self.sessions
-            .get(session_key)
-            .is_some_and(|sender| sender.send(msg).is_ok())
+        match self.sessions.get(session_key) {
+            Some(conn) => match conn.sender.send(msg) {
+                Ok(()) => true,
+                Err(_) => {
+                    let gen = conn.gen;
+                    let cancel = conn.cancel.clone();
+                    drop(conn);
+                    self.evict_dead_connection(session_key, gen, &cancel);
+                    false
+                }
+            },
+            None => false,
+        }
     }
 
     /// Drain this session's pending queue into `sender`, dropping entries
@@ -109,7 +126,12 @@ impl SessionManager {
 mod tests {
     use super::super::test_support::make_output;
     use super::*;
+    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
+
+    fn register(mgr: &SessionManager, key: &str, sender: super::super::ProxySender) -> u64 {
+        mgr.register_session(key.into(), sender, CancellationToken::new())
+    }
 
     #[test]
     fn send_to_unregistered_queues_pending() {
@@ -119,7 +141,7 @@ mod tests {
         assert!(mgr.send_to_session(&"s1".into(), make_output(2)));
 
         let (tx, mut rx) = mpsc::unbounded_channel();
-        mgr.register_session("s1".into(), tx);
+        register(&mgr, "s1", tx);
 
         let msg1 = rx.try_recv().unwrap();
         let msg2 = rx.try_recv().unwrap();
@@ -138,7 +160,7 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::unbounded_channel();
-        mgr.register_session("s1".into(), tx);
+        register(&mgr, "s1", tx);
 
         let mut received = vec![];
         while let Ok(msg) = rx.try_recv() {
@@ -158,7 +180,8 @@ mod tests {
     fn send_to_session_queues_message_returned_by_closed_channel() {
         let mgr = SessionManager::new();
         let (tx, rx) = mpsc::unbounded_channel();
-        mgr.register_session("s1".into(), tx);
+        let cancel = CancellationToken::new();
+        mgr.register_session("s1".into(), tx, cancel.clone());
         drop(rx);
 
         let queued = mgr.send_to_session(
@@ -176,6 +199,9 @@ mod tests {
             pending.front().unwrap().msg,
             ServerToProxy::OutputAck { ack_seq: 7, .. }
         ));
+        // #1256: the dead entry must also be evicted and its socket closed.
+        assert!(!mgr.sessions.contains_key("s1"));
+        assert!(cancel.is_cancelled());
     }
 
     #[test]
@@ -183,14 +209,14 @@ mod tests {
         let mgr = SessionManager::new();
         let (tx, _rx) = mpsc::unbounded_channel();
 
-        let gen = mgr.register_session("s1".into(), tx);
+        let gen = register(&mgr, "s1", tx);
         mgr.unregister_session(&"s1".into(), Some(gen));
 
         mgr.send_to_session(&"s1".into(), make_output(1));
         mgr.send_to_session(&"s1".into(), make_output(2));
 
         let (tx2, mut rx2) = mpsc::unbounded_channel();
-        mgr.register_session("s1".into(), tx2);
+        register(&mgr, "s1", tx2);
 
         let msg1 = rx2.try_recv().unwrap();
         let msg2 = rx2.try_recv().unwrap();

--- a/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
+++ b/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
@@ -4,16 +4,24 @@
 use std::sync::atomic::Ordering;
 
 use shared::ServerToProxy;
-use tracing::info;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
 use uuid::Uuid;
 
-use super::{ProxySender, SessionId, SessionManager};
+use super::{ProxyConnection, ProxySender, SessionId, SessionManager};
 
 impl SessionManager {
     /// Register a proxy connection for a session. Returns a generation number
     /// that must be passed to `unregister_session` to prevent stale cleanup
-    /// from removing a newer connection.
-    pub fn register_session(&self, session_key: SessionId, sender: ProxySender) -> u64 {
+    /// from removing a newer connection. `cancel` is the socket task's
+    /// cancellation token; the manager fires it to force-close a connection
+    /// whose channel has died (see `evict_dead_connection`).
+    pub fn register_session(
+        &self,
+        session_key: SessionId,
+        sender: ProxySender,
+        cancel: CancellationToken,
+    ) -> u64 {
         let gen = self.gen_counter.fetch_add(1, Ordering::Relaxed);
         info!("Registering session: {} (gen={})", session_key, gen);
 
@@ -25,8 +33,14 @@ impl SessionManager {
             );
         }
 
-        self.connection_gen.insert(session_key.clone(), gen);
-        self.sessions.insert(session_key, sender);
+        self.sessions.insert(
+            session_key,
+            ProxyConnection {
+                sender,
+                gen,
+                cancel,
+            },
+        );
         gen
     }
 
@@ -35,36 +49,64 @@ impl SessionManager {
     /// connection's cleanup from removing a newer connection's registration.
     /// Pass `None` to force removal (e.g. admin delete).
     pub fn unregister_session(&self, session_key: &SessionId, gen: Option<u64>) {
-        if let Some(expected) = gen {
-            if let Some(current) = self.connection_gen.get(session_key) {
-                if *current != expected {
-                    info!(
-                        "Skipping stale unregister for session {} (gen {} != current {})",
-                        session_key, expected, *current
-                    );
-                    return;
-                }
-            }
+        let removed = match gen {
+            // Atomic compare-and-remove under one shard lock (the previous
+            // separate check-then-remove had a small TOCTOU window).
+            Some(expected) => self
+                .sessions
+                .remove_if(session_key, |_, conn| conn.gen == expected)
+                .is_some(),
+            None => self.sessions.remove(session_key).is_some(),
+        };
+        if removed {
+            info!("Unregistering session: {}", session_key);
+        } else if gen.is_some() {
+            info!(
+                "Skipping stale unregister for session {} (superseded or already gone)",
+                session_key
+            );
         }
-        info!("Unregistering session: {}", session_key);
-        self.connection_gen.remove(session_key);
-        self.sessions.remove(session_key);
+    }
+
+    /// A send to this registered connection failed: its channel is closed, so
+    /// the socket task is dead — or wedged half-open (inbound frames still
+    /// arriving, outbound writer gone: the #1256 incident shape). Evict the
+    /// registry entry (generation-guarded) and cancel the socket task so the
+    /// transport actually closes and the peer's reconnect logic takes over,
+    /// instead of the send failure looping silently forever.
+    pub(super) fn evict_dead_connection(
+        &self,
+        session_key: &SessionId,
+        gen: u64,
+        cancel: &CancellationToken,
+    ) {
+        if self
+            .sessions
+            .remove_if(session_key, |_, conn| conn.gen == gen)
+            .is_some()
+        {
+            warn!(
+                "Evicted dead proxy connection for session {} (gen {}); closing its socket",
+                session_key, gen
+            );
+        }
+        cancel.cancel();
     }
 
     /// Check whether the given generation is still the current connection for
     /// this session. Used by cleanup code to avoid overwriting a newer
     /// connection's DB status.
     pub fn is_current_connection(&self, session_key: &SessionId, gen: u64) -> bool {
-        self.connection_gen
+        self.sessions
             .get(session_key)
-            .is_none_or(|current| *current == gen)
+            .is_none_or(|conn| conn.gen == gen)
     }
 
     /// The current connection generation for a session, if a proxy is
     /// registered. Used to bind a tunnel stream to the exact connection it
     /// was opened on.
     pub fn current_connection_gen(&self, session_key: &str) -> Option<u64> {
-        self.connection_gen.get(session_key).map(|g| *g)
+        self.sessions.get(session_key).map(|conn| conn.gen)
     }
 
     /// Stop a directly-connected proxy by sending it a termination message.
@@ -72,8 +114,8 @@ impl SessionManager {
     /// Returns true if the session was found and the message was sent.
     pub fn disconnect_session(&self, session_id: Uuid) -> bool {
         let key = session_id.to_string();
-        if let Some(sender) = self.sessions.get(&key) {
-            sender
+        if let Some(conn) = self.sessions.get(&key) {
+            conn.sender
                 .send(ServerToProxy::SessionTerminated {
                     reason: "Session stopped by user".to_string(),
                 })
@@ -95,12 +137,16 @@ mod tests {
     use super::*;
     use tokio::sync::mpsc;
 
+    fn register(mgr: &SessionManager, key: &str, sender: ProxySender) -> u64 {
+        mgr.register_session(key.into(), sender, CancellationToken::new())
+    }
+
     #[test]
     fn session_register_and_send() {
         let mgr = SessionManager::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
 
-        mgr.register_session("s1".into(), tx);
+        register(&mgr, "s1", tx);
 
         assert!(mgr.send_to_session(&"s1".into(), make_heartbeat()));
 
@@ -113,7 +159,7 @@ mod tests {
         let mgr = SessionManager::new();
         let (tx, _rx) = mpsc::unbounded_channel();
 
-        let gen = mgr.register_session("s1".into(), tx);
+        let gen = register(&mgr, "s1", tx);
         assert!(mgr.sessions.contains_key("s1"));
 
         mgr.unregister_session(&"s1".into(), Some(gen));
@@ -125,7 +171,7 @@ mod tests {
         let mgr = SessionManager::new();
         let (tx, _rx) = mpsc::unbounded_channel();
 
-        mgr.register_session("s1".into(), tx);
+        register(&mgr, "s1", tx);
         assert!(mgr.sessions.contains_key("s1"));
 
         mgr.unregister_session(&"s1".into(), None);
@@ -139,10 +185,10 @@ mod tests {
         let (tx2, mut rx2) = mpsc::unbounded_channel();
 
         // Old connection registers
-        let old_gen = mgr.register_session("s1".into(), tx1);
+        let old_gen = register(&mgr, "s1", tx1);
 
         // New connection registers (simulates reconnect)
-        let _new_gen = mgr.register_session("s1".into(), tx2);
+        let _new_gen = register(&mgr, "s1", tx2);
 
         // Old connection's cleanup tries to unregister with stale gen
         mgr.unregister_session(&"s1".into(), Some(old_gen));
@@ -158,12 +204,62 @@ mod tests {
         let mgr = SessionManager::new();
         let (tx1, _rx1) = mpsc::unbounded_channel();
 
-        let gen1 = mgr.register_session("s1".into(), tx1);
+        let gen1 = register(&mgr, "s1", tx1);
         assert!(mgr.is_current_connection(&"s1".into(), gen1));
 
         let (tx2, _rx2) = mpsc::unbounded_channel();
-        let gen2 = mgr.register_session("s1".into(), tx2);
+        let gen2 = register(&mgr, "s1", tx2);
         assert!(!mgr.is_current_connection(&"s1".into(), gen1));
         assert!(mgr.is_current_connection(&"s1".into(), gen2));
+    }
+
+    /// #1256: a send to a registered connection whose channel has died must
+    /// evict the entry, fire its cancel token (so the socket task closes the
+    /// transport), and still queue the message for the successor.
+    #[test]
+    fn send_failure_evicts_and_cancels_dead_connection() {
+        let mgr = SessionManager::new();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
+        mgr.register_session("s1".into(), tx, cancel.clone());
+
+        // Kill the receiving side: the socket task is "dead".
+        drop(rx);
+
+        // The direct send fails internally; the message is queued for the
+        // successor (hence `true`), the dead entry is evicted, and its
+        // socket is told to close.
+        assert!(mgr.send_to_session(&"s1".into(), make_heartbeat()));
+        assert!(!mgr.sessions.contains_key("s1"));
+        assert!(cancel.is_cancelled());
+
+        // A reconnect replays the queued message.
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        register(&mgr, "s1", tx2);
+        assert!(matches!(rx2.try_recv().unwrap(), ServerToProxy::Heartbeat));
+    }
+
+    /// The eviction must be generation-guarded: if a successor has already
+    /// re-registered by the time the dead connection's send failure is
+    /// observed, the successor's entry must survive.
+    #[test]
+    fn evict_dead_connection_spares_successor() {
+        let mgr = SessionManager::new();
+        let (tx1, rx1) = mpsc::unbounded_channel();
+        let cancel1 = CancellationToken::new();
+        let gen1 = mgr.register_session("s1".into(), tx1, cancel1.clone());
+
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        register(&mgr, "s1", tx2);
+
+        drop(rx1);
+        mgr.evict_dead_connection(&"s1".into(), gen1, &cancel1);
+
+        // Successor survives and still receives.
+        assert!(mgr.sessions.contains_key("s1"));
+        assert!(mgr.send_to_session(&"s1".into(), make_heartbeat()));
+        assert!(matches!(rx2.try_recv().unwrap(), ServerToProxy::Heartbeat));
+        // The dead connection's socket still gets closed.
+        assert!(cancel1.is_cancelled());
     }
 }

--- a/backend/src/handlers/websocket/session_manager/tunnel_client.rs
+++ b/backend/src/handlers/websocket/session_manager/tunnel_client.rs
@@ -157,13 +157,12 @@ impl SessionManager {
         port: u16,
     ) -> Result<tokio::io::DuplexStream, TunnelError> {
         // Capture the sender and its connection generation together so the
-        // stream is reaped with the exact connection it rode on.
-        let (proxy_tx, gen): (ProxySender, u64) = match (
-            self.sessions.get(session_key),
-            self.current_connection_gen(session_key),
-        ) {
-            (Some(entry), Some(gen)) => (entry.value().clone(), gen),
-            _ => return Err(TunnelError::NotConnected),
+        // stream is reaped with the exact connection it rode on. Single
+        // lookup — sender and gen live in the same entry, so they can't
+        // disagree.
+        let (proxy_tx, gen): (ProxySender, u64) = match self.sessions.get(session_key) {
+            Some(conn) => (conn.sender.clone(), conn.gen),
+            None => return Err(TunnelError::NotConnected),
         };
 
         let stream_id = Uuid::new_v4();

--- a/backend/src/handlers/websocket/uploads.rs
+++ b/backend/src/handlers/websocket/uploads.rs
@@ -372,7 +372,11 @@ mod tests {
         let session_manager = SessionManager::new();
         let session_key: SessionId = "test-session".to_string();
         let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
-        session_manager.register_session(session_key.clone(), proxy_tx);
+        session_manager.register_session(
+            session_key.clone(),
+            proxy_tx,
+            tokio_util::sync::CancellationToken::new(),
+        );
 
         let mut pending_uploads: HashMap<String, PendingUpload> = HashMap::new();
         let upload_id = "u1".to_string();
@@ -445,7 +449,11 @@ mod tests {
         let session_manager = SessionManager::new();
         let session_key: SessionId = "test-session-2".to_string();
         let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
-        session_manager.register_session(session_key.clone(), proxy_tx);
+        session_manager.register_session(
+            session_key.clone(),
+            proxy_tx,
+            tokio_util::sync::CancellationToken::new(),
+        );
 
         let mut pending_uploads: HashMap<String, PendingUpload> = HashMap::new();
         let upload_id = "u2".to_string();


### PR DESCRIPTION
Part 1 of 2 for #1256 (stacked on #1266; part 2 adds the liveness sweeper).

The 2026-07-08 incident (#1256): a reconnect flap left connections that were alive inbound but unroutable outbound for 9+ hours. The proxy registry got generation guards previously; this PR finishes the identity model:

**One registry entry, one identity.** The proxy `sessions` map now stores `ProxyConnection { sender, gen, cancel }` — the separate `connection_gen` map is deleted, so sender and generation can never disagree (the tunnel opener's two-map lookup collapses to one), and `unregister_session` becomes an atomic `remove_if` (the old check-then-remove had a small TOCTOU).

**Launchers get the same guard.** A launcher reconnect reuses its stable `launcher_id`, so the old socket's late cleanup could remove the *new* socket's registry entry — the launcher half of the #1256 race, previously unguarded. `LauncherConnection` now carries a generation; cleanup is compare-and-remove.

**Dead connections are evicted and closed, not tolerated.** Every registry entry carries a `CancellationToken` for its socket task. When a send to a registered connection fails (channel closed ⇒ socket task dead or half-open), the manager evicts the entry (gen-guarded, sparing any successor) and fires the token; the socket task's select loop exits and normal cleanup runs. The peer's reconnect logic — which already works well — takes over. Previously launcher send failures were logged and dropped *forever* (the 9-hour reconcile loop in the incident), and proxy sends queued behind a corpse entry.

## Tests
- `send_failure_evicts_and_cancels_dead_connection`, `evict_dead_connection_spares_successor` (proxy)
- `stale_launcher_unregister_is_noop`, `launcher_send_failure_evicts_and_cancels` (launcher — pins the same-id reconnect race)
- Existing queue/replay/dedup tests extended; 142 backend tests green; clippy `-Dwarnings` workspace-wide; fmt clean.