### PR TITLE
Evict half-open connections via server-side liveness sweep

### DIFF
--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -97,6 +97,28 @@ pub fn spawn_stale_session_cleanup(pool: DbPool, manager: SessionManager) {
     });
 }
 
+/// Evict proxy/launcher connections that have gone silent past their
+/// liveness deadline (see `session_manager/liveness.rs`, #1256). The
+/// eviction cancels each stale connection's socket task, so the client's
+/// reconnect logic recovers automatically.
+pub async fn run_liveness_sweep(app_state: Arc<AppState>) {
+    use crate::handlers::websocket::{
+        LAUNCHER_LIVENESS_DEADLINE_SECS, PROXY_LIVENESS_DEADLINE_SECS,
+    };
+
+    let (proxies, launchers) = app_state.session_manager.sweep_stale_connections(
+        PROXY_LIVENESS_DEADLINE_SECS,
+        LAUNCHER_LIVENESS_DEADLINE_SECS,
+    );
+    if proxies > 0 || launchers > 0 {
+        tracing::warn!(
+            "Liveness sweep evicted {} proxy and {} launcher connection(s)",
+            proxies,
+            launchers
+        );
+    }
+}
+
 /// Query user spend from DB and broadcast to all connected web clients
 pub async fn broadcast_user_spend_updates(app_state: Arc<AppState>) {
     use diesel::prelude::*;

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -388,6 +388,7 @@ mod tests {
             version: "test".to_string(),
             cancel: tokio_util::sync::CancellationToken::new(),
             gen: 0,
+            last_seen: std::sync::atomic::AtomicU64::new(0),
         }
     }
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -182,6 +182,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
             version: version.unwrap_or_default(),
             cancel: cancel.clone(),
             gen: 0, // stamped by try_register_launcher
+            last_seen: std::sync::atomic::AtomicU64::new(0), // stamped by try_register_launcher
         },
     );
 
@@ -247,6 +248,9 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
             result = ws_receiver.recv() => {
                 match result {
                     Some(Ok(msg)) => {
+                        // Liveness stamp: any decodable inbound frame proves
+                        // the transport is alive (see liveness.rs).
+                        app_state.session_manager.touch_launcher(&launcher_id);
                         handle_launcher_message(
                             msg,
                             launcher_id,

--- a/backend/src/handlers/websocket/mod.rs
+++ b/backend/src/handlers/websocket/mod.rs
@@ -13,7 +13,8 @@ mod web_client_socket;
 
 pub use session_manager::{
     ForwardHealth, LauncherConnection, ProxySender, SessionId, SessionManager, TunnelError,
-    TunnelIn, WebClientSender,
+    TunnelIn, WebClientSender, LAUNCHER_LIVENESS_DEADLINE_SECS, LIVENESS_SWEEP_INTERVAL_SECS,
+    PROXY_LIVENESS_DEADLINE_SECS,
 };
 
 use axum::{

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -57,6 +57,11 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
         };
         match result {
             Ok(proxy_msg) => {
+                // Liveness stamp: any decodable inbound frame proves the
+                // transport is alive (see liveness.rs).
+                if let Some(key) = session_key.as_ref() {
+                    session_manager.touch_session(key);
+                }
                 let flow = handle_proxy_message(
                     proxy_msg,
                     &app_state,

--- a/backend/src/handlers/websocket/session_manager/launcher_registry.rs
+++ b/backend/src/handlers/websocket/session_manager/launcher_registry.rs
@@ -27,6 +27,9 @@ pub struct LauncherConnection {
     pub cancel: CancellationToken,
     /// Stamped by `try_register_launcher`; caller-supplied values are ignored.
     pub gen: u64,
+    /// Epoch seconds of the last inbound frame; read by the liveness
+    /// sweeper (see `liveness.rs`). Stamped at registration.
+    pub last_seen: std::sync::atomic::AtomicU64,
 }
 
 impl SessionManager {
@@ -48,6 +51,9 @@ impl SessionManager {
         mut connection: LauncherConnection,
     ) -> Result<u64, String> {
         connection.gen = self.gen_counter.fetch_add(1, Ordering::Relaxed);
+        connection
+            .last_seen
+            .store(super::liveness::epoch_secs(), Ordering::Relaxed);
         let dedup_key = (connection.user_id, connection.hostname.clone());
 
         // Use `entry().or_insert_with` so the duplicate check and the
@@ -220,6 +226,7 @@ mod tests {
             version: "test".to_string(),
             cancel: CancellationToken::new(),
             gen: 0,
+            last_seen: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -331,6 +338,7 @@ mod tests {
             version: "test".to_string(),
             cancel: cancel.clone(),
             gen: 0,
+            last_seen: std::sync::atomic::AtomicU64::new(0),
         };
         mgr.try_register_launcher(id, conn).expect("register");
         drop(rx);
@@ -401,6 +409,7 @@ mod tests {
                         version: "test".to_string(),
                         cancel: CancellationToken::new(),
                         gen: 0,
+                        last_seen: std::sync::atomic::AtomicU64::new(0),
                     }
                 };
                 mgr_clone

--- a/backend/src/handlers/websocket/session_manager/launcher_registry.rs
+++ b/backend/src/handlers/websocket/session_manager/launcher_registry.rs
@@ -86,8 +86,8 @@ impl SessionManager {
     /// Unregister a launcher. If `gen` is provided, only removes the entry
     /// when it matches — a reconnect reuses the same `launcher_id`, so the
     /// old socket's cleanup must not remove the new socket's registration.
-    /// Pass `None` to force removal.
-    pub fn unregister_launcher(&self, launcher_id: &Uuid, gen: Option<u64>) {
+    /// Pass `None` to force removal. Returns whether an entry was removed.
+    pub fn unregister_launcher(&self, launcher_id: &Uuid, gen: Option<u64>) -> bool {
         let removed = match gen {
             Some(expected) => self
                 .launchers
@@ -104,6 +104,7 @@ impl SessionManager {
                 let dedup_key = (connection.user_id, connection.hostname);
                 self.launcher_dedup
                     .remove_if(&dedup_key, |_, claimed_by| claimed_by == launcher_id);
+                true
             }
             None => {
                 if gen.is_some() {
@@ -112,6 +113,7 @@ impl SessionManager {
                         launcher_id
                     );
                 }
+                false
             }
         }
     }

--- a/backend/src/handlers/websocket/session_manager/liveness.rs
+++ b/backend/src/handlers/websocket/session_manager/liveness.rs
@@ -74,6 +74,7 @@ impl SessionManager {
             .map(|e| (e.key().clone(), e.value().gen))
             .collect();
 
+        let mut proxies_evicted = 0;
         for (key, gen) in &stale_sessions {
             if let Some(conn) = self.sessions.get(key) {
                 if conn.gen != *gen {
@@ -81,11 +82,13 @@ impl SessionManager {
                 }
                 let cancel = conn.cancel.clone();
                 drop(conn);
-                warn!(
-                    "Liveness sweep: proxy connection for session {} silent > {}s; evicting",
-                    key, proxy_deadline_secs
-                );
-                self.evict_dead_connection(key, *gen, &cancel);
+                if self.evict_dead_connection(key, *gen, &cancel) {
+                    warn!(
+                        "Liveness sweep: proxy connection for session {} silent > {}s; evicted",
+                        key, proxy_deadline_secs
+                    );
+                    proxies_evicted += 1;
+                }
             }
         }
 
@@ -99,6 +102,7 @@ impl SessionManager {
             .map(|e| (*e.key(), e.value().gen))
             .collect();
 
+        let mut launchers_evicted = 0;
         for (id, gen) in &stale_launchers {
             if let Some(conn) = self.launchers.get(id) {
                 if conn.gen != *gen {
@@ -106,16 +110,21 @@ impl SessionManager {
                 }
                 let cancel = conn.cancel.clone();
                 drop(conn);
-                warn!(
-                    "Liveness sweep: launcher {} silent > {}s; evicting",
-                    id, launcher_deadline_secs
-                );
-                self.unregister_launcher(id, Some(*gen));
+                if self.unregister_launcher(id, Some(*gen)) {
+                    warn!(
+                        "Liveness sweep: launcher {} silent > {}s; evicted",
+                        id, launcher_deadline_secs
+                    );
+                    launchers_evicted += 1;
+                }
                 cancel.cancel();
             }
         }
 
-        (stale_sessions.len(), stale_launchers.len())
+        // Real evictions, not stale candidates — a candidate can be spared
+        // by the gen re-check when it reconnected mid-sweep, and incident
+        // forensics should never overcount.
+        (proxies_evicted, launchers_evicted)
     }
 }
 

--- a/backend/src/handlers/websocket/session_manager/liveness.rs
+++ b/backend/src/handlers/websocket/session_manager/liveness.rs
@@ -1,0 +1,224 @@
+//! Server-side liveness for proxy and launcher connections (#1256).
+//!
+//! Disconnect detection is otherwise purely transport-driven: a connection
+//! is torn down only when its socket task observes the WS stream ending. A
+//! half-open TCP connection (peer gone, FIN never delivered — observed in
+//! production as an inbound-alive/outbound-dead socket) never triggers
+//! that, so its registry entry lingers and outbound delivery wedges until
+//! someone restarts a daemon.
+//!
+//! Both connection types already send application-level heartbeats (proxy:
+//! every 1s; launcher: every 30s). The socket tasks stamp `last_seen` on
+//! every inbound frame; the sweeper spawned from `lib.rs` evicts and
+//! force-closes any connection silent past its deadline. The client's
+//! reconnect logic — which is reliable — does the rest.
+
+use std::sync::atomic::Ordering;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tracing::warn;
+use uuid::Uuid;
+
+use super::{SessionId, SessionManager};
+
+/// A proxy heartbeats every 1s; a minute of silence means the transport is
+/// gone (or so congested that a reconnect is the right outcome anyway).
+pub const PROXY_LIVENESS_DEADLINE_SECS: u64 = 60;
+
+/// A launcher heartbeats every 30s; three missed beats.
+pub const LAUNCHER_LIVENESS_DEADLINE_SECS: u64 = 90;
+
+/// How often the sweeper runs.
+pub const LIVENESS_SWEEP_INTERVAL_SECS: u64 = 30;
+
+pub(super) fn epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+impl SessionManager {
+    /// Record inbound activity from a proxy connection.
+    pub fn touch_session(&self, session_key: &SessionId) {
+        if let Some(conn) = self.sessions.get(session_key) {
+            conn.last_seen.store(epoch_secs(), Ordering::Relaxed);
+        }
+    }
+
+    /// Record inbound activity from a launcher connection.
+    pub fn touch_launcher(&self, launcher_id: &Uuid) {
+        if let Some(conn) = self.launchers.get(launcher_id) {
+            conn.last_seen.store(epoch_secs(), Ordering::Relaxed);
+        }
+    }
+
+    /// Evict and force-close every connection that has been silent past its
+    /// deadline. Returns `(proxies_evicted, launchers_evicted)`.
+    pub fn sweep_stale_connections(
+        &self,
+        proxy_deadline_secs: u64,
+        launcher_deadline_secs: u64,
+    ) -> (usize, usize) {
+        let now = epoch_secs();
+
+        // Collect victims first: evicting while iterating a DashMap can
+        // deadlock on the shard being iterated.
+        let stale_sessions: Vec<(SessionId, u64)> = self
+            .sessions
+            .iter()
+            .filter(|e| {
+                now.saturating_sub(e.value().last_seen.load(Ordering::Relaxed))
+                    > proxy_deadline_secs
+            })
+            .map(|e| (e.key().clone(), e.value().gen))
+            .collect();
+
+        for (key, gen) in &stale_sessions {
+            if let Some(conn) = self.sessions.get(key) {
+                if conn.gen != *gen {
+                    continue; // superseded since we looked
+                }
+                let cancel = conn.cancel.clone();
+                drop(conn);
+                warn!(
+                    "Liveness sweep: proxy connection for session {} silent > {}s; evicting",
+                    key, proxy_deadline_secs
+                );
+                self.evict_dead_connection(key, *gen, &cancel);
+            }
+        }
+
+        let stale_launchers: Vec<(Uuid, u64)> = self
+            .launchers
+            .iter()
+            .filter(|e| {
+                now.saturating_sub(e.value().last_seen.load(Ordering::Relaxed))
+                    > launcher_deadline_secs
+            })
+            .map(|e| (*e.key(), e.value().gen))
+            .collect();
+
+        for (id, gen) in &stale_launchers {
+            if let Some(conn) = self.launchers.get(id) {
+                if conn.gen != *gen {
+                    continue;
+                }
+                let cancel = conn.cancel.clone();
+                drop(conn);
+                warn!(
+                    "Liveness sweep: launcher {} silent > {}s; evicting",
+                    id, launcher_deadline_secs
+                );
+                self.unregister_launcher(id, Some(*gen));
+                cancel.cancel();
+            }
+        }
+
+        (stale_sessions.len(), stale_launchers.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::make_heartbeat;
+    use super::super::LauncherConnection;
+    use super::*;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    fn launcher_conn(
+        user_id: Uuid,
+        hostname: &str,
+        cancel: CancellationToken,
+    ) -> LauncherConnection {
+        let (sender, rx) = mpsc::unbounded_channel();
+        // Keep the channel open so eviction is attributable to liveness,
+        // not to a dead channel.
+        std::mem::forget(rx);
+        LauncherConnection {
+            sender,
+            launcher_name: format!("launcher-{hostname}"),
+            hostname: hostname.to_string(),
+            user_id,
+            running_sessions: Vec::new(),
+            working_directory: None,
+            version: "test".to_string(),
+            cancel,
+            gen: 0,
+            last_seen: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    #[test]
+    fn sweep_evicts_silent_connections_and_spares_fresh() {
+        let mgr = SessionManager::new();
+
+        // Fresh proxy connection.
+        let (tx_fresh, _rx_fresh) = mpsc::unbounded_channel();
+        mgr.register_session("fresh".into(), tx_fresh, CancellationToken::new());
+
+        // Silent proxy connection: backdate its last_seen.
+        let (tx_stale, mut rx_stale) = mpsc::unbounded_channel();
+        let stale_cancel = CancellationToken::new();
+        mgr.register_session("stale".into(), tx_stale, stale_cancel.clone());
+        mgr.sessions
+            .get("stale")
+            .unwrap()
+            .last_seen
+            .store(epoch_secs() - 3600, Ordering::Relaxed);
+
+        // Silent launcher.
+        let launcher_id = Uuid::new_v4();
+        let launcher_cancel = CancellationToken::new();
+        mgr.try_register_launcher(
+            launcher_id,
+            launcher_conn(Uuid::new_v4(), "host1", launcher_cancel.clone()),
+        )
+        .expect("register launcher");
+        mgr.launchers
+            .get(&launcher_id)
+            .unwrap()
+            .last_seen
+            .store(epoch_secs() - 3600, Ordering::Relaxed);
+
+        let (proxies, launchers) = mgr.sweep_stale_connections(
+            PROXY_LIVENESS_DEADLINE_SECS,
+            LAUNCHER_LIVENESS_DEADLINE_SECS,
+        );
+
+        assert_eq!((proxies, launchers), (1, 1));
+        assert!(mgr.sessions.contains_key("fresh"));
+        assert!(!mgr.sessions.contains_key("stale"));
+        assert!(stale_cancel.is_cancelled());
+        assert!(!mgr.launchers.contains_key(&launcher_id));
+        assert!(launcher_cancel.is_cancelled());
+
+        // The evicted proxy's channel was still open — no message was sent
+        // to it during eviction.
+        assert!(rx_stale.try_recv().is_err());
+    }
+
+    #[test]
+    fn touch_resets_the_clock() {
+        let mgr = SessionManager::new();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        mgr.register_session("s1".into(), tx, CancellationToken::new());
+        mgr.sessions
+            .get("s1")
+            .unwrap()
+            .last_seen
+            .store(epoch_secs() - 3600, Ordering::Relaxed);
+
+        // An inbound frame arrives: the connection is alive after all.
+        mgr.touch_session(&"s1".into());
+
+        let (proxies, _) = mgr.sweep_stale_connections(
+            PROXY_LIVENESS_DEADLINE_SECS,
+            LAUNCHER_LIVENESS_DEADLINE_SECS,
+        );
+        assert_eq!(proxies, 0);
+        assert!(mgr.sessions.contains_key("s1"));
+        assert!(mgr.send_to_session(&"s1".into(), make_heartbeat()));
+    }
+}

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -28,6 +28,7 @@ mod correlation;
 mod input_dedup;
 mod input_queue;
 mod launcher_registry;
+mod liveness;
 mod pending_queue;
 mod proxy_lifecycle;
 mod session_tracking;
@@ -35,6 +36,9 @@ mod tunnel_client;
 
 pub(crate) use input_dedup::{DedupVerdict, InputDeliveryState};
 pub use launcher_registry::LauncherConnection;
+pub use liveness::{
+    LAUNCHER_LIVENESS_DEADLINE_SECS, LIVENESS_SWEEP_INTERVAL_SECS, PROXY_LIVENESS_DEADLINE_SECS,
+};
 use pending_queue::PendingMessage;
 use tunnel_client::TunnelStreamMap;
 pub use tunnel_client::{TunnelError, TunnelIn};
@@ -52,6 +56,11 @@ pub struct ProxyConnection {
     pub sender: ProxySender,
     pub gen: u64,
     pub cancel: tokio_util::sync::CancellationToken,
+    /// Epoch seconds of the last inbound frame from this connection.
+    /// Stamped by the socket task; read by the liveness sweeper, which
+    /// evicts connections silent past their deadline (proxies heartbeat
+    /// every 1s, so a long silence means a dead transport). #1256.
+    pub last_seen: std::sync::atomic::AtomicU64,
 }
 
 /// Latest probe verdict for a forwarded port, as reported by the proxy's

--- a/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
+++ b/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
@@ -39,6 +39,7 @@ impl SessionManager {
                 sender,
                 gen,
                 cancel,
+                last_seen: std::sync::atomic::AtomicU64::new(super::liveness::epoch_secs()),
             },
         );
         gen

--- a/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
+++ b/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
@@ -75,23 +75,27 @@ impl SessionManager {
     /// registry entry (generation-guarded) and cancel the socket task so the
     /// transport actually closes and the peer's reconnect logic takes over,
     /// instead of the send failure looping silently forever.
+    /// Returns whether this call actually removed the entry (false when a
+    /// newer generation had already replaced it — the socket is still
+    /// cancelled either way).
     pub(super) fn evict_dead_connection(
         &self,
         session_key: &SessionId,
         gen: u64,
         cancel: &CancellationToken,
-    ) {
-        if self
+    ) -> bool {
+        let removed = self
             .sessions
             .remove_if(session_key, |_, conn| conn.gen == gen)
-            .is_some()
-        {
+            .is_some();
+        if removed {
             warn!(
                 "Evicted dead proxy connection for session {} (gen {}); closing its socket",
                 session_key, gen
             );
         }
         cancel.cancel();
+        removed
     }
 
     /// Check whether the given generation is still the current connection for

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -193,6 +193,12 @@ pub async fn run() -> anyhow::Result<()> {
         app_state.clone(),
         background::run_expired_token_cleanup,
     );
+    background::spawn_periodic(
+        "connection liveness sweep (every 30 seconds)",
+        Duration::from_secs(handlers::websocket::LIVENESS_SWEEP_INTERVAL_SECS),
+        app_state.clone(),
+        background::run_liveness_sweep,
+    );
 
     // Run the server with graceful shutdown
     let addr = format!("{}:{}", config.host, config.port);


### PR DESCRIPTION
Part 2 of 2 for #1256 (stacked on #1267). Closes #1256 when merged.

Disconnect detection was purely transport-driven: nothing server-side ever noticed a half-open connection (peer gone, FIN never delivered). The 2026-07-08 incident rode exactly that — a wedged socket survived 9+ hours because no code path ever examined connection age.

**Changes**
- `ProxyConnection` / `LauncherConnection` gain `last_seen` (epoch secs, atomic), stamped at registration and on every decodable inbound frame. Heartbeats already flow on both socket types (proxy 1s, launcher 30s), so a live connection is always fresh.
- New `liveness.rs`: `sweep_stale_connections` evicts + cancels any connection silent past its deadline (proxy 60s, launcher 90s), generation-guarded so a concurrent reconnect's fresh entry is never touched. Eviction reuses the PR-#1267 machinery: entry removed, cancel token fired, socket task exits through normal cleanup, peer reconnects.
- Wired as a `spawn_periodic` background task (30s cadence) alongside the existing sweeps.

Worst-case recovery for the entire #1256 wedge class drops from "manual daemon restart, whenever a human notices" to ≤ ~2 minutes, automatic.

**Tests**: sweep evicts silent proxy+launcher and spares fresh ones (channel kept deliberately open to prove eviction is liveness-driven, not dead-channel-driven); `touch` resets the clock. 144 backend tests green, clippy -Dwarnings, fmt clean.