### PR TITLE
Backend input idempotency by client_msg_id, outbox resends all unacked

### DIFF
--- a/backend/migrations/2026-07-10-144459_add_client_msg_id_to_pending_inputs/down.sql
+++ b/backend/migrations/2026-07-10-144459_add_client_msg_id_to_pending_inputs/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pending_inputs DROP COLUMN client_msg_id;

--- a/backend/migrations/2026-07-10-144459_add_client_msg_id_to_pending_inputs/up.sql
+++ b/backend/migrations/2026-07-10-144459_add_client_msg_id_to_pending_inputs/up.sql
@@ -1,0 +1,5 @@
+-- Delivery-tracking id for pending inputs (#1236). Carried from the web
+-- client's outbox so (a) replay after a proxy reconnect preserves delivery
+-- tracking instead of degrading to content reconciliation, and (b) the
+-- backend can deduplicate an input the client resends after a reconnect.
+ALTER TABLE pending_inputs ADD COLUMN client_msg_id UUID;

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -549,6 +549,7 @@ fn handle_launcher_message(
                     seq_num: next_seq,
                     content: serde_json::to_string(&content_value).unwrap_or_default(),
                     send_mode: None,
+                    client_msg_id: None,
                 };
                 let _ = diesel::insert_into(pending_inputs::table)
                     .values(&new_input)

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -99,9 +99,11 @@ pub fn replay_pending_inputs_from_db(
             seq: input.seq_num,
             content,
             send_mode: input.send_mode.as_deref().and_then(parse_send_mode),
-            // Replayed inputs aren't delivery-tracked (the original browser
-            // row is long gone); UI falls back to content reconciliation.
-            client_msg_id: None,
+            // Persisted with the row (#1236) so replay keeps delivery
+            // tracking: the proxy's InputProgressAck still resolves the
+            // browser's outbox entry, and the idempotency gate keeps
+            // recognizing the id after a proxy reconnect.
+            client_msg_id: input.client_msg_id,
         };
 
         if sender.send(msg).is_ok() {

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -314,6 +314,26 @@ fn handle_proxy_message(
                 );
                 return ControlFlow::Continue(());
             }
+            // Record terminal stages for the idempotency gate (#1236): a
+            // client resending this id after a reconnect gets the terminal
+            // stage re-emitted instead of a duplicate delivery.
+            match stage {
+                shared::InputDeliveryStage::AgentAccepted => {
+                    session_manager.record_input_terminal(
+                        current_session_id,
+                        client_msg_id,
+                        super::session_manager::InputDeliveryState::Accepted,
+                    );
+                }
+                shared::InputDeliveryStage::Failed => {
+                    session_manager.record_input_terminal(
+                        current_session_id,
+                        client_msg_id,
+                        super::session_manager::InputDeliveryState::Failed,
+                    );
+                }
+                _ => {}
+            }
             // Relay the proxy's per-stage delivery signal to the session's web
             // clients (#939); each frontend advances the matching optimistic
             // row by client_msg_id. Failure detail isn't carried on this hop.

--- a/backend/src/handlers/websocket/session_manager/input_dedup.rs
+++ b/backend/src/handlers/websocket/session_manager/input_dedup.rs
@@ -1,0 +1,174 @@
+//! Server-side input idempotency by `client_msg_id` (#1236).
+//!
+//! The web client's send outbox (#1235) resends unacked inputs after a
+//! reconnect. Resending anything that *might* have reached the backend
+//! risks a duplicate reaching the agent, so the outbox used to resend only
+//! frames never handed to the transport — leaving an in-flight-loss window
+//! (frame accepted by the socket queue, socket dies before the write).
+//!
+//! This module closes it from the server side: the backend remembers the
+//! recent `client_msg_id`s per session and their delivery state, so the
+//! client can resend *everything* unacked (at-least-once) and the backend
+//! collapses duplicates (idempotent), re-emitting the terminal stage so the
+//! client's outbox still resolves.
+//!
+//! Bounds: ids per session are capped (resends happen within seconds of the
+//! original; the cap is generous). The per-session entry survives proxy
+//! reconnects deliberately — it must, since replayed inputs carry the same
+//! ids. Memory: ≤ `MAX_TRACKED_IDS_PER_SESSION` small tuples per live
+//! session. A backend restart clears the map; the durable `pending_inputs`
+//! rows (which now persist `client_msg_id`) backstop the in-flight case,
+//! checked by the caller in `web_client_socket`.
+
+use std::collections::VecDeque;
+
+use uuid::Uuid;
+
+use super::SessionManager;
+
+/// Cap on remembered ids per session. Resends arrive within seconds of the
+/// original send; 256 covers a pathological burst without meaningful memory.
+const MAX_TRACKED_IDS_PER_SESSION: usize = 256;
+
+/// Delivery state of a tracked input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputDeliveryState {
+    /// Enqueued toward the agent; no terminal ack from the proxy yet.
+    InFlight,
+    /// The agent process accepted the input (proxy reported `AgentAccepted`).
+    Accepted,
+    /// The proxy reported delivery failure.
+    Failed,
+}
+
+/// Outcome of checking an incoming `client_msg_id` against the tracker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DedupVerdict {
+    /// Never seen: recorded as in-flight; caller proceeds with delivery.
+    New,
+    /// Already tracked with the given state; caller must NOT re-deliver.
+    Duplicate(InputDeliveryState),
+}
+
+impl SessionManager {
+    /// Check an incoming input's `client_msg_id`; if new, record it as
+    /// in-flight. One entry-lock operation, so two concurrent duplicates
+    /// can't both see `New`.
+    pub(crate) fn check_and_record_input(
+        &self,
+        session_id: Uuid,
+        client_msg_id: Uuid,
+    ) -> DedupVerdict {
+        let mut tracked = self.input_dedup.entry(session_id).or_default();
+        if let Some((_, state)) = tracked.iter().find(|(id, _)| *id == client_msg_id) {
+            return DedupVerdict::Duplicate(*state);
+        }
+        if tracked.len() >= MAX_TRACKED_IDS_PER_SESSION {
+            tracked.pop_front();
+        }
+        tracked.push_back((client_msg_id, InputDeliveryState::InFlight));
+        DedupVerdict::New
+    }
+
+    /// Record a terminal delivery state reported by the proxy. Inserts the
+    /// id if untracked (e.g. the backend restarted between enqueue and ack)
+    /// so a later resend still re-acks instead of re-delivering.
+    pub(crate) fn record_input_terminal(
+        &self,
+        session_id: Uuid,
+        client_msg_id: Uuid,
+        state: InputDeliveryState,
+    ) {
+        let mut tracked = self.input_dedup.entry(session_id).or_default();
+        match tracked.iter_mut().find(|(id, _)| *id == client_msg_id) {
+            Some(entry) => entry.1 = state,
+            None => {
+                if tracked.len() >= MAX_TRACKED_IDS_PER_SESSION {
+                    tracked.pop_front();
+                }
+                tracked.push_back((client_msg_id, state));
+            }
+        }
+    }
+}
+
+pub(super) type InputDedupQueue = VecDeque<(Uuid, InputDeliveryState)>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_in_flight_and_terminal_transitions() {
+        let mgr = SessionManager::new();
+        let session = Uuid::new_v4();
+        let id = Uuid::new_v4();
+
+        assert_eq!(mgr.check_and_record_input(session, id), DedupVerdict::New);
+        assert_eq!(
+            mgr.check_and_record_input(session, id),
+            DedupVerdict::Duplicate(InputDeliveryState::InFlight)
+        );
+
+        mgr.record_input_terminal(session, id, InputDeliveryState::Accepted);
+        assert_eq!(
+            mgr.check_and_record_input(session, id),
+            DedupVerdict::Duplicate(InputDeliveryState::Accepted)
+        );
+    }
+
+    #[test]
+    fn terminal_for_untracked_id_is_recorded() {
+        let mgr = SessionManager::new();
+        let session = Uuid::new_v4();
+        let id = Uuid::new_v4();
+
+        // Simulates a backend restart between enqueue and the proxy's ack.
+        mgr.record_input_terminal(session, id, InputDeliveryState::Failed);
+        assert_eq!(
+            mgr.check_and_record_input(session, id),
+            DedupVerdict::Duplicate(InputDeliveryState::Failed)
+        );
+    }
+
+    #[test]
+    fn tracker_is_bounded_per_session() {
+        let mgr = SessionManager::new();
+        let session = Uuid::new_v4();
+        let first = Uuid::new_v4();
+        assert_eq!(
+            mgr.check_and_record_input(session, first),
+            DedupVerdict::New
+        );
+
+        for _ in 0..MAX_TRACKED_IDS_PER_SESSION {
+            mgr.check_and_record_input(session, Uuid::new_v4());
+        }
+
+        // The oldest id fell off the window: it reads as new again. This is
+        // the accepted bound — resends arrive within seconds, not after 256
+        // intervening sends.
+        assert_eq!(
+            mgr.check_and_record_input(session, first),
+            DedupVerdict::New
+        );
+        assert!(
+            mgr.input_dedup.get(&session).unwrap().len() <= MAX_TRACKED_IDS_PER_SESSION,
+            "tracker must stay bounded"
+        );
+    }
+
+    #[test]
+    fn sessions_are_tracked_independently() {
+        let mgr = SessionManager::new();
+        let id = Uuid::new_v4();
+        assert_eq!(
+            mgr.check_and_record_input(Uuid::new_v4(), id),
+            DedupVerdict::New
+        );
+        assert_eq!(
+            mgr.check_and_record_input(Uuid::new_v4(), id),
+            DedupVerdict::New
+        );
+    }
+}

--- a/backend/src/handlers/websocket/session_manager/input_queue.rs
+++ b/backend/src/handlers/websocket/session_manager/input_queue.rs
@@ -71,6 +71,7 @@ impl SessionManager {
                     seq_num: next_seq,
                     content: serde_json::to_string(&content).unwrap_or_default(),
                     send_mode: send_mode.as_ref().map(|m| m.as_str().to_string()),
+                    client_msg_id,
                 };
                 match diesel::insert_into(pending_inputs::table)
                     .values(&new_input)

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -25,6 +25,7 @@ use uuid::Uuid;
 
 mod client_fanout;
 mod correlation;
+mod input_dedup;
 mod input_queue;
 mod launcher_registry;
 mod pending_queue;
@@ -32,6 +33,7 @@ mod proxy_lifecycle;
 mod session_tracking;
 mod tunnel_client;
 
+pub(crate) use input_dedup::{DedupVerdict, InputDeliveryState};
 pub use launcher_registry::LauncherConnection;
 use pending_queue::PendingMessage;
 use tunnel_client::TunnelStreamMap;
@@ -93,6 +95,9 @@ pub struct SessionManager {
     /// session's `output_tokens` at result time so session totals (and the admin
     /// spend dashboard) don't under-count sub-agent usage.
     subagent_tokens: Arc<DashMap<Uuid, i64>>,
+    /// Recent web-client input ids per session and their delivery state —
+    /// the server half of input idempotency (#1236, see `input_dedup.rs`).
+    input_dedup: Arc<DashMap<Uuid, input_dedup::InputDedupQueue>>,
     /// Monotonic counter for connection generations (prevents stale cleanup)
     gen_counter: Arc<AtomicU64>,
     /// Current connection generation per session
@@ -119,6 +124,7 @@ impl Default for SessionManager {
             pending_launch_sessions: Arc::new(DashMap::new()),
             last_input_sender: Arc::new(DashMap::new()),
             subagent_tokens: Arc::new(DashMap::new()),
+            input_dedup: Arc::new(DashMap::new()),
             gen_counter: Arc::new(AtomicU64::new(1)),
             connection_gen: Arc::new(DashMap::new()),
         }

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -123,9 +123,46 @@ fn handle_web_client_message(
                     return false;
                 }
             }
+            // Idempotency gate (#1236): the outbox resends everything unacked
+            // after a reconnect, so a resent id may already be tracked. Known
+            // terminal → re-emit the terminal stage (idempotent ack) and stop;
+            // known in-flight → drop the duplicate (the original's acks will
+            // arrive); new → recorded in-flight, proceed.
+            if let (Some(id), Some(session_id)) = (client_msg_id, *verified_session_id) {
+                use super::session_manager::{DedupVerdict, InputDeliveryState};
+                let verdict = match session_manager.check_and_record_input(session_id, id) {
+                    // The in-memory tracker is empty after a backend restart;
+                    // a pending_inputs row with this id proves the original
+                    // was already accepted for delivery.
+                    DedupVerdict::New if pending_input_exists(db_pool, session_id, id) => {
+                        DedupVerdict::Duplicate(InputDeliveryState::InFlight)
+                    }
+                    v => v,
+                };
+                match verdict {
+                    DedupVerdict::New => {}
+                    DedupVerdict::Duplicate(InputDeliveryState::InFlight) => return false,
+                    DedupVerdict::Duplicate(InputDeliveryState::Accepted) => {
+                        let _ = tx.send(ServerToClient::InputProgress {
+                            client_msg_id: id,
+                            stage: shared::InputDeliveryStage::AgentAccepted,
+                            message: None,
+                        });
+                        return false;
+                    }
+                    DedupVerdict::Duplicate(InputDeliveryState::Failed) => {
+                        let _ = tx.send(ServerToClient::InputProgress {
+                            client_msg_id: id,
+                            stage: shared::InputDeliveryStage::Failed,
+                            message: Some("delivery previously failed".to_string()),
+                        });
+                        return false;
+                    }
+                }
+            }
             // First delivery stage: the backend accepted the input frame. Later
             // stages (ProxyReceived / AgentAccepted) come from the proxy ack
-            // path — a follow-up slice threads client_msg_id through there.
+            // path.
             if let Some(id) = client_msg_id {
                 let _ = tx.send(ServerToClient::InputProgress {
                     client_msg_id: id,
@@ -321,6 +358,28 @@ fn handle_web_register(
             true // close connection
         }
     }
+}
+
+/// DB backstop for the idempotency gate (#1236): the in-memory tracker dies
+/// with the backend, but an undelivered original leaves a `pending_inputs`
+/// row carrying its `client_msg_id`. Errors read as "not found" — a dup
+/// slipping through on a DB blip is the at-least-once side of the contract.
+fn pending_input_exists(
+    db_pool: &crate::db::DbPool,
+    session_id: Uuid,
+    client_msg_id: Uuid,
+) -> bool {
+    use crate::schema::pending_inputs;
+    let Ok(mut conn) = db_pool.get() else {
+        return false;
+    };
+    diesel::select(diesel::dsl::exists(
+        pending_inputs::table
+            .filter(pending_inputs::session_id.eq(session_id))
+            .filter(pending_inputs::client_msg_id.eq(client_msg_id)),
+    ))
+    .get_result::<bool>(&mut conn)
+    .unwrap_or(false)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -275,6 +275,10 @@ pub struct PendingInput {
     pub content: String,
     pub created_at: NaiveDateTime,
     pub send_mode: Option<String>,
+    /// Browser outbox delivery-tracking id (#1236). Persisted so replay
+    /// keeps delivery tracking and resends can be deduplicated across a
+    /// backend restart. `None` for non-browser inputs.
+    pub client_msg_id: Option<Uuid>,
 }
 
 #[derive(Debug, Insertable)]
@@ -284,6 +288,7 @@ pub struct NewPendingInput {
     pub seq_num: i64,
     pub content: String,
     pub send_mode: Option<String>,
+    pub client_msg_id: Option<Uuid>,
 }
 
 // ============================================================================

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -60,6 +60,7 @@ diesel::table! {
         created_at -> Timestamp,
         #[max_length = 32]
         send_mode -> Nullable<Varchar>,
+        client_msg_id -> Nullable<Uuid>,
     }
 }
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -808,14 +808,16 @@ impl SessionView {
         }
     }
 
-    /// Resend every outbox frame not yet handed to the transport. Called on
-    /// reconnect. Dup-free: already-transmitted frames are skipped, so a frame
-    /// the backend already received is never sent twice.
+    /// Resend every unresolved outbox frame on reconnect — including ones
+    /// already handed to the old (now dead) transport, closing the
+    /// in-flight-loss window. The backend dedupes by `client_msg_id` and
+    /// re-acks anything it already handled (#1236), so this is at-least-once
+    /// with idempotent delivery, never duplicate delivery.
     fn flush_outbox(&mut self) {
         let Some(sender) = self.ws_sender.clone() else {
             return;
         };
-        for (client_msg_id, frame) in self.outbox.untransmitted() {
+        for (client_msg_id, frame) in self.outbox.unresolved() {
             if send_message(&sender, frame) {
                 self.outbox.mark_transmitted(client_msg_id);
             }

--- a/frontend/src/pages/dashboard/session_view/outbox.rs
+++ b/frontend/src/pages/dashboard/session_view/outbox.rs
@@ -10,18 +10,19 @@
 //! The outbox closes that hole:
 //! - Every `AgentInput` is recorded here, keyed by its `client_msg_id`, with a
 //!   `transmitted` flag: was the frame actually handed to the transport?
-//! - On reconnect the caller flushes only the **un-transmitted** frames.
-//!   Because those provably never reached the backend, resending them cannot
-//!   duplicate — so no backend dedupe is required.
+//! - On reconnect the caller flushes **every unresolved frame**, including
+//!   ones already handed to a transport that then died before writing them
+//!   (the in-flight-loss window). The backend deduplicates by
+//!   `client_msg_id` (#1236) and re-emits the terminal stage for anything it
+//!   already handled, so at-least-once resending cannot duplicate delivery.
 //! - An entry is removed once the backend resolves it: `AgentAccepted`
 //!   (delivered) or `Failed` (terminal).
 //! - The outbox is bounded; the oldest entry is evicted past the cap so a
 //!   perpetually-unacked backlog can't grow without limit.
 //!
-//! NOT covered here (would require backend idempotency keyed on
-//! `client_msg_id`, tracked as a follow-up): a frame handed to a socket that
-//! dies before it transmits. Such a frame is marked `transmitted` and
-//! deliberately not resent, keeping the outbox strictly dup-free.
+//! The `transmitted` flag still gates *non-reconnect* sends (a frame handed
+//! to a healthy transport isn't blindly re-sent) — only the reconnect flush
+//! resends transmitted-but-unresolved entries.
 
 use shared::ClientToServer;
 use uuid::Uuid;
@@ -77,14 +78,16 @@ impl Outbox {
         self.entries.len() != before
     }
 
-    /// `(client_msg_id, frame)` clones for every entry never handed to the
-    /// transport, in send order. The caller sends each and calls
+    /// `(client_msg_id, frame)` clones for every unresolved entry, in send
+    /// order — including transmitted-but-unacked ones, which may have died
+    /// in flight with the old socket. Safe to resend wholesale: the backend
+    /// dedupes by `client_msg_id` and re-acks anything already handled
+    /// (#1236). The caller sends each and calls
     /// [`mark_transmitted`](Self::mark_transmitted) on success — so a flush
     /// that itself fails leaves the entry queued for the next reconnect.
-    pub(super) fn untransmitted(&self) -> Vec<(Uuid, ClientToServer)> {
+    pub(super) fn unresolved(&self) -> Vec<(Uuid, ClientToServer)> {
         self.entries
             .iter()
-            .filter(|e| !e.transmitted)
             .map(|e| (e.client_msg_id, e.frame.clone()))
             .collect()
     }
@@ -108,7 +111,10 @@ mod tests {
     }
 
     #[test]
-    fn untransmitted_lists_only_unsent_in_order() {
+    fn unresolved_includes_transmitted_entries_in_order() {
+        // #1236: transmitted-but-unacked frames may have died in flight with
+        // the old socket — the reconnect flush must include them. The backend
+        // dedupes by client_msg_id, so this cannot double-deliver.
         let mut ob = Outbox::default();
         let a = Uuid::from_u128(1);
         let b = Uuid::from_u128(2);
@@ -116,26 +122,22 @@ mod tests {
         ob.record(b, input("b"));
         ob.mark_transmitted(a);
 
-        let pending: Vec<Uuid> = ob.untransmitted().into_iter().map(|(id, _)| id).collect();
-        assert_eq!(pending, vec![b], "only the un-transmitted frame flushes");
+        let pending: Vec<Uuid> = ob.unresolved().into_iter().map(|(id, _)| id).collect();
+        assert_eq!(pending, vec![a, b], "every unresolved frame flushes");
     }
 
     #[test]
-    fn flush_is_dup_free_after_marking_transmitted() {
-        // The reconnect flush must not re-send a frame it already sent — this
-        // is what keeps resends free of duplicates without backend dedupe.
+    fn resolved_entries_never_flush_again() {
+        // Resolution (AgentAccepted/Failed) is what stops resends — a
+        // resolved id must never be flushed on a later reconnect.
         let mut ob = Outbox::default();
         let a = Uuid::from_u128(1);
         ob.record(a, input("a"));
-
-        // First flush: send + mark.
-        for (id, _frame) in ob.untransmitted() {
-            ob.mark_transmitted(id);
-        }
-        // Second flush (e.g. a later reconnect) returns nothing.
+        ob.mark_transmitted(a);
+        assert!(ob.resolve(a));
         assert!(
-            ob.untransmitted().is_empty(),
-            "a transmitted frame is never re-sent"
+            ob.unresolved().is_empty(),
+            "a resolved frame is never re-sent"
         );
     }
 


### PR DESCRIPTION
Fixes #1236; closes the #939 phase-2/3 remainder.

#1235's client outbox made web input reliable across reconnects but deliberately never resent a frame already handed to a transport — resending might duplicate, so a frame that died in flight with its socket was silently lost. This PR adds the server-side idempotency that makes resending everything safe.

**Backend**
- `pending_inputs.client_msg_id` (migration + model): the delivery-tracking id is persisted with the row, and replay now carries it — delivery tracking survives proxy reconnects instead of degrading to content reconciliation, and the idempotency gate keeps recognizing replayed ids.
- New `input_dedup` module: bounded per-session tracker (256 ids) of `client_msg_id → InFlight/Accepted/Failed`. `check_and_record_input` is one entry-lock op, so concurrent duplicates can't both read `New`.
- `AgentInput` gate in the web-client socket: duplicate in-flight → dropped (original's acks will arrive); duplicate terminal → the terminal `InputProgress` stage is re-emitted so the client's outbox resolves (idempotent ack); new → proceeds. DB backstop: after a backend restart the tracker is empty, so a `pending_inputs` row with the same id counts as in-flight.
- The proxy's `InputProgressAck` terminal stages are recorded into the tracker.

**Frontend**
- The reconnect flush resends **every unresolved** outbox entry, including transmitted-but-unacked ones (`untransmitted()` → `unresolved()`). At-least-once + idempotent = the in-flight-loss window is closed and "Sending…" always resolves truthfully.

**Documented residual**: a terminal state recorded only in memory is lost if the backend restarts before the client's ack round-trip completes AND the pending row was already deleted — a resend then re-delivers. Rare (double failure in a seconds-wide window), and a visible duplicate beats a silent loss.

**Tests**: dedup transitions (in-flight → accepted, terminal-for-untracked, per-session boundedness, independence), outbox resend-all + never-resend-resolved. Backend 141, frontend 379, clippy `-Dwarnings` both targets, fmt clean.