### PR TITLE
Transactional file uploads: temp-file commit, result acks, gated prompt

### DIFF
--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -403,6 +403,17 @@ fn handle_proxy_message(
                 );
             }
         }
+        ProxyToServer::FileUploadResult(result) => {
+            // Relay the upload's terminal outcome to the session's web
+            // clients — the uploader is holding back the prompt that
+            // references the file until this arrives (#939 phase 4).
+            if let Some(key) = session_key {
+                session_manager.broadcast_to_web_clients(
+                    key,
+                    shared::ServerToClient::FileUploadResult(result),
+                );
+            }
+        }
         ProxyToServer::SessionStatus { .. } => {}
         ProxyToServer::ForwardStatus(status) => {
             if let Some(session_id) = *db_session_id {

--- a/backend/src/handlers/websocket/uploads.rs
+++ b/backend/src/handlers/websocket/uploads.rs
@@ -31,10 +31,23 @@ pub(super) struct PendingUpload {
     received_bytes: u64,
 }
 
+/// Tell the uploading web client its upload definitively failed (#939
+/// phase 4) — it is holding back the prompt that references the file.
+fn send_upload_failure(tx: &super::WebClientSender, upload_id: String, error: &str) {
+    let _ = tx.send(shared::ServerToClient::FileUploadResult(
+        shared::FileUploadResultFields {
+            upload_id,
+            success: false,
+            error: Some(error.to_string()),
+        },
+    ));
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn handle_file_upload_start(
     session_manager: &SessionManager,
     session_key: &Option<SessionId>,
+    tx: &super::WebClientSender,
     pending_uploads: &mut HashMap<String, PendingUpload>,
     upload_id: String,
     filename: String,
@@ -48,6 +61,7 @@ pub(super) fn handle_file_upload_start(
             "Invalid total_chunks {} for upload {}",
             total_chunks, upload_id
         );
+        send_upload_failure(tx, upload_id, "invalid chunk count");
         return;
     }
 
@@ -60,6 +74,7 @@ pub(super) fn handle_file_upload_start(
             "Upload {} declared total_size {} > server cap {} bytes; rejecting",
             upload_id, total_size, effective_max_total_bytes
         );
+        send_upload_failure(tx, upload_id, "file exceeds server size limit");
         return;
     }
 
@@ -69,8 +84,28 @@ pub(super) fn handle_file_upload_start(
         safe_filename, total_chunks, total_size, upload_id
     );
 
+    // Uploads are connected-only transactions: the in-memory pending queue
+    // caps at 100 frames, so "queueing" a multi-thousand-chunk upload for a
+    // disconnected proxy silently drops most of it. Failing fast is honest.
+    let Some(key) = session_key else {
+        send_upload_failure(tx, upload_id, "session not registered");
+        return;
+    };
+    let msg = ServerToProxy::FileUploadStart(shared::FileUploadStartFields {
+        upload_id: upload_id.clone(),
+        filename: safe_filename,
+        content_type,
+        total_chunks,
+        total_size,
+    });
+    if !session_manager.send_to_connected_session(key, msg) {
+        warn!("Session not connected for file upload start");
+        send_upload_failure(tx, upload_id, "agent is offline");
+        return;
+    }
+
     pending_uploads.insert(
-        upload_id.clone(),
+        upload_id,
         PendingUpload {
             total_chunks,
             total_size,
@@ -79,20 +114,6 @@ pub(super) fn handle_file_upload_start(
             received_bytes: 0,
         },
     );
-
-    // Forward start message to proxy
-    if let Some(ref key) = session_key {
-        let msg = ServerToProxy::FileUploadStart(shared::FileUploadStartFields {
-            upload_id,
-            filename: safe_filename,
-            content_type,
-            total_chunks,
-            total_size,
-        });
-        if !session_manager.send_to_session(key, msg) {
-            warn!("Session not connected for file upload start");
-        }
-    }
 }
 
 /// Result of validating an incoming chunk against the `PendingUpload` state.
@@ -153,12 +174,15 @@ fn validate_and_record_chunk(
 pub(super) fn handle_file_upload_chunk(
     session_manager: &SessionManager,
     session_key: &Option<SessionId>,
+    tx: &super::WebClientSender,
     pending_uploads: &mut HashMap<String, PendingUpload>,
     upload_id: String,
     chunk_index: u32,
     data: String,
 ) {
     let Some(upload) = pending_uploads.get_mut(&upload_id) else {
+        // Post-abort stragglers; the failure was already reported when the
+        // entry was dropped.
         warn!("Received chunk for unknown upload_id={}", upload_id);
         return;
     };
@@ -175,6 +199,7 @@ pub(super) fn handle_file_upload_chunk(
                 upload_id, chunk_index
             );
             pending_uploads.remove(&upload_id);
+            send_upload_failure(tx, upload_id, "invalid chunk encoding");
             return;
         }
     };
@@ -194,28 +219,36 @@ pub(super) fn handle_file_upload_chunk(
                 upload_id, chunk_index, reason
             );
             pending_uploads.remove(&upload_id);
+            send_upload_failure(tx, upload_id, reason);
             return;
         }
         ChunkOutcome::Accept | ChunkOutcome::AcceptAndComplete => {}
     }
 
-    // Forward chunk directly to proxy
+    // Forward chunk directly to proxy. Connected-only (see
+    // `handle_file_upload_start`): a proxy that dropped mid-upload can't
+    // resume a partial stream, so fail the transaction honestly.
+    let total_chunks = upload.total_chunks;
     if let Some(ref key) = session_key {
         let msg = ServerToProxy::FileUploadChunk(shared::FileUploadChunkFields {
             upload_id: upload_id.clone(),
             chunk_index,
             data,
         });
-        if !session_manager.send_to_session(key, msg) {
+        if !session_manager.send_to_connected_session(key, msg) {
             warn!("Session not connected for file upload chunk");
+            pending_uploads.remove(&upload_id);
+            send_upload_failure(tx, upload_id, "agent disconnected during upload");
+            return;
         }
     }
 
-    // Clean up tracking when all chunks forwarded
+    // Clean up tracking when all chunks forwarded. The success result comes
+    // from the proxy once the file is committed to disk — not from here.
     if outcome == ChunkOutcome::AcceptAndComplete {
         info!(
             "All {} chunks forwarded for upload_id={}",
-            upload.total_chunks, upload_id
+            total_chunks, upload_id
         );
         pending_uploads.remove(&upload_id);
     }
@@ -372,6 +405,7 @@ mod tests {
         let session_manager = SessionManager::new();
         let session_key: SessionId = "test-session".to_string();
         let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
+        let (client_tx, _client_rx) = mpsc::unbounded_channel();
         session_manager.register_session(
             session_key.clone(),
             proxy_tx,
@@ -388,6 +422,7 @@ mod tests {
         handle_file_upload_chunk(
             &session_manager,
             &Some(session_key.clone()),
+            &client_tx,
             &mut pending_uploads,
             upload_id.clone(),
             0,
@@ -397,6 +432,7 @@ mod tests {
         handle_file_upload_chunk(
             &session_manager,
             &Some(session_key.clone()),
+            &client_tx,
             &mut pending_uploads,
             upload_id.clone(),
             0,
@@ -410,6 +446,7 @@ mod tests {
         handle_file_upload_chunk(
             &session_manager,
             &Some(session_key.clone()),
+            &client_tx,
             &mut pending_uploads,
             upload_id.clone(),
             1,
@@ -418,6 +455,7 @@ mod tests {
         handle_file_upload_chunk(
             &session_manager,
             &Some(session_key.clone()),
+            &client_tx,
             &mut pending_uploads,
             upload_id.clone(),
             2,
@@ -449,6 +487,7 @@ mod tests {
         let session_manager = SessionManager::new();
         let session_key: SessionId = "test-session-2".to_string();
         let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
+        let (client_tx, _client_rx) = mpsc::unbounded_channel();
         session_manager.register_session(
             session_key.clone(),
             proxy_tx,
@@ -465,6 +504,7 @@ mod tests {
         handle_file_upload_chunk(
             &session_manager,
             &Some(session_key.clone()),
+            &client_tx,
             &mut pending_uploads,
             upload_id.clone(),
             0,

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -203,6 +203,7 @@ fn handle_web_client_message(
             handle_file_upload_start(
                 session_manager,
                 session_key,
+                tx,
                 pending_uploads,
                 upload_id,
                 filename,
@@ -230,6 +231,7 @@ fn handle_web_client_message(
             handle_file_upload_chunk(
                 session_manager,
                 session_key,
+                tx,
                 pending_uploads,
                 upload_id,
                 chunk_index,

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -1047,6 +1047,44 @@ fn is_codex_compaction_event(value: &serde_json::Value) -> bool {
 }
 
 /// Handle a file upload event (start or chunk)
+/// Report an upload's terminal outcome to the backend (relayed to the web
+/// client, which gates the prompt referencing the file on it — #939).
+async fn send_upload_result(
+    state: &ConnectionState,
+    upload_id: String,
+    success: bool,
+    error: Option<String>,
+) {
+    let mut ws = state.ws_write.lock().await;
+    if let Err(e) = ws
+        .send(ProxyToServer::FileUploadResult(
+            shared::FileUploadResultFields {
+                upload_id,
+                success,
+                error,
+            },
+        ))
+        .await
+    {
+        error!("Failed to send file upload result: {}", e);
+    }
+}
+
+/// Abort an in-flight upload: drop its state, best-effort delete the
+/// partial temp file, and report the failure.
+async fn fail_upload(state: &mut ConnectionState, upload_id: String, reason: String) {
+    if let Some(recv_state) = state.active_uploads.remove(&upload_id) {
+        drop(recv_state.file_handle);
+        let _ = tokio::fs::remove_file(&recv_state.temp_path).await;
+    }
+    error!(
+        "[upload {}] Failed: {}",
+        &upload_id[..8.min(upload_id.len())],
+        reason
+    );
+    send_upload_result(state, upload_id, false, Some(reason)).await;
+}
+
 async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut ConnectionState) {
     match upload_event {
         FileUploadEvent::Start {
@@ -1070,8 +1108,15 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
                 safe_name
             };
 
-            let file_path = std::path::Path::new(&state.working_directory).join(&safe_name);
-            match tokio::fs::File::create(&file_path).await {
+            // Write to a hidden temp path; renamed to the real name only on
+            // completion so the agent can never read a truncated file.
+            let temp_name = format!(
+                ".{}.{}.upload",
+                safe_name,
+                &upload_id[..8.min(upload_id.len())]
+            );
+            let temp_path = std::path::Path::new(&state.working_directory).join(&temp_name);
+            match tokio::fs::File::create(&temp_path).await {
                 Ok(fh) => {
                     state.active_uploads.insert(
                         upload_id,
@@ -1084,11 +1129,13 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
                             file_handle: Some(fh),
                             start_time: Instant::now(),
                             last_log_percent: 0,
+                            temp_path,
                         },
                     );
                 }
                 Err(e) => {
-                    error!("Failed to create file {}: {}", file_path.display(), e);
+                    let reason = format!("failed to create {}: {}", temp_path.display(), e);
+                    fail_upload(state, upload_id, reason).await;
                 }
             }
         }
@@ -1098,6 +1145,8 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
 
             let upload_id_short = &upload_id[..8.min(upload_id.len())];
             let Some(recv_state) = state.active_uploads.get_mut(&upload_id) else {
+                // Post-abort stragglers land here; the failure was already
+                // reported when the upload state was dropped.
                 warn!("[upload {}] Chunk for unknown upload", upload_id_short);
                 return;
             };
@@ -1105,14 +1154,16 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
             let decoded = match base64::engine::general_purpose::STANDARD.decode(&data) {
                 Ok(b) => b,
                 Err(e) => {
-                    error!("[upload {}] Base64 decode error: {}", upload_id_short, e);
+                    let reason = format!("base64 decode error: {e}");
+                    fail_upload(state, upload_id, reason).await;
                     return;
                 }
             };
 
             if let Some(ref mut fh) = recv_state.file_handle {
                 if let Err(e) = fh.write_all(&decoded).await {
-                    error!("[upload {}] Write error: {}", upload_id_short, e);
+                    let reason = format!("write error: {e}");
+                    fail_upload(state, upload_id, reason).await;
                     return;
                 }
             }
@@ -1157,17 +1208,32 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
                     0.0
                 };
 
-                // Flush and close file
+                // Flush + close, then commit: rename the temp file to its
+                // real name. Only a successful rename counts as delivered.
                 if let Some(mut fh) = recv_state.file_handle.take() {
-                    let _ = fh.flush().await;
+                    if let Err(e) = fh.flush().await {
+                        let reason = format!("flush error: {e}");
+                        fail_upload(state, upload_id, reason).await;
+                        return;
+                    }
                 }
 
                 let filename = recv_state.filename.clone();
+                let received_bytes = recv_state.received_bytes;
+                let final_path = std::path::Path::new(&state.working_directory).join(&filename);
+                let temp_path = recv_state.temp_path.clone();
+                if let Err(e) = tokio::fs::rename(&temp_path, &final_path).await {
+                    let reason = format!("rename to {} failed: {e}", final_path.display());
+                    fail_upload(state, upload_id, reason).await;
+                    return;
+                }
+
                 info!(
                     "[upload {}] Complete: {} ({} bytes in {:.1}s, avg {:.1} KB/s)",
-                    upload_id_short, filename, recv_state.received_bytes, elapsed, rate_kb
+                    upload_id_short, filename, received_bytes, elapsed, rate_kb
                 );
                 state.active_uploads.remove(&upload_id);
+                send_upload_result(state, upload_id, true, None).await;
             }
         }
     }

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -1108,6 +1108,18 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
                 safe_name
             };
 
+            // A duplicate Start for an in-flight upload_id (client bug or
+            // retry) must not leak the old entry's temp file: drop the old
+            // state and delete its partial before starting over.
+            if let Some(old) = state.active_uploads.remove(&upload_id) {
+                warn!(
+                    "[upload {}] Duplicate start; discarding previous partial",
+                    &upload_id[..8.min(upload_id.len())]
+                );
+                drop(old.file_handle);
+                let _ = tokio::fs::remove_file(&old.temp_path).await;
+            }
+
             // Write to a hidden temp path; renamed to the real name only on
             // completion so the agent can never read a truncated file.
             let temp_name = format!(

--- a/claude-session-lib/src/proxy_session/ws_reader.rs
+++ b/claude-session-lib/src/proxy_session/ws_reader.rs
@@ -33,6 +33,9 @@ pub(crate) struct FileReceiveState {
     pub(crate) file_handle: Option<tokio::fs::File>,
     pub(crate) start_time: std::time::Instant,
     pub(crate) last_log_percent: u32,
+    /// Bytes are written here and renamed to `filename` only on completion,
+    /// so a consumer (the agent) can never read a truncated file (#939).
+    pub(crate) temp_path: std::path::PathBuf,
 }
 
 /// A portal input classified by send mode: a plain user input or a

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -139,9 +139,20 @@ pub enum SessionViewMsg {
     /// `ClientToServer::ClaudeInput` frame.
     SendText(String, SendMode),
     /// InputBar emitted a raw WS frame (used by the file-upload pipeline
-    /// for `FileUploadStart` / `FileUploadChunk` / the final combined
-    /// `ClaudeInput`). We just forward it over the WebSocket.
+    /// for `FileUploadStart` / `FileUploadChunk`). We just forward it over
+    /// the WebSocket.
     SendFrame(ClientToServer),
+    /// InputBar finished emitting upload chunks and hands us the composed
+    /// prompt plus the upload ids it references. We hold the prompt until
+    /// every id commits (`WsEvent::UploadResult`), then dispatch it as a
+    /// normal agent input (#939 phase 4).
+    UploadPrompt {
+        content: String,
+        upload_ids: Vec<String>,
+    },
+    /// The upload-commit wait expired (old proxy or very slow link):
+    /// dispatch the held prompt anyway — pre-transactional behavior.
+    UploadCommitTimeout,
     /// InputBar reports that a submission landed — bumps the parent's
     /// `on_message_sent` prop.
     MessageSent,
@@ -167,6 +178,17 @@ pub enum SessionViewMsg {
 }
 
 /// SessionView - Main terminal view for a single session
+/// A composed upload prompt held back until every file it references has
+/// been committed on the proxy host (#939 phase 4).
+struct PendingUploadPrompt {
+    remaining: std::collections::HashSet<String>,
+    content: String,
+    /// Compat fallback: proxies that predate upload acks never send
+    /// `FileUploadResult`, so fire the prompt anyway after this window
+    /// (pre-transactional behavior). Cancelled by drop.
+    _timeout: Timeout,
+}
+
 pub struct SessionView {
     messages: Vec<RenderedMessage>,
     ws_connected: bool,
@@ -174,6 +196,12 @@ pub struct SessionView {
     /// Unacked `AgentInput` frames, resent on reconnect so inputs typed while
     /// the socket is down aren't silently dropped. See [`Outbox`].
     outbox: Outbox,
+    /// See [`PendingUploadPrompt`].
+    pending_upload_prompt: Option<PendingUploadPrompt>,
+    /// Upload outcomes that arrived before the prompt handoff (a small
+    /// file can commit while later files are still streaming). Bounded;
+    /// consumed by `handle_upload_prompt`.
+    early_upload_results: std::collections::HashMap<String, Result<(), String>>,
     messages_ref: NodeRef,
     should_autoscroll: bool,
     #[allow(dead_code)]
@@ -281,6 +309,8 @@ impl Component for SessionView {
             ws_connected: false,
             ws_sender: None,
             outbox: Outbox::default(),
+            pending_upload_prompt: None,
+            early_upload_results: HashMap::new(),
             messages_ref: NodeRef::default(),
             should_autoscroll: true,
             scroll_listener: None,
@@ -452,6 +482,25 @@ impl Component for SessionView {
                     false
                 }
             },
+            SessionViewMsg::UploadPrompt {
+                content,
+                upload_ids,
+            } => self.handle_upload_prompt(ctx, content, upload_ids),
+            SessionViewMsg::UploadCommitTimeout => {
+                if let Some(pending) = self.pending_upload_prompt.take() {
+                    // Old proxy (no upload acks) or a very slow link: fall
+                    // back to pre-transactional behavior instead of eating
+                    // the prompt.
+                    log::warn!(
+                        "Upload commit ack timed out ({} outstanding); sending prompt anyway",
+                        pending.remaining.len()
+                    );
+                    self.dispatch_agent_input(serde_json::Value::String(pending.content), None);
+                    true
+                } else {
+                    false
+                }
+            }
             SessionViewMsg::MessageSent => {
                 let session_id = ctx.props().session.id;
                 ctx.props().on_message_sent.emit(session_id);
@@ -716,7 +765,99 @@ impl SessionView {
                 self.forwards_refresh = self.forwards_refresh.wrapping_add(1);
                 true
             }
+            WsEvent::UploadResult(fields) => self.handle_upload_result(fields),
         }
+    }
+
+    /// InputBar handed over the composed upload prompt: consume any commit
+    /// results that raced ahead of the handoff, then either dispatch
+    /// immediately, fail loudly, or hold for the outstanding ids (#939).
+    fn handle_upload_prompt(
+        &mut self,
+        ctx: &Context<Self>,
+        content: String,
+        upload_ids: Vec<String>,
+    ) -> bool {
+        let mut remaining: std::collections::HashSet<String> = upload_ids.into_iter().collect();
+        let mut early_failure: Option<String> = None;
+        remaining.retain(|id| match self.early_upload_results.remove(id) {
+            Some(Ok(())) => false,
+            Some(Err(e)) => {
+                early_failure = Some(e);
+                true
+            }
+            None => true,
+        });
+        self.early_upload_results.clear();
+
+        if let Some(err) = early_failure {
+            self.push_upload_error(&err);
+            return true;
+        }
+        if remaining.is_empty() {
+            self.dispatch_agent_input(serde_json::Value::String(content), None);
+            return true;
+        }
+
+        let link = ctx.link().clone();
+        let timeout = Timeout::new(45_000, move || {
+            link.send_message(SessionViewMsg::UploadCommitTimeout);
+        });
+        self.pending_upload_prompt = Some(PendingUploadPrompt {
+            remaining,
+            content,
+            _timeout: timeout,
+        });
+        false
+    }
+
+    /// A `FileUploadResult` arrived from the proxy (or was synthesized by
+    /// the backend). Resolve the held prompt, or stash the result if the
+    /// prompt handoff hasn't happened yet.
+    fn handle_upload_result(&mut self, fields: shared::FileUploadResultFields) -> bool {
+        if let Some(ref mut pending) = self.pending_upload_prompt {
+            if pending.remaining.contains(&fields.upload_id) {
+                if fields.success {
+                    pending.remaining.remove(&fields.upload_id);
+                    if pending.remaining.is_empty() {
+                        if let Some(done) = self.pending_upload_prompt.take() {
+                            self.dispatch_agent_input(
+                                serde_json::Value::String(done.content),
+                                None,
+                            );
+                        }
+                    }
+                } else {
+                    self.pending_upload_prompt = None;
+                    let err = fields.error.unwrap_or_else(|| "upload failed".to_string());
+                    self.push_upload_error(&err);
+                }
+                return true;
+            }
+        }
+        // Pre-handoff (or unrelated) result: stash for handle_upload_prompt.
+        if self.early_upload_results.len() < 64 {
+            let outcome = if fields.success {
+                Ok(())
+            } else {
+                Err(fields.error.unwrap_or_else(|| "upload failed".to_string()))
+            };
+            self.early_upload_results.insert(fields.upload_id, outcome);
+        }
+        false
+    }
+
+    /// Surface a terminal upload failure in the transcript. The prompt
+    /// referencing the file is deliberately NOT sent — the agent must never
+    /// be told about a file that isn't fully on disk.
+    fn push_upload_error(&mut self, err: &str) {
+        let error_msg = ErrorMessage::new(format!(
+            "File upload failed: {err} — your message was not sent"
+        ));
+        self.messages.push(RenderedMessage::new(
+            serde_json::to_string(&error_msg).unwrap_or_default(),
+            None,
+        ));
     }
 
     /// Hydrate the message buffer + task panel from a REST history batch.
@@ -918,6 +1059,12 @@ impl SessionView {
         let on_send_text =
             link.callback(|(text, mode): (String, SendMode)| SessionViewMsg::SendText(text, mode));
         let on_send_frame = link.callback(SessionViewMsg::SendFrame);
+        let on_upload_prompt = link.callback(|(content, upload_ids): (String, Vec<String>)| {
+            SessionViewMsg::UploadPrompt {
+                content,
+                upload_ids,
+            }
+        });
         let on_message_sent = link.callback(|_| SessionViewMsg::MessageSent);
         html! {
             <InputBar
@@ -927,6 +1074,7 @@ impl SessionView {
                 {on_register}
                 {on_send_text}
                 {on_send_frame}
+                {on_upload_prompt}
                 {on_message_sent}
             />
         }

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -46,9 +46,14 @@ pub struct InputBarProps {
     /// and emits the optimistic local echo.
     pub on_send_text: Callback<(String, SendMode)>,
     /// Raw WS frame emitted by the bar. Used by the file-upload pipeline
-    /// to stream `FileUploadStart` / `FileUploadChunk` / the combined
-    /// `ClaudeInput` frames.
+    /// to stream `FileUploadStart` / `FileUploadChunk` frames.
     pub on_send_frame: Callback<ClientToServer>,
+    /// The composed upload prompt plus the upload ids it references,
+    /// handed to the parent AFTER all chunks are emitted. The parent holds
+    /// the prompt until every upload commits on the proxy host (#939
+    /// phase 4) — the agent must never be told about a file that isn't
+    /// fully on disk.
+    pub on_upload_prompt: Callback<(String, Vec<String>)>,
     /// Fires once per submit (text or upload) so the parent can bump its
     /// per-session "I sent something" bookkeeping.
     pub on_message_sent: Callback<()>,
@@ -515,9 +520,11 @@ impl InputBar {
 
         let link = ctx.link().clone();
         let on_send_frame = ctx.props().on_send_frame.clone();
+        let on_upload_prompt = ctx.props().on_upload_prompt.clone();
 
         spawn_local(async move {
             let mut uploaded_files: Vec<(String, u64)> = Vec::new();
+            let mut upload_ids: Vec<String> = Vec::new();
             let total_files = files.len();
 
             for (file_idx, file) in files.iter().enumerate() {
@@ -575,20 +582,17 @@ impl InputBar {
                 }
 
                 uploaded_files.push((file_name, file_size));
+                upload_ids.push(upload_id);
 
                 let overall_progress = (file_idx + 1) as f32 / total_files as f32;
                 link.send_message(InputBarMsg::FileUploadProgress(overall_progress));
             }
 
+            // Hand the composed prompt to the parent instead of sending it:
+            // the parent dispatches it only once every upload above has
+            // committed on the proxy host (#939 phase 4).
             let combined = build_upload_message(&user_input, &uploaded_files);
-            on_send_frame.emit(ClientToServer::AgentInput {
-                content: serde_json::Value::String(combined),
-                send_mode: None,
-                // `SessionView::prepare_outbound_frame` assigns the
-                // browser-side correlation id and optimistic row for every
-                // AgentInput frame, including file-upload summaries.
-                client_msg_id: None,
-            });
+            on_upload_prompt.emit((combined, upload_ids));
 
             link.send_message(InputBarMsg::FileUploaded(
                 uploaded_files

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -52,6 +52,9 @@ pub enum WsEvent {
     /// The session's port-forward set changed; the view refetches
     /// `GET /api/sessions/{id}/forwards` (docs/PORT_FORWARDING.md).
     ForwardsChanged,
+    /// Terminal outcome of a file upload (#939 phase 4). The view gates the
+    /// prompt referencing the file on this.
+    UploadResult(shared::FileUploadResultFields),
 }
 
 /// Connect to WebSocket and start receiving messages.
@@ -173,6 +176,9 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
                 input,
                 permission_suggestions,
             }));
+        }
+        ServerToClient::FileUploadResult(fields) => {
+            on_event.emit(WsEvent::UploadResult(fields));
         }
         ServerToClient::Error { message } => {
             let error_msg = ErrorMessage::new(message);
@@ -587,6 +593,7 @@ mod tests {
             WsEvent::TurnMetrics(_) => "TurnMetrics",
             WsEvent::InputProgress { .. } => "InputProgress",
             WsEvent::ForwardsChanged => "ForwardsChanged",
+            WsEvent::UploadResult(_) => "UploadResult",
         }
     }
 }

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -3,7 +3,8 @@ use uuid::Uuid;
 use ws_bridge::WsEndpoint;
 
 use super::types::{
-    FileUploadChunkFields, FileUploadStartFields, PermissionResponseFields, RegisterFields,
+    FileUploadChunkFields, FileUploadResultFields, FileUploadStartFields, PermissionResponseFields,
+    RegisterFields,
 };
 use crate::{AgentType, PermissionSuggestion, SendMode, SessionCost, SessionStatus, TurnMetrics};
 
@@ -243,6 +244,12 @@ pub enum ServerToClient {
 
     /// Error message
     Error { message: String },
+
+    /// Terminal outcome of a chunked file upload (#939 phase 4). Relayed
+    /// from the proxy (or synthesized by the backend for failures it can
+    /// detect itself); the client withholds the prompt referencing the
+    /// file until every named upload commits.
+    FileUploadResult(FileUploadResultFields),
 
     /// Session metadata changed
     SessionUpdate {

--- a/shared/src/endpoints/session.rs
+++ b/shared/src/endpoints/session.rs
@@ -4,9 +4,10 @@ use ws_bridge::WsEndpoint;
 
 use super::types::{
     FileDownloadRequestFields, FileDownloadResponseFields, FileUploadChunkFields,
-    FileUploadStartFields, ForwardPortFields, ForwardStatusFields, PermissionResponseFields,
-    RegisterFields, SessionLimitContinuationFields, TunnelCloseFields, TunnelDataFields,
-    TunnelOpenFields, TunnelRefusedFields, TunnelStreamFields, TunnelWindowFields,
+    FileUploadResultFields, FileUploadStartFields, ForwardPortFields, ForwardStatusFields,
+    PermissionResponseFields, RegisterFields, SessionLimitContinuationFields, TunnelCloseFields,
+    TunnelDataFields, TunnelOpenFields, TunnelRefusedFields, TunnelStreamFields,
+    TunnelWindowFields,
 };
 use crate::{AgentType, PermissionSuggestion, SendMode, SessionStatus, TurnMetrics};
 
@@ -131,6 +132,10 @@ pub enum ProxyToServer {
 
     /// Response to a backend-requested local file download.
     FileDownloadResponse(FileDownloadResponseFields),
+
+    /// Terminal outcome of a chunked file upload: the file is fully written
+    /// and renamed into place, or has definitively failed (#939 phase 4).
+    FileUploadResult(FileUploadResultFields),
 
     /// Reply to `ForwardOpen`: allowlist updated + probe-dial result
     /// (docs/PORT_FORWARDING.md).

--- a/shared/src/endpoints/types.rs
+++ b/shared/src/endpoints/types.rs
@@ -129,6 +129,21 @@ pub struct FileUploadChunkFields {
     pub data: String,
 }
 
+/// Terminal outcome of a file upload (#939 phase 4).
+///
+/// Emitted by the proxy once the file is fully written and renamed into
+/// place (or has definitively failed), relayed by the backend to the web
+/// client — which withholds the prompt referencing the file until every
+/// upload it names has committed. The backend also synthesizes failures it
+/// can detect itself (proxy offline, size-cap abort).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileUploadResultFields {
+    pub upload_id: String,
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 // ---- Port forwarding (docs/PORT_FORWARDING.md) ------------------------------
 
 /// Open a tunnel stream to `127.0.0.1:{port}` on the proxy host.


### PR DESCRIPTION
#939 phase 4. Uploads were fire-and-forward on all three legs with zero acknowledgement: the proxy wrote bytes **directly to the final path** (an agent could read a truncated file mid-upload), every failure was a local log line, and the browser dispatched the prompt referencing the file unconditionally — so a dropped chunk still produced a prompt about a file that doesn't fully exist.

## Changes

**Protocol** — new `FileUploadResultFields { upload_id, success, error }`; carried as `ProxyToServer::FileUploadResult` and `ServerToClient::FileUploadResult` (additive; old peers ignore/skip them).

**Proxy** — writes to a hidden temp path (`.{name}.{id8}.upload`) and renames into place only when all chunks are flushed: the commit barrier. Every failure path (create, decode, write, flush, rename) now cleans up the partial file, drops the state, and reports a failure result; completion reports success. Write errors previously didn't even bump the chunk counter — the upload stalled forever, silently.

**Backend** — relays the proxy's result to the session's web clients, and synthesizes failures it can already detect: invalid chunk count, size-cap rejections (previously *silent drops*), abort outcomes, and proxy-offline. Uploads are now connected-only (`send_to_connected_session`): the old queue-through path capped at 100 in-memory frames, so \"queueing\" a multi-thousand-chunk upload for a disconnected proxy silently dropped most of it — failing fast is honest.

**Frontend** — the InputBar hands the composed prompt + upload ids to the SessionView instead of dispatching it; the view holds the prompt until every id commits, then dispatches through the normal outbox path. Failure surfaces as a transcript error (\"your message was not sent\") — the agent is never told about a file that isn't fully on disk. Results that race ahead of the prompt handoff are stashed and consumed. A 45s timeout falls back to pre-transactional behavior for old proxies that never ack.

## Compat matrix
- new browser + old proxy: timeout fallback → today's behavior
- old browser + new proxy/backend: extra result frames are unknown-variant no-ops
- new browser + new stack: full transaction

Tests: existing upload validation suite extended for the new signatures (5 e2e call sites); full workspace clippy `-Dwarnings`, wasm clippy, backend 148 / frontend 379 tests, fmt.