### PR TITLE
Bound per-connection outbound channels with evict-on-overflow

### DIFF
--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -374,10 +374,9 @@ pub async fn probe_agents(
 mod tests {
     use super::*;
     use crate::handlers::websocket::LauncherConnection;
-    use tokio::sync::mpsc;
 
     fn launcher_for(user_id: Uuid, hostname: &str) -> LauncherConnection {
-        let (sender, _rx) = mpsc::unbounded_channel();
+        let (sender, _rx) = crate::handlers::websocket::conn_channel(64);
         LauncherConnection {
             sender,
             launcher_name: format!("launcher-{}", hostname),

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -5,7 +5,6 @@ use shared::{
     ServerToProxy, SessionStatus,
 };
 use std::sync::Arc;
-use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
@@ -318,7 +317,8 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
     }
 
     // Create channel for sending messages to this launcher
-    let (tx, mut rx) = mpsc::unbounded_channel::<ServerToLauncher>();
+    let (tx, mut rx) =
+        super::session_manager::conn_channel::<ServerToLauncher>(super::LAUNCHER_CHANNEL_CAPACITY);
     let tx_for_sync = tx.clone();
 
     // Server-side kill switch: fired by the SessionManager if it evicts this

--- a/backend/src/handlers/websocket/mod.rs
+++ b/backend/src/handlers/websocket/mod.rs
@@ -12,9 +12,10 @@ mod uploads;
 mod web_client_socket;
 
 pub use session_manager::{
-    ForwardHealth, LauncherConnection, ProxySender, SessionId, SessionManager, TunnelError,
-    TunnelIn, WebClientSender, LAUNCHER_LIVENESS_DEADLINE_SECS, LIVENESS_SWEEP_INTERVAL_SECS,
-    PROXY_LIVENESS_DEADLINE_SECS,
+    conn_channel, ConnSender, ForwardHealth, LauncherConnection, ProxySender, SessionId,
+    SessionManager, TunnelError, TunnelIn, WebClientSender, LAUNCHER_CHANNEL_CAPACITY,
+    LAUNCHER_LIVENESS_DEADLINE_SECS, LIVENESS_SWEEP_INTERVAL_SECS, PROXY_CHANNEL_CAPACITY,
+    PROXY_LIVENESS_DEADLINE_SECS, WEB_CLIENT_CHANNEL_CAPACITY,
 };
 
 use axum::{

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -12,7 +12,6 @@ use diesel::prelude::*;
 use shared::{ProxyToServer, ServerToClient, ServerToProxy, SessionEndpoint, SessionStatus};
 use std::ops::ControlFlow;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -21,7 +20,8 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
     let db_pool = app_state.db_pool.clone();
     let conn = ws_bridge::server::into_connection::<SessionEndpoint>(socket);
     let (mut ws_sender, mut ws_receiver) = conn.split();
-    let (tx, mut rx) = mpsc::unbounded_channel::<ServerToProxy>();
+    let (tx, mut rx) =
+        super::session_manager::conn_channel::<ServerToProxy>(super::PROXY_CHANNEL_CAPACITY);
 
     let mut session_key: Option<SessionId> = None;
     let mut db_session_id: Option<Uuid> = None;

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -291,9 +291,9 @@ mod replay_tests {
     /// injection without standing up a full WS round-trip.
     fn capture_sender() -> (
         super::WebClientSender,
-        tokio::sync::mpsc::UnboundedReceiver<shared::ServerToClient>,
+        tokio::sync::mpsc::Receiver<shared::ServerToClient>,
     ) {
-        tokio::sync::mpsc::unbounded_channel::<shared::ServerToClient>()
+        crate::handlers::websocket::conn_channel::<shared::ServerToClient>(64)
     }
 
     /// The fix's whole point: `replay_history` with a `replay_after`

--- a/backend/src/handlers/websocket/session_manager/client_fanout.rs
+++ b/backend/src/handlers/websocket/session_manager/client_fanout.rs
@@ -98,13 +98,12 @@ impl SessionManager {
 mod tests {
     use super::super::test_support::make_client_msg;
     use super::*;
-    use tokio::sync::mpsc;
 
     #[test]
     fn broadcast_to_web_clients() {
         let mgr = SessionManager::new();
-        let (tx1, mut rx1) = mpsc::unbounded_channel();
-        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        let (tx1, mut rx1) = crate::handlers::websocket::conn_channel(64);
+        let (tx2, mut rx2) = crate::handlers::websocket::conn_channel(64);
 
         mgr.add_web_client("s1".into(), tx1);
         mgr.add_web_client("s1".into(), tx2);
@@ -124,8 +123,8 @@ mod tests {
     #[test]
     fn broadcast_removes_closed_clients() {
         let mgr = SessionManager::new();
-        let (tx1, rx1) = mpsc::unbounded_channel();
-        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        let (tx1, rx1) = crate::handlers::websocket::conn_channel(64);
+        let (tx2, mut rx2) = crate::handlers::websocket::conn_channel(64);
 
         mgr.add_web_client("s1".into(), tx1);
         mgr.add_web_client("s1".into(), tx2);
@@ -149,9 +148,9 @@ mod tests {
         // closed channel in that last slot still prunes correctly and the
         // open clients before it were already served.
         let mgr = SessionManager::new();
-        let (tx1, mut rx1) = mpsc::unbounded_channel();
-        let (tx2, mut rx2) = mpsc::unbounded_channel();
-        let (tx3, rx3) = mpsc::unbounded_channel();
+        let (tx1, mut rx1) = crate::handlers::websocket::conn_channel(64);
+        let (tx2, mut rx2) = crate::handlers::websocket::conn_channel(64);
+        let (tx3, rx3) = crate::handlers::websocket::conn_channel(64);
 
         mgr.add_web_client("s1".into(), tx1);
         mgr.add_web_client("s1".into(), tx2);
@@ -177,7 +176,7 @@ mod tests {
     fn broadcast_to_user() {
         let mgr = SessionManager::new();
         let user_id = Uuid::new_v4();
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = crate::handlers::websocket::conn_channel(64);
 
         mgr.add_user_client(user_id, tx);
         mgr.broadcast_to_user(&user_id, make_client_msg());
@@ -191,9 +190,9 @@ mod tests {
     #[test]
     fn broadcast_shutdown_reaches_all() {
         let mgr = SessionManager::new();
-        let (session_tx, mut session_rx) = mpsc::unbounded_channel();
-        let (web_tx, mut web_rx) = mpsc::unbounded_channel();
-        let (user_tx, mut user_rx) = mpsc::unbounded_channel();
+        let (session_tx, mut session_rx) = crate::handlers::websocket::conn_channel(64);
+        let (web_tx, mut web_rx) = crate::handlers::websocket::conn_channel(64);
+        let (user_tx, mut user_rx) = crate::handlers::websocket::conn_channel(64);
 
         mgr.register_session(
             "s1".into(),
@@ -224,8 +223,8 @@ mod tests {
         let mgr = SessionManager::new();
         let id1 = Uuid::new_v4();
         let id2 = Uuid::new_v4();
-        let (tx1, _rx1) = mpsc::unbounded_channel();
-        let (tx2, _rx2) = mpsc::unbounded_channel();
+        let (tx1, _rx1) = crate::handlers::websocket::conn_channel(64);
+        let (tx2, _rx2) = crate::handlers::websocket::conn_channel(64);
 
         mgr.add_user_client(id1, tx1);
         mgr.add_user_client(id2, tx2);

--- a/backend/src/handlers/websocket/session_manager/launcher_registry.rs
+++ b/backend/src/handlers/websocket/session_manager/launcher_registry.rs
@@ -1,13 +1,12 @@
 use shared::ServerToLauncher;
 use std::sync::atomic::Ordering;
-use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use uuid::Uuid;
 
 use super::SessionManager;
 
-pub type LauncherSender = mpsc::UnboundedSender<ServerToLauncher>;
+pub type LauncherSender = super::ConnSender<ServerToLauncher>;
 
 /// A connected launcher daemon.
 ///
@@ -217,7 +216,7 @@ mod tests {
     use super::*;
 
     fn make_launcher_connection(user_id: Uuid, hostname: &str) -> LauncherConnection {
-        let (sender, _rx) = mpsc::unbounded_channel();
+        let (sender, _rx) = crate::handlers::websocket::conn_channel(64);
         LauncherConnection {
             sender,
             launcher_name: format!("launcher-{}", hostname),
@@ -328,7 +327,7 @@ mod tests {
         let user_id = Uuid::new_v4();
         let id = Uuid::new_v4();
 
-        let (sender, rx) = mpsc::unbounded_channel();
+        let (sender, rx) = crate::handlers::websocket::conn_channel(64);
         let cancel = CancellationToken::new();
         let conn = LauncherConnection {
             sender,
@@ -400,7 +399,7 @@ mod tests {
             handles.push(tokio::spawn(async move {
                 let launcher_id = Uuid::new_v4();
                 let conn = {
-                    let (sender, _rx) = mpsc::unbounded_channel();
+                    let (sender, _rx) = crate::handlers::websocket::conn_channel(64);
                     LauncherConnection {
                         sender,
                         launcher_name: format!("launcher-{}", launcher_id),

--- a/backend/src/handlers/websocket/session_manager/liveness.rs
+++ b/backend/src/handlers/websocket/session_manager/liveness.rs
@@ -133,7 +133,6 @@ mod tests {
     use super::super::test_support::make_heartbeat;
     use super::super::LauncherConnection;
     use super::*;
-    use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
 
     fn launcher_conn(
@@ -141,7 +140,7 @@ mod tests {
         hostname: &str,
         cancel: CancellationToken,
     ) -> LauncherConnection {
-        let (sender, rx) = mpsc::unbounded_channel();
+        let (sender, rx) = crate::handlers::websocket::conn_channel(64);
         // Keep the channel open so eviction is attributable to liveness,
         // not to a dead channel.
         std::mem::forget(rx);
@@ -164,11 +163,11 @@ mod tests {
         let mgr = SessionManager::new();
 
         // Fresh proxy connection.
-        let (tx_fresh, _rx_fresh) = mpsc::unbounded_channel();
+        let (tx_fresh, _rx_fresh) = crate::handlers::websocket::conn_channel(64);
         mgr.register_session("fresh".into(), tx_fresh, CancellationToken::new());
 
         // Silent proxy connection: backdate its last_seen.
-        let (tx_stale, mut rx_stale) = mpsc::unbounded_channel();
+        let (tx_stale, mut rx_stale) = crate::handlers::websocket::conn_channel(64);
         let stale_cancel = CancellationToken::new();
         mgr.register_session("stale".into(), tx_stale, stale_cancel.clone());
         mgr.sessions
@@ -211,7 +210,7 @@ mod tests {
     #[test]
     fn touch_resets_the_clock() {
         let mgr = SessionManager::new();
-        let (tx, _rx) = mpsc::unbounded_channel();
+        let (tx, _rx) = crate::handlers::websocket::conn_channel(64);
         mgr.register_session("s1".into(), tx, CancellationToken::new());
         mgr.sessions
             .get("s1")

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -44,8 +44,55 @@ use tunnel_client::TunnelStreamMap;
 pub use tunnel_client::{TunnelError, TunnelIn};
 
 pub type SessionId = String;
-pub type ProxySender = mpsc::UnboundedSender<ServerToProxy>;
-pub type WebClientSender = mpsc::UnboundedSender<ServerToClient>;
+pub type ProxySender = ConnSender<ServerToProxy>;
+pub type WebClientSender = ConnSender<ServerToClient>;
+
+/// Bounded, non-blocking sender for per-connection outbound channels
+/// (#939 phase 5).
+///
+/// Overflow is deliberately indistinguishable from a closed channel: the
+/// caller's existing send-failure handling evicts the connection and
+/// closes its socket (#1256 machinery), because a peer that can't drain
+/// its queue within the capacity budget is operationally identical to a
+/// wedged one — and an unbounded queue behind it grows memory without
+/// limit, which is the failure mode this bounds.
+pub struct ConnSender<T>(mpsc::Sender<T>);
+
+// Manual impl: `#[derive(Clone)]` would needlessly require `T: Clone`.
+impl<T> Clone for ConnSender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> ConnSender<T> {
+    pub fn send(&self, value: T) -> Result<(), mpsc::error::SendError<T>> {
+        self.0.try_send(value).map_err(|e| match e {
+            mpsc::error::TrySendError::Full(v) => mpsc::error::SendError(v),
+            mpsc::error::TrySendError::Closed(v) => mpsc::error::SendError(v),
+        })
+    }
+}
+
+/// Construct a bounded per-connection channel (see [`ConnSender`]).
+pub fn conn_channel<T>(capacity: usize) -> (ConnSender<T>, mpsc::Receiver<T>) {
+    let (tx, rx) = mpsc::channel(capacity);
+    (ConnSender(tx), rx)
+}
+
+/// Proxy outbound capacity. Sized so a full maximum-size file upload
+/// (PORTAL_MAX_IMAGE_MB=10MiB at ~1KiB decoded per chunk ≈ 10,240 frames)
+/// fits even when the proxy's link is much slower than the uploader's —
+/// the chunk fan-in is the largest legitimate burst this channel carries.
+pub const PROXY_CHANNEL_CAPACITY: usize = 16 * 1024;
+
+/// Launcher outbound capacity: reconcile/launch/schedule traffic is a few
+/// frames per heartbeat; this is orders of magnitude above legitimate use.
+pub const LAUNCHER_CHANNEL_CAPACITY: usize = 1024;
+
+/// Web-client outbound capacity: streamed agent output is paced by the
+/// agent; history replay is a single batched frame.
+pub const WEB_CLIENT_CHANNEL_CAPACITY: usize = 4096;
 
 /// A live proxy connection. `gen` identifies THIS socket (as opposed to a
 /// reconnect for the same session) — every registry mutation is guarded on

--- a/backend/src/handlers/websocket/session_manager/pending_queue.rs
+++ b/backend/src/handlers/websocket/session_manager/pending_queue.rs
@@ -140,7 +140,7 @@ mod tests {
         assert!(mgr.send_to_session(&"s1".into(), make_output(1)));
         assert!(mgr.send_to_session(&"s1".into(), make_output(2)));
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = crate::handlers::websocket::conn_channel(64);
         register(&mgr, "s1", tx);
 
         let msg1 = rx.try_recv().unwrap();
@@ -159,7 +159,10 @@ mod tests {
             mgr.send_to_session(&"s1".into(), make_output(i));
         }
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        // Must exceed MAX_PENDING_MESSAGES_PER_SESSION: registration replays
+        // the whole pending queue into this channel in one burst.
+        let (tx, mut rx) =
+            crate::handlers::websocket::conn_channel(MAX_PENDING_MESSAGES_PER_SESSION * 2);
         register(&mgr, "s1", tx);
 
         let mut received = vec![];
@@ -179,7 +182,7 @@ mod tests {
     #[test]
     fn send_to_session_queues_message_returned_by_closed_channel() {
         let mgr = SessionManager::new();
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = crate::handlers::websocket::conn_channel(64);
         let cancel = CancellationToken::new();
         mgr.register_session("s1".into(), tx, cancel.clone());
         drop(rx);
@@ -207,7 +210,7 @@ mod tests {
     #[test]
     fn send_to_disconnected_session_queues_and_replays() {
         let mgr = SessionManager::new();
-        let (tx, _rx) = mpsc::unbounded_channel();
+        let (tx, _rx) = crate::handlers::websocket::conn_channel(64);
 
         let gen = register(&mgr, "s1", tx);
         mgr.unregister_session(&"s1".into(), Some(gen));
@@ -215,7 +218,7 @@ mod tests {
         mgr.send_to_session(&"s1".into(), make_output(1));
         mgr.send_to_session(&"s1".into(), make_output(2));
 
-        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = crate::handlers::websocket::conn_channel(64);
         register(&mgr, "s1", tx2);
 
         let msg1 = rx2.try_recv().unwrap();

--- a/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
+++ b/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
@@ -139,7 +139,6 @@ impl SessionManager {
 mod tests {
     use super::super::test_support::make_heartbeat;
     use super::*;
-    use tokio::sync::mpsc;
 
     fn register(mgr: &SessionManager, key: &str, sender: ProxySender) -> u64 {
         mgr.register_session(key.into(), sender, CancellationToken::new())
@@ -148,7 +147,7 @@ mod tests {
     #[test]
     fn session_register_and_send() {
         let mgr = SessionManager::new();
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = crate::handlers::websocket::conn_channel(64);
 
         register(&mgr, "s1", tx);
 
@@ -161,7 +160,7 @@ mod tests {
     #[test]
     fn unregister_removes_session() {
         let mgr = SessionManager::new();
-        let (tx, _rx) = mpsc::unbounded_channel();
+        let (tx, _rx) = crate::handlers::websocket::conn_channel(64);
 
         let gen = register(&mgr, "s1", tx);
         assert!(mgr.sessions.contains_key("s1"));
@@ -173,7 +172,7 @@ mod tests {
     #[test]
     fn unregister_force_removes_without_gen() {
         let mgr = SessionManager::new();
-        let (tx, _rx) = mpsc::unbounded_channel();
+        let (tx, _rx) = crate::handlers::websocket::conn_channel(64);
 
         register(&mgr, "s1", tx);
         assert!(mgr.sessions.contains_key("s1"));
@@ -185,8 +184,8 @@ mod tests {
     #[test]
     fn stale_unregister_is_noop() {
         let mgr = SessionManager::new();
-        let (tx1, _rx1) = mpsc::unbounded_channel();
-        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        let (tx1, _rx1) = crate::handlers::websocket::conn_channel(64);
+        let (tx2, mut rx2) = crate::handlers::websocket::conn_channel(64);
 
         // Old connection registers
         let old_gen = register(&mgr, "s1", tx1);
@@ -206,12 +205,12 @@ mod tests {
     #[test]
     fn is_current_connection_checks_gen() {
         let mgr = SessionManager::new();
-        let (tx1, _rx1) = mpsc::unbounded_channel();
+        let (tx1, _rx1) = crate::handlers::websocket::conn_channel(64);
 
         let gen1 = register(&mgr, "s1", tx1);
         assert!(mgr.is_current_connection(&"s1".into(), gen1));
 
-        let (tx2, _rx2) = mpsc::unbounded_channel();
+        let (tx2, _rx2) = crate::handlers::websocket::conn_channel(64);
         let gen2 = register(&mgr, "s1", tx2);
         assert!(!mgr.is_current_connection(&"s1".into(), gen1));
         assert!(mgr.is_current_connection(&"s1".into(), gen2));
@@ -223,7 +222,7 @@ mod tests {
     #[test]
     fn send_failure_evicts_and_cancels_dead_connection() {
         let mgr = SessionManager::new();
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = crate::handlers::websocket::conn_channel(64);
         let cancel = CancellationToken::new();
         mgr.register_session("s1".into(), tx, cancel.clone());
 
@@ -238,7 +237,7 @@ mod tests {
         assert!(cancel.is_cancelled());
 
         // A reconnect replays the queued message.
-        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = crate::handlers::websocket::conn_channel(64);
         register(&mgr, "s1", tx2);
         assert!(matches!(rx2.try_recv().unwrap(), ServerToProxy::Heartbeat));
     }
@@ -249,11 +248,11 @@ mod tests {
     #[test]
     fn evict_dead_connection_spares_successor() {
         let mgr = SessionManager::new();
-        let (tx1, rx1) = mpsc::unbounded_channel();
+        let (tx1, rx1) = crate::handlers::websocket::conn_channel(64);
         let cancel1 = CancellationToken::new();
         let gen1 = mgr.register_session("s1".into(), tx1, cancel1.clone());
 
-        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = crate::handlers::websocket::conn_channel(64);
         register(&mgr, "s1", tx2);
 
         drop(rx1);

--- a/backend/src/handlers/websocket/session_manager/tunnel_client.rs
+++ b/backend/src/handlers/websocket/session_manager/tunnel_client.rs
@@ -346,6 +346,8 @@ mod tests {
         key: &str,
         gen: u64,
     ) -> (Uuid, mpsc::UnboundedReceiver<TunnelIn>) {
+        // Tunnel inboxes are NOT connection senders — they stay unbounded
+        // (flow control is the tunnel window, not the channel).
         let (tx, rx) = mpsc::unbounded_channel();
         let id = Uuid::new_v4();
         mgr.tunnel_streams.insert(

--- a/backend/src/handlers/websocket/uploads.rs
+++ b/backend/src/handlers/websocket/uploads.rs
@@ -295,7 +295,6 @@ mod tests {
     use super::*;
     use base64::Engine;
     use shared::ServerToProxy;
-    use tokio::sync::mpsc;
 
     fn upload_with(total_chunks: u32, total_size: u64, server_cap_bytes: u64) -> PendingUpload {
         PendingUpload {
@@ -404,8 +403,8 @@ mod tests {
         // chunk count hits `total_chunks`.
         let session_manager = SessionManager::new();
         let session_key: SessionId = "test-session".to_string();
-        let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
-        let (client_tx, _client_rx) = mpsc::unbounded_channel();
+        let (proxy_tx, mut proxy_rx) = crate::handlers::websocket::conn_channel(64);
+        let (client_tx, _client_rx) = crate::handlers::websocket::conn_channel(64);
         session_manager.register_session(
             session_key.clone(),
             proxy_tx,
@@ -486,8 +485,8 @@ mod tests {
         // upload_id are silently dropped (the unknown-upload_id path).
         let session_manager = SessionManager::new();
         let session_key: SessionId = "test-session-2".to_string();
-        let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
-        let (client_tx, _client_rx) = mpsc::unbounded_channel();
+        let (proxy_tx, mut proxy_rx) = crate::handlers::websocket::conn_channel(64);
+        let (client_tx, _client_rx) = crate::handlers::websocket::conn_channel(64);
         session_manager.register_session(
             session_key.clone(),
             proxy_tx,

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -11,7 +11,6 @@ use shared::{
 };
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -21,7 +20,8 @@ pub async fn handle_web_client_socket(socket: WebSocket, app_state: Arc<AppState
     let initial_replay_limit = app_state.message_retention_count;
     let conn = ws_bridge::server::into_connection::<ClientEndpoint>(socket);
     let (mut ws_sender, mut ws_receiver) = conn.split();
-    let (tx, mut rx) = mpsc::unbounded_channel::<ServerToClient>();
+    let (tx, mut rx) =
+        super::session_manager::conn_channel::<ServerToClient>(super::WEB_CLIENT_CHANNEL_CAPACITY);
 
     let mut session_key: Option<SessionId> = None;
     let mut verified_session_id: Option<Uuid> = None;


### PR DESCRIPTION
#939 phase 5, the final PR of the connection-lifecycle series. Closes #939.

Every per-connection outbound channel (backend → proxy / launcher / web client) was an unbounded mpsc: a slow-but-alive consumer let the queue grow without limit — the last unbounded memory growth path on the connection plane.

## Design

New `ConnSender<T>`: a bounded channel whose `send` is a non-blocking `try_send`, with **overflow deliberately indistinguishable from a closed channel**. That means no new error handling anywhere: the existing #1256 machinery (send-failure → gen-guarded evict + cancel token → socket closes → peer reconnects) handles an over-budget consumer exactly like a wedged one — operationally the same thing.

## Capacities

- **Proxy: 16 384 frames** — sized so a full maximum-size upload (10 MiB at ~1 KiB decoded/chunk ≈ 10 240 frames) fits even when the proxy's downlink is much slower than the uploader's; the chunk fan-in is the largest legitimate burst on this channel. Tunnel streams are self-limited by their flow-control window.
- **Launcher: 1 024** — reconcile/launch/schedule traffic is a few frames per 30s heartbeat.
- **Web client: 4 096** — output is agent-paced; history replay is one batched frame.

Worst-case memory is now bounded per connection instead of unbounded, and the failure mode is a clean reconnect instead of OOM.

Tunnel inbox channels are explicitly NOT converted (comment added) — they're flow-controlled by the tunnel window, not connection senders.

**Tests**: all 153 backend tests green (the pending-queue overflow test's channel is sized above the replay burst it deliberately provokes, with a comment); workspace clippy `-Dwarnings`, fmt.