### PR TITLE
Fix Codex file change permissions

### DIFF
--- a/codex-session-lib/src/classifier.rs
+++ b/codex-session-lib/src/classifier.rs
@@ -153,6 +153,7 @@ fn classify_request(request_id: String, request: ServerRequest) -> Vec<AgentOutp
             request_id,
             CodexPermissionInput::FileChange {
                 item_id: p.item_id,
+                paths: vec![],
                 reason: p.reason,
                 grant_root: p.grant_root,
             },

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -138,27 +138,29 @@ fn render_item(item: Option<&CodexItem>, completed: bool, session_id: Uuid) -> H
             // here to avoid duplication.
             ThreadItem::UserMessage(_) => html! {},
         },
-        CodexItem::AppServer(AppServerThreadItem::ContextCompaction { .. }) => {
-            render_context_compaction_item(completed)
-        }
-        CodexItem::AppServer(AppServerThreadItem::CollabAgentToolCall {
-            agents_states,
-            model,
-            prompt,
-            reasoning_effort,
-            status,
-            tool,
-            ..
-        }) => render_collab_agent_tool_call(
-            tool,
-            model.as_deref(),
-            reasoning_effort.as_ref(),
-            status,
-            prompt.as_deref(),
-            agents_states,
-            completed,
-        ),
-        CodexItem::AppServer(_) => html! {},
+        CodexItem::AppServer(item) => match item.as_ref() {
+            AppServerThreadItem::ContextCompaction { .. } => {
+                render_context_compaction_item(completed)
+            }
+            AppServerThreadItem::CollabAgentToolCall {
+                agents_states,
+                model,
+                prompt,
+                reasoning_effort,
+                status,
+                tool,
+                ..
+            } => render_collab_agent_tool_call(
+                tool,
+                model.as_deref(),
+                reasoning_effort.as_ref(),
+                status,
+                prompt.as_deref(),
+                agents_states,
+                completed,
+            ),
+            _ => html! {},
+        },
     }
 }
 
@@ -355,10 +357,13 @@ mod tests {
 
         let event: CodexEvent = serde_json::from_str(json).unwrap();
         let CodexEvent::ItemStarted {
-            item: Some(CodexItem::AppServer(AppServerThreadItem::ContextCompaction { ref id })),
+            item: Some(CodexItem::AppServer(item)),
         } = event
         else {
             panic!("expected ItemStarted{{ContextCompaction}}, got {:?}", event);
+        };
+        let AppServerThreadItem::ContextCompaction { id } = item.as_ref() else {
+            panic!("expected ContextCompaction item, got {:?}", item);
         };
         assert_eq!(id, "9edb35c0-6b6b-407f-84e3-d03a03050a2a");
         assert_eq!(
@@ -392,18 +397,7 @@ mod tests {
         }"#;
         let event: CodexEvent = serde_json::from_str(json).unwrap();
         let CodexEvent::ItemCompleted {
-            item:
-                Some(CodexItem::AppServer(AppServerThreadItem::CollabAgentToolCall {
-                    agents_states,
-                    id,
-                    model,
-                    prompt,
-                    reasoning_effort,
-                    receiver_thread_ids,
-                    sender_thread_id,
-                    status,
-                    tool,
-                })),
+            item: Some(CodexItem::AppServer(item)),
         } = event
         else {
             panic!(
@@ -411,18 +405,32 @@ mod tests {
                 event
             );
         };
+        let AppServerThreadItem::CollabAgentToolCall {
+            agents_states,
+            id,
+            model,
+            prompt,
+            reasoning_effort,
+            receiver_thread_ids,
+            sender_thread_id,
+            status,
+            tool,
+        } = item.as_ref()
+        else {
+            panic!("expected CollabAgentToolCall item, got {:?}", item);
+        };
         assert_eq!(id, "call_i1HC5jbTllWgsrMnJjqmRU05");
-        assert_eq!(tool, serde_json::Value::String("spawnAgent".to_string()));
+        assert_eq!(tool, &serde_json::Value::String("spawnAgent".to_string()));
         assert_eq!(model.as_deref(), Some("gpt-5.5"));
         assert_eq!(
             reasoning_effort.as_ref().map(|effort| effort.0.as_str()),
             Some("medium")
         );
-        assert_eq!(status, serde_json::Value::String("completed".to_string()));
+        assert_eq!(status, &serde_json::Value::String("completed".to_string()));
         assert_eq!(sender_thread_id, "019ed195-44b1-77e0-a234-10307ce08eac");
         assert_eq!(
-            receiver_thread_ids,
-            vec!["019ed247-768f-7603-8c71-911fd841766e".to_string()]
+            receiver_thread_ids.as_slice(),
+            ["019ed247-768f-7603-8c71-911fd841766e"]
         );
         assert_eq!(agents_states.len(), 1);
         assert!(matches!(

--- a/frontend/src/components/codex_renderer/events.rs
+++ b/frontend/src/components/codex_renderer/events.rs
@@ -95,16 +95,13 @@ pub enum CodexEvent {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-// codex-codes 0.143 grew the app-server item payloads past clippy's variant
-// gap threshold. Transient per-render value (see `AgentFrame`); not boxed.
-#[allow(clippy::large_enum_variant)]
 pub enum CodexItem {
     /// Exec-level item wrapper used by the stable codex renderer paths.
     Thread(ThreadItem),
     /// App-server item wrapper for item variants that the exec-level helper
     /// model intentionally does not expose yet, such as `contextCompaction`
     /// and `collabAgentToolCall`.
-    AppServer(AppServerThreadItem),
+    AppServer(Box<AppServerThreadItem>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -287,9 +284,11 @@ pub fn thread_item_id(item: &ThreadItem) -> &str {
 pub fn codex_item_id(item: &CodexItem) -> Option<&str> {
     match item {
         CodexItem::Thread(it) => Some(thread_item_id(it)),
-        CodexItem::AppServer(AppServerThreadItem::ContextCompaction { id }) => Some(id),
-        CodexItem::AppServer(AppServerThreadItem::CollabAgentToolCall { id, .. }) => Some(id),
-        CodexItem::AppServer(_) => None,
+        CodexItem::AppServer(item) => match item.as_ref() {
+            AppServerThreadItem::ContextCompaction { id } => Some(id),
+            AppServerThreadItem::CollabAgentToolCall { id, .. } => Some(id),
+            _ => None,
+        },
     }
 }
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -26,8 +26,8 @@ use yew::prelude::*;
 
 use super::forward_chips::ForwardChips;
 use super::helpers::{
-    autoscroll_transition, classify_output_msg_type, is_claude_awaiting, reconcile_pending_sends,
-    update_pending_send_delivery, ActivityTag,
+    autoscroll_transition, classify_output_msg_type, enrich_codex_file_change_permission,
+    is_claude_awaiting, reconcile_pending_sends, update_pending_send_delivery, ActivityTag,
 };
 use super::input_bar::{InputBar, InputBarInbound};
 use super::outbox::Outbox;
@@ -713,6 +713,7 @@ impl SessionView {
                 true
             }
             WsEvent::Permission(perm) => {
+                let perm = enrich_codex_file_change_permission(perm, &self.messages);
                 self.last_permission_request = Some(perm.clone());
                 if let Some(ref dispatcher) = self.permission_dispatcher {
                     dispatcher.emit(perm);

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -10,6 +10,9 @@
 
 use crate::components::message_renderer::types::ClaudeMessage;
 use crate::components::message_renderer::RenderedMessage;
+use crate::pages::dashboard::types::PendingPermission;
+use codex_codes::io::items::{FileUpdateChange, ThreadItem};
+use std::collections::HashSet;
 
 /// Cross-agent activity classification used by the session-rail sparkline and
 /// the pending-send reconciler. The same enum bridges Claude wire shapes
@@ -50,6 +53,91 @@ pub(crate) enum ActivityTag {
     TaskStart,
     /// End of a sub-task range.
     TaskEnd,
+}
+
+/// Enrich Codex FileChange permission requests with filenames resolved from
+/// the already-streamed item events. The Codex approval request carries only
+/// `itemId`, while the matching `item.started` / patch-updated frames carry
+/// the human-readable paths and diffs.
+pub(crate) fn enrich_codex_file_change_permission(
+    mut perm: PendingPermission,
+    messages: &[RenderedMessage],
+) -> PendingPermission {
+    let Ok(shared::CodexPermissionInput::FileChange {
+        item_id,
+        paths,
+        reason,
+        grant_root,
+    }) = serde_json::from_value::<shared::CodexPermissionInput>(perm.input.clone())
+    else {
+        return perm;
+    };
+
+    if !paths.is_empty() {
+        return perm;
+    }
+
+    let resolved_paths = codex_file_change_paths_for_item(messages, &item_id);
+    if resolved_paths.is_empty() {
+        return perm;
+    }
+
+    let enriched = shared::CodexPermissionInput::FileChange {
+        item_id,
+        paths: resolved_paths,
+        reason,
+        grant_root,
+    };
+    if let Ok(input) = serde_json::to_value(enriched) {
+        perm.input = input;
+    }
+    perm
+}
+
+fn codex_file_change_paths_for_item(messages: &[RenderedMessage], item_id: &str) -> Vec<String> {
+    use crate::components::codex_renderer::{CodexEvent, CodexItem};
+
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    for message in messages {
+        let Ok(event) = serde_json::from_str::<CodexEvent>(&message.content) else {
+            continue;
+        };
+        match event {
+            CodexEvent::ItemStarted {
+                item: Some(CodexItem::Thread(ThreadItem::FileChange(file_change))),
+            }
+            | CodexEvent::ItemUpdated {
+                item: Some(CodexItem::Thread(ThreadItem::FileChange(file_change))),
+            }
+            | CodexEvent::ItemCompleted {
+                item: Some(CodexItem::Thread(ThreadItem::FileChange(file_change))),
+            } if file_change.id == item_id => {
+                push_file_change_paths(&mut paths, &mut seen, &file_change.changes);
+            }
+            CodexEvent::FileChangePatchUpdated {
+                params: Some(params),
+            } if params.item_id.as_deref() == Some(item_id) => {
+                if let Some(changes) = params.changes {
+                    push_file_change_paths(&mut paths, &mut seen, &changes);
+                }
+            }
+            _ => {}
+        }
+    }
+    paths
+}
+
+fn push_file_change_paths(
+    paths: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+    changes: &[FileUpdateChange],
+) {
+    for change in changes {
+        if seen.insert(change.path.clone()) {
+            paths.push(change.path.clone());
+        }
+    }
 }
 
 impl ActivityTag {
@@ -233,11 +321,11 @@ fn classify_codex_event(output: &str) -> Option<ActivityTag> {
         CodexEvent::ItemStarted { item: Some(item) }
         | CodexEvent::ItemUpdated { item: Some(item) }
         | CodexEvent::ItemCompleted { item: Some(item) } => match item {
-            CodexItem::AppServer(
+            CodexItem::AppServer(item) => match item.as_ref() {
                 AppServerThreadItem::ContextCompaction { .. }
-                | AppServerThreadItem::CollabAgentToolCall { .. },
-            ) => Some(ActivityTag::Assistant),
-            CodexItem::AppServer(_) => None,
+                | AppServerThreadItem::CollabAgentToolCall { .. } => Some(ActivityTag::Assistant),
+                _ => None,
+            },
             CodexItem::Thread(ThreadItem::Error(_)) => Some(ActivityTag::Error),
             CodexItem::Thread(ThreadItem::CommandExecution(ref it))
                 if command_execution_reads_file(&it.command) =>
@@ -456,6 +544,48 @@ mod tests {
         assert!(ActivityTag::CompactionEnd.is_compaction_end());
         assert!(ActivityTag::TaskStart.is_task_start());
         assert!(ActivityTag::TaskEnd.is_task_end());
+    }
+
+    #[test]
+    fn enrich_codex_file_change_permission_resolves_paths_from_item_events() {
+        let messages = vec![
+            RenderedMessage::new(
+                r#"{"type":"item.started","item":{"type":"fileChange","id":"fc1","changes":[{"path":"src/main.rs","kind":{"type":"update"},"diff":"@@ -1 +1 @@"},{"path":"src/lib.rs","kind":{"type":"add"},"diff":"new"}],"status":"inProgress"}}"#
+                    .to_string(),
+                None,
+            ),
+            RenderedMessage::new(
+                r#"{"type":"item/fileChange/patchUpdated","params":{"itemId":"fc1","changes":[{"path":"src/main.rs","kind":{"type":"update"},"diff":"@@ -1 +1 @@"},{"path":"tests/app.rs","kind":{"type":"delete"},"diff":"gone"}]}}"#
+                    .to_string(),
+                None,
+            ),
+        ];
+        let perm = PendingPermission {
+            request_id: "rid-1".to_string(),
+            tool_name: "FileChange".to_string(),
+            input: serde_json::json!({
+                "tool": "fileChange",
+                "itemId": "fc1"
+            }),
+            permission_suggestions: vec![],
+        };
+
+        let enriched = enrich_codex_file_change_permission(perm, &messages);
+        let parsed: shared::CodexPermissionInput = serde_json::from_value(enriched.input).unwrap();
+
+        assert_eq!(
+            parsed,
+            shared::CodexPermissionInput::FileChange {
+                item_id: "fc1".to_string(),
+                paths: vec![
+                    "src/main.rs".to_string(),
+                    "src/lib.rs".to_string(),
+                    "tests/app.rs".to_string()
+                ],
+                reason: None,
+                grant_root: None,
+            }
+        );
     }
 
     // --- classify_output_msg_type ---

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -243,17 +243,27 @@ fn format_codex_permission_input(input: &shared::CodexPermissionInput) -> String
     match input {
         C::FileChange {
             item_id,
+            paths,
             reason,
             grant_root,
         } => {
-            let mut lines = vec![format!("File change for item `{}`", item_id)];
+            let mut lines = if paths.is_empty() {
+                vec![
+                    "File change".to_string(),
+                    format!("Item: `{}`", item_id),
+                    "(diff streamed above under this item id)".to_string(),
+                ]
+            } else {
+                let mut lines = vec![format!("File change {} file(s):", paths.len())];
+                lines.extend(paths.iter().map(|p| format!("  {}", p)));
+                lines
+            };
             if let Some(r) = reason.as_deref().filter(|s| !s.is_empty()) {
                 lines.push(format!("Reason: {}", r));
             }
             if let Some(g) = grant_root.as_deref().filter(|s| !s.is_empty()) {
                 lines.push(format!("Grant root: {}", g));
             }
-            lines.push("(diff streamed above under this item id)".to_string());
             lines.join("\n")
         }
         C::ApplyPatch { file_changes, .. } => {
@@ -343,5 +353,20 @@ mod tests {
             "cwd": "/tmp"
         });
         assert_eq!(format_permission_input("Bash", &input), "$ ls");
+    }
+
+    #[test]
+    fn format_codex_file_change_permission_prefers_paths() {
+        let input = serde_json::json!({
+            "tool": "fileChange",
+            "itemId": "fc1",
+            "paths": ["src/main.rs", "tests/app.rs"],
+            "reason": "needs approval"
+        });
+
+        assert_eq!(
+            format_permission_input("FileChange", &input),
+            "File change 2 file(s):\n  src/main.rs\n  tests/app.rs\nReason: needs approval"
+        );
     }
 }

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -37,12 +37,15 @@ mod tests {
         // — item_id present, reason and grantRoot optional.
         let input = CodexPermissionInput::FileChange {
             item_id: "call_HKaP84kozIUwWE1Ynd5hPpCN".to_string(),
+            paths: vec!["src/main.rs".to_string(), "src/lib.rs".to_string()],
             reason: None,
             grant_root: None,
         };
         let json = serde_json::to_value(&input).unwrap();
         assert_eq!(json["tool"], "fileChange");
         assert_eq!(json["itemId"], "call_HKaP84kozIUwWE1Ynd5hPpCN");
+        assert_eq!(json["paths"][0], "src/main.rs");
+        assert_eq!(json["paths"][1], "src/lib.rs");
         // Optional `None`s should not be serialized
         assert!(json.get("reason").is_none());
         assert!(json.get("grantRoot").is_none());
@@ -50,6 +53,25 @@ mod tests {
         let parsed: CodexPermissionInput = serde_json::from_value(json).unwrap();
         assert_eq!(parsed, input);
         assert_eq!(parsed.tool_name(), "FileChange");
+    }
+
+    #[test]
+    fn codex_permission_input_file_change_paths_default_empty() {
+        let json = serde_json::json!({
+            "tool": "fileChange",
+            "itemId": "call_HKaP84kozIUwWE1Ynd5hPpCN"
+        });
+
+        let parsed: CodexPermissionInput = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            parsed,
+            CodexPermissionInput::FileChange {
+                item_id: "call_HKaP84kozIUwWE1Ynd5hPpCN".to_string(),
+                paths: vec![],
+                reason: None,
+                grant_root: None,
+            }
+        );
     }
 
     #[test]
@@ -212,10 +234,12 @@ mod tests {
         match parsed {
             CodexPermissionInput::FileChange {
                 item_id,
+                paths,
                 reason,
                 grant_root,
             } => {
                 assert_eq!(item_id, "call_HKaP84kozIUwWE1Ynd5hPpCN");
+                assert!(paths.is_empty());
                 assert!(reason.is_none());
                 assert!(grant_root.is_none());
             }

--- a/shared/src/api/permissions.rs
+++ b/shared/src/api/permissions.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// Serializes with a `tool` discriminant in camelCase:
 ///
 /// ```json
-/// {"tool": "fileChange", "itemId": "call_…", "reason": null, "grantRoot": null}
+/// {"tool": "fileChange", "itemId": "call_…", "paths": ["src/main.rs"], "reason": null, "grantRoot": null}
 /// {"tool": "applyPatch", "fileChanges": {…}, "grantRoot": null, "reason": null}
 /// {"tool": "bash", "command": "ls -la", "cwd": "/tmp"}
 /// {"tool": "execCommand", "command": "ls -la", "cwd": "/tmp", "parsedCmd": [...]}
@@ -34,10 +34,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "tool", rename_all = "camelCase")]
 pub enum CodexPermissionInput {
     /// Codex `item/fileChange/requestApproval` — file-modification approval.
-    /// The actual diff streamed earlier under the matching `itemId`.
+    /// The actual diff streamed earlier under the matching `itemId`; the
+    /// frontend may enrich the request with `paths` resolved from that item.
     FileChange {
         #[serde(rename = "itemId")]
         item_id: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        paths: Vec<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         reason: Option<String>,
         #[serde(rename = "grantRoot", default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- keep the Codex FileChange object-kind/diff typed path on top of the workspace SDK bump from #1278
- enrich Codex FileChange permission requests with filenames resolved from matching item events
- box the app-server CodexItem wrapper to keep clippy clean without a large_enum_variant allow

## Tests
- cargo test -p shared codex_permission_input_file_change --lib
- cargo test -p frontend enrich_codex_file_change_permission_resolves_paths_from_item_events --lib
- cargo test -p frontend format_codex_file_change_permission_prefers_paths --lib
- cargo test -p frontend event_item_started_with_file_change_no_longer_silently_drops --lib
- cargo test -p codex-session-lib --lib
- RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets
- cargo check -p shared --locked

Fixes #827

Notes: checked codex-codes 0.143.x against #1050/#1146. MCP elicitation request params still do not expose server_name; app-server ContextCompaction/CollabAgentToolCall typed variants are present and already used by frontend main.