### PR TITLE
Bump claude-codes 2.1.160 and codex-codes 0.143.1, wire subagent rollup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,9 +474,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.159"
+version = "2.1.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ec342792a75382f891a20b6898cdf297c8fed1b7d450b154ac762ba43bb58d"
+checksum = "7fa83c7d339f486dac04be90454e13db9328deed4a398d6b848f8075251d64e9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.142.0"
+version = "0.143.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456182c080103eb13cb02130e2c629a325f65f57695cf3b0afccae661968186"
+checksum = "ea80f1d28514a83fde0bd2909ff8be4eb7065d78673ffbcda6767241757d57b1"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,10 +71,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.159", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.160", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.142.0", default-features = false, features = ["types"] }
+codex-codes = { version = "0.143.1", default-features = false, features = ["types"] }
 
 # Frontend (Yew)
 yew = { version = "0.21", features = ["csr"] }

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -100,10 +100,14 @@ pub(crate) async fn claude_io_task(
     // know either on its own.
     let mut current_model: Option<String> = None;
     let mut current_service_tier: Option<String> = None;
-    // Per-turn subagent (`Task`) token rollup: summed from each Task result's
-    // typed `SubagentResult.total_tokens` (claude-codes 2.1.159, #169), reset
-    // at every turn start so it matches the turn the metrics row represents.
-    let mut current_turn_subagent_tokens: i64 = 0;
+    // Session-lifetime subagent (`Task`) usage rollup (claude-codes 2.1.160,
+    // #1275). Unlike the hand-rolled per-turn sum it replaces, the rollup
+    // dedupes Task results by agentId — so frames replayed on resume can
+    // never double-count. Per-turn attribution is total-at-finalize minus
+    // total-at-turn-start; resume-replayed results that arrive BEFORE the
+    // first turn starts land outside every turn window.
+    let mut subagent_rollup = claude_codes::SubagentUsageRollup::default();
+    let mut subagent_tokens_at_turn_start: i64 = 0;
 
     loop {
         tokio::select! {
@@ -124,7 +128,7 @@ pub(crate) async fn claude_io_task(
                         rate_limit_attempts = 0;
                         current_turn_was_rate_limited = false;
                         pending_session_limit = None;
-                        current_turn_subagent_tokens = 0;
+                        subagent_tokens_at_turn_start = subagent_rollup.subagent_tokens as i64;
                         // Begin per-turn metrics capture. Wall-clock UTC is
                         // chrono::Utc::now(); the monotonic instant is the
                         // anchor for TTFT / total / gap durations.
@@ -153,6 +157,9 @@ pub(crate) async fn claude_io_task(
             result = client.receive() => {
                 match result {
                     Ok(output) => {
+                        // Feed every frame to the subagent rollup (cheap
+                        // no-op for non-Task-result frames; agentId-deduped).
+                        subagent_rollup.observe(&output);
                         // Classify the frame before forwarding so we can
                         // decide whether the turn's terminator triggers an
                         // auto-retry, and feed the per-turn metrics tracker.
@@ -219,16 +226,6 @@ pub(crate) async fn claude_io_task(
                                 current_turn_was_rate_limited = false;
                                 pending_session_limit = None;
                             }
-                            ClaudeOutput::User(user) => {
-                                // A `Task` tool's result is echoed as a user
-                                // message carrying a typed `SubagentResult` in
-                                // `tool_use_result`. Sum its `total_tokens` into
-                                // the per-turn rollup (claude-codes 2.1.159, #169).
-                                if let Some(sub) = user.subagent_result() {
-                                    current_turn_subagent_tokens +=
-                                        sub.total_tokens.unwrap_or(0) as i64;
-                                }
-                            }
                             _ => {}
                         }
 
@@ -261,12 +258,13 @@ pub(crate) async fn claude_io_task(
                                     .map(|u| u.cache_read_input_tokens as i64)
                                     .unwrap_or(0),
                                 thinking_tokens: 0,
-                                // Subagent (`Task`) tokens summed across this
-                                // turn's Task results via the typed
-                                // `SubagentResult.total_tokens` (claude-codes
-                                // 2.1.159, #169) — the `<subagent_tokens>` line
-                                // the CLI renders in its terminal `<usage>`.
-                                subagent_tokens: current_turn_subagent_tokens,
+                                // Subagent (`Task`) tokens attributed to THIS
+                                // turn: the session-lifetime rollup's total
+                                // minus its value when the turn started —
+                                // the `<subagent_tokens>` line the CLI renders
+                                // in its terminal `<usage>` (2.1.160, #1275).
+                                subagent_tokens: (subagent_rollup.subagent_tokens as i64)
+                                    .saturating_sub(subagent_tokens_at_turn_start),
                                 stop_reason: r.stop_reason.clone(),
                                 is_error: r.is_error,
                                 total_cost_usd: Some(r.total_cost_usd),
@@ -377,7 +375,7 @@ pub(crate) async fn claude_io_task(
                                 // turn from a metrics standpoint, but tag
                                 // the new turn with a stream-restart count
                                 // so the dashboard can spot retried turns.
-                                current_turn_subagent_tokens = 0;
+                                subagent_tokens_at_turn_start = subagent_rollup.subagent_tokens as i64;
                                 turn_tracker.start(Instant::now(), chrono::Utc::now());
                                 turn_tracker.record_stream_restart();
                                 if let Err(e) = client.send(&input).await {
@@ -399,7 +397,7 @@ pub(crate) async fn claude_io_task(
                                         let new_input = ClaudeInput::user_message(text, session_id);
                                         rate_limit_attempts = 0;
                                         pending_session_limit = None;
-                                        current_turn_subagent_tokens = 0;
+                                        subagent_tokens_at_turn_start = subagent_rollup.subagent_tokens as i64;
                                         turn_tracker.start(Instant::now(), chrono::Utc::now());
                                         let r = client.send(&new_input).await;
                                         last_input = Some(new_input);
@@ -686,6 +684,44 @@ mod tests {
         };
         let sub = user.subagent_result().expect("typed SubagentResult");
         assert_eq!(sub.total_tokens, Some(12345));
+    }
+
+    /// Locks the rollup semantics the per-turn attribution relies on
+    /// (claude-codes 2.1.160, #1275): Task results are deduped by agentId,
+    /// so a frame replayed on resume contributes zero to a later
+    /// turn-boundary diff — and results lacking an agentId/totalTokens
+    /// (arbitrary tool_use_result objects) don't count at all.
+    #[test]
+    fn subagent_rollup_dedupes_replayed_task_results_by_agent_id() {
+        let task_result = |agent_id: &str, tokens: u64| {
+            serde_json::from_value::<ClaudeOutput>(serde_json::json!({
+                "type": "user",
+                "session_id": "00000000-0000-0000-0000-000000000000",
+                "message": { "role": "user", "content": [] },
+                "tool_use_result": {
+                    "status": "completed",
+                    "agentId": agent_id,
+                    "totalTokens": tokens
+                }
+            }))
+            .expect("parses as ClaudeOutput")
+        };
+
+        let mut rollup = claude_codes::SubagentUsageRollup::default();
+        rollup.observe(&task_result("agent-a", 1000));
+        assert_eq!(rollup.subagent_tokens, 1000);
+
+        // Turn boundary: snapshot, then replay the SAME result (resume).
+        let at_turn_start = rollup.subagent_tokens;
+        rollup.observe(&task_result("agent-a", 1000));
+        assert_eq!(
+            rollup.subagent_tokens, at_turn_start,
+            "replayed Task result must not re-count"
+        );
+
+        // A genuinely new subagent in this turn is attributed by the diff.
+        rollup.observe(&task_result("agent-b", 500));
+        assert_eq!(rollup.subagent_tokens - at_turn_start, 500);
     }
 
     #[test]

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -570,13 +570,20 @@ fn log_claude_output(output: &ClaudeOutput) {
         ClaudeOutput::RateLimitEvent(evt) => {
             let info = &evt.rate_limit_info;
             debug!(
-                "← [rate_limit_event] status={} type={:?} resets_at={:?} utilization={:?} overage={}",
+                "← [rate_limit_event] status={} type={:?} resets_at={:?} utilization={:?} overage={:?}",
                 info.status,
                 info.rate_limit_type,
                 info.resets_at,
                 info.utilization,
                 info.is_using_overage
             );
+        }
+        // 2.1.160 wire coverage: stream_event / tool_progress / auth_status /
+        // tool_use_summary / prompt_suggestion / conversation_reset plus the
+        // transcript-corpus variants. This fn only produces debug logging, so
+        // a variant-tag line is all they need.
+        other => {
+            debug!("← [{}]", other.message_type());
         }
     }
 }

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -480,6 +480,13 @@ mod tests {
             terminal_reason: None,
             fast_mode_state: None,
             model_usage: None,
+            // 2.1.160 additions — all absent in a minimal test result.
+            time_to_request_from_spawn_ms: None,
+            warm_spare_claimed: None,
+            time_origin_ms: None,
+            structured_output: None,
+            deferred_tool_use: None,
+            origin: None,
         }
     }
 

--- a/frontend/src/components/agent_frame.rs
+++ b/frontend/src/components/agent_frame.rs
@@ -11,6 +11,11 @@ use super::codex_renderer::CodexEvent;
 use super::message_renderer::types::ClaudeMessage;
 
 #[derive(Debug, Clone)]
+// SDK 2.1.160 grew `ClaudeMessage`'s largest payloads past clippy's variant
+// gap threshold. `AgentFrame` is a transient per-render classification (never
+// stored in bulk), so boxing would churn every construction/match site for no
+// retained-memory win.
+#[allow(clippy::large_enum_variant)]
 pub enum AgentFrame {
     Claude(ClaudeMessage),
     Codex(CodexEvent),

--- a/frontend/src/components/codex_renderer/events.rs
+++ b/frontend/src/components/codex_renderer/events.rs
@@ -95,6 +95,9 @@ pub enum CodexEvent {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+// codex-codes 0.143 grew the app-server item payloads past clippy's variant
+// gap threshold. Transient per-render value (see `AgentFrame`); not boxed.
+#[allow(clippy::large_enum_variant)]
 pub enum CodexItem {
     /// Exec-level item wrapper used by the stable codex renderer paths.
     Thread(ThreadItem),

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -316,7 +316,7 @@ pub fn render_rate_limit_event(msg: &shared::RateLimitEvent, timestamp: Option<&
                     if let Some(text) = reset_text {
                         <span class="rate-limit-detail">{ text }</span>
                     }
-                    if using_overage {
+                    if using_overage.unwrap_or(false) {
                         <span class="rate-limit-detail">{ "using overage" }</span>
                     }
                     if let Some(text) = utilization_text {

--- a/frontend/src/components/message_renderer/renderers/system.rs
+++ b/frontend/src/components/message_renderer/renderers/system.rs
@@ -179,10 +179,12 @@ fn render_task_started(msg: &shared::SystemMessage, timestamp: Option<&str>) -> 
 
     let type_label = task
         .as_ref()
-        .map(|t| t.task_type.clone())
+        .and_then(|t| t.task_type.clone())
         .map(|tt| match tt {
             shared::TaskType::LocalAgent => "Sub-agent",
             shared::TaskType::LocalBash => "Background Bash",
+            // Open enum (2.1.160): unrecognized task types render generically.
+            _ => "Task",
         })
         .unwrap_or("Task");
 

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -65,8 +65,10 @@ impl ClaudeMessage {
                 shared::ClaudeOutput::Result(msg) => Self::Result(msg),
                 shared::ClaudeOutput::Error(msg) => Self::Error(msg),
                 shared::ClaudeOutput::RateLimitEvent(msg) => Self::RateLimitEvent(msg),
-                shared::ClaudeOutput::ControlRequest(_)
-                | shared::ClaudeOutput::ControlResponse(_) => Self::Unknown,
+                // Wildcard: control frames plus the 2.1.160 wire additions
+                // (stream_event, tool_progress, transcript variants, …) that
+                // have no dedicated renderer yet.
+                _ => Self::Unknown,
             });
         }
 
@@ -88,8 +90,10 @@ impl<'de> Deserialize<'de> for ClaudeMessage {
                 shared::ClaudeOutput::Result(msg) => Self::Result(msg),
                 shared::ClaudeOutput::Error(msg) => Self::Error(msg),
                 shared::ClaudeOutput::RateLimitEvent(msg) => Self::RateLimitEvent(msg),
-                shared::ClaudeOutput::ControlRequest(_)
-                | shared::ClaudeOutput::ControlResponse(_) => Self::Unknown,
+                // Wildcard: control frames plus the 2.1.160 wire additions
+                // (stream_event, tool_progress, transcript variants, …) that
+                // have no dedicated renderer yet.
+                _ => Self::Unknown,
             });
         }
         serde_json::from_value::<LocalMessage>(value)

--- a/frontend/src/pages/dashboard/session_view/tasks_panel.rs
+++ b/frontend/src/pages/dashboard/session_view/tasks_panel.rs
@@ -551,14 +551,18 @@ pub(super) fn derive_task_events(
     match claude_msg {
         shared::ClaudeOutput::System(sys) => {
             if let Some(task) = sys.as_task_started() {
-                let task_type = match task.task_type {
-                    shared::TaskType::LocalAgent => "local_agent",
-                    shared::TaskType::LocalBash => "local_bash",
-                }
-                .to_string();
+                // 2.1.160: `task_type`/`tool_use_id` became Option and
+                // TaskType is an open enum; `as_str` yields the wire tag
+                // ("local_agent"/"local_bash"/…) the panel matches on.
+                let task_type = task
+                    .task_type
+                    .as_ref()
+                    .map(|tt| tt.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
                 events.push(TaskEvent::Started {
                     task_id: task.task_id.clone(),
-                    tool_use_id: task.tool_use_id.clone(),
+                    tool_use_id: task.tool_use_id.clone().unwrap_or_default(),
                     task_type,
                     description: task.description.clone(),
                     started_at: resolve_ts(),
@@ -567,28 +571,38 @@ pub(super) fn derive_task_events(
                 events.push(TaskEvent::Progress {
                     task_id: progress.task_id.clone(),
                     description: progress.description.clone(),
-                    last_tool_name: progress.last_tool_name.clone(),
+                    // Option in 2.1.160; empty string renders as "no tool yet".
+                    last_tool_name: progress.last_tool_name.clone().unwrap_or_default(),
                     duration_ms: progress.usage.duration_ms,
                     tool_uses: progress.usage.tool_uses,
                     total_tokens: progress.usage.total_tokens,
                     fallback_started_at: resolve_ts(),
                 });
             } else if let Some(notif) = sys.as_task_notification() {
-                let status = match notif.status {
-                    shared::TaskStatus::Completed => TaskStatus::Completed,
-                    shared::TaskStatus::Failed => TaskStatus::Failed,
+                // 2.1.160: TaskStatus is an open enum with non-terminal
+                // states. Only terminal statuses complete a panel entry;
+                // killed/stopped read as failure, non-terminal and unknown
+                // statuses leave the task running.
+                let status = match &notif.status {
+                    shared::TaskStatus::Completed => Some(TaskStatus::Completed),
+                    shared::TaskStatus::Failed
+                    | shared::TaskStatus::Killed
+                    | shared::TaskStatus::Stopped => Some(TaskStatus::Failed),
+                    _ => None,
                 };
-                let usage = notif
-                    .usage
-                    .as_ref()
-                    .map(|u| (u.duration_ms, u.tool_uses, u.total_tokens));
-                events.push(TaskEvent::Notification {
-                    task_id: notif.task_id.clone(),
-                    summary: notif.summary.clone(),
-                    status,
-                    completed_at: resolve_ts(),
-                    usage,
-                });
+                if let Some(status) = status {
+                    let usage = notif
+                        .usage
+                        .as_ref()
+                        .map(|u| (u.duration_ms, u.tool_uses, u.total_tokens));
+                    events.push(TaskEvent::Notification {
+                        task_id: notif.task_id.clone(),
+                        summary: notif.summary.clone(),
+                        status,
+                        completed_at: resolve_ts(),
+                        usage,
+                    });
+                }
             }
         }
         shared::ClaudeOutput::User(user_msg) => {


### PR DESCRIPTION
Closes #1275.

## Dependency bumps
- claude-codes 2.1.159 → **2.1.160** (full Claude CLI 2.1.205 wire coverage; `SubagentUsageRollup`)
- codex-codes 0.142.0 → **0.143.1**

## Breaking-change catch-up
- `ClaudeOutput` gained 18 variants: debug logger gets a variant-tag wildcard; `ClaudeMessage::parse`/deserialize map unrendered new frames to `Unknown` (previously they failed `ClaudeOutput` parse entirely).
- `TaskType`/`TaskStatus` are open enums: task-type labels use `as_str()` (exact wire tags the panel already matches); **task notifications with non-terminal statuses (pending/running/paused/unknown) no longer complete a panel entry** — only completed/failed/killed/stopped are terminal.
- `TaskStartedMessage.task_type`/`tool_use_id`, `TaskProgressMessage.last_tool_name`, `RateLimitInfo.is_using_overage` became `Option` — handled with explicit fallbacks.
- Two `large_enum_variant` allows with rationale (transient per-render enums; boxing churns ~30 sites for no retained-memory win) — reviewers may overrule.

## Subagent rollup (the payoff)
`io_task.rs` replaces its hand-rolled per-turn `Task`-result token sum with the SDK's `SubagentUsageRollup`, which **dedupes by agentId** — fixing a latent double-count when Task results are replayed on `--resume` (the manual sum had no dedup). Per-turn attribution is boundary-diffed: snapshot the rollup total at turn start, subtract at finalize; replayed results arriving before the first turn land outside every turn window (topology confirmed with the SDK author). New lock test pins the dedup + boundary-diff semantics against future SDK reshapes.

## Gates
Workspace clippy `-Dwarnings`, wasm clippy, full workspace tests, fmt.