### PR TITLE
Extend copy buttons to error, raw JSON, and Codex message headers

### DIFF
--- a/frontend/src/components/codex_renderer/messages.rs
+++ b/frontend/src/components/codex_renderer/messages.rs
@@ -1,4 +1,5 @@
 use super::item_card_classes;
+use crate::components::copy_button::CopyButton;
 use crate::components::markdown::render_markdown_for_session;
 use uuid::Uuid;
 use yew::prelude::*;
@@ -12,6 +13,7 @@ pub(super) fn render_agent_message(text: &str, completed: bool, session_id: Uuid
         <div class={class}>
             <div class="message-header">
                 <span class="message-type-badge assistant">{ "Codex" }</span>
+                <CopyButton text={text.to_string()} title="Copy message" />
             </div>
             <div class="message-body">{ render_agent_message_content(text, session_id) }</div>
         </div>
@@ -49,6 +51,7 @@ pub(super) fn render_error_block(message: Option<&str>) -> Html {
         <div class="claude-message error-message-display">
             <div class="message-header">
                 <span class="message-type-badge result error">{ "Error" }</span>
+                <CopyButton text={message.to_string()} title="Copy error" />
             </div>
             <div class="message-body">
                 <div class="error-text">{ message }</div>

--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -1,6 +1,7 @@
 use super::renderers;
 use super::types::{ClaudeMessage, RenderedMessage};
 use crate::components::agent_frame::{AgentFrame, AgentFrameRegistry, FrameRenderer};
+use crate::components::copy_button::CopyButton;
 use serde_json::Value;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -163,6 +164,7 @@ fn render_raw_json(json: &str) -> Html {
         <div class="claude-message raw-message">
             <div class="message-header">
                 <span class="message-type-badge raw">{ "Unrecognized Message" }</span>
+                <CopyButton text={display.clone()} title="Copy raw JSON" />
             </div>
             <div class="message-body">
                 <pre class="raw-json">{ display }</pre>

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -241,6 +241,7 @@ pub fn render_error_message(msg: &shared::AnthropicError, timestamp: Option<&str
                 {
                     html! { <span class="error-type">{ error_type }</span> }
                 }
+                <CopyButton text={message.to_string()} title="Copy error" />
             </div>
             <div class="message-body">
                 <div class="error-text">{ crate::components::markdown::linkify_urls(message) }</div>


### PR DESCRIPTION
Fixes #1270.

The existing `CopyButton` component (already on user/assistant/portal headers) is extended to the remaining payload-bearing block headers:
- **Error blocks** (Claude error + Codex error): copies the error text — the thing you paste into a search or an issue.
- **Unrecognized Message (raw JSON fallback)**: copies the pretty-printed frame — exactly what the block's hint asks you to file upstream.
- **Codex assistant messages**: parity with the Claude assistant renderer.

Deliberately skipped: task chips, turn-completed and thread-lifecycle headers (metadata chips with no meaningful payload), and tool groups (their payloads already have copy affordances via the assistant renderer). Same `navigator.clipboard` + 1.5s copied-state behavior as the existing buttons; no new CSS needed.

Gates: wasm clippy, frontend tests, fmt.