### PR TITLE
Push LaunchersChanged so dashboards track launcher state live

### DIFF
--- a/backend/src/handlers/websocket/session_manager/launcher_registry.rs
+++ b/backend/src/handlers/websocket/session_manager/launcher_registry.rs
@@ -74,11 +74,15 @@ impl SessionManager {
         drop(entry);
 
         let gen = connection.gen;
+        let user_id = connection.user_id;
         info!(
             "Registering launcher: {} ({}) (gen={})",
             connection.launcher_name, launcher_id, gen
         );
         self.launchers.insert(launcher_id, connection);
+        // Push signal so open dashboards reflect the launcher coming
+        // online without a refresh (#710).
+        self.broadcast_to_user(&user_id, shared::ServerToClient::LaunchersChanged);
         Ok(gen)
     }
 
@@ -100,9 +104,14 @@ impl SessionManager {
                 // Only release the dedup slot if it still points at us — a
                 // different launcher_id may have claimed (user_id, hostname)
                 // since, and must not be evicted.
+                let user_id = connection.user_id;
                 let dedup_key = (connection.user_id, connection.hostname);
                 self.launcher_dedup
                     .remove_if(&dedup_key, |_, claimed_by| claimed_by == launcher_id);
+                // Covers clean disconnects, dead-channel evictions, and
+                // liveness-sweep evictions alike — they all come through
+                // here (#710).
+                self.broadcast_to_user(&user_id, shared::ServerToClient::LaunchersChanged);
                 true
             }
             None => {

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -190,6 +190,11 @@ fn is_path_home_scoped(path: &str, home_root: Option<&str>) -> bool {
 pub struct LaunchDialogProps {
     pub on_close: Callback<()>,
     pub on_launched: Callback<()>,
+    /// Ticks on `ServerToClient::LaunchersChanged` (#710): the dialog
+    /// refetches its launcher list live, so a launcher coming online while
+    /// the dialog is open appears without reopening it.
+    #[prop_or(0)]
+    pub launcher_refresh: u32,
 }
 
 #[function_component(LaunchDialog)]
@@ -215,7 +220,8 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     let agent_installs = use_state(Vec::<AgentInstall>::new);
     let probing_agents = use_state(|| false);
 
-    // Fetch launchers on mount; auto-select install mode when none are connected
+    // Fetch launchers on mount and on every LaunchersChanged tick (#710);
+    // auto-select install mode when none are connected.
     {
         let launchers = launchers.clone();
         let selected_launcher = selected_launcher.clone();
@@ -223,18 +229,23 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let dir = dir.clone();
         let agent_installs = agent_installs.clone();
         let probing_agents = probing_agents.clone();
-        use_effect_with((), move |_| {
+        use_effect_with(props.launcher_refresh, move |_| {
             spawn_local(async move {
                 if let Ok(data) =
                     utils::fetch_json::<Vec<LauncherInfo>>("/api/launchers", On401::Ignore).await
                 {
-                    if let Some(first) = data.first() {
-                        let lid = first.launcher_id;
-                        selected_launcher.set(Some(lid));
-                        dir.fetch(lid, "~".to_string(), true);
-                        probe_agents_for(lid, agent_installs.clone(), probing_agents.clone());
-                    } else {
-                        show_install.set(true);
+                    // Only steer selection/install-mode from scratch; a
+                    // live refresh must not yank an existing selection.
+                    if selected_launcher.is_none() {
+                        if let Some(first) = data.first() {
+                            let lid = first.launcher_id;
+                            selected_launcher.set(Some(lid));
+                            dir.fetch(lid, "~".to_string(), true);
+                            probe_agents_for(lid, agent_installs.clone(), probing_agents.clone());
+                            show_install.set(false);
+                        } else {
+                            show_install.set(true);
+                        }
                     }
                     launchers.set(data);
                 }

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -234,9 +234,15 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                 if let Ok(data) =
                     utils::fetch_json::<Vec<LauncherInfo>>("/api/launchers", On401::Ignore).await
                 {
-                    // Only steer selection/install-mode from scratch; a
-                    // live refresh must not yank an existing selection.
-                    if selected_launcher.is_none() {
+                    // A live refresh must not yank a selection that is
+                    // still valid — but a selection whose launcher just
+                    // dropped off the list is stale, and launching against
+                    // it would send a dead launcher_id (codex review on
+                    // this PR). Re-steer whenever the current selection
+                    // isn't in the fresh list.
+                    let selection_valid = selected_launcher
+                        .is_some_and(|id| data.iter().any(|l| l.launcher_id == id));
+                    if !selection_valid {
                         if let Some(first) = data.first() {
                             let lid = first.launcher_id;
                             selected_launcher.set(Some(lid));
@@ -244,6 +250,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                             probe_agents_for(lid, agent_installs.clone(), probing_agents.clone());
                             show_install.set(false);
                         } else {
+                            selected_launcher.set(None);
                             show_install.set(true);
                         }
                     }

--- a/frontend/src/hooks/client_websocket_events.rs
+++ b/frontend/src/hooks/client_websocket_events.rs
@@ -13,6 +13,7 @@ pub(crate) fn handle_server_message(
     shutdown_reason: &UseStateHandle<Option<String>>,
     recent_turn_metrics: &UseStateHandle<Vec<TurnMetrics>>,
     launch_event_counter: &UseStateHandle<u32>,
+    launcher_event_counter: &UseStateHandle<u32>,
 ) {
     match msg {
         ServerToClient::UserSpendUpdate {
@@ -51,6 +52,11 @@ pub(crate) fn handle_server_message(
                 );
             }
             launch_event_counter.set(launch_event_counter.wrapping_add(1));
+        }
+        ServerToClient::LaunchersChanged => {
+            // A launcher connected, dropped, or was evicted: tick so open
+            // launcher lists refetch at the moment the change is visible.
+            launcher_event_counter.set(launcher_event_counter.wrapping_add(1));
         }
         _ => {}
     }

--- a/frontend/src/hooks/use_client_websocket.rs
+++ b/frontend/src/hooks/use_client_websocket.rs
@@ -37,6 +37,10 @@ pub struct UseClientWebSocket {
     /// the new session becomes findable — no polling burst needed. The
     /// value itself is opaque; only its *change* is meaningful.
     pub launch_event_counter: u32,
+    /// Ticks on every `ServerToClient::LaunchersChanged` broadcast — a
+    /// launcher connected, disconnected, or was evicted. Consumers hang a
+    /// `use_effect_with` on it to refetch `/api/launchers` (#710).
+    pub launcher_event_counter: u32,
 }
 
 /// Calculate exponential backoff delay for reconnection attempts.
@@ -85,6 +89,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
     let update_available = use_state(|| None::<String>);
     let recent_turn_metrics = use_state(Vec::<TurnMetrics>::new);
     let launch_event_counter = use_state(|| 0u32);
+    let launcher_event_counter = use_state(|| 0u32);
 
     // One-shot REST hydration on hook mount. Fires alongside (not gated on)
     // the WS connect — the dashboard pill shows immediately if the user
@@ -110,6 +115,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
         let update_available = update_available.clone();
         let recent_turn_metrics = recent_turn_metrics.clone();
         let launch_event_counter = launch_event_counter.clone();
+        let launcher_event_counter = launcher_event_counter.clone();
 
         use_effect_with((), move |_| {
             let total_spend = total_spend.clone();
@@ -117,6 +123,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
             let update_available = update_available.clone();
             let recent_turn_metrics = recent_turn_metrics.clone();
             let launch_event_counter = launch_event_counter.clone();
+            let launcher_event_counter = launcher_event_counter.clone();
 
             spawn_local(async move {
                 let mut attempt: u32 = 0;
@@ -161,6 +168,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
                                         &shutdown_reason,
                                         &recent_turn_metrics,
                                         &launch_event_counter,
+                                        &launcher_event_counter,
                                     ),
                                     Err(e) => {
                                         log::error!("Client WebSocket error: {:?}", e);
@@ -199,6 +207,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
         update_available: (*update_available).clone(),
         recent_turn_metrics: (*recent_turn_metrics).clone(),
         launch_event_counter: *launch_event_counter,
+        launcher_event_counter: *launcher_event_counter,
     }
 }
 

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -570,7 +570,11 @@ pub fn dashboard_page() -> Html {
 
             // Launch session dialog
             if ui_state.show_launch_dialog {
-                <LaunchDialog on_close={on_launch_close.clone()} on_launched={on_launch_success.clone()} />
+                <LaunchDialog
+                    on_close={on_launch_close.clone()}
+                    on_launched={on_launch_success.clone()}
+                    launcher_refresh={ws_hook.launcher_event_counter}
+                />
             }
 
             if loading {

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -108,6 +108,9 @@ pub fn launchers_panel() -> Html {
     let loading = use_state(|| true);
     let action_result = use_state(|| None::<(bool, String)>);
     let update_in_progress = use_state(|| None::<Uuid>);
+    // Live LaunchersChanged ticks (#710): a launcher restarting while this
+    // panel is open shows its reconnect without a page refresh.
+    let ws_hook = crate::hooks::use_client_websocket();
 
     let fetch_launchers = {
         let launchers = launchers.clone();
@@ -130,7 +133,7 @@ pub fn launchers_panel() -> Html {
 
     {
         let fetch = fetch_launchers.clone();
-        use_effect_with((), move |_| {
+        use_effect_with(ws_hook.launcher_event_counter, move |_| {
             fetch.emit(());
             || ()
         });

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -271,6 +271,11 @@ pub enum ServerToClient {
         session_costs: Vec<SessionCost>,
     },
 
+    /// The user's launcher set changed (connected, disconnected, or
+    /// evicted). Push signal for the #710 live-dashboard direction: clients
+    /// refetch `GET /api/launchers` instead of waiting for a page refresh.
+    LaunchersChanged,
+
     /// Server is shutting down
     ServerShutdown {
         reason: String,


### PR DESCRIPTION
The push half of #710 (severable slice — the issue's all-at-once warning is about half-migrating the *RPCs* into a second correlation system, which this deliberately does not touch: all RPCs stay REST; this is purely additive push).

**The pain this fixes**: during the 2026-07-09 triage, a launcher restarted and reconnected fine — but every open dashboard kept showing it offline until a manual refresh. Nothing ever told the browser.

**Changes**
- `ServerToClient::LaunchersChanged` (unit variant, additive): broadcast to the owning user's clients from `try_register_launcher` (launcher online) and `unregister_launcher` (clean disconnect, dead-channel eviction, and liveness-sweep eviction all funnel through it).
- `use_client_websocket` exposes a `launcher_event_counter` that ticks per broadcast, mirroring the existing `launch_event_counter` pattern.
- **Launch dialog** refetches its launcher list on each tick while open — a launcher coming online appears live; an existing selection is never yanked by a refresh (selection steering only runs from the unselected state).
- **Settings → Launchers panel** hangs its fetch on the same tick, so a restarting launcher's disconnect + reconnect both render as they happen.

The remaining scope of #710 (RPCs over WS, request-id correlation, REST deprecation) stays open on the issue — this PR takes the "no more polling / no more stale panels" UX without prejudging that migration.

Gates: workspace clippy -Dwarnings, wasm clippy, backend 153 + frontend 381 tests, fmt.