### PR TITLE
Synthesize Claude user echoes

### DIFF
--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -7,6 +7,7 @@
 //! turn-retry state machine (see the `RATE_LIMIT_TEXT_PREFIX` comment
 //! below).
 
+use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
 use chrono::{NaiveTime, TimeZone, Utc};
@@ -20,7 +21,7 @@ use session_lib::{
     AgentOutputClassifier, ClaudeAdapter, PermissionDecision, TurnOutcome, TurnTracker,
 };
 use shared::PortalMessage;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
 /// Build a Claude `ControlResponse` from a neutral [`PermissionDecision`].
@@ -51,6 +52,181 @@ fn claude_control_response(request_id: &str, decision: PermissionDecision) -> Co
 const SESSION_LIMIT_TEXT: &str = "You've hit your session limit";
 const SESSION_LIMIT_CONTINUE_PROMPT: &str =
     "Continue from where you stopped before the Claude session limit was reached.";
+
+#[derive(Debug)]
+struct EchoDropMarker {
+    expected_text: String,
+}
+
+struct ClaudeUserInputSend<'a> {
+    client: &'a mut ClaudeAsyncClient,
+    session_id: Uuid,
+    text: String,
+    delivered: Option<oneshot::Sender<Result<(), String>>>,
+    display_event: Option<Box<serde_json::Value>>,
+    event_tx: &'a mpsc::UnboundedSender<IoEvent>,
+    pending_echo_drops: &'a mut VecDeque<EchoDropMarker>,
+    synthesize_visible_echo: bool,
+}
+
+async fn send_claude_user_input(
+    args: ClaudeUserInputSend<'_>,
+) -> Result<ClaudeInput, claude_codes::Error> {
+    let ClaudeUserInputSend {
+        client,
+        session_id,
+        text,
+        delivered,
+        display_event,
+        event_tx,
+        pending_echo_drops,
+        synthesize_visible_echo,
+    } = args;
+    let input = ClaudeInput::user_message(text.clone(), session_id);
+    let result = client.send(&input).await;
+
+    if result.is_ok() {
+        pending_echo_drops.push_back(EchoDropMarker {
+            expected_text: text.clone(),
+        });
+        if synthesize_visible_echo {
+            if let Some(value) = synthetic_user_echo_value(&text, display_event, session_id) {
+                let _ = event_tx.send(IoEvent::RawOutput(value));
+            }
+        }
+    }
+
+    if let Some(delivered) = delivered {
+        let _ = delivered.send(result.as_ref().map(|_| ()).map_err(|e| e.to_string()));
+    }
+
+    result.map(|_| input)
+}
+
+pub(crate) fn claude_user_echo_value(text: String, session_id: Uuid) -> serde_json::Value {
+    let input = ClaudeInput::user_message(text, session_id);
+    let ClaudeInput::User(user) = input else {
+        return serde_json::Value::Null;
+    };
+    serde_json::to_value(ClaudeOutput::User(user)).unwrap_or_default()
+}
+
+fn synthetic_user_echo_value(
+    text: &str,
+    display_event: Option<Box<serde_json::Value>>,
+    session_id: Uuid,
+) -> Option<serde_json::Value> {
+    if let Some(event) = display_event {
+        return Some(*event);
+    }
+    if should_suppress_synthetic_user_echo(text) {
+        return None;
+    }
+    Some(claude_user_echo_value(text.to_string(), session_id))
+}
+
+fn plain_input_text(input: &ClaudeInput) -> Option<String> {
+    let ClaudeInput::User(user) = input else {
+        return None;
+    };
+    let mut text = String::new();
+    let mut saw_text = false;
+    for block in &user.message.content {
+        match block {
+            ContentBlock::Text(t) => {
+                saw_text = true;
+                text.push_str(&t.text);
+            }
+            _ => return None,
+        }
+    }
+    saw_text.then_some(text)
+}
+
+fn should_suppress_synthetic_user_echo(text: &str) -> bool {
+    text.trim().is_empty() || is_system_reminder_text(text)
+}
+
+fn is_system_reminder_text(text: &str) -> bool {
+    text.trim_start().starts_with("<system-reminder>")
+}
+
+fn plain_user_echo_text(output: &ClaudeOutput) -> Option<String> {
+    let ClaudeOutput::User(user) = output else {
+        return None;
+    };
+    if user.tool_use_result.is_some() {
+        return None;
+    }
+
+    let mut saw_text = false;
+    let mut text = String::new();
+    for block in &user.message.content {
+        match block {
+            ContentBlock::Text(t) => {
+                saw_text = true;
+                text.push_str(&t.text);
+            }
+            // Tool results, images, and other structured user frames are real
+            // agent output, not CLI echoes of stdin.
+            _ => return None,
+        }
+    }
+
+    saw_text.then_some(text)
+}
+
+fn should_drop_claude_user_echo(
+    output: &ClaudeOutput,
+    pending_echo_drops: &mut VecDeque<EchoDropMarker>,
+) -> bool {
+    let Some(echoed_text) = plain_user_echo_text(output) else {
+        return false;
+    };
+
+    if is_system_reminder_text(&echoed_text) {
+        tracing::debug!("Dropping system-reminder user echo from transcript");
+        return true;
+    }
+
+    if echoed_text.trim().is_empty() {
+        tracing::debug!("Dropping empty user echo from transcript");
+        return true;
+    }
+
+    if let Some(marker) = pending_echo_drops.pop_front() {
+        if marker.expected_text != echoed_text {
+            tracing::warn!(
+                "Dropping Claude user echo with mismatched text; expected={}, echoed={}",
+                truncate_for_log(&marker.expected_text),
+                truncate_for_log(&echoed_text)
+            );
+        }
+        return true;
+    }
+
+    false
+}
+
+fn clear_stale_echo_markers_at_turn_boundary(pending_echo_drops: &mut VecDeque<EchoDropMarker>) {
+    let count = pending_echo_drops.len();
+    if count == 0 {
+        return;
+    }
+    pending_echo_drops.clear();
+    tracing::warn!(
+        "Cleared {} pending Claude user echo drop marker(s) at turn boundary",
+        count
+    );
+}
+
+fn truncate_for_log(text: &str) -> String {
+    const LIMIT: usize = 120;
+    if text.chars().count() <= LIMIT {
+        return text.to_string();
+    }
+    format!("{}...", text.chars().take(LIMIT).collect::<String>())
+}
 
 /// Background task that owns the Claude process and handles all I/O.
 ///
@@ -108,22 +284,18 @@ pub(crate) async fn claude_io_task(
     // first turn starts land outside every turn window.
     let mut subagent_rollup = claude_codes::SubagentUsageRollup::default();
     let mut subagent_tokens_at_turn_start: i64 = 0;
+    let mut pending_echo_drops: VecDeque<EchoDropMarker> = VecDeque::new();
 
     loop {
         tokio::select! {
             // Handle incoming commands (input to send to Claude).
             Some(cmd) = command_rx.recv() => {
                 let result = match cmd {
-                    // `display_event` is for agents that don't echo (Codex);
-                    // claude echoes its input and the proxy swaps the typed
-                    // event in via output_forwarder, so it's ignored here.
                     IoCommand::UserInput {
                         text,
                         delivered,
-                        display_event: _,
+                        display_event,
                     } => {
-                        // Build Claude's wire form from the neutral text.
-                        let input = ClaudeInput::user_message(text, session_id);
                         // Each fresh user input gets its own retry budget.
                         rate_limit_attempts = 0;
                         current_turn_was_rate_limited = false;
@@ -133,12 +305,21 @@ pub(crate) async fn claude_io_task(
                         // chrono::Utc::now(); the monotonic instant is the
                         // anchor for TTFT / total / gap durations.
                         turn_tracker.start(Instant::now(), chrono::Utc::now());
-                        let r = client.send(&input).await;
-                        last_input = Some(input);
-                        if let Some(delivered) = delivered {
-                            let _ = delivered.send(r.as_ref().map(|_| ()).map_err(|e| e.to_string()));
+                        let r = send_claude_user_input(ClaudeUserInputSend {
+                            client: &mut client,
+                            session_id,
+                            text,
+                            delivered,
+                            display_event,
+                            event_tx: &event_tx,
+                            pending_echo_drops: &mut pending_echo_drops,
+                            synthesize_visible_echo: true,
+                        })
+                        .await;
+                        if let Ok(input) = &r {
+                            last_input = Some(input.clone());
                         }
-                        r
+                        r.map(|_| ())
                     }
                     IoCommand::Permission {
                         request_id,
@@ -157,6 +338,10 @@ pub(crate) async fn claude_io_task(
             result = client.receive() => {
                 match result {
                     Ok(output) => {
+                        if should_drop_claude_user_echo(&output, &mut pending_echo_drops) {
+                            continue;
+                        }
+
                         // Feed every frame to the subagent rollup (cheap
                         // no-op for non-Task-result frames; agentId-deduped).
                         subagent_rollup.observe(&output);
@@ -235,6 +420,7 @@ pub(crate) async fn claude_io_task(
                         // turn (which will get its own row when `start` runs
                         // again).
                         if let ClaudeOutput::Result(ref r) = output {
+                            clear_stale_echo_markers_at_turn_boundary(&mut pending_echo_drops);
                             let usage = r.usage.as_ref();
                             let model = current_model.clone();
                             let outcome = TurnOutcome {
@@ -382,6 +568,10 @@ pub(crate) async fn claude_io_task(
                                     let _ = event_tx.send(IoEvent::Error(
                                         SessionError::Agent(e.to_string()),
                                     ));
+                                } else if let Some(expected_text) = plain_input_text(&input) {
+                                    pending_echo_drops.push_back(EchoDropMarker {
+                                        expected_text,
+                                    });
                                 }
                             }
                             Some(cmd) = command_rx.recv() => {
@@ -389,26 +579,35 @@ pub(crate) async fn claude_io_task(
                                     IoCommand::UserInput {
                                         text,
                                         delivered,
-                                        display_event: _,
+                                        display_event,
                                     } => {
                                         // User typed something while we were waiting
                                         // — honor that, abandon the retry, and reset
                                         // the budget for the new prompt.
-                                        let new_input = ClaudeInput::user_message(text, session_id);
                                         rate_limit_attempts = 0;
                                         pending_session_limit = None;
                                         subagent_tokens_at_turn_start = subagent_rollup.subagent_tokens as i64;
                                         turn_tracker.start(Instant::now(), chrono::Utc::now());
-                                        let r = client.send(&new_input).await;
-                                        last_input = Some(new_input);
-                                        if let Some(delivered) = delivered {
-                                            let _ = delivered
-                                                .send(r.as_ref().map(|_| ()).map_err(|e| e.to_string()));
-                                        }
-                                        if let Err(e) = r {
-                                            let _ = event_tx.send(IoEvent::Error(
-                                                SessionError::Agent(e.to_string()),
-                                            ));
+                                        let r = send_claude_user_input(ClaudeUserInputSend {
+                                            client: &mut client,
+                                            session_id,
+                                            text,
+                                            delivered,
+                                            display_event,
+                                            event_tx: &event_tx,
+                                            pending_echo_drops: &mut pending_echo_drops,
+                                            synthesize_visible_echo: true,
+                                        })
+                                        .await;
+                                        match r {
+                                            Ok(new_input) => {
+                                                last_input = Some(new_input);
+                                            }
+                                            Err(e) => {
+                                                let _ = event_tx.send(IoEvent::Error(
+                                                    SessionError::Agent(e.to_string()),
+                                                ));
+                                            }
                                         }
                                     }
                                     IoCommand::Permission {
@@ -722,6 +921,157 @@ mod tests {
         // A genuinely new subagent in this turn is attributed by the diff.
         rollup.observe(&task_result("agent-b", 500));
         assert_eq!(rollup.subagent_tokens - at_turn_start, 500);
+    }
+
+    fn user_output_with_content(content: serde_json::Value) -> ClaudeOutput {
+        serde_json::from_value(serde_json::json!({
+            "type": "user",
+            "session_id": "00000000-0000-0000-0000-000000000000",
+            "message": {
+                "role": "user",
+                "content": content,
+            },
+        }))
+        .expect("valid user output")
+    }
+
+    fn text_user_output(text: &str) -> ClaudeOutput {
+        user_output_with_content(serde_json::json!([
+            { "type": "text", "text": text }
+        ]))
+    }
+
+    #[test]
+    fn claude_user_echo_value_roundtrips_as_plain_user_output() {
+        let value = claude_user_echo_value("hello portal".to_string(), Uuid::nil());
+        let output: ClaudeOutput = serde_json::from_value(value).expect("synthetic output parses");
+        assert_eq!(
+            plain_user_echo_text(&output).as_deref(),
+            Some("hello portal")
+        );
+    }
+
+    #[test]
+    fn synthetic_user_echo_prefers_display_event_and_suppresses_private_prompts() {
+        let display = serde_json::json!({"type": "portal", "message": "agent card"});
+        assert_eq!(
+            synthetic_user_echo_value("agent-facing", Some(Box::new(display.clone())), Uuid::nil()),
+            Some(display)
+        );
+        assert!(synthetic_user_echo_value(
+            "<system-reminder>hidden</system-reminder>",
+            None,
+            Uuid::nil()
+        )
+        .is_none());
+        assert!(synthetic_user_echo_value("   \n\t", None, Uuid::nil()).is_none());
+    }
+
+    #[test]
+    fn pending_echo_drop_markers_are_fifo() {
+        let mut pending = VecDeque::from([
+            EchoDropMarker {
+                expected_text: "first".to_string(),
+            },
+            EchoDropMarker {
+                expected_text: "second".to_string(),
+            },
+        ]);
+
+        assert!(should_drop_claude_user_echo(
+            &text_user_output("first"),
+            &mut pending
+        ));
+        assert_eq!(pending.len(), 1);
+        assert!(should_drop_claude_user_echo(
+            &text_user_output("second"),
+            &mut pending
+        ));
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn pending_echo_marker_drops_mismatched_plain_echo_but_not_future_frames() {
+        let mut pending = VecDeque::from([EchoDropMarker {
+            expected_text: "expected".to_string(),
+        }]);
+
+        assert!(should_drop_claude_user_echo(
+            &text_user_output("changed by cli"),
+            &mut pending
+        ));
+        assert!(pending.is_empty());
+        assert!(!should_drop_claude_user_echo(
+            &text_user_output("future legitimate user frame"),
+            &mut pending
+        ));
+    }
+
+    #[test]
+    fn stale_echo_markers_clear_at_turn_boundary() {
+        let mut pending = VecDeque::from([EchoDropMarker {
+            expected_text: "never echoed".to_string(),
+        }]);
+        clear_stale_echo_markers_at_turn_boundary(&mut pending);
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn system_reminder_and_empty_user_echoes_drop_without_marker() {
+        let mut pending = VecDeque::new();
+        assert!(should_drop_claude_user_echo(
+            &text_user_output("<system-reminder>hidden</system-reminder>"),
+            &mut pending
+        ));
+        assert!(should_drop_claude_user_echo(
+            &text_user_output(" \n\t "),
+            &mut pending
+        ));
+    }
+
+    #[test]
+    fn unconditional_echo_drops_do_not_consume_pending_marker() {
+        let mut pending = VecDeque::from([EchoDropMarker {
+            expected_text: "real prompt".to_string(),
+        }]);
+
+        assert!(should_drop_claude_user_echo(
+            &text_user_output(" \n\t "),
+            &mut pending
+        ));
+        assert_eq!(pending.len(), 1);
+
+        assert!(should_drop_claude_user_echo(
+            &text_user_output("<system-reminder>hidden</system-reminder>"),
+            &mut pending
+        ));
+        assert_eq!(pending.len(), 1);
+
+        assert!(should_drop_claude_user_echo(
+            &text_user_output("real prompt"),
+            &mut pending
+        ));
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn structured_user_frames_are_not_plain_echoes() {
+        let mut pending = VecDeque::from([EchoDropMarker {
+            expected_text: "next prompt".to_string(),
+        }]);
+        let tool_result = user_output_with_content(serde_json::json!([
+            {
+                "type": "tool_result",
+                "tool_use_id": "tool-1",
+                "content": "ok"
+            }
+        ]));
+        assert!(!should_drop_claude_user_echo(&tool_result, &mut pending));
+        assert_eq!(pending.len(), 1);
+
+        let no_blocks = user_output_with_content(serde_json::json!([]));
+        assert!(!should_drop_claude_user_echo(&no_blocks, &mut pending));
+        assert_eq!(pending.len(), 1);
     }
 
     #[test]

--- a/claude-session-lib/src/proxy_session/input_delivery.rs
+++ b/claude-session-lib/src/proxy_session/input_delivery.rs
@@ -2,10 +2,10 @@
 //!
 //! Extracted from the `run_main_loop` `select!` so the god-loop reads as thin
 //! dispatch. Hands a [`PortalInput`] to the agent: refreshes git metadata,
-//! emits the [`InputDeliveryStage`](shared::InputDeliveryStage) progress
-//! events (#939), stashes the typed display-event echo for Claude's
-//! `output_forwarder` to swap in (#1124), and schedules the final
-//! `AgentAccepted`/input ack without blocking the connection loop.
+//! emits the [`InputDeliveryStage`](shared::InputDeliveryStage) progress events
+//! (#939), and schedules the final `AgentAccepted`/input ack without blocking
+//! the connection loop. Display-event echo synthesis now lives in the agent
+//! I/O task so it enters the replay buffer before proxy forwarding.
 
 use tokio::sync::oneshot;
 use tracing::{debug, error};
@@ -16,20 +16,17 @@ use session_lib::session::Session;
 
 use super::git_metadata::{check_and_send_branch_update_if_branch_changed, GitMetadataState};
 use super::{
-    ack_portal_input, emit_input_progress, truncate, ConnectionResult, PendingInputDisplayEvent,
-    PendingInputDisplayEvents, PortalInput, PortalInputAck, SharedWsWrite,
+    ack_portal_input, emit_input_progress, truncate, ConnectionResult, PortalInput, PortalInputAck,
+    SharedWsWrite,
 };
 
 /// Deliver one user input to the agent. Returns `Some(ConnectionResult)` to end
 /// the connection (delivery failure), or `None` to continue the loop.
-#[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_input<A: Agent>(
     ws_write: &SharedWsWrite,
     session_id: Uuid,
     working_directory: &str,
     git_metadata: &GitMetadataState,
-    agent_type: shared::AgentType,
-    pending_input_display_events: &PendingInputDisplayEvents,
     claude_session: &mut Session<A>,
     input: PortalInput,
 ) -> Option<ConnectionResult> {
@@ -52,24 +49,6 @@ pub(super) async fn handle_input<A: Agent>(
         shared::InputDeliveryStage::ProxyReceived,
     )
     .await;
-
-    // Two mechanisms deliver the typed display event, exactly one per agent —
-    // never both:
-    //  - Claude echoes its input, so we stash the event here for the
-    //    output_forwarder to swap in on the matching ClaudeOutput::User.
-    //  - Codex doesn't echo, so its io-task emits the event itself (handed in
-    //    via send_input_with_display below).
-    // Gate the stash on Claude: pushing for Codex would leak the VecDeque entry
-    // forever, since nothing consumes it there (#1124).
-    if agent_type == shared::AgentType::Claude {
-        if let Some(display_event) = input.display_event.clone() {
-            let mut pending = pending_input_display_events.lock().await;
-            pending.push_back(PendingInputDisplayEvent {
-                echoed_text: input.text.clone(),
-                content: display_event,
-            });
-        }
-    }
 
     let delivered = match claude_session
         .enqueue_input_with_display(serde_json::Value::String(input.text), input.display_event)

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -16,7 +16,6 @@ pub(crate) use portal_reminder::inject_portal_reminder;
 pub use wiggum::wiggum_prompt;
 pub use ws_reader::{classify_portal_input, RoutedPortalInput};
 
-use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -212,8 +211,8 @@ pub struct PermissionResponseData {
 /// Portal-originated user input plus optional backend ack metadata.
 pub struct PortalInput {
     pub text: String,
-    /// Optional typed portal event that should replace the agent's echoed user
-    /// text in the transcript.
+    /// Optional typed portal event that the agent I/O task should synthesize
+    /// into the transcript instead of a plain user-text echo.
     pub display_event: Option<serde_json::Value>,
     pub ack: Option<PortalInputAck>,
     /// Browser-assigned delivery-tracking id (#939). When present, the main
@@ -226,13 +225,6 @@ pub struct PortalInputAck {
     pub session_id: Uuid,
     pub seq: i64,
 }
-
-pub(crate) struct PendingInputDisplayEvent {
-    pub echoed_text: String,
-    pub content: serde_json::Value,
-}
-
-pub(crate) type PendingInputDisplayEvents = Arc<Mutex<VecDeque<PendingInputDisplayEvent>>>;
 
 /// Signal for graceful server shutdown with recommended reconnect delay
 pub struct GracefulShutdown {
@@ -365,9 +357,6 @@ struct ConnectionState {
     /// [`CodexThreadIdSink`] doc. Cloned out of `ProxySessionConfig` so
     /// the per-connection state doesn't need to carry a config reference.
     codex_thread_id_sink: Option<CodexThreadIdSink>,
-    /// Typed portal events waiting to replace the corresponding echoed user
-    /// message from the agent process.
-    pending_input_display_events: PendingInputDisplayEvents,
 }
 
 /// Run the WebSocket connection loop with auto-reconnect
@@ -790,9 +779,6 @@ async fn run_message_loop<A: Agent>(
     // Shared state for tracking git branch, PR URL, and repo URL updates
     let git_metadata = GitMetadataState::new(config.git_branch.clone());
 
-    let pending_input_display_events: PendingInputDisplayEvents =
-        Arc::new(Mutex::new(VecDeque::new()));
-
     // Spawn output forwarder task with buffer
     let output_task = spawn_output_forwarder(
         output_rx,
@@ -805,7 +791,6 @@ async fn run_message_loop<A: Agent>(
         session.output_buffer.clone(),
         max_image_mb,
         config.agent_type,
-        pending_input_display_events.clone(),
     );
 
     // Spawn WebSocket reader task
@@ -849,7 +834,6 @@ async fn run_message_loop<A: Agent>(
         git_metadata,
         git_refresh: GitRefreshTrigger::default(),
         codex_thread_id_sink: config.codex_thread_id_sink.clone(),
-        pending_input_display_events,
     };
 
     // On the very first connection of this session, inject the portal
@@ -968,8 +952,6 @@ async fn run_main_loop<A: Agent>(
                     state.session_id,
                     &state.working_directory,
                     &state.git_metadata,
-                    state.agent_type,
-                    &state.pending_input_display_events,
                     claude_session,
                     input,
                 )
@@ -1032,7 +1014,7 @@ async fn run_main_loop<A: Agent>(
 /// Re-parse a neutral `Visible` output value back to the typed `ClaudeOutput`
 /// at the Claude proxy edge. `Session` is now agent-neutral (it forwards raw
 /// `Value`s); the Claude-specific consumers — the `output_forwarder`'s
-/// image/git/echo handling and `wiggum`'s DONE detection — re-parse here.
+/// image/git handling and `wiggum`'s DONE detection — re-parse here.
 /// Returns `None` for malformed/non-Claude frames, which callers forward
 /// verbatim rather than drop (#1165 item 2, slice 1).
 pub(super) fn parse_visible_claude_output(value: &serde_json::Value) -> Option<ClaudeOutput> {
@@ -1349,8 +1331,8 @@ mod tests {
     use uuid::Uuid;
 
     /// The Claude proxy-edge re-parse gate (#1165 item 2, slice 1). Valid Claude
-    /// frames parse to `Some`, so the typed side-effects (echo replacement,
-    /// wiggum DONE, image/git handling) run; malformed / non-Claude frames yield
+    /// frames parse to `Some`, so the typed side-effects (wiggum DONE,
+    /// image/git handling) run; malformed / non-Claude frames yield
     /// `None`, so the caller forwards the original raw value verbatim — never
     /// dropping or rewriting it, and never panicking.
     #[test]

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -18,7 +18,7 @@ use super::git_metadata::{
     check_and_send_branch_update, claude_output_has_git_signal, GitMetadataState, GitRefreshTrigger,
 };
 use super::image_uploader::upload_image;
-use super::{format_duration, truncate, PendingInputDisplayEvents, SharedWsWrite};
+use super::{format_duration, truncate, SharedWsWrite};
 
 /// Images at or above this raw-byte size get sent via the chunked upload
 /// stream (`/ws/session/upload`) instead of inlined as base64 on the main
@@ -41,7 +41,6 @@ pub fn spawn_output_forwarder(
     output_buffer: std::sync::Arc<tokio::sync::Mutex<PendingOutputBuffer>>,
     max_image_mb: u32,
     agent_type: AgentType,
-    pending_input_display_events: PendingInputDisplayEvents,
 ) -> tokio::task::JoinHandle<()> {
     let max_bytes = max_image_mb as usize * 1024 * 1024;
     tokio::spawn(async move {
@@ -51,10 +50,10 @@ pub fn spawn_output_forwarder(
 
         while let Some(value) = output_rx.recv().await {
             // `Session` is now agent-neutral and forwards raw wire JSON. Re-parse
-            // it to `ClaudeOutput` here, ONCE, at the Claude proxy edge; all the
-            // typed side-effects (logging, git-signal, image extraction, echo
-            // replacement) hang off this `Option`. Malformed / non-Claude frames
-            // skip the typed work and are forwarded verbatim — never dropped or
+            // it to `ClaudeOutput` here, ONCE, at the Claude proxy edge; all
+            // the typed side-effects (logging, git-signal, image extraction)
+            // hang off this `Option`. Malformed / non-Claude frames skip the
+            // typed work and are forwarded verbatim — never dropped or
             // rewritten (#1165 item 2, slice 1).
             let parsed = super::parse_visible_claude_output(&value);
 
@@ -85,16 +84,7 @@ pub fn spawn_output_forwarder(
                 // large images, base64 for small ones).
                 let image_items = extract_image_work_items(output, &mut image_read_map, max_bytes);
 
-                // Echo-replacement swaps the rendered content for typed portal
-                // inputs (`agent-portal message`); otherwise persist + forward
-                // the EXACT raw value (invariant: exact raw Value is what gets
-                // persisted and sent).
-                let content =
-                    replacement_input_display_event(output, &pending_input_display_events)
-                        .await
-                        .unwrap_or_else(|| value.clone());
-
-                (content, image_items)
+                (value.clone(), image_items)
             } else {
                 // Malformed / non-Claude frame: forward verbatim, no typed work.
                 (value.clone(), Vec::new())
@@ -205,33 +195,6 @@ enum ImageWorkItem {
     },
     /// Image exceeded the hard cap; this is a textual rejection notice.
     TooLarge(shared::PortalMessage),
-}
-
-async fn replacement_input_display_event(
-    output: &ClaudeOutput,
-    pending_input_display_events: &PendingInputDisplayEvents,
-) -> Option<serde_json::Value> {
-    let echoed_text = user_text_echo(output)?;
-    let mut pending = pending_input_display_events.lock().await;
-    let pos = pending
-        .iter()
-        .position(|event| event.echoed_text == echoed_text)?;
-    pending.remove(pos).map(|event| event.content)
-}
-
-fn user_text_echo(output: &ClaudeOutput) -> Option<String> {
-    let ClaudeOutput::User(user) = output else {
-        return None;
-    };
-    let mut text_blocks = user.message.content.iter().filter_map(|block| match block {
-        ContentBlock::Text(text) => Some(text.text.clone()),
-        _ => None,
-    });
-    let text = text_blocks.next()?;
-    if text_blocks.next().is_some() {
-        return None;
-    }
-    Some(text)
 }
 
 /// Return the MIME type for a supported image extension, or None.

--- a/claude-session-lib/src/proxy_session/session_event.rs
+++ b/claude-session-lib/src/proxy_session/session_event.rs
@@ -35,7 +35,7 @@ pub(super) async fn handle_next_event<A: Agent>(
     // `SessionEvent::RawOutput(value)`. Route by agent at the proxy edge: Codex
     // uses this simple inline path; Claude falls through to the
     // wiggum/output-forwarder path, which re-parses the value to `ClaudeOutput`
-    // for its image/git/echo/wiggum side-effects.
+    // for its image/git/wiggum side-effects.
     if state.agent_type != shared::AgentType::Claude {
         if let Some(SessionEvent::RawOutput(ref value)) = event {
             if state.git_refresh.should_check_before_message() {
@@ -132,6 +132,7 @@ pub(super) async fn handle_next_event<A: Agent>(
 
     handle_session_event_with_wiggum(
         event,
+        state.session_id,
         &state.output_tx,
         &state.ws_write,
         state.connection_start,

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use claude_codes::io::ContentBlock;
 use claude_codes::ClaudeOutput;
 use shared::{AgentType, ProxyToServer};
 use tokio::sync::{mpsc, Mutex};
@@ -13,6 +12,8 @@ use uuid::Uuid;
 use session_lib::agent::Agent;
 use session_lib::output_buffer::PendingOutputBuffer;
 use session_lib::session::Session;
+
+use crate::io_task::claude_user_echo_value;
 
 use super::git_metadata::{check_and_send_branch_update_if_branch_changed, GitMetadataState};
 use super::{
@@ -81,15 +82,17 @@ pub(super) async fn handle_wiggum_activation<A: Agent>(
         shared::InputDeliveryStage::ProxyReceived,
     )
     .await;
-    let prompt = wiggum_prompt(&wiggum_input.text);
+    let original_prompt = wiggum_input.text.clone();
+    let prompt = wiggum_prompt(&original_prompt);
+    let display_event = claude_user_echo_value(original_prompt.clone(), session_id);
     *wiggum_state = Some(WiggumState {
-        original_prompt: wiggum_input.text,
+        original_prompt,
         iteration: 1,
         loop_start: Instant::now(),
         loop_durations: Vec::new(),
     });
     if let Err(e) = claude_session
-        .send_input(serde_json::Value::String(prompt))
+        .send_input_with_display(serde_json::Value::String(prompt), Some(display_event))
         .await
     {
         error!("Failed to send wiggum prompt to Claude: {}", e);
@@ -117,6 +120,7 @@ pub(super) async fn handle_wiggum_activation<A: Agent>(
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
     event: Option<session_lib::SessionEvent>,
+    session_id: Uuid,
     output_tx: &mpsc::UnboundedSender<serde_json::Value>,
     ws_write: &SharedWsWrite,
     connection_start: Instant,
@@ -131,8 +135,8 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
         Some(SessionEvent::RawOutput(ref value)) => {
             // Claude visible output now arrives as neutral raw JSON. Re-parse to
             // `ClaudeOutput` for the typed side-effects (wiggum DONE, compaction
-            // reminder, system-reminder echo drop); malformed/non-Claude frames
-            // skip those and are forwarded verbatim, never dropped.
+            // reminder); malformed/non-Claude frames skip those and are
+            // forwarded verbatim, never dropped.
             let Some(output) = super::parse_visible_claude_output(value) else {
                 if output_tx.send(value.clone()).is_err() {
                     error!("Failed to forward Claude output");
@@ -168,23 +172,6 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
                 ClaudeOutput::System(sys) => shared::is_compaction_boundary(sys),
                 _ => false,
             };
-
-            // The portal-features reminder is injected as user input wrapped in
-            // <system-reminder> tags. Claude echoes that back as a User message
-            // on its stdout — if we forward it, the wrapper text leaks into the
-            // user's transcript as if they had typed it. Drop those echoes.
-            if is_system_reminder_echo(&output) {
-                debug!("Dropping system-reminder user echo from transcript");
-                // Skip forwarding and skip the rest of the handler.
-                return None;
-            }
-
-            // Same classification, different disguise: loop-priming user
-            // echoes with no visible text render as blank bubbles (#715).
-            if is_empty_user_echo(&output) {
-                debug!("Dropping empty user echo from transcript");
-                return None;
-            }
 
             // Forward the output
             if output_tx.send(value.clone()).is_err() {
@@ -244,8 +231,13 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
 
                         // Resend the prompt
                         let prompt = wiggum_prompt(&state.original_prompt);
+                        let display_event =
+                            claude_user_echo_value(state.original_prompt.clone(), session_id);
                         if let Err(e) = claude_session
-                            .send_input(serde_json::Value::String(prompt))
+                            .send_input_with_display(
+                                serde_json::Value::String(prompt),
+                                Some(display_event),
+                            )
                             .await
                         {
                             error!("Failed to resend wiggum prompt: {}", e);
@@ -375,45 +367,6 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
     }
 }
 
-/// Check if Claude's result indicates wiggum completion (responded with "DONE")
-/// Is this Claude output Claude's echo of a `<system-reminder>`-wrapped user
-/// input? Those wrapped messages are how we inject the portal-features
-/// reminder (and similar out-of-band context); they shouldn't leak into the
-/// user's transcript as if the user had typed them.
-fn is_system_reminder_echo(output: &ClaudeOutput) -> bool {
-    let ClaudeOutput::User(user) = output else {
-        return false;
-    };
-    user.message.content.iter().any(|block| {
-        matches!(block, ContentBlock::Text(t) if t.text.trim_start().starts_with("<system-reminder>"))
-    })
-}
-
-/// Is this Claude output a user echo whose every text block is empty or
-/// whitespace-only? The CLI occasionally emits these loop-priming echoes;
-/// rendering them fragments the transcript with blank "user" bubbles
-/// (#715). Echoes with no text blocks at all (tool results, images) are
-/// real content and must NOT match.
-fn is_empty_user_echo(output: &ClaudeOutput) -> bool {
-    let ClaudeOutput::User(user) = output else {
-        return false;
-    };
-    let mut saw_text = false;
-    for block in &user.message.content {
-        match block {
-            ContentBlock::Text(t) => {
-                saw_text = true;
-                if !t.text.trim().is_empty() {
-                    return false;
-                }
-            }
-            // Any non-text block means this echo carries real content.
-            _ => return false,
-        }
-    }
-    saw_text
-}
-
 fn check_wiggum_done(result: &claude_codes::io::ResultMessage) -> bool {
     // Check if it was an error (don't continue on errors)
     if result.is_error {
@@ -528,60 +481,6 @@ mod tests {
             result: Some("failed".to_string()),
             ..result_message("failed")
         }
-    }
-
-    /// Build a `ClaudeOutput::User` frame from raw content blocks, the same
-    /// way the CLI ships them.
-    fn user_frame(content: serde_json::Value) -> ClaudeOutput {
-        serde_json::from_value(serde_json::json!({
-            "type": "user",
-            "session_id": "00000000-0000-0000-0000-000000000000",
-            "message": { "role": "user", "content": content }
-        }))
-        .expect("parses as ClaudeOutput")
-    }
-
-    /// #715 predicate contract: drop ONLY user echoes whose every text
-    /// block is empty/whitespace — anything carrying real content (tool
-    /// results, images, non-empty text, or no text blocks at all) must
-    /// render.
-    #[test]
-    fn empty_user_echo_predicate_contract() {
-        // Whitespace-only text → dropped.
-        assert!(is_empty_user_echo(&user_frame(serde_json::json!([
-            { "type": "text", "text": "   \n\t" }
-        ]))));
-        assert!(is_empty_user_echo(&user_frame(serde_json::json!([
-            { "type": "text", "text": "" },
-            { "type": "text", "text": " " }
-        ]))));
-
-        // No content blocks at all → NOT what we filter.
-        assert!(!is_empty_user_echo(&user_frame(serde_json::json!([]))));
-
-        // Tool-result / non-text block → real content, passes through.
-        assert!(!is_empty_user_echo(&user_frame(serde_json::json!([
-            { "type": "tool_result", "tool_use_id": "t1", "content": "ok" }
-        ]))));
-
-        // Mixed empty text + non-text → passes through.
-        assert!(!is_empty_user_echo(&user_frame(serde_json::json!([
-            { "type": "text", "text": "" },
-            { "type": "tool_result", "tool_use_id": "t1", "content": "ok" }
-        ]))));
-
-        // Non-empty text → passes through.
-        assert!(!is_empty_user_echo(&user_frame(serde_json::json!([
-            { "type": "text", "text": "hello" }
-        ]))));
-
-        // Non-user frames never match.
-        let result_frame: ClaudeOutput = serde_json::from_value(serde_json::json!({
-            "type": "system", "subtype": "init",
-            "session_id": "00000000-0000-0000-0000-000000000000"
-        }))
-        .expect("parses");
-        assert!(!is_empty_user_echo(&result_frame));
     }
 
     #[test]

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -23,12 +23,12 @@ pub enum IoCommand {
         /// user-message form.
         text: String,
         delivered: Option<oneshot::Sender<Result<(), String>>>,
-        /// Optional typed portal event to display in place of the agent's echo
-        /// of this input (e.g. an inter-agent `PortalContent::AgentMessage`).
-        /// Claude relies on the proxy's echo-replacement and ignores this;
-        /// Codex — which doesn't echo — emits this verbatim as its synthetic
-        /// echo so inter-agent messages render as the typed card with
-        /// provenance instead of a raw `[message from …]` / JSON user bubble.
+        /// Optional typed portal event to display in place of the user-facing
+        /// text for this input (e.g. an inter-agent
+        /// `PortalContent::AgentMessage`). Agent I/O tasks emit this verbatim
+        /// as their synthetic echo so inter-agent messages render as the typed
+        /// provenance card instead of a raw `[message from …]` / JSON user
+        /// bubble.
         /// Boxed to keep this variant from dominating `IoCommand`'s size.
         display_event: Option<Box<serde_json::Value>>,
     },
@@ -96,9 +96,9 @@ pub enum SessionEvent {
     ///
     /// Both backends now arrive here: the per-agent I/O task classifies its
     /// native output and `Session` forwards each `AgentOutput::Visible` value
-    /// verbatim. Agent-specific consumers (e.g. the Claude proxy
-    /// `output_forwarder`, which re-parses for image/git/echo handling) live at
-    /// the proxy edge, keyed on `agent_type` — `Session` stays neutral.
+    /// verbatim. Agent-specific consumers (e.g. the Claude proxy edge, which
+    /// re-parses for image/git handling and wiggum DONE detection) live outside
+    /// `Session`, keyed on `agent_type` — `Session` stays neutral.
     RawOutput(serde_json::Value),
 
     /// The agent is requesting permission for a tool.

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -327,8 +327,9 @@ impl<A: Agent> Session<A> {
     /// Like [`send_input`](Self::send_input), but carries an optional typed
     /// portal `display_event` to render in place of the agent's echo (see
     /// [`IoCommand::UserInput::display_event`]). The proxy passes the inter-agent
-    /// `PortalContent::AgentMessage` envelope here so the Codex path (which
-    /// can't rely on echo-replacement) still renders the typed card.
+    /// `PortalContent::AgentMessage` envelope here so the agent I/O task can
+    /// synthesize the typed card into the replay buffer instead of relying on a
+    /// CLI echo.
     pub async fn send_input_with_display(
         &mut self,
         content: serde_json::Value,


### PR DESCRIPTION
## Summary
- synthesize Claude-visible user echoes in `claude_io_task` after `client.send` succeeds instead of waiting for the CLI echo
- drop the real CLI echo with FIFO markers, warning on text mismatches and clearing stale markers at `Result` turn boundaries
- move system-reminder and empty-user echo filtering into `claude_io_task`; structured user frames and tool results still pass through
- remove proxy-side echo replacement queues so `display_event` is emitted through the same RawOutput/PendingOutputBuffer path
- update Wiggum to send the suffixed prompt to Claude while displaying the original prompt once per iteration

## Review foci
1. `send_claude_user_input` still ties the delivered/InputAck result to actual `client.send`; synthesized echo rendering is separate, preserving #1236 semantics.
2. FIFO `EchoDropMarker` behavior is deliberately order-based: even a mismatched plain CLI echo consumes exactly one marker and gets dropped.
3. Stale markers are cleared at `ClaudeOutput::Result` so a missing CLI echo cannot eat a future legitimate user frame.
4. Wiggum activation and continuation both use the same IoCommand path with a display event for the original prompt, so each iteration should show exactly one visible user event.
5. This branch moves the #1276 empty/system-reminder echo filters down into `io_task`; if #1276 lands first, I will rebase and remove any upper-layer residue.

## Notes
Synthesized echoes now enter `PendingOutputBuffer` with a sequence number, so user echo delivery becomes reconnect-durable instead of depending on an unbuffered CLI echo observed later by the proxy.

Fixes #1225.

## Tests
- `cargo test -p claude-session-lib echo --lib`
- `cargo test -p claude-session-lib wiggum --lib`
- `cargo test -p claude-session-lib --lib`
- `mkdir -p frontend/dist && RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets`