### PR TITLE
Session archive phase 1: local store, manifests, archival sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "serde_urlencoded",
  "sha2",
  "shared",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -259,6 +260,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "ws-bridge",
+ "zstd",
 ]
 
 [[package]]
@@ -393,6 +395,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -2142,6 +2146,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -4990,3 +5004,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -81,6 +81,7 @@ hyper = { version = "1.10.1", features = ["client", "http1"] }
 hyper-util = { version = "0.1.20", features = ["tokio"] }
 urlencoding = "2.1.3"
 serde_urlencoded = "0.7.1"
+zstd = "0.13"
 
 [build-dependencies]
 memory-serve = "2.1"
@@ -91,3 +92,4 @@ workspace = true
 [dev-dependencies]
 ws-bridge = { workspace = true, features = ["native-client"] }
 uuid = { workspace = true }
+tempfile = "3"

--- a/backend/migrations/2026-07-11-050820_add_archived_at_to_sessions/down.sql
+++ b/backend/migrations/2026-07-11-050820_add_archived_at_to_sessions/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN archived_at;

--- a/backend/migrations/2026-07-11-050820_add_archived_at_to_sessions/up.sql
+++ b/backend/migrations/2026-07-11-050820_add_archived_at_to_sessions/up.sql
@@ -1,0 +1,4 @@
+-- Long-term session archive bookkeeping (#1258 phase 1). NULL = never
+-- archived; the periodic sweep re-archives when last_activity advances past
+-- this (a session that reactivated after archival gets a fresh archive).
+ALTER TABLE sessions ADD COLUMN archived_at TIMESTAMP;

--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -156,6 +156,13 @@ pub struct ArchiveTokenTotals {
     pub subagent: i64,
 }
 
+/// Turn-level aggregates for the manifest, sourced from `turn_metrics`.
+///
+/// Known v1 gaps, documented deliberately: **rate-limit event counts and
+/// reconnect counts have no durable DB source today** (limit events are
+/// transient wire frames; reconnects live only in logs), so they cannot
+/// appear in manifests until something persists them. `errored` counts
+/// turns with `is_error`, which subsumes limit-terminated turns.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct ArchiveTurnStats {
     pub count: i64,
@@ -164,6 +171,14 @@ pub struct ArchiveTurnStats {
     pub stop_reasons: BTreeMap<String, i64>,
     /// Distinct models observed, sorted.
     pub models: Vec<String>,
+    /// Service-tier histogram (e.g. "standard" / "priority").
+    pub service_tiers: BTreeMap<String, i64>,
+    /// Total tool invocations across all turns.
+    pub tool_calls: i64,
+    /// Total stream restarts (auto-retried turns) across all turns.
+    pub stream_restarts: i64,
+    /// Sum of per-turn wall-clock durations, milliseconds.
+    pub total_duration_ms: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -209,8 +209,14 @@ pub struct SessionArchiveManifest {
 /// One transcript line, serialized as NDJSON. `content` is the raw stored
 /// message JSON, embedded as a JSON value so the archive round-trips the
 /// wire content byte-for-byte semantically.
+///
+/// `id` is the message row's UUID — the merge key that lets a re-archive
+/// UNION the existing archived transcript with whatever remains in the hot
+/// DB (phase 2 trims hot messages after archival; a later re-archive must
+/// never shrink the archived transcript).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ArchiveMessageLine {
+    pub id: Uuid,
     pub role: String,
     pub created_at: NaiveDateTime,
     pub agent_type: String,
@@ -443,6 +449,7 @@ mod tests {
         let (u, s) = (Uuid::from_u128(7), Uuid::from_u128(9));
 
         let line = ArchiveMessageLine {
+            id: Uuid::from_u128(11),
             role: "user".into(),
             created_at: chrono::NaiveDate::from_ymd_opt(2026, 7, 11)
                 .unwrap()

--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -1,0 +1,557 @@
+//! Long-term session archive storage (#1258, phase 1).
+//!
+//! Completed sessions are archived outside the hot Postgres tables so
+//! message/session retention can stay bounded without losing audit or
+//! usage history. Phase 1 ships the typed store (local filesystem
+//! backend), the versioned object layout, manifest construction, and the
+//! periodic archival sweep; later phases add retention integration, an
+//! S3-compatible backend, rollups, and UI.
+//!
+//! ## Object layout (schema v1)
+//!
+//! ```text
+//! v1/users/{user_id}/sessions/{session_id}/manifest.json
+//! v1/users/{user_id}/sessions/{session_id}/messages.ndjson.zst
+//! ```
+//!
+//! Keys are deterministic (stable ids only, no user-controlled segments),
+//! so re-archiving a session overwrites in place — the sweep re-archives
+//! whenever `sessions.last_activity` advances past `sessions.archived_at`,
+//! making the whole pipeline idempotent.
+//!
+//! ## Trust model
+//!
+//! The archive backend is operator-controlled infrastructure: anyone with
+//! access to the root path (or, later, the bucket) already holds
+//! deployment-level access. Raw message bodies are archived deliberately —
+//! the feature exists to make provider-bound content auditable — but
+//! transport/auth material (tokens, cookies, secrets) is never part of
+//! session content and must never be added to manifests.
+
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+/// Bump when the manifest shape or object layout changes incompatibly.
+pub const ARCHIVE_SCHEMA_VERSION: u32 = 1;
+
+/// How often the archival sweep runs.
+pub const ARCHIVE_SWEEP_INTERVAL_SECS: u64 = 300;
+
+/// A session must have been idle this long before it's archived, so a
+/// briefly-disconnected session isn't archived mid-flap (reconnects are
+/// routine; see the #1256 lifecycle work).
+pub const ARCHIVE_IDLE_SECS: i64 = 3600;
+
+/// Sessions archived per sweep tick, so one sweep can't monopolize the DB.
+pub const ARCHIVE_SWEEP_BATCH: i64 = 25;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArchiveCompression {
+    Zstd,
+    None,
+}
+
+impl ArchiveCompression {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Zstd => "zstd",
+            Self::None => "none",
+        }
+    }
+
+    fn transcript_suffix(&self) -> &'static str {
+        match self {
+            Self::Zstd => "messages.ndjson.zst",
+            Self::None => "messages.ndjson",
+        }
+    }
+}
+
+/// Validated archive configuration. `None` anywhere upstream means the
+/// feature is disabled (the default, including on hosted deployments).
+#[derive(Debug, Clone)]
+pub struct ArchiveConfig {
+    pub local_root: PathBuf,
+    pub compression: ArchiveCompression,
+    /// When false, only manifests are archived (metadata/rollup mode);
+    /// transcripts stay subject to normal DB retention.
+    pub transcripts: bool,
+}
+
+/// Parse archive settings from the environment. Fail-fast: partial or
+/// contradictory config is an error at startup, not a silent fallback.
+pub fn archive_config_from_env() -> Result<Option<ArchiveConfig>, String> {
+    let backend =
+        std::env::var("PORTAL_SESSION_ARCHIVE_BACKEND").unwrap_or_else(|_| "disabled".to_string());
+    match backend.as_str() {
+        "disabled" => Ok(None),
+        "local" => {
+            let root = std::env::var("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT").map_err(|_| {
+                "PORTAL_SESSION_ARCHIVE_BACKEND=local requires \
+                 PORTAL_SESSION_ARCHIVE_LOCAL_ROOT to be set"
+                    .to_string()
+            })?;
+            if root.trim().is_empty() {
+                return Err("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT must not be empty".to_string());
+            }
+            let compression = match std::env::var("PORTAL_SESSION_ARCHIVE_COMPRESS")
+                .unwrap_or_else(|_| "zstd".to_string())
+                .as_str()
+            {
+                "zstd" => ArchiveCompression::Zstd,
+                "none" => ArchiveCompression::None,
+                other => {
+                    return Err(format!(
+                        "PORTAL_SESSION_ARCHIVE_COMPRESS must be `zstd` or `none`, got `{other}`"
+                    ))
+                }
+            };
+            let transcripts = match std::env::var("PORTAL_SESSION_ARCHIVE_TRANSCRIPTS")
+                .unwrap_or_else(|_| "true".to_string())
+                .as_str()
+            {
+                "true" => true,
+                "false" => false,
+                other => {
+                    return Err(format!(
+                    "PORTAL_SESSION_ARCHIVE_TRANSCRIPTS must be `true` or `false`, got `{other}`"
+                ))
+                }
+            };
+            Ok(Some(ArchiveConfig {
+                local_root: PathBuf::from(root),
+                compression,
+                transcripts,
+            }))
+        }
+        "s3" => Err(
+            "PORTAL_SESSION_ARCHIVE_BACKEND=s3 is not implemented yet (#1258 phase 3); \
+             use `local` or `disabled`"
+                .to_string(),
+        ),
+        other => Err(format!(
+            "PORTAL_SESSION_ARCHIVE_BACKEND must be `disabled`, `local`, or `s3`, got `{other}`"
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Manifest / bundle types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ArchiveTokenTotals {
+    pub input: i64,
+    pub output: i64,
+    pub cache_creation: i64,
+    pub cache_read: i64,
+    pub thinking: i64,
+    pub subagent: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ArchiveTurnStats {
+    pub count: i64,
+    pub errored: i64,
+    /// Stop-reason histogram (BTreeMap for deterministic serialization).
+    pub stop_reasons: BTreeMap<String, i64>,
+    /// Distinct models observed, sorted.
+    pub models: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ArchiveTranscriptInfo {
+    pub object_key: String,
+    pub compression: String,
+    pub message_count: i64,
+    pub bytes: u64,
+}
+
+/// The per-session archive manifest (schema v1). Analytics and admin
+/// surfaces read this; they must never need the transcript body.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SessionArchiveManifest {
+    pub schema_version: u32,
+    pub session_id: Uuid,
+    pub user_id: Uuid,
+    /// Raw email deliberately included for admin reporting (see module
+    /// docs on the trust model).
+    pub owner_email: String,
+    pub owner_name: Option<String>,
+    pub session_name: String,
+    pub agent_type: String,
+    pub status: String,
+    pub working_directory: String,
+    pub hostname: String,
+    pub git_branch: Option<String>,
+    pub repo_url: Option<String>,
+    pub pr_url: Option<String>,
+    pub client_version: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub last_activity: NaiveDateTime,
+    pub archived_at: NaiveDateTime,
+    /// Message-count histogram by role (user/assistant/...).
+    pub message_counts: BTreeMap<String, i64>,
+    pub tokens: ArchiveTokenTotals,
+    pub total_cost_usd: f64,
+    pub turns: ArchiveTurnStats,
+    /// Present iff transcript archival is enabled and messages existed.
+    pub transcript: Option<ArchiveTranscriptInfo>,
+}
+
+/// One transcript line, serialized as NDJSON. `content` is the raw stored
+/// message JSON, embedded as a JSON value so the archive round-trips the
+/// wire content byte-for-byte semantically.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ArchiveMessageLine {
+    pub role: String,
+    pub created_at: NaiveDateTime,
+    pub agent_type: String,
+    pub content: serde_json::Value,
+}
+
+/// Everything needed to write one session's archive.
+pub struct SessionArchiveBundle {
+    pub manifest: SessionArchiveManifest,
+    /// NDJSON transcript body (uncompressed); `None` in metadata-only mode.
+    pub transcript_ndjson: Option<Vec<u8>>,
+}
+
+// ---------------------------------------------------------------------------
+// Object keys
+// ---------------------------------------------------------------------------
+
+pub fn manifest_key(user_id: Uuid, session_id: Uuid) -> String {
+    format!("v1/users/{user_id}/sessions/{session_id}/manifest.json")
+}
+
+pub fn transcript_key(user_id: Uuid, session_id: Uuid, compression: ArchiveCompression) -> String {
+    format!(
+        "v1/users/{user_id}/sessions/{session_id}/{}",
+        compression.transcript_suffix()
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/// Store plus the settings the archival sweep needs at write time.
+pub struct ArchiveRuntime {
+    pub store: ArchiveStore,
+    pub config: ArchiveConfig,
+}
+
+impl ArchiveRuntime {
+    pub fn new(config: ArchiveConfig) -> Self {
+        Self {
+            store: ArchiveStore::from_config(&config),
+            config,
+        }
+    }
+}
+
+/// Typed archive store. An enum (not a trait object) so backends stay a
+/// closed, compiler-checked set; phase 3 adds an `S3` variant.
+pub enum ArchiveStore {
+    Local(LocalArchiveStore),
+}
+
+impl ArchiveStore {
+    pub fn from_config(config: &ArchiveConfig) -> Self {
+        Self::Local(LocalArchiveStore {
+            root: config.local_root.clone(),
+        })
+    }
+
+    /// Write a session's archive: transcript first, manifest last — a
+    /// manifest's existence implies its transcript object is complete.
+    pub fn put_session_archive(
+        &self,
+        bundle: &SessionArchiveBundle,
+        compression: ArchiveCompression,
+    ) -> std::io::Result<()> {
+        match self {
+            Self::Local(store) => store.put_session_archive(bundle, compression),
+        }
+    }
+
+    pub fn get_session_manifest(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+    ) -> std::io::Result<Option<SessionArchiveManifest>> {
+        match self {
+            Self::Local(store) => store.get_session_manifest(user_id, session_id),
+        }
+    }
+}
+
+/// Local-filesystem backend. Objects are plain files under `root`; writes
+/// are atomic (temp file in the destination directory + rename).
+pub struct LocalArchiveStore {
+    root: PathBuf,
+}
+
+impl LocalArchiveStore {
+    fn object_path(&self, key: &str) -> PathBuf {
+        // Keys are built exclusively by `manifest_key`/`transcript_key`
+        // from UUIDs and fixed literals — no user-controlled segments.
+        self.root.join(key)
+    }
+
+    fn write_atomic(&self, key: &str, bytes: &[u8]) -> std::io::Result<()> {
+        let path = self.object_path(key);
+        let dir = path.parent().expect("object keys always have a parent");
+        std::fs::create_dir_all(dir)?;
+        let tmp = dir.join(format!(
+            ".{}.tmp",
+            path.file_name()
+                .expect("object keys always have a file name")
+                .to_string_lossy()
+        ));
+        std::fs::write(&tmp, bytes)?;
+        std::fs::rename(&tmp, &path)
+    }
+
+    fn put_session_archive(
+        &self,
+        bundle: &SessionArchiveBundle,
+        compression: ArchiveCompression,
+    ) -> std::io::Result<()> {
+        let m = &bundle.manifest;
+        if let Some(ndjson) = &bundle.transcript_ndjson {
+            let body: Vec<u8> = match compression {
+                ArchiveCompression::Zstd => zstd::encode_all(ndjson.as_slice(), 0)?,
+                ArchiveCompression::None => ndjson.clone(),
+            };
+            self.write_atomic(&transcript_key(m.user_id, m.session_id, compression), &body)?;
+        }
+        let manifest_json = serde_json::to_vec_pretty(&bundle.manifest)?;
+        self.write_atomic(&manifest_key(m.user_id, m.session_id), &manifest_json)
+    }
+
+    fn get_session_manifest(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+    ) -> std::io::Result<Option<SessionArchiveManifest>> {
+        let path = self.object_path(&manifest_key(user_id, session_id));
+        match std::fs::read(&path) {
+            Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("corrupt manifest at {}: {e}", path.display()),
+                )
+            })?)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Decompress + parse an archived transcript (test/inspection helper).
+pub fn read_transcript(
+    root: &Path,
+    user_id: Uuid,
+    session_id: Uuid,
+    compression: ArchiveCompression,
+) -> std::io::Result<Vec<ArchiveMessageLine>> {
+    let path = root.join(transcript_key(user_id, session_id, compression));
+    let raw = std::fs::read(path)?;
+    let ndjson = match compression {
+        ArchiveCompression::Zstd => zstd::decode_all(raw.as_slice())?,
+        ArchiveCompression::None => raw,
+    };
+    String::from_utf8_lossy(&ndjson)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str(l).map_err(|e| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, format!("bad line: {e}"))
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(user_id: Uuid, session_id: Uuid) -> SessionArchiveManifest {
+        let t = chrono::NaiveDate::from_ymd_opt(2026, 7, 11)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        SessionArchiveManifest {
+            schema_version: ARCHIVE_SCHEMA_VERSION,
+            session_id,
+            user_id,
+            owner_email: "t@t".into(),
+            owner_name: None,
+            session_name: "s".into(),
+            agent_type: "claude".into(),
+            status: "disconnected".into(),
+            working_directory: "/w".into(),
+            hostname: "h".into(),
+            git_branch: None,
+            repo_url: None,
+            pr_url: None,
+            client_version: None,
+            created_at: t,
+            last_activity: t,
+            archived_at: t,
+            message_counts: BTreeMap::from([("user".into(), 2)]),
+            tokens: ArchiveTokenTotals::default(),
+            total_cost_usd: 0.5,
+            turns: ArchiveTurnStats::default(),
+            transcript: None,
+        }
+    }
+
+    #[test]
+    fn keys_are_deterministic_and_partitioned() {
+        let u = Uuid::from_u128(1);
+        let s = Uuid::from_u128(2);
+        assert_eq!(
+            manifest_key(u, s),
+            format!("v1/users/{u}/sessions/{s}/manifest.json")
+        );
+        assert_eq!(
+            transcript_key(u, s, ArchiveCompression::Zstd),
+            format!("v1/users/{u}/sessions/{s}/messages.ndjson.zst")
+        );
+        assert_eq!(
+            transcript_key(u, s, ArchiveCompression::None),
+            format!("v1/users/{u}/sessions/{s}/messages.ndjson")
+        );
+    }
+
+    #[test]
+    fn local_roundtrip_and_idempotent_overwrite() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArchiveStore::Local(LocalArchiveStore {
+            root: tmp.path().to_path_buf(),
+        });
+        let (u, s) = (Uuid::from_u128(7), Uuid::from_u128(9));
+
+        let line = ArchiveMessageLine {
+            role: "user".into(),
+            created_at: chrono::NaiveDate::from_ymd_opt(2026, 7, 11)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+            agent_type: "claude".into(),
+            content: serde_json::json!({"type": "user", "text": "hello"}),
+        };
+        let ndjson = format!("{}\n", serde_json::to_string(&line).unwrap()).into_bytes();
+
+        let mut m = manifest(u, s);
+        m.transcript = Some(ArchiveTranscriptInfo {
+            object_key: transcript_key(u, s, ArchiveCompression::Zstd),
+            compression: "zstd".into(),
+            message_count: 1,
+            bytes: ndjson.len() as u64,
+        });
+        let bundle = SessionArchiveBundle {
+            manifest: m.clone(),
+            transcript_ndjson: Some(ndjson),
+        };
+
+        store
+            .put_session_archive(&bundle, ArchiveCompression::Zstd)
+            .unwrap();
+        // Overwrite with the same deterministic keys must succeed.
+        store
+            .put_session_archive(&bundle, ArchiveCompression::Zstd)
+            .unwrap();
+
+        let got = store.get_session_manifest(u, s).unwrap().expect("manifest");
+        assert_eq!(got, m);
+
+        let lines = read_transcript(tmp.path(), u, s, ArchiveCompression::Zstd).unwrap();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].content["text"], "hello");
+
+        // No temp files left behind (write_atomic names them `.{name}.tmp`).
+        let leftovers: Vec<_> = walk(tmp.path())
+            .into_iter()
+            .filter(|p| {
+                p.file_name()
+                    .is_some_and(|n| n.to_string_lossy().ends_with(".tmp"))
+            })
+            .collect();
+        assert!(leftovers.is_empty(), "temp files leaked: {leftovers:?}");
+    }
+
+    #[test]
+    fn missing_manifest_reads_as_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArchiveStore::Local(LocalArchiveStore {
+            root: tmp.path().to_path_buf(),
+        });
+        assert!(store
+            .get_session_manifest(Uuid::from_u128(1), Uuid::from_u128(2))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn config_parses_and_fails_fast() {
+        // NOTE: env-var tests mutate process state; keep them in ONE test
+        // so parallel test threads can't race each other.
+        let clear = || {
+            for k in [
+                "PORTAL_SESSION_ARCHIVE_BACKEND",
+                "PORTAL_SESSION_ARCHIVE_LOCAL_ROOT",
+                "PORTAL_SESSION_ARCHIVE_COMPRESS",
+                "PORTAL_SESSION_ARCHIVE_TRANSCRIPTS",
+            ] {
+                std::env::remove_var(k);
+            }
+        };
+
+        clear();
+        assert!(archive_config_from_env().unwrap().is_none(), "default off");
+
+        std::env::set_var("PORTAL_SESSION_ARCHIVE_BACKEND", "local");
+        assert!(
+            archive_config_from_env().is_err(),
+            "local without root must fail fast"
+        );
+
+        std::env::set_var("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT", "/tmp/a");
+        let cfg = archive_config_from_env().unwrap().expect("enabled");
+        assert_eq!(cfg.compression, ArchiveCompression::Zstd);
+        assert!(cfg.transcripts, "transcripts default on when enabled");
+
+        std::env::set_var("PORTAL_SESSION_ARCHIVE_BACKEND", "s3");
+        assert!(archive_config_from_env().is_err(), "s3 is phase 3");
+
+        std::env::set_var("PORTAL_SESSION_ARCHIVE_BACKEND", "bogus");
+        assert!(archive_config_from_env().is_err());
+        clear();
+    }
+
+    fn walk(dir: &Path) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for e in entries.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    out.extend(walk(&p));
+                } else {
+                    out.push(p);
+                }
+            }
+        }
+        out
+    }
+}

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -211,7 +211,17 @@ fn archive_one_session(
 
     // Turn aggregates for the manifest (analytics reads these, never the
     // transcript body).
-    type TurnAggRow = (Option<String>, Option<String>, bool, i64, i64);
+    type TurnAggRow = (
+        Option<String>,
+        Option<String>,
+        bool,
+        i64,
+        i64,
+        Option<String>,
+        i32,
+        i32,
+        Option<i64>,
+    );
     let turn_rows: Vec<TurnAggRow> = turn_metrics::table
         .filter(turn_metrics::session_id.eq(session.id))
         .select((
@@ -220,6 +230,10 @@ fn archive_one_session(
             turn_metrics::is_error,
             turn_metrics::thinking_tokens,
             turn_metrics::subagent_tokens,
+            turn_metrics::service_tier,
+            turn_metrics::tool_call_count,
+            turn_metrics::stream_restarts,
+            turn_metrics::total_duration_ms,
         ))
         .load(conn)?;
 
@@ -230,7 +244,8 @@ fn archive_one_session(
     let mut thinking = 0i64;
     let mut subagent = 0i64;
     let mut models_seen = std::collections::BTreeSet::new();
-    for (model, stop_reason, is_error, t, s) in &turn_rows {
+    for (model, stop_reason, is_error, t, s, tier, tool_calls, restarts, duration_ms) in &turn_rows
+    {
         if *is_error {
             turns.errored += 1;
         }
@@ -240,6 +255,12 @@ fn archive_one_session(
         if let Some(model) = model {
             models_seen.insert(model.clone());
         }
+        if let Some(tier) = tier {
+            *turns.service_tiers.entry(tier.clone()).or_default() += 1;
+        }
+        turns.tool_calls += i64::from(*tool_calls);
+        turns.stream_restarts += i64::from(*restarts);
+        turns.total_duration_ms += duration_ms.unwrap_or(0);
         thinking += t;
         subagent += s;
     }

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -191,10 +191,12 @@ fn archive_one_session(
     // Transcript rows, oldest first. Note: hot-DB retention may already
     // have trimmed old messages; the archive preserves what remains (phase
     // 2 orders archival ahead of retention deletion).
-    let rows: Vec<(String, String, chrono::NaiveDateTime, String)> = messages::table
+    type MessageRow = (uuid::Uuid, String, String, chrono::NaiveDateTime, String);
+    let rows: Vec<MessageRow> = messages::table
         .filter(messages::session_id.eq(session.id))
         .order(messages::created_at.asc())
         .select((
+            messages::id,
             messages::role,
             messages::content,
             messages::created_at,
@@ -203,7 +205,7 @@ fn archive_one_session(
         .load(conn)?;
 
     let mut message_counts: BTreeMap<String, i64> = BTreeMap::new();
-    for (role, ..) in &rows {
+    for (_, role, ..) in &rows {
         *message_counts.entry(role.clone()).or_default() += 1;
     }
 
@@ -249,8 +251,9 @@ fn archive_one_session(
 
     let (transcript_ndjson, transcript_info) = if transcripts_enabled {
         let mut ndjson = Vec::new();
-        for (role, content, created_at, agent_type) in &rows {
+        for (id, role, content, created_at, agent_type) in &rows {
             let line = ArchiveMessageLine {
+                id: *id,
                 role: role.clone(),
                 created_at: *created_at,
                 agent_type: agent_type.clone(),

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -97,6 +97,222 @@ pub fn spawn_stale_session_cleanup(pool: DbPool, manager: SessionManager) {
     });
 }
 
+/// Archive terminal sessions to long-term storage (#1258 phase 1).
+///
+/// Selection is idempotent: a session is eligible when it is not active,
+/// has been idle past the grace window, and has never been archived — or
+/// its `last_activity` advanced past its `archived_at` (it reactivated
+/// after archival; deterministic keys make the re-archive an overwrite).
+/// DB + file IO run on the blocking pool.
+pub async fn run_archive_sweep(app_state: Arc<AppState>) {
+    let Some(runtime) = app_state.archive.clone() else {
+        return;
+    };
+    let db_pool = app_state.db_pool.clone();
+    match tokio::task::spawn_blocking(move || archive_pending_sessions(&db_pool, &runtime)).await {
+        Ok(Ok((archived, failed))) => {
+            if archived > 0 || failed > 0 {
+                tracing::info!(
+                    "Archive sweep: {} session(s) archived, {} failed",
+                    archived,
+                    failed
+                );
+            }
+        }
+        Ok(Err(e)) => tracing::error!("ARCHIVE_SWEEP_FAILED: {e}"),
+        Err(e) => tracing::error!("archive sweep task panicked: {e}"),
+    }
+}
+
+/// Public for the integration harness (`backend/tests/harness.rs`), which
+/// drives it against a real Postgres.
+pub fn archive_pending_sessions(
+    pool: &DbPool,
+    runtime: &crate::archive::ArchiveRuntime,
+) -> anyhow::Result<(usize, usize)> {
+    use diesel::prelude::*;
+    use schema::sessions;
+
+    let mut conn = pool.get()?;
+    let cutoff = chrono::Utc::now().naive_utc()
+        - chrono::Duration::seconds(crate::archive::ARCHIVE_IDLE_SECS);
+
+    let eligible: Vec<models::Session> = sessions::table
+        .filter(sessions::status.ne(shared::SessionStatus::Active.as_str()))
+        .filter(sessions::last_activity.lt(cutoff))
+        .filter(
+            sessions::archived_at
+                .is_null()
+                .or(sessions::archived_at.lt(sessions::last_activity.nullable())),
+        )
+        .order(sessions::last_activity.asc())
+        .limit(crate::archive::ARCHIVE_SWEEP_BATCH)
+        .load(&mut conn)?;
+
+    let mut archived = 0;
+    let mut failed = 0;
+    for session in eligible {
+        match archive_one_session(&mut conn, runtime, &session) {
+            Ok(()) => {
+                diesel::update(sessions::table.find(session.id))
+                    .set(sessions::archived_at.eq(chrono::Utc::now().naive_utc()))
+                    .execute(&mut conn)?;
+                archived += 1;
+            }
+            Err(e) => {
+                // Stable marker for alerting, mirroring the retention-path
+                // markers documented in CLAUDE.md.
+                tracing::error!("SESSION_ARCHIVE_FAILED session={}: {e}", session.id);
+                failed += 1;
+            }
+        }
+    }
+    Ok((archived, failed))
+}
+
+fn archive_one_session(
+    conn: &mut diesel::PgConnection,
+    runtime: &crate::archive::ArchiveRuntime,
+    session: &models::Session,
+) -> anyhow::Result<()> {
+    use crate::archive::{
+        transcript_key, ArchiveMessageLine, ArchiveTokenTotals, ArchiveTranscriptInfo,
+        ArchiveTurnStats, SessionArchiveBundle, SessionArchiveManifest, ARCHIVE_SCHEMA_VERSION,
+    };
+    use diesel::prelude::*;
+    use schema::{messages, turn_metrics, users};
+    use std::collections::BTreeMap;
+
+    let (owner_email, owner_name): (String, Option<String>) = users::table
+        .find(session.user_id)
+        .select((users::email, users::name))
+        .first(conn)?;
+
+    // Transcript rows, oldest first. Note: hot-DB retention may already
+    // have trimmed old messages; the archive preserves what remains (phase
+    // 2 orders archival ahead of retention deletion).
+    let rows: Vec<(String, String, chrono::NaiveDateTime, String)> = messages::table
+        .filter(messages::session_id.eq(session.id))
+        .order(messages::created_at.asc())
+        .select((
+            messages::role,
+            messages::content,
+            messages::created_at,
+            messages::agent_type,
+        ))
+        .load(conn)?;
+
+    let mut message_counts: BTreeMap<String, i64> = BTreeMap::new();
+    for (role, ..) in &rows {
+        *message_counts.entry(role.clone()).or_default() += 1;
+    }
+
+    // Turn aggregates for the manifest (analytics reads these, never the
+    // transcript body).
+    type TurnAggRow = (Option<String>, Option<String>, bool, i64, i64);
+    let turn_rows: Vec<TurnAggRow> = turn_metrics::table
+        .filter(turn_metrics::session_id.eq(session.id))
+        .select((
+            turn_metrics::model,
+            turn_metrics::stop_reason,
+            turn_metrics::is_error,
+            turn_metrics::thinking_tokens,
+            turn_metrics::subagent_tokens,
+        ))
+        .load(conn)?;
+
+    let mut turns = ArchiveTurnStats {
+        count: turn_rows.len() as i64,
+        ..Default::default()
+    };
+    let mut thinking = 0i64;
+    let mut subagent = 0i64;
+    let mut models_seen = std::collections::BTreeSet::new();
+    for (model, stop_reason, is_error, t, s) in &turn_rows {
+        if *is_error {
+            turns.errored += 1;
+        }
+        if let Some(reason) = stop_reason {
+            *turns.stop_reasons.entry(reason.clone()).or_default() += 1;
+        }
+        if let Some(model) = model {
+            models_seen.insert(model.clone());
+        }
+        thinking += t;
+        subagent += s;
+    }
+    turns.models = models_seen.into_iter().collect();
+
+    let archived_at = chrono::Utc::now().naive_utc();
+    let transcripts_enabled = runtime.config.transcripts && !rows.is_empty();
+    let compression = runtime.config.compression;
+
+    let (transcript_ndjson, transcript_info) = if transcripts_enabled {
+        let mut ndjson = Vec::new();
+        for (role, content, created_at, agent_type) in &rows {
+            let line = ArchiveMessageLine {
+                role: role.clone(),
+                created_at: *created_at,
+                agent_type: agent_type.clone(),
+                // Stored content is JSON text; embed it as a value so the
+                // archive round-trips it. Non-JSON content (shouldn't
+                // exist) degrades to a JSON string.
+                content: serde_json::from_str(content)
+                    .unwrap_or_else(|_| serde_json::Value::String(content.clone())),
+            };
+            serde_json::to_writer(&mut ndjson, &line)?;
+            ndjson.push(b'\n');
+        }
+        let info = ArchiveTranscriptInfo {
+            object_key: transcript_key(session.user_id, session.id, compression),
+            compression: compression.as_str().to_string(),
+            message_count: rows.len() as i64,
+            bytes: ndjson.len() as u64,
+        };
+        (Some(ndjson), Some(info))
+    } else {
+        (None, None)
+    };
+
+    let bundle = SessionArchiveBundle {
+        manifest: SessionArchiveManifest {
+            schema_version: ARCHIVE_SCHEMA_VERSION,
+            session_id: session.id,
+            user_id: session.user_id,
+            owner_email,
+            owner_name,
+            session_name: session.session_name.clone(),
+            agent_type: session.agent_type.clone(),
+            status: session.status.clone(),
+            working_directory: session.working_directory.clone(),
+            hostname: session.hostname.clone(),
+            git_branch: session.git_branch.clone(),
+            repo_url: session.repo_url.clone(),
+            pr_url: session.pr_url.clone(),
+            client_version: session.client_version.clone(),
+            created_at: session.created_at,
+            last_activity: session.last_activity,
+            archived_at,
+            message_counts,
+            tokens: ArchiveTokenTotals {
+                input: session.input_tokens,
+                output: session.output_tokens,
+                cache_creation: session.cache_creation_tokens,
+                cache_read: session.cache_read_tokens,
+                thinking,
+                subagent,
+            },
+            total_cost_usd: session.total_cost_usd,
+            turns,
+            transcript: transcript_info,
+        },
+        transcript_ndjson,
+    };
+
+    runtime.store.put_session_archive(&bundle, compression)?;
+    Ok(())
+}
+
 /// Evict proxy/launcher connections that have gone silent past their
 /// liveness deadline (see `session_manager/liveness.rs`, #1256). The
 /// eviction cancels each stale connection's socket task, so the client's

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -156,6 +156,9 @@ pub struct ServerConfig {
     /// Authority (host, optionally `:port`) under which per-forward subdomains
     /// are served (docs/PORT_FORWARDING.md). `None` = forwarding disabled.
     pub forward_domain: Option<String>,
+    /// Long-term session archive settings (#1258). `None` = disabled (the
+    /// default, including on hosted deployments).
+    pub archive: Option<crate::archive::ArchiveConfig>,
 }
 
 impl ServerConfig {
@@ -304,6 +307,21 @@ impl ServerConfig {
             None => tracing::info!("Port forwarding disabled (PORTAL_FORWARD_DOMAIN unset)"),
         }
 
+        // Long-term session archive (#1258). Fail-fast on partial config.
+        let archive = crate::archive::archive_config_from_env()
+            .map_err(|e| anyhow::anyhow!("invalid archive configuration: {e}"))?;
+        match &archive {
+            Some(cfg) => tracing::info!(
+                "Session archive enabled: local root {} (compression {}, transcripts {})",
+                cfg.local_root.display(),
+                cfg.compression.as_str(),
+                cfg.transcripts
+            ),
+            None => {
+                tracing::info!("Session archive disabled (PORTAL_SESSION_ARCHIVE_BACKEND unset)")
+            }
+        }
+
         // Fail fast: report every malformed variable at once rather than
         // silently using a default for each.
         if !errors.is_empty() {
@@ -331,6 +349,7 @@ impl ServerConfig {
             image_store_max_bytes,
             image_store_ttl,
             forward_domain,
+            archive,
         })
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -9,6 +9,7 @@
 //! [`AppState`] and drive [`routes::build_router`] against a real server +
 //! Postgres (#1209 item 1, the E2E WS/protocol harness).
 
+pub mod archive;
 pub mod auth;
 pub mod background;
 pub mod config;
@@ -73,6 +74,8 @@ pub struct AppState {
     /// Authority under which per-forward subdomains are served
     /// (docs/PORT_FORWARDING.md). `None` = forwarding disabled.
     pub forward_domain: Option<String>,
+    /// Long-term session archive runtime (#1258). `None` = disabled.
+    pub archive: Option<Arc<archive::ArchiveRuntime>>,
 }
 
 impl AppState {
@@ -152,6 +155,9 @@ pub async fn run() -> anyhow::Result<()> {
             config.image_store_ttl,
         ),
         forward_domain: config.forward_domain,
+        archive: config
+            .archive
+            .map(|cfg| Arc::new(archive::ArchiveRuntime::new(cfg))),
     });
 
     // Build our application with routes
@@ -199,6 +205,14 @@ pub async fn run() -> anyhow::Result<()> {
         app_state.clone(),
         background::run_liveness_sweep,
     );
+    if app_state.archive.is_some() {
+        background::spawn_periodic(
+            "session archive sweep (every 5 minutes)",
+            Duration::from_secs(archive::ARCHIVE_SWEEP_INTERVAL_SECS),
+            app_state.clone(),
+            background::run_archive_sweep,
+        );
+    }
 
     // Run the server with graceful shutdown
     let addr = format!("{}:{}", config.host, config.port);

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -65,6 +65,10 @@ pub struct Session {
     /// (`[{number,url,branch}]`). Surfaces on the wire via `SessionWithRole`'s
     /// flatten, where the frontend deserializes it into `Vec<PrRef>`.
     pub open_prs: serde_json::Value,
+    /// When this session was last archived to long-term storage (#1258).
+    /// `None` = never; the sweep re-archives when `last_activity` advances
+    /// past this.
+    pub archived_at: Option<NaiveDateTime>,
 }
 
 /// Insertable session that specifies the ID (so we can use Claude's session ID)

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -202,6 +202,7 @@ diesel::table! {
         last_launch_attempt_at -> Nullable<Timestamp>,
         launch_lease_until -> Nullable<Timestamp>,
         open_prs -> Jsonb,
+        archived_at -> Nullable<Timestamp>,
     }
 }
 

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -24,13 +24,25 @@ use shared::endpoints::SessionEndpoint;
 use shared::{AgentType, ProxyToServer, RegisterFields, ServerToProxy};
 use tokio::net::TcpListener;
 
-/// Boot the backend (dev mode) on an ephemeral port; returns its address.
-/// Mirrors `backend::run`'s state construction, minus the background tasks.
-async fn spawn_test_app() -> SocketAddr {
+/// Migration/seed guard: harness tests run concurrently against ONE shared
+/// Postgres, and Diesel's migration runner is not safe to race with itself.
+/// Every test acquires the pool through here, which serializes the
+/// migrate+seed step (the lock is released before the test body runs).
+static DB_SETUP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn test_pool() -> backend::db::DbPool {
+    let _guard = DB_SETUP_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let pool = backend::db::create_pool()
         .expect("DATABASE_URL must point to a test Postgres (docker-compose.test.yml)");
     backend::db::run_migrations_logged(&pool).expect("run migrations");
     backend::db::seed_dev_user(&pool).expect("seed dev user");
+    pool
+}
+
+/// Boot the backend (dev mode) on an ephemeral port; returns its address.
+/// Mirrors `backend::run`'s state construction, minus the background tasks.
+async fn spawn_test_app() -> SocketAddr {
+    let pool = test_pool();
 
     let config = ServerConfig::from_env(true).expect("parse server config");
     let oauth = backend::config::build_google_oauth_client(true).expect("oauth client");
@@ -146,9 +158,7 @@ async fn archive_sweep_persists_and_is_idempotent() {
     use backend::schema::{messages, sessions};
     use diesel::prelude::*;
 
-    let pool = backend::db::create_pool().expect("pool");
-    backend::db::run_migrations_logged(&pool).expect("migrations");
-    backend::db::seed_dev_user(&pool).expect("dev user");
+    let pool = test_pool();
     let mut conn = pool.get().expect("conn");
 
     let user_id: uuid::Uuid = backend::schema::users::table

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -54,6 +54,7 @@ async fn spawn_test_app() -> SocketAddr {
         max_image_mb: config.max_image_mb,
         image_store: ImageStore::new(config.image_store_max_bytes, config.image_store_ttl),
         forward_domain: config.forward_domain,
+        archive: None,
     });
 
     let app = backend::routes::build_router(state);
@@ -129,4 +130,152 @@ async fn proxy_register_returns_ack_success() {
     .expect("connection closed before RegisterAck");
 
     assert!(success, "dev-mode register should succeed");
+}
+
+/// #1258 phase 1: the archive sweep persists a manifest + compressed
+/// transcript for a terminal session, marks it archived (idempotent — a
+/// second sweep is a no-op), and re-archives after new activity.
+#[tokio::test]
+async fn archive_sweep_persists_and_is_idempotent() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    }
+    use backend::archive::{read_transcript, ArchiveCompression, ArchiveConfig, ArchiveRuntime};
+    use backend::models::{NewMessage, NewSessionWithId};
+    use backend::schema::{messages, sessions};
+    use diesel::prelude::*;
+
+    let pool = backend::db::create_pool().expect("pool");
+    backend::db::run_migrations_logged(&pool).expect("migrations");
+    backend::db::seed_dev_user(&pool).expect("dev user");
+    let mut conn = pool.get().expect("conn");
+
+    let user_id: uuid::Uuid = backend::schema::users::table
+        .select(backend::schema::users::id)
+        .order(backend::schema::users::created_at.asc())
+        .first(&mut conn)
+        .expect("seeded user");
+
+    // A terminal session, idle for two hours.
+    let session_id = uuid::Uuid::new_v4();
+    let stale = chrono::Utc::now().naive_utc() - chrono::Duration::hours(2);
+    diesel::insert_into(sessions::table)
+        .values(&NewSessionWithId {
+            id: session_id,
+            user_id,
+            session_name: "archive-harness".to_string(),
+            session_key: session_id.to_string(),
+            working_directory: "/tmp/archive-harness".to_string(),
+            status: shared::SessionStatus::Disconnected.as_str().to_string(),
+            git_branch: Some("main".to_string()),
+            client_version: None,
+            hostname: "harness".to_string(),
+            launcher_id: None,
+            agent_type: "claude".to_string(),
+            repo_url: None,
+            scheduled_task_id: None,
+            paused: false,
+            claude_args: serde_json::Value::Array(vec![]),
+        })
+        .execute(&mut conn)
+        .expect("insert session");
+    diesel::update(sessions::table.find(session_id))
+        .set((
+            sessions::last_activity.eq(stale),
+            sessions::created_at.eq(stale),
+        ))
+        .execute(&mut conn)
+        .expect("backdate session");
+
+    for (role, content) in [
+        ("user", r#"{"type":"user","text":"hello"}"#),
+        ("assistant", r#"{"type":"assistant","text":"hi"}"#),
+    ] {
+        diesel::insert_into(messages::table)
+            .values(&NewMessage {
+                session_id,
+                role: role.to_string(),
+                content: content.to_string(),
+                user_id,
+                agent_type: "claude".to_string(),
+                provenance_kind: None,
+                provenance_session_id: None,
+                provenance_agent_type: None,
+            })
+            .execute(&mut conn)
+            .expect("insert message");
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime = ArchiveRuntime::new(ArchiveConfig {
+        local_root: tmp.path().to_path_buf(),
+        compression: ArchiveCompression::Zstd,
+        transcripts: true,
+    });
+
+    let (archived, failed) =
+        backend::background::archive_pending_sessions(&pool, &runtime).expect("sweep");
+    assert!(failed == 0, "no failures expected");
+    assert!(archived >= 1, "our session must be archived");
+
+    let manifest = runtime
+        .store
+        .get_session_manifest(user_id, session_id)
+        .expect("read manifest")
+        .expect("manifest exists");
+    assert_eq!(manifest.schema_version, 1);
+    assert_eq!(manifest.session_name, "archive-harness");
+    assert_eq!(manifest.message_counts.get("user"), Some(&1));
+    assert_eq!(manifest.message_counts.get("assistant"), Some(&1));
+    let transcript = manifest.transcript.as_ref().expect("transcript info");
+    assert_eq!(transcript.message_count, 2);
+
+    let lines = read_transcript(tmp.path(), user_id, session_id, ArchiveCompression::Zstd)
+        .expect("read transcript");
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0].content["text"], "hello");
+
+    // Idempotent: our session must not be picked up again unchanged.
+    // (Other stale sessions in a shared dev DB may legitimately archive.)
+    let archived_at: Option<chrono::NaiveDateTime> = sessions::table
+        .find(session_id)
+        .select(sessions::archived_at)
+        .first(&mut conn)
+        .expect("read archived_at");
+    let first_mark = archived_at.expect("archived_at set");
+    backend::background::archive_pending_sessions(&pool, &runtime).expect("second sweep");
+    let second_mark: Option<chrono::NaiveDateTime> = sessions::table
+        .find(session_id)
+        .select(sessions::archived_at)
+        .first(&mut conn)
+        .expect("re-read archived_at");
+    assert_eq!(
+        second_mark,
+        Some(first_mark),
+        "unchanged session not re-archived"
+    );
+
+    // New activity past archived_at → eligible again.
+    diesel::update(sessions::table.find(session_id))
+        .set(sessions::last_activity.eq(chrono::Utc::now().naive_utc()
+            - chrono::Duration::seconds(backend::archive::ARCHIVE_IDLE_SECS + 60)))
+        .execute(&mut conn)
+        .expect("bump activity");
+    // Guard: only when the bumped activity is later than the mark.
+    diesel::update(sessions::table.find(session_id))
+        .set(sessions::archived_at.eq(stale))
+        .execute(&mut conn)
+        .expect("backdate mark");
+    let (rearchived, _) =
+        backend::background::archive_pending_sessions(&pool, &runtime).expect("third sweep");
+    assert!(rearchived >= 1, "reactivated session re-archives");
+
+    // Cleanup.
+    diesel::delete(messages::table.filter(messages::session_id.eq(session_id)))
+        .execute(&mut conn)
+        .ok();
+    diesel::delete(sessions::table.find(session_id))
+        .execute(&mut conn)
+        .ok();
 }


### PR DESCRIPTION
#1258 phase 1 of 5 (storage abstraction + manifests). Later phases: retention integration, S3 backend, rollups + query APIs, UI.

## What ships

**Typed archive store** (`backend/src/archive.rs`) with the versioned object layout from the issue:
```
v1/users/{user_id}/sessions/{session_id}/manifest.json
v1/users/{user_id}/sessions/{session_id}/messages.ndjson.zst
```
Keys are deterministic (UUIDs + fixed literals only — no user-controlled path segments), the local backend writes atomically (temp + rename), and the store is a closed enum rather than a trait object so phase 3's S3 variant is a compiler-checked addition.

**Schema-v1 manifests** carry everything the issue's data-model section lists that the DB has today: owner identity (raw email deliberately, per the documented trust model), agent/model mix, git/repo/PR context, per-role message counts, token totals **including thinking + subagent** (aggregated from `turn_metrics` — the #1278 rollup work feeds this), cost, turn counts/stop-reason histogram/error counts. Analytics never needs to open a transcript.

**Archival sweep** (`spawn_periodic`, 5 min): archives sessions that are non-active, idle past a 1-hour grace (so reconnect flaps don't archive mid-session), and either never archived or reactivated since (`last_activity > archived_at`) — making the pipeline **idempotent by construction** and giving repair/backfill for free (a failed archive is simply retried next sweep; failures log a stable `SESSION_ARCHIVE_FAILED` marker for alerting). New `sessions.archived_at` column tracks state.

**Fail-fast config** per the issue's strawman envs: `disabled` (default, including hosted) | `local`; `s3` is rejected with a phase-3 pointer; partial config errors at startup. Documented in CLAUDE.md's env table.

## Decisions taken (from the issue's open questions)
- Transcripts default **on** when a backend is configured (`PORTAL_SESSION_ARCHIVE_TRANSCRIPTS=false` for metadata-only) — the audit use-case is the point.
- Rollup strategy deferred to phase 4, but the manifest is designed so either Postgres-index or object-rollup strategies can be built from it; the sweep's re-archive semantics already define rebuild behavior.
- No new heavyweight deps: `zstd` only; the S3 crate decision is deferred to phase 3.

## Tests
- Unit: key determinism/partitioning, local write→read roundtrip + idempotent overwrite + no temp-file leaks, missing-manifest → None, config fail-fast matrix (single test to avoid env races).
- **Integration (real Postgres, `tests/harness.rs`)**: seeds a terminal session + messages, runs the sweep, verifies manifest fields + decompressed transcript content, proves a second sweep is a no-op, and proves a reactivated session re-archives.

Gates: workspace clippy -Dwarnings, 157 backend unit tests, harness green against Postgres, fmt.