### PR TITLE
Archive phase 2: retention gating, merge-on-rearchive, stats

### DIFF
--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -268,6 +268,7 @@ pub fn transcript_key(user_id: Uuid, session_id: Uuid, compression: ArchiveCompr
 pub struct ArchiveRuntime {
     pub store: ArchiveStore,
     pub config: ArchiveConfig,
+    pub stats: ArchiveStats,
 }
 
 impl ArchiveRuntime {
@@ -275,8 +276,59 @@ impl ArchiveRuntime {
         Self {
             store: ArchiveStore::from_config(&config),
             config,
+            stats: ArchiveStats::default(),
         }
     }
+}
+
+/// Process-lifetime archival counters (#1258 phase 2 observability).
+/// Logged by the sweep; a later phase surfaces them on an admin endpoint.
+#[derive(Default)]
+pub struct ArchiveStats {
+    pub archived_total: std::sync::atomic::AtomicU64,
+    pub failed_total: std::sync::atomic::AtomicU64,
+    pub bytes_written: std::sync::atomic::AtomicU64,
+    pub last_error: std::sync::Mutex<Option<String>>,
+}
+
+impl ArchiveStats {
+    pub fn record_success(&self, bytes: u64) {
+        use std::sync::atomic::Ordering;
+        self.archived_total.fetch_add(1, Ordering::Relaxed);
+        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    pub fn record_failure(&self, error: &str) {
+        use std::sync::atomic::Ordering;
+        self.failed_total.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut last) = self.last_error.lock() {
+            *last = Some(error.to_string());
+        }
+    }
+}
+
+/// Union an existing archived transcript with the messages currently in the
+/// hot DB, keyed by message id (#1258 phase 2). Retention may have trimmed
+/// hot rows that only exist in the archive, and the DB may hold rows newer
+/// than the archive — the merge keeps both, ordered by `created_at` (id as
+/// a deterministic tiebreaker). A re-archive can therefore never shrink an
+/// archived transcript.
+pub fn merge_transcript_lines(
+    existing: Vec<ArchiveMessageLine>,
+    current: Vec<ArchiveMessageLine>,
+) -> Vec<ArchiveMessageLine> {
+    let mut by_id: BTreeMap<Uuid, ArchiveMessageLine> = BTreeMap::new();
+    for line in existing {
+        by_id.insert(line.id, line);
+    }
+    // Current DB rows win on id collision (content is immutable in
+    // practice; this just prefers the freshest serialization).
+    for line in current {
+        by_id.insert(line.id, line);
+    }
+    let mut merged: Vec<ArchiveMessageLine> = by_id.into_values().collect();
+    merged.sort_by(|a, b| (a.created_at, a.id).cmp(&(b.created_at, b.id)));
+    merged
 }
 
 /// Typed archive store. An enum (not a trait object) so backends stay a
@@ -311,6 +363,25 @@ impl ArchiveStore {
     ) -> std::io::Result<Option<SessionArchiveManifest>> {
         match self {
             Self::Local(store) => store.get_session_manifest(user_id, session_id),
+        }
+    }
+
+    /// Read an archived transcript's lines, or `None` if no transcript
+    /// object exists yet. Used by the merge-on-rearchive path.
+    pub fn read_transcript_lines(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+        compression: ArchiveCompression,
+    ) -> std::io::Result<Option<Vec<ArchiveMessageLine>>> {
+        match self {
+            Self::Local(store) => {
+                match read_transcript(&store.root, user_id, session_id, compression) {
+                    Ok(lines) => Ok(Some(lines)),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                    Err(e) => Err(e),
+                }
+            }
         }
     }
 }
@@ -511,6 +582,53 @@ mod tests {
             })
             .collect();
         assert!(leftovers.is_empty(), "temp files leaked: {leftovers:?}");
+    }
+
+    /// #1258 phase 2: the merge is a union by message id, ordered by
+    /// (created_at, id), with current DB rows winning id collisions — a
+    /// re-archive can only grow a transcript, never shrink it.
+    #[test]
+    fn merge_never_shrinks_and_orders_deterministically() {
+        let t0 = chrono::NaiveDate::from_ymd_opt(2026, 7, 11)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        let line = |id: u128, secs: u32, text: &str| ArchiveMessageLine {
+            id: Uuid::from_u128(id),
+            role: "user".into(),
+            created_at: t0 + chrono::Duration::seconds(secs as i64),
+            agent_type: "claude".into(),
+            content: serde_json::json!({ "text": text }),
+        };
+
+        // Archive holds 1,2 (retention later trimmed them from the DB);
+        // DB holds 2 (fresher serialization) and 3 (new).
+        let existing = vec![line(1, 0, "one"), line(2, 10, "two-old")];
+        let current = vec![line(2, 10, "two-new"), line(3, 20, "three")];
+
+        let merged = merge_transcript_lines(existing, current);
+        let texts: Vec<&str> = merged
+            .iter()
+            .map(|l| l.content["text"].as_str().unwrap())
+            .collect();
+        assert_eq!(texts, vec!["one", "two-new", "three"]);
+
+        // Idempotent: merging the result with itself changes nothing.
+        let again = merge_transcript_lines(
+            merged.iter().map(clone_line).collect(),
+            merged.iter().map(clone_line).collect(),
+        );
+        assert_eq!(again.len(), merged.len());
+    }
+
+    fn clone_line(l: &ArchiveMessageLine) -> ArchiveMessageLine {
+        ArchiveMessageLine {
+            id: l.id,
+            role: l.role.clone(),
+            created_at: l.created_at,
+            agent_type: l.agent_type.clone(),
+            content: l.content.clone(),
+        }
     }
 
     #[test]

--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -327,7 +327,7 @@ pub fn merge_transcript_lines(
         by_id.insert(line.id, line);
     }
     let mut merged: Vec<ArchiveMessageLine> = by_id.into_values().collect();
-    merged.sort_by(|a, b| (a.created_at, a.id).cmp(&(b.created_at, b.id)));
+    merged.sort_by_key(|line| (line.created_at, line.id));
     merged
 }
 

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -152,19 +152,10 @@ pub fn archive_pending_sessions(
     let mut archived = 0;
     let mut failed = 0;
     for session in eligible {
-        match archive_one_session(&mut conn, runtime, &session) {
-            Ok(()) => {
-                diesel::update(sessions::table.find(session.id))
-                    .set(sessions::archived_at.eq(chrono::Utc::now().naive_utc()))
-                    .execute(&mut conn)?;
-                archived += 1;
-            }
-            Err(e) => {
-                // Stable marker for alerting, mirroring the retention-path
-                // markers documented in CLAUDE.md.
-                tracing::error!("SESSION_ARCHIVE_FAILED session={}: {e}", session.id);
-                failed += 1;
-            }
+        if ensure_session_archived(&mut conn, runtime, &session) {
+            archived += 1;
+        } else {
+            failed += 1;
         }
     }
     Ok((archived, failed))
@@ -204,9 +195,35 @@ fn archive_one_session(
         ))
         .load(conn)?;
 
+    let current_lines: Vec<ArchiveMessageLine> = rows
+        .into_iter()
+        .map(
+            |(id, role, content, created_at, agent_type)| ArchiveMessageLine {
+                id,
+                role,
+                created_at,
+                agent_type,
+                // Stored content is JSON text; embed it as a value so the
+                // archive round-trips it. Non-JSON content (shouldn't exist)
+                // degrades to a JSON string.
+                content: serde_json::from_str(&content)
+                    .unwrap_or_else(|_| serde_json::Value::String(content)),
+            },
+        )
+        .collect();
+
+    // Merge with any previously-archived transcript (#1258 phase 2):
+    // retention may have trimmed hot rows that only survive in the
+    // archive; a re-archive must never shrink it.
+    let existing_lines = runtime
+        .store
+        .read_transcript_lines(session.user_id, session.id, runtime.config.compression)?
+        .unwrap_or_default();
+    let merged_lines = crate::archive::merge_transcript_lines(existing_lines, current_lines);
+
     let mut message_counts: BTreeMap<String, i64> = BTreeMap::new();
-    for (_, role, ..) in &rows {
-        *message_counts.entry(role.clone()).or_default() += 1;
+    for line in &merged_lines {
+        *message_counts.entry(line.role.clone()).or_default() += 1;
     }
 
     // Turn aggregates for the manifest (analytics reads these, never the
@@ -267,30 +284,19 @@ fn archive_one_session(
     turns.models = models_seen.into_iter().collect();
 
     let archived_at = chrono::Utc::now().naive_utc();
-    let transcripts_enabled = runtime.config.transcripts && !rows.is_empty();
+    let transcripts_enabled = runtime.config.transcripts && !merged_lines.is_empty();
     let compression = runtime.config.compression;
 
     let (transcript_ndjson, transcript_info) = if transcripts_enabled {
         let mut ndjson = Vec::new();
-        for (id, role, content, created_at, agent_type) in &rows {
-            let line = ArchiveMessageLine {
-                id: *id,
-                role: role.clone(),
-                created_at: *created_at,
-                agent_type: agent_type.clone(),
-                // Stored content is JSON text; embed it as a value so the
-                // archive round-trips it. Non-JSON content (shouldn't
-                // exist) degrades to a JSON string.
-                content: serde_json::from_str(content)
-                    .unwrap_or_else(|_| serde_json::Value::String(content.clone())),
-            };
-            serde_json::to_writer(&mut ndjson, &line)?;
+        for line in &merged_lines {
+            serde_json::to_writer(&mut ndjson, line)?;
             ndjson.push(b'\n');
         }
         let info = ArchiveTranscriptInfo {
             object_key: transcript_key(session.user_id, session.id, compression),
             compression: compression.as_str().to_string(),
-            message_count: rows.len() as i64,
+            message_count: merged_lines.len() as i64,
             bytes: ndjson.len() as u64,
         };
         (Some(ndjson), Some(info))
@@ -333,8 +339,117 @@ fn archive_one_session(
         transcript_ndjson,
     };
 
+    let bytes = bundle
+        .transcript_ndjson
+        .as_ref()
+        .map(|b| b.len() as u64)
+        .unwrap_or(0);
     runtime.store.put_session_archive(&bundle, compression)?;
+    runtime.stats.record_success(bytes);
     Ok(())
+}
+
+/// Archive every session whose messages the retention trim is about to
+/// touch (#1258 phase 2): sessions holding messages older than the age
+/// cutoff, plus sessions over the per-session count cap. Unlike the idle
+/// sweep, this deliberately ignores idle/status eligibility — an ACTIVE
+/// long-running session gets its history captured before it's trimmed,
+/// and merge-on-rearchive folds later messages in.
+fn archive_retention_candidates(
+    conn: &mut diesel::PgConnection,
+    runtime: &crate::archive::ArchiveRuntime,
+    config: &handlers::retention::RetentionConfig,
+) {
+    use diesel::dsl::count_star;
+    use diesel::prelude::*;
+    use schema::{messages, sessions};
+
+    let mut affected: std::collections::HashSet<uuid::Uuid> = std::collections::HashSet::new();
+
+    if config.retention_days > 0 {
+        let cutoff = chrono::Utc::now().naive_utc()
+            - chrono::Duration::days(i64::from(config.retention_days));
+        match messages::table
+            .filter(messages::created_at.lt(cutoff))
+            .select(messages::session_id)
+            .distinct()
+            .load::<uuid::Uuid>(conn)
+        {
+            Ok(ids) => affected.extend(ids),
+            Err(e) => tracing::error!("Failed to query age-retention candidates: {e}"),
+        }
+    }
+
+    match messages::table
+        .group_by(messages::session_id)
+        .having(count_star().gt(config.max_messages_per_session))
+        .select(messages::session_id)
+        .load::<uuid::Uuid>(conn)
+    {
+        Ok(ids) => affected.extend(ids),
+        Err(e) => tracing::error!("Failed to query count-retention candidates: {e}"),
+    }
+
+    if affected.is_empty() {
+        return;
+    }
+
+    let candidates: Vec<models::Session> = match sessions::table
+        .filter(sessions::id.eq_any(affected.iter().copied().collect::<Vec<_>>()))
+        .load(conn)
+    {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("Failed to load retention-candidate sessions: {e}");
+            return;
+        }
+    };
+
+    let mut archived = 0;
+    for session in &candidates {
+        if ensure_session_archived(conn, runtime, session) {
+            archived += 1;
+        }
+    }
+    if archived > 0 {
+        tracing::info!(
+            "Pre-retention archive: {} of {} candidate session(s) captured",
+            archived,
+            candidates.len()
+        );
+    }
+}
+
+/// Archive `session` if its archive is missing or stale, updating
+/// `archived_at` on success. Returns whether the session now has a fresh
+/// archive. Shared by the sweep and the retention gates (#1258 phase 2).
+fn ensure_session_archived(
+    conn: &mut diesel::PgConnection,
+    runtime: &crate::archive::ArchiveRuntime,
+    session: &models::Session,
+) -> bool {
+    use diesel::prelude::*;
+    use schema::sessions;
+
+    let fresh = session
+        .archived_at
+        .is_some_and(|archived| archived >= session.last_activity);
+    if fresh {
+        return true;
+    }
+    match archive_one_session(conn, runtime, session) {
+        Ok(()) => {
+            let _ = diesel::update(sessions::table.find(session.id))
+                .set(sessions::archived_at.eq(chrono::Utc::now().naive_utc()))
+                .execute(conn);
+            true
+        }
+        Err(e) => {
+            runtime.stats.record_failure(&e.to_string());
+            tracing::error!("SESSION_ARCHIVE_FAILED session={}: {e}", session.id);
+            false
+        }
+    }
 }
 
 /// Evict proxy/launcher connections that have gone silent past their
@@ -483,6 +598,15 @@ pub async fn run_retention_cleanup(app_state: Arc<AppState>) {
         app_state.message_retention_days,
     );
 
+    // #1258 phase 2: capture messages into the archive BEFORE the trim
+    // deletes them from the hot DB. Sessions whose archive attempt fails
+    // still get trimmed (best-effort with an explicit recorded failure) —
+    // the merge-on-rearchive semantics mean anything captured earlier is
+    // never lost, only the failed delta.
+    if let Some(runtime) = &app_state.archive {
+        archive_retention_candidates(&mut conn, runtime, &config);
+    }
+
     let (age_deleted, count_deleted) = run_retention_cleanup(&mut conn, session_ids, config);
 
     if age_deleted > 0 || count_deleted > 0 {
@@ -535,7 +659,18 @@ pub async fn run_session_age_cleanup(app_state: Arc<AppState>) {
     }
 
     let mut deleted = 0;
+    let mut held = 0;
     for session in &old_sessions {
+        // #1258 phase 2: when archiving is enabled, an eligible session is
+        // only deleted once it has a fresh archive; on archive failure the
+        // deletion is HELD (retried next cycle) and the failure recorded —
+        // retention can never silently destroy the last copy.
+        if let Some(runtime) = &app_state.archive {
+            if !ensure_session_archived(&mut conn, runtime, session) {
+                held += 1;
+                continue;
+            }
+        }
         match delete_session_with_data(&mut conn, session, true) {
             Ok(_) => deleted += 1,
             Err(e) => tracing::error!("Failed to delete old session {}: {:?}", session.id, e),
@@ -543,9 +678,14 @@ pub async fn run_session_age_cleanup(app_state: Arc<AppState>) {
     }
 
     tracing::info!(
-        "Session age cleanup: deleted {} sessions older than {} days",
+        "Session age cleanup: deleted {} sessions older than {} days{}",
         deleted,
-        max_days
+        max_days,
+        if held > 0 {
+            format!(" ({held} held pending archive)")
+        } else {
+            String::new()
+        }
     );
 }
 

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -197,19 +197,22 @@ fn archive_one_session(
 
     let current_lines: Vec<ArchiveMessageLine> = rows
         .into_iter()
-        .map(
-            |(id, role, content, created_at, agent_type)| ArchiveMessageLine {
+        .map(|(id, role, content, created_at, agent_type)| {
+            // Stored content is JSON text; embed it as a value so the
+            // archive round-trips it. Non-JSON content (shouldn't exist)
+            // degrades to a JSON string.
+            let content = match serde_json::from_str(&content) {
+                Ok(value) => value,
+                Err(_) => serde_json::Value::String(content),
+            };
+            ArchiveMessageLine {
                 id,
                 role,
                 created_at,
                 agent_type,
-                // Stored content is JSON text; embed it as a value so the
-                // archive round-trips it. Non-JSON content (shouldn't exist)
-                // degrades to a JSON string.
-                content: serde_json::from_str(&content)
-                    .unwrap_or_else(|_| serde_json::Value::String(content)),
-            },
-        )
+                content,
+            }
+        })
         .collect();
 
     // Merge with any previously-archived transcript (#1258 phase 2):

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -144,6 +144,11 @@ async fn proxy_register_returns_ack_success() {
     assert!(success, "dev-mode register should succeed");
 }
 
+/// The archive tests each run a global sweep against the SHARED test
+/// Postgres — two sweeps racing can re-mark each other's sessions and
+/// break idempotency assertions. Serialize them.
+static ARCHIVE_DB_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// #1258 phase 1: the archive sweep persists a manifest + compressed
 /// transcript for a terminal session, marks it archived (idempotent — a
 /// second sweep is a no-op), and re-archives after new activity.
@@ -153,6 +158,7 @@ async fn archive_sweep_persists_and_is_idempotent() {
         eprintln!("skipping: DATABASE_URL not set");
         return;
     }
+    let _guard = ARCHIVE_DB_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     use backend::archive::{read_transcript, ArchiveCompression, ArchiveConfig, ArchiveRuntime};
     use backend::models::{NewMessage, NewSessionWithId};
     use backend::schema::{messages, sessions};
@@ -282,6 +288,142 @@ async fn archive_sweep_persists_and_is_idempotent() {
     assert!(rearchived >= 1, "reactivated session re-archives");
 
     // Cleanup.
+    diesel::delete(messages::table.filter(messages::session_id.eq(session_id)))
+        .execute(&mut conn)
+        .ok();
+    diesel::delete(sessions::table.find(session_id))
+        .execute(&mut conn)
+        .ok();
+}
+
+/// #1258 phase 2: a re-archive after hot-DB messages were trimmed must
+/// MERGE with the archived transcript, never shrink it.
+#[tokio::test]
+async fn rearchive_after_trim_merges_transcript() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    }
+    let _guard = ARCHIVE_DB_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    use backend::archive::{read_transcript, ArchiveCompression, ArchiveConfig, ArchiveRuntime};
+    use backend::models::{NewMessage, NewSessionWithId};
+    use backend::schema::{messages, sessions};
+    use diesel::prelude::*;
+
+    let pool = backend::db::create_pool().expect("pool");
+    backend::db::run_migrations_logged(&pool).expect("migrations");
+    backend::db::seed_dev_user(&pool).expect("dev user");
+    let mut conn = pool.get().expect("conn");
+    let user_id: uuid::Uuid = backend::schema::users::table
+        .select(backend::schema::users::id)
+        .order(backend::schema::users::created_at.asc())
+        .first(&mut conn)
+        .expect("seeded user");
+
+    let session_id = uuid::Uuid::new_v4();
+    let stale = chrono::Utc::now().naive_utc() - chrono::Duration::hours(2);
+    diesel::insert_into(sessions::table)
+        .values(&NewSessionWithId {
+            id: session_id,
+            user_id,
+            session_name: "merge-harness".to_string(),
+            session_key: session_id.to_string(),
+            working_directory: "/tmp/merge-harness".to_string(),
+            status: shared::SessionStatus::Disconnected.as_str().to_string(),
+            git_branch: None,
+            client_version: None,
+            hostname: "harness".to_string(),
+            launcher_id: None,
+            agent_type: "claude".to_string(),
+            repo_url: None,
+            scheduled_task_id: None,
+            paused: false,
+            claude_args: serde_json::Value::Array(vec![]),
+        })
+        .execute(&mut conn)
+        .expect("insert session");
+    diesel::update(sessions::table.find(session_id))
+        .set(sessions::last_activity.eq(stale))
+        .execute(&mut conn)
+        .expect("backdate");
+
+    let insert_msg = |conn: &mut diesel::PgConnection, text: &str| {
+        diesel::insert_into(messages::table)
+            .values(&NewMessage {
+                session_id,
+                role: "user".to_string(),
+                content: format!(r#"{{"text":"{text}"}}"#),
+                user_id,
+                agent_type: "claude".to_string(),
+                provenance_kind: None,
+                provenance_session_id: None,
+                provenance_agent_type: None,
+            })
+            .execute(conn)
+            .expect("insert message");
+    };
+    insert_msg(&mut conn, "first");
+    insert_msg(&mut conn, "second");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime = ArchiveRuntime::new(ArchiveConfig {
+        local_root: tmp.path().to_path_buf(),
+        compression: ArchiveCompression::Zstd,
+        transcripts: true,
+    });
+
+    // First archive captures both messages.
+    backend::background::archive_pending_sessions(&pool, &runtime).expect("first sweep");
+    assert_eq!(
+        read_transcript(tmp.path(), user_id, session_id, ArchiveCompression::Zstd)
+            .expect("read")
+            .len(),
+        2
+    );
+
+    // Retention trims one hot row; a third message arrives; re-archive.
+    diesel::delete(
+        messages::table
+            .filter(messages::session_id.eq(session_id))
+            .filter(messages::content.like("%first%")),
+    )
+    .execute(&mut conn)
+    .expect("trim");
+    insert_msg(&mut conn, "third");
+    diesel::update(sessions::table.find(session_id))
+        .set((
+            sessions::last_activity.eq(chrono::Utc::now().naive_utc()
+                - chrono::Duration::seconds(backend::archive::ARCHIVE_IDLE_SECS + 60)),
+            sessions::archived_at.eq(stale),
+        ))
+        .execute(&mut conn)
+        .expect("make stale again");
+    backend::background::archive_pending_sessions(&pool, &runtime).expect("second sweep");
+
+    let lines = read_transcript(tmp.path(), user_id, session_id, ArchiveCompression::Zstd)
+        .expect("read merged");
+    let texts: Vec<String> = lines
+        .iter()
+        .map(|l| l.content["text"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert_eq!(
+        lines.len(),
+        3,
+        "merge must keep the trimmed message: {texts:?}"
+    );
+    assert!(
+        texts.contains(&"first".to_string()),
+        "trimmed message survives"
+    );
+    assert!(texts.contains(&"third".to_string()), "new message included");
+
+    let manifest = runtime
+        .store
+        .get_session_manifest(user_id, session_id)
+        .expect("manifest read")
+        .expect("manifest");
+    assert_eq!(manifest.message_counts.get("user"), Some(&3));
+
     diesel::delete(messages::table.filter(messages::session_id.eq(session_id)))
         .execute(&mut conn)
         .ok();

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -310,9 +310,7 @@ async fn rearchive_after_trim_merges_transcript() {
     use backend::schema::{messages, sessions};
     use diesel::prelude::*;
 
-    let pool = backend::db::create_pool().expect("pool");
-    backend::db::run_migrations_logged(&pool).expect("migrations");
-    backend::db::seed_dev_user(&pool).expect("dev user");
+    let pool = test_pool();
     let mut conn = pool.get().expect("conn");
     let user_id: uuid::Uuid = backend::schema::users::table
         .select(backend::schema::users::id)


### PR DESCRIPTION
#1258 phase 2 (stacked on #1285). Retention can no longer destroy the last copy of anything.

## The invariant

**A re-archive can only grow a transcript, never shrink it.** `merge_transcript_lines` unions the existing archived transcript with the current hot-DB rows by message id (ordered by `created_at`, id tiebreak; DB rows win id collisions). This is why phase 1 added the message id to transcript lines.

## Retention integration

- **Session-age cleanup** (deletes whole sessions): when archiving is enabled, an eligible session is deleted only after `ensure_session_archived` succeeds; on archive failure the deletion is **held** and retried next cycle, with the failure recorded — satisfying the acceptance criterion that retention "cannot delete an eligible session without either archiving it or recording an explicit archive failure".
- **Message retention** (trims old/over-cap messages): a pre-trim pass archives every session whose messages the trim will touch — including ACTIVE sessions, which the idle sweep deliberately skips; merge semantics make mid-life snapshots safe. A failed pre-trim archive records the failure and lets the trim proceed (anything previously captured is safe; only the failed delta is at risk, and the merge picks it up on the next successful archive if it still exists).

## Observability

`ArchiveStats` on the runtime: archived_total / failed_total / bytes_written / last_error, updated by every archive path (per the phase-2 spec); currently surfaced via logs, wired for an admin endpoint in phase 4/5.

## Tests

- Unit: merge never shrinks + deterministic ordering + idempotent self-merge.
- **Harness (real Postgres)**: archive → trim a hot row → new message arrives → re-archive → transcript contains all three messages and the manifest counts the merged set. Archive harness tests are serialized via a shared lock (two global sweeps racing on the shared test DB re-mark each other's sessions).

Gates: workspace clippy -Dwarnings, 158 backend tests, 3 harness tests, fmt.