### PR TITLE
Archive phase 3: S3 backend, transcripts always zstd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -825,6 +825,11 @@ When making changes, verify:
 | `PORTAL_IMAGE_STORE_MAX_MB` | Backend served-image cache total-byte cap (LRU eviction past this) | Optional (default: 256) |
 | `PORTAL_IMAGE_STORE_TTL_SECS` | Backend served-image per-entry TTL in seconds | Optional (default: 3600) |
 | `PORTAL_REMINDER_FILE` | Path to a markdown file overriding the bundled portal-features reminder (proxy/launcher side). Falls back to default if unset/unreadable. | Optional |
+| `PORTAL_SESSION_ARCHIVE_BACKEND` | Long-term session archive (#1258): `disabled`, `local`, or `s3` | Optional (default: disabled) |
+| `PORTAL_SESSION_ARCHIVE_LOCAL_ROOT` | Filesystem root for the `local` archive backend | Required when backend=local |
+| `PORTAL_SESSION_ARCHIVE_S3_BUCKET` | Bucket for the `s3` archive backend (region/credentials/endpoint via standard `AWS_*` vars) | Required when backend=s3 |
+| `PORTAL_SESSION_ARCHIVE_S3_PREFIX` | Key prefix inside the archive bucket | Optional |
+| `PORTAL_SESSION_ARCHIVE_TRANSCRIPTS` | Archive transcript bodies (always zstd-compressed), not just manifests | Optional (default: true) |
 
 Note: Dev mode is enabled via `--dev-mode` CLI flag, not an environment variable. Voice input is browser-native (Web Speech API on Chromium / Safari); no server-side speech credentials are needed.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "dirs",
  "portal-auth",
  "portal-update",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",
@@ -163,6 +163,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,8 +263,9 @@ dependencies = [
  "memory-serve",
  "mini-moka",
  "oauth2",
+ "object_store",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -304,6 +328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -413,6 +446,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,7 +554,7 @@ dependencies = [
  "libc",
  "portal-auth",
  "portal-update",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "session-lib",
@@ -546,6 +590,15 @@ dependencies = [
  "uuid",
  "which",
  "ws-bridge",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -592,6 +645,16 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -656,6 +719,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +780,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -904,9 +995,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -987,6 +1088,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -1130,6 +1237,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1370,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1795,7 +1909,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1864,6 +1978,21 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2142,10 +2271,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -2279,6 +2466,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2588,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nonempty"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,13 +2675,55 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "sha2",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "object_store"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64",
+ "bytes",
+ "chrono",
+ "crc-fast",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools",
+ "md-5",
+ "nix",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2649,7 +2900,7 @@ dependencies = [
  "anyhow",
  "colored",
  "hostname",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "shared",
@@ -2663,7 +2914,7 @@ version = "2.13.0"
 dependencies = [
  "anyhow",
  "hex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "sha2",
  "tracing",
@@ -2812,6 +3063,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,6 +3098,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2920,6 +3182,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,6 +3229,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-cpuid"
@@ -3060,6 +3339,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,6 +3404,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +3431,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3135,11 +3463,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3349,8 +3705,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3360,8 +3716,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3422,6 +3778,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,6 +3847,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spinning_top"
@@ -4321,6 +4699,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4350,6 +4741,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -82,6 +82,7 @@ hyper-util = { version = "0.1.20", features = ["tokio"] }
 urlencoding = "2.1.3"
 serde_urlencoded = "0.7.1"
 zstd = "0.13"
+object_store = { version = "0.14.0", features = ["aws"] }
 
 [build-dependencies]
 memory-serve = "2.1"

--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -1,11 +1,11 @@
-//! Long-term session archive storage (#1258, phase 1).
+//! Long-term session archive storage (#1258).
 //!
 //! Completed sessions are archived outside the hot Postgres tables so
 //! message/session retention can stay bounded without losing audit or
-//! usage history. Phase 1 ships the typed store (local filesystem
-//! backend), the versioned object layout, manifest construction, and the
-//! periodic archival sweep; later phases add retention integration, an
-//! S3-compatible backend, rollups, and UI.
+//! usage history. Backends: local filesystem and S3-compatible object
+//! storage (via `object_store`). Reading/analytics happens in a separate
+//! viewer tool — this module only writes (and re-reads for the
+//! merge-on-rearchive invariant).
 //!
 //! ## Object layout (schema v1)
 //!
@@ -13,6 +13,10 @@
 //! v1/users/{user_id}/sessions/{session_id}/manifest.json
 //! v1/users/{user_id}/sessions/{session_id}/messages.ndjson.zst
 //! ```
+//!
+//! Transcripts are always zstd-compressed — they are text-heavy NDJSON
+//! and shrink dramatically; there is deliberately no plaintext option.
+//! Manifests stay plain JSON so external tools can list/scan them cheaply.
 //!
 //! Keys are deterministic (stable ids only, no user-controlled segments),
 //! so re-archiving a session overwrites in place — the sweep re-archives
@@ -29,6 +33,7 @@
 //! session content and must never be added to manifests.
 
 use chrono::NaiveDateTime;
+use object_store::ObjectStoreExt as _;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -48,38 +53,41 @@ pub const ARCHIVE_IDLE_SECS: i64 = 3600;
 /// Sessions archived per sweep tick, so one sweep can't monopolize the DB.
 pub const ARCHIVE_SWEEP_BATCH: i64 = 25;
 
+/// zstd level for transcript bodies. Archival is write-once/read-rare and
+/// runs on the blocking pool, so a higher-than-default level is a good
+/// trade: noticeably smaller objects for a little more CPU.
+const ZSTD_LEVEL: i32 = 9;
+
+/// The manifest's `transcript.compression` value. Fixed — transcripts are
+/// always zstd; the field exists so external viewers stay self-describing
+/// if a future schema version ever changes the codec.
+pub const TRANSCRIPT_COMPRESSION: &str = "zstd";
+
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ArchiveCompression {
-    Zstd,
-    None,
-}
-
-impl ArchiveCompression {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Zstd => "zstd",
-            Self::None => "none",
-        }
-    }
-
-    fn transcript_suffix(&self) -> &'static str {
-        match self {
-            Self::Zstd => "messages.ndjson.zst",
-            Self::None => "messages.ndjson",
-        }
-    }
+/// Which object store the archive writes to.
+#[derive(Debug, Clone)]
+pub enum ArchiveBackendConfig {
+    Local {
+        root: PathBuf,
+    },
+    /// S3-compatible object storage. Credentials, region, and endpoint
+    /// come from the standard `AWS_*` environment variables (validated at
+    /// startup when the store is built).
+    S3 {
+        bucket: String,
+        /// Optional key prefix inside the bucket (no trailing slash).
+        prefix: Option<String>,
+    },
 }
 
 /// Validated archive configuration. `None` anywhere upstream means the
 /// feature is disabled (the default, including on hosted deployments).
 #[derive(Debug, Clone)]
 pub struct ArchiveConfig {
-    pub local_root: PathBuf,
-    pub compression: ArchiveCompression,
+    pub backend: ArchiveBackendConfig,
     /// When false, only manifests are archived (metadata/rollup mode);
     /// transcripts stay subject to normal DB retention.
     pub transcripts: bool,
@@ -88,10 +96,17 @@ pub struct ArchiveConfig {
 /// Parse archive settings from the environment. Fail-fast: partial or
 /// contradictory config is an error at startup, not a silent fallback.
 pub fn archive_config_from_env() -> Result<Option<ArchiveConfig>, String> {
+    if std::env::var("PORTAL_SESSION_ARCHIVE_COMPRESS").is_ok() {
+        return Err(
+            "PORTAL_SESSION_ARCHIVE_COMPRESS has been removed; transcripts are \
+             always zstd-compressed — unset it"
+                .to_string(),
+        );
+    }
     let backend =
         std::env::var("PORTAL_SESSION_ARCHIVE_BACKEND").unwrap_or_else(|_| "disabled".to_string());
-    match backend.as_str() {
-        "disabled" => Ok(None),
+    let backend = match backend.as_str() {
+        "disabled" => return Ok(None),
         "local" => {
             let root = std::env::var("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT").map_err(|_| {
                 "PORTAL_SESSION_ARCHIVE_BACKEND=local requires \
@@ -101,45 +116,57 @@ pub fn archive_config_from_env() -> Result<Option<ArchiveConfig>, String> {
             if root.trim().is_empty() {
                 return Err("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT must not be empty".to_string());
             }
-            let compression = match std::env::var("PORTAL_SESSION_ARCHIVE_COMPRESS")
-                .unwrap_or_else(|_| "zstd".to_string())
-                .as_str()
-            {
-                "zstd" => ArchiveCompression::Zstd,
-                "none" => ArchiveCompression::None,
-                other => {
-                    return Err(format!(
-                        "PORTAL_SESSION_ARCHIVE_COMPRESS must be `zstd` or `none`, got `{other}`"
-                    ))
-                }
-            };
-            let transcripts = match std::env::var("PORTAL_SESSION_ARCHIVE_TRANSCRIPTS")
-                .unwrap_or_else(|_| "true".to_string())
-                .as_str()
-            {
-                "true" => true,
-                "false" => false,
-                other => {
-                    return Err(format!(
-                    "PORTAL_SESSION_ARCHIVE_TRANSCRIPTS must be `true` or `false`, got `{other}`"
-                ))
-                }
-            };
-            Ok(Some(ArchiveConfig {
-                local_root: PathBuf::from(root),
-                compression,
-                transcripts,
-            }))
+            ArchiveBackendConfig::Local {
+                root: PathBuf::from(root),
+            }
         }
-        "s3" => Err(
-            "PORTAL_SESSION_ARCHIVE_BACKEND=s3 is not implemented yet (#1258 phase 3); \
-             use `local` or `disabled`"
-                .to_string(),
-        ),
-        other => Err(format!(
-            "PORTAL_SESSION_ARCHIVE_BACKEND must be `disabled`, `local`, or `s3`, got `{other}`"
-        )),
-    }
+        "s3" => {
+            let bucket = std::env::var("PORTAL_SESSION_ARCHIVE_S3_BUCKET").map_err(|_| {
+                "PORTAL_SESSION_ARCHIVE_BACKEND=s3 requires \
+                 PORTAL_SESSION_ARCHIVE_S3_BUCKET to be set"
+                    .to_string()
+            })?;
+            if bucket.trim().is_empty() {
+                return Err("PORTAL_SESSION_ARCHIVE_S3_BUCKET must not be empty".to_string());
+            }
+            let prefix = match std::env::var("PORTAL_SESSION_ARCHIVE_S3_PREFIX") {
+                Ok(p) => {
+                    let p = p.trim().trim_matches('/').to_string();
+                    if p.is_empty() {
+                        return Err(
+                            "PORTAL_SESSION_ARCHIVE_S3_PREFIX must not be empty (unset it \
+                             to archive at the bucket root)"
+                                .to_string(),
+                        );
+                    }
+                    Some(p)
+                }
+                Err(_) => None,
+            };
+            ArchiveBackendConfig::S3 { bucket, prefix }
+        }
+        other => {
+            return Err(format!(
+                "PORTAL_SESSION_ARCHIVE_BACKEND must be `disabled`, `local`, or `s3`, got `{other}`"
+            ))
+        }
+    };
+    let transcripts = match std::env::var("PORTAL_SESSION_ARCHIVE_TRANSCRIPTS")
+        .unwrap_or_else(|_| "true".to_string())
+        .as_str()
+    {
+        "true" => true,
+        "false" => false,
+        other => {
+            return Err(format!(
+                "PORTAL_SESSION_ARCHIVE_TRANSCRIPTS must be `true` or `false`, got `{other}`"
+            ))
+        }
+    };
+    Ok(Some(ArchiveConfig {
+        backend,
+        transcripts,
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -253,11 +280,8 @@ pub fn manifest_key(user_id: Uuid, session_id: Uuid) -> String {
     format!("v1/users/{user_id}/sessions/{session_id}/manifest.json")
 }
 
-pub fn transcript_key(user_id: Uuid, session_id: Uuid, compression: ArchiveCompression) -> String {
-    format!(
-        "v1/users/{user_id}/sessions/{session_id}/{}",
-        compression.transcript_suffix()
-    )
+pub fn transcript_key(user_id: Uuid, session_id: Uuid) -> String {
+    format!("v1/users/{user_id}/sessions/{session_id}/messages.ndjson.zst")
 }
 
 // ---------------------------------------------------------------------------
@@ -272,12 +296,14 @@ pub struct ArchiveRuntime {
 }
 
 impl ArchiveRuntime {
-    pub fn new(config: ArchiveConfig) -> Self {
-        Self {
-            store: ArchiveStore::from_config(&config),
+    /// Build the runtime, constructing the backing store. Fails fast on
+    /// invalid S3 configuration (bad bucket, missing region, no runtime).
+    pub fn new(config: ArchiveConfig) -> Result<Self, String> {
+        Ok(Self {
+            store: ArchiveStore::from_config(&config)?,
             config,
             stats: ArchiveStats::default(),
-        }
+        })
     }
 }
 
@@ -332,27 +358,32 @@ pub fn merge_transcript_lines(
 }
 
 /// Typed archive store. An enum (not a trait object) so backends stay a
-/// closed, compiler-checked set; phase 3 adds an `S3` variant.
+/// closed, compiler-checked set.
 pub enum ArchiveStore {
     Local(LocalArchiveStore),
+    /// S3-compatible object storage in production; any `ObjectStore`
+    /// implementation (e.g. in-memory) in tests.
+    Object(ObjectArchiveStore),
 }
 
 impl ArchiveStore {
-    pub fn from_config(config: &ArchiveConfig) -> Self {
-        Self::Local(LocalArchiveStore {
-            root: config.local_root.clone(),
-        })
+    pub fn from_config(config: &ArchiveConfig) -> Result<Self, String> {
+        match &config.backend {
+            ArchiveBackendConfig::Local { root } => {
+                Ok(Self::Local(LocalArchiveStore { root: root.clone() }))
+            }
+            ArchiveBackendConfig::S3 { bucket, prefix } => Ok(Self::Object(
+                ObjectArchiveStore::s3_from_env(bucket, prefix.clone())?,
+            )),
+        }
     }
 
     /// Write a session's archive: transcript first, manifest last — a
     /// manifest's existence implies its transcript object is complete.
-    pub fn put_session_archive(
-        &self,
-        bundle: &SessionArchiveBundle,
-        compression: ArchiveCompression,
-    ) -> std::io::Result<()> {
+    pub fn put_session_archive(&self, bundle: &SessionArchiveBundle) -> std::io::Result<()> {
         match self {
-            Self::Local(store) => store.put_session_archive(bundle, compression),
+            Self::Local(store) => store.put_session_archive(bundle),
+            Self::Object(store) => store.put_session_archive(bundle),
         }
     }
 
@@ -363,6 +394,7 @@ impl ArchiveStore {
     ) -> std::io::Result<Option<SessionArchiveManifest>> {
         match self {
             Self::Local(store) => store.get_session_manifest(user_id, session_id),
+            Self::Object(store) => store.get_session_manifest(user_id, session_id),
         }
     }
 
@@ -372,16 +404,104 @@ impl ArchiveStore {
         &self,
         user_id: Uuid,
         session_id: Uuid,
-        compression: ArchiveCompression,
     ) -> std::io::Result<Option<Vec<ArchiveMessageLine>>> {
-        match self {
+        let raw = match self {
             Self::Local(store) => {
-                match read_transcript(&store.root, user_id, session_id, compression) {
-                    Ok(lines) => Ok(Some(lines)),
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-                    Err(e) => Err(e),
+                match std::fs::read(store.object_path(&transcript_key(user_id, session_id))) {
+                    Ok(bytes) => bytes,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                    Err(e) => return Err(e),
                 }
             }
+            Self::Object(store) => match store.get_bytes(&transcript_key(user_id, session_id)) {
+                Ok(Some(bytes)) => bytes,
+                Ok(None) => return Ok(None),
+                Err(e) => return Err(e),
+            },
+        };
+        parse_transcript_ndjson(&zstd::decode_all(raw.as_slice())?).map(Some)
+    }
+}
+
+/// S3-compatible (or any `object_store`) backend. Store methods are sync —
+/// they run on the blocking pool alongside the DB work — so each call
+/// blocks on the async client via the captured runtime handle.
+pub struct ObjectArchiveStore {
+    store: std::sync::Arc<dyn object_store::ObjectStore>,
+    /// Key prefix inside the bucket (no trailing slash).
+    prefix: Option<String>,
+    handle: tokio::runtime::Handle,
+}
+
+impl ObjectArchiveStore {
+    /// Build against S3. Bucket/prefix come from portal config; region,
+    /// credentials, and custom endpoints come from the standard `AWS_*`
+    /// environment variables (`object_store`'s `from_env`).
+    fn s3_from_env(bucket: &str, prefix: Option<String>) -> Result<Self, String> {
+        let handle = tokio::runtime::Handle::try_current().map_err(|_| {
+            "archive S3 store must be constructed inside the tokio runtime".to_string()
+        })?;
+        let s3 = object_store::aws::AmazonS3Builder::from_env()
+            .with_bucket_name(bucket)
+            .build()
+            .map_err(|e| format!("invalid S3 archive configuration: {e}"))?;
+        Ok(Self {
+            store: std::sync::Arc::new(s3),
+            prefix,
+            handle,
+        })
+    }
+
+    fn object_path(&self, key: &str) -> object_store::path::Path {
+        match &self.prefix {
+            Some(prefix) => object_store::path::Path::from(format!("{prefix}/{key}")),
+            None => object_store::path::Path::from(key),
+        }
+    }
+
+    fn put_bytes(&self, key: &str, bytes: Vec<u8>) -> std::io::Result<()> {
+        let path = self.object_path(key);
+        self.handle
+            .block_on(self.store.put(&path, bytes.into()))
+            .map(|_| ())
+            .map_err(std::io::Error::from)
+    }
+
+    fn get_bytes(&self, key: &str) -> std::io::Result<Option<Vec<u8>>> {
+        let path = self.object_path(key);
+        let result = self
+            .handle
+            .block_on(async { self.store.get(&path).await?.bytes().await });
+        match result {
+            Ok(bytes) => Ok(Some(bytes.to_vec())),
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(e) => Err(std::io::Error::from(e)),
+        }
+    }
+
+    fn put_session_archive(&self, bundle: &SessionArchiveBundle) -> std::io::Result<()> {
+        let m = &bundle.manifest;
+        if let Some(ndjson) = &bundle.transcript_ndjson {
+            let body = zstd::encode_all(ndjson.as_slice(), ZSTD_LEVEL)?;
+            self.put_bytes(&transcript_key(m.user_id, m.session_id), body)?;
+        }
+        let manifest_json = serde_json::to_vec_pretty(&bundle.manifest)?;
+        self.put_bytes(&manifest_key(m.user_id, m.session_id), manifest_json)
+    }
+
+    fn get_session_manifest(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+    ) -> std::io::Result<Option<SessionArchiveManifest>> {
+        match self.get_bytes(&manifest_key(user_id, session_id))? {
+            Some(bytes) => Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("corrupt manifest for session {session_id}: {e}"),
+                )
+            })?)),
+            None => Ok(None),
         }
     }
 }
@@ -413,18 +533,11 @@ impl LocalArchiveStore {
         std::fs::rename(&tmp, &path)
     }
 
-    fn put_session_archive(
-        &self,
-        bundle: &SessionArchiveBundle,
-        compression: ArchiveCompression,
-    ) -> std::io::Result<()> {
+    fn put_session_archive(&self, bundle: &SessionArchiveBundle) -> std::io::Result<()> {
         let m = &bundle.manifest;
         if let Some(ndjson) = &bundle.transcript_ndjson {
-            let body: Vec<u8> = match compression {
-                ArchiveCompression::Zstd => zstd::encode_all(ndjson.as_slice(), 0)?,
-                ArchiveCompression::None => ndjson.clone(),
-            };
-            self.write_atomic(&transcript_key(m.user_id, m.session_id, compression), &body)?;
+            let body = zstd::encode_all(ndjson.as_slice(), ZSTD_LEVEL)?;
+            self.write_atomic(&transcript_key(m.user_id, m.session_id), &body)?;
         }
         let manifest_json = serde_json::to_vec_pretty(&bundle.manifest)?;
         self.write_atomic(&manifest_key(m.user_id, m.session_id), &manifest_json)
@@ -454,15 +567,13 @@ pub fn read_transcript(
     root: &Path,
     user_id: Uuid,
     session_id: Uuid,
-    compression: ArchiveCompression,
 ) -> std::io::Result<Vec<ArchiveMessageLine>> {
-    let path = root.join(transcript_key(user_id, session_id, compression));
-    let raw = std::fs::read(path)?;
-    let ndjson = match compression {
-        ArchiveCompression::Zstd => zstd::decode_all(raw.as_slice())?,
-        ArchiveCompression::None => raw,
-    };
-    String::from_utf8_lossy(&ndjson)
+    let raw = std::fs::read(root.join(transcript_key(user_id, session_id)))?;
+    parse_transcript_ndjson(&zstd::decode_all(raw.as_slice())?)
+}
+
+fn parse_transcript_ndjson(ndjson: &[u8]) -> std::io::Result<Vec<ArchiveMessageLine>> {
+    String::from_utf8_lossy(ndjson)
         .lines()
         .filter(|l| !l.trim().is_empty())
         .map(|l| {
@@ -517,23 +628,12 @@ mod tests {
             format!("v1/users/{u}/sessions/{s}/manifest.json")
         );
         assert_eq!(
-            transcript_key(u, s, ArchiveCompression::Zstd),
+            transcript_key(u, s),
             format!("v1/users/{u}/sessions/{s}/messages.ndjson.zst")
-        );
-        assert_eq!(
-            transcript_key(u, s, ArchiveCompression::None),
-            format!("v1/users/{u}/sessions/{s}/messages.ndjson")
         );
     }
 
-    #[test]
-    fn local_roundtrip_and_idempotent_overwrite() {
-        let tmp = tempfile::tempdir().unwrap();
-        let store = ArchiveStore::Local(LocalArchiveStore {
-            root: tmp.path().to_path_buf(),
-        });
-        let (u, s) = (Uuid::from_u128(7), Uuid::from_u128(9));
-
+    fn bundle_with_one_line(u: Uuid, s: Uuid) -> (SessionArchiveManifest, SessionArchiveBundle) {
         let line = ArchiveMessageLine {
             id: Uuid::from_u128(11),
             role: "user".into(),
@@ -548,8 +648,8 @@ mod tests {
 
         let mut m = manifest(u, s);
         m.transcript = Some(ArchiveTranscriptInfo {
-            object_key: transcript_key(u, s, ArchiveCompression::Zstd),
-            compression: "zstd".into(),
+            object_key: transcript_key(u, s),
+            compression: TRANSCRIPT_COMPRESSION.into(),
             message_count: 1,
             bytes: ndjson.len() as u64,
         });
@@ -557,21 +657,32 @@ mod tests {
             manifest: m.clone(),
             transcript_ndjson: Some(ndjson),
         };
+        (m, bundle)
+    }
 
-        store
-            .put_session_archive(&bundle, ArchiveCompression::Zstd)
-            .unwrap();
+    #[test]
+    fn local_roundtrip_and_idempotent_overwrite() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArchiveStore::Local(LocalArchiveStore {
+            root: tmp.path().to_path_buf(),
+        });
+        let (u, s) = (Uuid::from_u128(7), Uuid::from_u128(9));
+        let (m, bundle) = bundle_with_one_line(u, s);
+
+        store.put_session_archive(&bundle).unwrap();
         // Overwrite with the same deterministic keys must succeed.
-        store
-            .put_session_archive(&bundle, ArchiveCompression::Zstd)
-            .unwrap();
+        store.put_session_archive(&bundle).unwrap();
 
         let got = store.get_session_manifest(u, s).unwrap().expect("manifest");
         assert_eq!(got, m);
 
-        let lines = read_transcript(tmp.path(), u, s, ArchiveCompression::Zstd).unwrap();
+        let lines = read_transcript(tmp.path(), u, s).unwrap();
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].content["text"], "hello");
+
+        // The on-disk transcript must actually be zstd, not plaintext.
+        let raw = std::fs::read(tmp.path().join(transcript_key(u, s))).unwrap();
+        assert_eq!(&raw[..4], &[0x28, 0xb5, 0x2f, 0xfd], "zstd magic bytes");
 
         // No temp files left behind (write_atomic names them `.{name}.tmp`).
         let leftovers: Vec<_> = walk(tmp.path())
@@ -582,6 +693,38 @@ mod tests {
             })
             .collect();
         assert!(leftovers.is_empty(), "temp files leaked: {leftovers:?}");
+    }
+
+    /// The `Object` (S3) backend, exercised via `object_store`'s in-memory
+    /// implementation from a plain thread — same block-on-handle path the
+    /// blocking sweep uses in production.
+    #[test]
+    fn object_store_roundtrip_and_missing_reads() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let store = ArchiveStore::Object(ObjectArchiveStore {
+            store: std::sync::Arc::new(object_store::memory::InMemory::new()),
+            prefix: Some("portal-archive".into()),
+            handle: rt.handle().clone(),
+        });
+        let (u, s) = (Uuid::from_u128(7), Uuid::from_u128(9));
+
+        assert!(store.get_session_manifest(u, s).unwrap().is_none());
+        assert!(store.read_transcript_lines(u, s).unwrap().is_none());
+
+        let (m, bundle) = bundle_with_one_line(u, s);
+        store.put_session_archive(&bundle).unwrap();
+        // Deterministic-key overwrite must succeed (re-archive path).
+        store.put_session_archive(&bundle).unwrap();
+
+        let got = store.get_session_manifest(u, s).unwrap().expect("manifest");
+        assert_eq!(got, m);
+
+        let lines = store
+            .read_transcript_lines(u, s)
+            .unwrap()
+            .expect("transcript");
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].content["text"], "hello");
     }
 
     /// #1258 phase 2: the merge is a union by message id, ordered by
@@ -653,6 +796,8 @@ mod tests {
                 "PORTAL_SESSION_ARCHIVE_LOCAL_ROOT",
                 "PORTAL_SESSION_ARCHIVE_COMPRESS",
                 "PORTAL_SESSION_ARCHIVE_TRANSCRIPTS",
+                "PORTAL_SESSION_ARCHIVE_S3_BUCKET",
+                "PORTAL_SESSION_ARCHIVE_S3_PREFIX",
             ] {
                 std::env::remove_var(k);
             }
@@ -669,11 +814,36 @@ mod tests {
 
         std::env::set_var("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT", "/tmp/a");
         let cfg = archive_config_from_env().unwrap().expect("enabled");
-        assert_eq!(cfg.compression, ArchiveCompression::Zstd);
+        assert!(
+            matches!(cfg.backend, ArchiveBackendConfig::Local { .. }),
+            "local backend"
+        );
         assert!(cfg.transcripts, "transcripts default on when enabled");
 
+        // The removed compression knob must be rejected, not ignored.
+        std::env::set_var("PORTAL_SESSION_ARCHIVE_COMPRESS", "none");
+        assert!(
+            archive_config_from_env().is_err(),
+            "removed COMPRESS knob fails fast"
+        );
+        std::env::remove_var("PORTAL_SESSION_ARCHIVE_COMPRESS");
+
         std::env::set_var("PORTAL_SESSION_ARCHIVE_BACKEND", "s3");
-        assert!(archive_config_from_env().is_err(), "s3 is phase 3");
+        assert!(
+            archive_config_from_env().is_err(),
+            "s3 without bucket must fail fast"
+        );
+
+        std::env::set_var("PORTAL_SESSION_ARCHIVE_S3_BUCKET", "my-bucket");
+        std::env::set_var("PORTAL_SESSION_ARCHIVE_S3_PREFIX", "/portal/archive/");
+        let cfg = archive_config_from_env().unwrap().expect("enabled");
+        match cfg.backend {
+            ArchiveBackendConfig::S3 { bucket, prefix } => {
+                assert_eq!(bucket, "my-bucket");
+                assert_eq!(prefix.as_deref(), Some("portal/archive"), "slashes trimmed");
+            }
+            other => panic!("expected S3 backend, got {other:?}"),
+        }
 
         std::env::set_var("PORTAL_SESSION_ARCHIVE_BACKEND", "bogus");
         assert!(archive_config_from_env().is_err());

--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -297,7 +297,10 @@ pub struct ArchiveRuntime {
 
 impl ArchiveRuntime {
     /// Build the runtime, constructing the backing store. Fails fast on
-    /// invalid S3 configuration (bad bucket, missing region, no runtime).
+    /// malformed S3 configuration (invalid bucket name, missing region,
+    /// no runtime) — but bucket reachability and credential validity are
+    /// only proven by the first write; watch `SESSION_ARCHIVE_FAILED`
+    /// after enabling.
     pub fn new(config: ArchiveConfig) -> Result<Self, String> {
         Ok(Self {
             store: ArchiveStore::from_config(&config)?,

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -220,7 +220,7 @@ fn archive_one_session(
     // archive; a re-archive must never shrink it.
     let existing_lines = runtime
         .store
-        .read_transcript_lines(session.user_id, session.id, runtime.config.compression)?
+        .read_transcript_lines(session.user_id, session.id)?
         .unwrap_or_default();
     let merged_lines = crate::archive::merge_transcript_lines(existing_lines, current_lines);
 
@@ -288,7 +288,6 @@ fn archive_one_session(
 
     let archived_at = chrono::Utc::now().naive_utc();
     let transcripts_enabled = runtime.config.transcripts && !merged_lines.is_empty();
-    let compression = runtime.config.compression;
 
     let (transcript_ndjson, transcript_info) = if transcripts_enabled {
         let mut ndjson = Vec::new();
@@ -297,8 +296,8 @@ fn archive_one_session(
             ndjson.push(b'\n');
         }
         let info = ArchiveTranscriptInfo {
-            object_key: transcript_key(session.user_id, session.id, compression),
-            compression: compression.as_str().to_string(),
+            object_key: transcript_key(session.user_id, session.id),
+            compression: crate::archive::TRANSCRIPT_COMPRESSION.to_string(),
             message_count: merged_lines.len() as i64,
             bytes: ndjson.len() as u64,
         };
@@ -347,7 +346,7 @@ fn archive_one_session(
         .as_ref()
         .map(|b| b.len() as u64)
         .unwrap_or(0);
-    runtime.store.put_session_archive(&bundle, compression)?;
+    runtime.store.put_session_archive(&bundle)?;
     runtime.stats.record_success(bytes);
     Ok(())
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -311,12 +311,24 @@ impl ServerConfig {
         let archive = crate::archive::archive_config_from_env()
             .map_err(|e| anyhow::anyhow!("invalid archive configuration: {e}"))?;
         match &archive {
-            Some(cfg) => tracing::info!(
-                "Session archive enabled: local root {} (compression {}, transcripts {})",
-                cfg.local_root.display(),
-                cfg.compression.as_str(),
-                cfg.transcripts
-            ),
+            Some(cfg) => {
+                let backend = match &cfg.backend {
+                    crate::archive::ArchiveBackendConfig::Local { root } => {
+                        format!("local root {}", root.display())
+                    }
+                    crate::archive::ArchiveBackendConfig::S3 { bucket, prefix } => format!(
+                        "s3 bucket {bucket}{}",
+                        prefix
+                            .as_deref()
+                            .map(|p| format!(" prefix {p}"))
+                            .unwrap_or_default()
+                    ),
+                };
+                tracing::info!(
+                    "Session archive enabled: {backend} (zstd transcripts: {})",
+                    cfg.transcripts
+                );
+            }
             None => {
                 tracing::info!("Session archive disabled (PORTAL_SESSION_ARCHIVE_BACKEND unset)")
             }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -155,9 +155,12 @@ pub async fn run() -> anyhow::Result<()> {
             config.image_store_ttl,
         ),
         forward_domain: config.forward_domain,
-        archive: config
-            .archive
-            .map(|cfg| Arc::new(archive::ArchiveRuntime::new(cfg))),
+        archive: match config.archive {
+            Some(cfg) => Some(Arc::new(
+                archive::ArchiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!(e))?,
+            )),
+            None => None,
+        },
     });
 
     // Build our application with routes

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -159,7 +159,7 @@ async fn archive_sweep_persists_and_is_idempotent() {
         return;
     }
     let _guard = ARCHIVE_DB_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-    use backend::archive::{read_transcript, ArchiveCompression, ArchiveConfig, ArchiveRuntime};
+    use backend::archive::{read_transcript, ArchiveBackendConfig, ArchiveConfig, ArchiveRuntime};
     use backend::models::{NewMessage, NewSessionWithId};
     use backend::schema::{messages, sessions};
     use diesel::prelude::*;
@@ -225,10 +225,12 @@ async fn archive_sweep_persists_and_is_idempotent() {
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let runtime = ArchiveRuntime::new(ArchiveConfig {
-        local_root: tmp.path().to_path_buf(),
-        compression: ArchiveCompression::Zstd,
+        backend: ArchiveBackendConfig::Local {
+            root: tmp.path().to_path_buf(),
+        },
         transcripts: true,
-    });
+    })
+    .expect("local archive runtime");
 
     let (archived, failed) =
         backend::background::archive_pending_sessions(&pool, &runtime).expect("sweep");
@@ -247,8 +249,7 @@ async fn archive_sweep_persists_and_is_idempotent() {
     let transcript = manifest.transcript.as_ref().expect("transcript info");
     assert_eq!(transcript.message_count, 2);
 
-    let lines = read_transcript(tmp.path(), user_id, session_id, ArchiveCompression::Zstd)
-        .expect("read transcript");
+    let lines = read_transcript(tmp.path(), user_id, session_id).expect("read transcript");
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].content["text"], "hello");
 
@@ -305,7 +306,7 @@ async fn rearchive_after_trim_merges_transcript() {
         return;
     }
     let _guard = ARCHIVE_DB_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-    use backend::archive::{read_transcript, ArchiveCompression, ArchiveConfig, ArchiveRuntime};
+    use backend::archive::{read_transcript, ArchiveBackendConfig, ArchiveConfig, ArchiveRuntime};
     use backend::models::{NewMessage, NewSessionWithId};
     use backend::schema::{messages, sessions};
     use diesel::prelude::*;
@@ -365,15 +366,17 @@ async fn rearchive_after_trim_merges_transcript() {
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let runtime = ArchiveRuntime::new(ArchiveConfig {
-        local_root: tmp.path().to_path_buf(),
-        compression: ArchiveCompression::Zstd,
+        backend: ArchiveBackendConfig::Local {
+            root: tmp.path().to_path_buf(),
+        },
         transcripts: true,
-    });
+    })
+    .expect("local archive runtime");
 
     // First archive captures both messages.
     backend::background::archive_pending_sessions(&pool, &runtime).expect("first sweep");
     assert_eq!(
-        read_transcript(tmp.path(), user_id, session_id, ArchiveCompression::Zstd)
+        read_transcript(tmp.path(), user_id, session_id)
             .expect("read")
             .len(),
         2
@@ -398,8 +401,7 @@ async fn rearchive_after_trim_merges_transcript() {
         .expect("make stale again");
     backend::background::archive_pending_sessions(&pool, &runtime).expect("second sweep");
 
-    let lines = read_transcript(tmp.path(), user_id, session_id, ArchiveCompression::Zstd)
-        .expect("read merged");
+    let lines = read_transcript(tmp.path(), user_id, session_id).expect("read merged");
     let texts: Vec<String> = lines
         .iter()
         .map(|l| l.content["text"].as_str().unwrap_or_default().to_string())


### PR DESCRIPTION
Closes out the storage side of #1258 (phase 3). Reading/analytics (old phases 4–5) is descoped to a separate viewer tool.

## What
- **S3-compatible backend** via `object_store` (`aws` feature): `ArchiveStore::Object(ObjectArchiveStore)` holds an `Arc<dyn ObjectStore>` — `AmazonS3` in production, `InMemory` in tests. Store methods stay sync (the sweep runs on the blocking pool next to its DB work) and block on the captured runtime handle per call.
- **Config**: `PORTAL_SESSION_ARCHIVE_BACKEND=s3` + `PORTAL_SESSION_ARCHIVE_S3_BUCKET` (required) + `PORTAL_SESSION_ARCHIVE_S3_PREFIX` (optional, slash-trimmed). Region/credentials/endpoint come from standard `AWS_*` env and are validated fail-fast at startup (`ArchiveRuntime::new` now returns `Result`).
- **Compression is no longer optional**: transcripts are always zstd (level 9 — write-once, text-heavy NDJSON). The `PORTAL_SESSION_ARCHIVE_COMPRESS` knob is removed and now *fails fast if set*, rather than being silently ignored. Manifests remain plain JSON so the future viewer can list/scan cheaply.
- `transcript_key` / `read_transcript` / `put_session_archive` signatures drop the compression parameter; `TRANSCRIPT_COMPRESSION` const keeps manifests self-describing.

## Invariants preserved
- Transcript-first, manifest-last write ordering on both backends (manifest existence ⇒ complete transcript). S3 PUTs are atomic per object; local keeps temp+rename.
- Merge-on-rearchive reads via the same store enum on both backends (`read_transcript_lines` NotFound ⇒ `None` ⇒ fresh archive).

## Tests
- New `object_store_roundtrip_and_missing_reads`: exercises the Object backend through `InMemory` from a plain thread — the same block-on-handle path production uses — including missing-object reads and deterministic-key overwrite.
- Local roundtrip now asserts the on-disk transcript starts with the zstd magic bytes.
- Config test covers the S3 arm (bucket required, prefix slash-trimming) and asserts the removed `_COMPRESS` knob fails fast.
- All 159 backend unit tests + 3 DB-backed harness tests green; workspace clippy `-Dwarnings` clean.