### PR TITLE
Match runtime base image glibc to the CI build runner

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
     name: Build Container
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@
 # Uses pre-built binaries from CI (faster builds with caching)
 # =============================================================================
 
-FROM debian:bookworm-slim
+# Base must provide a glibc at least as new as the CI build runner's
+# (container.yml pins runs-on: ubuntu-24.04) — the backend binary is built
+# there and copied in below. Keep these two in lockstep.
+FROM ubuntu:24.04
 
 WORKDIR /app
 
@@ -12,7 +15,7 @@ RUN apt-get update && \
     apt-get install -y \
     ca-certificates \
     libpq5 \
-    libssl3 \
+    libssl3t64 \
     curl \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

The published `ghcr.io/meawoppl/agent-portal:latest` image crash-loops since #1287, which took down txcl.io for ~43 minutes today (18:59–19:42 UTC) when Watchtower pulled it:

```
/app/backend: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /app/backend)
```

The container workflow builds the backend on the GitHub `ubuntu-latest` runner (glibc 2.39) and copies the binary into a `debian:bookworm-slim` runtime image (glibc 2.36). That mismatch was latent — the binary happened not to reference any post-2.36 symbols — until #1287's new dependencies pulled in a `GLIBC_2.38` symbol.

## Fix

Pin both sides to the same glibc so they can't drift:
- `container.yml`: `runs-on: ubuntu-24.04` (instead of `ubuntu-latest`, which will silently roll forward)
- `Dockerfile`: `FROM ubuntu:24.04` (glibc 2.39, matches the runner); `libssl3` → `libssl3t64` per the noble t64 transition

## Server state

The EC2 box is currently pinned to the last good image (`agent-portal:d828645`) to keep txcl.io up. After this merges and a good `:latest` publishes, the pin should be reverted to `:latest` so Watchtower resumes auto-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)