### PR TITLE
docs: mobile apps plan + demo walkthrough script

### DIFF
--- a/PORTAL_DEMO_SCRIPT.md
+++ b/PORTAL_DEMO_SCRIPT.md
@@ -1,0 +1,180 @@
+# Agent Portal — Demo Walkthrough Script
+
+*~15 minutes full run; each act stands alone if you need a 3-minute cut.
+Format per beat: **SAY** (your line), **DO** (clicks/commands), **DETAIL**
+(ammo for questions). Pre-flight checklist at the bottom — do it first.*
+
+---
+
+## Cold open (30 seconds)
+
+**SAY:** "Every AI coding tool assumes you're sitting at the machine the agent
+runs on. I don't want that. I want to hand a task to an agent on my desktop,
+close the laptop, and check on it from my phone at lunch — see everything it
+did, answer its questions, look at the app it built, all from a browser tab.
+That's what this is. All of it is Rust — the server, the daemon, even this
+web page you're looking at is Rust compiled to WebAssembly."
+
+**DO:** Have the dashboard already open, several sessions in the list, at
+least one actively streaming output.
+
+**DETAIL:** Axum + PostgreSQL backend, Yew/WASM frontend, a launcher daemon
+on each work machine, everything talking over typed WebSocket protocols.
+One binary per role, shared protocol crate so the compiler catches drift.
+
+---
+
+## Act 1 — A session from anywhere (3 min)
+
+**SAY:** "Each of these is a live agent session running on one of my machines.
+The portal isn't a replay — it's the live wire. Watch."
+
+**DO:**
+- Click into a running session. Let output stream.
+- Point at the header: session name, host, working directory, git branch,
+  **launcher version chip**, cost ticker.
+- Send a message from the input bar; the agent picks it up mid-flight.
+- If on desktop, open the same session on your phone.
+
+**SAY:** "Everything renders the way a human wants to read it — markdown,
+syntax-highlighted diffs, LaTeX if the agent gets mathematical, inline images
+when it reads a plot. When the agent needs a decision, I don't get a wall of
+text — I get a form."
+
+**DO:** Show a permission prompt or `AskUserQuestion` card if one's handy —
+click-to-answer multiple choice.
+
+**SAY:** "And the little cost badge shakes every time the agent spends money.
+That's not a feature request I got. It's a feature everyone deserves."
+
+**DETAIL:**
+- Reconnects replay from a server-assigned watermark, so a flaky phone
+  connection never loses transcript.
+- Web input goes through a client-side outbox with idempotency — closing the
+  tab mid-send doesn't drop or double a message.
+- Voice input is browser-native (Web Speech API), no server credentials.
+- Sound settings tab: fully synthesized notification sounds with an ADSR
+  editor, because why not.
+
+---
+
+## Act 2 — Agents that talk to each other (2 min)
+
+**SAY:** "Sessions aren't isolated. Any agent can message any of my other
+agents from its shell — no setup, it reuses the session's own identity."
+
+**DO:** In a session terminal (or narrate over a transcript):
+```console
+agent-portal message list          # see your other agents
+agent-portal message send <id> "how's the build looking?"
+```
+Show the message landing as a turn in the other session.
+
+**SAY:** "This is not a toy. Last week I shipped about twenty PRs where one
+agent wrote the code and a *different* agent — a Codex session — did the code
+review. They negotiated over this exact channel: 'here's the PR, focus on the
+auth boundary' … 'blocker: your cache can be clobbered by a stale status' …
+fix pushed … 'LGTM, merge on green.' The reviewer caught real security bugs
+I'd have shipped. Two models, adversarially collaborating, unattended."
+
+**DETAIL:** Messages arrive prefixed `[message from agent <id>]`; agents reply
+by id. Attribution rides the session identity (`CLAUDE_CODE_SESSION_ID`), so
+there's no credential handling in agent code.
+
+---
+
+## Act 3 — Port forwarding, the showpiece (5 min)
+
+*This is the money demo. Stage it: a session with no forward, and
+`python3 -m http.server 8899` ready to paste.*
+
+**SAY:** "Agents build web things — dev servers, Jupyter, little dashboards.
+Normally those are trapped on localhost of whatever machine the agent's on.
+Here, the agent just asks for a door."
+
+**DO:** In the session:
+```console
+agent-portal forward 8899
+```
+It prints one URL: `https://<8-hex>.portal.…/` — and warns nothing is
+listening yet.
+
+**SAY:** "One command, one URL. The subdomain is a hash of the *session*, not
+the port — so the URL never changes even if the agent moves the service to a
+different port. And look at the header —"
+
+**DO:** Point at the new chip: `:8899 ↗` — currently **flat red**.
+
+**SAY:** "Red means the portal probed the port and nothing's home. The proxy
+checks every ten seconds — a loopback dial, microseconds — and only phones
+home when the answer *changes*. Now let's give it something to serve."
+
+**DO:** Start the server:
+```console
+python3 -m http.server 8899 --bind 127.0.0.1
+```
+Wait ≤10s. The chip starts **breathing green**. Hover it: `python3 — https://…`.
+
+**SAY:** "Green, softly breathing — alive. And it knows *who* answered: hover
+says `python3`. The proxy asked the OS which process owns the socket. Swap in
+a Vite server on the same port and the label updates itself. Now, the part I
+like most —"
+
+**DO:** **Click the chip.** The preview window genies out of the chip.
+- Drag it around by the title bar.
+- Resize from the corner grip.
+- Collapse (▾) — point out the title bar remembers the app: `python3 :8899 — …`.
+- Expand — "the app never unloaded; it kept running while collapsed."
+- Click **Visit site ↗** — full page in a new tab, authenticated.
+- Close (×) — it collapses back into the chip.
+
+**SAY:** "That's the live app, in a floating window, inside the portal.
+WebSockets and server-sent events work through it — Jupyter kernels, Vite
+hot-reload, all of it. And it's private by default: that URL bounced through
+a token handoff only my login can complete. If I *want* it public —"
+
+**DO:** Settings ▸ **Forwarding** → flip the toggle to **Public**.
+Open the URL in an incognito window: it loads with no login.
+
+**SAY:** "— one switch, ngrok-style sharing. And it's paranoid in the right
+ways: if the agent moves the forward to a different port, the public flag
+resets to private. You opted in to sharing *that* service, not whatever
+binds the port next."
+
+**DO (optional, admin flourish):** Admin ▸ **Subdomains** → give the session
+a friendly name: type `demo`, save, open `https://demo.portal.…/`.
+
+**SAY:** "Admins can hand out human subdomains. Both URLs route; typos and
+reserved names get rejected with an explanation right in the form."
+
+**DO (finale):** Kill the server (`Ctrl-C`). Within ten seconds the chip goes
+**flat red** again.
+
+**SAY:** "Nothing polled from your browser, no page refresh. The proxy
+noticed, told the server once, the server nudged every open tab."
+
+**DETAIL (deep bench, if asked):**
+- Transport: a multiplexed byte tunnel over the session's existing WebSocket —
+  credit-windowed (256 KiB/direction/stream), 16 KiB frames, 64 streams, so a
+  fat download can't starve the agent's own traffic.
+- The reverse proxy is a real hyper HTTP/1.1 client whose "TCP" is the tunnel;
+  WebSocket upgrade is spliced with `copy_bidirectional`.
+- Auth: 60-second JWT handoff → host-only cookie on the forward origin; the
+  portal cookie never crosses origins; forwarded apps are origin-isolated
+  from the portal *and* from each other.
+- The preview iframe works because the proxy re-scopes `X-Frame-Options` /
+  `frame-ancestors` to portal-or-self — *stricter* than the nothing most dev
+  servers ship.
+- Every piece of this was reviewed by the Codex agent from Act 2. It found
+  five real bugs, including a public-flag-survives-port-change privilege leak.
+
+---
+
+## Act 4 — Ops that take care of themselves (2 min)
+
+**SAY:** "The boring parts are where remote agents usually die, so those got
+the most engineering."
+
+Narrate over the launchers tab / a terminal:
+
+- **"Launchers self-update and self-heal."** The daemon updates it

--- a/docs/MOBILE_APPS_PLAN.md
+++ b/docs/MOBILE_APPS_PLAN.md
@@ -1,0 +1,452 @@
+# Mobile Apps Plan — iOS & Android access to Agent Portal
+
+Status: **proposal / planning document** (no code changes implied by merging this).
+Author: planning session 2026-07-11. Reviewed by: _pending_.
+
+---
+
+## 1. Executive summary
+
+The cheapest credible path to "Agent Portal on my phone, in my pocket, with
+notifications" is **not** a from-scratch native app. The existing stack is
+unusually well positioned for mobile:
+
+- The Yew/WASM frontend is already responsive and runs on mobile browsers today.
+- The typed WS protocol lives in `shared/` (WASM-clean, compiles for any target)
+  and `ws-bridge` already has **three faces**: axum server, browser client, and
+  a rustls-based native client (`ws-bridge::native_client`) used by the proxy,
+  launcher, and test harness.
+- The connection-lifecycle work (#1256/#1236/#939) already solved the hard
+  mobile problems: reconnect with replay watermarks (`replay_after`), input
+  idempotency (`client_msg_id` + outbox resend), bounded queues, liveness
+  sweeps. Mobile backgrounding is just an aggressive flavor of the flaky-proxy
+  problem we already engineered for.
+- Device-flow auth already mints JWTs for out-of-browser clients.
+
+What is **genuinely missing** for mobile is exactly three things:
+
+1. **Push notifications** (turn complete, permission request) — net-new backend
+   epic, and the single highest-value mobile feature.
+2. **Token auth for `/ws/client`** — it is cookie-only today
+   (`handle_web_client_websocket` → `extract_user_id(&cookies)`); an app shell
+   or PWA-adjacent client needs a bearer path. Device flow gets us 90% there.
+3. **Store presence / app shell** — installability, deep links, share sheet,
+   native push registration.
+
+**Recommendation (staged):**
+
+- **M0 — PWA hardening** (days): manifest + service worker + icons. Installable
+  on Android and iOS immediately; zero new distribution process.
+- **M1 — Mobile token auth** (small): accept portal JWTs on `/ws/client` and
+  the REST surface; same-device device-flow login via system browser.
+- **M2 — Push** (the real work): `push_subscriptions` table, Web Push (VAPID)
+  first — it serves the installed PWA on **both** platforms today — with
+  APNs/FCM native push as a follow-on inside the app shell.
+- **M3 — App shell via Tauri 2 mobile** (Rust-coherent wrapper): remote-URL
+  WebView shell + native push + deep links + share target.
+- **M4 — Store packaging & CI lanes** (TestFlight / Play internal → prod).
+- **M5 (contingent) — native escalation** (Dioxus or UniFFI core + SwiftUI/
+  Compose) only if WebView quality or App Store review forces it.
+
+Total to a store-published v1 (M0–M4): roughly **6–9 engineer-weeks** at our
+PR cadence, of which push (M2) is ~40%.
+
+---
+
+## 2. Goals and non-goals
+
+### Goals
+
+- Read + drive sessions from a phone: view streaming output, send input,
+  answer permission requests, launch sessions on connected launchers.
+- **Be interruptible**: a permission prompt or finished turn reaches the user's
+  lock screen within seconds.
+- Reuse the existing frontend and protocol; keep one source of truth for UI.
+- Fit the existing tooling: Rust workspace, GH Actions, squash-merge train,
+  commit-count versioning, Codex cross-review.
+
+### Non-goals (v1)
+
+- Offline authoring / queueing input while fully offline (the outbox makes
+  brief drops safe; multi-hour offline queues are out of scope).
+- Feature parity for admin surfaces (usable via responsive web view is enough).
+- Tablet-optimized layouts (they inherit the responsive web layout).
+- Running agents **on** the phone. The phone is a remote control, never a host.
+
+---
+
+## 3. Inventory: what we already have (and what it buys us)
+
+| Asset | Where | Mobile relevance |
+|---|---|---|
+| Typed WS protocol | `shared/src/endpoints.rs` | Compiles to any target incl. `aarch64-apple-ios` / `aarch64-linux-android`; a native core reuses it verbatim |
+| `ws-bridge` native client | `ws-bridge::native_client` (tokio-tungstenite + **rustls-webpki-roots**) | No OpenSSL cross-compile pain on mobile; same client the proxy/launcher/harness use |
+| Reconnect + replay | `RegisterFields.replay_after`, reconnect backoff, replay watermarks | Foreground-after-background = reconnect + catch-up, already server-supported |
+| Input idempotency | `client_msg_id` + outbox resend-all (#1236) | Send-then-suspend on mobile can't double-deliver |
+| Device flow auth | `/api/auth/device/{code,poll,verify,approve,deny}` → JWT | The out-of-browser login primitive already exists and is rate-limited (#1047) |
+| Token rotation precedent | Launcher `TokenRefresh`/`TokenRefreshAck` (#1237) | The pattern for long-lived mobile tokens is already designed |
+| Transactional uploads | temp + rename, `FileUploadResult` (#939) | Camera/share-sheet image sends ride the existing upload path |
+| Responsive frontend | Yew app; portal officially supports mobile browsers | M0 is hardening, not a rewrite |
+| Voice input | `frontend/src/components/voice_input.rs` (Web Speech API) | Works in Safari/Chrome; **not** in WKWebView (see §8.4) |
+| Frontend embedded in backend | build-time asset embedding | PWA assets deploy with a normal backend release; no new hosting |
+| Commit-count versioning | `shared::VERSION` (major.minor.commit-count) | Monotonic integer — drops straight into Android `versionCode` and pairs with `CFBundleVersion` |
+
+---
+
+## 4. The mobile-specific problem set
+
+Every option below is scored against these five problems; they are the
+whole difference between "the website on a phone" and "an app".
+
+- **P1 Push**: permission requests and turn completions must reach a pocketed
+  phone. Requires server-side push infra + a client registration surface.
+- **P2 Auth without cookies**: WS + REST need a bearer-token path; login must
+  work without a same-origin browser session.
+- **P3 Lifecycle**: OS suspends the app ⇒ WS dies silently. Need fast
+  foreground reconnect + replay, and push to cover the gap while suspended.
+- **P4 Input affordances**: camera, share sheet ("share this file/screenshot
+  to a session"), paste-image, dictation.
+- **P5 Distribution**: App Store / Play Store presence, signing, review risk,
+  update cadence.
+
+---
+
+## 5. Options analysis
+
+### Option A — PWA (harden what exists)
+
+Add `manifest.webmanifest`, icons, a service worker (network-first for the
+app shell, cache-first for static assets), iOS meta tags. Trunk supports
+copying extra assets; the backend already serves everything same-origin.
+
+| Problem | How A handles it |
+|---|---|
+| P1 Push | **Web Push (VAPID)** — full support on Android (Chrome); iOS ≥16.4 **only when installed to home screen**, no install-prompt API, Apple may throttle background delivery |
+| P2 Auth | Unchanged (cookies work — it *is* the browser) |
+| P3 Lifecycle | Browser tab lifecycle; reconnect logic already exists in `use_client_websocket` |
+| P4 Input | Web share target (Android only), `<input capture>` camera, keyboard dictation |
+| P5 Distribution | None (that's the point) — or PWABuilder wrapping later |
+
+- **Cost**: ~1 engineer-week including SW cache-invalidation care.
+- **Ceiling**: iOS push UX is second-class (manual install ritual, no badge
+  control, delivery throttling anecdotes), no share-sheet on iOS, no store
+  presence.
+- **Verdict**: do it regardless — it is the substrate for M2's Web Push and
+  costs almost nothing. Not sufficient alone for the iOS experience we want.
+
+### Option B — WebView app shell (Tauri 2 mobile vs Capacitor)
+
+A native shell around the existing web UI. Two sub-decisions: **which shell
+framework** and **remote vs bundled frontend** (the crux — see §5.B.2).
+
+#### B.1 Shell framework
+
+| | **Tauri 2 mobile** | **Capacitor** |
+|---|---|---|
+| Language/toolchain | Rust CLI, Rust plugin host — fits repo | Node/npm + TS config — new toolchain in a pure-Rust repo |
+| Maturity (mobile) | Stable since 2.0 (Oct 2024); mobile is newer than desktop | Very mature, huge plugin ecosystem |
+| Push plugin | Community/early (`tauri-plugin-push-notifications`); may need our own thin Swift/Kotlin bridge (~200 lines/platform) | First-party, battle-tested |
+| Deep links, biometrics | First-party plugins | First-party plugins |
+| Team fit | High — Rust across the board; our shell logic (token store, push registration relay) can be Rust | Low — introduces JS build + dependency surface we deliberately don't have |
+| Risk | Younger mobile story; we self-insure on push bridge | npm supply-chain + toolchain drift |
+
+**Choice: Tauri 2.** Rationale: repo coherence beats plugin convenience; the
+one weak spot (push bridge) is small, well-bounded native code we'd want to
+control anyway. **Reversible**: the web app doesn't know or care what wraps
+it; swapping shells later doesn't touch the portal.
+
+#### B.2 Remote-URL vs bundled frontend (the crux tradeoff)
+
+- **Remote**: shell loads `https://portal.example.com` directly.
+  - ✅ Zero frontend duplication; server-driven updates (ship a fix by
+    deploying the backend, no store review); **same-origin assumptions all
+    hold** — cookies, relative API/WS URLs, embedded assets.
+  - ⚠️ Needs network for first paint (splash + cached shell mitigates);
+    slightly higher App Store 4.2 "just a website" risk (mitigated by push,
+    deep links, share extension — see §9).
+- **Bundled**: frontend assets packed into the app, calling the backend
+  cross-origin.
+  - ✅ Instant first paint, review-proof asset story.
+  - ❌ Breaks the same-origin assumption everywhere: the frontend derives API
+    and WS URLs from `window.location`, auth is a same-origin cookie, assets
+    are embedded in the backend. Bundling forces configurable base URLs,
+    CORS on the whole API, token auth for **every** REST call, and a
+    frontend-version-vs-backend-version skew matrix. That is a large,
+    ongoing tax — not a one-time cost.
+
+**Choice: remote-URL shell.** The bundled tax buys nothing our users need in
+v1. Revisit only if review or first-paint metrics force it. (M1's token auth
+is still required — for the *shell's* login handoff and for push registration
+REST calls made outside the WebView cookie jar.)
+
+| Problem | How B (Tauri, remote) handles it |
+|---|---|
+| P1 Push | Native APNs/FCM registration in the shell; token POSTed to backend; backend pushes natively. First-class lock-screen UX, badges, sounds |
+| P2 Auth | Device-flow variant in system browser → JWT held by shell → injected into WebView session (§7) |
+| P3 Lifecycle | Shell observes foreground events → nudges WebView reconnect immediately instead of waiting for timer |
+| P4 Input | Share extension (iOS) / share target (Android) → upload path; camera via WebView permission; keyboard dictation |
+| P5 Distribution | Full store presence; review risk analyzed in §9 |
+
+- **Cost**: ~3–4 engineer-weeks including push bridges and store setup.
+- **Verdict**: the recommended v1 app.
+
+### Option C — Rust-native UI (Dioxus mobile / Slint)
+
+Rewrite the client UI in a Rust framework with mobile renderers, reusing
+`shared/` + `ws-bridge` natively.
+
+- ✅ Maximum type-sharing; one language.
+- ❌ **Second UI to maintain forever** — the dashboard is large (message
+  renderers for two agent protocols, permission dialogs, uploads, voice,
+  admin). Dioxus mobile is pre-1.0 in exactly the areas we'd stress
+  (keyboards, IME, scroll performance, a11y).
+- **Verdict: rejected for v1.** Escalation path only, and Option D is the
+  better-understood escalation.
+
+### Option D — Native shells + shared Rust core (UniFFI)
+
+SwiftUI + Compose apps over a `mobile-core` Rust crate (session list, WS
+client on `ws-bridge::native_client`, outbox, auth) exposed via UniFFI.
+
+- ✅ Best possible UX ceiling; protocol logic stays typed Rust (no
+  Swift/Kotlin protocol drift — honoring the "no JSON poking" rule).
+- ❌ Two UIs + a bindings layer; roughly 3–4× Option B's cost; slowest
+  iteration (every protocol addition = core + two UIs).
+- **Verdict**: the *right* long-term architecture **if** the portal becomes a
+  primary phone-first product. Not v1. The M1/M2 backend work is 100% shared
+  with this future, so nothing in the recommended path is throwaway.
+
+### Option E — Fully native, no shared core
+
+- ❌ Reimplements the WS protocol twice in non-Rust; guaranteed drift; violates
+  the repo's typed-interface ethos. **Rejected without further analysis.**
+
+### Summary matrix
+
+| | A PWA | B Tauri shell | C Dioxus | D UniFFI native | E Full native |
+|---|---|---|---|---|---|
+| Push quality (iOS) | ⚠️ installed-PWA only | ✅ APNs | ✅ APNs | ✅ APNs | ✅ APNs |
+| UI reuse | ✅ 100% | ✅ 100% | ❌ rewrite | ❌ rewrite ×2 | ❌ rewrite ×2 |
+| Protocol reuse | ✅ | ✅ | ✅ | ✅ (UniFFI) | ❌ |
+| Store presence | ❌ | ✅ | ✅ | ✅ | ✅ |
+| New toolchains | none | Xcode/AS + Tauri | Xcode/AS + Dioxus | Xcode/AS + UniFFI + Swift/Kotlin | Xcode/AS + Swift/Kotlin |
+| Cost to v1 | ~1 wk | ~3–4 wk | ~8–10 wk | ~10–14 wk | ~14+ wk |
+| Throwaway work if we later go D | none | shell only (~1 wk) | most of it | — | — |
+
+---
+
+## 6. Recommended architecture (M0–M4)
+
+```
+┌─ iPhone / Android ────────────────────────────────┐
+│  Tauri 2 shell (Rust)                             │
+│  ├─ WKWebView / Android WebView ──────────────────┼── https://portal (same-origin: cookies, WS, assets)
+│  ├─ Push bridge (Swift/Kotlin, ~200 lines each) ──┼── APNs / FCM registration token
+│  ├─ Deep links: https://portal/app/session/{id}   │
+│  ├─ Share extension → POST upload → open session  │
+│  └─ Auth handoff: system browser device-flow → JWT│
+└───────────────────────────────────────────────────┘
+                        │
+┌─ backend ─────────────▼───────────────────────────┐
+│  NEW  /api/push/subscriptions (register/list/del) │
+│  NEW  push dispatcher (Web Push now, APNs/FCM M3) │
+│  NEW  bearer-JWT auth on /ws/client + REST        │
+│  hooks: permission request, turn Result, session  │
+│         error → dispatch if user has no live      │
+│         web client (presence via SessionManager)  │
+└───────────────────────────────────────────────────┘
+```
+
+---
+
+## 7. Auth design (M1)
+
+**Today**: `/ws/client` extracts the user from the signed session cookie and
+rejects otherwise; every REST handler uses `CurrentUserId` (cookie). Device
+flow (`/api/auth/device/*`) already mints JWTs after browser approval, with
+rate limiting.
+
+**Plan**:
+
+1. **Accept `Authorization: Bearer <jwt>`** as an alternative to the cookie in
+   `extract_user` (one function; every handler and the WS upgrade inherit it).
+   Token audience `mobile` distinct from proxy/launcher tokens so revocation
+   can be per-class.
+2. **Same-device login without code-typing**: app opens
+   `https://portal/device?user_code=XXXX` (the existing verify page,
+   pre-filled) in `ASWebAuthenticationSession` / Custom Tabs; the user does the
+   normal Google login + approve; the app's poll on `/api/auth/device/poll`
+   completes with a JWT. Zero new Google Console configuration, reuses the
+   #1047-hardened endpoints. (The CLI types a code because it can't open a
+   browser on the same screen — a phone can.)
+3. **Rotation**: 30-day expiry with half-life refresh, mirroring launcher token
+   rotation (#1237): refresh over the live WS (`TokenRefresh` variant on the
+   client endpoint) or a `POST /api/auth/refresh`. Store in Keychain /
+   Keystore via the shell.
+4. **WebView session handoff**: the shell holds the JWT; the WebView still uses
+   the cookie it gets from the device-flow completion redirect. Fallback: a
+   `POST /api/auth/token-login` that exchanges a bearer JWT for a session
+   cookie inside the WebView (small handler, same audience checks).
+
+Backend delta: ~2 focused PRs (bearer path + refresh; token-login exchange).
+
+## 8. Push architecture (M2 — the real epic)
+
+### 8.1 Events worth a push (v1)
+
+| Event | Source hook | Priority |
+|---|---|---|
+| Permission request pending | permission dispatch to web clients | **highest** — this is the "agent is blocked on you" interrupt |
+| Turn complete (Result) | proxy `SequencedOutput` Result finalize | high; collapse per session |
+| Session errored/disconnected unexpectedly | status transition | medium |
+| Inter-agent message received | message delivery | low, off by default |
+
+### 8.2 Delivery policy
+
+- **Suppress when present**: if the user has a live web client
+  (`SessionManager` user-client registry — the presence source already exists),
+  deliver in-app only. Push is for the pocketed phone.
+- **Collapse keys**: one visible notification per session, newest wins
+  (`apns-collapse-id` / FCM `collapse_key` / Web Push `tag`).
+- **Payload discipline**: session id + event kind + short preview only. The tap
+  deep-links to the session; content stays server-side.
+- Per-user, per-event-kind toggles in Settings (new `notification_prefs` on
+  users or a small table).
+
+### 8.3 Transport strategy
+
+- **Stage 1 — Web Push (VAPID)** via the `web-push` crate:
+  one integration that serves installed PWAs on Android **and** iOS ≥16.4 and
+  desktop browsers. New table:
+
+  ```sql
+  push_subscriptions(id, user_id, platform,        -- 'webpush' | 'apns' | 'fcm'
+                     endpoint_or_token, p256dh, auth,  -- webpush keys; NULL for native
+                     device_label, created_at, last_success_at, disabled_at)
+  ```
+
+  Dead-endpoint pruning on 404/410 responses.
+- **Stage 2 (M3) — native APNs + FCM** for the shell:
+  direct APNs via the `a2` crate (HTTP/2, p8 key) and FCM v1 via HTTP + service
+  account. **Decision: direct integrations, not FCM-for-iOS routing** — one
+  fewer intermediary, no Firebase SDK inside the app, and `a2` keeps it Rust.
+  The dispatcher fans out one event to every non-disabled subscription for the
+  user, per policy above.
+- Failure marker: `PUSH_DISPATCH_FAILED` (mirrors `SESSION_ARCHIVE_FAILED` /
+  `PENDING_INPUT_PERSIST_FAILED` conventions for alerting).
+
+### 8.4 Known capability gaps to accept in v1
+
+- **Web Speech in WKWebView**: `SpeechRecognition` is unavailable inside
+  WKWebView — the mic button should hide when unsupported (it already gates on
+  API presence); keyboard dictation covers the need. Native speech plugin is a
+  v2 nicety.
+- **iOS PWA installs** can't register through the shell path; they use Web Push
+  and live with its limits.
+
+---
+
+## 9. App Store / Play review risk
+
+- **Precedent**: GitHub, Slack, Termius, Working Copy — "client for a developer
+  service" is an accepted category. The agents run server-side; the app
+  executes nothing (no 2.5.2 exposure).
+- **Apple 4.2 (minimum functionality / repackaged website)** is the real risk
+  for a remote-URL WebView app. Mitigations that historically satisfy review:
+  native push, deep links / universal links, share extension, native settings
+  entry points, app-specific login handoff. All are in M3 scope. Residual risk:
+  a strict reviewer → contingency is bundling the frontend (§5.B.2 tax) or
+  adding a native session-list screen (first slice of Option D).
+- **Sign-in-with-Google-only** apps on iOS trip guideline 4.8 (must offer a
+  comparable privacy-preserving option — in practice, Sign in with Apple).
+  **Open question O3**: add Apple OAuth to the backend (moderate: second
+  provider in `auth.rs`, same allowlist gates) or gate store release on it.
+- **Play**: low risk; data-safety form + privacy policy URL needed (we should
+  publish one regardless).
+
+## 10. CI/CD, signing, versioning
+
+- **Android lane**: ubuntu runner — SDK + NDK, `tauri android build`, sign with
+  a keystore in GH secrets, upload to Play internal track (fastlane supply or
+  `gradle-play-publisher`).
+- **iOS lane**: macOS runner — Xcode, certs/profiles via **fastlane match**
+  (private certs repo) or App Store Connect API key in secrets,
+  `tauri ios build`, upload via `altool`/fastlane pilot to TestFlight.
+- **Versioning**: `shared::VERSION`'s commit-count patch is monotonic —
+  `versionCode` = commit count, `CFBundleVersion` likewise;
+  `CFBundleShortVersionString` / `versionName` = full `major.minor.patch`.
+  No new human knobs, consistent with #1096.
+- **Cadence**: store binaries only change when the *shell* changes (remote-URL
+  frontend updates ship with backend deploys). Expect a shell release every
+  few weeks, not per-merge. CI builds every PR touching `mobile/`; store upload
+  on manual dispatch or tag.
+- **Repo shape**: `mobile/` at workspace root (Tauri project; its Rust crate
+  joins the workspace; Xcode/Gradle projects generated + committed).
+
+## 11. Phased plan (PR-series shape, per repo process)
+
+Each phase = a PR series, cross-reviewed by Codex, squash-merged serially.
+
+**M0 — PWA baseline** (~1 wk): manifest + icons + iOS meta (1 PR); service
+worker with cache-versioning tied to `shared::VERSION` (1 PR); install hint UI
+(1 PR). *Exit*: installable on both platforms, Lighthouse PWA pass.
+
+**M1 — Mobile token auth** (~1 wk): bearer-JWT alternative in `extract_user` +
+audience + tests (1 PR); refresh + `token-login` cookie exchange (1 PR);
+pre-filled `user_code` verify page polish (1 PR). *Exit*: WS + REST usable
+with a device-flow JWT end to end.
+
+**M2 — Push** (~2–2.5 wk): `push_subscriptions` migration + CRUD API (1 PR);
+dispatcher + Web Push + event hooks + suppression policy (2 PRs); Settings
+toggles + frontend subscribe flow (1 PR); prefs + pruning + `PUSH_DISPATCH_FAILED`
+observability (1 PR). *Exit*: locked Android phone + installed PWA receives a
+permission-request push that deep-links into the session.
+
+**M3 — Tauri shell** (~2–3 wk): scaffold + remote-URL config + CI debug builds
+(1 PR); auth handoff via system browser (1 PR); APNs bridge + `a2` dispatch
+(1–2 PRs); FCM bridge + dispatch (1 PR); deep links + share extension → upload
+(1–2 PRs). *Exit*: TestFlight/internal-track builds with native push.
+
+**M4 — Store launch** (~1 wk + review latency): assets, privacy policy, data
+safety, review notes; Apple sign-in decision (O3) resolved; staged rollout.
+
+**M5 — contingent**: only on explicit demand signals (review rejection ⇒
+bundle/native-first-screen; WebView jank ⇒ Option D spike starting with the
+session list).
+
+## 12. Risks
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| Apple rejects WebView shell (4.2) | M | H | M3 native surface area; contingency: bundle or native first screen |
+| Tauri mobile push plugin immature | H | M | Own thin bridges (~200 lines/platform), planned not discovered |
+| iOS Web Push unreliability (M2 gap era) | M | M | Positioned as interim; APNs lands in M3 |
+| SW caching serves stale WASM | M | M | Version-keyed cache from `shared::VERSION`; network-first for `index.html` |
+| Google-only login blocks iOS launch (4.8) | M | H | Decide O3 early — it's backend work with lead time |
+| WS battery drain in foreground | L | L | Existing heartbeats are modest; shell releases socket on background |
+| Cert/signing ops on solo project | M | M | fastlane match + documented runbook in `mobile/README` |
+
+## 13. Decision log
+
+| # | Decision | Rationale | Reversibility |
+|---|---|---|---|
+| D1 | PWA first, regardless of shell | Substrate for Web Push; near-zero cost | n/a |
+| D2 | Tauri 2 over Capacitor | Rust coherence; push bridge self-insured | High — shell is swappable |
+| D3 | Remote-URL over bundled frontend | Preserves same-origin assumptions; avoids CORS/base-URL/version-skew tax | Medium — bundling is additive later |
+| D4 | Device-flow (pre-filled code) over new OAuth PKCE | Reuses hardened endpoints; zero Google Console changes | High |
+| D5 | Direct APNs (`a2`) + FCM v1, not FCM-for-everything | Fewer intermediaries; no Firebase SDK on iOS; Rust-native | Medium |
+| D6 | Web Push before native push | One integration serves both platforms + desktop immediately | n/a (kept either way) |
+| D7 | No Dioxus/UniFFI in v1 | Second UI is the most expensive artifact we could create | Path preserved: M1/M2 fully shared with Option D |
+
+## 14. Open questions for Matt
+
+- **O1**: iPhone or Android first for dogfooding? (Determines which push
+  bridge lands first in M3.)
+- **O2**: Store presence a hard requirement, or is installed-PWA + push (M0–M2)
+  possibly sufficient? M2 is the natural checkpoint to reassess.
+- **O3**: Add Sign in with Apple to the backend (Apple 4.8), or defer store
+  launch until we're ready to do it?
+- **O4**: Push preview content — session name only, or include a text snippet
+  of the permission/turn? (Privacy vs. usefulness on the lock screen.)
+- **O5**: Should launchers be drivable from the phone in v1 (launch new
+  sessions), or is driving existing sessions enough?

--- a/docs/MOBILE_APPS_PLAN.md
+++ b/docs/MOBILE_APPS_PLAN.md
@@ -2,6 +2,9 @@
 
 Status: **proposal / planning document** (no code changes implied by merging this).
 Author: planning session 2026-07-11. Reviewed by: _pending_.
+Rev 2 (2026-07-11): claims verified against the codebase (file:line refs added,
+JWT `aud` → `token_type` corrected, presence-pruning caveat added); §15 work
+breakdown and §16 parallel execution plan added.
 
 ---
 
@@ -49,7 +52,10 @@ What is **genuinely missing** for mobile is exactly three things:
   Compose) only if WebView quality or App Store review forces it.
 
 Total to a store-published v1 (M0–M4): roughly **6–9 engineer-weeks** at our
-PR cadence, of which push (M2) is ~40%.
+PR cadence, of which push (M2) is ~40%. Because most tracks are mutually
+independent (§16), running them as parallel agent sessions compresses M0–M2 to
+roughly **1.5–2 wall-clock weeks** and M0–M4 to **3–4**, gated mostly by store
+review latency and the merge train, not by engineering.
 
 ---
 
@@ -118,6 +124,19 @@ whole difference between "the website on a phone" and "an app".
 Add `manifest.webmanifest`, icons, a service worker (network-first for the
 app shell, cache-first for static assets), iOS meta tags. Trunk supports
 copying extra assets; the backend already serves everything same-origin.
+
+Grounding (verified): **no PWA scaffolding exists today** — no manifest, no
+service worker, no `apple-touch-icon`/`theme-color` meta. Static assets are
+added via `data-trunk rel="copy-file"` links in `frontend/index.html:96-102`
+and served by `memory_serve` from the embedded `dist/`
+(`backend/src/routes.rs:325-334`). Two serving details that shape the work:
+the router has an **SPA fallback that returns `index.html` with 200 for any
+unknown path**, so `/sw.js` and `/manifest.webmanifest` must be real emitted
+assets (a typo'd path would silently serve HTML as your service worker); and
+`html_cache_control = NoCache` while hashed assets get `Long` — exactly the
+split a network-first-shell / cache-first-assets SW wants. The viewport is
+already `viewport-fit=cover` (`index.html:5`) and `styles/session-mobile.css`
+exists, confirming M0 is additive hardening.
 
 | Problem | How A handles it |
 |---|---|
@@ -261,17 +280,38 @@ client on `ws-bridge::native_client`, outbox, auth) exposed via UniFFI.
 
 ## 7. Auth design (M1)
 
-**Today**: `/ws/client` extracts the user from the signed session cookie and
-rejects otherwise; every REST handler uses `CurrentUserId` (cookie). Device
-flow (`/api/auth/device/*`) already mints JWTs after browser approval, with
-rate limiting.
+**Today** (verified against the code):
+
+- REST handlers authenticate via the `CurrentUserId` extractor
+  (`backend/src/auth.rs:83`), which reads the signed session cookie in
+  `extract_user` (`auth.rs:44`) and rejects disabled users.
+- `/ws/client` uses the same cookie path: `handle_web_client_websocket` →
+  `extract_user_id` (`backend/src/handlers/websocket/mod.rs:58`); 401 otherwise.
+- A bearer path **already exists on some REST routes**: `resolve_user`
+  (`backend/src/handlers/agent_comms.rs:30`) accepts `Authorization: Bearer`
+  (proxy token) *or* the cookie, and `/api/sessions/{id}/forwards*` follows the
+  same dual convention (`backend/src/routes.rs:167`). M1 generalizes an
+  existing in-repo pattern; it does not invent one.
+- JWT claims: `ProxyTokenClaims` (`shared/src/proxy_tokens.rs:15`) carries
+  `jti` (revocation key), `sub`, `email`, `iat`, optional `exp`, and a
+  `token_type` string (`"proxy"` | `"launcher"`). **There is no `aud` claim** —
+  the per-class discriminator in this codebase is `token_type`.
+- Device flow completion (`complete_device_flow`,
+  `backend/src/handlers/device_flow.rs:476`) currently mints **non-expiring**
+  tokens (`expires_in_days = None`, per #932). DB-backed revocation,
+  ban-checking, and `last_used_at` tracking already exist
+  (`verify_and_get_user_with_token`,
+  `backend/src/handlers/proxy_tokens.rs:271`).
 
 **Plan**:
 
 1. **Accept `Authorization: Bearer <jwt>`** as an alternative to the cookie in
-   `extract_user` (one function; every handler and the WS upgrade inherit it).
-   Token audience `mobile` distinct from proxy/launcher tokens so revocation
-   can be per-class.
+   `extract_user` (one function; every `CurrentUserId` handler and the WS
+   upgrade inherit it). Mobile tokens get `token_type: "mobile"` (extending the
+   existing `"proxy"`/`"launcher"` values — there is no `aud` claim in this
+   codebase) so revocation and policy can be per-class. Unlike device tokens,
+   mobile tokens are minted **expiring** (30 days) — the device-flow completion
+   gains an `expires_in_days` knob for the mobile client class.
 2. **Same-device login without code-typing**: app opens
    `https://portal/device?user_code=XXXX` (the existing verify page,
    pre-filled) in `ASWebAuthenticationSession` / Custom Tabs; the user does the
@@ -294,18 +334,26 @@ Backend delta: ~2 focused PRs (bearer path + refresh; token-login exchange).
 
 ### 8.1 Events worth a push (v1)
 
-| Event | Source hook | Priority |
+| Event | Source hook (verified) | Priority |
 |---|---|---|
-| Permission request pending | permission dispatch to web clients | **highest** — this is the "agent is blocked on you" interrupt |
-| Turn complete (Result) | proxy `SequencedOutput` Result finalize | high; collapse per session |
-| Session errored/disconnected unexpectedly | status transition | medium |
+| Permission request pending | `handle_permission_request` → `broadcast_to_web_clients` (`backend/src/handlers/websocket/permissions.rs:73`) | **highest** — this is the "agent is blocked on you" interrupt |
+| Turn complete (Result) | Result role detected + `store_result_metadata` (`backend/src/handlers/websocket/message_handlers.rs:309`) | high; collapse per session |
+| Session disconnected unexpectedly | `Disconnected` transitions: proxy socket teardown (`proxy_socket.rs:116`), stale-session sweep (`background.rs:83`), launcher cleanup (`launcher_socket.rs:577`). Note: `SessionStatus` has no `Errored` variant — "errored" collapses into `Disconnected` here | medium |
 | Inter-agent message received | message delivery | low, off by default |
 
 ### 8.2 Delivery policy
 
 - **Suppress when present**: if the user has a live web client
-  (`SessionManager` user-client registry — the presence source already exists),
-  deliver in-app only. Push is for the pocketed phone.
+  (`SessionManager.user_clients`, a per-user `DashMap`
+  at `session_manager/mod.rs:127`), deliver in-app only. Push is for the
+  pocketed phone.
+- **Presence caveat (verified)**: `user_clients` is pruned **lazily** — dead
+  senders are only removed when a send to them fails
+  (`client_fanout.rs:13`); there is no disconnect-time removal. A phone that
+  backgrounded 20 minutes ago can still look "present" and wrongly suppress a
+  push. Prerequisite work item (C5 in §15): remove the sender eagerly on
+  socket close in `web_client_socket.rs` so suppression is trustworthy. Small,
+  independent, and load-bearing for the whole delivery policy.
 - **Collapse keys**: one visible notification per session, newest wins
   (`apns-collapse-id` / FCM `collapse_key` / Web Push `tag`).
 - **Payload discipline**: session id + event kind + short preview only. The tap
@@ -386,6 +434,10 @@ Backend delta: ~2 focused PRs (bearer path + refresh; token-login exchange).
 ## 11. Phased plan (PR-series shape, per repo process)
 
 Each phase = a PR series, cross-reviewed by Codex, squash-merged serially.
+The milestones below are the *sequential* story; §15 breaks them into
+individually-shippable work items and §16 shows which of those run in
+parallel (the milestones overlap heavily — M1, M2, and M3's scaffold can all
+be in flight at once).
 
 **M0 — PWA baseline** (~1 wk): manifest + icons + iOS meta (1 PR); service
 worker with cache-versioning tied to `shared::VERSION` (1 PR); install hint UI
@@ -450,3 +502,179 @@ session list).
   of the permission/turn? (Privacy vs. usefulness on the lock screen.)
 - **O5**: Should launchers be drivable from the phone in v1 (launch new
   sessions), or is driving existing sessions enough?
+
+---
+
+## 15. Work breakdown structure
+
+Every item below is one PR (occasionally two), independently shippable and
+independently revertable. IDs are used by the dependency graph and wave plan
+in §16. Sizes: **XS** < half a day, **S** ~a day, **M** 2–4 days.
+
+### W0 — API contracts (do this first; it unblocks three tracks)
+
+| ID | Deliverable | Files | Size | Depends on |
+|---|---|---|---|---|
+| W0 | Typed request/response structs for push-subscription CRUD (`RegisterPushSubscriptionRequest`, `PushSubscriptionInfo`, …) and `NotificationPrefs`, plus agreed endpoint paths (`/api/push/subscriptions`, `/api/push/prefs`), per the no-`serde_json::json!` rule | `shared/src/api.rs` | XS | — |
+
+W0 is deliberately tiny: once the wire contract is merged, the backend
+implementation (C1/C6), the frontend subscribe flow (D2) and settings panel
+(D3), and the shell registration calls (E4/E5) can all be built **against the
+contract, concurrently**, instead of serializing on the backend landing first.
+
+### Track A — PWA baseline (M0)
+
+| ID | Deliverable | Files | Size | Depends on |
+|---|---|---|---|---|
+| A1 | `manifest.webmanifest`, icon set (maskable + `apple-touch-icon`), `theme-color`/iOS meta, `copy-file` links | `frontend/index.html`, `frontend/assets/` | S | — |
+| A2 | Service worker: network-first `index.html`, cache-first hashed assets, cache name keyed on `shared::VERSION` (injected at build); registration in app bootstrap. Must be a real emitted asset — the SPA fallback (`routes.rs:325`) returns HTML/200 for unknown paths | `frontend/sw.js` (new), `frontend/index.html`, small build glue | M | A1 |
+| A3 | Install-hint UI (iOS "Add to Home Screen" ritual has no prompt API); standalone-display detection polish | `frontend/src/` | S | A1 |
+
+*Exit test*: Lighthouse PWA pass; installed app on Android + iOS survives a
+backend deploy without serving stale WASM (the SW-cache risk from §12).
+
+### Track B — Mobile token auth (M1)
+
+| ID | Deliverable | Files | Size | Depends on |
+|---|---|---|---|---|
+| B1 | Bearer-JWT alternative in `extract_user` (mirrors the `resolve_user` dual path); `token_type: "mobile"`; expiring mint variant in device-flow completion; tests for cookie/bearer/disabled/revoked/expired matrix | `backend/src/auth.rs`, `backend/src/handlers/device_flow.rs`, `shared/src/proxy_tokens.rs` | M | — |
+| B2 | `POST /api/auth/refresh` (half-life policy, mirroring `maybe_issue_launcher_token_refresh`, `launcher_socket.rs:55`) + `POST /api/auth/token-login` (bearer → session cookie, for the WebView handoff) | `backend/src/handlers/`, `backend/src/routes.rs` | M | B1 |
+| B3 | Device verify page accepts pre-filled `?user_code=`; mobile-layout polish of the approve screen | `frontend/src/pages/` | S | — |
+
+*Exit test*: a device-flow JWT drives `/ws/client` and the session REST
+surface end to end, refresh included, with no cookie in play.
+
+### Track C — Push backend (M2 core)
+
+| ID | Deliverable | Files | Size | Depends on |
+|---|---|---|---|---|
+| C1 | `push_subscriptions` migration (§8.3 schema) + Diesel models + CRUD handlers + routes | `backend/migrations/`, `models.rs`, `handlers/push.rs` (new), `routes.rs` | M | W0 |
+| C2 | Dispatcher core: `NotificationEvent` enum, mpsc channel on `AppState`, policy engine (suppression via presence, collapse keys, prefs lookup), `PushTransport` trait, `PUSH_DISPATCH_FAILED` marker | `backend/src/push/` (new module) | M | C1 (schema only) |
+| C3 | Web Push transport: `web-push` crate, `PORTAL_VAPID_{PUBLIC,PRIVATE}_KEY` env, dead-endpoint pruning on 404/410 → `disabled_at` | `backend/src/push/webpush.rs`, workspace `Cargo.toml` | M | C2 |
+| C4 | Event hooks: emit `NotificationEvent` from the three verified points — `permissions.rs:73`, `message_handlers.rs:309`, and the `Disconnected` transitions (`proxy_socket.rs:116`, `background.rs:83`, `launcher_socket.rs:577`) | those files | S | C2 |
+| C5 | **Presence liveness** (§8.2 caveat): eagerly remove `user_clients` senders on socket close in `web_client_socket.rs` instead of lazy prune-on-failed-send | `backend/src/handlers/websocket/` | S | — |
+| C6 | `notification_prefs` storage (jsonb on `users`, same pattern as the existing `sound_config` column) + GET/PUT API | migration, `handlers/push.rs` | S | W0 |
+| C7 | Native transports: APNs via `a2` (HTTP/2, p8 key) + FCM v1 (HTTP, service account) behind the same `PushTransport` trait | `backend/src/push/{apns,fcm}.rs`, `Cargo.toml` | M | C2 |
+
+*Exit test* (C1–C6): locked Android phone with the installed PWA receives a
+permission-request push that deep-links into the session; an open dashboard
+tab suppresses the same push.
+
+### Track D — Frontend push UX
+
+| ID | Deliverable | Files | Size | Depends on |
+|---|---|---|---|---|
+| D1 | SW `push` event handler + `notificationclick` deep link to `/app/session/{id}`; collapse via Web Push `tag` | `frontend/sw.js` | S | A2 |
+| D2 | Subscribe flow: `pushManager.subscribe` with VAPID public key, POST to `/api/push/subscriptions`, notification-permission prompt UX, unsubscribe | `frontend/src/` | M | A2, W0 (e2e needs C1/C3) |
+| D3 | Settings → Notifications panel: new `SettingsTab` variant + panel alongside `sounds_panel.rs` (`frontend/src/pages/settings/mod.rs:20`); per-event-kind toggles | `frontend/src/pages/settings/` | S | W0 (e2e needs C6) |
+
+### Track E — Tauri shell (M3)
+
+| ID | Deliverable | Files | Size | Depends on |
+|---|---|---|---|---|
+| E1 | Scaffold: `mobile/` Tauri 2 project, remote-URL WebView config, splash, workspace membership, dev-run docs (`mobile/README.md`) | `mobile/` (new), workspace `Cargo.toml` | M | — |
+| E2 | Deep links: universal links / app links; backend serves `/.well-known/assetlinks.json` + `apple-app-site-association` (tiny handler); shell routes links into the WebView | `mobile/`, `backend/src/routes.rs` | S–M | E1 |
+| E3 | Auth handoff: `ASWebAuthenticationSession` / Custom Tabs → device flow → JWT in Keychain/Keystore → `token-login` cookie exchange into the WebView | `mobile/` | M | E1, B2 |
+| E4 | APNs bridge: ~200-line Swift registration bridge, token POST to `/api/push/subscriptions` (platform `apns`) | `mobile/ios/` | M | E1, W0 (e2e needs C7) |
+| E5 | FCM bridge: Kotlin equivalent (platform `fcm`) | `mobile/android/` | M | E1, W0 (e2e needs C7) |
+| E6 | Share extension (iOS) / share target (Android) → existing transactional upload path → open session | `mobile/` | M | E1, E3 |
+
+### Track F — CI, signing, ops
+
+| ID | Deliverable | Files | Size | Depends on |
+|---|---|---|---|---|
+| F1 | Android CI lane: SDK/NDK setup, `tauri android build` on PRs touching `mobile/`, debug APK artifact | `.github/workflows/` | S–M | E1 |
+| F2 | iOS CI lane: macOS runner, cert/profile injection, `tauri ios build`, TestFlight upload on dispatch/tag | `.github/workflows/` | M | E1, F3 |
+| F3 | **Ops, not code**: Play Console + App Store Connect accounts, bundle IDs, keystore + fastlane match cert repo, APNs p8 key, FCM service account, GH secrets | — | S (elapsed days) | — |
+
+### Track G / H — launch prerequisites
+
+| ID | Deliverable | Files | Size | Depends on |
+|---|---|---|---|---|
+| G1 | Sign in with Apple as a second OAuth provider (O3), same allowlist gates as Google | `backend/src/handlers/auth.rs`, `routes.rs` | M | — (decision O3) |
+| H1 | Privacy policy page, store listings, screenshots, data-safety form answers | `docs/`, store consoles | S | — |
+
+---
+
+## 16. Parallel execution plan
+
+This repo is developed by concurrent agent sessions feeding a squash-merge
+train, so the unit of parallelism is a **track owned by one session**, and
+the scarce resource is not engineering time but **merge serialization on hot
+files**. The plan below maximizes independent lanes and calls out the files
+where lanes collide.
+
+### 16.1 Dependency graph
+
+```
+W0 ──┬────────────► C1 ──► C2 ──┬─► C3 ──► (M2 exit test w/ D2)
+     │                          ├─► C4
+     │                          └─► C7 ◄─── (e2e: E4, E5)
+     ├────────────► C6
+     ├────────────► D2 ◄── A2 ◄── A1 ──► A3
+     ├────────────► D3            └────► D1 (after A2)
+     └────────────► E4, E5 ◄── E1 ──► E2, F1
+B1 ──► B2 ──► E3 ◄── E1          └───► F2 ◄── F3
+B3   C5   G1   H1   F3            (no incoming edges: start anytime)
+```
+
+**Critical path**: `W0 → C1 → C2 → C3 → D2 → M2 exit test` — push, as
+predicted (~40% of total). Everything else parallelizes around it, so the
+critical path should be staffed first and never blocked on review.
+
+### 16.2 Wave plan
+
+**Wave 1 — start immediately, all mutually independent (up to 9 lanes):**
+
+| Lane | Items | Why it's independent |
+|---|---|---|
+| 1 | W0 (hours) then C1 → C2 | The critical path; W0 unblocks lanes 4–6 the same day |
+| 2 | A1 → A2 → A3 | Pure frontend assets; touches nothing the backend lanes touch |
+| 3 | B1 → B2 | `auth.rs`/`device_flow.rs` only |
+| 4 | C5 | Tiny, zero deps, prerequisite for trustworthy suppression |
+| 5 | E1 | New `mobile/` dir; conflicts with nothing |
+| 6 | G1 | `auth.rs` OAuth section — coordinate merge order with B1 (see 16.3) |
+| 7 | B3 | Frontend device page only |
+| 8 | F3 | Ops/accounts — pure elapsed time, start day 1 because cert/console provisioning has multi-day latency |
+| 9 | H1 | Prose + assets |
+
+**Wave 2 — unblocked as Wave 1 lands:** C3, C4, C6 (after C2); D1, D2
+(after A2 + W0); D3 (after W0); E2, F1, F2 (after E1).
+
+**Wave 3 — integration:** E3 (needs B2 + E1); C7; E4 + E5 (need C7 for
+end-to-end, buildable against the C1 contract before that); E6.
+
+**Wave 4 — launch:** M4 store submission (needs E-track + F-track + G1 + H1);
+O3 decision must be resolved before this wave, not during it.
+
+### 16.3 Hot files — where parallel lanes collide
+
+Conflicts here are guaranteed but trivial (a few lines each); the mitigation
+is *scheduling*, not redesign: keep each PR's touch on these files minimal
+and land them in a known order rather than simultaneously.
+
+| File | Touched by | Handling |
+|---|---|---|
+| `backend/src/routes.rs` | B2, C1, C6, E2, G1 | Each adds 1–3 route lines; rebase-and-merge serially, any order |
+| `backend/src/auth.rs` | B1, G1 | Different regions (token vs OAuth provider); land B1 first — G1 is decision-gated anyway |
+| `frontend/index.html` | A1, A2 | Same lane by design (Track A is one session) |
+| `shared/src/api.rs` | W0, then read-only for C/D/E | W0 lands first precisely to freeze this file |
+| workspace `Cargo.toml` | C3 (`web-push`), C7 (`a2`), E1 (tauri) | One-line dep adds; trivial |
+| `backend/src/handlers/websocket/*` | C4, C5 | Adjacent code; land C5 before C4 so hooks are written against corrected presence |
+
+### 16.4 What this buys
+
+Serial estimate (§1) is 6–9 engineer-weeks. The work above has ~9 independent
+Wave-1 lanes and a critical path of roughly 2 weeks (W0→C1→C2→C3→D2 plus the
+exit test). With 4–6 concurrent sessions and the merge train as the only
+synchronization point:
+
+- **M0–M2** (installed PWA with working push — the O2 checkpoint):
+  ~1.5–2 wall-clock weeks.
+- **M0–M4** (store-published): ~3–4 wall-clock weeks, dominated by store
+  review latency and F3 provisioning, both of which start in Wave 1 for
+  exactly that reason.
+
+The two things that would break this schedule: letting the critical-path lane
+(push) wait on review while side lanes merge, and starting F3/O3 late — every
+other item is code we control end to end.


### PR DESCRIPTION
Adds two docs:

- **docs/MOBILE_APPS_PLAN.md** — full iOS/Android plan: options analysis (PWA / Tauri shell / native), staged milestones M0–M4, auth + push architecture grounded in code facts (file:line verified), §15 per-PR work breakdown, §16 parallel execution plan with dependency graph and 9-lane wave schedule.
- **PORTAL_DEMO_SCRIPT.md** — ~15-minute demo walkthrough script.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)