### PR TITLE
feat: eagerly prune web-client presence on disconnect (C5)

### DIFF
--- a/backend/src/handlers/websocket/session_manager/client_fanout.rs
+++ b/backend/src/handlers/websocket/session_manager/client_fanout.rs
@@ -43,6 +43,26 @@ impl SessionManager {
         }
     }
 
+    /// Eagerly remove `sender`'s connection from a session's web-client
+    /// registry when its socket task ends, dropping the map entry once the
+    /// last client leaves.
+    ///
+    /// WHY: presence must not contain dead senders. Push-notification
+    /// suppression ("don't push if the user has a live web client") reads
+    /// these registries; without eager removal, a disconnected tab/phone
+    /// would keep suppressing pushes until the next failed send lazily
+    /// pruned it (see docs/MOBILE_APPS_PLAN.md §8.2). The lazy prune in
+    /// `fanout_to_clients` stays as a backstop.
+    pub fn remove_web_client(&self, session_key: &SessionId, sender: &WebClientSender) {
+        if let Some(mut clients) = self.web_clients.get_mut(session_key) {
+            clients.retain(|c| !c.same_channel(sender));
+            if clients.is_empty() {
+                drop(clients);
+                self.web_clients.remove(session_key);
+            }
+        }
+    }
+
     pub fn add_user_client(&self, user_id: Uuid, sender: WebClientSender) {
         info!("Adding web client for user: {}", user_id);
         self.user_clients.entry(user_id).or_default().push(sender);
@@ -51,6 +71,27 @@ impl SessionManager {
     pub fn broadcast_to_user(&self, user_id: &Uuid, msg: ServerToClient) {
         if let Some(mut clients) = self.user_clients.get_mut(user_id) {
             fanout_to_clients(clients.value_mut(), msg);
+        }
+    }
+
+    /// Eagerly remove `sender`'s connection from a user's client registry
+    /// when its socket task ends, dropping the map entry once the user's
+    /// last client leaves.
+    ///
+    /// WHY: presence must not contain dead senders. Push-notification
+    /// suppression ("don't push if the user has a live web client") reads
+    /// `user_clients` (and treats a present key as "user is watching");
+    /// without eager removal, a disconnected tab/phone would keep
+    /// suppressing pushes until the next failed send lazily pruned it (see
+    /// docs/MOBILE_APPS_PLAN.md §8.2). The lazy prune in `fanout_to_clients`
+    /// stays as a backstop.
+    pub fn remove_user_client(&self, user_id: &Uuid, sender: &WebClientSender) {
+        if let Some(mut clients) = self.user_clients.get_mut(user_id) {
+            clients.retain(|c| !c.same_channel(sender));
+            if clients.is_empty() {
+                drop(clients);
+                self.user_clients.remove(user_id);
+            }
         }
     }
 
@@ -216,6 +257,44 @@ mod tests {
             user_rx.try_recv().unwrap(),
             ServerToClient::ServerShutdown { .. }
         ));
+    }
+
+    #[test]
+    fn remove_web_client_drops_entry_when_empty() {
+        let mgr = SessionManager::new();
+        let (tx1, _rx1) = crate::handlers::websocket::conn_channel(64);
+        let (tx2, _rx2) = crate::handlers::websocket::conn_channel(64);
+
+        mgr.add_web_client("s1".into(), tx1.clone());
+        mgr.add_web_client("s1".into(), tx2.clone());
+
+        // Removing one sender leaves the other and keeps the entry.
+        mgr.remove_web_client(&"s1".into(), &tx1);
+        assert_eq!(mgr.web_clients.get("s1").unwrap().len(), 1);
+
+        // Removing the last sender drops the map entry entirely, so presence
+        // checks (map contains session) stay correct.
+        mgr.remove_web_client(&"s1".into(), &tx2);
+        assert!(mgr.web_clients.get("s1").is_none());
+    }
+
+    #[test]
+    fn remove_user_client_drops_entry_when_empty() {
+        let mgr = SessionManager::new();
+        let user_id = Uuid::new_v4();
+        let (tx1, _rx1) = crate::handlers::websocket::conn_channel(64);
+        let (tx2, _rx2) = crate::handlers::websocket::conn_channel(64);
+
+        mgr.add_user_client(user_id, tx1.clone());
+        mgr.add_user_client(user_id, tx2.clone());
+
+        mgr.remove_user_client(&user_id, &tx1);
+        assert_eq!(mgr.user_clients.get(&user_id).unwrap().len(), 1);
+
+        mgr.remove_user_client(&user_id, &tx2);
+        assert!(mgr.user_clients.get(&user_id).is_none());
+        // Presence query must no longer see the user.
+        assert!(!mgr.get_all_user_ids().contains(&user_id));
     }
 
     #[test]

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -72,6 +72,13 @@ impl<T> ConnSender<T> {
             mpsc::error::TrySendError::Closed(v) => mpsc::error::SendError(v),
         })
     }
+
+    /// Whether `self` and `other` are handles to the same underlying channel
+    /// (i.e. clones of one another). Used to identify a specific connection's
+    /// sender for eager removal from the presence registries on disconnect.
+    pub fn same_channel(&self, other: &Self) -> bool {
+        self.0.same_channel(&other.0)
+    }
 }
 
 /// Construct a bounded per-connection channel (see [`ConnSender`]).

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -64,6 +64,17 @@ pub async fn handle_web_client_socket(socket: WebSocket, app_state: Arc<AppState
     }
 
     send_task.abort();
+
+    // Eagerly drop this connection's senders from the presence registries.
+    // All exit paths of the loop above (client close, decode-fatal break,
+    // access-denied replace) funnel through here, so presence never retains
+    // a dead sender — push-notification suppression depends on that
+    // (docs/MOBILE_APPS_PLAN.md §8.2). The lazy prune in `fanout_to_clients`
+    // remains as a backstop for the send-failure path.
+    session_manager.remove_user_client(&user_id, &tx);
+    if let Some(ref key) = session_key {
+        session_manager.remove_web_client(key, &tx);
+    }
 }
 
 /// Returns true if the connection should be closed


### PR DESCRIPTION
## What

Implements work item **C5 (presence liveness)** of `docs/MOBILE_APPS_PLAN.md`.

Web-client senders were added to the presence registries (`web_clients` per session, `user_clients` per user) on connect but **never removed on disconnect** — dead senders were only pruned lazily when a send to them failed (`fanout_to_clients`). This makes presence untrustworthy: upcoming push-notification suppression ("don't push if the user has a live web client") would wrongly suppress pushes to a user whose tab/phone disconnected minutes ago.

## Changes

- **`ConnSender::same_channel`** (`session_manager/mod.rs`) — delegates to tokio mpsc's `same_channel()` so a connection's sender can be identified by channel identity across clones.
- **`remove_web_client` / `remove_user_client`** (`session_manager/client_fanout.rs`) — retain-out the matching sender and drop the map entry entirely once its `Vec` empties, so presence checks (map contains user/session) stay correct. Doc comments state the WHY (push-suppression correctness, §8.2).
- **Socket teardown** (`web_client_socket.rs`) — both removals run after the recv loop / `send_task.abort()`, covering all exit paths (client close, decode-fatal break, access-denied replace).
- Lazy prune in `fanout_to_clients` kept as a backstop.
- Unit tests: add-then-remove asserting map emptiness for both registries.

## Sender identity approach

Channel identity via `same_channel()` — no need to thread a Uuid through registration, since the socket task already holds the exact `ConnSender` it registered.

## Verify

- `cargo fmt` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test -p backend` (client_fanout suite, 8 passed) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)