### PR TITLE
Accept bearer tokens for web auth

### DIFF
--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -1,5 +1,6 @@
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
+use axum::http::{header, HeaderMap};
 use axum::response::{IntoResponse, Response};
 use diesel::prelude::*;
 use std::sync::Arc;
@@ -35,21 +36,19 @@ fn reject_disabled_user(user: User) -> Result<User, AppError> {
     }
 }
 
-/// Extract and load the authenticated user from the session cookie.
-///
-/// In dev mode, returns the test user without checking cookies. In production,
-/// reads the signed session cookie, parses the user ID, and loads the user row.
-/// Disabled users are rejected in both modes so a ban takes effect for existing
-/// browser sessions immediately.
-pub fn extract_user(app_state: &AppState, cookies: &Cookies) -> Result<User, AppError> {
-    let mut conn = app_state.conn()?;
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+}
 
+fn load_cookie_user(
+    app_state: &AppState,
+    conn: &mut PgConnection,
+    cookies: &Cookies,
+) -> Result<User, AppError> {
     use crate::schema::users;
-
-    if app_state.dev_mode {
-        let user = dev_user(&mut conn)?;
-        return reject_disabled_user(user);
-    }
 
     let cookie = cookies
         .signed(&app_state.cookie_key)
@@ -57,11 +56,57 @@ pub fn extract_user(app_state: &AppState, cookies: &Cookies) -> Result<User, App
         .ok_or(AppError::Unauthorized)?;
 
     let user_id: Uuid = cookie.value().parse().map_err(|_| AppError::Unauthorized)?;
+    users::table
+        .find(user_id)
+        .first::<User>(conn)
+        .map_err(|_| AppError::Unauthorized)
+}
+
+fn load_bearer_user(
+    app_state: &AppState,
+    conn: &mut PgConnection,
+    headers: &HeaderMap,
+) -> Result<Option<User>, AppError> {
+    let Some(token) = bearer_token(headers) else {
+        return Ok(None);
+    };
+    let (user_id, _email) =
+        crate::handlers::proxy_tokens::verify_and_get_user(app_state, conn, token)?;
+
+    use crate::schema::users;
     let user = users::table
         .find(user_id)
-        .first::<User>(&mut conn)
+        .first::<User>(conn)
         .map_err(|_| AppError::Unauthorized)?;
+    Ok(Some(user))
+}
 
+/// Extract and load the authenticated user from a bearer token or session cookie.
+///
+/// `Authorization: Bearer` takes precedence when present, matching the
+/// programmatic API auth path: a bad bearer must not silently fall through to a
+/// valid browser cookie. In dev mode with no bearer, returns the test user
+/// without checking cookies. Disabled users are rejected in every path so a ban
+/// takes effect for existing browser sessions and mobile tokens immediately.
+pub fn extract_user(
+    app_state: &AppState,
+    headers: Option<&HeaderMap>,
+    cookies: &Cookies,
+) -> Result<User, AppError> {
+    let mut conn = app_state.conn()?;
+
+    if let Some(headers) = headers {
+        if let Some(user) = load_bearer_user(app_state, &mut conn, headers)? {
+            return reject_disabled_user(user);
+        }
+    }
+
+    if app_state.dev_mode {
+        let user = dev_user(&mut conn)?;
+        return reject_disabled_user(user);
+    }
+
+    let user = load_cookie_user(app_state, &mut conn, cookies)?;
     reject_disabled_user(user)
 }
 
@@ -70,8 +115,12 @@ pub fn extract_user(app_state: &AppState, cookies: &Cookies) -> Result<User, App
 /// In dev mode, returns the test user's ID without checking cookies.
 /// In production, reads the signed session cookie and parses the user ID.
 /// Disabled users are rejected in both modes.
-pub fn extract_user_id(app_state: &AppState, cookies: &Cookies) -> Result<Uuid, AppError> {
-    extract_user(app_state, cookies).map(|user| user.id)
+pub fn extract_user_id(
+    app_state: &AppState,
+    headers: Option<&HeaderMap>,
+    cookies: &Cookies,
+) -> Result<Uuid, AppError> {
+    extract_user(app_state, headers, cookies).map(|user| user.id)
 }
 
 /// Axum extractor for the authenticated user's ID.
@@ -92,7 +141,7 @@ impl FromRequestParts<Arc<AppState>> for CurrentUserId {
         let cookies = Cookies::from_request_parts(parts, state)
             .await
             .map_err(|rejection| rejection.into_response())?;
-        extract_user_id(state, &cookies)
+        extract_user_id(state, Some(&parts.headers), &cookies)
             .map(CurrentUserId)
             .map_err(|e| e.into_response())
     }
@@ -101,6 +150,17 @@ impl FromRequestParts<Arc<AppState>> for CurrentUserId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::handlers::images::ImageStore;
+    use crate::handlers::proxy_tokens::{issue_proxy_token_with_type, TokenPersist};
+    use crate::handlers::websocket::SessionManager;
+    use crate::models::NewUser;
+    use crate::schema::{proxy_auth_tokens, users};
+    use axum::http::{header::AUTHORIZATION, HeaderValue};
+    use std::time::Duration;
+    use tower_cookies::cookie::Key;
+    use tower_cookies::Cookie;
+
+    static DB_SETUP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn user(disabled: bool) -> User {
         User {
@@ -129,6 +189,240 @@ mod tests {
         assert!(matches!(
             reject_disabled_user(user(true)),
             Err(AppError::Forbidden)
+        ));
+    }
+
+    fn test_pool() -> Option<crate::db::DbPool> {
+        if std::env::var("DATABASE_URL").is_err() {
+            eprintln!("DATABASE_URL not set, skipping DB-backed auth test");
+            return None;
+        }
+        let _guard = DB_SETUP_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let pool = crate::db::create_pool().expect("create test DB pool");
+        crate::db::run_migrations_logged(&pool).expect("run migrations");
+        Some(pool)
+    }
+
+    fn test_state(pool: crate::db::DbPool) -> AppState {
+        AppState {
+            dev_mode: false,
+            db_pool: pool,
+            session_manager: SessionManager::new(),
+            oauth_basic_client: None,
+            device_flow_store: None,
+            public_url: "http://localhost:3000".to_string(),
+            cookie_key: Key::generate(),
+            jwt_secret: "test-secret-key-at-least-32-bytes".to_string(),
+            app_title: "Agent Portal Test".to_string(),
+            splash_text: None,
+            allowed_email_domain: None,
+            allowed_emails: None,
+            message_retention_count: 100,
+            message_retention_days: 30,
+            session_max_age_days: 14,
+            max_image_mb: 10,
+            image_store: ImageStore::new(1024 * 1024, Duration::from_secs(60)),
+            forward_domain: None,
+            archive: None,
+        }
+    }
+
+    fn insert_user(conn: &mut PgConnection, disabled: bool) -> User {
+        let id = Uuid::new_v4();
+        let mut user: User = diesel::insert_into(users::table)
+            .values(&NewUser {
+                google_id: format!("google-{id}"),
+                email: format!("auth-{id}@example.com"),
+                name: Some("Auth Test".to_string()),
+                avatar_url: None,
+            })
+            .get_result(conn)
+            .expect("insert user");
+        if disabled {
+            user = diesel::update(users::table.find(user.id))
+                .set(users::disabled.eq(true))
+                .get_result(conn)
+                .expect("disable user");
+        }
+        user
+    }
+
+    fn signed_cookie(app_state: &AppState, user_id: Uuid) -> Cookies {
+        let cookies = Cookies::default();
+        cookies.signed(&app_state.cookie_key).add(Cookie::new(
+            shared::protocol::SESSION_COOKIE_NAME,
+            user_id.to_string(),
+        ));
+        cookies
+    }
+
+    fn bearer_headers(token: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}")).expect("valid header"),
+        );
+        headers
+    }
+
+    fn issue_mobile_token(
+        app_state: &AppState,
+        conn: &mut PgConnection,
+        user_id: Uuid,
+    ) -> (Uuid, String) {
+        let issued = issue_proxy_token_with_type(
+            conn,
+            app_state.jwt_secret.as_bytes(),
+            user_id,
+            TokenPersist::Create {
+                name: "mobile-test",
+            },
+            Some(30),
+            shared::TOKEN_TYPE_MOBILE,
+        )
+        .expect("issue mobile token");
+        let claims = crate::jwt::verify_proxy_token(app_state.jwt_secret.as_bytes(), &issued.token)
+            .expect("issued token verifies");
+        assert_eq!(claims.token_type, shared::TOKEN_TYPE_MOBILE);
+        assert!(claims.exp.is_some(), "mobile tokens must expire");
+        (issued.row_id, issued.token)
+    }
+
+    #[test]
+    fn extract_user_allows_valid_cookie() {
+        let Some(pool) = test_pool() else {
+            return;
+        };
+        let app_state = test_state(pool);
+        let mut conn = app_state.conn().expect("conn");
+        let user = insert_user(&mut conn, false);
+        let cookies = signed_cookie(&app_state, user.id);
+
+        let got = extract_user(&app_state, None, &cookies).expect("cookie auth");
+        assert_eq!(got.id, user.id);
+    }
+
+    #[test]
+    fn extract_user_rejects_disabled_cookie_user() {
+        let Some(pool) = test_pool() else {
+            return;
+        };
+        let app_state = test_state(pool);
+        let mut conn = app_state.conn().expect("conn");
+        let user = insert_user(&mut conn, true);
+        let cookies = signed_cookie(&app_state, user.id);
+
+        assert!(matches!(
+            extract_user(&app_state, None, &cookies),
+            Err(AppError::Forbidden)
+        ));
+    }
+
+    #[test]
+    fn extract_user_rejects_missing_cookie() {
+        let Some(pool) = test_pool() else {
+            return;
+        };
+        let app_state = test_state(pool);
+        let cookies = Cookies::default();
+
+        assert!(matches!(
+            extract_user(&app_state, None, &cookies),
+            Err(AppError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn extract_user_allows_valid_mobile_bearer() {
+        let Some(pool) = test_pool() else {
+            return;
+        };
+        let app_state = test_state(pool);
+        let mut conn = app_state.conn().expect("conn");
+        let user = insert_user(&mut conn, false);
+        let (_row_id, token) = issue_mobile_token(&app_state, &mut conn, user.id);
+        let headers = bearer_headers(&token);
+
+        let got =
+            extract_user(&app_state, Some(&headers), &Cookies::default()).expect("bearer auth");
+        assert_eq!(got.id, user.id);
+    }
+
+    #[test]
+    fn extract_user_rejects_expired_mobile_bearer() {
+        let Some(pool) = test_pool() else {
+            return;
+        };
+        let app_state = test_state(pool);
+        let mut conn = app_state.conn().expect("conn");
+        let user = insert_user(&mut conn, false);
+        let (row_id, token) = issue_mobile_token(&app_state, &mut conn, user.id);
+        diesel::update(proxy_auth_tokens::table.find(row_id))
+            .set(proxy_auth_tokens::expires_at.eq(Some(
+                (chrono::Utc::now() - chrono::Duration::minutes(1)).naive_utc(),
+            )))
+            .execute(&mut conn)
+            .expect("expire token row");
+        let headers = bearer_headers(&token);
+
+        assert!(matches!(
+            extract_user(&app_state, Some(&headers), &Cookies::default()),
+            Err(AppError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn extract_user_rejects_revoked_mobile_bearer() {
+        let Some(pool) = test_pool() else {
+            return;
+        };
+        let app_state = test_state(pool);
+        let mut conn = app_state.conn().expect("conn");
+        let user = insert_user(&mut conn, false);
+        let (row_id, token) = issue_mobile_token(&app_state, &mut conn, user.id);
+        diesel::update(proxy_auth_tokens::table.find(row_id))
+            .set(proxy_auth_tokens::revoked.eq(true))
+            .execute(&mut conn)
+            .expect("revoke token row");
+        let headers = bearer_headers(&token);
+
+        assert!(matches!(
+            extract_user(&app_state, Some(&headers), &Cookies::default()),
+            Err(AppError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn extract_user_rejects_disabled_mobile_bearer_user() {
+        let Some(pool) = test_pool() else {
+            return;
+        };
+        let app_state = test_state(pool);
+        let mut conn = app_state.conn().expect("conn");
+        let user = insert_user(&mut conn, true);
+        let (_row_id, token) = issue_mobile_token(&app_state, &mut conn, user.id);
+        let headers = bearer_headers(&token);
+
+        assert!(matches!(
+            extract_user(&app_state, Some(&headers), &Cookies::default()),
+            Err(AppError::Forbidden)
+        ));
+    }
+
+    #[test]
+    fn extract_user_does_not_fall_back_from_bad_bearer_to_valid_cookie() {
+        let Some(pool) = test_pool() else {
+            return;
+        };
+        let app_state = test_state(pool);
+        let mut conn = app_state.conn().expect("conn");
+        let user = insert_user(&mut conn, false);
+        let cookies = signed_cookie(&app_state, user.id);
+        let headers = bearer_headers("not-a-jwt");
+
+        assert!(matches!(
+            extract_user(&app_state, Some(&headers), &cookies),
+            Err(AppError::Unauthorized)
         ));
     }
 }

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -4,6 +4,7 @@
 
 use axum::{
     extract::{Path, State},
+    http::HeaderMap,
     Json,
 };
 use diesel::prelude::*;
@@ -26,10 +27,14 @@ use crate::{
 // Admin Guard - extracts and validates admin user from cookies
 // ============================================================================
 
-/// Extract the current user from cookies and verify they are an admin.
+/// Extract the current user from bearer/cookies and verify they are an admin.
 /// Returns the User if they are an admin, or an appropriate application error.
-pub fn require_admin(app_state: &Arc<AppState>, cookies: &Cookies) -> Result<User, AppError> {
-    let user = crate::auth::extract_user(app_state, cookies)?;
+pub fn require_admin(
+    app_state: &Arc<AppState>,
+    headers: &HeaderMap,
+    cookies: &Cookies,
+) -> Result<User, AppError> {
+    let user = crate::auth::extract_user(app_state, Some(headers), cookies)?;
 
     if !user.is_admin {
         warn!("Non-admin user {} attempted admin access", user.email);
@@ -90,9 +95,10 @@ struct DeletedCostStats {
 
 pub async fn get_stats(
     State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
     cookies: Cookies,
 ) -> Result<Json<AdminStats>, AppError> {
-    let admin = require_admin(&app_state, &cookies)?;
+    let admin = require_admin(&app_state, &headers, &cookies)?;
     info!("Admin {} requested system stats", admin.email);
 
     let mut conn = app_state.conn()?;
@@ -168,9 +174,10 @@ pub async fn get_stats(
 
 pub async fn list_users(
     State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
     cookies: Cookies,
 ) -> Result<Json<AdminUsersResponse>, AppError> {
-    let admin = require_admin(&app_state, &cookies)?;
+    let admin = require_admin(&app_state, &headers, &cookies)?;
     info!("Admin {} requested user list", admin.email);
 
     let mut conn = app_state.conn()?;
@@ -212,11 +219,12 @@ pub async fn list_users(
 
 pub async fn update_user(
     State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
     cookies: Cookies,
     Path(user_id): Path<Uuid>,
     Json(update): Json<UpdateUserRequest>,
 ) -> Result<EmptyResponse, AppError> {
-    let admin = require_admin(&app_state, &cookies)?;
+    let admin = require_admin(&app_state, &headers, &cookies)?;
 
     // Prevent admin from demoting themselves
     if user_id == admin.id && update.is_admin == Some(false) {
@@ -324,9 +332,10 @@ pub async fn update_user(
 
 pub async fn list_sessions(
     State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
     cookies: Cookies,
 ) -> Result<Json<AdminSessionsResponse>, AppError> {
-    let admin = require_admin(&app_state, &cookies)?;
+    let admin = require_admin(&app_state, &headers, &cookies)?;
     info!("Admin {} requested sessions list", admin.email);
 
     let mut conn = app_state.conn()?;
@@ -371,10 +380,11 @@ pub async fn list_sessions(
 
 pub async fn delete_session(
     State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
     cookies: Cookies,
     Path(session_id): Path<Uuid>,
 ) -> Result<EmptyResponse, AppError> {
-    let admin = require_admin(&app_state, &cookies)?;
+    let admin = require_admin(&app_state, &headers, &cookies)?;
 
     let mut conn = app_state.conn()?;
 

--- a/backend/src/handlers/admin_subdomains.rs
+++ b/backend/src/handlers/admin_subdomains.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     Json,
 };
 use chrono::{DateTime, Utc};
@@ -73,9 +73,10 @@ fn validate_custom_label(label: &str) -> Result<(), &'static str> {
 /// GET /api/admin/subdomains — all custom subdomains, newest first.
 pub async fn list_custom_subdomains(
     State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
     cookies: Cookies,
 ) -> Result<Json<CustomSubdomainsResponse>, AppError> {
-    require_admin(&app_state, &cookies)?;
+    require_admin(&app_state, &headers, &cookies)?;
     let mut conn = app_state.conn()?;
 
     use crate::schema::{custom_subdomains as cs, sessions};
@@ -111,10 +112,11 @@ pub async fn list_custom_subdomains(
 /// a taken label or a session that already has one is a 409.
 pub async fn create_custom_subdomain(
     State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
     cookies: Cookies,
     Json(req): Json<CreateCustomSubdomainRequest>,
 ) -> Result<(StatusCode, Json<CustomSubdomainInfo>), AppError> {
-    let admin = require_admin(&app_state, &cookies)?;
+    let admin = require_admin(&app_state, &headers, &cookies)?;
     let label = req.label.trim().to_ascii_lowercase();
     validate_custom_label(&label).map_err(AppError::BadRequest)?;
     if app_state.forward_domain.is_none() {
@@ -197,9 +199,10 @@ pub async fn create_custom_subdomain(
 pub async fn delete_custom_subdomain(
     State(app_state): State<Arc<AppState>>,
     Path(label): Path<String>,
+    headers: HeaderMap,
     cookies: Cookies,
 ) -> Result<StatusCode, AppError> {
-    let admin = require_admin(&app_state, &cookies)?;
+    let admin = require_admin(&app_state, &headers, &cookies)?;
     let mut conn = app_state.conn()?;
 
     use crate::schema::custom_subdomains as cs;
@@ -215,9 +218,10 @@ pub async fn delete_custom_subdomain(
 /// admin subdomain-assignment picker.
 pub async fn list_admin_forwards(
     State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
     cookies: Cookies,
 ) -> Result<Json<AdminForwardsResponse>, AppError> {
-    require_admin(&app_state, &cookies)?;
+    require_admin(&app_state, &headers, &cookies)?;
     let mut conn = app_state.conn()?;
 
     use crate::schema::{forward_subdomains as fs, session_forwards as sf, sessions, users};

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -32,17 +32,7 @@ pub(crate) fn resolve_user(
     headers: &HeaderMap,
     cookies: &Cookies,
 ) -> Result<Uuid, AppError> {
-    if let Some(token) = headers
-        .get(axum::http::header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.strip_prefix("Bearer "))
-    {
-        let mut conn = app_state.conn()?;
-        let (user_id, _email) =
-            crate::handlers::proxy_tokens::verify_and_get_user(app_state, &mut conn, token)?;
-        return Ok(user_id);
-    }
-    crate::auth::extract_user_id(app_state, cookies)
+    crate::auth::extract_user_id(app_state, Some(headers), cookies)
 }
 
 /// Look up a display name for `user_id` (name, falling back to email).

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -1,5 +1,6 @@
 use axum::{
     extract::{Query, State},
+    http::HeaderMap,
     response::{IntoResponse, Redirect},
     Json,
 };
@@ -292,9 +293,11 @@ pub async fn callback(
 
 pub async fn me(
     State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
     cookies: Cookies,
 ) -> Result<Json<MeResponse>, AppError> {
-    let user = crate::auth::extract_user(&app_state, &cookies).map_err(auth_user_error)?;
+    let user =
+        crate::auth::extract_user(&app_state, Some(&headers), &cookies).map_err(auth_user_error)?;
 
     Ok(Json(MeResponse {
         id: user.id,

--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -16,11 +16,12 @@ use uuid::Uuid;
 
 use crate::{
     auth,
-    handlers::proxy_tokens::{issue_proxy_token, TokenPersist},
+    handlers::proxy_tokens::{issue_proxy_token_with_type, TokenPersist},
     routes, AppState,
 };
 
 use shared::protocol::{DEVICE_CODE_EXPIRES_SECS, SESSION_COOKIE_NAME};
+use shared::TOKEN_TYPE_MOBILE;
 
 mod api_error;
 mod render;
@@ -32,6 +33,8 @@ use api_error::{auth_error_to_device_flow, DeviceFlowApiError};
 use render::render_approval_page;
 use state::{generate_device_code, generate_user_code, VerifyQuery};
 pub use state::{DeviceFlowState, DeviceFlowStatus, DeviceFlowStore};
+
+const MOBILE_TOKEN_TTL_DAYS: u32 = 30;
 
 // POST /auth/device/code
 pub async fn device_code(
@@ -251,7 +254,7 @@ pub async fn device_approve(
         event = "device_approve_request",
         user_code = %req.user_code,
     );
-    let user_id = auth::extract_user_id(&app_state, &cookies).map_err(|e| {
+    let user_id = auth::extract_user_id(&app_state, None, &cookies).map_err(|e| {
         warn!(
             target: "auth_audit",
             event = "device_approve_denied",
@@ -308,7 +311,7 @@ pub async fn device_deny(
         event = "device_deny_request",
         user_code = %req.user_code,
     );
-    let user_id = auth::extract_user_id(&app_state, &cookies).map_err(|e| {
+    let user_id = auth::extract_user_id(&app_state, None, &cookies).map_err(|e| {
         warn!(
             target: "auth_audit",
             event = "device_deny_denied",
@@ -479,23 +482,40 @@ pub async fn complete_device_flow(
     user_code: &str,
     user_id: Uuid,
 ) -> Result<(), ()> {
+    complete_device_flow_with_expiry(
+        app_state,
+        store,
+        user_code,
+        user_id,
+        Some(MOBILE_TOKEN_TTL_DAYS),
+    )
+    .await
+}
+
+async fn complete_device_flow_with_expiry(
+    app_state: &AppState,
+    store: &DeviceFlowStore,
+    user_code: &str,
+    user_id: Uuid,
+    expires_in_days: Option<u32>,
+) -> Result<(), ()> {
     let mut conn = app_state.db_pool.get().map_err(|e| {
         error!("Failed to get database connection: {}", e);
     })?;
 
-    // Initial device-flow tokens have no fixed expiry so freshly authenticated
-    // CLIs can start immediately. Launchers rotate these to expiring
-    // credentials on websocket registration (#1237).
+    // Device-flow credentials are mobile bearer tokens with a fixed lifetime;
+    // B2 adds the refresh endpoint so native shells can rotate before expiry.
     let name = format!(
         "Device auth {}",
         chrono::Utc::now().format("%Y-%m-%d %H:%M")
     );
-    let issued = issue_proxy_token(
+    let issued = issue_proxy_token_with_type(
         &mut conn,
         app_state.jwt_secret.as_bytes(),
         user_id,
         TokenPersist::Create { name: &name },
-        None,
+        expires_in_days,
+        TOKEN_TYPE_MOBILE,
     )
     .map_err(|e| {
         error!("Failed to issue device token: {:?}", e);

--- a/backend/src/handlers/proxy_tokens.rs
+++ b/backend/src/handlers/proxy_tokens.rs
@@ -20,11 +20,12 @@ use crate::{
     auth::CurrentUserId,
     errors::AppError,
     handlers::responses::EmptyResponse,
-    jwt::{create_proxy_token, hash_token},
+    jwt::{create_proxy_token_with_type, hash_token},
     models::{NewProxyAuthToken, ProxyAuthToken, User},
     schema::proxy_auth_tokens,
     AppState,
 };
+use shared::TOKEN_TYPE_PROXY;
 
 /// How [`issue_proxy_token`] persists the freshly minted token.
 pub enum TokenPersist<'a> {
@@ -68,18 +69,37 @@ pub fn issue_proxy_token(
     persist: TokenPersist<'_>,
     expires_in_days: Option<u32>,
 ) -> Result<IssuedProxyToken, AppError> {
+    issue_proxy_token_with_type(
+        conn,
+        jwt_secret,
+        user_id,
+        persist,
+        expires_in_days,
+        TOKEN_TYPE_PROXY,
+    )
+}
+
+pub fn issue_proxy_token_with_type(
+    conn: &mut diesel::pg::PgConnection,
+    jwt_secret: &[u8],
+    user_id: Uuid,
+    persist: TokenPersist<'_>,
+    expires_in_days: Option<u32>,
+    token_type: &str,
+) -> Result<IssuedProxyToken, AppError> {
     use crate::schema::users;
     let user: User = users::table.find(user_id).first(conn)?;
 
     let expires_at =
         expires_in_days.map(|days| chrono::Utc::now() + chrono::Duration::days(days as i64));
 
-    let token = create_proxy_token(
+    let token = create_proxy_token_with_type(
         jwt_secret,
         Uuid::new_v4(),
         user_id,
         &user.email,
         expires_in_days,
+        token_type,
     )
     .map_err(|e| AppError::Internal(e.to_string()))?;
 

--- a/backend/src/handlers/websocket/mod.rs
+++ b/backend/src/handlers/websocket/mod.rs
@@ -20,7 +20,7 @@ pub use session_manager::{
 
 use axum::{
     extract::{ws::WebSocketUpgrade, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
 use std::sync::Arc;
@@ -53,9 +53,10 @@ pub async fn handle_launcher_websocket(
 pub async fn handle_web_client_websocket(
     ws: WebSocketUpgrade,
     State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
     cookies: Cookies,
 ) -> Response {
-    let user_id = match crate::auth::extract_user_id(&app_state, &cookies).ok() {
+    let user_id = match crate::auth::extract_user_id(&app_state, Some(&headers), &cookies).ok() {
         Some(id) => id,
         None => {
             warn!("Unauthenticated WebSocket connection attempt to /ws/client");

--- a/backend/src/jwt.rs
+++ b/backend/src/jwt.rs
@@ -6,7 +6,7 @@
 use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use sha2::{Digest, Sha256};
-use shared::ProxyTokenClaims;
+use shared::{ProxyTokenClaims, TOKEN_TYPE_PROXY};
 use uuid::Uuid;
 
 /// Error type for JWT operations
@@ -35,6 +35,24 @@ pub fn create_proxy_token(
     email: &str,
     expires_in_days: Option<u32>,
 ) -> Result<String, JwtError> {
+    create_proxy_token_with_type(
+        secret,
+        token_id,
+        user_id,
+        email,
+        expires_in_days,
+        TOKEN_TYPE_PROXY,
+    )
+}
+
+pub fn create_proxy_token_with_type(
+    secret: &[u8],
+    token_id: Uuid,
+    user_id: Uuid,
+    email: &str,
+    expires_in_days: Option<u32>,
+    token_type: &str,
+) -> Result<String, JwtError> {
     let now = Utc::now();
     let exp = expires_in_days.map(|days| (now + Duration::days(days as i64)).timestamp());
 
@@ -44,7 +62,7 @@ pub fn create_proxy_token(
         email: email.to_string(),
         iat: now.timestamp(),
         exp,
-        token_type: "proxy".to_string(),
+        token_type: token_type.to_string(),
     };
 
     let token = encode(

--- a/shared/src/proxy_tokens.rs
+++ b/shared/src/proxy_tokens.rs
@@ -10,6 +10,10 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+pub const TOKEN_TYPE_PROXY: &str = "proxy";
+pub const TOKEN_TYPE_LAUNCHER: &str = "launcher";
+pub const TOKEN_TYPE_MOBILE: &str = "mobile";
+
 /// JWT claims for proxy authentication tokens
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProxyTokenClaims {
@@ -26,13 +30,13 @@ pub struct ProxyTokenClaims {
     /// instead of a fixed TTL. See #932.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exp: Option<i64>,
-    /// Token type: "proxy" or "launcher"
+    /// Token type: "proxy", "launcher", or "mobile".
     #[serde(default = "default_token_type")]
     pub token_type: String,
 }
 
 fn default_token_type() -> String {
-    "proxy".to_string()
+    TOKEN_TYPE_PROXY.to_string()
 }
 
 /// Configuration encoded in the init URL


### PR DESCRIPTION
## Summary
- allow standard web auth extraction to accept Authorization: Bearer JWTs before falling back to cookies
- thread bearer-aware auth through CurrentUserId, /ws/client, /api/auth/me, admin, and agent-comms callers
- add mobile token type constants and mint device-flow tokens as expiring mobile JWTs
- cover cookie/bearer valid, missing, expired, revoked, disabled, and bad-bearer precedence cases

## Review foci
1. Bearer precedence: invalid bearer should not silently fall back to a valid cookie.
2. Scope: B1 avoids routes.rs and keeps device approve/deny cookie-only, while /ws/client and normal REST auth get bearer.
3. Token typing: device-flow mint now uses token_type=mobile with a 30-day exp; existing proxy-token create/renew still defaults to proxy.

## Tests
- cargo test -p backend auth::tests --lib
- cargo test -p backend jwt::tests --lib
- cargo test -p backend handlers::device_flow::tests --lib
- cargo test -p shared proxy_tokens
- cargo check -p backend
- cargo clippy -p backend -- -D warnings