### PR TITLE
feat: notification prefs GET/PUT endpoints + storage (C6)

### DIFF
--- a/backend/migrations/2026-07-11-000000_add_notification_prefs/down.sql
+++ b/backend/migrations/2026-07-11-000000_add_notification_prefs/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN notification_prefs;

--- a/backend/migrations/2026-07-11-000000_add_notification_prefs/up.sql
+++ b/backend/migrations/2026-07-11-000000_add_notification_prefs/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN notification_prefs JSONB;

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -175,6 +175,7 @@ mod tests {
             disabled,
             ban_reason: None,
             sound_config: None,
+            notification_prefs: None,
         }
     }
 

--- a/backend/src/handlers/push.rs
+++ b/backend/src/handlers/push.rs
@@ -12,7 +12,8 @@ use axum::{
 };
 use diesel::prelude::*;
 use shared::api::{
-    PushSubscriptionInfo, PushSubscriptionsResponse, RegisterPushSubscriptionRequest,
+    NotificationPrefs, PushSubscriptionInfo, PushSubscriptionsResponse,
+    RegisterPushSubscriptionRequest,
 };
 use std::sync::Arc;
 use tracing::info;
@@ -132,4 +133,144 @@ pub async fn delete_subscription(
         subscription_id, user_id
     );
     Ok(EmptyResponse::NO_CONTENT)
+}
+
+/// GET /api/push/prefs — the caller's own notification preferences.
+///
+/// The prefs live in the nullable `users.notification_prefs` jsonb column. A
+/// NULL column (user never saved prefs) or a value that no longer parses into
+/// the current [`NotificationPrefs`] shape both fall back to
+/// [`NotificationPrefs::default`], so an older/partial stored payload never
+/// wedges the endpoint.
+pub async fn get_prefs(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+) -> Result<Json<NotificationPrefs>, AppError> {
+    use crate::schema::users;
+    let mut conn = app_state.conn()?;
+
+    let stored: Option<serde_json::Value> = users::table
+        .find(user_id)
+        .select(users::notification_prefs)
+        .first(&mut conn)?;
+
+    let prefs = stored
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or_default();
+
+    Ok(Json(prefs))
+}
+
+/// PUT /api/push/prefs — replace the caller's notification preferences.
+///
+/// Stores the typed prefs as jsonb and echoes back the stored value.
+pub async fn put_prefs(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+    Json(prefs): Json<NotificationPrefs>,
+) -> Result<Json<NotificationPrefs>, AppError> {
+    use crate::schema::users;
+    let mut conn = app_state.conn()?;
+
+    // `NotificationPrefs` is a flat struct of bools, so serialization can only
+    // fail on OOM — an `AppError::Internal` is the honest response.
+    let value = serde_json::to_value(prefs).map_err(|e| AppError::Internal(e.to_string()))?;
+
+    diesel::update(users::table.find(user_id))
+        .set(users::notification_prefs.eq(Some(value)))
+        .execute(&mut conn)?;
+
+    Ok(Json(prefs))
+}
+
+// DB-touching round-trip test for the notification-prefs query path.
+//
+// Mirrors the harness in `messages.rs::db_tests` / `auth.rs`: auto-skips when
+// `DATABASE_URL` is unset (CI stays green without a DB) and runs locally via:
+//
+//   DATABASE_URL=postgresql://claude_portal:dev_password_change_in_production@localhost:5432/claude_portal \
+//     cargo test -p backend handlers::push::db_tests
+//
+// We exercise the query layer directly (read/update the jsonb column) rather
+// than the Axum handler, which needs a full `AppState`; the handlers are thin
+// wrappers over exactly this read/parse/write logic.
+#[cfg(test)]
+mod db_tests {
+    use super::*;
+    use crate::models::{NewUser, User};
+    use diesel::r2d2::{ConnectionManager, Pool};
+
+    type DbPool = Pool<ConnectionManager<diesel::pg::PgConnection>>;
+
+    fn try_pool() -> Option<DbPool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
+        Pool::builder().build(manager).ok()
+    }
+
+    fn make_user(conn: &mut diesel::pg::PgConnection) -> User {
+        use crate::schema::users;
+        let nonce = Uuid::new_v4();
+        let new_user = NewUser {
+            google_id: format!("test_push_prefs_{nonce}"),
+            email: format!("test_push_prefs_{nonce}@example.invalid"),
+            name: Some("Test Prefs".to_string()),
+            avatar_url: None,
+        };
+        diesel::insert_into(users::table)
+            .values(&new_user)
+            .get_result::<User>(conn)
+            .expect("insert test user")
+    }
+
+    /// Read `users.notification_prefs`, applying the same NULL/parse-failure ->
+    /// default fallback as the `get_prefs` handler.
+    fn read_prefs(conn: &mut diesel::pg::PgConnection, user_id: Uuid) -> NotificationPrefs {
+        use crate::schema::users;
+        let stored: Option<serde_json::Value> = users::table
+            .find(user_id)
+            .select(users::notification_prefs)
+            .first(conn)
+            .expect("select notification_prefs");
+        stored
+            .and_then(|v| serde_json::from_value(v).ok())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn prefs_round_trip_default_then_custom() {
+        let Some(pool) = try_pool() else {
+            eprintln!("DATABASE_URL not set, skipping");
+            return;
+        };
+        let mut conn = pool.get().expect("get conn");
+        let user = make_user(&mut conn);
+
+        // GET on a fresh user: column is NULL -> defaults.
+        assert_eq!(read_prefs(&mut conn, user.id), NotificationPrefs::default());
+
+        // PUT a custom (non-default) value.
+        let custom = NotificationPrefs {
+            permission_request: false,
+            turn_complete: false,
+            session_disconnected: true,
+            agent_message: true,
+        };
+        assert_ne!(custom, NotificationPrefs::default());
+        {
+            use crate::schema::users;
+            let value = serde_json::to_value(custom).unwrap();
+            diesel::update(users::table.find(user.id))
+                .set(users::notification_prefs.eq(Some(value)))
+                .execute(&mut conn)
+                .expect("update prefs");
+        }
+
+        // GET again: the custom value round-trips.
+        assert_eq!(read_prefs(&mut conn, user.id), custom);
+
+        // Cleanup.
+        use crate::schema::users;
+        let _ = diesel::delete(users::table.find(user.id)).execute(&mut conn);
+    }
 }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -18,6 +18,7 @@ pub struct User {
     pub disabled: bool,
     pub ban_reason: Option<String>,
     pub sound_config: Option<serde_json::Value>,
+    pub notification_prefs: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Insertable)]

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -255,6 +255,10 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             "/api/push/subscriptions/{id}",
             axum::routing::delete(handlers::push::delete_subscription),
         )
+        .route(
+            "/api/push/prefs",
+            get(handlers::push::get_prefs).put(handlers::push::put_prefs),
+        )
         // Sound settings
         .route(
             "/api/settings/sound",

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -268,6 +268,7 @@ diesel::table! {
         disabled -> Bool,
         ban_reason -> Nullable<Text>,
         sound_config -> Nullable<Jsonb>,
+        notification_prefs -> Nullable<Jsonb>,
     }
 }
 


### PR DESCRIPTION
Implements work item **C6** (notification prefs) of `docs/MOBILE_APPS_PLAN.md` (§8.2, §15).

## What
Per-user notification preferences, persisted server-side and exposed through the push handler.

- **Migration** `2026-07-11-000000_add_notification_prefs`: adds a nullable `users.notification_prefs` jsonb column (NULL = defaults), mirroring the `sound_config` precedent. `down.sql` drops it.
- **User model** (`models.rs`) gains `notification_prefs: Option<serde_json::Value>`; `schema.rs` regenerated via `diesel migration run` (not hand-edited).
- **Handlers** in `backend/src/handlers/push.rs`, both `CurrentUserId`-scoped:
  - `GET /api/push/prefs` → `NotificationPrefs`. NULL column or a value that no longer parses falls back to `NotificationPrefs::default()`.
  - `PUT /api/push/prefs` (typed `NotificationPrefs` body) → stores as jsonb, echoes the stored value.
- **Routes**: two lines in `routes.rs` (`get(...).put(...)` on `/api/push/prefs`).
- The shared `NotificationPrefs` type (from #1293) is the wire contract on both ends — serialized via the typed struct, no `json!` macro.

## Tests
DB-gated round-trip in `handlers::push::db_tests` (default → PUT custom → GET custom), auto-skipped when `DATABASE_URL` is unset, matching the harness in `messages.rs` / `auth.rs`.

## Verification
- `cargo fmt --check` clean
- `cargo clippy -p backend -p shared --all-targets -- -D warnings` clean
- `cargo test -p backend handlers::push` passes (round-trip test green against local DB)

Built on top of #1293 (merged); rebased onto `main` so this PR contains only the C6 diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)