### PR TITLE
feat: push notification dispatcher core + event hooks (C2 + C4)

### DIFF
--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -225,6 +225,7 @@ mod tests {
             image_store: ImageStore::new(1024 * 1024, Duration::from_secs(60)),
             forward_domain: None,
             archive: None,
+            notifications: crate::push::channel().0,
         }
     }
 

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -36,7 +36,11 @@ where
 /// period, a backend restart would immediately hide all sessions from the
 /// frontend (which only shows status="active") and users would have to
 /// restart launchers to get sessions back.
-pub fn spawn_stale_session_cleanup(pool: DbPool, manager: SessionManager) {
+pub fn spawn_stale_session_cleanup(
+    pool: DbPool,
+    manager: SessionManager,
+    notifications: crate::push::NotificationSender,
+) {
     tokio::spawn(async move {
         const RECONNECT_GRACE_SECS: u64 = shared::protocol::MAX_RECONNECT_BACKOFF_SECS * 2;
         tracing::info!(
@@ -56,9 +60,9 @@ pub fn spawn_stale_session_cleanup(pool: DbPool, manager: SessionManager) {
         use diesel::prelude::*;
         use schema::sessions;
 
-        let active_sessions: Vec<(uuid::Uuid,)> = match sessions::table
+        let active_sessions: Vec<(uuid::Uuid, String)> = match sessions::table
             .filter(sessions::status.eq(shared::SessionStatus::Active.as_str()))
-            .select((sessions::id,))
+            .select((sessions::id, sessions::session_name))
             .load(&mut conn)
         {
             Ok(s) => s,
@@ -68,16 +72,20 @@ pub fn spawn_stale_session_cleanup(pool: DbPool, manager: SessionManager) {
             }
         };
 
-        let stale_ids: Vec<uuid::Uuid> = active_sessions
+        // These were ACTIVE and lost their proxy across the grace period — an
+        // unexpected disconnect, so each earns a SessionDisconnected push
+        // (mobile-apps plan §8.1). We keep the names to fill the payload.
+        let stale: Vec<(uuid::Uuid, String)> = active_sessions
             .into_iter()
-            .map(|(id,)| id)
-            .filter(|id| !connected_keys.contains(&id.to_string()))
+            .filter(|(id, _)| !connected_keys.contains(&id.to_string()))
             .collect();
 
-        if stale_ids.is_empty() {
+        if stale.is_empty() {
             tracing::info!("No stale sessions to clean up after reconnect grace period");
             return;
         }
+
+        let stale_ids: Vec<uuid::Uuid> = stale.iter().map(|(id, _)| *id).collect();
 
         match diesel::update(sessions::table.filter(sessions::id.eq_any(&stale_ids)))
             .set(sessions::status.eq(shared::SessionStatus::Disconnected.as_str()))
@@ -89,6 +97,12 @@ pub fn spawn_stale_session_cleanup(pool: DbPool, manager: SessionManager) {
                     updated,
                     RECONNECT_GRACE_SECS
                 );
+                for (session_id, session_name) in stale {
+                    notifications.emit(crate::push::NotificationEvent::SessionDisconnected {
+                        session_id,
+                        session_name,
+                    });
+                }
             }
             Err(e) => {
                 tracing::error!("Failed to mark stale sessions as disconnected: {}", e);

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -695,6 +695,7 @@ mod tests {
             image_store: ImageStore::new(1024 * 1024, Duration::from_secs(60)),
             forward_domain: None,
             archive: None,
+            notifications: crate::push::channel().0,
         })
     }
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -560,6 +560,15 @@ fn handle_launcher_message(
                     if let Ok(mut conn) = app_state.db_pool.get() {
                         use crate::schema::sessions;
                         use diesel::prelude::*;
+                        // Read prior status + name so we only push on a genuine
+                        // active → disconnected drop (mobile-apps plan §8.1); a
+                        // launch failure on a not-yet-active session is not a
+                        // "your running session dropped" event.
+                        let prior: Option<(String, String)> = sessions::table
+                            .find(session_id)
+                            .select((sessions::status, sessions::session_name))
+                            .first::<(String, String)>(&mut conn)
+                            .ok();
                         // Record the failure WITHOUT pausing. Pausing here used
                         // to wedge the session permanently: `paused` doubles as
                         // the user's "don't relaunch" flag, and reconcile only
@@ -583,6 +592,15 @@ fn handle_launcher_message(
                             .execute(&mut conn)
                         {
                             warn!("Failed to record launch failure for {}: {}", session_id, e);
+                        } else if let Some((status, session_name)) = prior {
+                            if status == SessionStatus::Active.as_str() {
+                                app_state.notifications.emit(
+                                    crate::push::NotificationEvent::SessionDisconnected {
+                                        session_id,
+                                        session_name,
+                                    },
+                                );
+                            }
                         }
                     }
                 }

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -144,6 +144,7 @@ pub fn handle_claude_output(
     session_key: &Option<String>,
     db_session_id: Option<Uuid>,
     db_pool: &DbPool,
+    notifications: &crate::push::NotificationSender,
     tx: &ProxySender,
     content: serde_json::Value,
     seq: Option<u64>,
@@ -309,6 +310,14 @@ pub fn handle_claude_output(
             if role == shared::MessageRole::Result {
                 let subagent_tokens = session_manager.subagent_tokens(session_id);
                 store_result_metadata(&mut conn, session_id, &content, subagent_tokens);
+
+                // Turn finished — emit a push (mobile-apps plan §8.1, collapsed
+                // per session by the dispatcher). Suppressed automatically when
+                // a live web client is present; name backfilled from the row.
+                notifications.emit(crate::push::NotificationEvent::TurnComplete {
+                    session_id,
+                    session_name: String::new(),
+                });
             }
 
             session_manager.queue_truncation(session_id);

--- a/backend/src/handlers/websocket/permissions.rs
+++ b/backend/src/handlers/websocket/permissions.rs
@@ -12,6 +12,7 @@ pub fn handle_permission_request(
     session_key: &Option<String>,
     db_session_id: Option<Uuid>,
     db_pool: &DbPool,
+    notifications: &crate::push::NotificationSender,
     request_id: String,
     tool_name: String,
     input: serde_json::Value,
@@ -62,6 +63,9 @@ pub fn handle_permission_request(
         }
     }
 
+    // Keep the tool name for the push event before the fanout moves it.
+    let push_tool_name = tool_name.clone();
+
     // Forward to web clients
     if let Some(ref key) = session_key {
         info!(
@@ -79,6 +83,18 @@ pub fn handle_permission_request(
                 permission_suggestions,
             },
         );
+    }
+
+    // Emit a push notification (mobile-apps plan §8.1 — the highest-value
+    // interrupt). The dispatcher resolves the owning user and suppresses the
+    // push if a live web client is already present, so this is a cheap fire.
+    // `session_name` is left empty; the dispatcher backfills it from the row.
+    if let Some(session_id) = db_session_id {
+        notifications.emit(crate::push::NotificationEvent::PermissionRequest {
+            session_id,
+            session_name: String::new(),
+            tool_name: push_tool_name,
+        });
     }
 }
 

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -112,9 +112,27 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
             match db_pool.get() {
                 Ok(mut conn) => {
                     use crate::schema::sessions;
+                    // Read the prior status + name first so we only push on a
+                    // genuine active → disconnected drop (never a user-requested
+                    // stop, which is already Inactive) — mobile-apps plan §8.1.
+                    let prior: Option<(String, String)> = sessions::table
+                        .find(session_id)
+                        .select((sessions::status, sessions::session_name))
+                        .first::<(String, String)>(&mut conn)
+                        .ok();
                     let _ = diesel::update(sessions::table.find(session_id))
                         .set(sessions::status.eq(SessionStatus::Disconnected.as_str()))
                         .execute(&mut conn);
+                    if let Some((status, session_name)) = prior {
+                        if status == SessionStatus::Active.as_str() {
+                            app_state.notifications.emit(
+                                crate::push::NotificationEvent::SessionDisconnected {
+                                    session_id,
+                                    session_name,
+                                },
+                            );
+                        }
+                    }
                 }
                 Err(e) => {
                     error!(
@@ -257,6 +275,7 @@ fn handle_proxy_message(
                 session_key,
                 *db_session_id,
                 db_pool,
+                &app_state.notifications,
                 tx,
                 content,
                 None,
@@ -274,6 +293,7 @@ fn handle_proxy_message(
                 session_key,
                 *db_session_id,
                 db_pool,
+                &app_state.notifications,
                 tx,
                 content,
                 Some(seq),
@@ -295,6 +315,7 @@ fn handle_proxy_message(
                 session_key,
                 *db_session_id,
                 db_pool,
+                &app_state.notifications,
                 request_id,
                 tool_name,
                 input,

--- a/backend/src/handlers/websocket/session_manager/client_fanout.rs
+++ b/backend/src/handlers/websocket/session_manager/client_fanout.rs
@@ -99,6 +99,17 @@ impl SessionManager {
         self.user_clients.iter().map(|r| *r.key()).collect()
     }
 
+    /// Whether `user_id` currently has at least one live web client. Used by the
+    /// push dispatcher to suppress a push when in-app WS delivery already covers
+    /// the user (mobile-apps plan §8.2). Presence is trustworthy because dead
+    /// senders are pruned eagerly on socket close (#1291): an empty (or absent)
+    /// vector means genuinely no live client.
+    pub fn has_user_client(&self, user_id: Uuid) -> bool {
+        self.user_clients
+            .get(&user_id)
+            .is_some_and(|clients| !clients.value().is_empty())
+    }
+
     /// Broadcast a shutdown message to all connected clients of every type.
     pub fn broadcast_shutdown(&self, reason: String, reconnect_delay_ms: u64) {
         let proxy_msg = ServerToProxy::ServerShutdown {
@@ -295,6 +306,34 @@ mod tests {
         assert!(mgr.user_clients.get(&user_id).is_none());
         // Presence query must no longer see the user.
         assert!(!mgr.get_all_user_ids().contains(&user_id));
+    }
+
+    #[test]
+    fn has_user_client_presence() {
+        let mgr = SessionManager::new();
+        let present = Uuid::new_v4();
+        let absent = Uuid::new_v4();
+        let (tx, _rx) = crate::handlers::websocket::conn_channel(64);
+
+        assert!(!mgr.has_user_client(present));
+        mgr.add_user_client(present, tx);
+        assert!(mgr.has_user_client(present));
+        // A user with no registered client (never added) is absent.
+        assert!(!mgr.has_user_client(absent));
+    }
+
+    #[test]
+    fn has_user_client_false_after_prune_empties_vec() {
+        // A dead sender pruned to an empty vec must read as "no live client"
+        // so the push dispatcher does not wrongly suppress (§8.2).
+        let mgr = SessionManager::new();
+        let user = Uuid::new_v4();
+        let (tx, rx) = crate::handlers::websocket::conn_channel(64);
+        mgr.add_user_client(user, tx);
+        drop(rx);
+        // Prune the dead sender via a fanout (fanout removes closed senders).
+        mgr.broadcast_to_user(&user, make_client_msg());
+        assert!(!mgr.has_user_client(user));
     }
 
     #[test]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -18,6 +18,7 @@ pub mod errors;
 pub mod handlers;
 pub mod jwt;
 pub mod models;
+pub mod push;
 pub mod routes;
 pub mod schema;
 
@@ -76,6 +77,10 @@ pub struct AppState {
     pub forward_domain: Option<String>,
     /// Long-term session archive runtime (#1258). `None` = disabled.
     pub archive: Option<Arc<archive::ArchiveRuntime>>,
+    /// Non-blocking handle for emitting push notification events
+    /// (mobile-apps plan §8). Drained by the dispatcher task spawned in
+    /// [`run`]; hooks call `notifications.emit(..)`.
+    pub notifications: push::NotificationSender,
 }
 
 impl AppState {
@@ -126,8 +131,19 @@ pub async fn run() -> anyhow::Result<()> {
     // Create session manager for WebSocket connections
     let session_manager = SessionManager::new();
 
-    // Mark sessions whose proxies do not reconnect within the grace period
-    background::spawn_stale_session_cleanup(pool.clone(), session_manager.clone());
+    // Push-notification channel (mobile-apps plan §8): the sender lives on
+    // AppState and is threaded into the event hooks; the receiver is drained by
+    // the dispatcher task spawned once AppState exists (below).
+    let (notifications, notification_rx) = push::channel();
+
+    // Mark sessions whose proxies do not reconnect within the grace period.
+    // A stale ACTIVE session losing its proxy is an unexpected disconnect, so
+    // the sweep emits SessionDisconnected pushes for the sessions it downs.
+    background::spawn_stale_session_cleanup(
+        pool.clone(),
+        session_manager.clone(),
+        notifications.clone(),
+    );
 
     // Parse remaining configuration from environment variables
     let config = config::ServerConfig::from_env(args.dev_mode)?;
@@ -161,7 +177,11 @@ pub async fn run() -> anyhow::Result<()> {
             )),
             None => None,
         },
+        notifications,
     });
+
+    // Drain notification events and dispatch pushes (mobile-apps plan §8.2).
+    push::spawn_dispatcher(app_state.clone(), notification_rx);
 
     // Build our application with routes
     let app = routes::build_router(app_state.clone());

--- a/backend/src/push/dispatcher.rs
+++ b/backend/src/push/dispatcher.rs
@@ -1,0 +1,331 @@
+//! The push dispatcher task (mobile-apps plan §8.2 delivery policy).
+//!
+//! One long-lived tokio task drains the notification channel and, for each
+//! [`NotificationEvent`]:
+//!
+//! 1. resolves the recipient (the session's owning user) and a display name;
+//! 2. suppresses the push when that user has a live web client — in-app
+//!    WS delivery already covers them (§8.2). Presence is trustworthy thanks to
+//!    the eager-prune work in #1291;
+//! 3. filters on the user's notification preferences;
+//! 4. loads the user's non-disabled subscriptions and delivers to each via the
+//!    [`PushTransport`], updating `last_success_at` / `disabled_at` and logging
+//!    real failures under the stable `PUSH_DISPATCH_FAILED` marker.
+
+use std::sync::Arc;
+
+use diesel::prelude::*;
+use shared::api::NotificationPrefs;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tracing::{debug, error};
+use uuid::Uuid;
+
+use crate::db::DbConnection;
+use crate::models::PushSubscription;
+use crate::push::transport::{LogTransport, PushTransport, SendOutcome};
+use crate::push::NotificationEvent;
+use crate::AppState;
+
+/// Stable log marker for a real (non-dead-endpoint) delivery failure. Alert on
+/// this: a recurring burst right after a deploy usually means a transport
+/// misconfiguration, mirroring the `PENDING_INPUT_PERSIST_FAILED` convention
+/// (CLAUDE.md "Schema-drift alerting").
+const PUSH_DISPATCH_FAILED: &str = "PUSH_DISPATCH_FAILED";
+
+/// Spawn the dispatcher task. Consumes the receiver end of the notification
+/// channel; runs until the channel closes (backend shutdown).
+pub fn spawn_dispatcher(app_state: Arc<AppState>, mut rx: UnboundedReceiver<NotificationEvent>) {
+    tokio::spawn(async move {
+        // v1 transport (C2): log delivery intent. Real Web Push (C3) and native
+        // transports (C7) slot in behind `PushTransport` without touching the
+        // policy engine below.
+        let transport = LogTransport;
+        tracing::info!("push dispatcher started");
+        while let Some(event) = rx.recv().await {
+            dispatch_one(&app_state, &transport, event).await;
+        }
+        tracing::warn!("push notification channel closed; dispatcher exiting");
+    });
+}
+
+/// Apply the §8.2 delivery policy to a single event. Never propagates errors —
+/// a push is best-effort and must never wedge the dispatcher.
+async fn dispatch_one<T: PushTransport>(
+    app_state: &AppState,
+    transport: &T,
+    event: NotificationEvent,
+) {
+    let session_id = event.session_id();
+
+    let mut conn = match app_state.db_pool.get() {
+        Ok(conn) => conn,
+        Err(e) => {
+            error!("{PUSH_DISPATCH_FAILED}: no DB connection resolving push recipient: {e}");
+            return;
+        }
+    };
+
+    // (a) Resolve recipient + name in one query. A missing row (session
+    // deleted between emit and dispatch) means we can't route — skip.
+    let resolved = match resolve_recipient(&mut conn, session_id) {
+        Ok(Some(pair)) => pair,
+        Ok(None) => {
+            debug!("push skipped: session {session_id} has no row (deleted?)");
+            return;
+        }
+        Err(e) => {
+            error!("{PUSH_DISPATCH_FAILED}: recipient lookup failed for {session_id}: {e}");
+            return;
+        }
+    };
+    let (user_id, db_name) = resolved;
+
+    // (b) Suppress when the user has a live web client — in-app WS delivery
+    // already covers them. Presence is trustworthy post-#1291 (eager prune).
+    if app_state.session_manager.has_user_client(user_id) {
+        debug!(
+            "push suppressed for user {user_id} (session {session_id}): live web client present"
+        );
+        return;
+    }
+
+    // (c) Prefs filter. Per-user prefs storage lands in C6; until then every
+    // user gets the defaults (permission/turn/disconnect on, agent chatter off).
+    let prefs = NotificationPrefs::default();
+    if !event.is_enabled(&prefs) {
+        debug!(
+            "push suppressed for user {user_id}: event kind {} disabled by prefs",
+            event.event_kind()
+        );
+        return;
+    }
+
+    // Prefer the name the hook supplied (freshest at the source); fall back to
+    // the DB name when the hook didn't have it cheaply.
+    let name = if event.session_name().is_empty() {
+        db_name
+    } else {
+        event.session_name().to_string()
+    };
+    let payload = event.into_payload(name);
+
+    // (d) Fan out to every non-disabled subscription for the user.
+    let subs: Vec<PushSubscription> = match crate::schema::push_subscriptions::table
+        .filter(crate::schema::push_subscriptions::user_id.eq(user_id))
+        .filter(crate::schema::push_subscriptions::disabled_at.is_null())
+        .load::<PushSubscription>(&mut conn)
+    {
+        Ok(subs) => subs,
+        Err(e) => {
+            error!("{PUSH_DISPATCH_FAILED}: loading subscriptions for {user_id} failed: {e}");
+            return;
+        }
+    };
+
+    if subs.is_empty() {
+        debug!("push: user {user_id} has no active subscriptions for session {session_id}");
+        return;
+    }
+
+    for sub in &subs {
+        match transport.send(sub, &payload).await {
+            Ok(SendOutcome::Delivered) => {
+                if let Err(e) = record_success(&mut conn, sub.id) {
+                    error!(
+                        "{PUSH_DISPATCH_FAILED}: recording success for {} failed: {e}",
+                        sub.id
+                    );
+                }
+            }
+            Ok(SendOutcome::GoneDeadEndpoint) => {
+                debug!("push endpoint {} gone; disabling subscription", sub.id);
+                if let Err(e) = disable_subscription(&mut conn, sub.id) {
+                    error!(
+                        "{PUSH_DISPATCH_FAILED}: disabling dead endpoint {} failed: {e}",
+                        sub.id
+                    );
+                }
+            }
+            Err(e) => {
+                error!("{PUSH_DISPATCH_FAILED}: delivery to {} failed: {e}", sub.id);
+            }
+        }
+    }
+}
+
+/// Resolve `(owning user, session name)` for a session, or `None` when the row
+/// is gone.
+fn resolve_recipient(
+    conn: &mut DbConnection,
+    session_id: Uuid,
+) -> QueryResult<Option<(Uuid, String)>> {
+    use crate::schema::sessions;
+    sessions::table
+        .find(session_id)
+        .select((sessions::user_id, sessions::session_name))
+        .first::<(Uuid, String)>(conn)
+        .optional()
+}
+
+/// Stamp `last_success_at = now()` after a delivered push.
+pub(crate) fn record_success(conn: &mut DbConnection, sub_id: Uuid) -> QueryResult<usize> {
+    use crate::schema::push_subscriptions;
+    diesel::update(push_subscriptions::table.find(sub_id))
+        .set(push_subscriptions::last_success_at.eq(chrono::Utc::now()))
+        .execute(conn)
+}
+
+/// Mark a subscription's endpoint dead (`disabled_at = now()`) so future
+/// dispatches skip it until a re-registration clears the timestamp.
+pub(crate) fn disable_subscription(conn: &mut DbConnection, sub_id: Uuid) -> QueryResult<usize> {
+    use crate::schema::push_subscriptions;
+    diesel::update(push_subscriptions::table.find(sub_id))
+        .set(push_subscriptions::disabled_at.eq(chrono::Utc::now()))
+        .execute(conn)
+}
+
+// DB-touching tests for the dead-endpoint / success bookkeeping. Auto-skip when
+// `DATABASE_URL` is unset (so CI without a DB stays green), mirroring the
+// pattern in `handlers::messages::db_tests`. Run locally via:
+//   DATABASE_URL=postgresql://claude_portal:dev_password_change_in_production@localhost:5432/claude_portal \
+//     cargo test -p backend push::dispatcher::db_tests
+#[cfg(test)]
+mod db_tests {
+    use super::*;
+    use crate::db::DbPool;
+    use crate::models::{NewPushSubscription, NewUser, PushSubscription, User};
+    use diesel::r2d2::{ConnectionManager, Pool};
+
+    fn try_pool() -> Option<DbPool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
+        Pool::builder().build(manager).ok()
+    }
+
+    fn make_user(conn: &mut DbConnection) -> User {
+        use crate::schema::users;
+        let nonce = Uuid::new_v4();
+        let new_user = NewUser {
+            google_id: format!("test_push_{nonce}"),
+            email: format!("test_push_{nonce}@example.invalid"),
+            name: Some("Push Test".to_string()),
+            avatar_url: None,
+        };
+        diesel::insert_into(users::table)
+            .values(&new_user)
+            .get_result::<User>(conn)
+            .expect("insert test user")
+    }
+
+    fn make_sub(conn: &mut DbConnection, user_id: Uuid) -> PushSubscription {
+        use crate::schema::push_subscriptions;
+        let new_sub = NewPushSubscription {
+            user_id,
+            platform: "webpush".to_string(),
+            endpoint_or_token: format!("https://example.invalid/{}", Uuid::new_v4()),
+            p256dh: Some("p256dh".to_string()),
+            auth: Some("auth".to_string()),
+            device_label: Some("test".to_string()),
+        };
+        diesel::insert_into(push_subscriptions::table)
+            .values(&new_sub)
+            .get_result::<PushSubscription>(conn)
+            .expect("insert test subscription")
+    }
+
+    #[test]
+    fn dead_endpoint_sets_disabled_at() {
+        let Some(pool) = try_pool() else {
+            eprintln!("DATABASE_URL not set, skipping push dispatcher DB test");
+            return;
+        };
+        let mut conn = pool.get().expect("db conn");
+        let user = make_user(&mut conn);
+        let sub = make_sub(&mut conn, user.id);
+        assert!(sub.disabled_at.is_none());
+
+        let n = disable_subscription(&mut conn, sub.id).expect("disable");
+        assert_eq!(n, 1);
+
+        use crate::schema::push_subscriptions;
+        let reloaded: PushSubscription = push_subscriptions::table
+            .find(sub.id)
+            .first(&mut conn)
+            .expect("reload");
+        assert!(reloaded.disabled_at.is_some(), "disabled_at should be set");
+
+        // A disabled endpoint drops out of the dispatch fan-out query.
+        let active: Vec<PushSubscription> = push_subscriptions::table
+            .filter(push_subscriptions::user_id.eq(user.id))
+            .filter(push_subscriptions::disabled_at.is_null())
+            .load(&mut conn)
+            .expect("load active");
+        assert!(active.iter().all(|s| s.id != sub.id));
+    }
+
+    #[test]
+    fn record_success_sets_last_success_at() {
+        let Some(pool) = try_pool() else {
+            eprintln!("DATABASE_URL not set, skipping push dispatcher DB test");
+            return;
+        };
+        let mut conn = pool.get().expect("db conn");
+        let user = make_user(&mut conn);
+        let sub = make_sub(&mut conn, user.id);
+        assert!(sub.last_success_at.is_none());
+
+        let n = record_success(&mut conn, sub.id).expect("record success");
+        assert_eq!(n, 1);
+
+        use crate::schema::push_subscriptions;
+        let reloaded: PushSubscription = push_subscriptions::table
+            .find(sub.id)
+            .first(&mut conn)
+            .expect("reload");
+        assert!(reloaded.last_success_at.is_some());
+    }
+
+    #[test]
+    fn resolve_recipient_finds_owner_and_name() {
+        let Some(pool) = try_pool() else {
+            eprintln!("DATABASE_URL not set, skipping push dispatcher DB test");
+            return;
+        };
+        let mut conn = pool.get().expect("db conn");
+        let user = make_user(&mut conn);
+
+        use crate::models::NewSessionWithId;
+        use crate::schema::sessions;
+        let session_id = Uuid::new_v4();
+        let new_session = NewSessionWithId {
+            id: session_id,
+            user_id: user.id,
+            session_name: "resolve-test".to_string(),
+            session_key: session_id.to_string(),
+            working_directory: "/tmp".to_string(),
+            status: shared::SessionStatus::Active.as_str().to_string(),
+            git_branch: None,
+            client_version: None,
+            hostname: "test-host".to_string(),
+            launcher_id: None,
+            agent_type: "claude".to_string(),
+            repo_url: None,
+            scheduled_task_id: None,
+            paused: false,
+            claude_args: serde_json::Value::Array(Vec::new()),
+        };
+        diesel::insert_into(sessions::table)
+            .values(&new_session)
+            .execute(&mut conn)
+            .expect("insert session");
+
+        let resolved = resolve_recipient(&mut conn, session_id).expect("resolve");
+        assert_eq!(resolved, Some((user.id, "resolve-test".to_string())));
+
+        // Unknown session resolves to None.
+        assert_eq!(
+            resolve_recipient(&mut conn, Uuid::new_v4()).expect("resolve missing"),
+            None
+        );
+    }
+}

--- a/backend/src/push/mod.rs
+++ b/backend/src/push/mod.rs
@@ -1,0 +1,265 @@
+//! Push-notification dispatch (mobile-apps plan §8, work items C2 + C4).
+//!
+//! This module is the server-side half of the "reach a pocketed phone" story:
+//! event hooks around the codebase [`NotificationSender::emit`] a
+//! [`NotificationEvent`]; a background dispatcher task
+//! ([`dispatcher::spawn_dispatcher`]) drains those events and, per the delivery
+//! policy in §8.2, resolves the owning user, suppresses the push when that user
+//! already has a live web client, filters on their notification preferences,
+//! and fans the surviving event out to every non-disabled push subscription
+//! via a [`PushTransport`].
+//!
+//! v1 ships only the [`transport::LogTransport`] (logs delivery intent); real
+//! Web Push / APNs / FCM transports land in C3 / C7 behind the same trait.
+
+pub mod dispatcher;
+pub mod transport;
+
+pub use dispatcher::spawn_dispatcher;
+pub use transport::{LogTransport, PushError, PushTransport, SendOutcome};
+
+use shared::api::NotificationPrefs;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use uuid::Uuid;
+
+/// A user-visible event worth a push. Each variant names the session it
+/// concerns so the dispatcher can resolve the owning user and (as a fallback)
+/// a display name. `session_name` is filled best-effort by the emitting hook —
+/// call sites that already hold it pass it through; others leave it empty and
+/// the dispatcher backfills it from the sessions row (see
+/// [`dispatcher`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NotificationEvent {
+    /// The agent is blocked waiting on a permission decision — the highest
+    /// value interrupt (§8.1).
+    PermissionRequest {
+        session_id: Uuid,
+        session_name: String,
+        tool_name: String,
+    },
+    /// A turn finished (a `Result` message was stored); collapse per session.
+    TurnComplete {
+        session_id: Uuid,
+        session_name: String,
+    },
+    /// A running session dropped unexpectedly (an `active` → `disconnected`
+    /// transition, never a user-requested stop/pause).
+    SessionDisconnected {
+        session_id: Uuid,
+        session_name: String,
+    },
+}
+
+impl NotificationEvent {
+    /// The session this event concerns.
+    pub fn session_id(&self) -> Uuid {
+        match self {
+            NotificationEvent::PermissionRequest { session_id, .. }
+            | NotificationEvent::TurnComplete { session_id, .. }
+            | NotificationEvent::SessionDisconnected { session_id, .. } => *session_id,
+        }
+    }
+
+    /// Best-effort display name supplied by the emitting hook; empty when the
+    /// hook didn't have it cheaply (the dispatcher then uses the DB name).
+    pub fn session_name(&self) -> &str {
+        match self {
+            NotificationEvent::PermissionRequest { session_name, .. }
+            | NotificationEvent::TurnComplete { session_name, .. }
+            | NotificationEvent::SessionDisconnected { session_name, .. } => session_name,
+        }
+    }
+
+    /// Stable wire tag for the event kind — mirrors the `NotificationPrefs`
+    /// field names and rides in the push payload so clients can theme/route.
+    pub fn event_kind(&self) -> &'static str {
+        match self {
+            NotificationEvent::PermissionRequest { .. } => "permission_request",
+            NotificationEvent::TurnComplete { .. } => "turn_complete",
+            NotificationEvent::SessionDisconnected { .. } => "session_disconnected",
+        }
+    }
+
+    /// Whether this event kind is enabled under the given preferences.
+    pub fn is_enabled(&self, prefs: &NotificationPrefs) -> bool {
+        match self {
+            NotificationEvent::PermissionRequest { .. } => prefs.permission_request,
+            NotificationEvent::TurnComplete { .. } => prefs.turn_complete,
+            NotificationEvent::SessionDisconnected { .. } => prefs.session_disconnected,
+        }
+    }
+
+    /// Build the transport-agnostic payload. `session_name` is the resolved
+    /// name (event name when the hook provided one, else the DB name). Payload
+    /// discipline (§8.2): a short preview only — the tap deep-links to the
+    /// session and richer content stays server-side.
+    pub fn into_payload(self, session_name: String) -> PushPayload {
+        let session_id = self.session_id();
+        let event_kind = self.event_kind().to_string();
+        // Collapse key = session id: one visible notification per session,
+        // newest wins (§8.2).
+        let collapse_key = session_id.to_string();
+        let title = if session_name.is_empty() {
+            "Agent Portal".to_string()
+        } else {
+            session_name
+        };
+        let body = match self {
+            NotificationEvent::PermissionRequest { tool_name, .. } => {
+                format!("Permission needed: {tool_name}")
+            }
+            NotificationEvent::TurnComplete { .. } => "Turn complete".to_string(),
+            NotificationEvent::SessionDisconnected { .. } => "Session disconnected".to_string(),
+        };
+        PushPayload {
+            session_id,
+            event_kind,
+            title,
+            body,
+            collapse_key,
+        }
+    }
+}
+
+/// A push payload, independent of transport. `collapse_key` is the session id
+/// string so a transport maps it to `apns-collapse-id` / FCM `collapse_key` /
+/// Web Push `tag` for one-notification-per-session collapsing (§8.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushPayload {
+    pub session_id: Uuid,
+    pub event_kind: String,
+    pub title: String,
+    pub body: String,
+    pub collapse_key: String,
+}
+
+/// Non-blocking, infallible-from-the-caller's-perspective handle for emitting
+/// [`NotificationEvent`]s. Cheap to clone; stored on `AppState` and threaded
+/// into the event hooks. A send failure (the dispatcher task is gone) is
+/// logged at debug and swallowed — a hook must never block or fail its calling
+/// path on notification delivery.
+#[derive(Clone)]
+pub struct NotificationSender {
+    tx: UnboundedSender<NotificationEvent>,
+}
+
+impl NotificationSender {
+    /// Emit an event. Errors (channel closed) are logged and dropped.
+    pub fn emit(&self, event: NotificationEvent) {
+        if let Err(e) = self.tx.send(event) {
+            tracing::debug!("push notification channel closed, dropping event: {e}");
+        }
+    }
+}
+
+/// Create the notification channel: a [`NotificationSender`] for the hooks and
+/// the receiver the dispatcher task drains.
+pub fn channel() -> (NotificationSender, UnboundedReceiver<NotificationEvent>) {
+    let (tx, rx) = unbounded_channel();
+    (NotificationSender { tx }, rx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn perm(name: &str) -> NotificationEvent {
+        NotificationEvent::PermissionRequest {
+            session_id: Uuid::nil(),
+            session_name: name.to_string(),
+            tool_name: "Bash".to_string(),
+        }
+    }
+
+    #[test]
+    fn event_kind_matches_prefs_fields() {
+        assert_eq!(perm("s").event_kind(), "permission_request");
+        assert_eq!(
+            NotificationEvent::TurnComplete {
+                session_id: Uuid::nil(),
+                session_name: "s".into()
+            }
+            .event_kind(),
+            "turn_complete"
+        );
+        assert_eq!(
+            NotificationEvent::SessionDisconnected {
+                session_id: Uuid::nil(),
+                session_name: "s".into()
+            }
+            .event_kind(),
+            "session_disconnected"
+        );
+    }
+
+    #[test]
+    fn default_prefs_enable_the_three_v1_events() {
+        let prefs = NotificationPrefs::default();
+        for ev in [
+            perm("s"),
+            NotificationEvent::TurnComplete {
+                session_id: Uuid::nil(),
+                session_name: "s".into(),
+            },
+            NotificationEvent::SessionDisconnected {
+                session_id: Uuid::nil(),
+                session_name: "s".into(),
+            },
+        ] {
+            assert!(
+                ev.is_enabled(&prefs),
+                "{} should be on by default",
+                ev.event_kind()
+            );
+        }
+    }
+
+    #[test]
+    fn is_enabled_honors_a_disabled_toggle() {
+        let prefs = NotificationPrefs {
+            turn_complete: false,
+            ..NotificationPrefs::default()
+        };
+        assert!(perm("s").is_enabled(&prefs));
+        assert!(!NotificationEvent::TurnComplete {
+            session_id: Uuid::nil(),
+            session_name: "s".into()
+        }
+        .is_enabled(&prefs));
+    }
+
+    #[test]
+    fn payload_uses_session_name_as_title_and_session_id_collapse_key() {
+        let id = Uuid::new_v4();
+        let ev = NotificationEvent::PermissionRequest {
+            session_id: id,
+            session_name: "my-session".into(),
+            tool_name: "Edit".into(),
+        };
+        let payload = ev.into_payload("my-session".to_string());
+        assert_eq!(payload.title, "my-session");
+        assert_eq!(payload.body, "Permission needed: Edit");
+        assert_eq!(payload.event_kind, "permission_request");
+        assert_eq!(payload.collapse_key, id.to_string());
+        assert_eq!(payload.session_id, id);
+    }
+
+    #[test]
+    fn payload_falls_back_to_generic_title_when_name_empty() {
+        let payload = NotificationEvent::TurnComplete {
+            session_id: Uuid::nil(),
+            session_name: String::new(),
+        }
+        .into_payload(String::new());
+        assert_eq!(payload.title, "Agent Portal");
+        assert_eq!(payload.body, "Turn complete");
+    }
+
+    #[test]
+    fn emit_after_receiver_dropped_is_silent() {
+        let (sender, rx) = channel();
+        drop(rx);
+        // Must not panic / must not block.
+        sender.emit(perm("s"));
+    }
+}

--- a/backend/src/push/transport.rs
+++ b/backend/src/push/transport.rs
@@ -1,0 +1,71 @@
+//! Push transports (mobile-apps plan §8.3).
+//!
+//! A [`PushTransport`] turns a resolved [`PushPayload`] into an actual push for
+//! one [`PushSubscription`]. The trait is the seam every stage plugs into: v1
+//! ships only [`LogTransport`] (logs delivery intent), C3 adds a `web-push`
+//! transport, and C7 adds native APNs/FCM — all behind this one contract, all
+//! driven by the same dispatcher.
+
+use crate::models::PushSubscription;
+use crate::push::PushPayload;
+
+/// Outcome of a single delivery attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SendOutcome {
+    /// The push provider accepted the payload.
+    Delivered,
+    /// The endpoint is permanently gone (e.g. a Web Push 404/410). The
+    /// dispatcher marks the subscription `disabled_at` so it is skipped until a
+    /// re-registration revives it.
+    GoneDeadEndpoint,
+}
+
+/// A transport-level failure that is *not* a dead endpoint (a transient network
+/// error, an auth/config problem, a serialization failure). The dispatcher logs
+/// these under the `PUSH_DISPATCH_FAILED` marker and leaves the subscription
+/// intact for the next event.
+#[derive(Debug, thiserror::Error)]
+pub enum PushError {
+    #[error("push transport error: {0}")]
+    Transport(String),
+}
+
+/// Deliver a [`PushPayload`] to one subscription.
+///
+/// Implementations must be cheap to hold across the dispatcher loop and safe to
+/// call concurrently. The method is spelled as a `-> impl Future + Send` rather
+/// than `async fn` so the returned future is guaranteed `Send` (the dispatcher
+/// runs on `tokio::spawn`); implementors may still write it as an `async fn`.
+pub trait PushTransport {
+    fn send(
+        &self,
+        sub: &PushSubscription,
+        payload: &PushPayload,
+    ) -> impl std::future::Future<Output = Result<SendOutcome, PushError>> + Send;
+}
+
+/// v1 transport: log the delivery intent at info level. Lets the whole
+/// dispatch pipeline (resolution, suppression, prefs, subscription fan-out,
+/// success/dead-endpoint bookkeeping) be exercised end to end before any real
+/// push crate is wired in (C3).
+pub struct LogTransport;
+
+impl PushTransport for LogTransport {
+    async fn send(
+        &self,
+        sub: &PushSubscription,
+        payload: &PushPayload,
+    ) -> Result<SendOutcome, PushError> {
+        tracing::info!(
+            "push delivery intent: platform={} subscription={} session={} kind={} title={:?} body={:?} collapse_key={}",
+            sub.platform,
+            sub.id,
+            payload.session_id,
+            payload.event_kind,
+            payload.title,
+            payload.body,
+            payload.collapse_key,
+        );
+        Ok(SendOutcome::Delivered)
+    }
+}

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -67,6 +67,9 @@ async fn spawn_test_app() -> SocketAddr {
         image_store: ImageStore::new(config.image_store_max_bytes, config.image_store_ttl),
         forward_domain: config.forward_domain,
         archive: None,
+        // No dispatcher is spawned in the harness; the receiver drops
+        // immediately, so emits are silently no-ops (see NotificationSender).
+        notifications: backend::push::channel().0,
     });
 
     let app = backend::routes::build_router(state);


### PR DESCRIPTION
Implements work items **C2** (dispatcher core) and **C4** (event hooks) of `docs/MOBILE_APPS_PLAN.md` (§8). Builds on the merged `push_subscriptions` schema/models + shared push API types (#1293).

## C2 — dispatcher core (`backend/src/push/`)

- **`NotificationEvent`** enum: `PermissionRequest { session_id, session_name, tool_name }`, `TurnComplete { session_id, session_name }`, `SessionDisconnected { session_id, session_name }`.
- **`NotificationSender`** on `AppState`: an `UnboundedSender` wrapper whose `emit()` is non-blocking and infallible from the caller (send errors → `debug!` and dropped). Created in `run()`, drained by a dispatcher tokio task spawned at startup.
- **Delivery policy** (§8.2), per event:
  - resolve the recipient — session's owning user (`sessions.user_id`) + display name, in one query;
  - **suppress** when the user has a live web client (new `SessionManager::has_user_client`, trustworthy thanks to the eager prune from #1291);
  - **prefs filter** — `NotificationPrefs::default()` for now (per-user storage lands in C6);
  - load non-disabled `push_subscriptions` and call the transport per row.
- **`PushTransport`** trait (`send(&sub, &payload) -> Result<SendOutcome, PushError>`; `SendOutcome::{Delivered, GoneDeadEndpoint}`) with **`LogTransport`** as the v1 transport (logs delivery intent — real Web Push is C3, no `web-push` dep added).
- On `Delivered` → stamp `last_success_at`; on `GoneDeadEndpoint` → set `disabled_at`; on error → log the stable **`PUSH_DISPATCH_FAILED`** marker.
- `PushPayload` keeps §8.2 payload discipline (short preview only); `collapse_key` = session id string.

## C4 — event hooks

Each hook is a few lines and never blocks/fails the calling path:

- **Permission request** — `permissions.rs`, after the web-client fanout.
- **Turn complete** — `message_handlers.rs`, in the `Result`-role path.
- **Session disconnected** — the `Disconnected` transitions in `proxy_socket.rs`, `background.rs` (stale sweep), and `launcher_socket.rs`, **only for genuine `active` → `disconnected` transitions** (prior status is read first, so user-requested stop/pause never pushes).

Session name for the payload is passed through when a hook cheaply has it (the stale sweep); otherwise left empty and backfilled from the sessions row inside the dispatcher.

## Tests

- Unit tests for payload construction, prefs filtering, event-kind mapping, and the silent-emit-after-drop behavior.
- Suppression-decision tests on `SessionManager::has_user_client` (incl. empty-after-prune reads as absent).
- `DATABASE_URL`-gated DB tests for dead-endpoint disabling, `last_success_at` stamping, and recipient resolution.

Verified: `cargo fmt --check`, `cargo clippy -p backend --all-targets -- -D warnings`, `cargo test -p backend` (185 pass single-threaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)