### PR TITLE
Preserve CLI device-flow token behavior

### DIFF
--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -6,7 +6,8 @@ use axum::{
 use diesel::prelude::*;
 use serde::Deserialize;
 use shared::api::{
-    DeviceCodeRequest, DeviceCodeResponse, DeviceFlowActionResponse, DeviceFlowPollRequest,
+    DeviceClientType, DeviceCodeRequest, DeviceCodeResponse, DeviceFlowActionResponse,
+    DeviceFlowPollRequest,
 };
 use shared::DevicePollResponse;
 use std::sync::Arc;
@@ -21,7 +22,7 @@ use crate::{
 };
 
 use shared::protocol::{DEVICE_CODE_EXPIRES_SECS, SESSION_COOKIE_NAME};
-use shared::TOKEN_TYPE_MOBILE;
+use shared::{TOKEN_TYPE_MOBILE, TOKEN_TYPE_PROXY};
 
 mod api_error;
 mod render;
@@ -50,6 +51,7 @@ pub async fn device_code(
     let req = body.map(|b| b.0).unwrap_or_default();
     let hostname = req.hostname;
     let working_directory = req.working_directory;
+    let client_type = req.client_type;
     let device_code = generate_device_code();
     let user_code = generate_user_code();
 
@@ -65,6 +67,7 @@ pub async fn device_code(
         status: DeviceFlowStatus::Pending,
         hostname: hostname.clone(),
         working_directory: working_directory.clone(),
+        client_type,
     };
 
     let mut store_lock = store.write().await;
@@ -77,6 +80,7 @@ pub async fn device_code(
         user_code = %user_code,
         hostname = ?hostname,
         working_directory = ?working_directory,
+        client_type = ?client_type,
     );
 
     Ok(Json(DeviceCodeResponse {
@@ -382,14 +386,7 @@ pub async fn complete_device_flow(
     user_code: &str,
     user_id: Uuid,
 ) -> Result<(), ()> {
-    complete_device_flow_with_expiry(
-        app_state,
-        store,
-        user_code,
-        user_id,
-        Some(MOBILE_TOKEN_TTL_DAYS),
-    )
-    .await
+    complete_device_flow_with_expiry(app_state, store, user_code, user_id).await
 }
 
 async fn complete_device_flow_with_expiry(
@@ -397,14 +394,26 @@ async fn complete_device_flow_with_expiry(
     store: &DeviceFlowStore,
     user_code: &str,
     user_id: Uuid,
-    expires_in_days: Option<u32>,
 ) -> Result<(), ()> {
     let mut conn = app_state.db_pool.get().map_err(|e| {
         error!("Failed to get database connection: {}", e);
     })?;
 
-    // Device-flow credentials are mobile bearer tokens with a fixed lifetime;
-    // B2 adds the refresh endpoint so native shells can rotate before expiry.
+    let client_type = {
+        let store_lock = store.read().await;
+        store_lock
+            .values()
+            .find(|s| s.user_code == user_code && s.status == DeviceFlowStatus::Pending)
+            .map(|state| state.client_type)
+            .ok_or_else(|| {
+                error!("Device flow state not found for user_code: {}", user_code);
+            })?
+    };
+
+    let (expires_in_days, token_type) = device_client_token_policy(client_type);
+
+    // CLI/proxy device-flow credentials intentionally remain non-expiring
+    // (#932). Mobile shells opt into expiring refreshable tokens.
     let name = format!(
         "Device auth {}",
         chrono::Utc::now().format("%Y-%m-%d %H:%M")
@@ -415,7 +424,7 @@ async fn complete_device_flow_with_expiry(
         user_id,
         TokenPersist::Create { name: &name },
         expires_in_days,
-        TOKEN_TYPE_MOBILE,
+        token_type,
     )
     .map_err(|e| {
         error!("Failed to issue device token: {:?}", e);
@@ -442,11 +451,20 @@ async fn complete_device_flow_with_expiry(
             user_code = %user_code,
             user_id = %user_id,
             user_email = %issued.user_email,
+            client_type = ?client_type,
+            token_type = %token_type,
         );
         Ok(())
     } else {
         error!("Device flow state not found for user_code: {}", user_code);
         Err(())
+    }
+}
+
+fn device_client_token_policy(client_type: DeviceClientType) -> (Option<u32>, &'static str) {
+    match client_type {
+        DeviceClientType::Cli => (None, TOKEN_TYPE_PROXY),
+        DeviceClientType::Mobile => (Some(MOBILE_TOKEN_TTL_DAYS), TOKEN_TYPE_MOBILE),
     }
 }
 
@@ -556,6 +574,18 @@ mod tests {
     }
 
     #[test]
+    fn device_client_token_policy_preserves_cli_proxy_tokens() {
+        assert_eq!(
+            device_client_token_policy(DeviceClientType::Cli),
+            (None, TOKEN_TYPE_PROXY)
+        );
+        assert_eq!(
+            device_client_token_policy(DeviceClientType::Mobile),
+            (Some(MOBILE_TOKEN_TTL_DAYS), TOKEN_TYPE_MOBILE)
+        );
+    }
+
+    #[test]
     fn test_device_flow_state_transitions() {
         // Test that DeviceFlowStatus can represent all states
         let pending = DeviceFlowStatus::Pending;
@@ -593,6 +623,7 @@ mod tests {
             status: DeviceFlowStatus::Pending,
             hostname: Some("test-host".to_string()),
             working_directory: Some("/home/user/project".to_string()),
+            client_type: DeviceClientType::Cli,
         };
 
         assert_eq!(state.device_code, device_code);
@@ -605,6 +636,7 @@ mod tests {
             state.working_directory,
             Some("/home/user/project".to_string())
         );
+        assert_eq!(state.client_type, DeviceClientType::Cli);
     }
 
     #[tokio::test]
@@ -625,6 +657,7 @@ mod tests {
             status: DeviceFlowStatus::Pending,
             hostname: Some("test-host".to_string()),
             working_directory: Some("/test/dir".to_string()),
+            client_type: DeviceClientType::Cli,
         };
 
         // Insert into store
@@ -775,6 +808,7 @@ mod tests {
             status: DeviceFlowStatus::Pending,
             hostname: None,
             working_directory: None,
+            client_type: DeviceClientType::Cli,
         };
 
         // Insert into store

--- a/backend/src/handlers/device_flow/state.rs
+++ b/backend/src/handlers/device_flow/state.rs
@@ -1,5 +1,6 @@
 use rand::{distributions::Alphanumeric, Rng};
 use serde::Deserialize;
+use shared::api::DeviceClientType;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -21,6 +22,8 @@ pub struct DeviceFlowState {
     pub hostname: Option<String>,
     /// Working directory / repository path
     pub working_directory: Option<String>,
+    /// Client class requested when the device flow was initiated.
+    pub client_type: DeviceClientType,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/portal-auth/src/lib.rs
+++ b/portal-auth/src/lib.rs
@@ -4,7 +4,7 @@ use reqwest::{
     header::{HeaderMap, RETRY_AFTER},
     StatusCode,
 };
-use shared::api::{DeviceCodeRequest, DeviceCodeResponse, DeviceFlowPollRequest};
+use shared::api::{DeviceClientType, DeviceCodeRequest, DeviceCodeResponse, DeviceFlowPollRequest};
 use shared::DevicePollResponse;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -64,6 +64,7 @@ pub async fn device_flow_login(
     let body = DeviceCodeRequest {
         hostname: Some(hostname),
         working_directory: working_directory.map(|s| s.to_string()),
+        client_type: DeviceClientType::Cli,
     };
     let http_response = client
         .post(&device_code_url)

--- a/shared/src/api/device_flow.rs
+++ b/shared/src/api/device_flow.rs
@@ -2,6 +2,17 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Device-flow client class. Existing CLI/proxy callers default to `cli`;
+/// mobile shells opt in with `mobile` so their tokens can be expiring and
+/// refreshable without regressing standalone proxy credentials.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeviceClientType {
+    #[default]
+    Cli,
+    Mobile,
+}
+
 /// Device flow code request response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceCodeResponse {
@@ -19,6 +30,8 @@ pub struct DeviceCodeRequest {
     pub hostname: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_directory: Option<String>,
+    #[serde(default)]
+    pub client_type: DeviceClientType,
 }
 
 /// Request body for polling device flow status
@@ -32,4 +45,26 @@ pub struct DeviceFlowPollRequest {
 pub struct DeviceFlowActionResponse {
     pub success: bool,
     pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_code_request_defaults_to_cli_client_type() {
+        let req: DeviceCodeRequest =
+            serde_json::from_str(r#"{"hostname":"devbox"}"#).expect("request should parse");
+
+        assert_eq!(req.hostname.as_deref(), Some("devbox"));
+        assert_eq!(req.client_type, DeviceClientType::Cli);
+    }
+
+    #[test]
+    fn device_code_request_accepts_mobile_client_type() {
+        let req: DeviceCodeRequest =
+            serde_json::from_str(r#"{"client_type":"mobile"}"#).expect("request should parse");
+
+        assert_eq!(req.client_type, DeviceClientType::Mobile);
+    }
 }


### PR DESCRIPTION
## Summary
- add `DeviceClientType` to device-code requests with a backwards-compatible default of `cli`
- store the client class in `DeviceFlowState`
- mint CLI/proxy device-flow tokens as non-expiring `token_type=proxy` tokens, preserving #932
- mint mobile device-flow tokens as 30-day `token_type=mobile` tokens for B2 refresh support
- have the maintained portal-auth device-flow client send `client_type: cli` explicitly

## Review focus
- missing `client_type` remains CLI/proxy behavior for old claude-portal binaries
- mobile opt-in still gets 30-day mobile tokens
- no stale B2/B3/E1 reverse diff remains after rebase to current main

## Tests
- `cargo test -p shared device_flow`
- `cargo test -p backend handlers::device_flow::tests --lib`
- `cargo clippy -p backend -p portal-auth -- -D warnings`
- `cargo fmt --check`