### PR TITLE
Add native push transports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -832,6 +832,11 @@ When making changes, verify:
 | `PORTAL_SESSION_ARCHIVE_TRANSCRIPTS` | Archive transcript bodies (always zstd-compressed), not just manifests | Optional (default: true) |
 | `PORTAL_VAPID_PUBLIC_KEY` | Web Push VAPID application-server public key, served to clients via `GET /api/push/vapid-key` (unset → endpoint 404s, frontend shows push unavailable) | Optional (Web Push only) |
 | `PORTAL_VAPID_PRIVATE_KEY` | Web Push VAPID private key, used by the Web Push sender to sign pushes; never served to clients | Optional (Web Push only) |
+| `PORTAL_APNS_KEY_P8_PATH` | APNs provider-token `.p8` private key path for native iOS push | Required with other `PORTAL_APNS_*` vars |
+| `PORTAL_APNS_KEY_ID` | APNs provider-token key id for native iOS push | Required with other `PORTAL_APNS_*` vars |
+| `PORTAL_APNS_TEAM_ID` | Apple Developer Team ID for native iOS push | Required with other `PORTAL_APNS_*` vars |
+| `PORTAL_APNS_BUNDLE_ID` | App bundle id used as the APNs topic | Required with other `PORTAL_APNS_*` vars |
+| `PORTAL_FCM_SERVICE_ACCOUNT_PATH` | Google service-account JSON path for FCM v1 native Android push | Optional (FCM disabled when unset) |
 
 Note: Dev mode is enabled via `--dev-mode` CLI flag, not an environment variable. Voice input is browser-native (Web Speech API on Chromium / Safari); no server-side speech credentials are needed.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,31 @@
 version = 4
 
 [[package]]
+name = "a2"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f279fc8b1f1a64138f0f4b9cda9be488ae35bc2f8556c7ffe60730f1c07d005a"
+dependencies = [
+ "base64 0.21.7",
+ "erased-serde 0.3.31",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
+ "parking_lot",
+ "pem",
+ "ring",
+ "rustls 0.22.4",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,7 +49,7 @@ dependencies = [
  "portal-auth",
  "portal-update",
  "reqwest 0.12.28",
- "rustls",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "session-lib",
@@ -275,6 +300,7 @@ dependencies = [
 name = "backend"
 version = "2.13.0"
 dependencies = [
+ "a2",
  "anyhow",
  "axum",
  "base64 0.22.1",
@@ -1527,6 +1553,15 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "erased-serde"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
@@ -2758,6 +2793,24 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
@@ -2765,10 +2818,10 @@ dependencies = [
  "http 1.4.0",
  "hyper",
  "hyper-util",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.7",
 ]
@@ -3645,7 +3698,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4407,7 +4460,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.40",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -4428,7 +4481,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -4669,7 +4722,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -4679,7 +4732,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -4688,7 +4741,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -4714,21 +4767,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4790,6 +4843,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
@@ -4798,7 +4865,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -4813,6 +4880,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4836,10 +4912,10 @@ dependencies = [
  "jni 0.22.4",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -4851,6 +4927,17 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -5028,7 +5115,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
 dependencies = [
- "erased-serde",
+ "erased-serde 0.4.10",
  "serde",
  "serde_core",
  "typeid",
@@ -5857,7 +5944,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -6042,11 +6129,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -6069,11 +6167,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
 ]
@@ -6454,7 +6552,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = { workspace = true }
 # OAuth for Google authentication
 oauth2 = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
+a2 = { version = "0.10.0", default-features = false, features = ["ring", "tracing"] }
 
 # Environment variables
 dotenvy = { workspace = true }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -14,6 +14,7 @@ use oauth2::{
 };
 use std::env;
 use std::fmt::Display;
+use std::path::PathBuf;
 use std::str::FromStr;
 use tower_cookies::Key;
 
@@ -163,6 +164,9 @@ pub struct ServerConfig {
     /// (`GET /api/push/vapid-key`). `None` = push unconfigured; the endpoint
     /// 404s and the frontend degrades to "push unavailable".
     pub vapid_public_key: Option<String>,
+    /// Native APNs/FCM push settings (mobile-apps plan C7). Missing provider
+    /// groups disable that provider; partial APNs config fails fast.
+    pub native_push: crate::push::NativePushConfig,
 }
 
 impl ServerConfig {
@@ -330,6 +334,8 @@ impl ServerConfig {
             None => tracing::info!("Web Push disabled (PORTAL_VAPID_PUBLIC_KEY unset)"),
         }
 
+        let native_push = native_push_config_from_env(&mut errors);
+
         // Long-term session archive (#1258). Fail-fast on partial config.
         let archive = crate::archive::archive_config_from_env()
             .map_err(|e| anyhow::anyhow!("invalid archive configuration: {e}"))?;
@@ -386,8 +392,102 @@ impl ServerConfig {
             forward_domain,
             archive,
             vapid_public_key,
+            native_push,
         })
     }
+}
+
+fn optional_non_empty(name: &str) -> Option<String> {
+    env::var(name).ok().and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn native_push_config_from_env(errors: &mut Vec<String>) -> crate::push::NativePushConfig {
+    let apns_path = optional_non_empty("PORTAL_APNS_KEY_P8_PATH");
+    let apns_key_id = optional_non_empty("PORTAL_APNS_KEY_ID");
+    let apns_team_id = optional_non_empty("PORTAL_APNS_TEAM_ID");
+    let apns_bundle_id = optional_non_empty("PORTAL_APNS_BUNDLE_ID");
+
+    let apns_any = apns_path.is_some()
+        || apns_key_id.is_some()
+        || apns_team_id.is_some()
+        || apns_bundle_id.is_some();
+    let apns = if apns_any {
+        for (name, value) in [
+            ("PORTAL_APNS_KEY_P8_PATH", &apns_path),
+            ("PORTAL_APNS_KEY_ID", &apns_key_id),
+            ("PORTAL_APNS_TEAM_ID", &apns_team_id),
+            ("PORTAL_APNS_BUNDLE_ID", &apns_bundle_id),
+        ] {
+            log_source(name, value.is_some());
+        }
+
+        match (apns_path, apns_key_id, apns_team_id, apns_bundle_id) {
+            (Some(key_p8_path), Some(key_id), Some(team_id), Some(bundle_id)) => {
+                tracing::info!("APNs push transport configured");
+                Some(crate::push::ApnsTransportConfig {
+                    key_p8_path: PathBuf::from(key_p8_path),
+                    key_id,
+                    team_id,
+                    bundle_id,
+                })
+            }
+            (path, key_id, team_id, bundle_id) => {
+                let mut missing = Vec::new();
+                if path.is_none() {
+                    missing.push("PORTAL_APNS_KEY_P8_PATH");
+                }
+                if key_id.is_none() {
+                    missing.push("PORTAL_APNS_KEY_ID");
+                }
+                if team_id.is_none() {
+                    missing.push("PORTAL_APNS_TEAM_ID");
+                }
+                if bundle_id.is_none() {
+                    missing.push("PORTAL_APNS_BUNDLE_ID");
+                }
+                errors.push(format!(
+                    "APNs push config is partial; missing {}",
+                    missing.join(", ")
+                ));
+                None
+            }
+        }
+    } else {
+        for name in [
+            "PORTAL_APNS_KEY_P8_PATH",
+            "PORTAL_APNS_KEY_ID",
+            "PORTAL_APNS_TEAM_ID",
+            "PORTAL_APNS_BUNDLE_ID",
+        ] {
+            log_source(name, false);
+        }
+        tracing::info!("APNs push transport disabled (PORTAL_APNS_* unset)");
+        None
+    };
+
+    let fcm = match optional_non_empty("PORTAL_FCM_SERVICE_ACCOUNT_PATH") {
+        Some(path) => {
+            log_source("PORTAL_FCM_SERVICE_ACCOUNT_PATH", true);
+            tracing::info!("FCM push transport configured");
+            Some(crate::push::FcmTransportConfig {
+                service_account_path: PathBuf::from(path),
+            })
+        }
+        None => {
+            log_source("PORTAL_FCM_SERVICE_ACCOUNT_PATH", false);
+            tracing::info!("FCM push transport disabled (PORTAL_FCM_SERVICE_ACCOUNT_PATH unset)");
+            None
+        }
+    };
+
+    crate::push::NativePushConfig { apns, fcm }
 }
 
 #[cfg(test)]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -150,6 +150,7 @@ pub async fn run() -> anyhow::Result<()> {
 
     // Parse remaining configuration from environment variables
     let config = config::ServerConfig::from_env(args.dev_mode)?;
+    let push_transport = push::ConfiguredTransport::from_native_config(config.native_push)?;
 
     // Create app state
     let app_state = Arc::new(AppState {
@@ -185,7 +186,7 @@ pub async fn run() -> anyhow::Result<()> {
     });
 
     // Drain notification events and dispatch pushes (mobile-apps plan §8.2).
-    push::spawn_dispatcher(app_state.clone(), notification_rx);
+    push::spawn_dispatcher(app_state.clone(), notification_rx, push_transport);
 
     // Build our application with routes
     let app = routes::build_router(app_state.clone());

--- a/backend/src/push/apns.rs
+++ b/backend/src/push/apns.rs
@@ -1,0 +1,269 @@
+//! Native APNs transport (mobile-apps plan C7).
+//!
+//! Uses direct APNs provider-token auth via the `a2` crate. The shell stores
+//! the APNs device token in `push_subscriptions.endpoint_or_token`.
+
+use std::fs::File;
+
+use a2::{
+    Client, ClientConfig, CollapseId, DefaultNotificationBuilder, Endpoint, ErrorReason,
+    NotificationBuilder, NotificationOptions, PushType,
+};
+use serde::Serialize;
+
+use crate::models::PushSubscription;
+use crate::push::transport::{PushError, PushTransport, SendOutcome};
+use crate::push::{ApnsTransportConfig, PushPayload};
+
+const APNS_PLATFORM: &str = "apns";
+
+#[derive(Debug, Serialize)]
+struct ApnsCustomData<'a> {
+    session_id: &'a str,
+    event_kind: &'a str,
+}
+
+pub struct ApnsTransport {
+    client: Client,
+    bundle_id: String,
+}
+
+impl ApnsTransport {
+    pub fn new(config: ApnsTransportConfig) -> anyhow::Result<Self> {
+        let mut key = File::open(&config.key_p8_path).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to open PORTAL_APNS_KEY_P8_PATH {}: {e}",
+                config.key_p8_path.display()
+            )
+        })?;
+        let client = Client::token(
+            &mut key,
+            config.key_id,
+            config.team_id,
+            ClientConfig::new(Endpoint::Production),
+        )
+        .map_err(|e| anyhow::anyhow!("failed to initialize APNs client: {e}"))?;
+        Ok(Self {
+            client,
+            bundle_id: config.bundle_id,
+        })
+    }
+
+    fn build_payload<'a>(
+        &'a self,
+        sub: &'a PushSubscription,
+        payload: &'a PushPayload,
+    ) -> Result<a2::request::payload::Payload<'a>, PushError> {
+        if sub.platform != APNS_PLATFORM {
+            return Err(PushError::Transport(format!(
+                "ApnsTransport cannot deliver to platform {:?} (subscription {})",
+                sub.platform, sub.id
+            )));
+        }
+
+        let collapse_id = CollapseId::new(&payload.collapse_key).map_err(|e| {
+            PushError::Transport(format!(
+                "invalid APNs collapse id for subscription {}: {e}",
+                sub.id
+            ))
+        })?;
+        let options = NotificationOptions {
+            apns_topic: Some(self.bundle_id.as_str()),
+            apns_push_type: Some(PushType::Alert),
+            apns_collapse_id: Some(collapse_id),
+            ..Default::default()
+        };
+
+        let mut notification = DefaultNotificationBuilder::new()
+            .set_title(&payload.title)
+            .set_body(&payload.body)
+            .set_sound("default")
+            .build(&sub.endpoint_or_token, options);
+        let session_id = payload.session_id.to_string();
+        notification
+            .add_custom_data(
+                "agent_portal",
+                &ApnsCustomData {
+                    session_id: &session_id,
+                    event_kind: &payload.event_kind,
+                },
+            )
+            .map_err(|e| {
+                PushError::Transport(format!(
+                    "APNs payload serialization failed for subscription {}: {e}",
+                    sub.id
+                ))
+            })?;
+        Ok(notification)
+    }
+
+    fn map_send_error(err: a2::Error) -> Result<SendOutcome, PushError> {
+        match err {
+            a2::Error::ResponseError(response) => {
+                let reason = response.error.as_ref().map(|e| &e.reason);
+                if response.code == 410
+                    || matches!(
+                        reason,
+                        Some(
+                            ErrorReason::Unregistered
+                                | ErrorReason::BadDeviceToken
+                                | ErrorReason::DeviceTokenNotForTopic
+                        )
+                    )
+                {
+                    Ok(SendOutcome::GoneDeadEndpoint)
+                } else {
+                    Err(PushError::Transport(format!(
+                        "APNs returned {}: {:?}",
+                        response.code, response.error
+                    )))
+                }
+            }
+            other => Err(PushError::Transport(format!(
+                "APNs request failed: {other}"
+            ))),
+        }
+    }
+}
+
+impl PushTransport for ApnsTransport {
+    async fn send(
+        &self,
+        sub: &PushSubscription,
+        payload: &PushPayload,
+    ) -> Result<SendOutcome, PushError> {
+        let notification = self.build_payload(sub, payload)?;
+        self.client
+            .send(notification)
+            .await
+            .map(|_| SendOutcome::Delivered)
+            .or_else(Self::map_send_error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use a2::{ErrorBody, Response};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    const TEST_APNS_KEY: &str = "-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8g/n6j9roKvnUkwu
+lCEIvbDqlUhA5FOzcakkG90E8L+hRANCAATKS2ZExEybUvchRDuKBftotMwVEus3
+jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
+-----END PRIVATE KEY-----";
+
+    fn test_client() -> Client {
+        Client::token(
+            std::io::Cursor::new(TEST_APNS_KEY.as_bytes()),
+            "KEYID",
+            "TEAMID",
+            ClientConfig::default(),
+        )
+        .unwrap()
+    }
+
+    fn sub(platform: &str) -> PushSubscription {
+        PushSubscription {
+            id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            platform: platform.to_string(),
+            endpoint_or_token: "apns-token".to_string(),
+            p256dh: None,
+            auth: None,
+            device_label: Some("ios".to_string()),
+            created_at: Utc::now(),
+            last_success_at: None,
+            disabled_at: None,
+        }
+    }
+
+    fn payload() -> PushPayload {
+        let id = Uuid::new_v4();
+        PushPayload {
+            session_id: id,
+            event_kind: "permission_request".to_string(),
+            title: "my-session".to_string(),
+            body: "Permission needed: Bash".to_string(),
+            collapse_key: id.to_string(),
+        }
+    }
+
+    fn response_error(code: u16, reason: ErrorReason) -> a2::Error {
+        a2::Error::ResponseError(Response {
+            apns_id: None,
+            code,
+            error: Some(ErrorBody {
+                reason,
+                timestamp: None,
+            }),
+        })
+    }
+
+    #[test]
+    fn apns_payload_contains_collapse_topic_and_custom_data() {
+        let transport = ApnsTransport {
+            client: test_client(),
+            bundle_id: "io.txcl.agentportal".to_string(),
+        };
+        let payload = payload();
+        let sub = sub(APNS_PLATFORM);
+        let notification = transport
+            .build_payload(&sub, &payload)
+            .expect("payload builds");
+        let json = serde_json::to_value(&notification).expect("serialize notification");
+        assert_eq!(json["aps"]["alert"]["title"], payload.title);
+        assert_eq!(json["aps"]["alert"]["body"], payload.body);
+        assert_eq!(
+            json["agent_portal"]["session_id"],
+            payload.session_id.to_string()
+        );
+        assert_eq!(json["agent_portal"]["event_kind"], payload.event_kind);
+        assert_eq!(notification.options.apns_topic, Some("io.txcl.agentportal"));
+        assert_eq!(
+            notification
+                .options
+                .apns_collapse_id
+                .as_ref()
+                .map(|id| id.value),
+            Some(payload.collapse_key.as_str())
+        );
+    }
+
+    #[test]
+    fn non_apns_platform_rejected_before_network() {
+        let transport = ApnsTransport {
+            client: test_client(),
+            bundle_id: "io.txcl.agentportal".to_string(),
+        };
+        let err = transport
+            .build_payload(&sub("fcm"), &payload())
+            .expect_err("wrong platform rejected");
+        let PushError::Transport(msg) = err;
+        assert!(msg.contains("fcm"));
+    }
+
+    #[test]
+    fn apns_unregistered_maps_to_dead_endpoint() {
+        assert_eq!(
+            ApnsTransport::map_send_error(response_error(410, ErrorReason::Unregistered))
+                .expect("mapped"),
+            SendOutcome::GoneDeadEndpoint
+        );
+        assert_eq!(
+            ApnsTransport::map_send_error(response_error(400, ErrorReason::BadDeviceToken))
+                .expect("mapped"),
+            SendOutcome::GoneDeadEndpoint
+        );
+    }
+
+    #[test]
+    fn apns_non_dead_error_stays_transport_error() {
+        let err =
+            ApnsTransport::map_send_error(response_error(500, ErrorReason::InternalServerError))
+                .expect_err("not dead endpoint");
+        let PushError::Transport(msg) = err;
+        assert!(msg.contains("APNs returned 500"));
+    }
+}

--- a/backend/src/push/dispatcher.rs
+++ b/backend/src/push/dispatcher.rs
@@ -22,8 +22,8 @@ use uuid::Uuid;
 
 use crate::db::DbConnection;
 use crate::models::PushSubscription;
-use crate::push::transport::{LogTransport, PushTransport, SendOutcome};
-use crate::push::NotificationEvent;
+use crate::push::transport::{PushTransport, SendOutcome};
+use crate::push::{ConfiguredTransport, NotificationEvent};
 use crate::AppState;
 
 /// Stable log marker for a real (non-dead-endpoint) delivery failure. Alert on
@@ -34,12 +34,12 @@ const PUSH_DISPATCH_FAILED: &str = "PUSH_DISPATCH_FAILED";
 
 /// Spawn the dispatcher task. Consumes the receiver end of the notification
 /// channel; runs until the channel closes (backend shutdown).
-pub fn spawn_dispatcher(app_state: Arc<AppState>, mut rx: UnboundedReceiver<NotificationEvent>) {
+pub fn spawn_dispatcher(
+    app_state: Arc<AppState>,
+    mut rx: UnboundedReceiver<NotificationEvent>,
+    transport: ConfiguredTransport,
+) {
     tokio::spawn(async move {
-        // v1 transport (C2): log delivery intent. Real Web Push (C3) and native
-        // transports (C7) slot in behind `PushTransport` without touching the
-        // policy engine below.
-        let transport = LogTransport;
         tracing::info!("push dispatcher started");
         while let Some(event) = rx.recv().await {
             dispatch_one(&app_state, &transport, event).await;

--- a/backend/src/push/fcm.rs
+++ b/backend/src/push/fcm.rs
@@ -1,0 +1,357 @@
+//! Native FCM v1 transport (mobile-apps plan C7).
+//!
+//! Android shell subscriptions store the FCM registration token in
+//! `push_subscriptions.endpoint_or_token`. This transport authenticates with a
+//! Google service-account JSON file and sends HTTP v1 messages directly.
+
+use std::fs;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use crate::models::PushSubscription;
+use crate::push::transport::{PushError, PushTransport, SendOutcome};
+use crate::push::{FcmTransportConfig, PushPayload};
+
+const FCM_PLATFORM: &str = "fcm";
+const FCM_SCOPE: &str = "https://www.googleapis.com/auth/firebase.messaging";
+const FCM_TOKEN_REFRESH_SLOP: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Deserialize)]
+struct ServiceAccountFile {
+    project_id: String,
+    client_email: String,
+    private_key: String,
+    #[serde(default = "default_token_uri")]
+    token_uri: String,
+}
+
+fn default_token_uri() -> String {
+    "https://oauth2.googleapis.com/token".to_string()
+}
+
+#[derive(Debug, Serialize)]
+struct ServiceAccountClaims<'a> {
+    iss: &'a str,
+    scope: &'a str,
+    aud: &'a str,
+    iat: u64,
+    exp: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    token_type: String,
+    expires_in: u64,
+}
+
+#[derive(Debug, Clone)]
+struct CachedToken {
+    access_token: String,
+    expires_at: Instant,
+}
+
+#[derive(Debug, Serialize)]
+struct FcmNotification {
+    title: String,
+    body: String,
+}
+
+#[derive(Debug, Serialize)]
+struct FcmAndroid {
+    collapse_key: String,
+}
+
+#[derive(Debug, Serialize)]
+struct FcmMessage {
+    token: String,
+    notification: FcmNotification,
+    data: FcmData,
+    android: FcmAndroid,
+}
+
+#[derive(Debug, Serialize)]
+struct FcmData {
+    session_id: String,
+    event_kind: String,
+}
+
+#[derive(Debug, Serialize)]
+struct FcmRequest {
+    message: FcmMessage,
+}
+
+pub struct FcmTransport {
+    service_account: ServiceAccountFile,
+    encoding_key: EncodingKey,
+    http: reqwest::Client,
+    token: Mutex<Option<CachedToken>>,
+    endpoint: String,
+}
+
+impl FcmTransport {
+    pub fn new(config: FcmTransportConfig) -> anyhow::Result<Self> {
+        let contents = fs::read_to_string(&config.service_account_path).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to read PORTAL_FCM_SERVICE_ACCOUNT_PATH {}: {e}",
+                config.service_account_path.display()
+            )
+        })?;
+        let service_account: ServiceAccountFile = serde_json::from_str(&contents).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to parse PORTAL_FCM_SERVICE_ACCOUNT_PATH {}: {e}",
+                config.service_account_path.display()
+            )
+        })?;
+        let encoding_key = EncodingKey::from_rsa_pem(service_account.private_key.as_bytes())
+            .map_err(|e| anyhow::anyhow!("invalid FCM service-account private_key: {e}"))?;
+        Ok(Self::from_parts(
+            service_account,
+            encoding_key,
+            reqwest::Client::new(),
+        ))
+    }
+
+    fn from_parts(
+        service_account: ServiceAccountFile,
+        encoding_key: EncodingKey,
+        http: reqwest::Client,
+    ) -> Self {
+        let endpoint = format!(
+            "https://fcm.googleapis.com/v1/projects/{}/messages:send",
+            service_account.project_id
+        );
+        Self {
+            service_account,
+            encoding_key,
+            http,
+            token: Mutex::new(None),
+            endpoint,
+        }
+    }
+
+    fn build_request(
+        sub: &PushSubscription,
+        payload: &PushPayload,
+    ) -> Result<FcmRequest, PushError> {
+        if sub.platform != FCM_PLATFORM {
+            return Err(PushError::Transport(format!(
+                "FcmTransport cannot deliver to platform {:?} (subscription {})",
+                sub.platform, sub.id
+            )));
+        }
+        Ok(FcmRequest {
+            message: FcmMessage {
+                token: sub.endpoint_or_token.clone(),
+                notification: FcmNotification {
+                    title: payload.title.clone(),
+                    body: payload.body.clone(),
+                },
+                data: FcmData {
+                    session_id: payload.session_id.to_string(),
+                    event_kind: payload.event_kind.clone(),
+                },
+                android: FcmAndroid {
+                    collapse_key: payload.collapse_key.clone(),
+                },
+            },
+        })
+    }
+
+    async fn access_token(&self) -> Result<String, PushError> {
+        let mut guard = self.token.lock().await;
+        if let Some(cached) = guard.as_ref() {
+            if cached.expires_at > Instant::now() + FCM_TOKEN_REFRESH_SLOP {
+                return Ok(cached.access_token.clone());
+            }
+        }
+
+        let token = self.fetch_access_token().await?;
+        let expires_at = Instant::now()
+            .checked_add(Duration::from_secs(token.expires_in))
+            .unwrap_or_else(Instant::now);
+        let access_token = token.access_token;
+        *guard = Some(CachedToken {
+            access_token: access_token.clone(),
+            expires_at,
+        });
+        Ok(access_token)
+    }
+
+    async fn fetch_access_token(&self) -> Result<TokenResponse, PushError> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| PushError::Transport(format!("system clock before epoch: {e}")))?
+            .as_secs();
+        let claims = ServiceAccountClaims {
+            iss: &self.service_account.client_email,
+            scope: FCM_SCOPE,
+            aud: &self.service_account.token_uri,
+            iat: now,
+            exp: now + 3600,
+        };
+        let assertion = encode(&Header::new(Algorithm::RS256), &claims, &self.encoding_key)
+            .map_err(|e| PushError::Transport(format!("FCM service-account JWT failed: {e}")))?;
+
+        let response = self
+            .http
+            .post(&self.service_account.token_uri)
+            .form(&[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+                ("assertion", assertion.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(|e| PushError::Transport(format!("FCM token request failed: {e}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(PushError::Transport(format!(
+                "FCM token endpoint returned {status}: {body}"
+            )));
+        }
+        let token: TokenResponse = response
+            .json()
+            .await
+            .map_err(|e| PushError::Transport(format!("FCM token response parse failed: {e}")))?;
+        if !token.token_type.is_empty() && !token.token_type.eq_ignore_ascii_case("bearer") {
+            return Err(PushError::Transport(format!(
+                "FCM token endpoint returned unsupported token_type {:?}",
+                token.token_type
+            )));
+        }
+        Ok(token)
+    }
+
+    fn map_send_response(status: StatusCode, body: &str) -> Result<SendOutcome, PushError> {
+        if status.is_success() {
+            Ok(SendOutcome::Delivered)
+        } else if status == StatusCode::NOT_FOUND
+            || status == StatusCode::GONE
+            || body.contains("UNREGISTERED")
+        {
+            Ok(SendOutcome::GoneDeadEndpoint)
+        } else {
+            Err(PushError::Transport(format!(
+                "FCM returned {status}: {body}"
+            )))
+        }
+    }
+}
+
+impl PushTransport for FcmTransport {
+    async fn send(
+        &self,
+        sub: &PushSubscription,
+        payload: &PushPayload,
+    ) -> Result<SendOutcome, PushError> {
+        let request = Self::build_request(sub, payload)?;
+        let access_token = self.access_token().await?;
+        let response = self
+            .http
+            .post(&self.endpoint)
+            .bearer_auth(access_token)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| PushError::Transport(format!("FCM send failed: {e}")))?;
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Self::map_send_response(status, &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn sub(platform: &str) -> PushSubscription {
+        PushSubscription {
+            id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            platform: platform.to_string(),
+            endpoint_or_token: "fcm-registration-token".to_string(),
+            p256dh: None,
+            auth: None,
+            device_label: Some("android".to_string()),
+            created_at: Utc::now(),
+            last_success_at: None,
+            disabled_at: None,
+        }
+    }
+
+    fn payload() -> PushPayload {
+        let id = Uuid::new_v4();
+        PushPayload {
+            session_id: id,
+            event_kind: "turn_complete".to_string(),
+            title: "my-session".to_string(),
+            body: "Turn complete".to_string(),
+            collapse_key: id.to_string(),
+        }
+    }
+
+    #[test]
+    fn fcm_request_serializes_typed_payload_and_collapse_key() {
+        let payload = payload();
+        let request =
+            FcmTransport::build_request(&sub(FCM_PLATFORM), &payload).expect("request builds");
+        let json = serde_json::to_value(&request).expect("serialize");
+        assert_eq!(json["message"]["token"], "fcm-registration-token");
+        assert_eq!(json["message"]["notification"]["title"], payload.title);
+        assert_eq!(json["message"]["notification"]["body"], payload.body);
+        assert_eq!(
+            json["message"]["data"]["session_id"],
+            payload.session_id.to_string()
+        );
+        assert_eq!(json["message"]["data"]["event_kind"], payload.event_kind);
+        assert_eq!(
+            json["message"]["android"]["collapse_key"],
+            payload.collapse_key
+        );
+    }
+
+    #[test]
+    fn non_fcm_platform_rejected_before_network() {
+        let err = FcmTransport::build_request(&sub("apns"), &payload())
+            .expect_err("wrong platform rejected");
+        let PushError::Transport(msg) = err;
+        assert!(msg.contains("apns"));
+    }
+
+    #[test]
+    fn fcm_status_mapping_matches_dead_endpoint_contract() {
+        assert_eq!(
+            FcmTransport::map_send_response(StatusCode::OK, "{}").expect("mapped"),
+            SendOutcome::Delivered
+        );
+        assert_eq!(
+            FcmTransport::map_send_response(StatusCode::NOT_FOUND, "{}").expect("mapped"),
+            SendOutcome::GoneDeadEndpoint
+        );
+        assert_eq!(
+            FcmTransport::map_send_response(
+                StatusCode::BAD_REQUEST,
+                r#"{"error":{"details":[{"errorCode":"UNREGISTERED"}]}}"#,
+            )
+            .expect("mapped"),
+            SendOutcome::GoneDeadEndpoint
+        );
+    }
+
+    #[test]
+    fn fcm_non_dead_error_stays_transport_error() {
+        let err = FcmTransport::map_send_response(StatusCode::UNAUTHORIZED, "bad auth")
+            .expect_err("not dead endpoint");
+        let PushError::Transport(msg) = err;
+        assert!(msg.contains("401"));
+    }
+}

--- a/backend/src/push/mod.rs
+++ b/backend/src/push/mod.rs
@@ -12,15 +12,102 @@
 //! v1 ships only the [`transport::LogTransport`] (logs delivery intent); real
 //! Web Push / APNs / FCM transports land in C3 / C7 behind the same trait.
 
+pub mod apns;
 pub mod dispatcher;
+pub mod fcm;
 pub mod transport;
 
 pub use dispatcher::spawn_dispatcher;
 pub use transport::{LogTransport, PushError, PushTransport, SendOutcome};
 
+use crate::models::PushSubscription;
 use shared::api::NotificationPrefs;
+use std::path::PathBuf;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
+
+/// APNs provider-token configuration. All fields must be present together; an
+/// absent group leaves APNs delivery disabled while the dispatcher still runs.
+#[derive(Debug, Clone)]
+pub struct ApnsTransportConfig {
+    pub key_p8_path: PathBuf,
+    pub key_id: String,
+    pub team_id: String,
+    pub bundle_id: String,
+}
+
+/// FCM v1 service-account configuration. Absent = FCM delivery disabled.
+#[derive(Debug, Clone)]
+pub struct FcmTransportConfig {
+    pub service_account_path: PathBuf,
+}
+
+/// Native mobile push configuration (C7). Web Push is intentionally separate
+/// (C3); this group only owns APNs and FCM.
+#[derive(Debug, Clone, Default)]
+pub struct NativePushConfig {
+    pub apns: Option<ApnsTransportConfig>,
+    pub fcm: Option<FcmTransportConfig>,
+}
+
+/// Startup-selected transport set. `PushTransport` is not object-safe because
+/// it returns `impl Future`, so static dispatch through an enum keeps the
+/// dispatcher generic-free while allowing APNs/FCM to be optional.
+pub enum ConfiguredTransport {
+    Log(LogTransport),
+    Native {
+        log: LogTransport,
+        apns: Option<Box<apns::ApnsTransport>>,
+        fcm: Option<Box<fcm::FcmTransport>>,
+    },
+}
+
+impl ConfiguredTransport {
+    pub fn from_native_config(config: NativePushConfig) -> anyhow::Result<Self> {
+        let apns = config
+            .apns
+            .map(apns::ApnsTransport::new)
+            .transpose()?
+            .map(Box::new);
+        let fcm = config
+            .fcm
+            .map(fcm::FcmTransport::new)
+            .transpose()?
+            .map(Box::new);
+        if apns.is_some() || fcm.is_some() {
+            Ok(Self::Native {
+                log: LogTransport,
+                apns,
+                fcm,
+            })
+        } else {
+            Ok(Self::Log(LogTransport))
+        }
+    }
+}
+
+impl PushTransport for ConfiguredTransport {
+    async fn send(
+        &self,
+        sub: &PushSubscription,
+        payload: &PushPayload,
+    ) -> Result<SendOutcome, PushError> {
+        match self {
+            ConfiguredTransport::Log(t) => t.send(sub, payload).await,
+            ConfiguredTransport::Native { log, apns, fcm } => match sub.platform.as_str() {
+                "apns" => match apns {
+                    Some(t) => t.send(sub, payload).await,
+                    None => log.send(sub, payload).await,
+                },
+                "fcm" => match fcm {
+                    Some(t) => t.send(sub, payload).await,
+                    None => log.send(sub, payload).await,
+                },
+                _ => log.send(sub, payload).await,
+            },
+        }
+    }
+}
 
 /// A user-visible event worth a push. Each variant names the session it
 /// concerns so the dispatcher can resolve the owning user and (as a fallback)


### PR DESCRIPTION
## Summary
- add APNs transport using `a2` provider-token auth and FCM v1 transport using service-account JWT auth
- add native push env config groups with disabled-by-default startup logging and APNs partial-config fail-fast
- route the dispatcher through a configured transport selector while preserving log fallback for unset providers
- document APNs/FCM environment variables

## Review focus
- APNs/FCM provider response mapping: success -> Delivered, dead token cases -> GoneDeadEndpoint, other provider/auth errors -> PushError
- config behavior: all native push vars optional, APNs all-or-none, invalid configured files fail at startup
- dispatcher integration: platform-based routing preserves current log behavior for unconfigured platforms and should be easy for #1304 Web Push to rebase into

## Tests
- `cargo test -p backend push:: --lib`
- `cargo clippy -p backend -- -D warnings`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --check`