### PR TITLE
Add mobile deep links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -832,6 +832,10 @@ When making changes, verify:
 | `PORTAL_SESSION_ARCHIVE_TRANSCRIPTS` | Archive transcript bodies (always zstd-compressed), not just manifests | Optional (default: true) |
 | `PORTAL_VAPID_PRIVATE_KEY` | VAPID application-server private key for Web Push (mobile-apps plan §8.3). URL-safe base64 (no padding) or a PEM EC private key. Unset = Web Push disabled (dispatcher keeps the log-only transport for webpush rows). Mint with `scripts/generate-vapid-keys.sh`. | Optional |
 | `PORTAL_VAPID_PUBLIC_KEY` | VAPID public key served to browsers as the `applicationServerKey` (`GET /api/push/vapid-key`). Must be the matching half of `PORTAL_VAPID_PRIVATE_KEY` (same `generate-vapid-keys.sh` run). | Optional |
+| `PORTAL_MOBILE_BUNDLE_ID` | Native shell bundle/package id for app-link association documents | Optional (default: `io.txcl.agentportal`) |
+| `PORTAL_MOBILE_ANDROID_SHA256_CERT_FINGERPRINTS` | Comma-separated Android signing certificate SHA-256 fingerprints for `/.well-known/assetlinks.json` | Optional (placeholder served when unset) |
+| `PORTAL_MOBILE_APPLE_TEAM_ID` | Apple Developer Team ID for `/.well-known/apple-app-site-association` | Optional (placeholder served when unset) |
+| `PORTAL_SHELL_URL` | Build-time mobile shell URL override baked by `mobile/src-tauri/build.rs`; unset keeps `https://txcl.io` | Optional (mobile build only) |
 | `PORTAL_APNS_KEY_P8_PATH` | APNs provider-token `.p8` private key path for native iOS push | Required with other `PORTAL_APNS_*` vars |
 | `PORTAL_APNS_KEY_ID` | APNs provider-token key id for native iOS push | Required with other `PORTAL_APNS_*` vars |
 | `PORTAL_APNS_TEAM_ID` | Apple Developer Team ID for native iOS push | Required with other `PORTAL_APNS_*` vars |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,8 +123,10 @@ dependencies = [
 name = "agent-portal-mobile"
 version = "2.13.0"
 dependencies = [
+ "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
 ]
 
 [[package]]
@@ -1017,6 +1019,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1178,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1670,6 +1698,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -3262,7 +3299,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -4539,6 +4576,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5454,6 +5501,16 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -6616,6 +6673,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry 0.5.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6815,6 +6909,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -8048,6 +8151,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -227,6 +227,7 @@ mod tests {
             archive: None,
             notifications: crate::push::channel().0,
             vapid_public_key: None,
+            mobile_app_links: crate::config::MobileAppLinksConfig::default(),
         }
     }
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -173,6 +173,32 @@ pub struct ServerConfig {
     /// The matching public half is `PORTAL_VAPID_PUBLIC_KEY`, served to browsers
     /// as the `applicationServerKey`.
     pub vapid_private_key: Option<String>,
+    /// Native mobile app-link association payload configuration.
+    pub mobile_app_links: MobileAppLinksConfig,
+}
+
+/// Public mobile app-link association payload configuration.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MobileAppLinksConfig {
+    pub bundle_id: String,
+    pub apple_team_id: String,
+    pub android_sha256_cert_fingerprints: Vec<String>,
+}
+
+impl Default for MobileAppLinksConfig {
+    fn default() -> Self {
+        Self {
+            bundle_id: "io.txcl.agentportal".to_string(),
+            apple_team_id: "TEAMID".to_string(),
+            android_sha256_cert_fingerprints: vec![
+                // Placeholder debug fingerprint. Hosted/prod builds should set
+                // PORTAL_MOBILE_ANDROID_SHA256_CERT_FINGERPRINTS to the release
+                // signing certificate fingerprint(s).
+                "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+                    .to_string(),
+            ],
+        }
+    }
 }
 
 impl ServerConfig {
@@ -341,6 +367,7 @@ impl ServerConfig {
         }
 
         let native_push = native_push_config_from_env(&mut errors);
+        let mobile_app_links = mobile_app_links_config_from_env();
 
         // Long-term session archive (#1258). Fail-fast on partial config.
         let archive = crate::archive::archive_config_from_env()
@@ -415,7 +442,62 @@ impl ServerConfig {
             vapid_public_key,
             native_push,
             vapid_private_key,
+            mobile_app_links,
         })
+    }
+}
+
+fn mobile_app_links_config_from_env() -> MobileAppLinksConfig {
+    let defaults = MobileAppLinksConfig::default();
+
+    let bundle_id = match optional_non_empty("PORTAL_MOBILE_BUNDLE_ID") {
+        Some(value) => {
+            log_source("PORTAL_MOBILE_BUNDLE_ID", true);
+            value
+        }
+        None => {
+            log_source("PORTAL_MOBILE_BUNDLE_ID", false);
+            defaults.bundle_id
+        }
+    };
+
+    let apple_team_id = match optional_non_empty("PORTAL_MOBILE_APPLE_TEAM_ID") {
+        Some(value) => {
+            log_source("PORTAL_MOBILE_APPLE_TEAM_ID", true);
+            value
+        }
+        None => {
+            log_source("PORTAL_MOBILE_APPLE_TEAM_ID", false);
+            defaults.apple_team_id
+        }
+    };
+
+    let android_sha256_cert_fingerprints =
+        match optional_non_empty("PORTAL_MOBILE_ANDROID_SHA256_CERT_FINGERPRINTS") {
+            Some(value) => {
+                log_source("PORTAL_MOBILE_ANDROID_SHA256_CERT_FINGERPRINTS", true);
+                let fingerprints = value
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|fingerprint| !fingerprint.is_empty())
+                    .map(str::to_string)
+                    .collect::<Vec<_>>();
+                if fingerprints.is_empty() {
+                    defaults.android_sha256_cert_fingerprints
+                } else {
+                    fingerprints
+                }
+            }
+            None => {
+                log_source("PORTAL_MOBILE_ANDROID_SHA256_CERT_FINGERPRINTS", false);
+                defaults.android_sha256_cert_fingerprints
+            }
+        };
+
+    MobileAppLinksConfig {
+        bundle_id,
+        apple_team_id,
+        android_sha256_cert_fingerprints,
     }
 }
 

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -697,6 +697,7 @@ mod tests {
             archive: None,
             notifications: crate::push::channel().0,
             vapid_public_key: None,
+            mobile_app_links: crate::config::MobileAppLinksConfig::default(),
         })
     }
 

--- a/backend/src/handlers/mobile_links.rs
+++ b/backend/src/handlers/mobile_links.rs
@@ -1,0 +1,148 @@
+//! Native mobile app-link association endpoints.
+
+use crate::AppState;
+use axum::{extract::State, Json};
+use serde::Serialize;
+use std::sync::Arc;
+
+#[derive(Serialize)]
+pub struct AssetLink {
+    relation: [&'static str; 1],
+    target: AssetLinkTarget,
+}
+
+#[derive(Serialize)]
+pub struct AssetLinkTarget {
+    namespace: &'static str,
+    package_name: String,
+    sha256_cert_fingerprints: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppleAppSiteAssociation {
+    applinks: AppleAppLinks,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppleAppLinks {
+    apps: [String; 0],
+    details: [AppleAppLinkDetail; 1],
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppleAppLinkDetail {
+    #[serde(rename = "appIDs")]
+    app_ids: [String; 1],
+    components: [AppleAppLinkComponent; 1],
+}
+
+#[derive(Serialize)]
+pub struct AppleAppLinkComponent {
+    #[serde(rename = "/")]
+    path: &'static str,
+    comment: &'static str,
+}
+
+/// Android App Links association document.
+pub async fn assetlinks(State(app_state): State<Arc<AppState>>) -> Json<[AssetLink; 1]> {
+    Json([AssetLink {
+        relation: ["delegate_permission/common.handle_all_urls"],
+        target: AssetLinkTarget {
+            namespace: "android_app",
+            package_name: app_state.mobile_app_links.bundle_id.clone(),
+            sha256_cert_fingerprints: app_state
+                .mobile_app_links
+                .android_sha256_cert_fingerprints
+                .clone(),
+        },
+    }])
+}
+
+/// Apple Universal Links association document. The route intentionally has no
+/// file extension; iOS expects `/.well-known/apple-app-site-association`.
+pub async fn apple_app_site_association(
+    State(app_state): State<Arc<AppState>>,
+) -> Json<AppleAppSiteAssociation> {
+    let app_id = format!(
+        "{}.{}",
+        app_state.mobile_app_links.apple_team_id, app_state.mobile_app_links.bundle_id
+    );
+
+    Json(AppleAppSiteAssociation {
+        applinks: AppleAppLinks {
+            apps: [],
+            details: [AppleAppLinkDetail {
+                app_ids: [app_id],
+                components: [AppleAppLinkComponent {
+                    path: "*",
+                    comment: "Open Agent Portal links in the mobile shell",
+                }],
+            }],
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::MobileAppLinksConfig;
+
+    #[test]
+    fn assetlinks_uses_configured_android_identity() {
+        let config = MobileAppLinksConfig {
+            bundle_id: "io.example.portal".to_string(),
+            apple_team_id: "TEAMID".to_string(),
+            android_sha256_cert_fingerprints: vec!["AA:BB".to_string()],
+        };
+
+        let link = AssetLink {
+            relation: ["delegate_permission/common.handle_all_urls"],
+            target: AssetLinkTarget {
+                namespace: "android_app",
+                package_name: config.bundle_id,
+                sha256_cert_fingerprints: config.android_sha256_cert_fingerprints,
+            },
+        };
+        let value = serde_json::to_value([link]).expect("serialize assetlinks");
+
+        assert_eq!(
+            value[0]["relation"][0],
+            "delegate_permission/common.handle_all_urls"
+        );
+        assert_eq!(value[0]["target"]["namespace"], "android_app");
+        assert_eq!(value[0]["target"]["package_name"], "io.example.portal");
+        assert_eq!(value[0]["target"]["sha256_cert_fingerprints"][0], "AA:BB");
+    }
+
+    #[test]
+    fn apple_association_uses_team_and_bundle_id() {
+        let config = MobileAppLinksConfig {
+            bundle_id: "io.example.portal".to_string(),
+            apple_team_id: "ABCDE12345".to_string(),
+            android_sha256_cert_fingerprints: vec![],
+        };
+        let app_id = format!("{}.{}", config.apple_team_id, config.bundle_id);
+        let value = serde_json::to_value(AppleAppSiteAssociation {
+            applinks: AppleAppLinks {
+                apps: [],
+                details: [AppleAppLinkDetail {
+                    app_ids: [app_id],
+                    components: [AppleAppLinkComponent {
+                        path: "*",
+                        comment: "Open Agent Portal links in the mobile shell",
+                    }],
+                }],
+            },
+        })
+        .expect("serialize apple app-site association");
+
+        assert_eq!(
+            value["applinks"]["details"][0]["appIDs"][0],
+            "ABCDE12345.io.example.portal"
+        );
+        assert_eq!(value["applinks"]["details"][0]["components"][0]["/"], "*");
+    }
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -12,6 +12,7 @@ pub mod helpers;
 pub mod images;
 pub mod launchers;
 pub mod messages;
+pub mod mobile_links;
 pub mod proxy_tokens;
 pub mod push;
 pub mod responses;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -84,6 +84,8 @@ pub struct AppState {
     /// VAPID application-server public key served to Web Push clients
     /// (`GET /api/push/vapid-key`). `None` = push unconfigured (endpoint 404s).
     pub vapid_public_key: Option<String>,
+    /// Native mobile app-link association payload configuration.
+    pub mobile_app_links: config::MobileAppLinksConfig,
 }
 
 impl AppState {
@@ -184,6 +186,7 @@ pub async fn run() -> anyhow::Result<()> {
         },
         notifications,
         vapid_public_key: config.vapid_public_key,
+        mobile_app_links: config.mobile_app_links,
     });
 
     // Drain notification events and dispatch pushes (mobile-apps plan §8.2).

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -125,6 +125,16 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
                 })
             }),
         )
+        // Native mobile app-link association files. These must be served at
+        // exact well-known paths, before the SPA fallback below.
+        .route(
+            "/.well-known/assetlinks.json",
+            get(handlers::mobile_links::assetlinks),
+        )
+        .route(
+            "/.well-known/apple-app-site-association",
+            get(handlers::mobile_links::apple_app_site_association),
+        )
         // App configuration (public, no auth required)
         .route("/api/config", get(handlers::config::get_config))
         // Session API routes

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -71,6 +71,7 @@ async fn spawn_test_app() -> SocketAddr {
         // immediately, so emits are silently no-ops (see NotificationSender).
         notifications: backend::push::channel().0,
         vapid_public_key: config.vapid_public_key,
+        mobile_app_links: config.mobile_app_links,
     });
 
     let app = backend::routes::build_router(state);

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -36,6 +36,31 @@ npm run ios:dev -- --config '{"app":{"windows":[{"url":"http://localhost:3000"}]
 
 Use a LAN IP instead of `localhost` for physical devices.
 
+For a self-hosted or long-lived dev shell build, bake the target URL into the
+native binary instead:
+
+```bash
+PORTAL_SHELL_URL="https://portal.example.com" npm run android:build
+```
+
+When unset, the app loads `https://txcl.io` directly with no startup redirect.
+
+## Deep Links
+
+The shell registers verified HTTPS app links / universal links for `txcl.io`.
+Opened links are routed into the existing WebView, so URLs such as
+`https://txcl.io/dashboard?session=<id>` land on the corresponding dashboard
+session.
+
+The backend serves the association documents at:
+
+- `/.well-known/assetlinks.json`
+- `/.well-known/apple-app-site-association`
+
+Set `PORTAL_MOBILE_ANDROID_SHA256_CERT_FINGERPRINTS` and
+`PORTAL_MOBILE_APPLE_TEAM_ID` on the backend before production verification.
+`PORTAL_MOBILE_BUNDLE_ID` defaults to `io.txcl.agentportal`.
+
 ## First-Time Native Project Generation
 
 Generate the platform project before the first device run:

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -12,7 +12,9 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
+serde_json = "1"
 tauri = { version = "2", features = [] }
+tauri-plugin-deep-link = "2"
 
 [lints]
 workspace = true

--- a/mobile/src-tauri/build.rs
+++ b/mobile/src-tauri/build.rs
@@ -1,4 +1,9 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=PORTAL_SHELL_URL");
+    if let Ok(shell_url) = std::env::var("PORTAL_SHELL_URL") {
+        println!("cargo:rustc-env=PORTAL_SHELL_URL={shell_url}");
+    }
+
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     if matches!(target_os.as_str(), "android" | "ios") {
         tauri_build::build();

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(any(target_os = "android", target_os = "ios"))]
 #[tauri::mobile_entry_point]
 pub fn run() {
-    if let Err(err) = tauri::Builder::default().run(tauri::generate_context!()) {
+    if let Err(err) = mobile::run() {
         eprintln!("failed to run Agent Portal mobile shell: {err}");
         std::process::exit(1);
     }
@@ -9,3 +9,122 @@ pub fn run() {
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub fn run() {}
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+mod mobile {
+    use tauri::{Manager, Url};
+    use tauri_plugin_deep_link::DeepLinkExt;
+
+    const DEFAULT_SHELL_URL: &str = "https://txcl.io";
+    const MAIN_WINDOW_LABEL: &str = "main";
+
+    pub fn run() -> tauri::Result<()> {
+        tauri::Builder::default()
+            .plugin(tauri_plugin_deep_link::init())
+            .setup(|app| {
+                let app_handle = app.handle().clone();
+
+                match app.deep_link().get_current() {
+                    Ok(Some(urls)) => route_deep_links(&app_handle, urls),
+                    Ok(None) => {
+                        if let Some(url) = shell_url_override() {
+                            navigate_main_window(&app_handle, url);
+                        }
+                    }
+                    Err(err) => eprintln!("failed to read startup deep link: {err}"),
+                }
+
+                let app_handle = app.handle().clone();
+                app.deep_link().on_open_url(move |event| {
+                    route_deep_links(&app_handle, event.urls());
+                });
+
+                Ok(())
+            })
+            .run(tauri::generate_context!())
+    }
+
+    fn route_deep_links<R: tauri::Runtime>(app: &tauri::AppHandle<R>, urls: Vec<Url>) {
+        for url in urls {
+            if is_allowed_shell_url(&url) {
+                navigate_main_window(app, url);
+            } else {
+                eprintln!("ignoring unexpected Agent Portal deep link: {url}");
+            }
+        }
+    }
+
+    fn navigate_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>, url: Url) {
+        match app.get_webview_window(MAIN_WINDOW_LABEL) {
+            Some(window) => {
+                if let Err(err) = window.navigate(url) {
+                    eprintln!("failed to navigate Agent Portal shell: {err}");
+                }
+            }
+            None => eprintln!("Agent Portal shell window is not available"),
+        }
+    }
+
+    fn shell_url_override() -> Option<Url> {
+        let raw = option_env!("PORTAL_SHELL_URL")?;
+        match Url::parse(raw) {
+            Ok(url) if is_http_url(&url) => Some(url),
+            Ok(url) => {
+                eprintln!("ignoring PORTAL_SHELL_URL with unsupported scheme: {url}");
+                None
+            }
+            Err(err) => {
+                eprintln!("ignoring invalid PORTAL_SHELL_URL: {err}");
+                None
+            }
+        }
+    }
+
+    fn is_allowed_shell_url(url: &Url) -> bool {
+        is_http_url(url)
+            && (same_origin(url, DEFAULT_SHELL_URL)
+                || option_env!("PORTAL_SHELL_URL")
+                    .and_then(|raw| Url::parse(raw).ok())
+                    .is_some_and(|shell_url| same_origin(url, shell_url.as_str())))
+    }
+
+    fn same_origin(url: &Url, origin: &str) -> bool {
+        Url::parse(origin).is_ok_and(|origin| {
+            url.scheme() == origin.scheme()
+                && url.host_str() == origin.host_str()
+                && url.port_or_known_default() == origin.port_or_known_default()
+        })
+    }
+
+    fn is_http_url(url: &Url) -> bool {
+        matches!(url.scheme(), "http" | "https") && url.host_str().is_some()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn hosted_dashboard_links_are_allowed() {
+            let url = Url::parse("https://txcl.io/dashboard?session=abc").unwrap();
+
+            assert!(is_allowed_shell_url(&url));
+        }
+
+        #[test]
+        fn unrelated_origins_are_rejected() {
+            let url = Url::parse("https://example.com/dashboard?session=abc").unwrap();
+
+            assert!(!is_allowed_shell_url(&url));
+        }
+
+        #[test]
+        fn same_origin_checks_scheme_host_and_port() {
+            let url = Url::parse("https://txcl.io/dashboard").unwrap();
+
+            assert!(same_origin(&url, "https://txcl.io"));
+            assert!(!same_origin(&url, "http://txcl.io"));
+            assert!(!same_origin(&url, "https://txcl.io:444"));
+        }
+    }
+}

--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -25,6 +25,18 @@
       "csp": null
     }
   },
+  "plugins": {
+    "deep-link": {
+      "mobile": [
+        {
+          "scheme": ["https"],
+          "host": "txcl.io",
+          "pathPrefix": ["/"],
+          "appLink": true
+        }
+      ]
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all"


### PR DESCRIPTION
## Summary
- add backend .well-known association endpoints for Android App Links and Apple Universal Links
- add PORTAL_SHELL_URL build-time shell override and Tauri deep-link routing into the main WebView
- document mobile association env vars and reuse the existing portal icon for mobile target builds

## Review foci
1. Association payloads: Android assetlinks and Apple AASA use the right typed JSON keys/content via Axum Json, with env-backed bundle/team/fingerprint values and safe placeholders when unset.
2. Shell routing: startup deep links win over PORTAL_SHELL_URL, runtime links navigate the existing WebView, and URL acceptance is limited to txcl.io plus an explicit build-time shell origin.
3. Tauri config/deps: deep-link plugin is mobile-target gated, Linux workspace builds stay empty, and the added icon unblocks mobile target generation.

## Local verification
- cargo fmt --check
- mkdir -p frontend/dist && cargo test -p backend mobile_links --lib
- cargo check -p agent-portal-mobile
- cargo check -p agent-portal-mobile --target aarch64-linux-android
- cargo clippy -p agent-portal-mobile --target aarch64-linux-android -- -D warnings
- mkdir -p frontend/dist && cargo clippy --workspace -- -D warnings