### PR TITLE
Add mobile auth handoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,10 +123,15 @@ dependencies = [
 name = "agent-portal-mobile"
 version = "2.13.0"
 dependencies = [
+ "reqwest 0.12.28",
  "serde_json",
+ "shared",
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-opener",
+ "tauri-plugin-store",
+ "tokio",
 ]
 
 [[package]]
@@ -241,6 +246,126 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -539,6 +664,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -988,6 +1126,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1900,6 +2047,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,6 +2116,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2153,6 +2348,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -3528,6 +3736,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4527,6 +4754,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "open"
+version = "5.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4586,6 +4824,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4633,6 +4881,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4802,6 +5056,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4875,6 +5140,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4999,6 +5278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
  "toml_edit 0.20.7",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -6710,6 +6998,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows 0.61.3",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-store"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c72dda16786eb4a3f903e43a17b64d8d78dc0f00fe2aa4b757c28f617a8630b"
+dependencies = [
+ "dunce",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7162,6 +7488,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.2",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7442,6 +7780,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -8484,6 +8833,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -8771,6 +9123,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.2",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
+dependencies = [
+ "serde",
+ "winnow 1.0.2",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8882,4 +9295,44 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.2",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.2",
 ]

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -61,6 +61,25 @@ Set `PORTAL_MOBILE_ANDROID_SHA256_CERT_FINGERPRINTS` and
 `PORTAL_MOBILE_APPLE_TEAM_ID` on the backend before production verification.
 `PORTAL_MOBILE_BUNDLE_ID` defaults to `io.txcl.agentportal`.
 
+## Mobile Authentication
+
+On first launch, the native shell requests a mobile device-flow code from the
+configured portal origin with `client_type=mobile`, opens the pre-filled verify
+page in the system browser, polls until the flow completes, and stores the
+returned mobile JWT in the Tauri store. The app then runs
+`POST /api/auth/token-login` from inside the WebView so the session cookie is
+written into the WebView's cookie jar before navigating to the current portal
+URL, preserving deep links such as `/dashboard?session=<id>`.
+
+On startup and when the app returns to the foreground, the shell calls
+`POST /api/auth/refresh` with the stored mobile JWT. If the backend returns a
+replacement token, the shell saves it and repeats the WebView token-login step.
+
+The initial token persistence uses `tauri-plugin-store`, which is app-private
+persistent storage and keeps this first auth handoff small and portable across
+Android/iOS. A later native-security pass can swap this for a platform keychain
+bridge without changing the backend API contract.
+
 ## First-Time Native Project Generation
 
 Generate the platform project before the first device run:

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -12,9 +12,14 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
+shared = { path = "../../shared" }
 tauri = { version = "2", features = [] }
 tauri-plugin-deep-link = "2"
+tauri-plugin-opener = "2"
+tauri-plugin-store = "2"
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -12,20 +12,41 @@ pub fn run() {}
 
 #[cfg(any(target_os = "android", target_os = "ios"))]
 mod mobile {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    use std::time::Duration;
+
+    use shared::api::{
+        DeviceClientType, DeviceCodeRequest, DeviceFlowPollRequest, TokenRefreshResponse,
+    };
+    use shared::DevicePollResponse;
     use tauri::{Manager, Url};
     use tauri_plugin_deep_link::DeepLinkExt;
+    use tauri_plugin_opener::OpenerExt;
+    use tauri_plugin_store::StoreExt;
 
     const DEFAULT_SHELL_URL: &str = "https://txcl.io";
     const MAIN_WINDOW_LABEL: &str = "main";
+    const AUTH_STORE_PATH: &str = "mobile-auth.json";
+    const AUTH_TOKEN_KEY: &str = "auth_token";
 
     pub fn run() -> tauri::Result<()> {
         tauri::Builder::default()
             .plugin(tauri_plugin_deep_link::init())
+            .plugin(tauri_plugin_opener::init())
+            .plugin(tauri_plugin_store::Builder::default().build())
             .setup(|app| {
                 let app_handle = app.handle().clone();
+                let auth_in_progress = Arc::new(AtomicBool::new(false));
 
+                let mut startup_destination = None;
                 match app.deep_link().get_current() {
-                    Ok(Some(urls)) => route_deep_links(&app_handle, urls),
+                    Ok(Some(urls)) => {
+                        startup_destination = first_allowed_shell_url(&urls);
+                        route_deep_links(&app_handle, urls);
+                    }
                     Ok(None) => {
                         if let Some(url) = shell_url_override() {
                             navigate_main_window(&app_handle, url);
@@ -34,14 +55,288 @@ mod mobile {
                     Err(err) => eprintln!("failed to read startup deep link: {err}"),
                 }
 
+                run_auth_handoff(&app_handle, auth_in_progress.clone(), startup_destination);
+
                 let app_handle = app.handle().clone();
                 app.deep_link().on_open_url(move |event| {
                     route_deep_links(&app_handle, event.urls());
                 });
 
+                let app_handle = app.handle().clone();
+                app.on_window_event(move |_window, event| {
+                    if matches!(event, tauri::WindowEvent::Focused(true)) {
+                        run_auth_handoff(&app_handle, auth_in_progress.clone(), None);
+                    }
+                });
+
                 Ok(())
             })
             .run(tauri::generate_context!())
+    }
+
+    fn run_auth_handoff<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+        in_progress: Arc<AtomicBool>,
+        destination_url: Option<Url>,
+    ) {
+        if in_progress
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let app = app.clone();
+        tauri::async_runtime::spawn(async move {
+            if let Err(err) = ensure_mobile_auth(&app, destination_url).await {
+                eprintln!("mobile auth handoff failed: {err}");
+            }
+            in_progress.store(false, Ordering::Release);
+        });
+    }
+
+    async fn ensure_mobile_auth<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+        destination_url: Option<Url>,
+    ) -> Result<(), String> {
+        let shell_url = shell_base_url();
+        let store = app
+            .store(AUTH_STORE_PATH)
+            .map_err(|err| format!("failed to open auth store: {err}"))?;
+
+        if let Some(token) = stored_auth_token(&store) {
+            match refresh_mobile_token(&shell_url, &token).await? {
+                RefreshDecision::UseExisting => {
+                    login_webview_with_token(app, &token, destination_url).await?;
+                    return Ok(());
+                }
+                RefreshDecision::UseReplacement(token) => {
+                    save_auth_token(&store, &token)?;
+                    login_webview_with_token(app, &token, destination_url).await?;
+                    return Ok(());
+                }
+                RefreshDecision::TokenRejected => {
+                    store.delete(AUTH_TOKEN_KEY);
+                    store
+                        .save()
+                        .map_err(|err| format!("failed to clear auth token: {err}"))?;
+                }
+            }
+        }
+
+        let token = run_device_flow(app, &shell_url).await?;
+        save_auth_token(&store, &token)?;
+        login_webview_with_token(app, &token, destination_url).await?;
+        Ok(())
+    }
+
+    enum RefreshDecision {
+        UseExisting,
+        UseReplacement(String),
+        TokenRejected,
+    }
+
+    async fn refresh_mobile_token(shell_url: &Url, token: &str) -> Result<RefreshDecision, String> {
+        let url = shell_url
+            .join("/api/auth/refresh")
+            .map_err(|err| format!("failed to build refresh URL: {err}"))?;
+        let response = reqwest::Client::new()
+            .post(url.as_str())
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|err| format!("refresh request failed: {err}"))?;
+
+        match response.status() {
+            reqwest::StatusCode::OK => {
+                let body = response
+                    .json::<TokenRefreshResponse>()
+                    .await
+                    .map_err(|err| format!("refresh response was invalid: {err}"))?;
+                Ok(match body.auth_token {
+                    Some(token) => RefreshDecision::UseReplacement(token),
+                    None => RefreshDecision::UseExisting,
+                })
+            }
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+                Ok(RefreshDecision::TokenRejected)
+            }
+            status => Err(format!("refresh request returned {status}")),
+        }
+    }
+
+    async fn run_device_flow<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+        shell_url: &Url,
+    ) -> Result<String, String> {
+        let code = create_mobile_device_code(shell_url).await?;
+        let verification_url = device_verification_url(&code.verification_uri, &code.user_code)?;
+        app.opener()
+            .open_url(verification_url.as_str(), None::<&str>)
+            .map_err(|err| format!("failed to open device verification URL: {err}"))?;
+
+        let interval = code.interval.max(5);
+        let expires_at = std::time::Instant::now() + Duration::from_secs(code.expires_in);
+        let poll_url = shell_url
+            .join("/api/auth/device/poll")
+            .map_err(|err| format!("failed to build poll URL: {err}"))?;
+        let client = reqwest::Client::new();
+
+        loop {
+            if std::time::Instant::now() >= expires_at {
+                return Err("device authorization expired".to_string());
+            }
+
+            tokio::time::sleep(Duration::from_secs(interval)).await;
+            let request = DeviceFlowPollRequest {
+                device_code: code.device_code.clone(),
+            };
+            let response = client
+                .post(poll_url.as_str())
+                .json(&request)
+                .send()
+                .await
+                .map_err(|err| format!("device poll failed: {err}"))?;
+
+            if !response.status().is_success() {
+                return Err(format!("device poll returned {}", response.status()));
+            }
+
+            match response
+                .json::<DevicePollResponse>()
+                .await
+                .map_err(|err| format!("device poll response was invalid: {err}"))?
+            {
+                DevicePollResponse::Pending => {}
+                DevicePollResponse::Complete { access_token, .. } => return Ok(access_token),
+                DevicePollResponse::Expired => {
+                    return Err("device authorization expired".to_string())
+                }
+                DevicePollResponse::Denied => return Err("device authorization denied".to_string()),
+            }
+        }
+    }
+
+    async fn create_mobile_device_code(
+        shell_url: &Url,
+    ) -> Result<shared::api::DeviceCodeResponse, String> {
+        let url = shell_url
+            .join("/api/auth/device/code")
+            .map_err(|err| format!("failed to build device-code URL: {err}"))?;
+        let request = DeviceCodeRequest {
+            hostname: Some("Agent Portal mobile".to_string()),
+            working_directory: None,
+            client_type: DeviceClientType::Mobile,
+        };
+
+        let response = reqwest::Client::new()
+            .post(url.as_str())
+            .json(&request)
+            .send()
+            .await
+            .map_err(|err| format!("device-code request failed: {err}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "device-code request returned {}",
+                response.status()
+            ));
+        }
+        response
+            .json::<shared::api::DeviceCodeResponse>()
+            .await
+            .map_err(|err| format!("device-code response was invalid: {err}"))
+    }
+
+    fn device_verification_url(verification_uri: &str, user_code: &str) -> Result<Url, String> {
+        let mut url = Url::parse(verification_uri)
+            .map_err(|err| format!("device verification URI was invalid: {err}"))?;
+        url.query_pairs_mut().append_pair("user_code", user_code);
+        Ok(url)
+    }
+
+    async fn login_webview_with_token<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+        token: &str,
+        preferred_destination_url: Option<Url>,
+    ) -> Result<(), String> {
+        let window = app
+            .get_webview_window(MAIN_WINDOW_LABEL)
+            .ok_or_else(|| "Agent Portal shell window is not available".to_string())?;
+        let shell_url = shell_base_url();
+        let mut destination_url = shell_url
+            .join("/dashboard")
+            .map_err(|err| format!("failed to build dashboard URL: {err}"))?;
+        let has_preferred_destination = preferred_destination_url.is_some();
+        if let Some(preferred_destination_url) =
+            preferred_destination_url.filter(|url| same_origin(url, shell_url.as_str()))
+        {
+            destination_url = preferred_destination_url;
+        }
+        match window.url() {
+            Ok(current_url) if same_origin(&current_url, shell_url.as_str()) => {
+                if !has_preferred_destination {
+                    destination_url = current_url;
+                }
+            }
+            Ok(_) | Err(_) => {
+                window
+                    .navigate(shell_url.clone())
+                    .map_err(|err| format!("failed to navigate Agent Portal shell: {err}"))?;
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+        let token = serde_json::to_string(token)
+            .map_err(|err| format!("failed to encode auth token for WebView: {err}"))?;
+        let token_login_url = shell_url
+            .join("/api/auth/token-login")
+            .map_err(|err| format!("failed to build token-login URL: {err}"))?;
+        let token_login_url = serde_json::to_string(token_login_url.as_str())
+            .map_err(|err| format!("failed to encode token-login URL: {err}"))?;
+        let destination_url = serde_json::to_string(destination_url.as_str())
+            .map_err(|err| format!("failed to encode dashboard URL: {err}"))?;
+        let script = format!(
+            r#"(async () => {{
+                try {{
+                    const response = await fetch({token_login_url}, {{
+                        method: "POST",
+                        headers: {{ "Authorization": "Bearer " + {token} }},
+                        credentials: "include"
+                    }});
+                    if (response.ok) {{
+                        window.location.assign({destination_url});
+                    }} else {{
+                        console.error("mobile token-login failed", response.status);
+                    }}
+                }} catch (error) {{
+                    console.error("mobile token-login failed", error);
+                }}
+            }})()"#
+        );
+        window
+            .eval(&script)
+            .map_err(|err| format!("failed to run token-login in WebView: {err}"))
+    }
+
+    fn first_allowed_shell_url(urls: &[Url]) -> Option<Url> {
+        urls.iter().find(|url| is_allowed_shell_url(url)).cloned()
+    }
+
+    fn stored_auth_token<R: tauri::Runtime>(
+        store: &tauri_plugin_store::Store<R>,
+    ) -> Option<String> {
+        store
+            .get(AUTH_TOKEN_KEY)
+            .and_then(|value| value.as_str().map(ToOwned::to_owned))
+    }
+
+    fn save_auth_token<R: tauri::Runtime>(
+        store: &tauri_plugin_store::Store<R>,
+        token: &str,
+    ) -> Result<(), String> {
+        store.set(AUTH_TOKEN_KEY, token);
+        store
+            .save()
+            .map_err(|err| format!("failed to save auth token: {err}"))
     }
 
     fn route_deep_links<R: tauri::Runtime>(app: &tauri::AppHandle<R>, urls: Vec<Url>) {
@@ -52,6 +347,10 @@ mod mobile {
                 eprintln!("ignoring unexpected Agent Portal deep link: {url}");
             }
         }
+    }
+
+    fn shell_base_url() -> Url {
+        shell_url_override().unwrap_or_else(|| Url::parse(DEFAULT_SHELL_URL).unwrap())
     }
 
     fn navigate_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>, url: Url) {


### PR DESCRIPTION
## Summary
- add mobile-shell device-flow handoff with `client_type=mobile`, system-browser verification, native polling, stored JWT, and WebView-local `/api/auth/token-login` cookie exchange
- refresh stored mobile JWTs on startup/foreground via `/api/auth/refresh`, saving replacements and clearing rejected tokens
- preserve startup deep-link destinations such as `/dashboard?session=<id>` after token-login
- document the mobile auth flow and the `tauri-plugin-store` persistence choice

## Review foci
1. WebView cookie boundary: native code polls/refreshes bearer tokens, but token-login runs as WebView `fetch()` so the session cookie lands in the WebView jar.
2. Deep-link preservation: startup app links are carried into auth completion so a logged-out `/dashboard?session=<id>` launch returns to that URL after login.
3. Storage/deps: JWT is persisted with `tauri-plugin-store` for this first pass; keychain/Stronghold hardening can replace it later without backend API changes.

## Local validation
- `cargo fmt --check`
- `cargo check -p agent-portal-mobile`
- `mkdir -p frontend/dist && cargo clippy --workspace -- -D warnings`

Note: local `cargo check -p agent-portal-mobile --target aarch64-linux-android` is blocked because this machine lacks an Android NDK sysroot/`aarch64-linux-android-clang` after adding the Rust HTTP stack; the PR Android Debug APK CI lane has the NDK and should validate the target-gated path.