### PR TITLE
Agent sessions API: awaiting_permission + last_activity

### DIFF
--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -64,7 +64,7 @@ pub async fn list_agent_sessions(
     let user_id = resolve_user(&app_state, &headers, &cookies)?;
     let mut conn = app_state.conn()?;
 
-    use crate::schema::{session_members, sessions};
+    use crate::schema::{pending_permission_requests, session_members, sessions};
     let rows: Vec<Session> = sessions::table
         .inner_join(session_members::table.on(session_members::session_id.eq(sessions::id)))
         .filter(session_members::user_id.eq(user_id))
@@ -74,10 +74,22 @@ pub async fn list_agent_sessions(
         .order(sessions::last_activity.desc())
         .load(&mut conn)?;
 
+    // One batched lookup for the "blocked on you" flag, not one per session.
+    let session_ids: Vec<Uuid> = rows.iter().map(|s| s.id).collect();
+    let awaiting: std::collections::HashSet<Uuid> = pending_permission_requests::table
+        .filter(pending_permission_requests::session_id.eq_any(&session_ids))
+        .select(pending_permission_requests::session_id)
+        .distinct()
+        .load::<Uuid>(&mut conn)?
+        .into_iter()
+        .collect();
+
     let sessions = rows
         .into_iter()
         .map(|s| AgentSessionInfo {
             id: s.id,
+            awaiting_permission: awaiting.contains(&s.id),
+            last_activity: s.last_activity.and_utc().to_rfc3339(),
             session_name: s.session_name,
             working_directory: s.working_directory,
             agent_type: s.agent_type,

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -213,6 +213,8 @@ mod tests {
             agent_type: "codex".to_string(),
             status: "active".to_string(),
             hostname: "host".to_string(),
+            awaiting_permission: false,
+            last_activity: String::new(),
         }
     }
 

--- a/shared/src/api/sessions.rs
+++ b/shared/src/api/sessions.rs
@@ -95,8 +95,9 @@ pub struct MessagesListResponse<T> {
 // ---- Inter-agent messaging --------------------------------------------------
 
 /// One of the caller's sessions, as listed for the agent-messaging page/API
-/// (`GET /api/agent/sessions`). A lightweight summary — enough to pick a
-/// recipient — not the full `SessionInfo`.
+/// and mobile status surfaces (`GET /api/agent/sessions`). A lightweight
+/// summary — enough to pick a recipient or render a widget row — not the
+/// full `SessionInfo`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AgentSessionInfo {
     pub id: Uuid,
@@ -105,6 +106,14 @@ pub struct AgentSessionInfo {
     pub agent_type: String,
     pub status: String,
     pub hostname: String,
+    /// True when the session has a pending permission request waiting on the
+    /// user — the "agent is blocked on you" signal mobile widgets surface.
+    #[serde(default)]
+    pub awaiting_permission: bool,
+    /// RFC3339 UTC timestamp of the session's last activity. Empty when the
+    /// backend predates this field (`serde(default)`).
+    #[serde(default)]
+    pub last_activity: String,
 }
 
 /// Response for `GET /api/agent/sessions`.
@@ -133,4 +142,27 @@ pub struct SendAgentMessageResponse {
     pub delivered: bool,
     /// The input sequence number assigned to the injected message.
     pub seq: i64,
+}
+
+#[cfg(test)]
+mod agent_session_wire_tests {
+    use super::*;
+
+    /// Widget/CLI consumers must be able to parse responses from backends
+    /// that predate the status-surface fields: absent `awaiting_permission`
+    /// and `last_activity` fall back to defaults rather than failing.
+    #[test]
+    fn agent_session_info_defaults_missing_status_fields() {
+        let old_wire = r#"{
+            "id": "00000000-0000-0000-0000-000000000001",
+            "session_name": "s",
+            "working_directory": "/w",
+            "agent_type": "claude",
+            "status": "active",
+            "hostname": "h"
+        }"#;
+        let parsed: AgentSessionInfo = serde_json::from_str(old_wire).unwrap();
+        assert!(!parsed.awaiting_permission);
+        assert!(parsed.last_activity.is_empty());
+    }
 }


### PR DESCRIPTION
Contract-first status-surface API for mobile widgets/persistent notifications (mobile-apps plan §15; coordinated lane item).

## What
- `AgentSessionInfo` (shared/src/api/sessions.rs) gains:
  - `awaiting_permission: bool` — true when the session has a row in `pending_permission_requests` (the "agent is blocked on you" signal)
  - `last_activity: String` — RFC3339 UTC (matches the `SessionInfo` convention: `and_utc().to_rfc3339()`)
  - both `#[serde(default)]` so widget/CLI clients parse responses from older backends
- `GET /api/agent/sessions` (already bearer+cookie dual-auth via `resolve_user`) fills them; the permission flag comes from **one batched** `distinct session_id` query, not per-row lookups
- Launcher test fixture updated; new wire-compat test asserts old JSON without the fields still parses

## Consumers
Android widget lane (Codex agent-portal-2) builds against this shape: `{id, session_name, working_directory, agent_type, status, hostname, awaiting_permission, last_activity}`. Note the existing field name is `session_name` (kept — renaming to `name` would break existing CLI/page consumers).