### PR TITLE
feat: launcher model picker from SDK model catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+- **Launcher model picker.** The launch dialog gains a "Model" selector fed by
+  the SDK crates' model catalogs — `claude_codes::ClaudeModel` (floating
+  aliases grouped separately from pinned models) and `codex_codes::CodexModel`
+  (hidden catalog entries excluded). The selection is passed as `--model <arg>`
+  (Claude) or `-c model=<slug>` (Codex), placed before the free-form extra
+  args so an explicit model there still wins; "Agent default" sends nothing.
+  Bumps claude-codes to 2.1.161 and codex-codes to 0.143.2.
+
 - **Versioning: patch is now the git commit count (issue #1096).** The reported version is `major.minor.{git rev-list --count HEAD}`, derived at build time by `shared/build.rs` and read everywhere as `shared::VERSION`. PRs no longer bump a version line — so parallel PRs can't collide on a hand-picked number, and the patch advances by exactly one per squash-merge. `major.minor` in `Cargo.toml` is the only human knob (its patch is a placeholder). This changelog is maintained by a periodic sweep rather than in lockstep per-PR; add notable changes under this `[Unreleased]` heading.
 
 ## 2.13.21

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,9 +976,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.160"
+version = "2.1.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa83c7d339f486dac04be90454e13db9328deed4a398d6b848f8075251d64e9"
+checksum = "43463847135e5131f36df274467ea944b610675ec2f40296af28b6a97cea6e62"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1074,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.143.1"
+version = "0.143.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea80f1d28514a83fde0bd2909ff8be4eb7065d78673ffbcda6767241757d57b1"
+checksum = "b68c487129969fd39175c7bd3d54f9c2a1cb42d2003ed91ecf8f80ec05bc420a"
 dependencies = [
  "log",
  "serde",
@@ -2275,6 +2275,7 @@ version = "2.13.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "claude-codes",
  "codex-codes",
  "futures-channel",
  "futures-util",
@@ -4472,7 +4473,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,10 +72,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.160", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.161", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.143.1", default-features = false, features = ["types"] }
+codex-codes = { version = "0.143.2", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -16,6 +16,10 @@ shared = { path = "../shared" }
 # PatchChangeKind types that drifted from the wire shape (#827).
 codex-codes = { workspace = true }
 
+# Typed Claude protocol types — ClaudeModel catalog for the launcher's
+# model picker (same types-only, WASM-compat configuration).
+claude-codes = { workspace = true }
+
 # Yew framework
 yew = { workspace = true }
 yew-router = { workspace = true }

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -5,6 +5,8 @@ use crate::components::skip_permissions::{skip_permissions_args, skip_permission
 use crate::components::ProxyTokenSetup;
 use crate::hooks::use_escape;
 use crate::utils::{self, FetchError, On401};
+use claude_codes::ClaudeModel;
+use codex_codes::CodexModel;
 use gloo::timers::callback::Timeout;
 use gloo_net::http::Request;
 use shared::api::{DirectoryListingResponse, LaunchRequest, ProbeAgentsResponse};
@@ -213,6 +215,9 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     };
     let extra_args = use_state(String::new);
     let agent_type = use_state(|| shared::AgentType::Claude);
+    // Model selector value — the CLI model argument, or "" for the agent's
+    // own default. Reset on agent switch since the catalogs don't overlap.
+    let model_arg = use_state(String::new);
     let skip_permissions = use_state(|| false);
     let launching = use_state(|| false);
     let error_msg = use_state(|| None::<String>);
@@ -293,6 +298,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
     let on_agent_type_change = {
         let agent_type = agent_type.clone();
+        let model_arg = model_arg.clone();
         Callback::from(move |e: Event| {
             if let Some(select) = e.target_dyn_into::<web_sys::HtmlSelectElement>() {
                 let val = select.value();
@@ -301,6 +307,16 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                 } else {
                     shared::AgentType::Claude
                 });
+                model_arg.set(String::new());
+            }
+        })
+    };
+
+    let on_model_change = {
+        let model_arg = model_arg.clone();
+        Callback::from(move |e: Event| {
+            if let Some(select) = e.target_dyn_into::<web_sys::HtmlSelectElement>() {
+                model_arg.set(select.value());
             }
         })
     };
@@ -372,6 +388,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let home_root = dir.home_root.clone();
         let extra_args = extra_args.clone();
         let agent_type = agent_type.clone();
+        let model_arg = model_arg.clone();
         let skip_permissions = skip_permissions.clone();
         let selected_launcher = selected_launcher.clone();
         let launching = launching.clone();
@@ -391,10 +408,20 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                 return;
             }
 
-            let mut claude_args: Vec<String> = (*extra_args)
-                .split_whitespace()
-                .map(|s| s.to_string())
-                .collect();
+            // Picker args go first so an explicit --model / -c model=… in the
+            // extra-args field still wins (both CLIs take the last occurrence).
+            let mut claude_args: Vec<String> = Vec::new();
+            if !model_arg.is_empty() {
+                match *agent_type {
+                    AgentType::Claude => {
+                        claude_args.extend(["--model".to_string(), (*model_arg).clone()]);
+                    }
+                    AgentType::Codex => {
+                        claude_args.extend(["-c".to_string(), format!("model={}", *model_arg)]);
+                    }
+                }
+            }
+            claude_args.extend((*extra_args).split_whitespace().map(|s| s.to_string()));
             if *skip_permissions {
                 claude_args.extend(
                     skip_permissions_args(*agent_type)
@@ -500,6 +527,41 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     let selected_agent_label = match *agent_type {
         AgentType::Claude => "Claude",
         AgentType::Codex => "Codex",
+    };
+
+    // Model catalog options for the selected agent, from the SDK crates'
+    // known-model tables. Values are the exact CLI model arguments.
+    let model_option = |value: &str, label: &str| -> Html {
+        html! {
+            <option value={value.to_string()} selected={*model_arg == value}>
+                { label }
+            </option>
+        }
+    };
+    let model_options: Html = match *agent_type {
+        AgentType::Claude => html! {
+            <>
+                <optgroup label="Aliases — track the newest model">
+                    { for ClaudeModel::known()
+                        .iter()
+                        .filter(|m| m.is_alias())
+                        .map(|m| model_option(m.cli_arg(), m.display_name())) }
+                </optgroup>
+                <optgroup label="Pinned models">
+                    { for ClaudeModel::known()
+                        .iter()
+                        .filter(|m| !m.is_alias())
+                        .map(|m| model_option(m.cli_arg(), m.display_name())) }
+                </optgroup>
+            </>
+        },
+        AgentType::Codex => html! {
+            // CodexAutoReview is hidden from Codex's own picker; mirror that.
+            { for CodexModel::known()
+                .iter()
+                .filter(|m| !matches!(m, CodexModel::CodexAutoReview))
+                .map(|m| model_option(m.cli_arg(), m.display_name())) }
+        },
     };
 
     // Pre-compute directory listing HTML
@@ -623,6 +685,18 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                             { "Codex support is highly experimental." }
                         </div>
                     }
+
+                    // Model picker — catalogs from the claude-codes /
+                    // codex-codes crates; "" means the agent's own default.
+                    <div class="launch-field">
+                        <label>{ "Model" }</label>
+                        <select class="launcher-select" onchange={on_model_change}>
+                            <option value="" selected={model_arg.is_empty()}>
+                                { "Agent default" }
+                            </option>
+                            { model_options.clone() }
+                        </select>
+                    </div>
 
                     // Directory browser
                     <div class="launch-field">


### PR DESCRIPTION
Adds a **Model** selector to the launch dialog, between the Agent selector and the directory browser.

## What
- Options come from the SDK crates' typed catalogs (new in claude-codes 2.1.161 / codex-codes 0.143.2, bumped here):
  - **Claude**: `ClaudeModel::known()` — an `optgroup` of floating aliases ("Sonnet (latest)", "Best available", 1M-context forms, …) and one of pinned models ("Fable 5", "Opus 4.8", … "Haiku 3.5"), labels from `display_name()`, values from `cli_arg()`
  - **Codex**: `CodexModel::known()` — GPT-5.6 Sol/Terra/Luna, 5.5, 5.4, 5.4-Mini, 5.2; `CodexAutoReview` excluded to mirror Codex's own picker visibility
- Selection maps to `--model <arg>` (Claude) / `-c model=<slug>` (Codex) in the launch args, **before** the free-form extra-args so an explicit model there still takes precedence (both CLIs honor the last occurrence)
- "Agent default" (empty) sends no model arg; switching agent type resets the selection since the catalogs don't overlap

## Verification
- `cargo check -p frontend --target wasm32-unknown-unknown` — clean
- `cargo clippy -p frontend --target wasm32-unknown-unknown` — no warnings
- `cargo test --workspace --exclude backend` — 634 passed, 0 failed (backend excluded only because its `build.rs` embeds `frontend/dist`, which doesn't exist in a fresh worktree; untouched by this diff)

Model catalog provenance: Claude list extracted from the CLI 2.1.205 binary's model registry; Codex list from `openai/codex@main`'s bundled `models-manager/models.json` (2026-07-11). See meawoppl/rust-code-agent-sdks#200.
