### PR TITLE
Notification content-detail option (O4a) + dispatcher prefs wiring

### DIFF
--- a/backend/src/handlers/push.rs
+++ b/backend/src/handlers/push.rs
@@ -271,6 +271,7 @@ mod db_tests {
             turn_complete: false,
             session_disconnected: true,
             agent_message: true,
+            content_detail: shared::api::NotificationContentDetail::Snippet,
         };
         assert_ne!(custom, NotificationPrefs::default());
         {

--- a/backend/src/handlers/websocket/permissions.rs
+++ b/backend/src/handlers/websocket/permissions.rs
@@ -63,8 +63,12 @@ pub fn handle_permission_request(
         }
     }
 
-    // Keep the tool name for the push event before the fanout moves it.
+    // Keep the tool name and a compact input excerpt for the push event
+    // before the fanout moves them. The excerpt is only shown to users who
+    // opted into `content_detail = snippet` (O4a); the dispatcher hard-caps
+    // it again at payload build.
     let push_tool_name = tool_name.clone();
+    let push_input_snippet = permission_input_snippet(&input);
 
     // Forward to web clients
     if let Some(ref key) = session_key {
@@ -94,8 +98,28 @@ pub fn handle_permission_request(
             session_id,
             session_name: String::new(),
             tool_name: push_tool_name,
+            input_snippet: push_input_snippet,
         });
     }
+}
+
+/// Compact one-line excerpt of a permission request's tool input for the
+/// snippet content level. Prefers the human-meaningful field the common tools
+/// put front and center (`command`, `file_path`, `url`); otherwise falls back
+/// to the compact JSON. Length is only roughly bounded here — the dispatcher
+/// enforces the hard cap when it builds the payload body.
+fn permission_input_snippet(input: &serde_json::Value) -> Option<String> {
+    const ROUGH_MAX: usize = 200;
+    let primary = ["command", "file_path", "url"]
+        .iter()
+        .find_map(|k| input.get(k).and_then(|v| v.as_str()))
+        .map(str::to_string)
+        .or_else(|| serde_json::to_string(input).ok())?;
+    let one_line = primary.split_whitespace().collect::<Vec<_>>().join(" ");
+    if one_line.is_empty() {
+        return None;
+    }
+    Some(one_line.chars().take(ROUGH_MAX).collect())
 }
 
 /// Handle a permission response from a web client: clear from DB and forward to proxy.

--- a/backend/src/push/dispatcher.rs
+++ b/backend/src/push/dispatcher.rs
@@ -78,7 +78,7 @@ async fn dispatch_one<T: PushTransport>(
             return;
         }
     };
-    let (user_id, db_name) = resolved;
+    let (user_id, db_name, prefs) = resolved;
 
     // (b) Suppress when the user has a live web client — in-app WS delivery
     // already covers them. Presence is trustworthy post-#1291 (eager prune).
@@ -89,9 +89,8 @@ async fn dispatch_one<T: PushTransport>(
         return;
     }
 
-    // (c) Prefs filter. Per-user prefs storage lands in C6; until then every
-    // user gets the defaults (permission/turn/disconnect on, agent chatter off).
-    let prefs = NotificationPrefs::default();
+    // (c) Prefs filter, on the user's stored prefs (C6 storage, loaded in the
+    // same query as the recipient above).
     if !event.is_enabled(&prefs) {
         debug!(
             "push suppressed for user {user_id}: event kind {} disabled by prefs",
@@ -107,7 +106,7 @@ async fn dispatch_one<T: PushTransport>(
     } else {
         event.session_name().to_string()
     };
-    let payload = event.into_payload(name);
+    let payload = event.into_payload(name, prefs.content_detail);
 
     // (d) Fan out to every non-disabled subscription for the user.
     let subs: Vec<PushSubscription> = match crate::schema::push_subscriptions::table
@@ -153,18 +152,32 @@ async fn dispatch_one<T: PushTransport>(
     }
 }
 
-/// Resolve `(owning user, session name)` for a session, or `None` when the row
-/// is gone.
+/// Resolve `(owning user, session name, notification prefs)` for a session in
+/// one round trip, or `None` when the session row is gone. Prefs semantics
+/// match the C6 endpoints: a NULL `users.notification_prefs` column or a
+/// stored value that no longer parses both fall back to
+/// [`NotificationPrefs::default`].
 fn resolve_recipient(
     conn: &mut DbConnection,
     session_id: Uuid,
-) -> QueryResult<Option<(Uuid, String)>> {
-    use crate::schema::sessions;
-    sessions::table
-        .find(session_id)
-        .select((sessions::user_id, sessions::session_name))
-        .first::<(Uuid, String)>(conn)
-        .optional()
+) -> QueryResult<Option<(Uuid, String, NotificationPrefs)>> {
+    use crate::schema::{sessions, users};
+    let row = sessions::table
+        .inner_join(users::table.on(users::id.eq(sessions::user_id)))
+        .filter(sessions::id.eq(session_id))
+        .select((
+            sessions::user_id,
+            sessions::session_name,
+            users::notification_prefs,
+        ))
+        .first::<(Uuid, String, Option<serde_json::Value>)>(conn)
+        .optional()?;
+    Ok(row.map(|(user_id, name, stored)| {
+        let prefs = stored
+            .and_then(|v| serde_json::from_value(v).ok())
+            .unwrap_or_default();
+        (user_id, name, prefs)
+    }))
 }
 
 /// Stamp `last_success_at = now()` after a delivered push.
@@ -320,7 +333,15 @@ mod db_tests {
             .expect("insert session");
 
         let resolved = resolve_recipient(&mut conn, session_id).expect("resolve");
-        assert_eq!(resolved, Some((user.id, "resolve-test".to_string())));
+        // A fresh user has NULL notification_prefs -> defaults (C6 semantics).
+        assert_eq!(
+            resolved,
+            Some((
+                user.id,
+                "resolve-test".to_string(),
+                NotificationPrefs::default()
+            ))
+        );
 
         // Unknown session resolves to None.
         assert_eq!(

--- a/backend/src/push/mod.rs
+++ b/backend/src/push/mod.rs
@@ -23,7 +23,7 @@ pub use transport::{LogTransport, PushError, PushTransport, SendOutcome};
 pub use webpush::WebPushTransport;
 
 use crate::models::PushSubscription;
-use shared::api::NotificationPrefs;
+use shared::api::{NotificationContentDetail, NotificationPrefs};
 use std::path::PathBuf;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
@@ -154,6 +154,10 @@ pub enum NotificationEvent {
         session_id: Uuid,
         session_name: String,
         tool_name: String,
+        /// Compact rendering of the tool input, supplied by the emitting
+        /// hook. Only shown under `content_detail = snippet` (O4a); capped
+        /// again in [`NotificationEvent::into_payload`].
+        input_snippet: Option<String>,
     },
     /// A turn finished (a `Result` message was stored); collapse per session.
     TurnComplete {
@@ -208,10 +212,15 @@ impl NotificationEvent {
     }
 
     /// Build the transport-agnostic payload. `session_name` is the resolved
-    /// name (event name when the hook provided one, else the DB name). Payload
+    /// name (event name when the hook provided one, else the DB name);
+    /// `detail` is the user's `content_detail` preference (O4a). Payload
     /// discipline (§8.2): a short preview only — the tap deep-links to the
     /// session and richer content stays server-side.
-    pub fn into_payload(self, session_name: String) -> PushPayload {
+    pub fn into_payload(
+        self,
+        session_name: String,
+        detail: NotificationContentDetail,
+    ) -> PushPayload {
         let session_id = self.session_id();
         let event_kind = self.event_kind().to_string();
         // Collapse key = session id: one visible notification per session,
@@ -223,9 +232,23 @@ impl NotificationEvent {
             session_name
         };
         let body = match self {
-            NotificationEvent::PermissionRequest { tool_name, .. } => {
-                format!("Permission needed: {tool_name}")
-            }
+            NotificationEvent::PermissionRequest {
+                tool_name,
+                input_snippet,
+                ..
+            } => match detail {
+                NotificationContentDetail::Generic => "Permission needed".to_string(),
+                NotificationContentDetail::ToolName => format!("Permission needed: {tool_name}"),
+                NotificationContentDetail::Snippet => match input_snippet {
+                    Some(snippet) if !snippet.trim().is_empty() => cap_snippet(&format!(
+                        "Permission needed: {tool_name} — {}",
+                        snippet.trim()
+                    )),
+                    // No excerpt available: degrade to the tool-name body
+                    // rather than an empty tease.
+                    _ => format!("Permission needed: {tool_name}"),
+                },
+            },
             NotificationEvent::TurnComplete { .. } => "Turn complete".to_string(),
             NotificationEvent::SessionDisconnected { .. } => "Session disconnected".to_string(),
         };
@@ -237,6 +260,22 @@ impl NotificationEvent {
             collapse_key,
         }
     }
+}
+
+/// Hard cap for snippet-detail bodies (O4a): lock screens truncate around
+/// here anyway, and the payload-discipline rule (§8.2) wants a preview, not
+/// the content. Applied on top of whatever the emitting hook produced.
+const SNIPPET_BODY_MAX_CHARS: usize = 120;
+
+/// Truncate to [`SNIPPET_BODY_MAX_CHARS`] on a char boundary, appending an
+/// ellipsis when anything was cut.
+fn cap_snippet(s: &str) -> String {
+    if s.chars().count() <= SNIPPET_BODY_MAX_CHARS {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(SNIPPET_BODY_MAX_CHARS - 1).collect();
+    out.push('…');
+    out
 }
 
 /// A push payload, independent of transport. `collapse_key` is the session id
@@ -286,6 +325,7 @@ mod tests {
             session_id: Uuid::nil(),
             session_name: name.to_string(),
             tool_name: "Bash".to_string(),
+            input_snippet: None,
         }
     }
 
@@ -353,8 +393,12 @@ mod tests {
             session_id: id,
             session_name: "my-session".into(),
             tool_name: "Edit".into(),
+            input_snippet: None,
         };
-        let payload = ev.into_payload("my-session".to_string());
+        let payload = ev.into_payload(
+            "my-session".to_string(),
+            NotificationContentDetail::ToolName,
+        );
         assert_eq!(payload.title, "my-session");
         assert_eq!(payload.body, "Permission needed: Edit");
         assert_eq!(payload.event_kind, "permission_request");
@@ -368,9 +412,76 @@ mod tests {
             session_id: Uuid::nil(),
             session_name: String::new(),
         }
-        .into_payload(String::new());
+        .into_payload(String::new(), NotificationContentDetail::ToolName);
         assert_eq!(payload.title, "Agent Portal");
         assert_eq!(payload.body, "Turn complete");
+    }
+
+    fn perm_with_snippet(snippet: Option<&str>) -> NotificationEvent {
+        NotificationEvent::PermissionRequest {
+            session_id: Uuid::nil(),
+            session_name: "s".into(),
+            tool_name: "Bash".into(),
+            input_snippet: snippet.map(str::to_string),
+        }
+    }
+
+    /// O4a: the three detail levels shape the permission body as specified —
+    /// generic never leaks the tool name, snippet includes the excerpt under
+    /// the hard cap, and a missing excerpt degrades to the tool-name body.
+    #[test]
+    fn content_detail_shapes_permission_body() {
+        let body = |ev: NotificationEvent, d| ev.into_payload("s".into(), d).body;
+
+        assert_eq!(
+            body(perm_with_snippet(None), NotificationContentDetail::Generic),
+            "Permission needed"
+        );
+        assert_eq!(
+            body(
+                perm_with_snippet(Some("rm -rf /tmp/x")),
+                NotificationContentDetail::ToolName
+            ),
+            "Permission needed: Bash"
+        );
+        assert_eq!(
+            body(
+                perm_with_snippet(Some("rm -rf /tmp/x")),
+                NotificationContentDetail::Snippet
+            ),
+            "Permission needed: Bash — rm -rf /tmp/x"
+        );
+        assert_eq!(
+            body(perm_with_snippet(None), NotificationContentDetail::Snippet),
+            "Permission needed: Bash",
+            "missing excerpt degrades to tool-name body"
+        );
+
+        let long = "x".repeat(500);
+        let capped = body(
+            perm_with_snippet(Some(&long)),
+            NotificationContentDetail::Snippet,
+        );
+        assert_eq!(capped.chars().count(), SNIPPET_BODY_MAX_CHARS);
+        assert!(capped.ends_with('…'));
+    }
+
+    /// Non-permission bodies carry no tool/content either way — detail level
+    /// must not change them.
+    #[test]
+    fn content_detail_leaves_other_events_unchanged() {
+        for d in [
+            NotificationContentDetail::Generic,
+            NotificationContentDetail::ToolName,
+            NotificationContentDetail::Snippet,
+        ] {
+            let payload = NotificationEvent::TurnComplete {
+                session_id: Uuid::nil(),
+                session_name: "s".into(),
+            }
+            .into_payload("s".into(), d);
+            assert_eq!(payload.body, "Turn complete");
+        }
     }
 
     #[test]

--- a/frontend/src/pages/settings/notifications_panel.rs
+++ b/frontend/src/pages/settings/notifications_panel.rs
@@ -18,8 +18,8 @@
 use base64::Engine;
 use gloo_net::http::Request;
 use shared::api::{
-    NotificationPrefs, PushPlatform, PushSubscriptionInfo, RegisterPushSubscriptionRequest,
-    VapidKeyResponse,
+    NotificationContentDetail, NotificationPrefs, PushPlatform, PushSubscriptionInfo,
+    RegisterPushSubscriptionRequest, VapidKeyResponse,
 };
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::{spawn_local, JsFuture};
@@ -201,7 +201,74 @@ pub fn notifications_panel() -> Html {
                     }
                 }) }
             </div>
+
+            { render_content_detail(&prefs) }
         </section>
+    }
+}
+
+/// The O4a content-depth radio group: how much a notification reveals on the
+/// lock screen.
+fn render_content_detail(prefs: &UseStateHandle<NotificationPrefs>) -> Html {
+    let make_select = |detail: NotificationContentDetail| {
+        let prefs = prefs.clone();
+        Callback::from(move |_: Event| {
+            let mut next = *prefs;
+            next.content_detail = detail;
+            prefs.set(next);
+            spawn_local(async move {
+                save_prefs(&next).await;
+            });
+        })
+    };
+
+    let options = [
+        (
+            NotificationContentDetail::Generic,
+            "Generic",
+            "Event and session name only — e.g. “Permission needed”.",
+        ),
+        (
+            NotificationContentDetail::ToolName,
+            "Tool name",
+            "Adds the tool being approved — e.g. “Permission needed: Bash”.",
+        ),
+        (
+            NotificationContentDetail::Snippet,
+            "Snippet",
+            "Adds a short excerpt of the request — e.g. the command being run.",
+        ),
+    ];
+
+    html! {
+        <div class="notification-prefs">
+            <h3>{ "Notification content" }</h3>
+            <p class="section-description">
+                { "How much detail notifications show on your lock screen." }
+            </p>
+            { for options.iter().map(|(detail, label, description)| {
+                let onchange = make_select(*detail);
+                html! {
+                    <label class="toggle-label" key={*label}>
+                        <span>
+                            { *label }
+                            <span class="section-description">{ format!(" — {description}") }</span>
+                        </span>
+                        <input
+                            type="radio"
+                            name="notification-content-detail"
+                            checked={prefs.content_detail == *detail}
+                            {onchange}
+                        />
+                    </label>
+                }
+            }) }
+            <p class="section-description">
+                { "Note: browser (Web Push) notifications are end-to-end encrypted, but \
+                   Apple (APNs) and Google (FCM) notifications are not — with “Snippet”, \
+                   excerpts of tool input may transit those services in plaintext." }
+            </p>
+        </div>
     }
 }
 

--- a/shared/src/api/push.rs
+++ b/shared/src/api/push.rs
@@ -108,6 +108,25 @@ fn default_true() -> bool {
     true
 }
 
+/// How much content push payloads carry (decision O4a).
+///
+/// Web Push payloads are end-to-end encrypted to the browser, but APNs and
+/// FCM payloads transit Apple/Google in plaintext — `Snippet` trades that
+/// exposure for lock-screen usefulness, which is why it is opt-in and the
+/// settings UI carries the warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum NotificationContentDetail {
+    /// Event kind + session name only.
+    Generic,
+    /// Adds the tool name to permission requests (the original behavior).
+    #[default]
+    ToolName,
+    /// Adds a short excerpt where available (e.g. permission tool input),
+    /// hard-capped server-side (~120 chars).
+    Snippet,
+}
+
 /// Per-user, per-event-kind notification toggles.
 ///
 /// Defaults are `(permission_request, turn_complete, session_disconnected) =
@@ -125,6 +144,10 @@ pub struct NotificationPrefs {
     pub session_disconnected: bool,
     #[serde(default)]
     pub agent_message: bool,
+    /// How much content notifications carry (O4a). Defaults to `ToolName`
+    /// for wire compat with prefs stored before this field existed.
+    #[serde(default)]
+    pub content_detail: NotificationContentDetail,
 }
 
 impl Default for NotificationPrefs {
@@ -134,6 +157,7 @@ impl Default for NotificationPrefs {
             turn_complete: true,
             session_disconnected: true,
             agent_message: false,
+            content_detail: NotificationContentDetail::default(),
         }
     }
 }
@@ -223,5 +247,19 @@ mod tests {
         assert!(!parsed.turn_complete);
         assert!(parsed.session_disconnected);
         assert!(!parsed.agent_message);
+        assert_eq!(parsed.content_detail, NotificationContentDetail::ToolName);
+    }
+
+    #[test]
+    fn content_detail_wire_values_are_snake_case() {
+        for (variant, wire) in [
+            (NotificationContentDetail::Generic, "\"generic\""),
+            (NotificationContentDetail::ToolName, "\"tool_name\""),
+            (NotificationContentDetail::Snippet, "\"snippet\""),
+        ] {
+            assert_eq!(serde_json::to_string(&variant).unwrap(), wire);
+            let parsed: NotificationContentDetail = serde_json::from_str(wire).unwrap();
+            assert_eq!(parsed, variant);
+        }
     }
 }


### PR DESCRIPTION
Second lane item (coordinated). Implements decision O4a: configurable push-notification content depth, and closes the C2/C6 seam where the dispatcher never read stored prefs.

## What
- **Contract** (`shared/src/api/push.rs`): `NotificationContentDetail` enum — `generic` | `tool_name` (serde default, wire-compat with prefs stored before this field) | `snippet` — as `NotificationPrefs.content_detail`.
- **Payload shaping** (`backend/src/push/mod.rs`): permission bodies by level — generic: `Permission needed`; tool_name: `Permission needed: Bash` (unchanged today-behavior); snippet: `Permission needed: Bash — rm -rf /tmp/x`, hard-capped at 120 chars (char-boundary safe, ellipsis). Missing excerpt degrades to the tool_name body. Turn-complete/disconnect bodies are unaffected by level (nothing to reveal).
- **Excerpt source** (`permissions.rs` hook): prefers the human-meaningful field (`command`/`file_path`/`url`), falls back to compact JSON; whitespace-flattened, roughly bounded at emit, hard-capped at payload build.
- **Dispatcher prefs wiring** (`backend/src/push/dispatcher.rs`): `resolve_recipient` now joins `users` and returns `(user_id, name, prefs)` in **one round trip** — the dispatcher previously used `NotificationPrefs::default()`, making the C6 Settings toggles server-side no-ops. NULL / parse-failure → defaults, matching the C6 endpoints exactly.
- **Settings UI**: "Notification content" radio group in the Notifications panel, with the required privacy note: Web Push payloads are e2e-encrypted, APNs/FCM are not — snippet excerpts may transit Apple/Google in plaintext.

## Tests
- Detail-level body shaping matrix (incl. cap + missing-excerpt degradation + other-events invariance)
- Wire values snake_case roundtrip; stored-prefs-without-field adopts `tool_name`
- `resolve_recipient` DB test asserts NULL prefs → defaults
- Workspace clippy `-Dwarnings` clean; frontend compiles to wasm32

## Note (pre-existing, not this PR)
Under the full parallel `cargo test -p backend` run, `auth::tests::extract_user_allows_valid_cookie` and `refresh_token_rotates_after_half_life_and_graces_old_row` flake on clean origin/main too (pool-creation panic under load; pass in isolation). Flagged to the coordinator separately.