### PR TITLE
test: shared DB pool for DB-gated tests (fix parallel-suite flake)

### DIFF
--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -160,8 +160,6 @@ mod tests {
     use tower_cookies::cookie::Key;
     use tower_cookies::Cookie;
 
-    static DB_SETUP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     fn user(disabled: bool) -> User {
         User {
             id: Uuid::new_v4(),
@@ -191,17 +189,6 @@ mod tests {
             reject_disabled_user(user(true)),
             Err(AppError::Forbidden)
         ));
-    }
-
-    fn test_pool() -> Option<crate::db::DbPool> {
-        if std::env::var("DATABASE_URL").is_err() {
-            eprintln!("DATABASE_URL not set, skipping DB-backed auth test");
-            return None;
-        }
-        let _guard = DB_SETUP_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        let pool = crate::db::create_pool().expect("create test DB pool");
-        crate::db::run_migrations_logged(&pool).expect("run migrations");
-        Some(pool)
     }
 
     fn test_state(pool: crate::db::DbPool) -> AppState {
@@ -294,7 +281,7 @@ mod tests {
 
     #[test]
     fn extract_user_allows_valid_cookie() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);
@@ -308,7 +295,7 @@ mod tests {
 
     #[test]
     fn extract_user_rejects_disabled_cookie_user() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);
@@ -324,7 +311,7 @@ mod tests {
 
     #[test]
     fn extract_user_rejects_missing_cookie() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);
@@ -338,7 +325,7 @@ mod tests {
 
     #[test]
     fn extract_user_allows_valid_mobile_bearer() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);
@@ -354,7 +341,7 @@ mod tests {
 
     #[test]
     fn extract_user_rejects_expired_mobile_bearer() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);
@@ -377,7 +364,7 @@ mod tests {
 
     #[test]
     fn extract_user_rejects_revoked_mobile_bearer() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);
@@ -398,7 +385,7 @@ mod tests {
 
     #[test]
     fn extract_user_rejects_disabled_mobile_bearer_user() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);
@@ -415,7 +402,7 @@ mod tests {
 
     #[test]
     fn extract_user_does_not_fall_back_from_bad_bearer_to_valid_cookie() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -661,19 +661,6 @@ mod tests {
         assert!(mobile_token_needs_refresh(created, None, now));
     }
 
-    static DB_SETUP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn test_pool() -> Option<crate::db::DbPool> {
-        if std::env::var("DATABASE_URL").is_err() {
-            eprintln!("DATABASE_URL not set, skipping DB-backed mobile auth test");
-            return None;
-        }
-        let _guard = DB_SETUP_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        let pool = crate::db::create_pool().expect("create test DB pool");
-        crate::db::run_migrations_logged(&pool).expect("run migrations");
-        Some(pool)
-    }
-
     fn test_state(pool: crate::db::DbPool) -> Arc<AppState> {
         Arc::new(AppState {
             dev_mode: false,
@@ -759,7 +746,7 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_token_waits_until_half_life() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);
@@ -785,7 +772,7 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_token_rotates_after_half_life_and_graces_old_row() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);
@@ -823,7 +810,7 @@ mod tests {
 
     #[tokio::test]
     async fn token_login_sets_session_cookie() {
-        let Some(pool) = test_pool() else {
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let app_state = test_state(pool);

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -289,16 +289,6 @@ mod db_tests {
     use super::*;
     use crate::models::{NewSessionWithId, NewUser, Session, User};
     use chrono::Utc;
-    use diesel::r2d2::{ConnectionManager, Pool};
-
-    type DbPool = Pool<ConnectionManager<diesel::pg::PgConnection>>;
-
-    fn try_pool() -> Option<DbPool> {
-        let url = std::env::var("DATABASE_URL").ok()?;
-        let manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
-        Pool::builder().build(manager).ok()
-    }
-
     fn make_user(conn: &mut diesel::pg::PgConnection, label: &str) -> User {
         use crate::schema::users;
         let nonce = uuid::Uuid::new_v4();
@@ -408,8 +398,7 @@ mod db_tests {
     /// frontend issues.
     #[test]
     fn default_returns_last_n_chronological() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("conn");
@@ -445,8 +434,7 @@ mod db_tests {
     /// limited to `limit` rows, chronological order.
     #[test]
     fn before_cursor_returns_older_page() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("conn");
@@ -483,8 +471,7 @@ mod db_tests {
     /// limited to `limit` rows, chronological order.
     #[test]
     fn after_cursor_returns_newer_page() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("conn");

--- a/backend/src/handlers/push.rs
+++ b/backend/src/handlers/push.rs
@@ -214,16 +214,6 @@ pub async fn put_prefs(
 mod db_tests {
     use super::*;
     use crate::models::{NewUser, User};
-    use diesel::r2d2::{ConnectionManager, Pool};
-
-    type DbPool = Pool<ConnectionManager<diesel::pg::PgConnection>>;
-
-    fn try_pool() -> Option<DbPool> {
-        let url = std::env::var("DATABASE_URL").ok()?;
-        let manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
-        Pool::builder().build(manager).ok()
-    }
-
     fn make_user(conn: &mut diesel::pg::PgConnection) -> User {
         use crate::schema::users;
         let nonce = Uuid::new_v4();
@@ -255,8 +245,7 @@ mod db_tests {
 
     #[test]
     fn prefs_round_trip_default_then_custom() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("get conn");

--- a/backend/src/handlers/session_access.rs
+++ b/backend/src/handlers/session_access.rs
@@ -192,18 +192,6 @@ pub fn is_session_mutator(app_state: &AppState, session_id: Uuid, user_id: Uuid)
 mod db_tests {
     use super::*;
     use crate::models::{NewSessionMember, NewSessionWithId, NewUser, Session, User};
-    use diesel::r2d2::{ConnectionManager, Pool};
-
-    type DbPool = Pool<ConnectionManager<diesel::pg::PgConnection>>;
-
-    /// Try to build a DB pool from `DATABASE_URL`; returns `None` if the env
-    /// var isn't set (so the test silently skips on CI without DB).
-    fn try_pool() -> Option<DbPool> {
-        let url = std::env::var("DATABASE_URL").ok()?;
-        let manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
-        Pool::builder().build(manager).ok()
-    }
-
     /// Insert a throwaway user with a random google_id/email and return its row.
     fn make_user(conn: &mut diesel::pg::PgConnection, label: &str) -> User {
         use crate::schema::users;
@@ -281,8 +269,7 @@ mod db_tests {
 
     #[test]
     fn viewer_cannot_mutate_and_editor_can() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("conn");
@@ -316,8 +303,7 @@ mod db_tests {
 
     #[test]
     fn non_member_cannot_mutate() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("conn");
@@ -337,8 +323,7 @@ mod db_tests {
 
     #[test]
     fn owner_member_row_can_mutate() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("conn");

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -130,16 +130,6 @@ mod replay_tests {
     use crate::models::{NewSessionWithId, NewUser, Session, User};
     use chrono::Utc;
     use diesel::prelude::*;
-    use diesel::r2d2::{ConnectionManager, Pool};
-
-    type DbPool = Pool<ConnectionManager<diesel::pg::PgConnection>>;
-
-    fn try_pool() -> Option<DbPool> {
-        let url = std::env::var("DATABASE_URL").ok()?;
-        let manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
-        Pool::builder().build(manager).ok()
-    }
-
     fn make_user(conn: &mut diesel::pg::PgConnection, label: &str) -> User {
         use crate::schema::users;
         let nonce = uuid::Uuid::new_v4();
@@ -237,8 +227,7 @@ mod replay_tests {
     /// the render-window default so the wire payload is bounded.
     #[test]
     fn replay_after_none_caps_to_retention_count() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("conn");
@@ -306,8 +295,7 @@ mod replay_tests {
     /// now performs end-to-end (#784).
     #[test]
     fn replay_history_strict_gt_round_trips_server_timestamp() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping replay_history test");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("conn");
@@ -378,8 +366,7 @@ mod replay_tests {
     /// the component takes when REST history returned empty / failed.
     #[test]
     fn replay_history_no_watermark_returns_all_and_advances_high_water() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping replay_history test");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("conn");

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -22,6 +22,9 @@ pub mod push;
 pub mod routes;
 pub mod schema;
 
+#[cfg(test)]
+pub mod test_support;
+
 use crate::db::DbPool;
 use crate::handlers::device_flow::DeviceFlowStore;
 use clap::Parser;

--- a/backend/src/push/dispatcher.rs
+++ b/backend/src/push/dispatcher.rs
@@ -192,15 +192,7 @@ pub(crate) fn disable_subscription(conn: &mut DbConnection, sub_id: Uuid) -> Que
 #[cfg(test)]
 mod db_tests {
     use super::*;
-    use crate::db::DbPool;
     use crate::models::{NewPushSubscription, NewUser, PushSubscription, User};
-    use diesel::r2d2::{ConnectionManager, Pool};
-
-    fn try_pool() -> Option<DbPool> {
-        let url = std::env::var("DATABASE_URL").ok()?;
-        let manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
-        Pool::builder().build(manager).ok()
-    }
 
     fn make_user(conn: &mut DbConnection) -> User {
         use crate::schema::users;
@@ -235,8 +227,7 @@ mod db_tests {
 
     #[test]
     fn dead_endpoint_sets_disabled_at() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping push dispatcher DB test");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("db conn");
@@ -265,8 +256,7 @@ mod db_tests {
 
     #[test]
     fn record_success_sets_last_success_at() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping push dispatcher DB test");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("db conn");
@@ -287,8 +277,7 @@ mod db_tests {
 
     #[test]
     fn resolve_recipient_finds_owner_and_name() {
-        let Some(pool) = try_pool() else {
-            eprintln!("DATABASE_URL not set, skipping push dispatcher DB test");
+        let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
         let mut conn = pool.get().expect("db conn");

--- a/backend/src/test_support.rs
+++ b/backend/src/test_support.rs
@@ -1,0 +1,63 @@
+//! Test-only DB support: one process-wide connection pool shared by every
+//! DB-gated unit test.
+//!
+//! WHY a shared pool: each `#[cfg(test)]` module used to build its own r2d2
+//! pool per test (via `create_pool()` / `Pool::builder()`). Under the full
+//! parallel `cargo test -p backend` run, dozens of those pools exist at once
+//! and each opens several Postgres connections, so the suite blew past
+//! Postgres `max_connections` (~100 in `docker-compose.test.yml`). DB-gated
+//! tests then intermittently panicked while checking out a connection (they
+//! passed in isolation / with `--test-threads=1`). A single, small, shared
+//! pool built once keeps total connections bounded regardless of test
+//! parallelism.
+
+use std::sync::OnceLock;
+
+use diesel::pg::PgConnection;
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use crate::db::DbPool;
+
+/// Max connections the shared test pool may open.
+///
+/// Sized to sit in the sweet spot between two failure modes:
+/// - **Too many** (the old per-test pools): dozens of pools × ~10 conns each
+///   blew past Postgres `max_connections` (100 in `docker-compose.test.yml`).
+/// - **Too few**: a single tiny pool starves the highly parallel suite. The
+///   default `cargo test` parallelism is the CPU count (80 on CI-class hosts),
+///   and several DB-gated tests hold one connection for the whole test body
+///   while the handler under test checks out a *second* one — so each such
+///   test needs 2 connections at once. Undersizing the pool deadlocks those
+///   tests until r2d2's 30s checkout timeout fires, then they panic.
+///
+/// 48 comfortably covers every DB-gated test running its 2-connection pattern
+/// concurrently while staying well under Postgres `max_connections`.
+const TEST_POOL_MAX_SIZE: u32 = 48;
+
+/// Returns a clone of the process-wide test pool, or `None` when `DATABASE_URL`
+/// is unset (DB-gated tests skip in that case, keeping CI green without a DB).
+///
+/// The pool is built exactly once via [`OnceLock`] and migrations run once
+/// against it; `OnceLock::get_or_init` serializes that init, subsuming the old
+/// per-module `DB_SETUP_LOCK` migrate guard. `DbPool` is an r2d2 handle whose
+/// clones share the underlying connection pool, so every caller draws from the
+/// same bounded set of connections — see the module docs for why that matters.
+pub fn shared_pool() -> Option<DbPool> {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("DATABASE_URL not set, skipping DB-backed test");
+        return None;
+    }
+
+    static POOL: OnceLock<DbPool> = OnceLock::new();
+    let pool = POOL.get_or_init(|| {
+        let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+        let manager = ConnectionManager::<PgConnection>::new(database_url);
+        let pool = Pool::builder()
+            .max_size(TEST_POOL_MAX_SIZE)
+            .build(manager)
+            .expect("build shared test DB pool");
+        crate::db::run_migrations_logged(&pool).expect("run migrations for shared test pool");
+        pool
+    });
+    Some(pool.clone())
+}

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -24,19 +24,29 @@ use shared::endpoints::SessionEndpoint;
 use shared::{AgentType, ProxyToServer, RegisterFields, ServerToProxy};
 use tokio::net::TcpListener;
 
-/// Migration/seed guard: harness tests run concurrently against ONE shared
-/// Postgres, and Diesel's migration runner is not safe to race with itself.
-/// Every test acquires the pool through here, which serializes the
-/// migrate+seed step (the lock is released before the test body runs).
-static DB_SETUP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
+/// One process-wide pool for the whole harness binary.
+///
+/// WHY: harness tests run concurrently against ONE shared Postgres. Building a
+/// fresh pool per test multiplies open connections and, together with the
+/// other DB-gated test binaries, can exhaust Postgres `max_connections` (~100
+/// in `docker-compose.test.yml`) — the parallel-suite flake this change fixes.
+/// The pool is built (and migrated+seeded) exactly once via `OnceLock`;
+/// `get_or_init` serializes that setup (Diesel's migration runner is not safe
+/// to race with itself), and `DbPool` clones share the underlying pool.
+///
+/// This mirrors `backend::test_support::shared_pool`, duplicated here because
+/// that module is `#[cfg(test)]`-gated in the lib and so isn't visible to this
+/// separate integration-test binary.
 fn test_pool() -> backend::db::DbPool {
-    let _guard = DB_SETUP_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-    let pool = backend::db::create_pool()
-        .expect("DATABASE_URL must point to a test Postgres (docker-compose.test.yml)");
-    backend::db::run_migrations_logged(&pool).expect("run migrations");
-    backend::db::seed_dev_user(&pool).expect("seed dev user");
-    pool
+    static POOL: std::sync::OnceLock<backend::db::DbPool> = std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        let pool = backend::db::create_pool()
+            .expect("DATABASE_URL must point to a test Postgres (docker-compose.test.yml)");
+        backend::db::run_migrations_logged(&pool).expect("run migrations");
+        backend::db::seed_dev_user(&pool).expect("seed dev user");
+        pool
+    })
+    .clone()
 }
 
 /// Boot the backend (dev mode) on an ephemeral port; returns its address.


### PR DESCRIPTION
## Problem

Under the full parallel `cargo test -p backend` run, DB-gated tests intermittently panicked in `create_pool` (e.g. `auth::tests::extract_user_allows_valid_cookie`, `handlers::auth::tests::refresh_token_rotates_after_half_life_and_graces_old_row`). They passed in isolation / `--test-threads=1`.

Root cause: each test module built its own r2d2 pool **per test** via `create_pool()` / `Pool::builder()`. With `cargo test` parallelism defaulting to the CPU count, dozens of pools existed at once and each opened several connections, exhausting Postgres `max_connections` (~100 in `docker-compose.test.yml`).

## Fix

One shared process-wide test pool in `backend/src/test_support.rs`:

- `shared_pool() -> Option<DbPool>` returns `None` (with the skip message) when `DATABASE_URL` is unset, else a `&'static`-cloned pool built once via `OnceLock`, migrating once (`get_or_init` serializes the migrate step, subsuming the old per-module `DB_SETUP_LOCK`).
- `DbPool` is an r2d2 handle whose clones share the underlying pool, so total connections are bounded regardless of test parallelism.
- Pool `max_size` = 48: large enough that the 80-way-parallel suite doesn't deadlock (several tests hold one connection while the handler under test checks out a second), small enough to stay well under `max_connections`.

Consolidated **7** duplicated per-module `test_pool()`/`try_pool()` + `DB_SETUP_LOCK` helpers (`auth`, `handlers::auth`, `handlers::messages`, `handlers::push`, `handlers::session_access`, `handlers::websocket::replay`, `push::dispatcher`) into `shared_pool()`. The integration harness (`backend/tests/harness.rs`) is a separate binary that can't see the `#[cfg(test)]` module, so it gets the same `OnceLock` treatment inline.

Change is test-only.

## Verification

- `cargo test -p backend` at default parallelism: 5 consecutive runs, all green (203 lib + 3 harness tests). Suite now finishes in ~0.7s vs the ~30s r2d2 checkout-timeout deadlock before.
- `cargo fmt --check` and `cargo clippy --all-targets -p backend -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)