### PR TITLE
Add Android status home-screen widget

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -80,6 +80,24 @@ persistent storage and keeps this first auth handoff small and portable across
 Android/iOS. A later native-security pass can swap this for a platform keychain
 bridge without changing the backend API contract.
 
+## Android Status Surfaces
+
+Android builds include a persistent status notification and a home-screen
+widget. Both use the stored mobile JWT to poll `GET /api/agent/sessions` while
+the app process is alive, currently every 45 seconds, and clear themselves when
+no active sessions are present. The notification runs as a `dataSync` foreground
+service; the widget renders the same saved session payload, so it updates
+whenever the notification poller receives fresh status.
+
+On Android 13+, the first status update requests `POST_NOTIFICATIONS`; if the
+permission is not granted yet, the shell skips the update and retries on the
+next poll. Dogfood should confirm that first-launch permission UX is clear.
+
+If device/OEM battery policy reaps the app process despite the foreground
+service, note the device and behavior here. The durable refresh path is the
+future E5 FCM data-message bridge, which will wake the Android surfaces without
+relying on process-local polling.
+
 ## First-Time Native Project Generation
 
 Generate the platform project before the first device run:

--- a/mobile/status-notification-plugin/android/src/main/AndroidManifest.xml
+++ b/mobile/status-notification-plugin/android/src/main/AndroidManifest.xml
@@ -5,6 +5,18 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application>
+        <receiver
+            android:name=".StatusWidgetProvider"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/agent_portal_status_widget" />
+        </receiver>
+
         <service
             android:name=".StatusNotificationService"
             android:exported="false"

--- a/mobile/status-notification-plugin/android/src/main/java/StatusNotificationService.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusNotificationService.kt
@@ -11,12 +11,13 @@ import android.net.Uri
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
-import org.json.JSONArray
 
 class StatusNotificationService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_CLEAR -> {
+                StatusPayloadStore.clear(this)
+                StatusWidgetProvider.updateAll(this)
                 if (Build.VERSION.SDK_INT >= 24) {
                     stopForeground(STOP_FOREGROUND_REMOVE)
                 } else {
@@ -26,12 +27,17 @@ class StatusNotificationService : Service() {
                 stopSelf()
             }
             ACTION_SHOW -> {
+                val summary = intent.getStringExtra(EXTRA_SUMMARY) ?: ""
+                val dashboardUrl = intent.getStringExtra(EXTRA_DASHBOARD_URL) ?: ""
+                val sessionsJson = intent.getStringExtra(EXTRA_SESSIONS_JSON) ?: "[]"
+                StatusPayloadStore.save(this, summary, dashboardUrl, sessionsJson)
+                StatusWidgetProvider.updateAll(this)
                 val notification = buildNotification(
                     context = this,
                     title = intent.getStringExtra(EXTRA_TITLE) ?: "Agent Portal",
-                    summary = intent.getStringExtra(EXTRA_SUMMARY) ?: "",
-                    dashboardUrl = intent.getStringExtra(EXTRA_DASHBOARD_URL) ?: "",
-                    sessionsJson = intent.getStringExtra(EXTRA_SESSIONS_JSON) ?: "[]",
+                    summary = summary,
+                    dashboardUrl = dashboardUrl,
+                    sessionsJson = sessionsJson,
                 )
                 startForeground(NOTIFICATION_ID, notification)
             }
@@ -49,7 +55,7 @@ class StatusNotificationService : Service() {
         sessionsJson: String,
     ): Notification {
         ensureChannel(context)
-        val sessions = parseSessions(sessionsJson)
+        val sessions = StatusPayloadStore.parseSessions(sessionsJson)
         val inbox = NotificationCompat.InboxStyle().setSummaryText(summary)
         sessions.take(MAX_LINES).forEach { session ->
             inbox.addLine("${session.name} - ${session.state}")
@@ -76,20 +82,6 @@ class StatusNotificationService : Service() {
         }
 
         return builder.build()
-    }
-
-    private fun parseSessions(sessionsJson: String): List<StatusSession> {
-        val sessions = mutableListOf<StatusSession>()
-        val json = JSONArray(sessionsJson)
-        for (index in 0 until json.length()) {
-            val item = json.getJSONObject(index)
-            val name = item.optString("name").ifBlank { "Session" }
-            val state = item.optString("state").ifBlank { "working" }
-            val url = item.optString("url")
-            if (url.isBlank()) continue
-            sessions.add(StatusSession(name, state, url))
-        }
-        return sessions
     }
 
     private fun ensureChannel(context: Context) {
@@ -122,14 +114,6 @@ class StatusNotificationService : Service() {
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
-    }
-
-    private data class StatusSession(
-        val name: String,
-        val state: String,
-        val url: String,
-    ) {
-        fun actionLabel(): String = "$name: $state".take(32)
     }
 
     companion object {

--- a/mobile/status-notification-plugin/android/src/main/java/StatusWidgetData.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusWidgetData.kt
@@ -1,0 +1,69 @@
+package io.txcl.agentportal.status
+
+import android.content.Context
+import org.json.JSONArray
+
+data class StatusSession(
+    val name: String,
+    val state: String,
+    val url: String,
+) {
+    fun actionLabel(): String = "$name: $state".take(32)
+}
+
+data class StatusPayload(
+    val summary: String,
+    val dashboardUrl: String,
+    val sessions: List<StatusSession>,
+)
+
+object StatusPayloadStore {
+    private const val PREFS_NAME = "agent_portal_status_widget"
+    private const val KEY_SUMMARY = "summary"
+    private const val KEY_DASHBOARD_URL = "dashboard_url"
+    private const val KEY_SESSIONS_JSON = "sessions_json"
+
+    fun save(context: Context, summary: String, dashboardUrl: String, sessionsJson: String) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_SUMMARY, summary)
+            .putString(KEY_DASHBOARD_URL, dashboardUrl)
+            .putString(KEY_SESSIONS_JSON, sessionsJson)
+            .apply()
+    }
+
+    fun clear(context: Context) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .apply()
+    }
+
+    fun load(context: Context): StatusPayload {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val sessionsJson = prefs.getString(KEY_SESSIONS_JSON, "[]") ?: "[]"
+        return StatusPayload(
+            summary = prefs.getString(KEY_SUMMARY, "No active sessions") ?: "No active sessions",
+            dashboardUrl = prefs.getString(KEY_DASHBOARD_URL, "") ?: "",
+            sessions = parseSessions(sessionsJson),
+        )
+    }
+
+    fun parseSessions(sessionsJson: String): List<StatusSession> {
+        val sessions = mutableListOf<StatusSession>()
+        try {
+            val json = JSONArray(sessionsJson)
+            for (index in 0 until json.length()) {
+                val item = json.getJSONObject(index)
+                val name = item.optString("name").ifBlank { "Session" }
+                val state = item.optString("state").ifBlank { "working" }
+                val url = item.optString("url")
+                if (url.isBlank()) continue
+                sessions.add(StatusSession(name, state, url))
+            }
+        } catch (_: Exception) {
+            return emptyList()
+        }
+        return sessions
+    }
+}

--- a/mobile/status-notification-plugin/android/src/main/java/StatusWidgetProvider.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusWidgetProvider.kt
@@ -1,0 +1,135 @@
+package io.txcl.agentportal.status
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.view.View
+import android.widget.RemoteViews
+
+class StatusWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        appWidgetIds.forEach { appWidgetId ->
+            updateWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    companion object {
+        private const val MAX_WIDGET_LINES = 3
+
+        fun updateAll(context: Context) {
+            val manager = AppWidgetManager.getInstance(context)
+            val component = ComponentName(context, StatusWidgetProvider::class.java)
+            val widgetIds = manager.getAppWidgetIds(component)
+            widgetIds.forEach { widgetId ->
+                updateWidget(context, manager, widgetId)
+            }
+        }
+
+        private fun updateWidget(
+            context: Context,
+            manager: AppWidgetManager,
+            widgetId: Int,
+        ) {
+            val payload = StatusPayloadStore.load(context)
+            val views = RemoteViews(context.packageName, R.layout.agent_portal_status_widget)
+            val sessions = payload.sessions.take(MAX_WIDGET_LINES)
+            val dashboardUrl = payload.dashboardUrl.ifBlank {
+                sessions.firstOrNull()?.url.orEmpty()
+            }
+
+            views.setTextViewText(R.id.widget_title, "Agent Portal")
+            views.setTextViewText(R.id.widget_summary, widgetSummary(payload, sessions))
+            views.setOnClickPendingIntent(
+                R.id.widget_root,
+                deepLinkPendingIntent(context, dashboardUrl, widgetId * 10),
+            )
+
+            bindRow(
+                context,
+                views,
+                R.id.widget_row_1,
+                R.id.widget_row_1_name,
+                R.id.widget_row_1_state,
+                sessions.getOrNull(0),
+                widgetId * 10 + 1,
+            )
+            bindRow(
+                context,
+                views,
+                R.id.widget_row_2,
+                R.id.widget_row_2_name,
+                R.id.widget_row_2_state,
+                sessions.getOrNull(1),
+                widgetId * 10 + 2,
+            )
+            bindRow(
+                context,
+                views,
+                R.id.widget_row_3,
+                R.id.widget_row_3_name,
+                R.id.widget_row_3_state,
+                sessions.getOrNull(2),
+                widgetId * 10 + 3,
+            )
+
+            manager.updateAppWidget(widgetId, views)
+        }
+
+        private fun widgetSummary(payload: StatusPayload, sessions: List<StatusSession>): String {
+            if (sessions.isEmpty()) return "No active sessions"
+            return payload.summary.ifBlank { "${sessions.size} active" }
+        }
+
+        private fun bindRow(
+            context: Context,
+            views: RemoteViews,
+            rowId: Int,
+            nameId: Int,
+            stateId: Int,
+            session: StatusSession?,
+            requestCode: Int,
+        ) {
+            if (session == null) {
+                views.setViewVisibility(rowId, View.GONE)
+                return
+            }
+            views.setViewVisibility(rowId, View.VISIBLE)
+            views.setTextViewText(nameId, session.name)
+            views.setTextViewText(stateId, session.state)
+            views.setOnClickPendingIntent(
+                rowId,
+                deepLinkPendingIntent(context, session.url, requestCode),
+            )
+        }
+
+        private fun deepLinkPendingIntent(
+            context: Context,
+            url: String,
+            requestCode: Int,
+        ): PendingIntent {
+            val intent = if (url.isBlank()) {
+                context.packageManager.getLaunchIntentForPackage(context.packageName)
+                    ?: Intent(Intent.ACTION_MAIN).setPackage(context.packageName)
+            } else {
+                Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                    setPackage(context.packageName)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                }
+            }
+            return PendingIntent.getActivity(
+                context,
+                requestCode,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+        }
+    }
+}

--- a/mobile/status-notification-plugin/android/src/main/res/drawable/widget_background.xml
+++ b/mobile/status-notification-plugin/android/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#202124" />
+    <corners android:radius="18dp" />
+    <padding
+        android:bottom="12dp"
+        android:left="12dp"
+        android:right="12dp"
+        android:top="12dp" />
+</shape>

--- a/mobile/status-notification-plugin/android/src/main/res/layout/agent_portal_status_widget.xml
+++ b/mobile/status-notification-plugin/android/src/main/res/layout/agent_portal_status_widget.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/widget_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:text="Agent Portal"
+        android:textColor="#FFFFFF"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/widget_summary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:text="No active sessions"
+        android:textColor="#BDC1C6"
+        android:textSize="12sp" />
+
+    <LinearLayout
+        android:id="@+id/widget_row_1"
+        style="@style/AgentPortalWidgetRow">
+
+        <TextView
+            android:id="@+id/widget_row_1_name"
+            style="@style/AgentPortalWidgetName" />
+
+        <TextView
+            android:id="@+id/widget_row_1_state"
+            style="@style/AgentPortalWidgetState" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/widget_row_2"
+        style="@style/AgentPortalWidgetRow">
+
+        <TextView
+            android:id="@+id/widget_row_2_name"
+            style="@style/AgentPortalWidgetName" />
+
+        <TextView
+            android:id="@+id/widget_row_2_state"
+            style="@style/AgentPortalWidgetState" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/widget_row_3"
+        style="@style/AgentPortalWidgetRow">
+
+        <TextView
+            android:id="@+id/widget_row_3_name"
+            style="@style/AgentPortalWidgetName" />
+
+        <TextView
+            android:id="@+id/widget_row_3_state"
+            style="@style/AgentPortalWidgetState" />
+    </LinearLayout>
+</LinearLayout>

--- a/mobile/status-notification-plugin/android/src/main/res/values/strings.xml
+++ b/mobile/status-notification-plugin/android/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="agent_portal_status_widget_description">Active Agent Portal session status</string>
+</resources>

--- a/mobile/status-notification-plugin/android/src/main/res/values/styles.xml
+++ b/mobile/status-notification-plugin/android/src/main/res/values/styles.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AgentPortalWidgetRow">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginTop">8dp</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:orientation">horizontal</item>
+    </style>
+
+    <style name="AgentPortalWidgetName">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:singleLine">true</item>
+        <item name="android:textColor">#FFFFFF</item>
+        <item name="android:textSize">13sp</item>
+    </style>
+
+    <style name="AgentPortalWidgetState">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:maxWidth">104dp</item>
+        <item name="android:singleLine">true</item>
+        <item name="android:textColor">#8AB4F8</item>
+        <item name="android:textSize">12sp</item>
+    </style>
+</resources>

--- a/mobile/status-notification-plugin/android/src/main/res/xml/agent_portal_status_widget.xml
+++ b/mobile/status-notification-plugin/android/src/main/res/xml/agent_portal_status_widget.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/agent_portal_status_widget_description"
+    android:initialLayout="@layout/agent_portal_status_widget"
+    android:minWidth="220dp"
+    android:minHeight="120dp"
+    android:previewLayout="@layout/agent_portal_status_widget"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
## Summary
- add an Android AppWidgetProvider for compact Agent Portal session status rows
- update the widget from the same saved session payload used by the persistent status notification
- deep-link widget rows to /dashboard?session=<id> and clear widget state when no sessions remain
- document Android status surfaces and dogfood notes in mobile/README.md

## Tests
- cargo fmt --check
- cargo check -p agent-portal-mobile
- cargo clippy -p agent-portal-mobile -- -D warnings

Android resource packaging is covered by the Mobile Android CI lane.