### PR TITLE
Add Android widget WorkManager refresh

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -89,6 +89,11 @@ no active sessions are present. The notification runs as a `dataSync` foreground
 service; the widget renders the same saved session payload, so it updates
 whenever the notification poller receives fresh status.
 
+The widget also schedules a native WorkManager refresh using the same stored
+mobile JWT and status endpoint. Android enforces a 15-minute minimum interval
+for periodic work; widget system updates also enqueue a one-time refresh when
+network is available.
+
 On Android 13+, the first status update requests `POST_NOTIFICATIONS`; if the
 permission is not granted yet, the shell skips the update and retries on the
 next poll. Dogfood should confirm that first-launch permission UX is clear.

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -438,6 +438,8 @@ mod mobile {
                         title: "Agent Portal sessions".to_string(),
                         summary,
                         dashboard_url: dashboard_url.to_string(),
+                        status_url: url.to_string(),
+                        auth_token: token.to_string(),
                         sessions_json,
                     })
                     .map_err(|err| format!("failed to show notification: {err}"))?;

--- a/mobile/status-notification-plugin/android/build.gradle.kts
+++ b/mobile/status-notification-plugin/android/build.gradle.kts
@@ -33,5 +33,6 @@ android {
 
 dependencies {
     implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.work:work-runtime-ktx:2.9.1")
     implementation(project(":tauri-android"))
 }

--- a/mobile/status-notification-plugin/android/src/main/java/StatusNotificationPlugin.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusNotificationPlugin.kt
@@ -18,6 +18,8 @@ class ShowArgs {
     lateinit var title: String
     lateinit var summary: String
     lateinit var dashboardUrl: String
+    lateinit var statusUrl: String
+    lateinit var authToken: String
     lateinit var sessionsJson: String
 }
 
@@ -36,6 +38,8 @@ class StatusNotificationPlugin(private val activity: Activity) : Plugin(activity
                 putExtra(StatusNotificationService.EXTRA_TITLE, args.title)
                 putExtra(StatusNotificationService.EXTRA_SUMMARY, args.summary)
                 putExtra(StatusNotificationService.EXTRA_DASHBOARD_URL, args.dashboardUrl)
+                putExtra(StatusNotificationService.EXTRA_STATUS_URL, args.statusUrl)
+                putExtra(StatusNotificationService.EXTRA_AUTH_TOKEN, args.authToken)
                 putExtra(StatusNotificationService.EXTRA_SESSIONS_JSON, args.sessionsJson)
             }
             ContextCompat.startForegroundService(activity, intent)

--- a/mobile/status-notification-plugin/android/src/main/java/StatusNotificationService.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusNotificationService.kt
@@ -18,6 +18,7 @@ class StatusNotificationService : Service() {
             ACTION_CLEAR -> {
                 StatusPayloadStore.clear(this)
                 StatusWidgetProvider.updateAll(this)
+                StatusWidgetRefreshWorker.cancel(this)
                 if (Build.VERSION.SDK_INT >= 24) {
                     stopForeground(STOP_FOREGROUND_REMOVE)
                 } else {
@@ -29,9 +30,12 @@ class StatusNotificationService : Service() {
             ACTION_SHOW -> {
                 val summary = intent.getStringExtra(EXTRA_SUMMARY) ?: ""
                 val dashboardUrl = intent.getStringExtra(EXTRA_DASHBOARD_URL) ?: ""
+                val statusUrl = intent.getStringExtra(EXTRA_STATUS_URL) ?: ""
+                val authToken = intent.getStringExtra(EXTRA_AUTH_TOKEN) ?: ""
                 val sessionsJson = intent.getStringExtra(EXTRA_SESSIONS_JSON) ?: "[]"
-                StatusPayloadStore.save(this, summary, dashboardUrl, sessionsJson)
+                StatusPayloadStore.save(this, summary, dashboardUrl, statusUrl, authToken, sessionsJson)
                 StatusWidgetProvider.updateAll(this)
+                StatusWidgetRefreshWorker.schedule(this)
                 val notification = buildNotification(
                     context = this,
                     title = intent.getStringExtra(EXTRA_TITLE) ?: "Agent Portal",
@@ -122,6 +126,8 @@ class StatusNotificationService : Service() {
         const val EXTRA_TITLE = "title"
         const val EXTRA_SUMMARY = "summary"
         const val EXTRA_DASHBOARD_URL = "dashboard_url"
+        const val EXTRA_STATUS_URL = "status_url"
+        const val EXTRA_AUTH_TOKEN = "auth_token"
         const val EXTRA_SESSIONS_JSON = "sessions_json"
 
         private const val CHANNEL_ID = "agent_portal_status"

--- a/mobile/status-notification-plugin/android/src/main/java/StatusWidgetData.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusWidgetData.kt
@@ -1,7 +1,9 @@
 package io.txcl.agentportal.status
 
 import android.content.Context
+import android.net.Uri
 import org.json.JSONArray
+import org.json.JSONObject
 
 data class StatusSession(
     val name: String,
@@ -21,13 +23,24 @@ object StatusPayloadStore {
     private const val PREFS_NAME = "agent_portal_status_widget"
     private const val KEY_SUMMARY = "summary"
     private const val KEY_DASHBOARD_URL = "dashboard_url"
+    private const val KEY_STATUS_URL = "status_url"
+    private const val KEY_AUTH_TOKEN = "auth_token"
     private const val KEY_SESSIONS_JSON = "sessions_json"
 
-    fun save(context: Context, summary: String, dashboardUrl: String, sessionsJson: String) {
+    fun save(
+        context: Context,
+        summary: String,
+        dashboardUrl: String,
+        statusUrl: String,
+        authToken: String,
+        sessionsJson: String,
+    ) {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .edit()
             .putString(KEY_SUMMARY, summary)
             .putString(KEY_DASHBOARD_URL, dashboardUrl)
+            .putString(KEY_STATUS_URL, statusUrl)
+            .putString(KEY_AUTH_TOKEN, authToken)
             .putString(KEY_SESSIONS_JSON, sessionsJson)
             .apply()
     }
@@ -49,6 +62,43 @@ object StatusPayloadStore {
         )
     }
 
+    fun loadRefreshConfig(context: Context): RefreshConfig? {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val statusUrl = prefs.getString(KEY_STATUS_URL, "") ?: ""
+        val dashboardUrl = prefs.getString(KEY_DASHBOARD_URL, "") ?: ""
+        val authToken = prefs.getString(KEY_AUTH_TOKEN, "") ?: ""
+        if (statusUrl.isBlank() || dashboardUrl.isBlank() || authToken.isBlank()) return null
+        return RefreshConfig(
+            statusUrl = statusUrl,
+            dashboardUrl = dashboardUrl,
+            authToken = authToken,
+        )
+    }
+
+    fun saveFromStatusResponse(
+        context: Context,
+        dashboardUrl: String,
+        statusUrl: String,
+        authToken: String,
+        responseBody: String,
+    ): Boolean {
+        val lines = statusLinesFromResponse(dashboardUrl, responseBody)
+        if (lines.isEmpty()) {
+            clear(context)
+            return false
+        }
+        val summary = statusSummary(lines)
+        save(
+            context = context,
+            summary = summary,
+            dashboardUrl = dashboardUrl,
+            statusUrl = statusUrl,
+            authToken = authToken,
+            sessionsJson = statusLinesJson(lines),
+        )
+        return true
+    }
+
     fun parseSessions(sessionsJson: String): List<StatusSession> {
         val sessions = mutableListOf<StatusSession>()
         try {
@@ -66,4 +116,97 @@ object StatusPayloadStore {
         }
         return sessions
     }
+
+    private fun statusLinesFromResponse(dashboardUrl: String, responseBody: String): List<StatusSession> {
+        val lines = mutableListOf<StatusSession>()
+        try {
+            val sessions = JSONObject(responseBody).optJSONArray("sessions") ?: return emptyList()
+            for (index in 0 until sessions.length()) {
+                val session = sessions.getJSONObject(index)
+                if (!shouldShow(session)) continue
+                val id = session.optString("id")
+                if (id.isBlank()) continue
+                lines.add(
+                    StatusSession(
+                        name = compactSessionName(session.optString("session_name")),
+                        state = statusState(session),
+                        url = dashboardSessionUrl(dashboardUrl, id),
+                    )
+                )
+                if (lines.size >= MAX_STATUS_SESSIONS) break
+            }
+        } catch (_: Exception) {
+            return emptyList()
+        }
+        return lines
+    }
+
+    private fun shouldShow(session: JSONObject): Boolean {
+        val status = session.optString("status").lowercase()
+        return session.optBoolean("awaiting_permission", false) ||
+            status.contains("active") ||
+            status.contains("working") ||
+            status.contains("running") ||
+            status.contains("disconnect")
+    }
+
+    private fun statusState(session: JSONObject): String {
+        if (session.optBoolean("awaiting_permission", false)) return "awaiting input"
+        return if (session.optString("status").lowercase().contains("disconnect")) {
+            "disconnected"
+        } else {
+            "working"
+        }
+    }
+
+    private fun compactSessionName(name: String): String {
+        val trimmed = name.trim()
+        if (trimmed.isBlank()) return "Session"
+        return if (trimmed.length <= MAX_SESSION_NAME_CHARS) {
+            trimmed
+        } else {
+            trimmed.take(MAX_SESSION_NAME_CHARS - 3) + "..."
+        }
+    }
+
+    private fun dashboardSessionUrl(dashboardUrl: String, sessionId: String): String {
+        return Uri.parse(dashboardUrl)
+            .buildUpon()
+            .encodedQuery(null)
+            .appendQueryParameter("session", sessionId)
+            .build()
+            .toString()
+    }
+
+    private fun statusSummary(lines: List<StatusSession>): String {
+        val awaiting = lines.count { it.state == "awaiting input" }
+        val disconnected = lines.count { it.state == "disconnected" }
+        return when {
+            awaiting > 0 -> "$awaiting awaiting input"
+            disconnected > 0 -> "$disconnected disconnected"
+            else -> "${lines.size} working"
+        }
+    }
+
+    private fun statusLinesJson(lines: List<StatusSession>): String {
+        val array = JSONArray()
+        lines.forEach { line ->
+            array.put(
+                JSONObject()
+                    .put("name", line.name)
+                    .put("state", line.state)
+                    .put("url", line.url)
+            )
+        }
+        return array.toString()
+    }
+
+    private const val MAX_STATUS_SESSIONS = 5
+    private const val MAX_SESSION_NAME_CHARS = 32
 }
+
+data class RefreshConfig(
+    val statusUrl: String,
+    val dashboardUrl: String,
+    val authToken: String,
+)

--- a/mobile/status-notification-plugin/android/src/main/java/StatusWidgetProvider.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusWidgetProvider.kt
@@ -19,6 +19,7 @@ class StatusWidgetProvider : AppWidgetProvider() {
         appWidgetIds.forEach { appWidgetId ->
             updateWidget(context, appWidgetManager, appWidgetId)
         }
+        StatusWidgetRefreshWorker.refreshNow(context)
     }
 
     companion object {

--- a/mobile/status-notification-plugin/android/src/main/java/StatusWidgetRefreshWorker.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusWidgetRefreshWorker.kt
@@ -1,0 +1,117 @@
+package io.txcl.agentportal.status
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.TimeUnit
+
+class StatusWidgetRefreshWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result {
+        val config = StatusPayloadStore.loadRefreshConfig(applicationContext) ?: return Result.success()
+        return try {
+            val response = fetchStatus(config)
+            if (response.statusCode == HttpURLConnection.HTTP_OK) {
+                val hasSessions = StatusPayloadStore.saveFromStatusResponse(
+                    context = applicationContext,
+                    dashboardUrl = config.dashboardUrl,
+                    statusUrl = config.statusUrl,
+                    authToken = config.authToken,
+                    responseBody = response.body,
+                )
+                StatusWidgetProvider.updateAll(applicationContext)
+                if (hasSessions) Result.success() else {
+                    cancel(applicationContext)
+                    Result.success()
+                }
+            } else if (response.statusCode == HttpURLConnection.HTTP_UNAUTHORIZED ||
+                response.statusCode == HttpURLConnection.HTTP_FORBIDDEN
+            ) {
+                StatusPayloadStore.clear(applicationContext)
+                StatusWidgetProvider.updateAll(applicationContext)
+                cancel(applicationContext)
+                Result.success()
+            } else {
+                Result.retry()
+            }
+        } catch (_: Exception) {
+            Result.retry()
+        }
+    }
+
+    private fun fetchStatus(config: RefreshConfig): StatusResponse {
+        val connection = (URL(config.statusUrl).openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            setRequestProperty("Authorization", "Bearer ${config.authToken}")
+            connectTimeout = 10_000
+            readTimeout = 10_000
+        }
+        return try {
+            val body = if (connection.responseCode in 200..299) {
+                connection.inputStream.bufferedReader().use { it.readText() }
+            } else {
+                connection.errorStream?.bufferedReader()?.use { it.readText() }.orEmpty()
+            }
+            StatusResponse(connection.responseCode, body)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private data class StatusResponse(
+        val statusCode: Int,
+        val body: String,
+    )
+
+    companion object {
+        private const val UNIQUE_PERIODIC_WORK = "agent_portal_status_widget_periodic_refresh"
+        private const val UNIQUE_IMMEDIATE_WORK = "agent_portal_status_widget_immediate_refresh"
+
+        private val networkConstraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        fun schedule(context: Context) {
+            val periodic = PeriodicWorkRequestBuilder<StatusWidgetRefreshWorker>(
+                15,
+                TimeUnit.MINUTES,
+            )
+                .setConstraints(networkConstraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                UNIQUE_PERIODIC_WORK,
+                androidx.work.ExistingPeriodicWorkPolicy.REPLACE,
+                periodic,
+            )
+        }
+
+        fun refreshNow(context: Context) {
+            val request = OneTimeWorkRequestBuilder<StatusWidgetRefreshWorker>()
+                .setConstraints(networkConstraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                UNIQUE_IMMEDIATE_WORK,
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_IMMEDIATE_WORK)
+            WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_PERIODIC_WORK)
+        }
+    }
+}

--- a/mobile/status-notification-plugin/src/lib.rs
+++ b/mobile/status-notification-plugin/src/lib.rs
@@ -21,6 +21,8 @@ pub struct StatusNotificationPayload {
     pub title: String,
     pub summary: String,
     pub dashboard_url: String,
+    pub status_url: String,
+    pub auth_token: String,
     pub sessions_json: String,
 }
 


### PR DESCRIPTION
## Summary
- add a native WorkManager periodic refresh for the Android status AppWidget at Android's 15 minute minimum interval
- reuse the stored mobile bearer token and GET /api/agent/sessions status URL to refresh widget rows while the app is not alive
- keep the existing update-now path from the app/foreground service, and clear/cancel widget refresh on no sessions or auth rejection

## Notes
- the widget stores the status URL and 30-day mobile JWT in app-private plugin preferences, matching the existing dogfood-phase local storage posture
- the Android Debug APK workflow is the binding native compile check for the Kotlin/WorkManager code

## Local checks
- cargo fmt --check
- cargo check -p agent-portal-mobile
- cargo clippy -p agent-portal-mobile -- -D warnings
- git diff --check