### PR TITLE
Add Android FCM bridge

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -99,9 +99,60 @@ permission is not granted yet, the shell skips the update and retries on the
 next poll. Dogfood should confirm that first-launch permission UX is clear.
 
 If device/OEM battery policy reaps the app process despite the foreground
-service, note the device and behavior here. The durable refresh path is the
-future E5 FCM data-message bridge, which will wake the Android surfaces without
-relying on process-local polling.
+service, note the device and behavior here. The FCM data-message bridge below
+is the durable refresh path that wakes the Android surfaces without relying
+only on process-local polling.
+
+## Android FCM Bridge
+
+Android builds include the Firebase Messaging receive bridge, but it is
+runtime-gated: without Firebase configuration, token registration is skipped
+and CI still builds a debug APK. When Firebase is configured, the shell obtains
+the FCM registration token after mobile auth and registers it with
+`POST /api/push/subscriptions` as:
+
+```json
+{
+  "platform": "fcm",
+  "endpoint_or_token": "<FCM registration token>",
+  "p256dh": null,
+  "auth": null,
+  "device_label": "Agent Portal Android"
+}
+```
+
+The request uses the stored mobile JWT as `Authorization: Bearer ...`.
+`onNewToken` re-posts the rotated token. When the shell rejects the stored JWT
+and clears auth, it also deletes the saved backend subscription id if one was
+registered.
+
+FCM data messages enqueue the same native status refresh used by the widget
+WorkManager path; that refresh updates the widget and best-effort re-shows the
+persistent status notification from the fetched session payload.
+
+To enable FCM for a local or release Android build, Matt must provision:
+
+- A Firebase project with an Android app for `io.txcl.agentportal`.
+- The app's `google-services.json` in the generated Android app module after
+  `npm run android:init` (`mobile/src-tauri/gen/android/app/google-services.json`).
+- Conditional Google Services plugin application in the generated Android app
+  Gradle file only when that JSON exists. Do not require it in CI.
+- A Firebase service-account JSON on the backend host and
+  `PORTAL_FCM_SERVICE_ACCOUNT_PATH=/path/to/service-account.json` so the
+  existing backend FCM transport can send to `platform=fcm` rows.
+
+The generated Android app Gradle file should apply Google Services only when
+the Firebase file is present, for example:
+
+```kotlin
+plugins {
+    id("com.google.gms.google-services") version "4.4.2" apply false
+}
+
+if (file("google-services.json").exists()) {
+    apply(plugin = "com.google.gms.google-services")
+}
+```
 
 ## First-Time Native Project Generation
 

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -20,7 +20,8 @@ mod mobile {
 
     #[cfg(target_os = "android")]
     use agent_portal_mobile_status_notification::{
-        StatusNotificationExt, StatusNotificationLine, StatusNotificationPayload,
+        FcmRegistrationPayload, StatusNotificationExt, StatusNotificationLine,
+        StatusNotificationPayload,
     };
     #[cfg(target_os = "android")]
     use shared::api::{AgentSessionInfo, AgentSessionsResponse};
@@ -128,12 +129,14 @@ mod mobile {
             match refresh_mobile_token(&shell_url, &token).await? {
                 RefreshDecision::UseExisting => {
                     login_webview_with_token(app, &token, destination_url).await?;
+                    register_fcm_subscription(app, &shell_url, &token).await;
                     update_status_notification_once(app, &shell_url, &token).await;
                     return Ok(());
                 }
                 RefreshDecision::UseReplacement(token) => {
                     save_auth_token(&store, &token)?;
                     login_webview_with_token(app, &token, destination_url).await?;
+                    register_fcm_subscription(app, &shell_url, &token).await;
                     update_status_notification_once(app, &shell_url, &token).await;
                     return Ok(());
                 }
@@ -142,6 +145,7 @@ mod mobile {
                     store
                         .save()
                         .map_err(|err| format!("failed to clear auth token: {err}"))?;
+                    unregister_fcm_subscription(app).await;
                 }
             }
         }
@@ -149,6 +153,7 @@ mod mobile {
         let token = run_device_flow(app, &shell_url).await?;
         save_auth_token(&store, &token)?;
         login_webview_with_token(app, &token, destination_url).await?;
+        register_fcm_subscription(app, &shell_url, &token).await;
         update_status_notification_once(app, &shell_url, &token).await;
         Ok(())
     }
@@ -350,6 +355,40 @@ mod mobile {
             eprintln!("failed to update Android status notification: {err}");
         }
     }
+
+    #[cfg(target_os = "android")]
+    async fn register_fcm_subscription<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+        shell_url: &Url,
+        token: &str,
+    ) {
+        let payload = FcmRegistrationPayload {
+            backend_url: shell_url.to_string(),
+            auth_token: token.to_string(),
+            device_label: "Agent Portal Android".to_string(),
+        };
+        if let Err(err) = app.status_notification().register_fcm(payload) {
+            eprintln!("failed to register Android FCM subscription: {err}");
+        }
+    }
+
+    #[cfg(not(target_os = "android"))]
+    async fn register_fcm_subscription<R: tauri::Runtime>(
+        _app: &tauri::AppHandle<R>,
+        _shell_url: &Url,
+        _token: &str,
+    ) {
+    }
+
+    #[cfg(target_os = "android")]
+    async fn unregister_fcm_subscription<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+        if let Err(err) = app.status_notification().unregister_fcm() {
+            eprintln!("failed to unregister Android FCM subscription: {err}");
+        }
+    }
+
+    #[cfg(not(target_os = "android"))]
+    async fn unregister_fcm_subscription<R: tauri::Runtime>(_app: &tauri::AppHandle<R>) {}
 
     #[cfg(target_os = "android")]
     fn start_status_notification_polling<R: tauri::Runtime>(app: tauri::AppHandle<R>) {

--- a/mobile/status-notification-plugin/android/build.gradle.kts
+++ b/mobile/status-notification-plugin/android/build.gradle.kts
@@ -34,5 +34,6 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.work:work-runtime-ktx:2.9.1")
+    implementation("com.google.firebase:firebase-messaging-ktx:24.0.1")
     implementation(project(":tauri-android"))
 }

--- a/mobile/status-notification-plugin/android/src/main/AndroidManifest.xml
+++ b/mobile/status-notification-plugin/android/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application>
         <receiver
@@ -21,5 +22,13 @@
             android:name=".StatusNotificationService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+
+        <service
+            android:name=".PortalFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/mobile/status-notification-plugin/android/src/main/java/PortalFcmBridge.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/PortalFcmBridge.kt
@@ -1,0 +1,176 @@
+package io.txcl.agentportal.status
+
+import android.content.Context
+import android.os.Build
+import com.google.firebase.FirebaseApp
+import com.google.firebase.messaging.FirebaseMessaging
+import java.net.HttpURLConnection
+import java.net.URL
+import org.json.JSONObject
+
+object PortalFcmBridge {
+    private const val PREFS_NAME = "agent_portal_fcm"
+    private const val KEY_BACKEND_URL = "backend_url"
+    private const val KEY_AUTH_TOKEN = "auth_token"
+    private const val KEY_DEVICE_LABEL = "device_label"
+    private const val KEY_SUBSCRIPTION_ID = "subscription_id"
+    private const val KEY_FCM_TOKEN = "fcm_token"
+
+    fun register(context: Context, backendUrl: String, authToken: String, deviceLabel: String) {
+        saveConfig(context, backendUrl, authToken, deviceLabel)
+        if (!firebaseAvailable(context)) return
+
+        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+            if (!task.isSuccessful) return@addOnCompleteListener
+            val fcmToken = task.result ?: return@addOnCompleteListener
+            registerTokenAsync(context.applicationContext, fcmToken)
+        }
+    }
+
+    fun unregister(context: Context) {
+        val config = loadConfig(context)
+        val subscriptionId = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_SUBSCRIPTION_ID, "")
+            .orEmpty()
+        if (config != null && subscriptionId.isNotBlank()) {
+            Thread {
+                runCatching { deleteSubscription(config, subscriptionId) }
+                clear(context)
+            }.start()
+        } else {
+            clear(context)
+        }
+        if (firebaseAvailable(context)) {
+            FirebaseMessaging.getInstance().deleteToken()
+        }
+    }
+
+    fun onNewToken(context: Context, fcmToken: String) {
+        registerTokenAsync(context.applicationContext, fcmToken)
+    }
+
+    fun onDataMessage(context: Context) {
+        StatusWidgetRefreshWorker.refreshNow(context)
+    }
+
+    private fun registerTokenAsync(context: Context, fcmToken: String) {
+        val config = loadConfig(context) ?: return
+        Thread {
+            runCatching {
+                val subscriptionId = postSubscription(config, fcmToken)
+                context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                    .edit()
+                    .putString(KEY_FCM_TOKEN, fcmToken)
+                    .putString(KEY_SUBSCRIPTION_ID, subscriptionId)
+                    .apply()
+            }
+        }.start()
+    }
+
+    private fun firebaseAvailable(context: Context): Boolean {
+        return try {
+            if (FirebaseApp.getApps(context).isNotEmpty()) return true
+            FirebaseApp.initializeApp(context) != null
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun saveConfig(
+        context: Context,
+        backendUrl: String,
+        authToken: String,
+        deviceLabel: String,
+    ) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_BACKEND_URL, backendUrl.trimEnd('/'))
+            .putString(KEY_AUTH_TOKEN, authToken)
+            .putString(KEY_DEVICE_LABEL, deviceLabel.ifBlank { defaultDeviceLabel() })
+            .apply()
+    }
+
+    private fun clear(context: Context) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .apply()
+    }
+
+    private fun loadConfig(context: Context): FcmConfig? {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val backendUrl = prefs.getString(KEY_BACKEND_URL, "") ?: ""
+        val authToken = prefs.getString(KEY_AUTH_TOKEN, "") ?: ""
+        val deviceLabel = prefs.getString(KEY_DEVICE_LABEL, "") ?: ""
+        if (backendUrl.isBlank() || authToken.isBlank()) return null
+        return FcmConfig(
+            backendUrl = backendUrl.trimEnd('/'),
+            authToken = authToken,
+            deviceLabel = deviceLabel.ifBlank { defaultDeviceLabel() },
+        )
+    }
+
+    private fun postSubscription(config: FcmConfig, fcmToken: String): String {
+        val connection = (URL("${config.backendUrl}/api/push/subscriptions").openConnection() as HttpURLConnection)
+            .apply {
+                requestMethod = "POST"
+                doOutput = true
+                connectTimeout = 10_000
+                readTimeout = 10_000
+                setRequestProperty("Authorization", "Bearer ${config.authToken}")
+                setRequestProperty("Content-Type", "application/json")
+            }
+        val body = JSONObject()
+            .put("platform", "fcm")
+            .put("endpoint_or_token", fcmToken)
+            .put("p256dh", JSONObject.NULL)
+            .put("auth", JSONObject.NULL)
+            .put("device_label", config.deviceLabel)
+            .toString()
+        return try {
+            connection.outputStream.use { output ->
+                output.write(body.toByteArray(Charsets.UTF_8))
+            }
+            val responseBody = if (connection.responseCode in 200..299) {
+                connection.inputStream.bufferedReader().use { it.readText() }
+            } else {
+                connection.errorStream?.bufferedReader()?.use { it.readText() }.orEmpty()
+            }
+            if (connection.responseCode !in 200..299) {
+                throw IllegalStateException("FCM subscription returned ${connection.responseCode}")
+            }
+            JSONObject(responseBody).optString("id")
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun deleteSubscription(config: FcmConfig, subscriptionId: String) {
+        val connection = (URL("${config.backendUrl}/api/push/subscriptions/$subscriptionId").openConnection() as HttpURLConnection)
+            .apply {
+                requestMethod = "DELETE"
+                connectTimeout = 10_000
+                readTimeout = 10_000
+                setRequestProperty("Authorization", "Bearer ${config.authToken}")
+            }
+        try {
+            connection.responseCode
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun defaultDeviceLabel(): String {
+        val model = listOf(Build.MANUFACTURER, Build.MODEL)
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+            .ifBlank { "Android" }
+        return "Agent Portal Android ($model)"
+    }
+
+    private data class FcmConfig(
+        val backendUrl: String,
+        val authToken: String,
+        val deviceLabel: String,
+    )
+}

--- a/mobile/status-notification-plugin/android/src/main/java/PortalFirebaseMessagingService.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/PortalFirebaseMessagingService.kt
@@ -1,0 +1,16 @@
+package io.txcl.agentportal.status
+
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+class PortalFirebaseMessagingService : FirebaseMessagingService() {
+    override fun onNewToken(token: String) {
+        PortalFcmBridge.onNewToken(applicationContext, token)
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        if (message.data.isNotEmpty()) {
+            PortalFcmBridge.onDataMessage(applicationContext)
+        }
+    }
+}

--- a/mobile/status-notification-plugin/android/src/main/java/StatusNotificationPlugin.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusNotificationPlugin.kt
@@ -23,6 +23,13 @@ class ShowArgs {
     lateinit var sessionsJson: String
 }
 
+@InvokeArg
+class FcmRegistrationArgs {
+    lateinit var backendUrl: String
+    lateinit var authToken: String
+    lateinit var deviceLabel: String
+}
+
 @TauriPlugin
 class StatusNotificationPlugin(private val activity: Activity) : Plugin(activity) {
     @Command
@@ -56,6 +63,32 @@ class StatusNotificationPlugin(private val activity: Activity) : Plugin(activity
                 action = StatusNotificationService.ACTION_CLEAR
             }
             activity.startService(intent)
+            invoke.resolve()
+        } catch (ex: Exception) {
+            invoke.reject(ex.message)
+        }
+    }
+
+    @Command
+    fun registerFcm(invoke: Invoke) {
+        try {
+            val args = invoke.parseArgs(FcmRegistrationArgs::class.java)
+            PortalFcmBridge.register(
+                context = activity.applicationContext,
+                backendUrl = args.backendUrl,
+                authToken = args.authToken,
+                deviceLabel = args.deviceLabel,
+            )
+            invoke.resolve()
+        } catch (ex: Exception) {
+            invoke.reject(ex.message)
+        }
+    }
+
+    @Command
+    fun unregisterFcm(invoke: Invoke) {
+        try {
+            PortalFcmBridge.unregister(activity.applicationContext)
             invoke.resolve()
         } catch (ex: Exception) {
             invoke.reject(ex.message)

--- a/mobile/status-notification-plugin/android/src/main/java/StatusNotificationService.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusNotificationService.kt
@@ -7,10 +7,12 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 
 class StatusNotificationService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -134,5 +136,32 @@ class StatusNotificationService : Service() {
         private const val NOTIFICATION_ID = 2401
         private const val MAX_LINES = 5
         private const val MAX_ACTIONS = 3
+
+        fun showStored(context: Context) {
+            if (Build.VERSION.SDK_INT >= 33 &&
+                ContextCompat.checkSelfPermission(
+                    context,
+                    android.Manifest.permission.POST_NOTIFICATIONS,
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                return
+            }
+            val config = StatusPayloadStore.loadRefreshConfig(context) ?: return
+            val payload = StatusPayloadStore.load(context)
+            val sessionsJson = StatusPayloadStore.statusLinesJson(payload.sessions)
+            if (sessionsJson == "[]") return
+            val intent = Intent(context, StatusNotificationService::class.java).apply {
+                action = ACTION_SHOW
+                putExtra(EXTRA_TITLE, "Agent Portal sessions")
+                putExtra(EXTRA_SUMMARY, payload.summary)
+                putExtra(EXTRA_DASHBOARD_URL, payload.dashboardUrl)
+                putExtra(EXTRA_STATUS_URL, config.statusUrl)
+                putExtra(EXTRA_AUTH_TOKEN, config.authToken)
+                putExtra(EXTRA_SESSIONS_JSON, sessionsJson)
+            }
+            runCatching {
+                ContextCompat.startForegroundService(context, intent)
+            }
+        }
     }
 }

--- a/mobile/status-notification-plugin/android/src/main/java/StatusWidgetData.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusWidgetData.kt
@@ -188,7 +188,7 @@ object StatusPayloadStore {
         }
     }
 
-    private fun statusLinesJson(lines: List<StatusSession>): String {
+    fun statusLinesJson(lines: List<StatusSession>): String {
         val array = JSONArray()
         lines.forEach { line ->
             array.put(

--- a/mobile/status-notification-plugin/android/src/main/java/StatusWidgetRefreshWorker.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusWidgetRefreshWorker.kt
@@ -31,7 +31,10 @@ class StatusWidgetRefreshWorker(
                     responseBody = response.body,
                 )
                 StatusWidgetProvider.updateAll(applicationContext)
-                if (hasSessions) Result.success() else {
+                if (hasSessions) {
+                    StatusNotificationService.showStored(applicationContext)
+                    Result.success()
+                } else {
                     cancel(applicationContext)
                     Result.success()
                 }

--- a/mobile/status-notification-plugin/permissions/autogenerated/commands/register-fcm.toml
+++ b/mobile/status-notification-plugin/permissions/autogenerated/commands/register-fcm.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-register-fcm"
+description = "Allows registering the Android FCM push token with Agent Portal."
+commands.allow = ["registerFcm"]
+
+[[permission]]
+identifier = "deny-register-fcm"
+description = "Denies registering the Android FCM push token with Agent Portal."
+commands.deny = ["registerFcm"]

--- a/mobile/status-notification-plugin/permissions/autogenerated/commands/unregister-fcm.toml
+++ b/mobile/status-notification-plugin/permissions/autogenerated/commands/unregister-fcm.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-unregister-fcm"
+description = "Allows unregistering the Android FCM push token from Agent Portal."
+commands.allow = ["unregisterFcm"]
+
+[[permission]]
+identifier = "deny-unregister-fcm"
+description = "Denies unregistering the Android FCM push token from Agent Portal."
+commands.deny = ["unregisterFcm"]

--- a/mobile/status-notification-plugin/permissions/autogenerated/reference.md
+++ b/mobile/status-notification-plugin/permissions/autogenerated/reference.md
@@ -6,7 +6,6 @@
 <th>Description</th>
 </tr>
 
-
 <tr>
 <td>
 
@@ -23,12 +22,12 @@ Enables the clear command without any pre-configured scope.
 <tr>
 <td>
 
-`agent-portal-mobile-status-notification:deny-clear`
+`agent-portal-mobile-status-notification:allow-register-fcm`
 
 </td>
 <td>
 
-Denies the clear command without any pre-configured scope.
+Allows registering the Android FCM push token with Agent Portal.
 
 </td>
 </tr>
@@ -49,12 +48,64 @@ Enables the show command without any pre-configured scope.
 <tr>
 <td>
 
+`agent-portal-mobile-status-notification:allow-unregister-fcm`
+
+</td>
+<td>
+
+Allows unregistering the Android FCM push token from Agent Portal.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`agent-portal-mobile-status-notification:deny-clear`
+
+</td>
+<td>
+
+Denies the clear command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`agent-portal-mobile-status-notification:deny-register-fcm`
+
+</td>
+<td>
+
+Denies registering the Android FCM push token with Agent Portal.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `agent-portal-mobile-status-notification:deny-show`
 
 </td>
 <td>
 
 Denies the show command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`agent-portal-mobile-status-notification:deny-unregister-fcm`
+
+</td>
+<td>
+
+Denies unregistering the Android FCM push token from Agent Portal.
 
 </td>
 </tr>

--- a/mobile/status-notification-plugin/src/lib.rs
+++ b/mobile/status-notification-plugin/src/lib.rs
@@ -32,6 +32,14 @@ pub struct ClearStatusNotification;
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct FcmRegistrationPayload {
+    pub backend_url: String,
+    pub auth_token: String,
+    pub device_label: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StatusNotificationLine {
     pub session_id: String,
     pub name: String,
@@ -83,6 +91,33 @@ impl<R: Runtime> StatusNotification<R> {
         {
             self.0
                 .run_mobile_plugin("clear", ClearStatusNotification)
+                .map_err(Into::into)
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            Ok(())
+        }
+    }
+
+    pub fn register_fcm(&self, payload: FcmRegistrationPayload) -> Result<()> {
+        #[cfg(target_os = "android")]
+        {
+            self.0
+                .run_mobile_plugin("registerFcm", payload)
+                .map_err(Into::into)
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            let _ = payload;
+            Ok(())
+        }
+    }
+
+    pub fn unregister_fcm(&self) -> Result<()> {
+        #[cfg(target_os = "android")]
+        {
+            self.0
+                .run_mobile_plugin("unregisterFcm", ClearStatusNotification)
                 .map_err(Into::into)
         }
         #[cfg(not(target_os = "android"))]


### PR DESCRIPTION
## Summary
- add the Android FirebaseMessaging bridge for E5, with runtime-gated token registration when Firebase is configured
- register/rotate FCM tokens via POST /api/push/subscriptions using platform=fcm and null Web Push key fields
- delete the saved backend subscription when the shell clears rejected mobile auth
- route FCM data messages into the existing status refresh path so notification/widget payloads refresh from GET /api/agent/sessions
- document Firebase project, google-services.json, conditional generated-app Gradle wiring, and PORTAL_FCM_SERVICE_ACCOUNT_PATH provisioning

## CI/credentials behavior
- Android builds compile without google-services.json; registration no-ops at runtime until FirebaseApp can initialize
- Google Services plugin application remains a generated Android app wiring step and must be conditional on google-services.json existing

## Local checks
- cargo fmt --check
- cargo check -p agent-portal-mobile
- cargo clippy -p agent-portal-mobile -- -D warnings
- git diff --check origin/main..HEAD

## Note
- local aarch64 Android clippy/build could not run because this environment has no Java/JAVA_HOME/NDK toolchain; the Android Debug APK workflow is the binding check for Kotlin/Gradle.