### PR TITLE
Add Android widget staleness hint

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -92,7 +92,11 @@ whenever the notification poller receives fresh status.
 The widget also schedules a native WorkManager refresh using the same stored
 mobile JWT and status endpoint. Android enforces a 15-minute minimum interval
 for periodic work; widget system updates also enqueue a one-time refresh when
-network is available.
+network is available. The widget summary includes a compact freshness label,
+switching to a stale marker after the expected refresh window so cached session
+state is visible as cached state. Tapping the widget opens the dashboard deep
+link, which brings the app process back and lets the poller/one-shot refresh
+run again.
 
 On Android 13+, the first status update requests `POST_NOTIFICATIONS`; if the
 permission is not granted yet, the shell skips the update and retries on the

--- a/mobile/status-notification-plugin/android/src/main/java/StatusWidgetData.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusWidgetData.kt
@@ -17,6 +17,7 @@ data class StatusPayload(
     val summary: String,
     val dashboardUrl: String,
     val sessions: List<StatusSession>,
+    val updatedAtMillis: Long,
 )
 
 object StatusPayloadStore {
@@ -26,6 +27,7 @@ object StatusPayloadStore {
     private const val KEY_STATUS_URL = "status_url"
     private const val KEY_AUTH_TOKEN = "auth_token"
     private const val KEY_SESSIONS_JSON = "sessions_json"
+    private const val KEY_UPDATED_AT_MS = "updated_at_ms"
 
     fun save(
         context: Context,
@@ -42,6 +44,7 @@ object StatusPayloadStore {
             .putString(KEY_STATUS_URL, statusUrl)
             .putString(KEY_AUTH_TOKEN, authToken)
             .putString(KEY_SESSIONS_JSON, sessionsJson)
+            .putLong(KEY_UPDATED_AT_MS, System.currentTimeMillis())
             .apply()
     }
 
@@ -59,6 +62,7 @@ object StatusPayloadStore {
             summary = prefs.getString(KEY_SUMMARY, "No active sessions") ?: "No active sessions",
             dashboardUrl = prefs.getString(KEY_DASHBOARD_URL, "") ?: "",
             sessions = parseSessions(sessionsJson),
+            updatedAtMillis = prefs.getLong(KEY_UPDATED_AT_MS, 0L),
         )
     }
 

--- a/mobile/status-notification-plugin/android/src/main/java/StatusWidgetProvider.kt
+++ b/mobile/status-notification-plugin/android/src/main/java/StatusWidgetProvider.kt
@@ -86,7 +86,29 @@ class StatusWidgetProvider : AppWidgetProvider() {
 
         private fun widgetSummary(payload: StatusPayload, sessions: List<StatusSession>): String {
             if (sessions.isEmpty()) return "No active sessions"
-            return payload.summary.ifBlank { "${sessions.size} active" }
+            val summary = payload.summary.ifBlank { "${sessions.size} active" }
+            val freshness = freshnessLabel(payload.updatedAtMillis)
+            return if (freshness.isBlank()) summary else "$summary • $freshness"
+        }
+
+        private fun freshnessLabel(updatedAtMillis: Long): String {
+            if (updatedAtMillis <= 0L) return ""
+            val ageMillis = (System.currentTimeMillis() - updatedAtMillis).coerceAtLeast(0L)
+            val age = compactAge(ageMillis)
+            return if (ageMillis > STALE_AFTER_MILLIS) {
+                "stale $age"
+            } else {
+                "updated $age"
+            }
+        }
+
+        private fun compactAge(ageMillis: Long): String {
+            val minutes = ageMillis / 60_000L
+            if (minutes < 1L) return "now"
+            if (minutes < 60L) return "${minutes}m"
+            val hours = minutes / 60L
+            if (hours < 24L) return "${hours}h"
+            return "${hours / 24L}d"
         }
 
         private fun bindRow(
@@ -132,5 +154,7 @@ class StatusWidgetProvider : AppWidgetProvider() {
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
             )
         }
+
+        private const val STALE_AFTER_MILLIS = 20L * 60L * 1000L
     }
 }


### PR DESCRIPTION
## Summary
- persist a widget payload refresh timestamp when native status data is saved
- show a compact updated/stale freshness label in the widget summary
- document that widget taps reopen the dashboard/app and restart refresh paths

## Verification
- cargo fmt --check
- cargo check -p agent-portal-mobile
- cargo clippy -p agent-portal-mobile -- -D warnings
- git diff --check