### PR TITLE
fix: persist backend_url with auth token on login (server switching)

### DIFF
--- a/launcher/src/config.rs
+++ b/launcher/src/config.rs
@@ -35,9 +35,21 @@ fn config_path() -> PathBuf {
     config_dir().join("launcher.json")
 }
 
+/// Human-readable location of the launcher config, for user-facing messages
+/// (e.g. telling `login` where it just saved credentials).
+pub fn config_path_display() -> String {
+    config_path().display().to_string()
+}
+
 pub fn load_config() -> LauncherConfig {
-    let path = config_path();
-    match std::fs::read_to_string(&path) {
+    load_config_at(&config_path())
+}
+
+/// Load a [`LauncherConfig`] from an explicit path. Split out from
+/// [`load_config`] so the read-modify-write helpers can be tested against a
+/// temp path (mirrors the [`read_or_create_id`] seam).
+fn load_config_at(path: &Path) -> LauncherConfig {
+    match std::fs::read_to_string(path) {
         Ok(contents) => match serde_json::from_str(&contents) {
             Ok(config) => {
                 tracing::info!("Loaded config from {}", path.display());
@@ -79,6 +91,31 @@ pub fn save_auth_token(token: &str) -> anyhow::Result<()> {
     config.auth_token = Some(token.to_string());
     save_config(&config)?;
     tracing::info!("Saved auth token to {}", config_path().display());
+    Ok(())
+}
+
+/// Persist `backend_url` and `auth_token` together in a single load/save cycle.
+///
+/// A token is only valid against the server that minted it, so the two MUST be
+/// written as a pair: `agent-portal login --backend-url wss://newhost` that
+/// stored only the token would leave `backend_url` pointing at the old server,
+/// and the next plain run (or the installed launchd/systemd unit, whose
+/// command line carries no `--backend-url`) would connect to the old host with
+/// a token it won't accept. Callers pass the *resolved* URL so a flag-supplied
+/// host sticks for subsequent runs. (`save_auth_token` remains for same-server
+/// token refreshes, where `backend_url` must not change.)
+pub fn save_credentials(backend_url: &str, token: &str) -> anyhow::Result<()> {
+    save_credentials_at(&config_path(), backend_url, token)
+}
+
+/// [`save_credentials`] against an explicit path, so the atomic round-trip can
+/// be unit-tested without touching the real config location.
+fn save_credentials_at(path: &Path, backend_url: &str, token: &str) -> anyhow::Result<()> {
+    let mut config = load_config_at(path);
+    config.backend_url = Some(backend_url.to_string());
+    config.auth_token = Some(token.to_string());
+    let contents = serde_json::to_string_pretty(&config)?;
+    write_config_atomic(path, &contents)?;
     Ok(())
 }
 
@@ -156,6 +193,44 @@ mod tests {
             Uuid::parse_str(std::fs::read_to_string(&path).unwrap().trim()).unwrap(),
             id
         );
+    }
+
+    #[test]
+    fn save_credentials_persists_both_fields_together() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("launcher.json");
+
+        // Fresh file: both fields land together.
+        save_credentials_at(&path, "wss://newhost.example", "tok_new").unwrap();
+        let config = load_config_at(&path);
+        assert_eq!(config.backend_url.as_deref(), Some("wss://newhost.example"));
+        assert_eq!(config.auth_token.as_deref(), Some("tok_new"));
+
+        // Switching servers updates the URL *and* the token in one cycle — the
+        // stale-URL-with-new-token drift this bug was about must not survive.
+        save_credentials_at(&path, "wss://other.example", "tok_other").unwrap();
+        let switched = load_config_at(&path);
+        assert_eq!(switched.backend_url.as_deref(), Some("wss://other.example"));
+        assert_eq!(switched.auth_token.as_deref(), Some("tok_other"));
+    }
+
+    #[test]
+    fn save_credentials_preserves_unrelated_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("launcher.json");
+        std::fs::write(
+            &path,
+            r#"{"backend_url":"wss://old","auth_token":"old","name":"my-launcher"}"#,
+        )
+        .unwrap();
+
+        save_credentials_at(&path, "wss://new", "tok_new").unwrap();
+
+        let config = load_config_at(&path);
+        assert_eq!(config.backend_url.as_deref(), Some("wss://new"));
+        assert_eq!(config.auth_token.as_deref(), Some("tok_new"));
+        // The load/save cycle must not drop fields it doesn't touch.
+        assert_eq!(config.name.as_deref(), Some("my-launcher"));
     }
 
     #[test]

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -314,8 +314,12 @@ async fn main() -> anyhow::Result<()> {
     if args.auth_token.is_none() && config.auth_token.is_none() && !args.dev {
         tracing::info!("No auth token found, starting device flow authentication");
         let result = portal_auth::device_flow_login(&backend_url, None).await?;
-        if let Err(e) = config::save_auth_token(&result.access_token) {
-            tracing::warn!("Failed to save auth token to config: {}", e);
+        // Persist the resolved backend_url alongside the token: the token is
+        // only valid against the server that minted it, so a plain restart or
+        // the installed service (no --backend-url on its command line) must
+        // reconnect to the same host.
+        if let Err(e) = config::save_credentials(&backend_url, &result.access_token) {
+            tracing::warn!("Failed to save credentials to config: {}", e);
         }
     }
     let launcher_name = args
@@ -364,9 +368,17 @@ async fn cmd_login(args: &Args) -> anyhow::Result<()> {
 
     println!("Authenticating with {}...", backend_url);
     let result = portal_auth::device_flow_login(&backend_url, None).await?;
-    config::save_auth_token(&result.access_token)?;
+    // Store the resolved backend_url with the token so switching servers
+    // (e.g. `login --backend-url wss://newhost`) sticks — a token minted by
+    // one server won't authenticate against another.
+    config::save_credentials(&backend_url, &result.access_token)?;
     println!();
     println!("Logged in as {}", result.user_email);
+    println!(
+        "Credentials for {} saved to {}",
+        backend_url,
+        config::config_path_display()
+    );
     Ok(())
 }
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -672,7 +672,14 @@ async fn resolve_auth_token(
             auth_token: result.access_token.clone(),
             user_email: Some(result.user_email),
             last_used: chrono::Utc::now().to_rfc3339(),
-            backend_url: None,
+            // Pin the resolved backend_url to the token we just minted. The
+            // two are only valid as a pair (a token authenticates against the
+            // server that issued it), and this per-directory URL is what the
+            // next run resolves before falling back to the default — so a
+            // `--backend-url wss://newhost` login must persist newhost here,
+            // otherwise the next plain run reconnects to the default host with
+            // a mismatched token.
+            backend_url: Some(backend_url.to_string()),
         },
     );
     config.atomic_save()?;


### PR DESCRIPTION
## Problem

A token is only valid against the server that minted it, yet the launcher's login paths persisted **only** the token, never `backend_url`.

Scenario: a user switching portals runs `agent-portal login --backend-url wss://portal.cosmicfrontier.org`. The device flow authenticates against the new host and stores its token, but `launcher.json` still has `backend_url: wss://txcl.io` from before. The next plain run — or, worse, the installed launchd/systemd service, whose unit command line carries **no** `--backend-url` flag — resolves the old host and connects with a token that host won't accept. The config is stuck wrong until manually edited.

## Fix (root cause, minimal)

**Launcher (`agent-portal`):**
- Add `config::save_credentials(backend_url, token)` — writes both fields atomically in a single load/save cycle (reusing the existing write-temp+rename seam), with a doc comment explaining *why* they must travel together (this bug).
- Call it from **both** successful `device_flow_login` sites — the `login` subcommand and the login-during-run bootstrap — persisting the **resolved** URL, so even a flag-supplied host sticks for later runs.
- `save_auth_token` is kept for the `TokenRefresh` path (same server re-issues a token; `backend_url` must not change).
- `login` now prints where credentials were saved and for which backend.
- Unit tests: round-trip that both fields persist together across a server switch, and that unrelated fields (e.g. `name`) survive the cycle.

**Proxy (`claude-portal`):** had the same class of bug — `resolve_auth_token` saved the per-directory `SessionAuth` with `backend_url: None`, so the next run fell back to the default host. Now it pins the resolved `backend_url` to the token it just minted (the `SessionAuth.backend_url` field and `get/set_backend_url` machinery already existed for exactly this).

## Verification
- `cargo build -p agent-portal -p claude-portal`
- `cargo test -p agent-portal` (incl. new `save_credentials_*` tests)
- `cargo clippy --workspace --exclude frontend --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)