### PR TITLE
Add opt-in git worktree creation for new sessions (#1325)

### DIFF
--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -79,6 +79,8 @@ pub async fn launch_session(
         agent_type: req.agent_type,
         scheduled_task_id: None,
         resume_session_id: Some(session_id),
+        create_worktree: req.create_worktree,
+        worktree_branch: req.worktree_branch.clone(),
     };
 
     if !app_state

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -314,6 +314,10 @@ pub async fn resume_session(
         agent_type,
         scheduled_task_id: session.scheduled_task_id,
         resume_session_id: Some(session.id),
+        // Resuming an existing session: run in its recorded working directory,
+        // never create a new worktree.
+        create_worktree: false,
+        worktree_branch: None,
     };
 
     if !app_state

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -747,6 +747,8 @@ fn handle_launcher_message(
                         agent_type,
                         scheduled_task_id,
                         resume_session_id: last_session_id,
+                        create_worktree: false,
+                        worktree_branch: None,
                     };
                     if !app_state
                         .session_manager
@@ -1086,6 +1088,8 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
             agent_type,
             scheduled_task_id: None,
             resume_session_id: Some(session.id),
+            create_worktree: false,
+            worktree_branch: None,
         };
 
         if !app_state

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -219,6 +219,10 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     // own default. Reset on agent switch since the catalogs don't overlap.
     let model_arg = use_state(String::new);
     let skip_permissions = use_state(|| false);
+    // Opt-in git worktree: when checked, the launcher creates a worktree from
+    // the repo containing the chosen directory and runs the session there.
+    let create_worktree = use_state(|| false);
+    let worktree_branch = use_state(String::new);
     let launching = use_state(|| false);
     let error_msg = use_state(|| None::<String>);
     let debounce_handle = use_mut_ref(|| None::<Timeout>);
@@ -330,6 +334,24 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         })
     };
 
+    let on_create_worktree = {
+        let create_worktree = create_worktree.clone();
+        Callback::from(move |e: Event| {
+            if let Some(input) = e.target_dyn_into::<HtmlInputElement>() {
+                create_worktree.set(input.checked());
+            }
+        })
+    };
+
+    let on_worktree_branch_input = {
+        let worktree_branch = worktree_branch.clone();
+        Callback::from(move |e: InputEvent| {
+            if let Some(input) = e.target_dyn_into::<HtmlInputElement>() {
+                worktree_branch.set(input.value());
+            }
+        })
+    };
+
     // navigate_to: Yew's Callback<String> is Rc-backed and cheap to clone,
     // replacing the previous Rc<dyn Fn(String)>. Call sites use .emit(path).
     let navigate_to: Callback<String> = {
@@ -390,6 +412,8 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let agent_type = agent_type.clone();
         let model_arg = model_arg.clone();
         let skip_permissions = skip_permissions.clone();
+        let create_worktree = create_worktree.clone();
+        let worktree_branch = worktree_branch.clone();
         let selected_launcher = selected_launcher.clone();
         let launching = launching.clone();
         let error_msg = error_msg.clone();
@@ -432,6 +456,13 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
             let launcher_id = *selected_launcher;
             let selected_agent_type = *agent_type;
+            let want_worktree = *create_worktree;
+            let branch = (*worktree_branch).trim().to_string();
+            let branch = if branch.is_empty() {
+                None
+            } else {
+                Some(branch)
+            };
             let launching = launching.clone();
             let error_msg = error_msg.clone();
             let on_close = on_close.clone();
@@ -446,6 +477,8 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     launcher_id,
                     claude_args,
                     agent_type: selected_agent_type,
+                    create_worktree: want_worktree,
+                    worktree_branch: branch,
                 };
 
                 match Request::post("/api/launch")
@@ -763,6 +796,31 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                             { format!(" {}", skip_permissions_label(*agent_type)) }
                         </label>
                     </div>
+
+                    // Git worktree: create an isolated worktree for this session
+                    // when the chosen directory lives in a git repository.
+                    <div class="launch-field launch-checkbox">
+                        <label>
+                            <input
+                                type="checkbox"
+                                checked={*create_worktree}
+                                onchange={on_create_worktree.clone()}
+                            />
+                            { " Create git worktree (requires a git repo)" }
+                        </label>
+                    </div>
+
+                    if *create_worktree {
+                        <div class="launch-field">
+                            <label>{ "Worktree branch (optional)" }</label>
+                            <input
+                                type="text"
+                                placeholder="defaults to session-<timestamp>"
+                                value={(*worktree_branch).clone()}
+                                oninput={on_worktree_branch_input.clone()}
+                            />
+                        </div>
+                    }
 
                     if let Some(ref err) = *error_msg {
                         <p class="launch-error">{ err }</p>

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -537,6 +537,8 @@ async fn handle_message(
             claude_args,
             agent_type,
             resume_session_id,
+            create_worktree,
+            worktree_branch,
             ..
         } => {
             // Check if this is a scheduler-owned launch.
@@ -566,6 +568,10 @@ async fn handle_message(
                     agent_type,
                     scheduled_task_id,
                     resume_session_id,
+                    // Scheduler-owned relaunches never create a worktree; the
+                    // backend leaves these fields at their defaults for them.
+                    create_worktree,
+                    worktree_branch,
                 })
                 .await;
 

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -11,6 +11,7 @@ mod path_policy;
 mod process_manager;
 mod scheduler;
 mod service;
+mod worktree;
 
 use clap::{Parser, Subcommand};
 use tracing::{info, warn};

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -102,6 +102,12 @@ pub struct SpawnParams {
     pub agent_type: shared::AgentType,
     pub scheduled_task_id: Option<Uuid>,
     pub resume_session_id: Option<Uuid>,
+    /// When true, create a git worktree from the repository containing
+    /// `working_directory` and run the session inside the new worktree.
+    pub create_worktree: bool,
+    /// Optional branch name for the worktree. When omitted a timestamped
+    /// default (`session-<YYYYMMDD-HHMMSS>`) is derived.
+    pub worktree_branch: Option<String>,
 }
 
 pub struct ProcessManager {
@@ -151,10 +157,24 @@ impl ProcessManager {
             );
         }
 
-        let working_directory =
-            path_policy::ensure_existing_dir_under_home(&params.working_directory)?
-                .to_string_lossy()
-                .to_string();
+        // Resolve (and validate) the base directory the request targets. It
+        // must exist and live under the launcher user's home directory.
+        let base_dir = path_policy::ensure_existing_dir_under_home(&params.working_directory)?;
+
+        // When the request opts into a worktree, create it from the repo that
+        // contains `base_dir` and run the session there instead. Otherwise the
+        // session runs directly in `base_dir`.
+        let working_directory = if params.create_worktree {
+            let worktree =
+                crate::worktree::create_worktree(&base_dir, params.worktree_branch.as_deref())?;
+            // The derived worktree must also be under home (create_worktree
+            // places it inside the repo, which already passed the check, but we
+            // re-validate defensively before running anything there).
+            path_policy::ensure_canonical_path_under_home(&worktree)?;
+            worktree.to_string_lossy().to_string()
+        } else {
+            base_dir.to_string_lossy().to_string()
+        };
 
         let (session_id, resume) = match params.resume_session_id {
             Some(id) => (id, true),

--- a/launcher/src/worktree.rs
+++ b/launcher/src/worktree.rs
@@ -1,0 +1,256 @@
+//! Opt-in git worktree creation for launched sessions (issue #1325).
+//!
+//! When a launch request sets `create_worktree`, the launcher creates a git
+//! worktree from the repository containing the requested directory and runs the
+//! session inside it, instead of running directly in the requested directory.
+//!
+//! ## Design decisions
+//!
+//! - **Location.** Worktrees live under `<repo_root>/.worktrees/<branch>`, where
+//!   `<repo_root>` is the top level reported by `git rev-parse --show-toplevel`.
+//!   Keeping them inside the repo guarantees they stay under the launcher user's
+//!   home directory (the launcher refuses to run anywhere else) and keeps them
+//!   discoverable next to the repo they belong to. Add `/.worktrees/` to the
+//!   repo's `.gitignore` so the checkouts don't show up as untracked files in
+//!   the primary working tree.
+//! - **Branch naming.** A caller-supplied branch is sanitized to a git-safe
+//!   name. When none is given we derive `session-<YYYYMMDD-HHMMSS>` so each new
+//!   session gets its own branch.
+//! - **Idempotency.** If the target worktree path already exists we reuse it
+//!   (a resume/relaunch shouldn't fail because the worktree is already there).
+//!   If the branch already exists we check it out into the new worktree instead
+//!   of trying to create it again.
+//! - **Lifecycle / cleanup.** v1 leaves cleanup manual: worktrees are *not*
+//!   removed when the session ends. Remove them with
+//!   `git worktree remove <path>` (and optionally delete the branch) when you no
+//!   longer need them. Automatic cleanup on session end is intentionally out of
+//!   scope for v1 — a session may end while its work is still uncommitted.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tracing::info;
+
+/// Create (or reuse) a git worktree for a session.
+///
+/// `base_dir` must be an existing directory inside a git repository. Returns the
+/// path to the worktree the session should run in.
+pub fn create_worktree(base_dir: &Path, branch: Option<&str>) -> Result<PathBuf> {
+    let repo_root = git_repo_root(base_dir).with_context(|| {
+        format!(
+            "Cannot create a worktree: {} is not inside a git repository",
+            base_dir.display()
+        )
+    })?;
+
+    let branch_name = branch
+        .map(sanitize_branch_name)
+        .filter(|b| !b.is_empty())
+        .unwrap_or_else(default_branch_name);
+
+    let worktree_path = repo_root.join(".worktrees").join(&branch_name);
+
+    // Reuse an existing worktree checkout rather than failing on relaunch.
+    if worktree_path.is_dir() {
+        info!(
+            "Reusing existing git worktree at {}",
+            worktree_path.display()
+        );
+        return worktree_path.canonicalize().with_context(|| {
+            format!(
+                "Failed to resolve worktree path {}",
+                worktree_path.display()
+            )
+        });
+    }
+
+    if let Some(parent) = worktree_path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create worktree parent directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let worktree_str = worktree_path.to_string_lossy().to_string();
+
+    // Try to create a brand-new branch for this worktree.
+    let create_new = run_git(
+        &repo_root,
+        &["worktree", "add", "-b", &branch_name, &worktree_str],
+    )?;
+
+    if !create_new.success {
+        // The branch may already exist — check it out into the worktree instead.
+        let check_out_existing = run_git(
+            &repo_root,
+            &["worktree", "add", &worktree_str, &branch_name],
+        )?;
+        if !check_out_existing.success {
+            anyhow::bail!(
+                "git worktree add failed: {} (retry with existing branch: {})",
+                create_new.stderr.trim(),
+                check_out_existing.stderr.trim()
+            );
+        }
+    }
+
+    info!(
+        "Created git worktree at {} on branch {}",
+        worktree_path.display(),
+        branch_name
+    );
+
+    worktree_path.canonicalize().with_context(|| {
+        format!(
+            "Failed to resolve worktree path {}",
+            worktree_path.display()
+        )
+    })
+}
+
+/// Return the top-level directory of the git repository containing `cwd`.
+fn git_repo_root(cwd: &Path) -> Option<PathBuf> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let root = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if root.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(root))
+}
+
+struct GitOutput {
+    success: bool,
+    stderr: String,
+}
+
+fn run_git(cwd: &Path, args: &[&str]) -> Result<GitOutput> {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .with_context(|| format!("Failed to run git {}", args.join(" ")))?;
+    Ok(GitOutput {
+        success: out.status.success(),
+        stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+    })
+}
+
+/// Reduce an arbitrary user string to a git-safe branch name.
+///
+/// Replaces any character outside `[A-Za-z0-9._/-]` with `-`, collapses runs of
+/// `-`, and trims leading/trailing separators. Returns an empty string if
+/// nothing usable remains (the caller then falls back to the default).
+fn sanitize_branch_name(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '/' | '-') {
+            out.push(ch);
+        } else {
+            out.push('-');
+        }
+    }
+    // Collapse consecutive '-' and trim separators from the ends.
+    let mut collapsed = String::with_capacity(out.len());
+    let mut prev_dash = false;
+    for ch in out.chars() {
+        if ch == '-' {
+            if !prev_dash {
+                collapsed.push(ch);
+            }
+            prev_dash = true;
+        } else {
+            collapsed.push(ch);
+            prev_dash = false;
+        }
+    }
+    collapsed
+        .trim_matches(|c| c == '-' || c == '/' || c == '.')
+        .to_string()
+}
+
+fn default_branch_name() -> String {
+    format!("session-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizes_unsafe_characters() {
+        assert_eq!(sanitize_branch_name("my feature"), "my-feature");
+        assert_eq!(sanitize_branch_name("fix/bug #42"), "fix/bug-42");
+        assert_eq!(sanitize_branch_name("  spaces  "), "spaces");
+        assert_eq!(sanitize_branch_name("a~b^c:d"), "a-b-c-d");
+        assert_eq!(sanitize_branch_name("--weird--"), "weird");
+        assert_eq!(sanitize_branch_name("///"), "");
+    }
+
+    #[test]
+    fn preserves_reasonable_branch_names() {
+        assert_eq!(
+            sanitize_branch_name("feature/new-thing"),
+            "feature/new-thing"
+        );
+        assert_eq!(sanitize_branch_name("v2.1.0"), "v2.1.0");
+    }
+
+    #[test]
+    fn default_branch_has_session_prefix() {
+        assert!(default_branch_name().starts_with("session-"));
+    }
+
+    #[test]
+    fn create_worktree_from_git_repo() {
+        // Skip when git isn't available in the environment.
+        if Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+
+        let tmp = std::env::temp_dir().join(format!("wt-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let run = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(&tmp)
+                .output()
+                .unwrap()
+        };
+        run(&["init", "-q"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(tmp.join("README.md"), "hi").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-qm", "init"]);
+
+        let wt = create_worktree(&tmp, Some("my-session")).unwrap();
+        assert!(wt.is_dir());
+        assert!(wt.ends_with(".worktrees/my-session"));
+        assert!(wt.join("README.md").exists());
+
+        // Reuse path (idempotent) on a second call.
+        let wt2 = create_worktree(&tmp, Some("my-session")).unwrap();
+        assert_eq!(wt, wt2);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn create_worktree_rejects_non_repo() {
+        let tmp = std::env::temp_dir().join(format!("wt-nonrepo-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let err = create_worktree(&tmp, None).unwrap_err();
+        assert!(err.to_string().contains("not inside a git repository"));
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/shared/src/api/launch.rs
+++ b/shared/src/api/launch.rs
@@ -12,6 +12,17 @@ pub struct LaunchRequest {
     pub claude_args: Vec<String>,
     #[serde(default)]
     pub agent_type: crate::AgentType,
+    /// When true, the launcher creates a git worktree from the repository that
+    /// contains `working_directory` and runs the session inside the new
+    /// worktree instead of `working_directory` itself. Requires
+    /// `working_directory` to be inside a git repository. Additive/opt-in:
+    /// older launchers ignore it via `#[serde(default)]`.
+    #[serde(default)]
+    pub create_worktree: bool,
+    /// Optional branch name for the worktree. When omitted, the launcher
+    /// derives a timestamped default (e.g. `session-20260715-143022`).
+    #[serde(default)]
+    pub worktree_branch: Option<String>,
 }
 
 /// Response from GET /api/launchers/:launcher_id/directories?path=…

--- a/shared/src/endpoints/launcher.rs
+++ b/shared/src/endpoints/launcher.rs
@@ -225,6 +225,15 @@ pub enum ServerToLauncher {
         /// use its local expected-session mapping for backwards compatibility.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         resume_session_id: Option<Uuid>,
+        /// When true, the launcher creates a git worktree from the repository
+        /// that contains `working_directory` and runs the session there.
+        /// Additive/opt-in: older launchers ignore it via `#[serde(default)]`.
+        #[serde(default)]
+        create_worktree: bool,
+        /// Optional branch name for the worktree. When omitted, the launcher
+        /// derives a timestamped default.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        worktree_branch: Option<String>,
     },
 
     /// Request to stop a session and remove the launcher's persisted

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -408,6 +408,8 @@ mod tests {
             agent_type: AgentType::Claude,
             scheduled_task_id: None,
             resume_session_id: None,
+            create_worktree: false,
+            worktree_branch: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"LaunchSession""#));


### PR DESCRIPTION
# SUMMARY

Adds an opt-in option to run a new session inside a freshly created **git worktree** instead of directly in the chosen directory (issue #1325). When enabled, the launcher creates a worktree from the repository that contains the selected directory and runs the agent there.

Closes #1325

## What changed

- **shared/** (`api/launch.rs`, `endpoints/launcher.rs`, `endpoints/mod.rs`): `LaunchRequest` and `ServerToLauncher::LaunchSession` gain `create_worktree: bool` and `worktree_branch: Option<String>`. Both are additive (`#[serde(default)]`), so existing proxies/launchers/backends stay wire-compatible.
- **backend/** (`handlers/launchers.rs`): threads the two request fields from the HTTP launch request into the `LaunchSession` message. All resume/reconcile/relaunch code paths (`sessions.rs`, `websocket/launcher_socket.rs`) explicitly set `create_worktree: false` — worktree creation only ever happens on an explicit user-initiated launch.
- **launcher/** (`worktree.rs` new, `process_manager.rs`, `connection.rs`, `main.rs`): `SpawnParams` carries the fields; `spawn()` validates the base dir (under home) and, when opted in, calls `worktree::create_worktree()` before spawning, then runs the session in the returned worktree path. The result is re-validated as being under the launcher user's home directory.
- **frontend/** (`components/launch_dialog.rs`): a "Create git worktree (requires a git repo)" checkbox plus a conditional optional branch-name field, wired into the launch request.

## Design decisions

- **Worktree location:** `<repo_root>/.worktrees/<branch>`, where `<repo_root>` is `git rev-parse --show-toplevel` run from the chosen directory. Inside the repo guarantees it stays under the launcher user's home (the launcher refuses paths outside home) and keeps it discoverable. Recommend adding `/.worktrees/` to the repo's `.gitignore`.
- **Branch naming:** a supplied branch is sanitized to a git-safe name (non `[A-Za-z0-9._/-]` → `-`, collapse/trim separators); if omitted or empty, defaults to `session-<YYYYMMDD-HHMMSS>`.
- **Idempotency:** if the worktree path already exists it is reused; if the branch already exists it is checked out into the new worktree instead of erroring.
- **Lifecycle / cleanup (v1):** cleanup is **manual** — worktrees are not removed on session end (a session may end with uncommitted work). Remove with `git worktree remove <path>`. Documented in the module header.
- **Error handling:** if the chosen directory is not inside a git repo, or `git worktree add` fails, the launcher returns a clear error surfaced back through `LaunchSessionResult`.

## Scoping / limitations

- The backend records the session's `working_directory` as the **requested base directory**, while the session actually runs in the derived worktree path (the branch may be timestamp-derived, so the final path isn't known backend-side). The git branch shown for the session reflects the worktree branch. Acceptable for v1.
- No automatic cleanup of worktrees/branches.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p shared -p agent-portal -p backend -p frontend` (frontend on `wasm32`) — no warnings
- `cargo build -p agent-portal` — ok; `cargo build --target wasm32-unknown-unknown -p shared` — ok; frontend `trunk build` — ok
- `cargo test -p agent-portal worktree` (5 tests) and `cargo test -p shared` (88 tests) — pass
- Note: local `cargo build -p backend` **links** fail due to an environment arch mismatch in `libpq.dylib` (x86_64 vs arm64), unrelated to this change; `cargo clippy -p backend` (type-checks the full crate) is clean.

## Version note

Per the current CLAUDE.md (issue #1096) the patch version is derived at build time from the git commit count and PRs must not touch `[workspace.package] version`; it is left unchanged.
