### PR TITLE
Add on-demand working-directory diff viewer (#1329)

### DIFF
--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -5,8 +5,8 @@ use axum::{
 use diesel::prelude::*;
 use serde::Serialize;
 use shared::api::{
-    AddMemberRequest, ResolveProxySessionRequest, ResolveProxySessionResponse, SessionMemberInfo,
-    SessionMembersResponse, UpdateMemberRoleRequest,
+    AddMemberRequest, ResolveProxySessionRequest, ResolveProxySessionResponse, SessionDiffResponse,
+    SessionMemberInfo, SessionMembersResponse, UpdateMemberRoleRequest,
 };
 use shared::SessionStatus;
 use std::sync::Arc;
@@ -171,6 +171,97 @@ pub async fn get_session(
         session,
         recent_messages,
     }))
+}
+
+/// On-demand diff viewer (#1329): return the unified diff of the session's
+/// working directory.
+///
+/// Runs `git diff HEAD` in the session's `working_directory` **on the backend
+/// host** and returns the raw unified diff. Any session member (viewer role
+/// included) may view it — the diff is read-only.
+///
+/// v1 scoping: the diff reflects the backend host's filesystem. This is the
+/// clean, self-contained slice — it covers co-located / single-host
+/// deployments and `--dev-mode`. When the working directory lives on a remote
+/// proxy host the path is absent on the backend, so we return
+/// `is_git_repo: false` with an empty diff (the UI surfaces a hint) rather
+/// than a misleading empty result. Routing the command through the proxy's
+/// WebSocket for distributed hosts is a follow-up (would need a new
+/// request/response protocol pair; out of scope for v1).
+pub async fn get_session_diff(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(current_user_id): CurrentUserId,
+    Path(session_id): Path<Uuid>,
+) -> Result<Json<SessionDiffResponse>, AppError> {
+    // Scope the pooled connection so it's released before the (potentially
+    // slow) git subprocess runs — never hold a DB connection across an await.
+    let working_directory = {
+        let mut conn = app_state.conn()?;
+        crate::handlers::session_access::verify_session_reader(
+            &mut conn,
+            session_id,
+            current_user_id,
+        )?
+        .working_directory
+    };
+
+    let (is_git_repo, diff) = compute_working_dir_diff(&working_directory).await;
+    if !is_git_repo {
+        tracing::info!(
+            "diff requested for session {} but {:?} is not a git work tree on this host",
+            session_id,
+            working_directory
+        );
+    }
+
+    Ok(Json(SessionDiffResponse {
+        working_directory,
+        is_git_repo,
+        diff,
+    }))
+}
+
+/// Run `git diff HEAD` in `dir` on the backend host, returning
+/// `(is_git_repo, diff_text)`. `is_git_repo` is `false` when the path is
+/// missing on this host or is not a git work tree (see the v1 scoping note on
+/// [`get_session_diff`]).
+async fn compute_working_dir_diff(dir: &str) -> (bool, String) {
+    // Confirm the path is a git work tree on this host first. This also
+    // gracefully handles the remote-proxy case: a missing directory makes the
+    // spawn fail, which we treat as "not a repo" rather than an error.
+    let inside = tokio::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(dir)
+        .output()
+        .await;
+    let is_repo = matches!(&inside, Ok(o) if o.status.success());
+    if !is_repo {
+        return (false, String::new());
+    }
+
+    // Prefer `git diff HEAD` (staged + unstaged tracked changes vs the last
+    // commit — the fullest picture of what the agent changed). Fall back to a
+    // plain `git diff` when HEAD is unborn (a fresh repo with no commits).
+    let diff = match run_git_diff(dir, &["diff", "HEAD"]).await {
+        Some(text) => text,
+        None => run_git_diff(dir, &["diff"]).await.unwrap_or_default(),
+    };
+    (true, diff)
+}
+
+/// Run `git <args>` in `dir` and return stdout as a `String`, or `None` when
+/// the command fails to spawn, exits non-zero, or emits non-UTF-8 output.
+async fn run_git_diff(dir: &str, args: &[&str]) -> Option<String> {
+    let output = tokio::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
 }
 
 pub async fn delete_session(

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -158,6 +158,11 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             "/api/sessions/{id}/resume",
             post(handlers::sessions::resume_session),
         )
+        // On-demand diff of the session's working directory (#1329)
+        .route(
+            "/api/sessions/{id}/diff",
+            get(handlers::sessions::get_session_diff),
+        )
         // Session member management routes
         .route(
             "/api/sessions/{id}/members",

--- a/frontend/src/components/diff.rs
+++ b/frontend/src/components/diff.rs
@@ -111,6 +111,90 @@ fn render_diff_html(lines: &[DiffLine<'_>]) -> Html {
     }
 }
 
+/// One file section parsed out of a multi-file `git diff` payload by
+/// [`split_git_diff`], ready to feed one `DiffCard`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GitDiffFile {
+    /// Display path (the post-image `b/…` path, which is also the pre-image
+    /// path for ordinary edits and deletions).
+    pub path: String,
+    /// `add` / `delete` / `update` — drives the `DiffCard` kind chip.
+    pub kind: String,
+    /// Hunk text from the first `@@` onward, fed to `DiffSource::Unified`.
+    /// Empty when the file has no textual hunks (binary, or a pure
+    /// rename/mode change) — the card then shows just the header.
+    pub hunks: String,
+}
+
+/// Split a raw `git diff` payload into per-file sections. Each section begins
+/// at a `diff --git a/… b/…` line. The `index`/`mode`/`---`/`+++` preamble is
+/// dropped (only the path, a change kind, and the hunk bodies are kept) so the
+/// UI can render one clean `DiffCard` per file.
+pub fn split_git_diff(diff: &str) -> Vec<GitDiffFile> {
+    let mut files: Vec<GitDiffFile> = Vec::new();
+    let mut path = String::new();
+    let mut kind = "update".to_string();
+    let mut hunks = String::new();
+    let mut in_file = false;
+    let mut in_hunks = false;
+
+    // Push the section we've been accumulating, if any.
+    let flush = |files: &mut Vec<GitDiffFile>, path: &str, kind: &str, hunks: &str| {
+        if !path.is_empty() {
+            files.push(GitDiffFile {
+                path: path.to_string(),
+                kind: kind.to_string(),
+                hunks: hunks.to_string(),
+            });
+        }
+    };
+
+    for line in diff.lines() {
+        if let Some(header) = line.strip_prefix("diff --git ") {
+            flush(&mut files, &path, &kind, &hunks);
+            path = parse_git_header_path(header);
+            kind = "update".to_string();
+            hunks = String::new();
+            in_file = true;
+            in_hunks = false;
+            continue;
+        }
+        if !in_file {
+            continue;
+        }
+        if line.starts_with("new file mode") {
+            kind = "add".to_string();
+        } else if line.starts_with("deleted file mode") {
+            kind = "delete".to_string();
+        }
+        if line.starts_with("@@ ") {
+            in_hunks = true;
+        }
+        if in_hunks {
+            hunks.push_str(line);
+            hunks.push('\n');
+        }
+    }
+    flush(&mut files, &path, &kind, &hunks);
+    files
+}
+
+/// Extract the display path from a `diff --git a/<path> b/<path>` header body
+/// (the part after `diff --git `). Prefers the post-image `b/` path (correct
+/// for renames); falls back to the raw header when the shape is unexpected.
+fn parse_git_header_path(header: &str) -> String {
+    if let Some(idx) = header.rfind(" b/") {
+        return header[idx + 3..].to_string();
+    }
+    header
+        .strip_prefix("a/")
+        .unwrap_or(header)
+        .split(" b/")
+        .next()
+        .unwrap_or(header)
+        .to_string()
+}
+
 /// Best-effort parse of a unified-diff payload. Skips file headers
 /// (`--- `, `+++ `), hunk headers (`@@ `), and the `\ No newline at end of file`
 /// marker. Body lines are classified by their leading character; lines without
@@ -286,6 +370,61 @@ mod tests {
         let diff = "@@ -1 +1 @@\n-old\n+new\n";
         let parsed = parse_unified_diff(diff);
         assert_eq!(classify(&parsed), vec![("rem", "old"), ("add", "new"),]);
+    }
+
+    #[test]
+    fn split_git_diff_multiple_files_with_kinds() {
+        let diff = "diff --git a/src/foo.rs b/src/foo.rs\n\
+index 111..222 100644\n\
+--- a/src/foo.rs\n\
++++ b/src/foo.rs\n\
+@@ -1,2 +1,2 @@\n a\n-b\n+B\n\
+diff --git a/new.txt b/new.txt\n\
+new file mode 100644\n\
+index 0000000..333\n\
+--- /dev/null\n\
++++ b/new.txt\n\
+@@ -0,0 +1 @@\n+hello\n\
+diff --git a/gone.txt b/gone.txt\n\
+deleted file mode 100644\n\
+index 444..0000000\n\
+--- a/gone.txt\n\
++++ /dev/null\n\
+@@ -1 +0,0 @@\n-bye\n";
+        let files = split_git_diff(diff);
+        assert_eq!(files.len(), 3);
+
+        assert_eq!(files[0].path, "src/foo.rs");
+        assert_eq!(files[0].kind, "update");
+        assert!(files[0].hunks.starts_with("@@ -1,2 +1,2 @@"));
+        // Preamble (index / ---/+++) must be excluded from the hunk body.
+        assert!(!files[0].hunks.contains("index 111"));
+
+        assert_eq!(files[1].path, "new.txt");
+        assert_eq!(files[1].kind, "add");
+        assert!(files[1].hunks.contains("+hello"));
+
+        assert_eq!(files[2].path, "gone.txt");
+        assert_eq!(files[2].kind, "delete");
+        assert!(files[2].hunks.contains("-bye"));
+    }
+
+    #[test]
+    fn split_git_diff_binary_file_has_empty_hunks() {
+        let diff = "diff --git a/img.png b/img.png\n\
+new file mode 100644\n\
+index 0000000..555\n\
+Binary files /dev/null and b/img.png differ\n";
+        let files = split_git_diff(diff);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "img.png");
+        assert_eq!(files[0].kind, "add");
+        assert!(files[0].hunks.is_empty());
+    }
+
+    #[test]
+    fn split_git_diff_empty_input() {
+        assert!(split_git_diff("").is_empty());
     }
 
     #[test]

--- a/frontend/src/components/diff_view.rs
+++ b/frontend/src/components/diff_view.rs
@@ -1,0 +1,178 @@
+//! On-demand working-directory diff viewer (#1329), rendered inline as a
+//! session-view tab (not a modal).
+//!
+//! Fetches `GET /api/sessions/{id}/diff` (a `git diff HEAD` run on the backend
+//! host) and renders it as one framed `DiffCard` per changed file, reusing the
+//! shared unified-diff parser/renderer from [`crate::components::diff`]. The
+//! panel fetches once on mount and offers a manual refresh.
+
+use shared::api::SessionDiffResponse;
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+use crate::components::diff::{split_git_diff, DiffCard, DiffSource, GitDiffFile};
+use crate::utils::{self, On401};
+
+#[derive(Properties, PartialEq)]
+pub struct SessionDiffPanelProps {
+    pub session_id: Uuid,
+    /// Directory shown in the header while the diff loads (from the session
+    /// record). The response echoes back the authoritative path.
+    pub working_directory: String,
+}
+
+pub enum SessionDiffPanelMsg {
+    Refresh,
+    Loaded(SessionDiffResponse),
+    Failed(String),
+}
+
+pub struct SessionDiffPanel {
+    diff: Option<SessionDiffResponse>,
+    error: Option<String>,
+    loading: bool,
+}
+
+impl SessionDiffPanel {
+    fn fetch(&mut self, ctx: &Context<Self>) {
+        self.loading = true;
+        self.error = None;
+        let session_id = ctx.props().session_id;
+        let link = ctx.link().clone();
+        spawn_local(async move {
+            match utils::fetch_json::<SessionDiffResponse>(
+                &format!("/api/sessions/{}/diff", session_id),
+                On401::Ignore,
+            )
+            .await
+            {
+                Ok(data) => link.send_message(SessionDiffPanelMsg::Loaded(data)),
+                Err(e) => {
+                    log::error!("Failed to load diff: {}", e);
+                    link.send_message(SessionDiffPanelMsg::Failed(
+                        "Failed to load diff".to_string(),
+                    ));
+                }
+            }
+        });
+    }
+}
+
+impl Component for SessionDiffPanel {
+    type Message = SessionDiffPanelMsg;
+    type Properties = SessionDiffPanelProps;
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let mut panel = Self {
+            diff: None,
+            error: None,
+            loading: false,
+        };
+        panel.fetch(ctx);
+        panel
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            SessionDiffPanelMsg::Refresh => {
+                self.fetch(ctx);
+            }
+            SessionDiffPanelMsg::Loaded(data) => {
+                self.diff = Some(data);
+                self.error = None;
+                self.loading = false;
+            }
+            SessionDiffPanelMsg::Failed(err) => {
+                self.error = Some(err);
+                self.loading = false;
+            }
+        }
+        true
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let on_refresh = ctx.link().callback(|_| SessionDiffPanelMsg::Refresh);
+        let path = self
+            .diff
+            .as_ref()
+            .map(|d| d.working_directory.clone())
+            .unwrap_or_else(|| ctx.props().working_directory.clone());
+
+        html! {
+            <div class="session-diff-panel">
+                <div class="session-diff-toolbar">
+                    <span class="session-diff-path" title={path.clone()}>{ path }</span>
+                    <button
+                        class="session-diff-refresh"
+                        onclick={on_refresh}
+                        disabled={self.loading}
+                        title="Re-run git diff"
+                    >
+                        { if self.loading { "Refreshing…" } else { "Refresh" } }
+                    </button>
+                </div>
+                <div class="session-diff-body">
+                    { self.view_body() }
+                </div>
+            </div>
+        }
+    }
+}
+
+impl SessionDiffPanel {
+    fn view_body(&self) -> Html {
+        if let Some(error) = &self.error {
+            return html! { <div class="session-diff-message error">{ error }</div> };
+        }
+        let Some(diff) = &self.diff else {
+            return html! { <div class="session-diff-message">{ "Loading diff…" }</div> };
+        };
+
+        if !diff.is_git_repo {
+            return html! {
+                <div class="session-diff-message">
+                    { "No git repository is reachable at this working directory on the \
+                       server host, so a diff can't be shown." }
+                </div>
+            };
+        }
+
+        let files = split_git_diff(&diff.diff);
+        if files.is_empty() {
+            return html! {
+                <div class="session-diff-message">
+                    { "No uncommitted changes in the working directory." }
+                </div>
+            };
+        }
+
+        html! {
+            <>
+                { for files.into_iter().map(render_file) }
+            </>
+        }
+    }
+}
+
+/// Render one changed file as a `DiffCard`. Files without textual hunks
+/// (binary, or a pure rename/mode change) show just the header row.
+fn render_file(file: GitDiffFile) -> Html {
+    let path = AttrValue::from(file.path);
+    let kind = AttrValue::from(file.kind);
+    if file.hunks.is_empty() {
+        html! {
+            <div class="diff-card">
+                <div class="diff-card-header">
+                    <span class="tool-icon">{ "\u{1f4dd}" }</span>
+                    <span class={classes!("diff-card-kind", kind.to_string())}>{ kind }</span>
+                    <span class="diff-card-path">{ path }</span>
+                    <span class="diff-card-cumulative">{ "no textual changes" }</span>
+                </div>
+            </div>
+        }
+    } else {
+        let source = DiffSource::Unified { text: file.hunks };
+        html! { <DiffCard {source} file_path={path} kind={kind} /> }
+    }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -7,6 +7,7 @@ mod copy_command;
 mod count_up;
 mod cron_describe;
 mod diff;
+mod diff_view;
 pub mod expandable;
 mod launch_dialog;
 pub(crate) mod markdown;
@@ -24,6 +25,7 @@ mod voice_input;
 pub use confirm_modal::{ConfirmModal, ConfirmModalStyle};
 pub use copy_command::CopyCommand;
 pub use count_up::CountUp;
+pub use diff_view::SessionDiffPanel;
 pub use launch_dialog::LaunchDialog;
 pub use message_renderer::{
     group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroupRenderer,

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -11,6 +11,7 @@
 use crate::components::message_renderer::{MessageRenderer, RenderedMessage};
 use crate::components::{
     group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroupRenderer,
+    SessionDiffPanel,
 };
 use crate::utils::{self, On401};
 use gloo::timers::callback::Timeout;
@@ -98,8 +99,19 @@ fn optimistic_user_message(
     )
 }
 
+/// Which view the session pane is currently showing. `Conversation` is the
+/// normal transcript; `Diff` swaps in the on-demand working-directory
+/// `git diff` panel (#1329).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionTab {
+    Conversation,
+    Diff,
+}
+
 /// Messages for the SessionView component
 pub enum SessionViewMsg {
+    /// Switch the session pane between the conversation and diff tabs.
+    SetTab(SessionTab),
     LoadHistory(Vec<MessageData>, Option<String>),
     ReceivedOutput(RenderedMessage),
     WebSocketConnected(WsSender),
@@ -250,6 +262,8 @@ pub struct SessionView {
     /// Monotonic tick bumped on every `ForwardsChanged` frame; passed to the
     /// forward-chip strip as a prop so it refetches (docs/PORT_FORWARDING.md).
     forwards_refresh: u32,
+    /// Which tab the pane is showing (conversation vs. working-dir diff).
+    active_tab: SessionTab,
 }
 
 impl Component for SessionView {
@@ -326,6 +340,7 @@ impl Component for SessionView {
             turn_metrics: Vec::new(),
             continuation_statuses: HashMap::new(),
             forwards_refresh: 0,
+            active_tab: SessionTab::Conversation,
         }
     }
 
@@ -373,6 +388,13 @@ impl Component for SessionView {
 
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
+            SessionViewMsg::SetTab(tab) => {
+                if self.active_tab == tab {
+                    return false;
+                }
+                self.active_tab = tab;
+                true
+            }
             SessionViewMsg::WsEvent(event) => self.handle_ws_event(ctx, event),
             SessionViewMsg::LoadHistory(messages, last_timestamp) => {
                 self.handle_load_history(ctx, messages, last_timestamp);
@@ -634,31 +656,60 @@ impl Component for SessionView {
                     />
                     <span class={status_class}>{ ctx.props().session.status.as_str() }</span>
                 </div>
-                <div class="session-view-scroll-area">
-                    <div class="session-view-messages" ref={self.messages_ref.clone()}>
-                        {
-                            groups.into_iter().enumerate().map(|(i, group)| {
-                                let key = group.key(i);
-                                let metrics = group_metrics.get(i).cloned().flatten();
-                                let thinking_start = thinking_starts.get(i).copied().unwrap_or(0);
-                                html! { <MessageGroupRenderer {key} group={group} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} {thinking_start} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
-                            }).collect::<Html>()
-                        }
-                        { for self.pending_sends.iter().enumerate().map(|(i, message)| {
-                            html! { <MessageRenderer key={format!("p{}", i)} message={message.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
-                        })}
-                    </div>
-                    if !is_tailing {
-                        <button
-                            class="jump-to-live-pill"
-                            onclick={on_jump_to_live}
-                            title="Resume live tailing of new messages"
-                        >
-                            { "Jump to live ↓" }
-                        </button>
-                    }
-                    { self.render_tasks_panel(ctx) }
+                <div class="session-view-tabs" role="tablist">
+                    <button
+                        type="button"
+                        role="tab"
+                        class={classes!("session-view-tab", (self.active_tab == SessionTab::Conversation).then_some("active"))}
+                        aria-selected={(self.active_tab == SessionTab::Conversation).to_string()}
+                        onclick={link.callback(|_| SessionViewMsg::SetTab(SessionTab::Conversation))}
+                    >
+                        { "Conversation" }
+                    </button>
+                    <button
+                        type="button"
+                        role="tab"
+                        class={classes!("session-view-tab", (self.active_tab == SessionTab::Diff).then_some("active"))}
+                        aria-selected={(self.active_tab == SessionTab::Diff).to_string()}
+                        onclick={link.callback(|_| SessionViewMsg::SetTab(SessionTab::Diff))}
+                    >
+                        { "Diff" }
+                    </button>
                 </div>
+                if self.active_tab == SessionTab::Diff {
+                    <div class="session-view-scroll-area">
+                        <SessionDiffPanel
+                            session_id={ctx.props().session.id}
+                            working_directory={ctx.props().session.working_directory.clone()}
+                        />
+                    </div>
+                } else {
+                    <div class="session-view-scroll-area">
+                        <div class="session-view-messages" ref={self.messages_ref.clone()}>
+                            {
+                                groups.into_iter().enumerate().map(|(i, group)| {
+                                    let key = group.key(i);
+                                    let metrics = group_metrics.get(i).cloned().flatten();
+                                    let thinking_start = thinking_starts.get(i).copied().unwrap_or(0);
+                                    html! { <MessageGroupRenderer {key} group={group} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} {thinking_start} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
+                                }).collect::<Html>()
+                            }
+                            { for self.pending_sends.iter().enumerate().map(|(i, message)| {
+                                html! { <MessageRenderer key={format!("p{}", i)} message={message.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
+                            })}
+                        </div>
+                        if !is_tailing {
+                            <button
+                                class="jump-to-live-pill"
+                                onclick={on_jump_to_live}
+                                title="Resume live tailing of new messages"
+                            >
+                                { "Jump to live ↓" }
+                            </button>
+                        }
+                        { self.render_tasks_panel(ctx) }
+                    </div>
+                }
 
                 { self.render_permission_handler(ctx) }
                 { self.render_input_bar(ctx) }

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -423,3 +423,101 @@
 .jump-to-live-pill:active {
     transform: translateX(-50%) translateY(0);
 }
+
+/* ==========================================================================
+   Session view tabs — Conversation vs. working-dir Diff (#1329).
+   ========================================================================== */
+
+.session-view-tabs {
+    display: flex;
+    gap: 0.25rem;
+    padding: 0 1.5rem;
+    background: rgba(0, 0, 0, 0.2);
+    border-bottom: 1px solid var(--border);
+}
+
+.session-view-tab {
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    font-weight: 500;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.session-view-tab:hover {
+    color: var(--text-primary);
+}
+
+.session-view-tab.active {
+    color: var(--text-primary);
+    border-bottom-color: var(--accent);
+}
+
+/* --- On-demand working-directory diff panel (#1329) --- */
+
+.session-diff-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+}
+
+.session-diff-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.5rem 1.5rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.session-diff-path {
+    font-family: var(--font-mono, monospace);
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.session-diff-refresh {
+    flex-shrink: 0;
+    background: rgba(122, 162, 247, 0.08);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-primary);
+    font-size: 0.78rem;
+    padding: 0.25rem 0.6rem;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.session-diff-refresh:hover:not(:disabled) {
+    background: rgba(122, 162, 247, 0.18);
+}
+
+.session-diff-refresh:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
+.session-diff-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.75rem 1.5rem 1rem;
+}
+
+.session-diff-message {
+    padding: 1.5rem 0.5rem;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.session-diff-message.error {
+    color: var(--error);
+}

--- a/shared/src/api/sessions.rs
+++ b/shared/src/api/sessions.rs
@@ -73,6 +73,31 @@ pub struct SessionMembersResponse {
     pub members: Vec<SessionMemberInfo>,
 }
 
+/// Response from `GET /api/sessions/:id/diff`.
+///
+/// The on-demand diff viewer (#1329): the backend runs `git diff HEAD` in the
+/// session's `working_directory` **on the backend host** and returns the raw
+/// unified diff. The frontend splits it into per-file cards for display.
+///
+/// v1 scope: this reflects the backend host's view of the path, so it works
+/// for co-located / single-host deployments (and `--dev-mode`). When the
+/// working directory lives on a remote proxy host that path won't exist on the
+/// backend, so `is_git_repo` is `false` and `diff` is empty — the UI shows a
+/// hint rather than a spurious empty diff.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SessionDiffResponse {
+    /// The working directory the diff was computed in.
+    pub working_directory: String,
+    /// Whether `working_directory` is a git work tree on the backend host.
+    /// When `false`, `diff` is empty.
+    #[serde(default)]
+    pub is_git_repo: bool,
+    /// Raw unified diff of `git diff HEAD` (empty when there are no changes,
+    /// or when `is_git_repo` is `false`). Untracked files are not included.
+    #[serde(default)]
+    pub diff: String,
+}
+
 /// Response envelope for listing messages.
 ///
 /// Generic over the message element type because the two sides project the


### PR DESCRIPTION
# SUMMARY

Adds a way to view a `git diff` of a session's working directory on demand, surfaced as a **Diff** tab in the session view (alongside the normal Conversation transcript) rather than only the per-`Edit` inline diffs that exist today. Closes #1329.

## What changed

**Backend** — new `GET /api/sessions/{id}/diff`:
- Handler `get_session_diff` in `backend/src/handlers/sessions.rs`, registered in `backend/src/routes.rs`. Uses `State<Arc<AppState>>` and returns `Result<Json<SessionDiffResponse>, AppError>` (no `unwrap`/panics; `tracing` for the not-a-repo case).
- Read-access gated via the existing `session_access::verify_session_reader` (any member, viewer included — the diff is read-only).
- Runs `git diff HEAD` in the session's `working_directory` via `tokio::process::Command` (same read-only `git` pattern as `get_git_branch`). Falls back to plain `git diff` when `HEAD` is unborn (fresh repo). The pooled DB connection is dropped before the subprocess runs (never held across an `await`).
- Response type `SessionDiffResponse` lives in `shared/src/api/sessions.rs` (typed, shared by both sides — no `serde_json::json!`).

**Frontend** — Diff tab in the session view:
- A lightweight tab switcher (**Conversation** / **Diff**) added to the top of the session view (`session_view/component.rs`), since none existed. Switching is local component state (`SessionTab`); the input bar and permission handler stay mounted across both tabs.
- New `SessionDiffPanel` component (`frontend/src/components/diff_view.rs`) fetches the endpoint on mount, has a **Refresh** button, and renders the result.
- Real `git diff` is multi-file/multi-hunk, so `split_git_diff` (added to `frontend/src/components/diff.rs`, with unit tests) splits the payload into per-file sections (path + add/update/delete kind + hunk text) and each file is rendered through the **existing** `DiffCard` component (`DiffSource::Unified`), reusing the established colored +/- line rendering. Binary / pure-mode-change files show a header-only card.

## Design decisions & v1 scoping

- **Where `git` runs (the key limitation):** the diff is computed on the **backend host's** filesystem using the stored `working_directory`. This is the cleanly-reachable slice and works for co-located / single-host deployments and `--dev-mode`. When a session's working directory lives on a **remote proxy host**, that path isn't present on the backend, so the endpoint returns `is_git_repo: false` with an empty diff and the UI shows a hint (rather than a misleading empty diff). Routing the command through the proxy's WebSocket for distributed hosts would need a new request/response protocol pair and is intentionally left as a follow-up.
- **`git diff HEAD`** (staged + unstaged tracked changes vs. the last commit) is used as the fullest picture of what the agent changed. Untracked files are not included in v1.
- **Diff parsed on the frontend**, keeping the backend response a simple typed `{ working_directory, is_git_repo, diff }` and reusing the existing unified-diff renderer.

## Versioning note

Per this repo's current convention (root `CLAUDE.md`, issue #1096) the patch version is derived at build time from the git commit count by `shared/build.rs`, and **PRs do not touch** `[workspace.package] version`. It is therefore left unchanged at `2.13.0`.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets` — no lints
- `cargo build -p backend` — builds/links
- `cd frontend && trunk build` — succeeds
- `cargo build --target wasm32-unknown-unknown -p shared` — succeeds
- `cargo test -p frontend --lib diff` / `cargo test -p shared` — pass (incl. new `split_git_diff` tests)

(Local backend link required pointing at an arm64 `libpq`; unrelated to these changes.)