### PR TITLE
feat: render diffs for MultiEdit tool calls

### DIFF
--- a/frontend/src/components/tool_renderers/edit.rs
+++ b/frontend/src/components/tool_renderers/edit.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use shared::{EditInput, WriteInput};
+use shared::{EditInput, MultiEditInput, WriteInput};
 use yew::prelude::*;
 
 use crate::components::diff::{DiffCard, DiffSource};
@@ -26,6 +26,37 @@ pub fn render_edit_tool(input: &Value) -> Html {
             file_path={AttrValue::from(edit.file_path)}
             {replace_all}
         />
+    }
+}
+
+pub fn render_multiedit_tool(input: &Value) -> Html {
+    let multi = extract_tool_input::<MultiEditInput>(input).unwrap_or(MultiEditInput {
+        file_path: "unknown file".to_string(),
+        edits: Vec::new(),
+    });
+    let file_path = AttrValue::from(multi.file_path);
+    let edit_count = multi.edits.len();
+
+    html! {
+        <div class="tool-use multiedit-tool">
+            <div class="tool-use-header">
+                <span class="tool-icon">{ "\u{270f}\u{fe0f}" }</span>
+                <span class="tool-name">{ "MultiEdit" }</span>
+                <span class="edit-file-path">{ &file_path }</span>
+                <span class="tool-meta">
+                    { format!("({} edit{})", edit_count, if edit_count == 1 { "" } else { "s" }) }
+                </span>
+            </div>
+            {
+                multi.edits.into_iter().map(|edit| {
+                    let source = DiffSource::OldNew {
+                        old: edit.old_string,
+                        new: edit.new_string,
+                    };
+                    html! { <DiffCard {source} /> }
+                }).collect::<Html>()
+            }
+        </div>
     }
 }
 

--- a/frontend/src/components/tool_renderers/mod.rs
+++ b/frontend/src/components/tool_renderers/mod.rs
@@ -10,7 +10,7 @@ use shared::{ReadInput, ToolInput};
 use yew::prelude::*;
 
 use self::bash::render_bash_tool;
-use self::edit::{render_edit_tool, render_write_tool};
+use self::edit::{render_edit_tool, render_multiedit_tool, render_write_tool};
 pub(crate) use self::interactive::{has_askuserquestion_answers, render_askuserquestion_result};
 use self::interactive::{
     render_askuserquestion_tool, render_exitplanmode_tool, render_todowrite_tool,
@@ -38,6 +38,7 @@ pub fn render_tool_use(name: &str, input: &Value) -> Html {
     let named_input = ToolInput::from_named_input(name, input.clone());
     match name {
         "Edit" => render_edit_tool(input),
+        "MultiEdit" => render_multiedit_tool(input),
         "Write" => render_write_tool(input),
         "TodoWrite" => render_todowrite_tool(input),
         "AskUserQuestion" => render_askuserquestion_tool(input),

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -81,9 +81,9 @@ pub use claude_codes::ClaudeOutput;
 // Re-export typed tool-input types so frontend renderers can match on enum
 // variants instead of poking at JSON field names.
 pub use claude_codes::tool_inputs::{
-    AskUserQuestionInput, BashInput, EditInput, GlobInput, GrepInput, Question, QuestionOption,
-    ReadInput, TaskInput, TodoItem, TodoStatus, TodoWriteInput, ToolInput, WebFetchInput,
-    WebSearchInput, WriteInput,
+    AskUserQuestionInput, BashInput, EditInput, GlobInput, GrepInput, MultiEditInput,
+    MultiEditOperation, Question, QuestionOption, ReadInput, TaskInput, TodoItem, TodoStatus,
+    TodoWriteInput, ToolInput, WebFetchInput, WebSearchInput, WriteInput,
 };
 pub use claude_codes::{AllowedPrompt, ExitPlanModeInput};
 


### PR DESCRIPTION
# SUMMARY

`MultiEdit` tool calls previously rendered no diff. This adds a `"MultiEdit"` dispatch arm and a renderer that shows the same red/green line diffs that single `Edit` calls show — one diff per entry in the `edits` array.

## Changes
- `frontend/src/components/tool_renderers/mod.rs` — add a `"MultiEdit"` arm dispatching to `render_multiedit_tool`.
- `frontend/src/components/tool_renderers/edit.rs` — new `render_multiedit_tool` that decodes the typed `MultiEditInput` (via `extract_tool_input`), renders a header (icon, name, file path, edit count), then one shared `<DiffCard source=OldNew{..} />` per edit. Reuses the existing diff component rather than duplicating the diff algorithm.
- `shared/src/lib.rs` — re-export `MultiEditInput` / `MultiEditOperation` from `claude-codes` so the frontend can match the typed shape instead of poking at JSON.

Malformed/missing input falls back to an empty edit list with an "unknown file" label (no panics).

## Verification
- `cargo fmt` — clean
- `cargo clippy --workspace` — no warnings
- `cd frontend && trunk build` — success

## Note on versioning
Left `[workspace.package] version` at `2.13.0` (unchanged). Per the current CLAUDE.md (issue #1096) the patch is auto-derived from the git commit count and PRs do not edit the version line.

Closes #1331
