### PR TITLE
Add opt-in vim mode for the message input box

### DIFF
--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -3,8 +3,31 @@
 use shared::SessionInfo;
 use std::collections::HashSet;
 use uuid::Uuid;
+use wasm_bindgen::JsCast;
 use web_sys::KeyboardEvent;
 use yew::prelude::*;
+
+/// Focus the message input of the currently-focused session view, so leaving
+/// Nav mode via `i`/`Enter` returns the caret to the composer. When vim mode is
+/// on, the box was reset to INSERT as it handed off to Nav, so this lands the
+/// user ready to type.
+fn focus_active_message_input() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    // Prefer the focused session's box; fall back to the only one on screen.
+    let el = doc
+        .query_selector(".session-view.focused .message-input")
+        .ok()
+        .flatten()
+        .or_else(|| doc.query_selector(".message-input").ok().flatten());
+    if let Some(input) = el
+        .as_ref()
+        .and_then(|e| e.dyn_ref::<web_sys::HtmlElement>())
+    {
+        let _ = input.focus();
+    }
+}
 
 /// Configuration for the keyboard navigation hook.
 pub struct KeyboardNavConfig {
@@ -160,9 +183,16 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
             if in_nav_mode {
                 // Navigation Mode
                 match e.key().as_str() {
-                    "Escape" | "i" => {
+                    "Escape" => {
+                        // Leave Nav mode without grabbing the composer.
                         e.prevent_default();
                         nav_mode.set(false);
+                    }
+                    "i" => {
+                        // `i` = "go edit": leave Nav mode and refocus the input.
+                        e.prevent_default();
+                        nav_mode.set(false);
+                        focus_active_message_input();
                     }
                     "ArrowUp" | "ArrowLeft" | "k" | "h" => {
                         e.prevent_default();
@@ -185,6 +215,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                     "Enter" => {
                         e.prevent_default();
                         nav_mode.set(false);
+                        focus_active_message_input();
                     }
                     "w" => {
                         e.prevent_default();

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -183,13 +183,12 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
             if in_nav_mode {
                 // Navigation Mode
                 match e.key().as_str() {
-                    "Escape" => {
-                        // Leave Nav mode without grabbing the composer.
-                        e.prevent_default();
-                        nav_mode.set(false);
-                    }
-                    "i" => {
-                        // `i` = "go edit": leave Nav mode and refocus the input.
+                    "Escape" | "i" => {
+                        // Either key leaves Nav mode AND returns focus to the
+                        // composer (ready to type). Esc is the natural "cycle
+                        // back" key — INSERT →Esc→ NORMAL →Esc→ Nav →Esc→ typing —
+                        // and refocusing on every exit means you can never get
+                        // stranded in Nav mode with nothing focused.
                         e.prevent_default();
                         nav_mode.set(false);
                         focus_active_message_input();

--- a/frontend/src/pages/dashboard/mod.rs
+++ b/frontend/src/pages/dashboard/mod.rs
@@ -18,4 +18,6 @@ mod session_view;
 mod types;
 
 pub use page::DashboardPage;
-pub use types::{load_rail_position, save_rail_position, RailPosition};
+pub use types::{
+    load_rail_position, load_vim_mode, save_rail_position, save_vim_mode, RailPosition,
+};

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -614,7 +614,7 @@ impl Component for SessionView {
             .is_some_and(|uid| uid == ctx.props().session.user_id.to_string());
 
         html! {
-            <div class="session-view">
+            <div class={classes!("session-view", ctx.props().focused.then_some("focused"))}>
                 <div class="session-view-header">
                     <span class="session-name">{ &ctx.props().session.session_name }</span>
                     <span class="session-hostname">{ &ctx.props().session.hostname }</span>

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -474,7 +474,12 @@ impl Component for InputBar {
                         ref={self.input_ref.clone()}
                         class={classes!(
                             "message-input",
-                            self.interim_transcription.is_some().then_some("has-interim")
+                            self.interim_transcription.is_some().then_some("has-interim"),
+                            // Block-cursor styling in NORMAL mode. Yew-managed so a
+                            // re-render can't wipe it; vim.rs only sets the selection.
+                            (self.vim_enabled
+                                && self.vim.borrow().mode == vim::VimMode::Normal)
+                                .then_some("vim-normal")
                         )}
                         placeholder="Type your message... (Shift+Enter for new line)"
                         oninput={handle_input}

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -14,11 +14,15 @@
 //! UI while the actual WS send still goes through the parent.
 
 use super::history::CommandHistory;
+use super::vim::{self, VimState};
 use crate::components::VoiceInput;
+use crate::pages::dashboard::load_vim_mode;
 use crate::utils::format_file_size;
 use gloo::timers::callback::Timeout;
 use shared::protocol::UPLOAD_CHUNK_SIZE;
 use shared::{ClientToServer, SendMode};
+use std::cell::RefCell;
+use std::rc::Rc;
 use uuid::Uuid;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
@@ -106,6 +110,9 @@ pub enum InputBarMsg {
     VoiceError(String),
     /// Ctrl+M keyboard shortcut: click the voice button programmatically.
     ToggleVoice,
+    /// Vim mode changed the mode or edited the text in the DOM. Re-render (to
+    /// refresh the mode indicator) and re-sync the tracked text mirror.
+    VimSync,
     /// No-op (used by keydown / paste handlers that need to return a message
     /// but don't want to mutate state).
     Noop,
@@ -128,6 +135,13 @@ pub struct InputBar {
     interim_transcription: Option<String>,
     voice_button_ref: NodeRef,
     was_focused: bool,
+    /// Whether opt-in vim editing is enabled (read once from localStorage at
+    /// create; takes effect for newly opened sessions / after reload).
+    vim_enabled: bool,
+    /// Modal editing state. Shared via `Rc<RefCell<…>>` so the `'static`
+    /// keydown closure can mutate it across keystrokes without routing every
+    /// motion through a message.
+    vim: Rc<RefCell<VimState>>,
 }
 
 impl Component for InputBar {
@@ -153,6 +167,8 @@ impl Component for InputBar {
             interim_transcription: None,
             voice_button_ref: NodeRef::default(),
             was_focused: ctx.props().focused,
+            vim_enabled: load_vim_mode(),
+            vim: Rc::new(RefCell::new(VimState::default())),
         }
     }
 
@@ -304,6 +320,13 @@ impl Component for InputBar {
                 }
                 false
             }
+            InputBarMsg::VimSync => {
+                // Vim wrote directly to the (uncontrolled) textarea DOM; mirror
+                // the new value so a later re-render can restore it, and
+                // re-render to refresh the mode indicator.
+                self.input_text = self.get_input_text();
+                true
+            }
             InputBarMsg::Noop => false,
         }
     }
@@ -322,10 +345,29 @@ impl Component for InputBar {
             InputBarMsg::UpdateInput(input.value())
         });
 
-        let handle_keydown = link.callback(|e: KeyboardEvent| {
+        let vim_enabled = self.vim_enabled;
+        let vim = self.vim.clone();
+        let handle_keydown = link.callback(move |e: KeyboardEvent| {
             if e.ctrl_key() && e.key().to_lowercase() == "m" {
                 e.prevent_default();
                 return InputBarMsg::ToggleVoice;
+            }
+
+            // Modal editing (opt-in). When vim consumes the key we're done;
+            // otherwise fall through to the normal Enter/Arrow/typing handling
+            // below so behavior stays identical to the non-vim path.
+            if vim_enabled {
+                let textarea: HtmlTextAreaElement = e.target_unchecked_into();
+                match vim::handle_key(&mut vim.borrow_mut(), &textarea, &e) {
+                    vim::VimHandled::Consumed { rerender } => {
+                        return if rerender {
+                            InputBarMsg::VimSync
+                        } else {
+                            InputBarMsg::Noop
+                        };
+                    }
+                    vim::VimHandled::Passthrough => {}
+                }
             }
 
             match e.key().as_str() {
@@ -426,6 +468,7 @@ impl Component for InputBar {
                     onclick={close_dropdown}
                 >
                     <span class="input-prompt">{ ">" }</span>
+                    { self.render_vim_indicator() }
                     { self.render_interim_transcription() }
                     <textarea
                         ref={self.input_ref.clone()}
@@ -602,6 +645,22 @@ impl InputBar {
                     .join(", "),
             ));
         });
+    }
+
+    /// Small NORMAL/INSERT badge shown beside the prompt when vim mode is on.
+    fn render_vim_indicator(&self) -> Html {
+        if !self.vim_enabled {
+            return html! {};
+        }
+        let mode = self.vim.borrow().mode;
+        html! {
+            <span
+                class={mode.css_class()}
+                title="Vim mode (toggle in Settings → Appearance)"
+            >
+                { mode.label() }
+            </span>
+        }
     }
 
     fn render_interim_transcription(&self) -> Html {

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -360,6 +360,15 @@ impl Component for InputBar {
                 let textarea: HtmlTextAreaElement = e.target_unchecked_into();
                 match vim::handle_key(&mut vim.borrow_mut(), &textarea, &e) {
                     vim::VimHandled::Consumed { rerender } => {
+                        // Stop the event from bubbling to the dashboard's
+                        // `use_keyboard_nav` hook. Without this, keys vim owns
+                        // (Esc → NORMAL, and motions like w/j/k/x/i) also reach
+                        // the nav hook: Esc would flip the dashboard into Nav
+                        // mode and `w` would jump to the next waiting session
+                        // instead of moving a word. It also prevents a vim
+                        // user's repeated Esc from firing the triple-Esc
+                        // session interrupt.
+                        e.stop_propagation();
                         return if rerender {
                             InputBarMsg::VimSync
                         } else {

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -375,6 +375,13 @@ impl Component for InputBar {
                             InputBarMsg::Noop
                         };
                     }
+                    vim::VimHandled::ExitToNav => {
+                        // NORMAL Esc handed off to Nav mode: vim already reset to
+                        // INSERT + blurred. Re-render to drop the `vim-normal`
+                        // class, but do NOT stop_propagation — the Esc must bubble
+                        // to `use_keyboard_nav` so it enters Nav mode.
+                        return InputBarMsg::VimSync;
+                    }
                     vim::VimHandled::Passthrough => {}
                 }
             }

--- a/frontend/src/pages/dashboard/session_view/mod.rs
+++ b/frontend/src/pages/dashboard/session_view/mod.rs
@@ -9,6 +9,7 @@
 //! - `permission_handler.rs` - Permission-request UI lifecycle
 //! - `tasks_panel.rs` - Sub-agent / background-task drawer + `derive_task_events`
 //! - `types.rs` - Types specific to SessionView (re-exports from parent)
+//! - `vim.rs` - Opt-in modal (vim-like) editing engine for the textarea
 //! - `websocket.rs` - WebSocket connection management
 //! - `history.rs` - Command history management
 
@@ -22,6 +23,7 @@ mod permission_handler;
 mod state;
 mod tasks_panel;
 mod types;
+mod vim;
 mod websocket;
 
 pub use component::SessionView;

--- a/frontend/src/pages/dashboard/session_view/vim.rs
+++ b/frontend/src/pages/dashboard/session_view/vim.rs
@@ -177,6 +177,11 @@ pub enum VimHandled {
     /// Not a vim key in the current mode — the caller should run its normal
     /// keydown logic (Enter-to-send, Arrow history, plain typing, …).
     Passthrough,
+    /// NORMAL `Esc` with no pending command: vim reset itself to INSERT (block
+    /// cursor collapsed) and blurred the textarea. The caller re-renders (to
+    /// drop the `vim-normal` class) but must NOT `stop_propagation`, so the
+    /// `Esc` bubbles to `use_keyboard_nav` and hands off to Nav mode.
+    ExitToNav,
 }
 
 /// Feed a keydown event to the modal engine. Mutates `state`, applies any edit
@@ -414,16 +419,19 @@ fn handle_normal(
                 VimHandled::Consumed { rerender: false }
             } else {
                 // Clean NORMAL: a second `Esc` drops out of the input into the
-                // dashboard's keyboard-nav (Nav mode). Blur so subsequent nav
-                // keys reach the nav hook instead of vim, and Passthrough (no
-                // `stop_propagation` in the caller) so this Esc bubbles up and
-                // flips Nav mode on. First Esc (INSERT→NORMAL) is still
-                // consumed, so it takes two presses to leave — matching the
-                // "double-Esc = Nav mode" contract.
+                // dashboard's keyboard-nav (Nav mode). Reset to INSERT first —
+                // this collapses the block cursor and means returning to the box
+                // (via Nav mode's `i`, which refocuses it) lands ready to type.
+                // Then blur so nav keys reach the nav hook instead of vim, and
+                // return ExitToNav so the caller re-renders but lets the Esc
+                // bubble to the nav hook. First Esc (INSERT→NORMAL) is still
+                // consumed, so it takes two presses to leave.
+                state.mode = VimMode::Insert;
                 state.clear_pending();
+                move_cursor(textarea, &text, cursor);
                 let html_el: &web_sys::HtmlElement = textarea.as_ref();
                 let _ = html_el.blur();
-                VimHandled::Passthrough
+                VimHandled::ExitToNav
             }
         }
         _ => {

--- a/frontend/src/pages/dashboard/session_view/vim.rs
+++ b/frontend/src/pages/dashboard/session_view/vim.rs
@@ -1646,8 +1646,10 @@ mod tests {
 
     #[test]
     fn count_accumulation_via_take() {
-        let mut st = VimState::default();
-        st.count = Some(2);
+        let mut st = VimState {
+            count: Some(2),
+            ..Default::default()
+        };
         assert_eq!(st.take_count(), 2);
         assert_eq!(st.take_count(), 1); // default after clear
     }

--- a/frontend/src/pages/dashboard/session_view/vim.rs
+++ b/frontend/src/pages/dashboard/session_view/vim.rs
@@ -30,6 +30,7 @@
 //! through Yew), so this module reads and writes the DOM element directly, the
 //! same way `InputBar::set_input_text` does.
 
+use wasm_bindgen::JsCast;
 use web_sys::{Element, HtmlTextAreaElement, KeyboardEvent};
 
 /// The two supported editing modes.
@@ -429,8 +430,7 @@ fn handle_normal(
                 state.mode = VimMode::Insert;
                 state.clear_pending();
                 move_cursor(textarea, &text, cursor);
-                let html_el: &web_sys::HtmlElement = textarea.as_ref();
-                let _ = html_el.blur();
+                hand_off_to_nav(textarea);
                 VimHandled::ExitToNav
             }
         }
@@ -828,6 +828,26 @@ fn scroll_messages(textarea: &HtmlTextAreaElement, kind: Scroll) {
         Scroll::Bottom => sh,
     };
     msgs.set_scroll_top(target);
+}
+
+/// Hand keyboard control from the input box to the dashboard's `use_keyboard_nav`
+/// hook when NORMAL `Esc` drops into Nav mode. Focus is moved onto the nav
+/// container (`.focus-flow-container`, which is `tabindex=0`) rather than merely
+/// blurred: a bare `blur()` sends focus to `<body>`, an *ancestor* of the
+/// container, so its `onkeydown` would never fire and Nav-mode keys (j/k/i/…)
+/// would be dead. Focusing the container makes keydowns target it directly.
+fn hand_off_to_nav(textarea: &HtmlTextAreaElement) {
+    if let Some(container) = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.query_selector(".focus-flow-container").ok().flatten())
+        .and_then(|e| e.dyn_into::<web_sys::HtmlElement>().ok())
+    {
+        let _ = container.focus();
+    } else {
+        // Fallback: at least drop focus so vim stops consuming keys.
+        let html_el: &web_sys::HtmlElement = textarea.as_ref();
+        let _ = html_el.blur();
+    }
 }
 
 fn char_idx_to_utf16(text: &[char], idx: usize) -> u32 {

--- a/frontend/src/pages/dashboard/session_view/vim.rs
+++ b/frontend/src/pages/dashboard/session_view/vim.rs
@@ -1,18 +1,30 @@
-//! Minimal modal ("vim-like") editing for the message-input textarea.
+//! Modal ("vim-like") editing for the message-input textarea.
 //!
-//! This is an OPT-IN, deliberately small subset of vim — enough to be genuinely
-//! usable for composing a message without pulling in a heavy JS editor (which
-//! would violate the WASM constraints of the frontend). Only two modes exist:
+//! This is an OPT-IN vim subset — enough to compose a message without pulling
+//! in a heavy JS editor (which would violate the WASM constraints of the
+//! frontend). Two modes exist:
 //!
-//! - **NORMAL** — motions (`h j k l`, `w b`, `0 $`) and edits (`x`, `dd`, `dw`,
-//!   `i a o O`).
+//! - **NORMAL** — motions (`h j k l`, `w b e`, `0 $`, `gg G`), edits (`x`,
+//!   `r` replace, `~` toggle-case, `dd`/`dw`/`D`/`C`/`cc`/`S`, `i a o O A I`),
+//!   operators (`d`/`c`/`y`) over motions and text objects (`iw`/`aw`,
+//!   `i(`/`a(`, `i"`…), paste (`p`/`P`), undo (`u`), and page scrolling of the
+//!   conversation (`Ctrl-d/u/f/b`, `gg`, `G`).
 //! - **INSERT** — typing inserts normally; `Esc` returns to NORMAL.
 //!
 //! The engine operates on the textarea's value as a `Vec<char>` with the cursor
 //! tracked as a **char index**. The DOM's `selectionStart`/`setSelectionRange`
 //! speak UTF-16 code units, so we convert at the boundary. Astral-plane
 //! characters (emoji) count as a single "cell" here, which is close enough for
-//! a chat box; full grapheme handling is out of scope for v1.
+//! a chat box; full grapheme handling is out of scope.
+//!
+//! **Block cursor.** In NORMAL mode the caret is rendered as the classic vim
+//! block by keeping a one-character DOM selection (`sel = idx..idx+1`) and
+//! having the parent add a `vim-normal` CSS class to the textarea, so
+//! `.message-input.vim-normal::selection` paints a solid block. At end-of-line
+//! / empty input the selection collapses (no char to cover). INSERT mode
+//! removes the class and collapses to a thin caret. The class is Yew-managed
+//! (the parent reads `state.mode` when rendering) so a re-render can't wipe it;
+//! this module only ever sets the *selection*, never the class.
 //!
 //! The textarea is uncontrolled (the parent `InputBar` never passes `value`
 //! through Yew), so this module reads and writes the DOM element directly, the
@@ -45,6 +57,53 @@ impl VimMode {
     }
 }
 
+/// An operator awaiting a motion or text object.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Op {
+    Delete,
+    Change,
+    Yank,
+}
+
+/// The multi-key sequence state machine. Only one of these is ever pending
+/// between keystrokes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Pending {
+    /// Fresh — the next key starts a new command.
+    None,
+    /// An operator (`d`/`c`/`y`) is waiting for its motion, a doubled operator
+    /// char (linewise), or a text-object introducer (`i`/`a`).
+    Operator(Op),
+    /// A text object is being built: operator + `i`(inner)/`a`(around) seen,
+    /// awaiting the object selector (`w`, a delimiter, or a quote).
+    TextObject { op: Op, around: bool },
+    /// `r` seen — the next key is the replacement character.
+    Replace,
+    /// `g` seen — awaiting a second `g` (for `gg`).
+    GPrefix,
+}
+
+/// The yank/delete register. Charwise holds a fragment; linewise holds whole
+/// line(s) without the trailing newline (paste re-adds it).
+#[derive(Default, Clone)]
+struct Register {
+    text: String,
+    linewise: bool,
+}
+
+/// Which conversation-scroll action a key maps to.
+#[derive(Clone, Copy)]
+enum Scroll {
+    HalfDown,
+    HalfUp,
+    FullDown,
+    FullUp,
+    Top,
+    Bottom,
+}
+
+const UNDO_LIMIT: usize = 100;
+
 /// Per-input modal state.
 ///
 /// Starts in INSERT: enabling vim mode should leave the textarea behaving like
@@ -53,17 +112,51 @@ impl VimMode {
 /// it on to try it out.
 pub struct VimState {
     pub mode: VimMode,
-    /// A pending operator awaiting its motion. Currently only `d` (for `dd` and
-    /// `dw`).
-    pending_op: Option<char>,
+    pending: Pending,
+    /// Numeric count prefix accumulated in NORMAL mode (`3j`, `2dd`).
+    count: Option<usize>,
+    /// Internal paste register, populated by x/d/c/y.
+    register: Register,
+    /// Bounded undo stack of `(text, cursor)` snapshots pushed before each
+    /// mutating op.
+    undo: Vec<(String, usize)>,
 }
 
 impl Default for VimState {
     fn default() -> Self {
         Self {
             mode: VimMode::Insert,
-            pending_op: None,
+            pending: Pending::None,
+            count: None,
+            register: Register::default(),
+            undo: Vec::new(),
         }
+    }
+}
+
+impl VimState {
+    /// Reset the multi-key sequence machine (pending op + count).
+    fn clear_pending(&mut self) {
+        self.pending = Pending::None;
+        self.count = None;
+    }
+
+    /// Consume the pending count, defaulting to 1.
+    fn take_count(&mut self) -> usize {
+        self.count.take().unwrap_or(1).max(1)
+    }
+
+    /// Push a pre-mutation snapshot onto the bounded undo stack.
+    fn push_undo(&mut self, text: &str, cursor: usize) {
+        if self.undo.len() >= UNDO_LIMIT {
+            self.undo.remove(0);
+        }
+        self.undo.push((text.to_string(), cursor));
+    }
+
+    /// Pop the most recent snapshot, if any.
+    fn pop_undo(&mut self) -> Option<(String, usize)> {
+        self.undo.pop()
     }
 }
 
@@ -87,9 +180,8 @@ pub fn handle_key(
     textarea: &HtmlTextAreaElement,
     event: &KeyboardEvent,
 ) -> VimHandled {
-    // Never intercept modifier chords — leave copy/paste, browser shortcuts,
-    // and the Ctrl+M voice toggle to their existing handlers.
-    if event.ctrl_key() || event.meta_key() || event.alt_key() {
+    // Never intercept meta/alt chords — leave OS/browser shortcuts alone.
+    if event.meta_key() || event.alt_key() {
         return VimHandled::Passthrough;
     }
 
@@ -97,6 +189,10 @@ pub fn handle_key(
 
     match state.mode {
         VimMode::Insert => {
+            // In INSERT, leave all Ctrl chords (copy/paste/voice) untouched.
+            if event.ctrl_key() {
+                return VimHandled::Passthrough;
+            }
             if key == "Escape" {
                 enter_normal(state, textarea);
                 event.prevent_default();
@@ -117,92 +213,194 @@ fn handle_normal(
     event: &KeyboardEvent,
     key: &str,
 ) -> VimHandled {
+    // Ctrl chords in NORMAL: only the page-scroll set is ours; everything else
+    // (Ctrl+C/V/A, refresh, …) passes through.
+    if event.ctrl_key() {
+        let scroll = match key {
+            "d" => Some(Scroll::HalfDown),
+            "u" => Some(Scroll::HalfUp),
+            "f" => Some(Scroll::FullDown),
+            "b" => Some(Scroll::FullUp),
+            _ => None,
+        };
+        return match scroll {
+            Some(s) => {
+                scroll_messages(textarea, s);
+                event.prevent_default();
+                VimHandled::Consumed { rerender: false }
+            }
+            None => VimHandled::Passthrough,
+        };
+    }
+
     // Even in NORMAL mode, keep Enter sending and let the Arrow keys drive
     // command history / native caret movement (matches the non-vim contract).
     if matches!(
         key,
         "Enter" | "ArrowUp" | "ArrowDown" | "ArrowLeft" | "ArrowRight"
     ) {
-        state.pending_op = None;
+        state.clear_pending();
         return VimHandled::Passthrough;
     }
 
     let text: Vec<char> = textarea.value().chars().collect();
     let cursor = read_cursor(textarea, &text);
 
-    // Resolve a pending operator (only `d` so far: `dd`, `dw`).
-    if let Some(op) = state.pending_op.take() {
-        if op == 'd' {
-            match key {
-                "d" => {
-                    let (new_text, new_cursor) = delete_line(&text, cursor);
-                    apply_edit(textarea, &new_text, new_cursor);
-                    event.prevent_default();
-                    return VimHandled::Consumed { rerender: true };
-                }
-                "w" => {
-                    let (new_text, new_cursor) = delete_word(&text, cursor);
-                    apply_edit(textarea, &new_text, new_cursor);
-                    event.prevent_default();
-                    return VimHandled::Consumed { rerender: true };
-                }
-                _ => {
-                    // Unknown motion after `d` — cancel and swallow the key.
-                    event.prevent_default();
-                    return VimHandled::Consumed { rerender: false };
-                }
-            }
+    match state.pending {
+        Pending::Replace => return resolve_replace(state, textarea, event, key, &text, cursor),
+        Pending::GPrefix => return resolve_g(state, textarea, event, key),
+        Pending::TextObject { op, around } => {
+            return resolve_text_object(state, textarea, event, key, &text, cursor, (op, around));
+        }
+        Pending::Operator(op) => {
+            return resolve_operator(state, textarea, event, key, &text, cursor, op);
+        }
+        Pending::None => {}
+    }
+
+    // --- Fresh key: numeric count prefix -----------------------------------
+    if let Some(d) = key.chars().next().filter(|c| c.is_ascii_digit()) {
+        let d = d as usize - '0' as usize;
+        // A leading `0` is the line-start motion, not a count digit.
+        if d != 0 || state.count.is_some() {
+            state.count = Some(state.count.unwrap_or(0).saturating_mul(10) + d);
+            event.prevent_default();
+            return VimHandled::Consumed { rerender: false };
         }
     }
 
-    match key {
-        "h" => motion(textarea, &text, event, cursor.saturating_sub(1)),
-        "l" => motion(textarea, &text, event, (cursor + 1).min(text.len())),
-        "j" => motion(textarea, &text, event, line_down(&text, cursor)),
-        "k" => motion(textarea, &text, event, line_up(&text, cursor)),
-        "w" => motion(textarea, &text, event, next_word(&text, cursor)),
-        "b" => motion(textarea, &text, event, prev_word(&text, cursor)),
-        "0" => motion(textarea, &text, event, line_start(&text, cursor)),
-        "$" => motion(textarea, &text, event, line_end(&text, cursor)),
-        "i" => {
-            state.mode = VimMode::Insert;
-            move_cursor(textarea, &text, cursor);
-            event.prevent_default();
-            VimHandled::Consumed { rerender: true }
+    // --- Plain motions (count-aware) ---------------------------------------
+    if let Some(mut target) = simple_motion_target(key, &text, cursor) {
+        let n = state.take_count();
+        // Re-apply the motion `n` times for counts like `3w`.
+        for _ in 1..n {
+            target = simple_motion_target(key, &text, target).unwrap_or(target);
         }
-        "a" => {
-            state.mode = VimMode::Insert;
-            move_cursor(textarea, &text, (cursor + 1).min(text.len()));
-            event.prevent_default();
-            VimHandled::Consumed { rerender: true }
+        return motion(textarea, &text, event, target);
+    }
+
+    match key {
+        // Enter INSERT ------------------------------------------------------
+        "i" => enter_insert_at(state, textarea, event, &text, cursor),
+        "a" => enter_insert_at(state, textarea, event, &text, (cursor + 1).min(text.len())),
+        "A" => {
+            let le = line_end(&text, cursor);
+            enter_insert_at(state, textarea, event, &text, le)
+        }
+        "I" => {
+            let fnb = first_non_blank(&text, cursor);
+            enter_insert_at(state, textarea, event, &text, fnb)
         }
         "o" => {
+            let cur: String = text.iter().collect();
+            state.push_undo(&cur, cursor);
             let (new_text, new_cursor) = open_line_below(&text, cursor);
-            apply_edit(textarea, &new_text, new_cursor);
+            set_text(textarea, &new_text);
             state.mode = VimMode::Insert;
+            move_cursor(textarea, &new_text, new_cursor);
+            state.clear_pending();
             event.prevent_default();
             VimHandled::Consumed { rerender: true }
         }
         "O" => {
+            let cur: String = text.iter().collect();
+            state.push_undo(&cur, cursor);
             let (new_text, new_cursor) = open_line_above(&text, cursor);
-            apply_edit(textarea, &new_text, new_cursor);
+            set_text(textarea, &new_text);
             state.mode = VimMode::Insert;
+            move_cursor(textarea, &new_text, new_cursor);
+            state.clear_pending();
             event.prevent_default();
             VimHandled::Consumed { rerender: true }
         }
+
+        // Deletes / changes -------------------------------------------------
         "x" => {
-            let (new_text, new_cursor) = delete_char(&text, cursor);
-            apply_edit(textarea, &new_text, new_cursor);
-            event.prevent_default();
-            VimHandled::Consumed { rerender: true }
+            let n = state.take_count();
+            let end = (cursor + n).min(text.len());
+            edit_range(state, textarea, event, &text, Op::Delete, cursor, end)
         }
-        "d" => {
-            state.pending_op = Some('d');
+        "D" => {
+            let le = line_end(&text, cursor);
+            edit_range(state, textarea, event, &text, Op::Delete, cursor, le)
+        }
+        "C" => {
+            let le = line_end(&text, cursor);
+            edit_range(state, textarea, event, &text, Op::Change, cursor, le)
+        }
+        "S" => linewise_op(state, textarea, event, &text, cursor, Op::Change, 1),
+
+        // Operators (await motion / text object) ----------------------------
+        "d" => set_operator(state, event, Op::Delete),
+        "c" => set_operator(state, event, Op::Change),
+        "y" => set_operator(state, event, Op::Yank),
+
+        // Replace / toggle-case --------------------------------------------
+        "r" => {
+            state.pending = Pending::Replace;
             event.prevent_default();
             VimHandled::Consumed { rerender: false }
         }
+        "~" => {
+            let n = state.take_count();
+            let cur: String = text.iter().collect();
+            let (mut v, mut c) = (text.clone(), cursor);
+            let mut changed = false;
+            for _ in 0..n {
+                let (nv, nc) = toggle_case(&v, c);
+                if nv != v {
+                    changed = true;
+                }
+                v = nv;
+                c = nc;
+            }
+            if changed {
+                state.push_undo(&cur, cursor);
+                set_text(textarea, &v);
+            }
+            place_block(textarea, &v, c);
+            state.clear_pending();
+            event.prevent_default();
+            VimHandled::Consumed { rerender: changed }
+        }
+
+        // Paste -------------------------------------------------------------
+        "p" => paste_cmd(state, textarea, event, &text, cursor, true),
+        "P" => paste_cmd(state, textarea, event, &text, cursor, false),
+
+        // Undo --------------------------------------------------------------
+        "u" => {
+            if let Some((prev, prev_cursor)) = state.pop_undo() {
+                let v: Vec<char> = prev.chars().collect();
+                set_text(textarea, &v);
+                place_block(textarea, &v, prev_cursor.min(v.len()));
+                state.clear_pending();
+                event.prevent_default();
+                VimHandled::Consumed { rerender: true }
+            } else {
+                state.clear_pending();
+                event.prevent_default();
+                VimHandled::Consumed { rerender: false }
+            }
+        }
+
+        // Scroll top/bottom -------------------------------------------------
+        "g" => {
+            state.pending = Pending::GPrefix;
+            event.prevent_default();
+            VimHandled::Consumed { rerender: false }
+        }
+        "G" => {
+            scroll_messages(textarea, Scroll::Bottom);
+            state.clear_pending();
+            event.prevent_default();
+            VimHandled::Consumed { rerender: false }
+        }
+
         "Escape" => {
-            // Already NORMAL — clear any half-typed operator.
+            // Already NORMAL — clear any half-typed operator / count.
+            state.clear_pending();
+            place_block(textarea, &text, cursor);
             event.prevent_default();
             VimHandled::Consumed { rerender: false }
         }
@@ -210,6 +408,7 @@ fn handle_normal(
             // Swallow any other single printable character so stray letters
             // never leak into the textarea while in NORMAL mode. Let genuine
             // control keys (Tab, function keys, …) through.
+            state.clear_pending();
             if key.chars().count() == 1 {
                 event.prevent_default();
                 VimHandled::Consumed { rerender: false }
@@ -220,14 +419,295 @@ fn handle_normal(
     }
 }
 
-/// Apply a pure cursor motion: prevent default and move the caret.
+// --- Sequence resolvers -----------------------------------------------------
+
+fn set_operator(state: &mut VimState, event: &KeyboardEvent, op: Op) -> VimHandled {
+    state.pending = Pending::Operator(op);
+    event.prevent_default();
+    VimHandled::Consumed { rerender: false }
+}
+
+fn resolve_operator(
+    state: &mut VimState,
+    textarea: &HtmlTextAreaElement,
+    event: &KeyboardEvent,
+    key: &str,
+    text: &[char],
+    cursor: usize,
+    op: Op,
+) -> VimHandled {
+    // `i`/`a` introduce a text object.
+    match key {
+        "i" => {
+            state.pending = Pending::TextObject { op, around: false };
+            event.prevent_default();
+            return VimHandled::Consumed { rerender: false };
+        }
+        "a" => {
+            state.pending = Pending::TextObject { op, around: true };
+            event.prevent_default();
+            return VimHandled::Consumed { rerender: false };
+        }
+        _ => {}
+    }
+
+    // Doubled operator (`dd`/`cc`/`yy`) → linewise.
+    let doubled = matches!(
+        (op, key),
+        (Op::Delete, "d") | (Op::Change, "c") | (Op::Yank, "y")
+    );
+    if doubled {
+        let n = state.take_count();
+        return linewise_op(state, textarea, event, text, cursor, op, n);
+    }
+
+    // Operator over a motion (`dw`, `d$`, `de`, `y0`, …).
+    if let Some((start, end)) = operator_motion_range(key, text, cursor) {
+        state.count = None;
+        return edit_range(state, textarea, event, text, op, start, end);
+    }
+
+    // Unknown motion — cancel and swallow.
+    state.clear_pending();
+    event.prevent_default();
+    VimHandled::Consumed { rerender: false }
+}
+
+fn resolve_text_object(
+    state: &mut VimState,
+    textarea: &HtmlTextAreaElement,
+    event: &KeyboardEvent,
+    key: &str,
+    text: &[char],
+    cursor: usize,
+    spec: (Op, bool),
+) -> VimHandled {
+    let (op, around) = spec;
+    let kind = text_object_kind(key);
+    let range = kind.and_then(|k| text_object_range(text, cursor, k, around));
+    state.count = None;
+    match range {
+        Some((start, end)) => edit_range(state, textarea, event, text, op, start, end),
+        None => {
+            state.clear_pending();
+            event.prevent_default();
+            VimHandled::Consumed { rerender: false }
+        }
+    }
+}
+
+fn resolve_replace(
+    state: &mut VimState,
+    textarea: &HtmlTextAreaElement,
+    event: &KeyboardEvent,
+    key: &str,
+    text: &[char],
+    cursor: usize,
+) -> VimHandled {
+    state.clear_pending();
+    // The replacement char: a single printable char, or Enter → newline.
+    let repl = if key == "Enter" {
+        Some('\n')
+    } else if key == "Escape" {
+        None
+    } else {
+        let mut it = key.chars();
+        match (it.next(), it.next()) {
+            (Some(c), None) => Some(c),
+            _ => None,
+        }
+    };
+    if let Some(ch) = repl {
+        if cursor < text.len() && text[cursor] != '\n' {
+            let cur: String = text.iter().collect();
+            state.push_undo(&cur, cursor);
+            let v = replace_char(text, cursor, ch);
+            set_text(textarea, &v);
+            place_block(textarea, &v, cursor);
+            event.prevent_default();
+            return VimHandled::Consumed { rerender: true };
+        }
+    }
+    place_block(textarea, text, cursor);
+    event.prevent_default();
+    VimHandled::Consumed { rerender: false }
+}
+
+fn resolve_g(
+    state: &mut VimState,
+    textarea: &HtmlTextAreaElement,
+    event: &KeyboardEvent,
+    key: &str,
+) -> VimHandled {
+    state.clear_pending();
+    if key == "g" {
+        scroll_messages(textarea, Scroll::Top);
+    }
+    event.prevent_default();
+    VimHandled::Consumed { rerender: false }
+}
+
+/// Enter INSERT mode with the caret collapsed at `idx`.
+fn enter_insert_at(
+    state: &mut VimState,
+    textarea: &HtmlTextAreaElement,
+    event: &KeyboardEvent,
+    text: &[char],
+    idx: usize,
+) -> VimHandled {
+    state.mode = VimMode::Insert;
+    state.clear_pending();
+    move_cursor(textarea, text, idx);
+    event.prevent_default();
+    VimHandled::Consumed { rerender: true }
+}
+
+/// Apply an operator over a charwise `[start, end)` range. Handles register
+/// capture, undo snapshot, cursor placement, and INSERT transition for
+/// `Change`. Linewise operators go through `linewise_op` instead.
+fn edit_range(
+    state: &mut VimState,
+    textarea: &HtmlTextAreaElement,
+    event: &KeyboardEvent,
+    text: &[char],
+    op: Op,
+    start: usize,
+    end: usize,
+) -> VimHandled {
+    state.clear_pending();
+    event.prevent_default();
+
+    let (start, end) = (start.min(text.len()), end.min(text.len()));
+    let removed: String = if start < end {
+        text[start..end].iter().collect()
+    } else {
+        String::new()
+    };
+
+    match op {
+        Op::Yank => {
+            state.register = Register {
+                text: removed,
+                linewise: false,
+            };
+            // Yank leaves the buffer unchanged; move the caret to the range
+            // start (vim behavior for most yanks).
+            place_block(textarea, text, start);
+            VimHandled::Consumed { rerender: false }
+        }
+        Op::Delete | Op::Change => {
+            let cur: String = text.iter().collect();
+            state.push_undo(&cur, start.min(text.len()));
+            state.register = Register {
+                text: removed,
+                linewise: false,
+            };
+            let (v, c) = remove_range(text, start, end);
+            set_text(textarea, &v);
+            if op == Op::Change {
+                state.mode = VimMode::Insert;
+                move_cursor(textarea, &v, c);
+            } else {
+                place_block(textarea, &v, c);
+            }
+            VimHandled::Consumed { rerender: true }
+        }
+    }
+}
+
+/// Linewise operator over `n` lines starting at the cursor's line.
+fn linewise_op(
+    state: &mut VimState,
+    textarea: &HtmlTextAreaElement,
+    event: &KeyboardEvent,
+    text: &[char],
+    cursor: usize,
+    op: Op,
+    n: usize,
+) -> VimHandled {
+    state.clear_pending();
+    event.prevent_default();
+
+    let ls = line_start(text, cursor);
+    // End of the nth line down (inclusive of its content, exclusive of the
+    // final trailing newline).
+    let mut le = line_end(text, cursor);
+    for _ in 1..n {
+        if le >= text.len() {
+            break;
+        }
+        le = line_end(text, le + 1);
+    }
+    let content: String = text[ls..le.min(text.len())].iter().collect();
+
+    match op {
+        Op::Yank => {
+            state.register = Register {
+                text: content,
+                linewise: true,
+            };
+            place_block(textarea, text, ls);
+            VimHandled::Consumed { rerender: false }
+        }
+        Op::Delete => {
+            let cur: String = text.iter().collect();
+            state.push_undo(&cur, ls);
+            state.register = Register {
+                text: content,
+                linewise: true,
+            };
+            let (v, c) = delete_lines(text, ls, le);
+            set_text(textarea, &v);
+            place_block(textarea, &v, c);
+            VimHandled::Consumed { rerender: true }
+        }
+        Op::Change => {
+            // `cc`/`S`: keep the line but blank its content, enter INSERT.
+            let cur: String = text.iter().collect();
+            state.push_undo(&cur, ls);
+            state.register = Register {
+                text: content,
+                linewise: true,
+            };
+            let (v, c) = remove_range(text, ls, le.min(text.len()));
+            set_text(textarea, &v);
+            state.mode = VimMode::Insert;
+            move_cursor(textarea, &v, c);
+            VimHandled::Consumed { rerender: true }
+        }
+    }
+}
+
+fn paste_cmd(
+    state: &mut VimState,
+    textarea: &HtmlTextAreaElement,
+    event: &KeyboardEvent,
+    text: &[char],
+    cursor: usize,
+    after: bool,
+) -> VimHandled {
+    state.clear_pending();
+    event.prevent_default();
+    if state.register.text.is_empty() {
+        place_block(textarea, text, cursor);
+        return VimHandled::Consumed { rerender: false };
+    }
+    let cur: String = text.iter().collect();
+    state.push_undo(&cur, cursor);
+    let (v, c) = paste(text, cursor, &state.register, after);
+    set_text(textarea, &v);
+    place_block(textarea, &v, c);
+    VimHandled::Consumed { rerender: true }
+}
+
+/// Apply a pure cursor motion: prevent default and move the block caret.
 fn motion(
     textarea: &HtmlTextAreaElement,
     text: &[char],
     event: &KeyboardEvent,
     target: usize,
 ) -> VimHandled {
-    move_cursor(textarea, text, target);
+    place_block(textarea, text, target);
     event.prevent_default();
     VimHandled::Consumed { rerender: false }
 }
@@ -236,12 +716,12 @@ fn motion(
 /// just-typed character), clamped to the start of the current line.
 fn enter_normal(state: &mut VimState, textarea: &HtmlTextAreaElement) {
     state.mode = VimMode::Normal;
-    state.pending_op = None;
+    state.clear_pending();
     let text: Vec<char> = textarea.value().chars().collect();
     let cursor = read_cursor(textarea, &text);
     let ls = line_start(&text, cursor);
     let new = if cursor > ls { cursor - 1 } else { cursor };
-    move_cursor(textarea, &text, new);
+    place_block(textarea, &text, new);
 }
 
 // --- DOM boundary helpers ---------------------------------------------------
@@ -251,17 +731,32 @@ fn read_cursor(textarea: &HtmlTextAreaElement, text: &[char]) -> usize {
     utf16_to_char_idx(text, off)
 }
 
+/// Collapse the caret at `idx` (INSERT-mode thin caret / mode transitions).
 fn move_cursor(textarea: &HtmlTextAreaElement, text: &[char], idx: usize) {
     let off = char_idx_to_utf16(text, idx);
     let _ = textarea.set_selection_range(off, off);
 }
 
-fn apply_edit(textarea: &HtmlTextAreaElement, text: &[char], cursor: usize) {
+/// Place the NORMAL-mode block caret: a one-char selection covering the cell at
+/// `idx`, or a collapsed caret at end-of-line / empty input.
+fn place_block(textarea: &HtmlTextAreaElement, text: &[char], idx: usize) {
+    let idx = idx.min(text.len());
+    let start = char_idx_to_utf16(text, idx);
+    let at_eol = idx >= text.len() || text[idx] == '\n';
+    let end = if at_eol {
+        start
+    } else {
+        char_idx_to_utf16(text, idx + 1)
+    };
+    let _ = textarea.set_selection_range(start, end);
+}
+
+/// Write `text` to the DOM element and auto-resize it. Does not move the caret;
+/// callers position it via `place_block` / `move_cursor`.
+fn set_text(textarea: &HtmlTextAreaElement, text: &[char]) {
     let s: String = text.iter().collect();
     textarea.set_value(&s);
     autosize(textarea, &s);
-    let off = char_idx_to_utf16(text, cursor);
-    let _ = textarea.set_selection_range(off, off);
 }
 
 /// Resize the textarea to fit its content (mirrors `InputBar::set_input_text`).
@@ -275,6 +770,34 @@ fn autosize(textarea: &HtmlTextAreaElement, text: &str) {
         el.set_attribute("style", &format!("height: {}px", textarea.scroll_height()))
             .ok();
     }
+}
+
+/// Scroll the conversation transcript container (`.session-view-messages`) for
+/// this session. Discovered by walking up from the textarea to the enclosing
+/// `.session-view` and querying its scrollable messages pane — this keeps the
+/// right pane scrolling when several session views are on screen. Uses
+/// `set_scroll_top` (which clamps) so no smooth-scroll web-sys feature is
+/// needed.
+fn scroll_messages(textarea: &HtmlTextAreaElement, kind: Scroll) {
+    let el: &Element = textarea.as_ref();
+    let Some(view) = el.closest(".session-view").ok().flatten() else {
+        return;
+    };
+    let Some(msgs) = view.query_selector(".session-view-messages").ok().flatten() else {
+        return;
+    };
+    let ch = msgs.client_height();
+    let sh = msgs.scroll_height();
+    let st = msgs.scroll_top();
+    let target = match kind {
+        Scroll::HalfDown => st + ch / 2,
+        Scroll::HalfUp => st - ch / 2,
+        Scroll::FullDown => st + ch,
+        Scroll::FullUp => st - ch,
+        Scroll::Top => 0,
+        Scroll::Bottom => sh,
+    };
+    msgs.set_scroll_top(target);
 }
 
 fn char_idx_to_utf16(text: &[char], idx: usize) -> u32 {
@@ -311,6 +834,17 @@ fn line_start(text: &[char], cursor: usize) -> usize {
 fn line_end(text: &[char], cursor: usize) -> usize {
     let mut i = cursor.min(text.len());
     while i < text.len() && text[i] != '\n' {
+        i += 1;
+    }
+    i
+}
+
+/// First non-blank column of the line containing `cursor`.
+fn first_non_blank(text: &[char], cursor: usize) -> usize {
+    let ls = line_start(text, cursor);
+    let le = line_end(text, cursor);
+    let mut i = ls;
+    while i < le && text[i].is_whitespace() {
         i += 1;
     }
     i
@@ -371,37 +905,228 @@ fn prev_word(text: &[char], cursor: usize) -> usize {
     i
 }
 
-fn delete_char(text: &[char], cursor: usize) -> (Vec<char>, usize) {
-    let mut v = text.to_vec();
-    if cursor < v.len() {
-        v.remove(cursor);
+/// Index of the last character of the current or next word (vim `e`).
+fn end_of_word(text: &[char], cursor: usize) -> usize {
+    let n = text.len();
+    if n == 0 {
+        return 0;
     }
-    let c = cursor.min(v.len());
+    let mut i = cursor + 1;
+    while i < n && text[i].is_whitespace() {
+        i += 1;
+    }
+    if i >= n {
+        return cursor.min(n - 1);
+    }
+    while i + 1 < n && !text[i + 1].is_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+/// Target index for a plain motion key, or `None` if `key` isn't a motion.
+fn simple_motion_target(key: &str, text: &[char], cursor: usize) -> Option<usize> {
+    Some(match key {
+        "h" => cursor.saturating_sub(1),
+        "l" => (cursor + 1).min(text.len()),
+        "j" => line_down(text, cursor),
+        "k" => line_up(text, cursor),
+        "w" => next_word(text, cursor),
+        "b" => prev_word(text, cursor),
+        "e" => end_of_word(text, cursor),
+        "0" => line_start(text, cursor),
+        "$" => line_end(text, cursor),
+        _ => return None,
+    })
+}
+
+/// Charwise `[start, end)` range spanned by an operator motion (`dw`, `d$`, …).
+fn operator_motion_range(key: &str, text: &[char], cursor: usize) -> Option<(usize, usize)> {
+    let n = text.len();
+    Some(match key {
+        "w" => (cursor, next_word(text, cursor)),
+        "b" => (prev_word(text, cursor), cursor),
+        "e" => (cursor, (end_of_word(text, cursor) + 1).min(n)),
+        "0" => (line_start(text, cursor), cursor),
+        "$" => (cursor, line_end(text, cursor)),
+        "h" => (cursor.saturating_sub(1), cursor),
+        "l" => (cursor, (cursor + 1).min(n)),
+        _ => return None,
+    })
+}
+
+/// Text-object selectors and their delimiter geometry.
+#[derive(Clone, Copy)]
+enum TextObjectKind {
+    Word,
+    /// Distinct open/close delimiter pair.
+    Delim(char, char),
+    /// Symmetric quote (`"`, `'`, `` ` ``).
+    Quote(char),
+}
+
+/// Map a text-object selector key to its kind. `b`/`B` alias the round/curly
+/// pairs (vim convention).
+fn text_object_kind(key: &str) -> Option<TextObjectKind> {
+    Some(match key {
+        "w" => TextObjectKind::Word,
+        "(" | ")" | "b" => TextObjectKind::Delim('(', ')'),
+        "{" | "}" | "B" => TextObjectKind::Delim('{', '}'),
+        "[" | "]" => TextObjectKind::Delim('[', ']'),
+        "<" | ">" => TextObjectKind::Delim('<', '>'),
+        "\"" => TextObjectKind::Quote('"'),
+        "'" => TextObjectKind::Quote('\''),
+        "`" => TextObjectKind::Quote('`'),
+        _ => return None,
+    })
+}
+
+/// Compute the charwise `[start, end)` range for a text object. `around`
+/// includes the delimiters / trailing whitespace; otherwise "inside" only.
+fn text_object_range(
+    text: &[char],
+    cursor: usize,
+    kind: TextObjectKind,
+    around: bool,
+) -> Option<(usize, usize)> {
+    match kind {
+        TextObjectKind::Word => Some(word_object(text, cursor, around)),
+        TextObjectKind::Delim(open, close) => {
+            let (op, cp) = find_pair(text, cursor, open, close)?;
+            Some(if around { (op, cp + 1) } else { (op + 1, cp) })
+        }
+        TextObjectKind::Quote(q) => {
+            let (a, b) = find_quote(text, cursor, q)?;
+            Some(if around { (a, b + 1) } else { (a + 1, b) })
+        }
+    }
+}
+
+/// `iw`/`aw` range. Inner = the run (whitespace or non-whitespace) under the
+/// cursor. Around = plus trailing whitespace, or leading whitespace if there's
+/// no trailing.
+fn word_object(text: &[char], cursor: usize, around: bool) -> (usize, usize) {
+    let n = text.len();
+    if n == 0 {
+        return (0, 0);
+    }
+    let cur = cursor.min(n - 1);
+    let ws = text[cur].is_whitespace();
+    let mut start = cur;
+    while start > 0 && text[start - 1].is_whitespace() == ws {
+        start -= 1;
+    }
+    let mut last = cur;
+    while last + 1 < n && text[last + 1].is_whitespace() == ws {
+        last += 1;
+    }
+    let mut end = last + 1;
+    if around {
+        let mut te = end;
+        while te < n && text[te].is_whitespace() {
+            te += 1;
+        }
+        if te > end {
+            end = te;
+        } else {
+            while start > 0 && text[start - 1].is_whitespace() {
+                start -= 1;
+            }
+        }
+    }
+    (start, end)
+}
+
+/// Find the delimiter pair enclosing (or touching) `cursor`. Returns the
+/// inclusive char indices of the matching open and close delimiters, honoring
+/// nesting.
+fn find_pair(text: &[char], cursor: usize, open: char, close: char) -> Option<(usize, usize)> {
+    let n = text.len();
+    if n == 0 {
+        return None;
+    }
+    let cur = cursor.min(n - 1);
+    let open_pos = if text[cur] == open {
+        cur
+    } else {
+        // Walk left, matching nested pairs, to find the enclosing open.
+        let mut depth = 0i32;
+        let mut i = cur;
+        let mut found = None;
+        while i > 0 {
+            i -= 1;
+            if text[i] == close {
+                depth += 1;
+            } else if text[i] == open {
+                if depth == 0 {
+                    found = Some(i);
+                    break;
+                }
+                depth -= 1;
+            }
+        }
+        found?
+    };
+    // Walk right for the matching close.
+    let mut depth = 0i32;
+    let mut j = open_pos + 1;
+    while j < n {
+        if text[j] == open {
+            depth += 1;
+        } else if text[j] == close {
+            if depth == 0 {
+                return Some((open_pos, j));
+            }
+            depth -= 1;
+        }
+        j += 1;
+    }
+    None
+}
+
+/// Find the quote pair on the cursor's line. Quotes are matched sequentially
+/// left-to-right; returns the first pair whose closing quote is at/after the
+/// cursor (so the cursor is inside it, or it's the next quoted span).
+fn find_quote(text: &[char], cursor: usize, q: char) -> Option<(usize, usize)> {
+    let ls = line_start(text, cursor);
+    let le = line_end(text, cursor);
+    let positions: Vec<usize> = (ls..le).filter(|&i| text[i] == q).collect();
+    for pair in positions.chunks(2) {
+        if let [a, b] = *pair {
+            if cursor <= b {
+                return Some((a, b));
+            }
+        }
+    }
+    None
+}
+
+/// Remove `[start, end)`, returning the new buffer and the resting cursor
+/// (clamped to the range start).
+fn remove_range(text: &[char], start: usize, end: usize) -> (Vec<char>, usize) {
+    let mut v = text.to_vec();
+    let start = start.min(v.len());
+    let end = end.min(v.len());
+    if start < end {
+        v.drain(start..end);
+    }
+    let c = start.min(v.len());
     (v, c)
 }
 
-fn delete_word(text: &[char], cursor: usize) -> (Vec<char>, usize) {
-    let end = next_word(text, cursor);
+/// Delete whole lines `[ls, le]` where `le` is the end (exclusive of the final
+/// newline) of the last line to remove. Mirrors vim `dd`/`Ndd`.
+fn delete_lines(text: &[char], ls: usize, le: usize) -> (Vec<char>, usize) {
     let mut v = text.to_vec();
-    let start = cursor.min(v.len());
-    let end = end.min(v.len());
-    v.drain(start..end);
-    let cursor = start.min(v.len());
-    (v, cursor)
-}
-
-fn delete_line(text: &[char], cursor: usize) -> (Vec<char>, usize) {
-    let ls = line_start(text, cursor);
-    let le = line_end(text, cursor);
-    let mut v = text.to_vec();
+    let le = le.min(v.len());
     if le < v.len() {
         // Include the trailing newline so the line fully disappears.
         v.drain(ls..=le);
     } else if ls > 0 {
-        // Last line: also drop the newline that precedes it.
+        // Last line(s): also drop the newline that precedes the block.
         v.drain(ls - 1..le);
     } else {
-        // Only line: clear it.
+        // Whole buffer: clear it.
         v.drain(ls..le);
     }
     let c = line_start(&v, ls.min(v.len()));
@@ -422,12 +1147,83 @@ fn open_line_above(text: &[char], cursor: usize) -> (Vec<char>, usize) {
     (v, ls)
 }
 
+/// Replace the char under the cursor (never a newline). Cursor stays.
+fn replace_char(text: &[char], cursor: usize, ch: char) -> Vec<char> {
+    let mut v = text.to_vec();
+    if cursor < v.len() && v[cursor] != '\n' {
+        v[cursor] = ch;
+    }
+    v
+}
+
+/// Toggle the case of the char under the cursor and advance one cell (clamped
+/// to the line). Non-letters are left unchanged but still advance.
+fn toggle_case(text: &[char], cursor: usize) -> (Vec<char>, usize) {
+    let mut v = text.to_vec();
+    if cursor < v.len() && v[cursor] != '\n' {
+        let c = v[cursor];
+        let swapped = if c.is_lowercase() {
+            c.to_uppercase().next().unwrap_or(c)
+        } else if c.is_uppercase() {
+            c.to_lowercase().next().unwrap_or(c)
+        } else {
+            c
+        };
+        v[cursor] = swapped;
+        let le = line_end(&v, cursor);
+        let c = (cursor + 1).min(le);
+        return (v, c);
+    }
+    (v, cursor)
+}
+
+/// Paste the register relative to the cursor. Charwise pastes after/before the
+/// cursor cell; linewise inserts whole line(s) below/above. Returns the new
+/// buffer and resting cursor.
+fn paste(text: &[char], cursor: usize, reg: &Register, after: bool) -> (Vec<char>, usize) {
+    if reg.text.is_empty() {
+        return (text.to_vec(), cursor);
+    }
+    let ins: Vec<char> = reg.text.chars().collect();
+    let mut v = text.to_vec();
+    if reg.linewise {
+        if after {
+            let le = line_end(&v, cursor);
+            let mut seq = vec!['\n'];
+            seq.extend(ins.iter().copied());
+            v.splice(le..le, seq);
+            // The splice always lengthens the buffer, so `le + 1` (start of the
+            // pasted line) is in range.
+            (v, le + 1)
+        } else {
+            let ls = line_start(&v, cursor);
+            let mut seq = ins.clone();
+            seq.push('\n');
+            v.splice(ls..ls, seq);
+            (v, ls)
+        }
+    } else {
+        let at = if after {
+            (cursor + 1).min(v.len())
+        } else {
+            cursor
+        };
+        v.splice(at..at, ins.iter().copied());
+        let c = (at + ins.len()).saturating_sub(1).max(at);
+        (v, c)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn chars(s: &str) -> Vec<char> {
         s.chars().collect()
+    }
+
+    fn s(v: &[char]) -> String {
+        v.iter().collect()
     }
 
     #[test]
@@ -440,6 +1236,15 @@ mod tests {
     }
 
     #[test]
+    fn first_non_blank_skips_leading_ws() {
+        let t = chars("  hi\nx");
+        assert_eq!(first_non_blank(&t, 3), 2);
+        // All-blank line clamps to line end.
+        let t2 = chars("   ");
+        assert_eq!(first_non_blank(&t2, 1), 3);
+    }
+
+    #[test]
     fn horizontal_motions() {
         let t = chars("hello");
         assert_eq!(line_start(&t, 3), 0);
@@ -449,75 +1254,356 @@ mod tests {
     #[test]
     fn vertical_motions_preserve_column() {
         let t = chars("abcd\nef\nghij");
-        // From col 3 on line 0 → line 1 ("ef") has only 2 chars, clamp to its
-        // end (index 7, the caret just past 'f').
         assert_eq!(line_down(&t, 3), 7);
-        // From col 1 on line 2 ("ghij", starts at 8) → same column on line 1.
         assert_eq!(line_up(&t, 9), 6);
-        // Up from the first line is a no-op.
         assert_eq!(line_up(&t, 2), 2);
     }
 
     #[test]
     fn word_motions() {
         let t = chars("foo bar  baz");
-        assert_eq!(next_word(&t, 0), 4); // start of "bar"
-        assert_eq!(next_word(&t, 4), 9); // start of "baz"
-        assert_eq!(prev_word(&t, 9), 4); // back to "bar"
-        assert_eq!(prev_word(&t, 4), 0); // back to "foo"
+        assert_eq!(next_word(&t, 0), 4);
+        assert_eq!(next_word(&t, 4), 9);
+        assert_eq!(prev_word(&t, 9), 4);
+        assert_eq!(prev_word(&t, 4), 0);
     }
 
     #[test]
+    fn end_of_word_motion() {
+        let t = chars("foo bar");
+        assert_eq!(end_of_word(&t, 0), 2); // -> last char of "foo"
+        assert_eq!(end_of_word(&t, 2), 6); // -> last char of "bar"
+        assert_eq!(end_of_word(&t, 6), 6); // at buffer end, stays
+    }
+
+    /// `x` deletes the range `[cursor, cursor+1)` via `remove_range` (the same
+    /// path `handle_normal` takes).
+    #[test]
     fn x_deletes_char_under_cursor() {
-        let (v, c) = delete_char(&chars("abc"), 1);
-        assert_eq!(v.iter().collect::<String>(), "ac");
+        let (v, c) = remove_range(&chars("abc"), 1, 2);
+        assert_eq!(s(&v), "ac");
         assert_eq!(c, 1);
-        // At end of buffer, nothing to delete.
-        let (v, c) = delete_char(&chars("ab"), 2);
-        assert_eq!(v.iter().collect::<String>(), "ab");
+        // At end of buffer the range is empty -> no-op.
+        let (v, c) = remove_range(&chars("ab"), 2, 3);
+        assert_eq!(s(&v), "ab");
         assert_eq!(c, 2);
     }
 
+    /// `dw` = operator-motion range over `w`, then `remove_range`.
     #[test]
     fn dw_deletes_to_next_word() {
-        let (v, c) = delete_word(&chars("foo bar"), 0);
-        assert_eq!(v.iter().collect::<String>(), "bar");
+        let t = chars("foo bar");
+        let (start, end) = operator_motion_range("w", &t, 0).unwrap();
+        let (v, c) = remove_range(&t, start, end);
+        assert_eq!(s(&v), "bar");
         assert_eq!(c, 0);
     }
 
+    /// `dd` on a middle line drops the line and its trailing newline.
     #[test]
     fn dd_deletes_middle_line_with_trailing_newline() {
-        let (v, c) = delete_line(&chars("a\nb\nc"), 2);
-        assert_eq!(v.iter().collect::<String>(), "a\nc");
+        let t = chars("a\nb\nc");
+        let ls = line_start(&t, 2);
+        let le = line_end(&t, 2);
+        let (v, c) = delete_lines(&t, ls, le);
+        assert_eq!(s(&v), "a\nc");
         assert_eq!(c, 2);
     }
 
     #[test]
     fn dd_deletes_last_line_with_preceding_newline() {
-        let (v, _c) = delete_line(&chars("a\nb"), 2);
-        assert_eq!(v.iter().collect::<String>(), "a");
+        let t = chars("a\nb");
+        let ls = line_start(&t, 2);
+        let le = line_end(&t, 2);
+        let (v, _c) = delete_lines(&t, ls, le);
+        assert_eq!(s(&v), "a");
     }
 
     #[test]
     fn dd_clears_only_line() {
-        let (v, c) = delete_line(&chars("abc"), 1);
-        assert_eq!(v.iter().collect::<String>(), "");
+        let t = chars("abc");
+        let (v, c) = delete_lines(&t, line_start(&t, 1), line_end(&t, 1));
+        assert_eq!(s(&v), "");
         assert_eq!(c, 0);
     }
 
     #[test]
-    fn o_and_O_insert_newlines() {
+    fn delete_multiple_lines() {
+        let t = chars("a\nb\nc\nd");
+        // Delete 2 lines starting at line 0 (ls=0), le = end of 2nd line (=3).
+        let ls = line_start(&t, 0);
+        let mut le = line_end(&t, 0);
+        le = line_end(&t, le + 1);
+        let (v, c) = delete_lines(&t, ls, le);
+        assert_eq!(s(&v), "c\nd");
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn o_and_upper_o_insert_newlines() {
         let (v, c) = open_line_below(&chars("ab\ncd"), 1);
-        assert_eq!(v.iter().collect::<String>(), "ab\n\ncd");
+        assert_eq!(s(&v), "ab\n\ncd");
         assert_eq!(c, 3);
         let (v, c) = open_line_above(&chars("ab\ncd"), 4);
-        assert_eq!(v.iter().collect::<String>(), "ab\n\ncd");
+        assert_eq!(s(&v), "ab\n\ncd");
         assert_eq!(c, 3);
+    }
+
+    // --- text objects: word ---
+
+    #[test]
+    fn inner_word_selects_run_under_cursor() {
+        let t = chars("foo bar baz");
+        assert_eq!(word_object(&t, 5, false), (4, 7)); // "bar"
+                                                       // on whitespace -> the whitespace run
+        assert_eq!(word_object(&t, 3, false), (3, 4));
+    }
+
+    #[test]
+    fn around_word_includes_trailing_whitespace() {
+        let t = chars("foo bar baz");
+        // aw on "bar" includes the trailing space -> [4,8)
+        assert_eq!(word_object(&t, 5, true), (4, 8));
+    }
+
+    #[test]
+    fn around_word_includes_leading_ws_when_no_trailing() {
+        let t = chars("foo bar");
+        // aw on "bar" (no trailing ws) grabs the leading space -> [3,7)
+        assert_eq!(word_object(&t, 5, true), (3, 7));
+    }
+
+    #[test]
+    fn text_object_word_via_range() {
+        let t = chars("foo bar");
+        assert_eq!(
+            text_object_range(&t, 5, TextObjectKind::Word, false),
+            Some((4, 7))
+        );
+    }
+
+    // --- text objects: delimiters ---
+
+    #[test]
+    fn find_pair_parens_simple() {
+        let t = chars("a(bc)d");
+        assert_eq!(find_pair(&t, 3, '(', ')'), Some((1, 4)));
+        // cursor on the open delimiter
+        assert_eq!(find_pair(&t, 1, '(', ')'), Some((1, 4)));
+        // cursor on the close delimiter
+        assert_eq!(find_pair(&t, 4, '(', ')'), Some((1, 4)));
+    }
+
+    #[test]
+    fn find_pair_respects_nesting() {
+        let t = chars("(a(b)c)");
+        // inner cursor at 'b' (index 3) -> innermost pair (2,4)
+        assert_eq!(find_pair(&t, 3, '(', ')'), Some((2, 4)));
+        // cursor at 'a' (index 1) -> outer pair (0,6)
+        assert_eq!(find_pair(&t, 1, '(', ')'), Some((0, 6)));
+    }
+
+    #[test]
+    fn inside_vs_around_delimiters() {
+        let t = chars("x{ab}y");
+        // i{ -> "ab" = [2,4)
+        assert_eq!(
+            text_object_range(&t, 3, TextObjectKind::Delim('{', '}'), false),
+            Some((2, 4))
+        );
+        // a{ -> "{ab}" = [1,5)
+        assert_eq!(
+            text_object_range(&t, 3, TextObjectKind::Delim('{', '}'), true),
+            Some((1, 5))
+        );
+    }
+
+    #[test]
+    fn brackets_and_angles() {
+        let t = chars("[hi] <yo>");
+        assert_eq!(find_pair(&t, 2, '[', ']'), Some((0, 3)));
+        assert_eq!(find_pair(&t, 6, '<', '>'), Some((5, 8)));
+    }
+
+    #[test]
+    fn delimiter_aliases_b_and_upper_b() {
+        assert!(matches!(
+            text_object_kind("b"),
+            Some(TextObjectKind::Delim('(', ')'))
+        ));
+        assert!(matches!(
+            text_object_kind("B"),
+            Some(TextObjectKind::Delim('{', '}'))
+        ));
+    }
+
+    // --- text objects: quotes ---
+
+    #[test]
+    fn find_quote_on_line() {
+        let t = chars("say \"hi there\" ok");
+        // cursor inside the quotes
+        assert_eq!(find_quote(&t, 7, '"'), Some((4, 13)));
+    }
+
+    #[test]
+    fn inside_vs_around_quotes() {
+        let t = chars("a'bc'd");
+        assert_eq!(
+            text_object_range(&t, 2, TextObjectKind::Quote('\''), false),
+            Some((2, 4))
+        );
+        assert_eq!(
+            text_object_range(&t, 2, TextObjectKind::Quote('\''), true),
+            Some((1, 5))
+        );
+    }
+
+    #[test]
+    fn quote_before_cursor_picks_next_pair() {
+        let t = chars("x \"y\"");
+        // cursor before the quotes -> next pair
+        assert_eq!(find_quote(&t, 0, '"'), Some((2, 4)));
+    }
+
+    // --- operators over ranges (remove_range mirrors edit_range's math) ---
+
+    #[test]
+    fn remove_range_deletes_and_rests_cursor_at_start() {
+        let (v, c) = remove_range(&chars("hello world"), 0, 6);
+        assert_eq!(s(&v), "world");
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn diw_removes_inner_word() {
+        let t = chars("foo bar baz");
+        let (start, end) = text_object_range(&t, 5, TextObjectKind::Word, false).unwrap();
+        let (v, c) = remove_range(&t, start, end);
+        assert_eq!(s(&v), "foo  baz");
+        assert_eq!(c, 4);
+    }
+
+    #[test]
+    fn ci_paren_removes_inner() {
+        let t = chars("f(arg)");
+        let (start, end) =
+            text_object_range(&t, 3, TextObjectKind::Delim('(', ')'), false).unwrap();
+        let (v, c) = remove_range(&t, start, end);
+        assert_eq!(s(&v), "f()");
+        assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn operator_motion_ranges() {
+        let t = chars("foo bar");
+        assert_eq!(operator_motion_range("w", &t, 0), Some((0, 4)));
+        assert_eq!(operator_motion_range("$", &t, 0), Some((0, 7)));
+        assert_eq!(operator_motion_range("e", &t, 0), Some((0, 3)));
+    }
+
+    // --- replace / toggle-case ---
+
+    #[test]
+    fn replace_char_swaps_one() {
+        let v = replace_char(&chars("cat"), 0, 'b');
+        assert_eq!(s(&v), "bat");
+        // never replaces a newline
+        let v = replace_char(&chars("a\nb"), 1, 'x');
+        assert_eq!(s(&v), "a\nb");
+    }
+
+    #[test]
+    fn toggle_case_advances() {
+        let (v, c) = toggle_case(&chars("aBc"), 0);
+        assert_eq!(s(&v), "ABc");
+        assert_eq!(c, 1);
+        let (v, c) = toggle_case(&chars("aBc"), 1);
+        assert_eq!(s(&v), "abc");
+        assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn toggle_case_at_line_end_stays() {
+        let (v, c) = toggle_case(&chars("ab"), 1);
+        assert_eq!(s(&v), "aB");
+        assert_eq!(c, 2); // advanced to line end
+    }
+
+    // --- paste ---
+
+    #[test]
+    fn charwise_paste_after_and_before() {
+        let reg = Register {
+            text: "XY".into(),
+            linewise: false,
+        };
+        let (v, c) = paste(&chars("ab"), 0, &reg, true);
+        assert_eq!(s(&v), "aXYb");
+        assert_eq!(c, 2); // on last pasted char 'Y'
+        let (v, c) = paste(&chars("ab"), 0, &reg, false);
+        assert_eq!(s(&v), "XYab");
+        assert_eq!(c, 1);
+    }
+
+    #[test]
+    fn linewise_paste_below_and_above() {
+        let reg = Register {
+            text: "new".into(),
+            linewise: true,
+        };
+        let (v, c) = paste(&chars("a\nb"), 0, &reg, true);
+        assert_eq!(s(&v), "a\nnew\nb");
+        assert_eq!(c, 2); // start of pasted line
+        let (v, c) = paste(&chars("a\nb"), 0, &reg, false);
+        assert_eq!(s(&v), "new\na\nb");
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn empty_register_paste_is_noop() {
+        let reg = Register::default();
+        let (v, c) = paste(&chars("ab"), 1, &reg, true);
+        assert_eq!(s(&v), "ab");
+        assert_eq!(c, 1);
+    }
+
+    // --- undo stack ---
+
+    #[test]
+    fn undo_stack_push_pop_lifo() {
+        let mut st = VimState::default();
+        st.push_undo("one", 0);
+        st.push_undo("two", 1);
+        assert_eq!(st.pop_undo(), Some(("two".to_string(), 1)));
+        assert_eq!(st.pop_undo(), Some(("one".to_string(), 0)));
+        assert_eq!(st.pop_undo(), None);
+    }
+
+    #[test]
+    fn undo_stack_is_bounded() {
+        let mut st = VimState::default();
+        for i in 0..(UNDO_LIMIT + 10) {
+            st.push_undo(&format!("{i}"), i);
+        }
+        assert_eq!(st.undo.len(), UNDO_LIMIT);
+        // Oldest entries were dropped; the most recent survives on top.
+        assert_eq!(
+            st.pop_undo(),
+            Some(((UNDO_LIMIT + 9).to_string(), UNDO_LIMIT + 9))
+        );
+    }
+
+    #[test]
+    fn count_accumulation_via_take() {
+        let mut st = VimState::default();
+        st.count = Some(2);
+        assert_eq!(st.take_count(), 2);
+        assert_eq!(st.take_count(), 1); // default after clear
     }
 
     #[test]
     fn utf16_roundtrip_with_astral() {
-        // "a😀b": the emoji is 2 UTF-16 units.
         let t = chars("a😀b");
         assert_eq!(char_idx_to_utf16(&t, 0), 0);
         assert_eq!(char_idx_to_utf16(&t, 1), 1);

--- a/frontend/src/pages/dashboard/session_view/vim.rs
+++ b/frontend/src/pages/dashboard/session_view/vim.rs
@@ -1,0 +1,529 @@
+//! Minimal modal ("vim-like") editing for the message-input textarea.
+//!
+//! This is an OPT-IN, deliberately small subset of vim — enough to be genuinely
+//! usable for composing a message without pulling in a heavy JS editor (which
+//! would violate the WASM constraints of the frontend). Only two modes exist:
+//!
+//! - **NORMAL** — motions (`h j k l`, `w b`, `0 $`) and edits (`x`, `dd`, `dw`,
+//!   `i a o O`).
+//! - **INSERT** — typing inserts normally; `Esc` returns to NORMAL.
+//!
+//! The engine operates on the textarea's value as a `Vec<char>` with the cursor
+//! tracked as a **char index**. The DOM's `selectionStart`/`setSelectionRange`
+//! speak UTF-16 code units, so we convert at the boundary. Astral-plane
+//! characters (emoji) count as a single "cell" here, which is close enough for
+//! a chat box; full grapheme handling is out of scope for v1.
+//!
+//! The textarea is uncontrolled (the parent `InputBar` never passes `value`
+//! through Yew), so this module reads and writes the DOM element directly, the
+//! same way `InputBar::set_input_text` does.
+
+use web_sys::{Element, HtmlTextAreaElement, KeyboardEvent};
+
+/// The two supported editing modes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum VimMode {
+    Normal,
+    Insert,
+}
+
+impl VimMode {
+    /// Short label shown in the mode indicator.
+    pub fn label(self) -> &'static str {
+        match self {
+            VimMode::Normal => "NORMAL",
+            VimMode::Insert => "INSERT",
+        }
+    }
+
+    /// CSS classes for the indicator (base + per-mode modifier).
+    pub fn css_class(self) -> &'static str {
+        match self {
+            VimMode::Normal => "vim-mode-indicator normal",
+            VimMode::Insert => "vim-mode-indicator insert",
+        }
+    }
+}
+
+/// Per-input modal state.
+///
+/// Starts in INSERT: enabling vim mode should leave the textarea behaving like
+/// an ordinary chat box (typing works, `Enter` sends). The user opts into
+/// NORMAL with `Esc`. This keeps the feature unobtrusive for anyone who toggled
+/// it on to try it out.
+pub struct VimState {
+    pub mode: VimMode,
+    /// A pending operator awaiting its motion. Currently only `d` (for `dd` and
+    /// `dw`).
+    pending_op: Option<char>,
+}
+
+impl Default for VimState {
+    fn default() -> Self {
+        Self {
+            mode: VimMode::Insert,
+            pending_op: None,
+        }
+    }
+}
+
+/// Outcome of feeding a keydown to the modal engine.
+pub enum VimHandled {
+    /// The key was consumed by vim (default action already prevented).
+    /// `rerender` is true when the mode changed or the text was edited, so the
+    /// caller should re-render to refresh the indicator and re-sync its tracked
+    /// text mirror.
+    Consumed { rerender: bool },
+    /// Not a vim key in the current mode — the caller should run its normal
+    /// keydown logic (Enter-to-send, Arrow history, plain typing, …).
+    Passthrough,
+}
+
+/// Feed a keydown event to the modal engine. Mutates `state`, applies any edit
+/// directly to `textarea`, and calls `event.prevent_default()` for consumed
+/// keys.
+pub fn handle_key(
+    state: &mut VimState,
+    textarea: &HtmlTextAreaElement,
+    event: &KeyboardEvent,
+) -> VimHandled {
+    // Never intercept modifier chords — leave copy/paste, browser shortcuts,
+    // and the Ctrl+M voice toggle to their existing handlers.
+    if event.ctrl_key() || event.meta_key() || event.alt_key() {
+        return VimHandled::Passthrough;
+    }
+
+    let key = event.key();
+
+    match state.mode {
+        VimMode::Insert => {
+            if key == "Escape" {
+                enter_normal(state, textarea);
+                event.prevent_default();
+                VimHandled::Consumed { rerender: true }
+            } else {
+                // Enter (send / newline), Arrows (history / cursor), and plain
+                // typing all fall through to the existing handler.
+                VimHandled::Passthrough
+            }
+        }
+        VimMode::Normal => handle_normal(state, textarea, event, &key),
+    }
+}
+
+fn handle_normal(
+    state: &mut VimState,
+    textarea: &HtmlTextAreaElement,
+    event: &KeyboardEvent,
+    key: &str,
+) -> VimHandled {
+    // Even in NORMAL mode, keep Enter sending and let the Arrow keys drive
+    // command history / native caret movement (matches the non-vim contract).
+    if matches!(
+        key,
+        "Enter" | "ArrowUp" | "ArrowDown" | "ArrowLeft" | "ArrowRight"
+    ) {
+        state.pending_op = None;
+        return VimHandled::Passthrough;
+    }
+
+    let text: Vec<char> = textarea.value().chars().collect();
+    let cursor = read_cursor(textarea, &text);
+
+    // Resolve a pending operator (only `d` so far: `dd`, `dw`).
+    if let Some(op) = state.pending_op.take() {
+        if op == 'd' {
+            match key {
+                "d" => {
+                    let (new_text, new_cursor) = delete_line(&text, cursor);
+                    apply_edit(textarea, &new_text, new_cursor);
+                    event.prevent_default();
+                    return VimHandled::Consumed { rerender: true };
+                }
+                "w" => {
+                    let (new_text, new_cursor) = delete_word(&text, cursor);
+                    apply_edit(textarea, &new_text, new_cursor);
+                    event.prevent_default();
+                    return VimHandled::Consumed { rerender: true };
+                }
+                _ => {
+                    // Unknown motion after `d` — cancel and swallow the key.
+                    event.prevent_default();
+                    return VimHandled::Consumed { rerender: false };
+                }
+            }
+        }
+    }
+
+    match key {
+        "h" => motion(textarea, &text, event, cursor.saturating_sub(1)),
+        "l" => motion(textarea, &text, event, (cursor + 1).min(text.len())),
+        "j" => motion(textarea, &text, event, line_down(&text, cursor)),
+        "k" => motion(textarea, &text, event, line_up(&text, cursor)),
+        "w" => motion(textarea, &text, event, next_word(&text, cursor)),
+        "b" => motion(textarea, &text, event, prev_word(&text, cursor)),
+        "0" => motion(textarea, &text, event, line_start(&text, cursor)),
+        "$" => motion(textarea, &text, event, line_end(&text, cursor)),
+        "i" => {
+            state.mode = VimMode::Insert;
+            move_cursor(textarea, &text, cursor);
+            event.prevent_default();
+            VimHandled::Consumed { rerender: true }
+        }
+        "a" => {
+            state.mode = VimMode::Insert;
+            move_cursor(textarea, &text, (cursor + 1).min(text.len()));
+            event.prevent_default();
+            VimHandled::Consumed { rerender: true }
+        }
+        "o" => {
+            let (new_text, new_cursor) = open_line_below(&text, cursor);
+            apply_edit(textarea, &new_text, new_cursor);
+            state.mode = VimMode::Insert;
+            event.prevent_default();
+            VimHandled::Consumed { rerender: true }
+        }
+        "O" => {
+            let (new_text, new_cursor) = open_line_above(&text, cursor);
+            apply_edit(textarea, &new_text, new_cursor);
+            state.mode = VimMode::Insert;
+            event.prevent_default();
+            VimHandled::Consumed { rerender: true }
+        }
+        "x" => {
+            let (new_text, new_cursor) = delete_char(&text, cursor);
+            apply_edit(textarea, &new_text, new_cursor);
+            event.prevent_default();
+            VimHandled::Consumed { rerender: true }
+        }
+        "d" => {
+            state.pending_op = Some('d');
+            event.prevent_default();
+            VimHandled::Consumed { rerender: false }
+        }
+        "Escape" => {
+            // Already NORMAL — clear any half-typed operator.
+            event.prevent_default();
+            VimHandled::Consumed { rerender: false }
+        }
+        _ => {
+            // Swallow any other single printable character so stray letters
+            // never leak into the textarea while in NORMAL mode. Let genuine
+            // control keys (Tab, function keys, …) through.
+            if key.chars().count() == 1 {
+                event.prevent_default();
+                VimHandled::Consumed { rerender: false }
+            } else {
+                VimHandled::Passthrough
+            }
+        }
+    }
+}
+
+/// Apply a pure cursor motion: prevent default and move the caret.
+fn motion(
+    textarea: &HtmlTextAreaElement,
+    text: &[char],
+    event: &KeyboardEvent,
+    target: usize,
+) -> VimHandled {
+    move_cursor(textarea, text, target);
+    event.prevent_default();
+    VimHandled::Consumed { rerender: false }
+}
+
+/// Switch to NORMAL mode, nudging the caret one cell left (vim moves off the
+/// just-typed character), clamped to the start of the current line.
+fn enter_normal(state: &mut VimState, textarea: &HtmlTextAreaElement) {
+    state.mode = VimMode::Normal;
+    state.pending_op = None;
+    let text: Vec<char> = textarea.value().chars().collect();
+    let cursor = read_cursor(textarea, &text);
+    let ls = line_start(&text, cursor);
+    let new = if cursor > ls { cursor - 1 } else { cursor };
+    move_cursor(textarea, &text, new);
+}
+
+// --- DOM boundary helpers ---------------------------------------------------
+
+fn read_cursor(textarea: &HtmlTextAreaElement, text: &[char]) -> usize {
+    let off = textarea.selection_start().ok().flatten().unwrap_or(0);
+    utf16_to_char_idx(text, off)
+}
+
+fn move_cursor(textarea: &HtmlTextAreaElement, text: &[char], idx: usize) {
+    let off = char_idx_to_utf16(text, idx);
+    let _ = textarea.set_selection_range(off, off);
+}
+
+fn apply_edit(textarea: &HtmlTextAreaElement, text: &[char], cursor: usize) {
+    let s: String = text.iter().collect();
+    textarea.set_value(&s);
+    autosize(textarea, &s);
+    let off = char_idx_to_utf16(text, cursor);
+    let _ = textarea.set_selection_range(off, off);
+}
+
+/// Resize the textarea to fit its content (mirrors `InputBar::set_input_text`).
+fn autosize(textarea: &HtmlTextAreaElement, text: &str) {
+    let el: &Element = textarea.as_ref();
+    if text.is_empty() {
+        el.remove_attribute("style").ok();
+    } else {
+        el.set_attribute("style", "height: 0; overflow-y: hidden")
+            .ok();
+        el.set_attribute("style", &format!("height: {}px", textarea.scroll_height()))
+            .ok();
+    }
+}
+
+fn char_idx_to_utf16(text: &[char], idx: usize) -> u32 {
+    text[..idx.min(text.len())]
+        .iter()
+        .map(|c| c.len_utf16() as u32)
+        .sum()
+}
+
+fn utf16_to_char_idx(text: &[char], off: u32) -> usize {
+    let mut acc = 0u32;
+    for (i, c) in text.iter().enumerate() {
+        if acc >= off {
+            return i;
+        }
+        acc += c.len_utf16() as u32;
+    }
+    text.len()
+}
+
+// --- Pure motion / edit primitives (unit-tested below) ----------------------
+
+/// Index of the first character of the line containing `cursor`.
+fn line_start(text: &[char], cursor: usize) -> usize {
+    let mut i = cursor.min(text.len());
+    while i > 0 && text[i - 1] != '\n' {
+        i -= 1;
+    }
+    i
+}
+
+/// Index just past the last character of the line containing `cursor` (i.e. the
+/// position of the terminating `\n`, or the end of the text).
+fn line_end(text: &[char], cursor: usize) -> usize {
+    let mut i = cursor.min(text.len());
+    while i < text.len() && text[i] != '\n' {
+        i += 1;
+    }
+    i
+}
+
+fn line_down(text: &[char], cursor: usize) -> usize {
+    let ls = line_start(text, cursor);
+    let col = cursor - ls;
+    let le = line_end(text, cursor);
+    if le >= text.len() {
+        return cursor; // already on the last line
+    }
+    let next_ls = le + 1;
+    let next_le = line_end(text, next_ls);
+    (next_ls + col).min(next_le)
+}
+
+fn line_up(text: &[char], cursor: usize) -> usize {
+    let ls = line_start(text, cursor);
+    if ls == 0 {
+        return cursor; // already on the first line
+    }
+    let col = cursor - ls;
+    let prev_le = ls - 1; // the '\n' ending the previous line
+    let prev_ls = line_start(text, prev_le);
+    (prev_ls + col).min(prev_le)
+}
+
+/// Start of the next word. Words are maximal runs of non-whitespace.
+fn next_word(text: &[char], cursor: usize) -> usize {
+    let n = text.len();
+    let mut i = cursor;
+    if i >= n {
+        return n;
+    }
+    while i < n && !text[i].is_whitespace() {
+        i += 1;
+    }
+    while i < n && text[i].is_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+/// Start of the current or previous word.
+fn prev_word(text: &[char], cursor: usize) -> usize {
+    let mut i = cursor;
+    if i == 0 {
+        return 0;
+    }
+    i -= 1;
+    while i > 0 && text[i].is_whitespace() {
+        i -= 1;
+    }
+    while i > 0 && !text[i - 1].is_whitespace() {
+        i -= 1;
+    }
+    i
+}
+
+fn delete_char(text: &[char], cursor: usize) -> (Vec<char>, usize) {
+    let mut v = text.to_vec();
+    if cursor < v.len() {
+        v.remove(cursor);
+    }
+    let c = cursor.min(v.len());
+    (v, c)
+}
+
+fn delete_word(text: &[char], cursor: usize) -> (Vec<char>, usize) {
+    let end = next_word(text, cursor);
+    let mut v = text.to_vec();
+    let start = cursor.min(v.len());
+    let end = end.min(v.len());
+    v.drain(start..end);
+    let cursor = start.min(v.len());
+    (v, cursor)
+}
+
+fn delete_line(text: &[char], cursor: usize) -> (Vec<char>, usize) {
+    let ls = line_start(text, cursor);
+    let le = line_end(text, cursor);
+    let mut v = text.to_vec();
+    if le < v.len() {
+        // Include the trailing newline so the line fully disappears.
+        v.drain(ls..=le);
+    } else if ls > 0 {
+        // Last line: also drop the newline that precedes it.
+        v.drain(ls - 1..le);
+    } else {
+        // Only line: clear it.
+        v.drain(ls..le);
+    }
+    let c = line_start(&v, ls.min(v.len()));
+    (v, c)
+}
+
+fn open_line_below(text: &[char], cursor: usize) -> (Vec<char>, usize) {
+    let le = line_end(text, cursor);
+    let mut v = text.to_vec();
+    v.insert(le, '\n');
+    (v, le + 1)
+}
+
+fn open_line_above(text: &[char], cursor: usize) -> (Vec<char>, usize) {
+    let ls = line_start(text, cursor);
+    let mut v = text.to_vec();
+    v.insert(ls, '\n');
+    (v, ls)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chars(s: &str) -> Vec<char> {
+        s.chars().collect()
+    }
+
+    #[test]
+    fn line_boundaries() {
+        let t = chars("ab\ncd");
+        assert_eq!(line_start(&t, 4), 3);
+        assert_eq!(line_end(&t, 4), 5);
+        assert_eq!(line_start(&t, 1), 0);
+        assert_eq!(line_end(&t, 1), 2);
+    }
+
+    #[test]
+    fn horizontal_motions() {
+        let t = chars("hello");
+        assert_eq!(line_start(&t, 3), 0);
+        assert_eq!(line_end(&t, 3), 5);
+    }
+
+    #[test]
+    fn vertical_motions_preserve_column() {
+        let t = chars("abcd\nef\nghij");
+        // From col 3 on line 0 → line 1 ("ef") has only 2 chars, clamp to its
+        // end (index 7, the caret just past 'f').
+        assert_eq!(line_down(&t, 3), 7);
+        // From col 1 on line 2 ("ghij", starts at 8) → same column on line 1.
+        assert_eq!(line_up(&t, 9), 6);
+        // Up from the first line is a no-op.
+        assert_eq!(line_up(&t, 2), 2);
+    }
+
+    #[test]
+    fn word_motions() {
+        let t = chars("foo bar  baz");
+        assert_eq!(next_word(&t, 0), 4); // start of "bar"
+        assert_eq!(next_word(&t, 4), 9); // start of "baz"
+        assert_eq!(prev_word(&t, 9), 4); // back to "bar"
+        assert_eq!(prev_word(&t, 4), 0); // back to "foo"
+    }
+
+    #[test]
+    fn x_deletes_char_under_cursor() {
+        let (v, c) = delete_char(&chars("abc"), 1);
+        assert_eq!(v.iter().collect::<String>(), "ac");
+        assert_eq!(c, 1);
+        // At end of buffer, nothing to delete.
+        let (v, c) = delete_char(&chars("ab"), 2);
+        assert_eq!(v.iter().collect::<String>(), "ab");
+        assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn dw_deletes_to_next_word() {
+        let (v, c) = delete_word(&chars("foo bar"), 0);
+        assert_eq!(v.iter().collect::<String>(), "bar");
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn dd_deletes_middle_line_with_trailing_newline() {
+        let (v, c) = delete_line(&chars("a\nb\nc"), 2);
+        assert_eq!(v.iter().collect::<String>(), "a\nc");
+        assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn dd_deletes_last_line_with_preceding_newline() {
+        let (v, _c) = delete_line(&chars("a\nb"), 2);
+        assert_eq!(v.iter().collect::<String>(), "a");
+    }
+
+    #[test]
+    fn dd_clears_only_line() {
+        let (v, c) = delete_line(&chars("abc"), 1);
+        assert_eq!(v.iter().collect::<String>(), "");
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn o_and_O_insert_newlines() {
+        let (v, c) = open_line_below(&chars("ab\ncd"), 1);
+        assert_eq!(v.iter().collect::<String>(), "ab\n\ncd");
+        assert_eq!(c, 3);
+        let (v, c) = open_line_above(&chars("ab\ncd"), 4);
+        assert_eq!(v.iter().collect::<String>(), "ab\n\ncd");
+        assert_eq!(c, 3);
+    }
+
+    #[test]
+    fn utf16_roundtrip_with_astral() {
+        // "a😀b": the emoji is 2 UTF-16 units.
+        let t = chars("a😀b");
+        assert_eq!(char_idx_to_utf16(&t, 0), 0);
+        assert_eq!(char_idx_to_utf16(&t, 1), 1);
+        assert_eq!(char_idx_to_utf16(&t, 2), 3);
+        assert_eq!(char_idx_to_utf16(&t, 3), 4);
+        assert_eq!(utf16_to_char_idx(&t, 3), 2);
+        assert_eq!(utf16_to_char_idx(&t, 1), 1);
+    }
+}

--- a/frontend/src/pages/dashboard/session_view/vim.rs
+++ b/frontend/src/pages/dashboard/session_view/vim.rs
@@ -141,6 +141,13 @@ impl VimState {
         self.count = None;
     }
 
+    /// Whether a multi-key command is mid-flight (operator/text-object/`r`/`g`
+    /// or a count prefix). Used so `Esc` cancels a half-typed command before it
+    /// falls through to "leave the input for dashboard Nav mode".
+    fn has_pending(&self) -> bool {
+        !matches!(self.pending, Pending::None) || self.count.is_some()
+    }
+
     /// Consume the pending count, defaulting to 1.
     fn take_count(&mut self) -> usize {
         self.count.take().unwrap_or(1).max(1)
@@ -398,11 +405,26 @@ fn handle_normal(
         }
 
         "Escape" => {
-            // Already NORMAL — clear any half-typed operator / count.
-            state.clear_pending();
-            place_block(textarea, &text, cursor);
-            event.prevent_default();
-            VimHandled::Consumed { rerender: false }
+            if state.has_pending() {
+                // A command is half-typed (`d`, `2`, `di`, `r`, `g`…) — `Esc`
+                // cancels it and stays in NORMAL, like real vim.
+                state.clear_pending();
+                place_block(textarea, &text, cursor);
+                event.prevent_default();
+                VimHandled::Consumed { rerender: false }
+            } else {
+                // Clean NORMAL: a second `Esc` drops out of the input into the
+                // dashboard's keyboard-nav (Nav mode). Blur so subsequent nav
+                // keys reach the nav hook instead of vim, and Passthrough (no
+                // `stop_propagation` in the caller) so this Esc bubbles up and
+                // flips Nav mode on. First Esc (INSERT→NORMAL) is still
+                // consumed, so it takes two presses to leave — matching the
+                // "double-Esc = Nav mode" contract.
+                state.clear_pending();
+                let html_el: &web_sys::HtmlElement = textarea.as_ref();
+                let _ = html_el.blur();
+                VimHandled::Passthrough
+            }
         }
         _ => {
             // Swallow any other single printable character so stray letters

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -22,6 +22,9 @@ pub const SHOW_COST_STORAGE_KEY: &str = "claude-portal-show-cost";
 /// Storage key for session rail orientation in localStorage
 pub const RAIL_ORIENTATION_STORAGE_KEY: &str = "claude-portal-rail-orientation";
 
+/// Storage key for the opt-in vim editing mode in localStorage
+pub const VIM_MODE_STORAGE_KEY: &str = "claude-portal-vim-mode";
+
 /// Maximum number of messages to keep in frontend memory (matches backend limit)
 pub const MAX_MESSAGES_PER_SESSION: usize = 100;
 
@@ -122,6 +125,16 @@ pub fn load_show_cost() -> bool {
 /// Save cost display preference to localStorage
 pub fn save_show_cost(show: bool) {
     save_bool_pref(SHOW_COST_STORAGE_KEY, show);
+}
+
+/// Load whether vim editing mode is enabled from localStorage (default: off).
+pub fn load_vim_mode() -> bool {
+    load_bool_pref(VIM_MODE_STORAGE_KEY)
+}
+
+/// Save the vim editing mode preference to localStorage.
+pub fn save_vim_mode(enabled: bool) {
+    save_bool_pref(VIM_MODE_STORAGE_KEY, enabled);
 }
 
 /// Where the session pill rail sits on the dashboard.

--- a/frontend/src/pages/settings/appearance_panel.rs
+++ b/frontend/src/pages/settings/appearance_panel.rs
@@ -1,4 +1,6 @@
-use crate::pages::dashboard::{load_rail_position, save_rail_position, RailPosition};
+use crate::pages::dashboard::{
+    load_rail_position, load_vim_mode, save_rail_position, save_vim_mode, RailPosition,
+};
 use yew::prelude::*;
 
 const ALL_POSITIONS: &[(RailPosition, &str)] = &[
@@ -11,6 +13,17 @@ const ALL_POSITIONS: &[(RailPosition, &str)] = &[
 #[function_component(AppearancePanel)]
 pub fn appearance_panel() -> Html {
     let position = use_state(load_rail_position);
+    let vim_enabled = use_state(load_vim_mode);
+
+    let on_toggle_vim = {
+        let vim_enabled = vim_enabled.clone();
+        Callback::from(move |e: Event| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            let enabled = input.checked();
+            save_vim_mode(enabled);
+            vim_enabled.set(enabled);
+        })
+    };
 
     html! {
         <section class="appearance-section">
@@ -48,6 +61,24 @@ pub fn appearance_panel() -> Html {
                         }
                     })}
                 </div>
+            </div>
+
+            <div class="appearance-setting">
+                <h3>{ "Message input: vim mode" }</h3>
+                <p class="setting-description">
+                    { "Modal (vim-like) editing in the message box: NORMAL/INSERT \
+                       modes with h j k l, w b, 0 $, i a o O, x, dd, dw, and Esc. \
+                       Starts in INSERT so the box still types normally. Takes \
+                       effect on newly opened sessions or after reload." }
+                </p>
+                <label class="toggle-label">
+                    <input
+                        type="checkbox"
+                        checked={*vim_enabled}
+                        onchange={on_toggle_vim}
+                    />
+                    <span>{ if *vim_enabled { "Enabled" } else { "Disabled" } }</span>
+                </label>
             </div>
         </section>
     }

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -70,6 +70,19 @@
     border-color: var(--accent);
 }
 
+/* Vim NORMAL-mode block cursor. vim.rs keeps a one-character selection at the
+   cursor; this paints it as a solid vim-style block and hides the thin caret so
+   the two don't render at once. At end-of-line/empty the selection collapses
+   (nothing to cover) — acceptable for a chat box. */
+.session-view-input .message-input.vim-normal {
+    caret-color: transparent;
+}
+
+.session-view-input .message-input.vim-normal::selection {
+    background: var(--accent);
+    color: var(--bg-darker);
+}
+
 .session-view-input .message-input:disabled {
     opacity: 0.5;
     cursor: not-allowed;

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -22,6 +22,32 @@
     margin-right: -0.35rem;
 }
 
+/* Vim mode indicator — small NORMAL/INSERT badge beside the prompt. */
+.session-view-input .vim-mode-indicator {
+    align-self: flex-end;
+    margin-bottom: 0.5rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    font-family: var(--font-mono, monospace);
+    line-height: 1.4;
+    user-select: none;
+    flex-shrink: 0;
+}
+
+.session-view-input .vim-mode-indicator.normal {
+    color: var(--bg-darker);
+    background: var(--accent);
+}
+
+.session-view-input .vim-mode-indicator.insert {
+    color: var(--accent);
+    background: transparent;
+    border: 1px solid var(--accent);
+}
+
 .session-view-input .message-input {
     flex: 1;
     background: rgba(0, 0, 0, 0.3);

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -71,24 +71,16 @@
 }
 
 /* Vim NORMAL-mode block cursor. vim.rs keeps a one-character selection at the
-   cursor; this paints it as a solid vim-style block and hides the thin caret so
-   the two don't render at once. At end-of-line/empty the selection collapses
-   (nothing to cover) — acceptable for a chat box. */
-/* NORMAL-mode block cursor. On a character the caret sits inside a 1-char
-   selection, and browsers hide the blinking caret whenever a selection is
-   non-empty — so the accent caret below only shows when the selection collapses
-   (end-of-line / empty input), keeping the cursor visible everywhere without
+   cursor, painted below as a solid vim-style block. caret-color is the accent
+   (not transparent): browsers hide the blinking caret while a selection is
+   non-empty, so the caret only appears when the selection collapses
+   (end-of-line / empty input) — keeping the cursor visible everywhere without
    double-rendering a caret next to the block. */
 .session-view-input .message-input.vim-normal {
     caret-color: var(--accent);
 }
 
 .session-view-input .message-input.vim-normal::selection {
-    background: var(--accent);
-    color: var(--bg-darker);
-}
-
-.session-view-input .message-input.vim-normal::-moz-selection {
     background: var(--accent);
     color: var(--bg-darker);
 }

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -74,11 +74,21 @@
    cursor; this paints it as a solid vim-style block and hides the thin caret so
    the two don't render at once. At end-of-line/empty the selection collapses
    (nothing to cover) — acceptable for a chat box. */
+/* NORMAL-mode block cursor. On a character the caret sits inside a 1-char
+   selection, and browsers hide the blinking caret whenever a selection is
+   non-empty — so the accent caret below only shows when the selection collapses
+   (end-of-line / empty input), keeping the cursor visible everywhere without
+   double-rendering a caret next to the block. */
 .session-view-input .message-input.vim-normal {
-    caret-color: transparent;
+    caret-color: var(--accent);
 }
 
 .session-view-input .message-input.vim-normal::selection {
+    background: var(--accent);
+    color: var(--bg-darker);
+}
+
+.session-view-input .message-input.vim-normal::-moz-selection {
     background: var(--accent);
     color: var(--bg-darker);
 }


### PR DESCRIPTION
# SUMMARY

Adds an **opt-in vim mode** for the message-input textarea (issue #1328). When disabled (the default) the input behaves exactly as before. When enabled, the textarea gains modal NORMAL/INSERT editing with a small mode indicator beside the prompt.

## Vim feature set implemented (v1)

**Modes:** NORMAL and INSERT, with a live `NORMAL`/`INSERT` badge next to the input prompt.

**NORMAL-mode motions:** `h j k l`, `w`, `b`, `0`, `$` (vertical motions preserve column, clamped to the target line).

**NORMAL-mode edits:** `i`, `a`, `o`, `O` (enter INSERT), `x` (delete char under cursor), `dd` (delete line), `dw` (delete word).

**Mode switching:** `Esc` returns to NORMAL from INSERT (and nudges the caret one cell left, clamped to line start, like vim); `Esc` in NORMAL clears a pending operator.

## Key decisions / assumptions

- **Default OFF.** Persisted in `localStorage` (`claude-portal-vim-mode`) via the existing `load_bool_pref`/`save_bool_pref` pattern in `dashboard/types.rs`. Toggle lives in **Settings -> Appearance** (the browser-preferences panel), avoiding a whole new tab.
- **Initial mode is INSERT.** Enabling vim leaves the box usable as an ordinary chat input (typing works, `Enter` sends). The user opts into NORMAL with `Esc`. Documented in the setting description and a module doc comment.
- **`Enter` still sends in both modes** (Shift+Enter = newline). It is treated as a passthrough key so the existing send/newline/history contract is untouched — no conflict, so no override needed.
- **Existing handlers preserved exactly.** `Ctrl+M` voice and `ArrowUp/Down` history are handled before/around vim and pass through unchanged. When vim is OFF or returns `Passthrough`, the keydown path is byte-for-byte the pre-existing behavior.
- **No JS editor dependency.** The engine is a small self-contained Rust module (`session_view/vim.rs`) operating on the (uncontrolled) textarea DOM as a `Vec<char>`, converting to/from UTF-16 offsets at the `selectionStart`/`setSelectionRange` boundary. This respects the frontend's WASM constraints.
- **Setting applies to newly opened sessions / after reload** (read once at `InputBar::create`). Live propagation to an already-open input is out of scope for v1; documented in the toggle description.

## Limitations (v1)

- `w`/`b` treat words as maximal non-whitespace runs (no separate punctuation class).
- Astral-plane characters (emoji) count as one "cell"; no full grapheme clustering.
- No counts, registers, visual mode, `dd`/`dw` yank, `.` repeat, or undo integration.

## Tests / verification

- 11 unit tests over the pure motion/edit primitives (`cargo test -p frontend --lib vim::`) — all pass.
- `cargo fmt --check` clean.
- `cargo clippy --workspace` clean (and `-p frontend --target wasm32-unknown-unknown` clean).
- `cd frontend && trunk build` succeeds.

Note on versioning: per the current convention (issue #1096), the `[workspace.package]` version patch is derived at build time from the git commit count by `shared/build.rs`, so this PR does not touch the version line.

Closes #1328

