### PR TITLE
fix: hold retention trims for sessions whose pre-trim archive failed

### DIFF
--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -371,11 +371,18 @@ fn archive_one_session(
 /// sweep, this deliberately ignores idle/status eligibility — an ACTIVE
 /// long-running session gets its history captured before it's trimmed,
 /// and merge-on-rearchive folds later messages in.
+///
+/// Returns the set of session ids whose archive attempt FAILED this cycle.
+/// Archive-first is the invariant: the caller holds the trim for these
+/// sessions (excludes them from both delete paths) so an archive outage that
+/// coincides with a retention cycle can never lose the unarchived delta — the
+/// trim is retried next cycle once the archive succeeds. Sessions with a
+/// fresh/successful archive are absent from the set and trim normally.
 fn archive_retention_candidates(
     conn: &mut diesel::PgConnection,
     runtime: &crate::archive::ArchiveRuntime,
     config: &handlers::retention::RetentionConfig,
-) {
+) -> std::collections::HashSet<uuid::Uuid> {
     use diesel::dsl::count_star;
     use diesel::prelude::*;
     use schema::{messages, sessions};
@@ -407,7 +414,7 @@ fn archive_retention_candidates(
     }
 
     if affected.is_empty() {
-        return;
+        return std::collections::HashSet::new();
     }
 
     let candidates: Vec<models::Session> = match sessions::table
@@ -417,14 +424,19 @@ fn archive_retention_candidates(
         Ok(s) => s,
         Err(e) => {
             tracing::error!("Failed to load retention-candidate sessions: {e}");
-            return;
+            // Could not confirm any archive this cycle: hold every candidate
+            // rather than risk trimming an unarchived session.
+            return affected;
         }
     };
 
     let mut archived = 0;
+    let mut failed: std::collections::HashSet<uuid::Uuid> = std::collections::HashSet::new();
     for session in &candidates {
         if ensure_session_archived(conn, runtime, session) {
             archived += 1;
+        } else {
+            failed.insert(session.id);
         }
     }
     if archived > 0 {
@@ -434,6 +446,7 @@ fn archive_retention_candidates(
             candidates.len()
         );
     }
+    failed
 }
 
 /// Archive `session` if its archive is missing or stale, updating
@@ -615,15 +628,31 @@ pub async fn run_retention_cleanup(app_state: Arc<AppState>) {
     );
 
     // #1258 phase 2: capture messages into the archive BEFORE the trim
-    // deletes them from the hot DB. Sessions whose archive attempt fails
-    // still get trimmed (best-effort with an explicit recorded failure) —
-    // the merge-on-rearchive semantics mean anything captured earlier is
-    // never lost, only the failed delta.
-    if let Some(runtime) = &app_state.archive {
-        archive_retention_candidates(&mut conn, runtime, &config);
+    // deletes them from the hot DB. Archive-first is the invariant — a
+    // session whose pre-trim archive FAILS this cycle has its trim HELD
+    // (excluded from both delete paths below) and retried next cycle, so an
+    // archive outage that coincides with a retention cycle never loses the
+    // unarchived delta. Trade-off: the hot DB keeps growing for those
+    // sessions until the archive recovers, which is the correct failure mode
+    // (data preserved over a bounded space cost). This mirrors the held
+    // semantics of run_session_age_cleanup. When archiving is DISABLED the
+    // held set is empty and trims run exactly as before — running retention
+    // without an archive is the operator's explicit choice.
+    let held_ids: std::collections::HashSet<uuid::Uuid> = match &app_state.archive {
+        Some(runtime) => archive_retention_candidates(&mut conn, runtime, &config),
+        None => std::collections::HashSet::new(),
+    };
+    if !held_ids.is_empty() {
+        // Stable marker aligned with SESSION_ARCHIVE_FAILED: alert on this to
+        // catch an archive outage that is silently blocking retention.
+        tracing::warn!(
+            "RETENTION_TRIM_HELD {} sessions pending archive",
+            held_ids.len()
+        );
     }
 
-    let (age_deleted, count_deleted) = run_retention_cleanup(&mut conn, session_ids, config);
+    let (age_deleted, count_deleted) =
+        run_retention_cleanup(&mut conn, session_ids, config, &held_ids);
 
     if age_deleted > 0 || count_deleted > 0 {
         tracing::info!(

--- a/backend/src/handlers/retention.rs
+++ b/backend/src/handlers/retention.rs
@@ -3,6 +3,7 @@
 use crate::schema::messages;
 use chrono::Utc;
 use diesel::prelude::*;
+use std::collections::HashSet;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -76,11 +77,19 @@ pub fn truncate_session_messages(
 }
 
 /// Delete messages older than the configured retention period, up to the per-cycle cap.
-/// Returns the number of deleted messages
+/// Returns the number of deleted messages.
+///
+/// `held_ids` names sessions whose pre-trim archive failed this cycle (#1258
+/// phase 2): their messages are excluded from the bulk delete so the
+/// unarchived delta survives to be retried next cycle. Archive-first is the
+/// invariant — retention never destroys the last copy. When the set is empty
+/// (the common case, and always when archiving is disabled) the query is
+/// unchanged and stays index-friendly on `created_at`.
 pub fn delete_old_messages(
     conn: &mut diesel::pg::PgConnection,
     config: RetentionConfig,
     budget: usize,
+    held_ids: &HashSet<Uuid>,
 ) -> Result<usize, diesel::result::Error> {
     if config.retention_days == 0 || budget == 0 {
         return Ok(0);
@@ -88,9 +97,17 @@ pub fn delete_old_messages(
 
     let cutoff = Utc::now().naive_utc() - chrono::Duration::days(config.retention_days as i64);
 
-    // Select IDs to delete, capped by remaining budget
-    let ids_to_delete: Vec<Uuid> = messages::table
+    // Select IDs to delete, capped by remaining budget. Boxed so we can add
+    // the held-session exclusion only when there is one (keeps the empty-set
+    // path identical to the pre-#1258 query plan).
+    let mut query = messages::table
         .filter(messages::created_at.lt(cutoff))
+        .into_boxed();
+    if !held_ids.is_empty() {
+        let held: Vec<Uuid> = held_ids.iter().copied().collect();
+        query = query.filter(messages::session_id.ne_all(held));
+    }
+    let ids_to_delete: Vec<Uuid> = query
         .order(messages::created_at.asc())
         .limit(budget as i64)
         .select(messages::id)
@@ -118,10 +135,17 @@ pub fn delete_old_messages(
 /// 2. Truncate per-session message counts
 ///
 /// Applies a 5-second statement timeout and caps total deletes at 1000 per cycle.
+///
+/// `held_ids` names sessions whose pre-trim archive failed this cycle (#1258
+/// phase 2). Both delete paths exclude them so no unarchived message is lost
+/// during an archive outage — the trim is held and retried next cycle. The
+/// set is always empty when archiving is disabled, in which case the trim
+/// runs exactly as before.
 pub fn run_retention_cleanup(
     conn: &mut diesel::pg::PgConnection,
     pending_session_ids: Vec<Uuid>,
     config: RetentionConfig,
+    held_ids: &HashSet<Uuid>,
 ) -> (usize, usize) {
     // Set a 5-second timeout for cleanup queries
     if let Err(e) = diesel::sql_query("SET LOCAL statement_timeout = '5000'").execute(conn) {
@@ -135,8 +159,8 @@ pub fn run_retention_cleanup(
     let mut age_deleted = 0;
     let mut count_deleted = 0;
 
-    // First, bulk delete old messages (up to budget)
-    match delete_old_messages(conn, config, budget) {
+    // First, bulk delete old messages (up to budget), skipping held sessions
+    match delete_old_messages(conn, config, budget, held_ids) {
         Ok(deleted) => {
             age_deleted = deleted;
             budget = budget.saturating_sub(deleted);
@@ -148,6 +172,10 @@ pub fn run_retention_cleanup(
     for session_id in pending_session_ids {
         if budget == 0 {
             break;
+        }
+        // Hold the trim for any session whose pre-trim archive failed.
+        if held_ids.contains(&session_id) {
+            continue;
         }
         match truncate_session_messages(conn, session_id, config, budget) {
             Ok(deleted) => {

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -312,6 +312,167 @@ async fn archive_sweep_persists_and_is_idempotent() {
         .ok();
 }
 
+/// Build a minimal `AppState` wired to the shared test pool, with the given
+/// archive runtime and a 1-day age-retention window. Used by the held-trim
+/// test to drive `background::run_retention_cleanup` directly.
+fn retention_test_state(archive: Option<Arc<backend::archive::ArchiveRuntime>>) -> Arc<AppState> {
+    let mut config = ServerConfig::from_env(true).expect("parse server config");
+    // A short age window so backdated messages are trim-eligible; a high
+    // per-session cap so only the age path (not truncation) is exercised.
+    config.message_retention_days = 1;
+    config.message_retention_count = 100_000;
+    let oauth = backend::config::build_google_oauth_client(true).expect("oauth client");
+    Arc::new(AppState {
+        dev_mode: true,
+        db_pool: test_pool(),
+        session_manager: SessionManager::new(),
+        oauth_basic_client: oauth,
+        device_flow_store: Some(DeviceFlowStore::default()),
+        public_url: config.public_url,
+        cookie_key: config.cookie_key,
+        jwt_secret: config.jwt_secret,
+        app_title: config.app_title,
+        splash_text: config.splash_text,
+        allowed_email_domain: config.allowed_email_domain,
+        allowed_emails: config.allowed_emails,
+        message_retention_count: config.message_retention_count,
+        message_retention_days: config.message_retention_days,
+        session_max_age_days: config.session_max_age_days,
+        max_image_mb: config.max_image_mb,
+        image_store: ImageStore::new(config.image_store_max_bytes, config.image_store_ttl),
+        forward_domain: config.forward_domain,
+        archive,
+        notifications: backend::push::channel().0,
+        vapid_public_key: config.vapid_public_key,
+        mobile_app_links: config.mobile_app_links,
+    })
+}
+
+/// #1258 phase 2: retention holds the message trim for a session whose
+/// pre-trim archive FAILED this cycle (archive-first invariant, matching
+/// `run_session_age_cleanup`). A cycle with a broken archive must leave the
+/// old messages in place; a later cycle with a working archive trims them.
+#[tokio::test]
+async fn retention_holds_trim_when_archive_fails() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    }
+    // No ARCHIVE_DB_LOCK: this test is self-isolating. Its 1-day age window
+    // excludes every other test's freshly-inserted rows, and its own session
+    // keeps a fresh `last_activity` so the idle-only global sweeps in the
+    // other archive tests never touch it. Holding the std lock across the
+    // `await`s below would trip `clippy::await_holding_lock`.
+    use backend::archive::{ArchiveBackendConfig, ArchiveConfig, ArchiveRuntime};
+    use backend::models::{NewMessage, NewSessionWithId};
+    use backend::schema::{messages, sessions};
+    use diesel::prelude::*;
+
+    let pool = test_pool();
+    let mut conn = pool.get().expect("conn");
+    let user_id: uuid::Uuid = backend::schema::users::table
+        .select(backend::schema::users::id)
+        .order(backend::schema::users::created_at.asc())
+        .first(&mut conn)
+        .expect("seeded user");
+
+    let session_id = uuid::Uuid::new_v4();
+    diesel::insert_into(sessions::table)
+        .values(&NewSessionWithId {
+            id: session_id,
+            user_id,
+            session_name: "held-trim-harness".to_string(),
+            session_key: session_id.to_string(),
+            working_directory: "/tmp/held-trim-harness".to_string(),
+            status: shared::SessionStatus::Disconnected.as_str().to_string(),
+            git_branch: None,
+            client_version: None,
+            hostname: "harness".to_string(),
+            launcher_id: None,
+            agent_type: "claude".to_string(),
+            repo_url: None,
+            scheduled_task_id: None,
+            paused: false,
+            claude_args: serde_json::Value::Array(vec![]),
+        })
+        .execute(&mut conn)
+        .expect("insert session");
+
+    // Two messages, backdated well past the 1-day age window so the age path
+    // would delete them if the trim were not held.
+    let old = chrono::Utc::now().naive_utc() - chrono::Duration::days(3);
+    for text in ["first", "second"] {
+        diesel::insert_into(messages::table)
+            .values(&NewMessage {
+                session_id,
+                role: "user".to_string(),
+                content: format!(r#"{{"text":"{text}"}}"#),
+                user_id,
+                agent_type: "claude".to_string(),
+                provenance_kind: None,
+                provenance_session_id: None,
+                provenance_agent_type: None,
+            })
+            .execute(&mut conn)
+            .expect("insert message");
+    }
+    diesel::update(messages::table.filter(messages::session_id.eq(session_id)))
+        .set(messages::created_at.eq(old))
+        .execute(&mut conn)
+        .expect("backdate messages");
+
+    let count = |conn: &mut diesel::PgConnection| -> i64 {
+        messages::table
+            .filter(messages::session_id.eq(session_id))
+            .count()
+            .get_result(conn)
+            .expect("count")
+    };
+    assert_eq!(count(&mut conn), 2, "precondition: two old messages");
+
+    // Cycle 1: archive backend is UNWRITABLE — root points at a plain file, so
+    // `create_dir_all` (and thus every put) fails. The session's archive fails,
+    // its id lands in the held set, and its old messages must survive.
+    let bad_root = tempfile::NamedTempFile::new().expect("temp file");
+    let broken = ArchiveRuntime::new(ArchiveConfig {
+        backend: ArchiveBackendConfig::Local {
+            root: bad_root.path().to_path_buf(),
+        },
+        transcripts: true,
+    })
+    .expect("runtime (construction succeeds; writes fail)");
+    backend::background::run_retention_cleanup(retention_test_state(Some(Arc::new(broken)))).await;
+    assert_eq!(
+        count(&mut conn),
+        2,
+        "archive failed → trim held, messages preserved"
+    );
+
+    // Cycle 2: a working archive. The session archives, then the age trim
+    // deletes the now-safely-captured old messages.
+    let good_root = tempfile::tempdir().expect("tempdir");
+    let working = ArchiveRuntime::new(ArchiveConfig {
+        backend: ArchiveBackendConfig::Local {
+            root: good_root.path().to_path_buf(),
+        },
+        transcripts: true,
+    })
+    .expect("working runtime");
+    backend::background::run_retention_cleanup(retention_test_state(Some(Arc::new(working)))).await;
+    assert_eq!(
+        count(&mut conn),
+        0,
+        "archive succeeded → age trim removes old messages"
+    );
+
+    diesel::delete(messages::table.filter(messages::session_id.eq(session_id)))
+        .execute(&mut conn)
+        .ok();
+    diesel::delete(sessions::table.find(session_id))
+        .execute(&mut conn)
+        .ok();
+}
+
 /// #1258 phase 2: a re-archive after hot-DB messages were trimmed must
 /// MERGE with the archived transcript, never shrink it.
 #[tokio::test]


### PR DESCRIPTION
## Problem

#1258 phase 2 gave retention **two** delete paths with **inconsistent** archive-failure semantics:

- `run_session_age_cleanup` (session deletion) is correct: it archives each session first and, on archive failure, **HOLDS** the deletion (`continue`) to retry next cycle — retention can never destroy the last copy.
- The **message-trim** path (`run_retention_cleanup` + `archive_retention_candidates`) archived every candidate *best-effort* and then trimmed **anyway**. If an archive outage coincided with a retention cycle, the unarchived delta was **permanently lost** — exactly the loss window archive-first was meant to close.

## Fix — give message trims the same held semantics

- `archive_retention_candidates` now returns the set of session ids whose archive attempt **failed** this cycle (empty when archiving is disabled; a defensive hold-all if candidate loading itself fails).
- `handlers::retention::run_retention_cleanup` threads that held set into **both** delete paths:
  - the age-based bulk delete adds a `messages::session_id.ne_all(...)` exclusion **only when the set is non-empty** (empty-set path keeps the original, index-friendly query plan);
  - the per-session truncation loop skips held ids.
- When archiving is **disabled**, the held set is always empty and trims run exactly as before — running retention without an archive is the operator's explicit choice.
- A held cycle logs once at `warn` with the stable marker `RETENTION_TRIM_HELD n sessions pending archive`, aligned with `SESSION_ARCHIVE_FAILED`, so an archive outage that is silently blocking retention is alertable.
- Comments at the old "best-effort trim" site now document the held semantics and the trade-off (the hot DB grows for held sessions during an archive outage — data preserved over a bounded space cost; archive-first is the invariant).

## Test

DB-gated harness test `retention_holds_trim_when_archive_fails`: archive failure is simulated with a **local backend whose root points at a plain file** (`tempfile::NamedTempFile`), so `create_dir_all`/every `put` errors without any mock. A cycle with that broken archive leaves a session's old messages in place; a subsequent cycle with a working `tempdir` archive trims them. Full backend suite (212 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)