### PR TITLE
fix: rotate to fresh session when a resume crashes early with no confirmed transcript

### DIFF
--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -390,6 +390,37 @@ async fn run_session_task(
                 // gap is the only signal — it did register, so the launch
                 // "succeeded"). A healthy run resets the backoff counter.
                 if alive < CRASH_LOOP_THRESHOLD {
+                    // A *resume* that dies this fast is almost always a wiped
+                    // transcript: `claude --resume <id>` prints "No conversation
+                    // found" and exits ~immediately, which surfaces here as a
+                    // clean NormalExit (not SessionNotFound). The pre-flight
+                    // guard only catches that when the project dir exists
+                    // (TranscriptStatus::Missing); when the whole project dir is
+                    // absent it returns Unknown and lets the spawn through — so
+                    // reconcile would relaunch the same doomed --resume forever.
+                    // Break the loop by rotating to a fresh session once. Skip
+                    // the rotation only when the transcript is confirmed Present:
+                    // then the early exit is some other fault, and discarding the
+                    // resume would needlessly lose conversation continuity.
+                    if config.resume
+                        && config.agent_type == shared::AgentType::Claude
+                        && claude_transcript_status(
+                            std::path::Path::new(&config.working_directory),
+                            config.session_id,
+                        ) != TranscriptStatus::Present
+                    {
+                        let old_id = config.session_id;
+                        let new_id = Uuid::new_v4();
+                        warn!(
+                            "Session {} exited after only {:.1?} on resume with no confirmed \
+                             transcript — rotating to fresh session {} instead of crash-looping",
+                            old_id, alive, new_id
+                        );
+                        config.session_id = new_id;
+                        config.resume = false;
+                        config.replaces_session_id = Some(old_id);
+                        continue;
+                    }
                     warn!(
                         "Session {} exited normally after only {:.1?} — likely crash loop, \
                          reporting CrashedEarly so reconcile backs off",


### PR DESCRIPTION
# SUMMARY

Fixes an infinite crash loop where a launcher session whose local transcript was wiped never appears in the available launch list.

## Symptom

Launch a session on a host whose \`~/.claude/\` was recently recreated (transcripts gone) and it logs in, spawns, then dies ~2s later and drops off the launch list — repeating forever. Logs show:

\`\`\`
ERROR ...portal_reminder: Failed to inject portal reminder into agent stdin: Broken pipe (os error 32)
ERROR ...wiggum: Session error: Broken pipe (os error 32)
INFO  Claude process exited, shutting down
WARN  Session ... exited normally after only 2.2s — likely crash loop ... CrashedEarly
\`\`\`

## Root cause

\`claude --resume <id>\` with a missing transcript prints \`No conversation found with session ID\` and exits almost immediately. That surfaces in \`run_session_task\` as a clean \`LoopResult::NormalExit\` (not \`SessionNotFound\`), so the existing \`SessionNotFound\` rotation (process_manager.rs) never triggers.

The pre-flight guard rotates only when \`claude_transcript_status\` is confidently \`Missing\` (project dir present, transcript file absent). When the **entire project directory is absent** — which is the case when the session never managed to write a transcript because it crashed every time — the function returns \`Unknown\`, and \`Unknown\` deliberately falls through to a normal \`--resume\` spawn. So reconcile relaunches the same doomed resume on every heartbeat.

## Fix

On an early \`NormalExit\` (\`alive < CRASH_LOOP_THRESHOLD\`) for a **Claude resume** whose transcript is **not confirmed \`Present\`**, rotate once to a fresh session (\`resume = false\`, \`replaces_session_id = old\`) and continue, instead of reporting \`CrashedEarly\`. This reuses the established rotation pattern already used for \`SessionNotFound\`.

- A resume whose transcript **is** \`Present\` still reports \`CrashedEarly\` — a legitimate resume is never discarded over an unrelated early fault (preserves conversation continuity).
- After rotation \`resume = false\`, so a fresh session that also crashes early falls through to \`CrashedEarly\` normally — no in-process infinite loop.
- Codex sessions are unaffected (guarded on \`AgentType::Claude\`).

## Test plan

- [x] \`cargo build -p agent-portal\`
- [x] \`cargo clippy -p agent-portal\` (no warnings)
- [x] \`cargo fmt --check\`
- [x] \`cargo test -p agent-portal -p claude-session-lib\` (46 passed)
- [x] Reproduced the underlying \`claude --resume <bad-id>\` → exit 1 / "No conversation found" on the affected host