### PR TITLE
Refactor WebSocket output handling context

### DIFF
--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -135,22 +135,43 @@ fn parse_send_mode(value: &str) -> Option<SendMode> {
     }
 }
 
+/// Stable dependencies for handling one proxy-originated output frame.
+pub struct ClaudeOutputContext<'a> {
+    pub session_manager: &'a SessionManager,
+    pub session_key: &'a Option<String>,
+    pub db_session_id: Option<Uuid>,
+    pub db_pool: &'a DbPool,
+    pub notifications: &'a crate::push::NotificationSender,
+    pub tx: &'a ProxySender,
+    pub image_store: &'a crate::handlers::images::ImageStore,
+}
+
+/// Event-specific output payload from the proxy.
+pub struct ClaudeOutputFrame {
+    pub content: serde_json::Value,
+    pub seq: Option<u64>,
+    pub agent_type: AgentType,
+}
+
 /// Handle Claude output (both legacy ClaudeOutput and new SequencedOutput).
 /// Broadcasts to web clients, deduplicates sequenced messages, stores in DB,
 /// and sends acknowledgments.
-#[allow(clippy::too_many_arguments)]
-pub fn handle_claude_output(
-    session_manager: &SessionManager,
-    session_key: &Option<String>,
-    db_session_id: Option<Uuid>,
-    db_pool: &DbPool,
-    notifications: &crate::push::NotificationSender,
-    tx: &ProxySender,
-    content: serde_json::Value,
-    seq: Option<u64>,
-    image_store: &crate::handlers::images::ImageStore,
-    agent_type: AgentType,
-) {
+pub fn handle_claude_output(ctx: ClaudeOutputContext<'_>, frame: ClaudeOutputFrame) {
+    let ClaudeOutputContext {
+        session_manager,
+        session_key,
+        db_session_id,
+        db_pool,
+        notifications,
+        tx,
+        image_store,
+    } = ctx;
+    let ClaudeOutputFrame {
+        content,
+        seq,
+        agent_type,
+    } = frame;
+
     // Deduplicate sequenced messages before broadcasting
     if let (Some(session_id), Some(seq_num)) = (db_session_id, seq) {
         let last_ack = session_manager.last_ack_seq(session_id);

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -1,6 +1,7 @@
 use super::continuations::handle_session_limit_reached;
 use super::message_handlers::{
     handle_claude_output, replay_forward_opens_from_db, replay_pending_inputs_from_db,
+    ClaudeOutputContext, ClaudeOutputFrame,
 };
 use super::permissions::handle_permission_request;
 use super::registration::{register_or_update_session, RegistrationParams};
@@ -271,16 +272,20 @@ fn handle_proxy_message(
             agent_type,
         } => {
             handle_claude_output(
-                session_manager,
-                session_key,
-                *db_session_id,
-                db_pool,
-                &app_state.notifications,
-                tx,
-                content,
-                None,
-                &app_state.image_store,
-                agent_type,
+                ClaudeOutputContext {
+                    session_manager,
+                    session_key,
+                    db_session_id: *db_session_id,
+                    db_pool,
+                    notifications: &app_state.notifications,
+                    tx,
+                    image_store: &app_state.image_store,
+                },
+                ClaudeOutputFrame {
+                    content,
+                    seq: None,
+                    agent_type,
+                },
             );
         }
         ProxyToServer::SequencedOutput {
@@ -289,16 +294,20 @@ fn handle_proxy_message(
             agent_type,
         } => {
             handle_claude_output(
-                session_manager,
-                session_key,
-                *db_session_id,
-                db_pool,
-                &app_state.notifications,
-                tx,
-                content,
-                Some(seq),
-                &app_state.image_store,
-                agent_type,
+                ClaudeOutputContext {
+                    session_manager,
+                    session_key,
+                    db_session_id: *db_session_id,
+                    db_pool,
+                    notifications: &app_state.notifications,
+                    tx,
+                    image_store: &app_state.image_store,
+                },
+                ClaudeOutputFrame {
+                    content,
+                    seq: Some(seq),
+                    agent_type,
+                },
             );
         }
         ProxyToServer::Heartbeat => {


### PR DESCRIPTION
## Summary

Addresses #1347 as a focused first slice.

The proxy-output path was the highest-value target called out in the issue: `handle_claude_output` accepted a long list of stable dependencies plus per-frame values and carried `#[allow(clippy::too_many_arguments)]`.

Changes:
- introduce `ClaudeOutputContext` for stable handler dependencies
- introduce `ClaudeOutputFrame` for event-specific output payload
- remove the `too_many_arguments` suppression from `handle_claude_output`
- update proxy socket call sites with explicit context/frame construction

Remaining backend WebSocket `too_many_arguments` suppressions are in other paths and remain covered by the broader #1165 architecture tracker.

## Tests

- `mkdir -p frontend/dist && cargo test -p backend websocket::message_handlers`
