### PR TITLE
Add PR title and body conventions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -910,6 +910,7 @@ use uuid::Uuid;
 
 - **Titles**: describe the change, not the ticket. Don't reference issue/PR numbers — they're noise in the title.
 - **Bodies**: focus on *what* the change does and *why*. Keep it concise — no commit-by-commit play-by-play.
+- **No attribution footer**: don't add "Generated with Claude Code" (or similar) to PR titles or bodies.
 
 ## SHIP Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -906,6 +906,11 @@ use uuid::Uuid;
 3. **Frontend**: Use `use_memo` for expensive computations in Yew
 4. **Backend**: Database connection pool already configured in `db.rs`
 
+## PR Conventions
+
+- **Titles**: describe the change, not the ticket. Don't reference issue/PR numbers — they're noise in the title.
+- **Bodies**: focus on *what* the change does and *why*. Keep it concise — no commit-by-commit play-by-play.
+
 ## SHIP Workflow
 
 When the user says **"SHIP"**, execute this workflow:


### PR DESCRIPTION
Adds a concise PR Conventions section to CLAUDE.md:

- Titles should describe the change, not reference issue/PR numbers.
- Bodies should stay focused on implementation and avoid a commit-by-commit play-by-play.
- PRs should omit the "Generated with Claude Code" attribution footer.