### PR TITLE
Fix nav number-select to match the rail's display order

### DIFF
--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -37,10 +37,6 @@ pub struct KeyboardNavConfig {
     pub focused_index: usize,
     /// Set of hidden session IDs
     pub hidden_sessions: HashSet<Uuid>,
-    /// Set of connected session IDs
-    pub connected_sessions: HashSet<Uuid>,
-    /// Whether inactive sessions are hidden
-    pub inactive_hidden: bool,
     /// Callback when session selection changes
     pub on_select: Callback<usize>,
     /// Callback to activate a session (mark it as having been viewed)
@@ -86,8 +82,6 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let sessions = config.sessions.clone();
         let focused_index = config.focused_index;
         let hidden_sessions = config.hidden_sessions.clone();
-        let connected_sessions = config.connected_sessions.clone();
-        let inactive_hidden = config.inactive_hidden;
         let on_select = config.on_select.clone();
         let on_activate = config.on_activate.clone();
         let on_interrupt = config.on_interrupt.clone();
@@ -229,37 +223,25 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                         // Placeholder for close session
                     }
                     key => {
-                        // Number keys 1-9 for direct selection
+                        // Number keys 1-9 select the Nth session *as shown in the
+                        // rail*. The rail (session_rail.rs) numbers the visible
+                        // sessions in `sessions` (already display-sorted) order,
+                        // hiding manually-hidden and cron/scheduled sessions — so
+                        // we must use the exact same order and filter here, or the
+                        // number won't match the badge the user sees.
                         if let Ok(num) = key.parse::<usize>() {
                             if (1..=9).contains(&num) {
-                                // Build visible session indices in display order
-                                let mut visible_indices: Vec<usize> = Vec::new();
-
-                                // Add active sessions first
-                                for (idx, session) in sessions.iter().enumerate() {
-                                    let is_connected = connected_sessions.contains(&session.id);
-                                    let is_hidden = hidden_sessions.contains(&session.id);
-                                    if is_connected && !is_hidden {
-                                        visible_indices.push(idx);
-                                    }
-                                }
-
-                                // Add inactive sessions if not hidden
-                                if !inactive_hidden {
-                                    for (idx, session) in sessions.iter().enumerate() {
-                                        let is_connected = connected_sessions.contains(&session.id);
-                                        let is_hidden = hidden_sessions.contains(&session.id);
-                                        if !is_connected || is_hidden {
-                                            visible_indices.push(idx);
-                                        }
-                                    }
-                                }
-
-                                // Map display number (1-based) to actual index
-                                let display_idx = num - 1;
-                                if display_idx < visible_indices.len() {
+                                let visible_indices: Vec<usize> = sessions
+                                    .iter()
+                                    .enumerate()
+                                    .filter(|(_, s)| {
+                                        !hidden_sessions.contains(&s.id)
+                                            && s.scheduled_task_id.is_none()
+                                    })
+                                    .map(|(idx, _)| idx)
+                                    .collect();
+                                if let Some(&actual_idx) = visible_indices.get(num - 1) {
                                     e.prevent_default();
-                                    let actual_idx = visible_indices[display_idx];
                                     if let Some(session) = sessions.get(actual_idx) {
                                         on_activate.emit(session.id);
                                     }

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -168,8 +168,6 @@ pub fn dashboard_page() -> Html {
         sessions: active_sessions.clone(),
         focused_index: focus.focused_index,
         hidden_sessions: effective_hidden_sessions.clone(),
-        connected_sessions: session_state.connected_sessions.clone(),
-        inactive_hidden: ui_state.inactive_hidden,
         on_select: focus.on_select_session.clone(),
         on_activate: focus.on_activate.clone(),
         on_interrupt: focus.on_interrupt.clone(),


### PR DESCRIPTION
# SUMMARY

Nav-mode number keys (`1`–`9`) selected the wrong session when multiple were **connected**.

**Why:** the number-select built its index list in a *connected-first* order (active/connected sessions first, then the rest), but the session rail numbers its cards in **display order** (`session_display_cmp`, skipping hidden + cron/scheduled sessions). So the number the user sees on a card didn't match what `esc+N` selected — e.g. with 4 connected sessions, `esc+4` could jump to the 3rd.

**Fix:** number in the exact same order and filter the rail uses — visible sessions from the already-display-sorted `sessions` list, skipping `hidden_sessions` and `scheduled_task_id.is_some()`. Drops the now-unused `connected_sessions` / `inactive_hidden` fields from `KeyboardNavConfig`.

Only manifests with connected sessions (disconnected-only sets happened to coincide). Pre-existing bug, independent of the keyboard-shortcuts work (#1338).

Verified: `cargo clippy -p frontend --target wasm32-unknown-unknown` (-Dwarnings) clean, frontend builds, 422 frontend tests pass.