### PR TITLE
Keyboard shortcuts help overlay (press `?`)

### DIFF
--- a/frontend/src/components/help_overlay.rs
+++ b/frontend/src/components/help_overlay.rs
@@ -1,0 +1,184 @@
+//! Keyboard shortcuts help overlay (issue #1324).
+//!
+//! A modal listing every keyboard shortcut, grouped by context. Opened by
+//! pressing `?` on the dashboard while not typing in the message textarea, and
+//! dismissed with `Esc` (capture-phase, so it never toggles nav mode) or a
+//! backdrop click.
+
+use crate::hooks::use_escape_capture;
+use web_sys::MouseEvent;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct HelpOverlayProps {
+    pub on_close: Callback<()>,
+}
+
+/// A single shortcut row: one or more key labels and what they do.
+struct Shortcut {
+    keys: &'static [&'static str],
+    description: &'static str,
+}
+
+/// A named group of shortcuts (a "context" such as edit mode or nav mode).
+struct ShortcutGroup {
+    title: &'static str,
+    shortcuts: &'static [Shortcut],
+}
+
+const GROUPS: &[ShortcutGroup] = &[
+    ShortcutGroup {
+        title: "Global",
+        shortcuts: &[
+            Shortcut {
+                keys: &["?"],
+                description: "Show this shortcuts overlay",
+            },
+            Shortcut {
+                keys: &["Shift", "Tab"],
+                description: "Jump to the next active session",
+            },
+        ],
+    },
+    ShortcutGroup {
+        title: "Edit mode (typing)",
+        shortcuts: &[
+            Shortcut {
+                keys: &["Enter"],
+                description: "Send message",
+            },
+            Shortcut {
+                keys: &["Shift", "Enter"],
+                description: "Insert a new line",
+            },
+            Shortcut {
+                keys: &["↑"],
+                description: "Previous message in input history",
+            },
+            Shortcut {
+                keys: &["↓"],
+                description: "Next message in input history",
+            },
+            Shortcut {
+                keys: &["Ctrl", "M"],
+                description: "Toggle voice input",
+            },
+            Shortcut {
+                keys: &["Esc"],
+                description: "Switch to nav mode",
+            },
+            Shortcut {
+                keys: &["Esc", "Esc", "Esc"],
+                description: "Interrupt the running agent",
+            },
+        ],
+    },
+    ShortcutGroup {
+        title: "Nav mode",
+        shortcuts: &[
+            Shortcut {
+                keys: &["↑", "↓", "←", "→"],
+                description: "Move between sessions",
+            },
+            Shortcut {
+                keys: &["h", "j", "k", "l"],
+                description: "Move between sessions (vim keys)",
+            },
+            Shortcut {
+                keys: &["1", "–", "9"],
+                description: "Jump directly to a session by number",
+            },
+            Shortcut {
+                keys: &["w"],
+                description: "Jump to the next waiting session",
+            },
+            Shortcut {
+                keys: &["n"],
+                description: "New session (open the launch dialog)",
+            },
+            Shortcut {
+                keys: &["x"],
+                description: "Hide / show the focused session",
+            },
+            Shortcut {
+                keys: &["i"],
+                description: "Return to edit mode",
+            },
+            Shortcut {
+                keys: &["Enter"],
+                description: "Return to edit mode",
+            },
+            Shortcut {
+                keys: &["Esc"],
+                description: "Return to edit mode",
+            },
+        ],
+    },
+];
+
+#[function_component(HelpOverlay)]
+pub fn help_overlay(props: &HelpOverlayProps) -> Html {
+    // Capture-phase Escape so it closes the overlay without reaching the
+    // bubble-phase keyboard-nav handler (which would toggle nav mode).
+    use_escape_capture(true, props.on_close.clone());
+
+    let on_backdrop = {
+        let on_close = props.on_close.clone();
+        Callback::from(move |_: MouseEvent| on_close.emit(()))
+    };
+
+    let on_close_button = {
+        let on_close = props.on_close.clone();
+        Callback::from(move |_: MouseEvent| on_close.emit(()))
+    };
+
+    // Stop clicks inside the panel from bubbling to the backdrop (which closes).
+    let stop = Callback::from(|e: MouseEvent| e.stop_propagation());
+
+    html! {
+        <div class="help-overlay" onclick={on_backdrop}>
+            <div class="help-dialog" onclick={stop}>
+                <div class="help-dialog-header">
+                    <h2>{ "Keyboard Shortcuts" }</h2>
+                    <button
+                        class="help-dialog-close"
+                        onclick={on_close_button}
+                        aria-label="Close"
+                    >
+                        { "×" }
+                    </button>
+                </div>
+                <div class="help-dialog-body">
+                    {
+                        GROUPS.iter().map(|group| html! {
+                            <section class="help-group" key={group.title}>
+                                <h3 class="help-group-title">{ group.title }</h3>
+                                <ul class="help-shortcut-list">
+                                    {
+                                        group.shortcuts.iter().map(|shortcut| html! {
+                                            <li class="help-shortcut">
+                                                <span class="help-keys">
+                                                    {
+                                                        shortcut.keys.iter().map(|key| html! {
+                                                            <kbd>{ *key }</kbd>
+                                                        }).collect::<Html>()
+                                                    }
+                                                </span>
+                                                <span class="help-description">
+                                                    { shortcut.description }
+                                                </span>
+                                            </li>
+                                        }).collect::<Html>()
+                                    }
+                                </ul>
+                            </section>
+                        }).collect::<Html>()
+                    }
+                </div>
+                <div class="help-dialog-footer">
+                    <span>{ "Press " }<kbd>{ "Esc" }</kbd>{ " or click outside to close" }</span>
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -8,6 +8,7 @@ mod count_up;
 mod cron_describe;
 mod diff;
 pub mod expandable;
+mod help_overlay;
 mod launch_dialog;
 pub(crate) mod markdown;
 pub mod message_renderer;
@@ -24,6 +25,7 @@ mod voice_input;
 pub use confirm_modal::{ConfirmModal, ConfirmModalStyle};
 pub use copy_command::CopyCommand;
 pub use count_up::CountUp;
+pub use help_overlay::HelpOverlay;
 pub use launch_dialog::LaunchDialog;
 pub use message_renderer::{
     group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroupRenderer,

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -47,6 +47,8 @@ pub struct KeyboardNavConfig {
     pub on_activate: Callback<Uuid>,
     /// Callback when triple-Escape interrupt is triggered
     pub on_interrupt: Callback<()>,
+    /// Callback to open the keyboard-shortcuts help overlay (`?`)
+    pub on_show_help: Callback<()>,
 }
 
 /// Return value from the use_keyboard_nav hook.
@@ -73,6 +75,10 @@ const TRIPLE_ESCAPE_WINDOW_MS: f64 = 600.0;
 /// - Enter/Escape/i -> Edit Mode
 /// - w -> next waiting session
 ///
+/// `?` opens the keyboard-shortcuts help overlay whenever focus is not in the
+/// message textarea (i.e. in nav mode, or in edit mode with a non-text element
+/// focused).
+///
 /// Triple-Escape (within 600ms) sends an interrupt to the focused session.
 #[hook]
 pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
@@ -91,10 +97,13 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let on_select = config.on_select.clone();
         let on_activate = config.on_activate.clone();
         let on_interrupt = config.on_interrupt.clone();
+        let on_show_help = config.on_show_help.clone();
         Callback::from(move |e: KeyboardEvent| {
-            // Don't handle keyboard nav when a modal overlay is open
+            // Don't handle keyboard nav when a modal overlay is open. The help
+            // overlay is included so its own keys (Esc / backdrop) win and nav
+            // shortcuts don't fire underneath it.
             if gloo::utils::document()
-                .query_selector(".sched-overlay, .share-dialog-overlay")
+                .query_selector(".sched-overlay, .share-dialog-overlay, .help-overlay")
                 .ok()
                 .flatten()
                 .is_some()
@@ -161,6 +170,25 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                     on_select.emit(new_idx);
                 }
                 return;
+            }
+
+            // `?` opens the keyboard-shortcuts help overlay, unless the user is
+            // typing into a text field (textarea/input). In nav mode the
+            // textarea keeps DOM focus, so allow it explicitly there.
+            if e.key() == "?" {
+                let target_is_text_input = e
+                    .target()
+                    .and_then(|t| t.dyn_into::<web_sys::Element>().ok())
+                    .map(|el| {
+                        let tag = el.tag_name();
+                        tag.eq_ignore_ascii_case("textarea") || tag.eq_ignore_ascii_case("input")
+                    })
+                    .unwrap_or(false);
+                if in_nav_mode || !target_is_text_input {
+                    e.prevent_default();
+                    on_show_help.emit(());
+                    return;
+                }
             }
 
             // Track Escape presses for triple-Escape interrupt detection

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -14,7 +14,9 @@ use super::types::{
     load_hidden_sessions, load_inactive_hidden, load_rail_position, load_show_cost,
     save_hidden_sessions, save_inactive_hidden, save_show_cost,
 };
-use crate::components::{ConfirmModal, ConfirmModalStyle, LaunchDialog, TurnMetricsHeaderPill};
+use crate::components::{
+    ConfirmModal, ConfirmModalStyle, HelpOverlay, LaunchDialog, TurnMetricsHeaderPill,
+};
 use crate::hooks::{use_client_websocket, use_keyboard_nav, use_sessions, KeyboardNavConfig};
 use crate::pages::admin::AdminPage;
 use crate::pages::settings::SettingsPage;
@@ -163,6 +165,12 @@ pub fn dashboard_page() -> Html {
         );
     }
 
+    // `?`: open the keyboard-shortcuts help overlay.
+    let on_show_help = {
+        let ui_state = ui_state.clone();
+        Callback::from(move |()| ui_state.dispatch(DashboardUiAction::ShowHelp))
+    };
+
     // Use the keyboard navigation hook
     let keyboard_nav = use_keyboard_nav(KeyboardNavConfig {
         sessions: active_sessions.clone(),
@@ -173,7 +181,13 @@ pub fn dashboard_page() -> Html {
         on_select: focus.on_select_session.clone(),
         on_activate: focus.on_activate.clone(),
         on_interrupt: focus.on_interrupt.clone(),
+        on_show_help,
     });
+
+    let close_help = {
+        let ui_state = ui_state.clone();
+        Callback::from(move |_: ()| ui_state.dispatch(DashboardUiAction::CloseHelp))
+    };
 
     // Modal open callbacks
     let go_to_admin = {
@@ -724,6 +738,7 @@ pub fn dashboard_page() -> Html {
                                             <span>{ "1-9 = select" }</span>
                                             <span>{ "w = next waiting" }</span>
                                             <span>{ "Enter/Esc = edit mode" }</span>
+                                            <span>{ "? = shortcuts" }</span>
                                         </>
                                     }
                                 } else {
@@ -733,6 +748,7 @@ pub fn dashboard_page() -> Html {
                                             <span>{ "Shift+Tab = next active" }</span>
                                             <span>{ "Ctrl+M = voice" }</span>
                                             <span>{ "Enter = send" }</span>
+                                            <span>{ "? = shortcuts" }</span>
                                         </>
                                     }
                                 }
@@ -791,6 +807,11 @@ pub fn dashboard_page() -> Html {
                 <div class="full-page-modal">
                     <SettingsPage on_close={close_settings.clone()} />
                 </div>
+            }
+
+            // Keyboard shortcuts help overlay (press `?`)
+            if ui_state.show_help {
+                <HelpOverlay on_close={close_help.clone()} />
             }
 
             // Leave confirmation modal

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -156,6 +156,7 @@ pub(super) struct DashboardUiState {
     pub show_launch_dialog: bool,
     pub show_admin: bool,
     pub show_settings: bool,
+    pub show_help: bool,
     pub inactive_hidden: bool,
     pub show_cost: bool,
     pub rail_position: RailPosition,
@@ -169,6 +170,7 @@ impl DashboardUiState {
             show_launch_dialog: false,
             show_admin: false,
             show_settings: false,
+            show_help: false,
             inactive_hidden,
             show_cost,
             rail_position,
@@ -186,6 +188,8 @@ pub(super) enum DashboardUiAction {
     CloseAdmin,
     ShowSettings,
     CloseSettings,
+    ShowHelp,
+    CloseHelp,
     SetInactiveHidden(bool),
     SetShowCost(bool),
     SetRailPosition(RailPosition),
@@ -219,6 +223,12 @@ impl Reducible for DashboardUiState {
             }
             DashboardUiAction::CloseSettings => {
                 state.show_settings = false;
+            }
+            DashboardUiAction::ShowHelp => {
+                state.show_help = true;
+            }
+            DashboardUiAction::CloseHelp => {
+                state.show_help = false;
             }
             DashboardUiAction::SetInactiveHidden(hidden) => {
                 state.inactive_hidden = hidden;
@@ -364,6 +374,11 @@ mod tests {
         assert!(state.show_settings);
         let state = state.reduce(DashboardUiAction::CloseSettings);
         assert!(!state.show_settings);
+
+        let state = state.reduce(DashboardUiAction::ShowHelp);
+        assert!(state.show_help);
+        let state = state.reduce(DashboardUiAction::CloseHelp);
+        assert!(!state.show_help);
     }
 
     #[test]

--- a/frontend/styles/keyboard.css
+++ b/frontend/styles/keyboard.css
@@ -142,6 +142,145 @@
 }
 
 /* ==========================================================================
+   Keyboard Shortcuts Help Overlay (press ?)
+   ========================================================================== */
+
+.help-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1100;
+    padding: 1rem;
+}
+
+.help-dialog {
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    width: 100%;
+    max-width: 640px;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.help-dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-darker);
+}
+
+.help-dialog-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.help-dialog-close {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    line-height: 1;
+    transition: background 0.15s, color 0.15s;
+}
+
+.help-dialog-close:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text-primary);
+}
+
+.help-dialog-body {
+    padding: 1rem 1.25rem;
+    overflow-y: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.25rem 2rem;
+}
+
+.help-group-title {
+    margin: 0 0 0.5rem;
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--accent);
+}
+
+.help-shortcut-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.help-shortcut {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.help-keys {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex-shrink: 0;
+}
+
+.help-keys kbd {
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.1rem 0.4rem;
+    font-family: monospace;
+    font-size: 0.75rem;
+    color: var(--text-primary);
+}
+
+.help-description {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    text-align: right;
+}
+
+.help-dialog-footer {
+    padding: 0.75rem 1.25rem;
+    border-top: 1px solid var(--border);
+    background: var(--bg-darker);
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    text-align: center;
+}
+
+.help-dialog-footer kbd {
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.1rem 0.4rem;
+    font-family: monospace;
+    font-size: 0.7rem;
+}
+
+/* ==========================================================================
    Mobile - hide keyboard hints (no keyboard on mobile)
    ========================================================================== */
 


### PR DESCRIPTION
## Summary
Adds a consolidated keyboard-shortcuts help overlay, opened by pressing `?` when focus is **not** in the message textarea. Closes #1324.

- New `HelpOverlay` component (`frontend/src/components/help_overlay.rs`) — a modal listing every shortcut, grouped by context (Global, Edit mode, Nav mode).
- `?` handler wired in `use_keyboard_nav.rs`, guarded so it does **not** fire while typing in a textarea/input (but explicitly allowed in nav mode, where the textarea keeps DOM focus).
- Dismiss with `Esc` (capture-phase, so it never toggles nav mode) or a backdrop click.
- Contextual hint bar now advertises `? = shortcuts` in both edit and nav mode.

## Scope
This is one of three PRs split out of the original combined `feat/keyboard-shortcuts` branch (which bundled the overlay, a new-session hotkey, and nav-mode `x`). **This PR is the overlay only** (#1324) — no `n` or `x` behavior.

## Testing
- `cargo check --target wasm32-unknown-unknown -p frontend` passes.
- Press `?` on the dashboard → overlay opens; `Esc` / backdrop / `×` close it; typing `?` inside the composer inserts a literal `?`.
