### PR TITLE
Nav-mode `n` opens the launch dialog

### DIFF
--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -45,6 +45,8 @@ pub struct KeyboardNavConfig {
     pub on_interrupt: Callback<()>,
     /// Callback to open the keyboard-shortcuts help overlay (`?`)
     pub on_show_help: Callback<()>,
+    /// Callback to open the launch dialog (nav-mode `n`)
+    pub on_new_session: Callback<()>,
 }
 
 /// Return value from the use_keyboard_nav hook.
@@ -70,6 +72,7 @@ const TRIPLE_ESCAPE_WINDOW_MS: f64 = 600.0;
 /// - Numbers 1-9 select directly
 /// - Enter/Escape/i -> Edit Mode
 /// - w -> next waiting session
+/// - n -> open the launch dialog (new session)
 ///
 /// `?` opens the keyboard-shortcuts help overlay whenever focus is not in the
 /// message textarea (i.e. in nav mode, or in edit mode with a non-text element
@@ -92,12 +95,17 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let on_activate = config.on_activate.clone();
         let on_interrupt = config.on_interrupt.clone();
         let on_show_help = config.on_show_help.clone();
+        let on_new_session = config.on_new_session.clone();
         Callback::from(move |e: KeyboardEvent| {
             // Don't handle keyboard nav when a modal overlay is open. The help
-            // overlay is included so its own keys (Esc / backdrop) win and nav
-            // shortcuts don't fire underneath it.
+            // overlay, launch dialog, and full-page modals are included so their
+            // own keys (Esc / backdrop) win and nav shortcuts don't fire
+            // underneath them.
             if gloo::utils::document()
-                .query_selector(".sched-overlay, .share-dialog-overlay, .help-overlay")
+                .query_selector(
+                    ".sched-overlay, .share-dialog-overlay, .help-overlay, \
+                     .launch-dialog-backdrop, .full-page-modal",
+                )
                 .ok()
                 .flatten()
                 .is_some()
@@ -246,6 +254,11 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                             }
                             on_select.emit(new_idx);
                         }
+                    }
+                    "n" => {
+                        // Open the launch dialog to start a new session.
+                        e.prevent_default();
+                        on_new_session.emit(());
                     }
                     "x" => {
                         // Placeholder for close session

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -43,10 +43,10 @@ pub struct KeyboardNavConfig {
     pub on_activate: Callback<Uuid>,
     /// Callback when triple-Escape interrupt is triggered
     pub on_interrupt: Callback<()>,
-    /// Callback to open the keyboard-shortcuts help overlay (`?`)
-    pub on_show_help: Callback<()>,
     /// Callback to open the launch dialog (nav-mode `n`)
     pub on_new_session: Callback<()>,
+    /// Callback to open the keyboard-shortcuts help overlay (`?`)
+    pub on_show_help: Callback<()>,
 }
 
 /// Return value from the use_keyboard_nav hook.
@@ -94,11 +94,11 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let on_select = config.on_select.clone();
         let on_activate = config.on_activate.clone();
         let on_interrupt = config.on_interrupt.clone();
-        let on_show_help = config.on_show_help.clone();
         let on_new_session = config.on_new_session.clone();
+        let on_show_help = config.on_show_help.clone();
         Callback::from(move |e: KeyboardEvent| {
-            // Don't handle keyboard nav when a modal overlay is open. The help
-            // overlay, launch dialog, and full-page modals are included so their
+            // Don't handle keyboard nav when a modal overlay is open. The launch
+            // dialog, full-page modals, and help overlay are included so their
             // own keys (Esc / backdrop) win and nav shortcuts don't fire
             // underneath them.
             if gloo::utils::document()

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -165,16 +165,16 @@ pub fn dashboard_page() -> Html {
         );
     }
 
-    // `?`: open the keyboard-shortcuts help overlay.
-    let on_show_help = {
-        let ui_state = ui_state.clone();
-        Callback::from(move |()| ui_state.dispatch(DashboardUiAction::ShowHelp))
-    };
-
     // Nav-mode `n`: open the launch dialog to start a new session.
     let on_new_session = {
         let ui_state = ui_state.clone();
         Callback::from(move |()| ui_state.dispatch(DashboardUiAction::ToggleLaunchDialog))
+    };
+
+    // `?`: open the keyboard-shortcuts help overlay.
+    let on_show_help = {
+        let ui_state = ui_state.clone();
+        Callback::from(move |()| ui_state.dispatch(DashboardUiAction::ShowHelp))
     };
 
     // Use the keyboard navigation hook
@@ -185,8 +185,8 @@ pub fn dashboard_page() -> Html {
         on_select: focus.on_select_session.clone(),
         on_activate: focus.on_activate.clone(),
         on_interrupt: focus.on_interrupt.clone(),
-        on_show_help,
         on_new_session,
+        on_show_help,
     });
 
     let close_help = {

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -171,6 +171,12 @@ pub fn dashboard_page() -> Html {
         Callback::from(move |()| ui_state.dispatch(DashboardUiAction::ShowHelp))
     };
 
+    // Nav-mode `n`: open the launch dialog to start a new session.
+    let on_new_session = {
+        let ui_state = ui_state.clone();
+        Callback::from(move |()| ui_state.dispatch(DashboardUiAction::ToggleLaunchDialog))
+    };
+
     // Use the keyboard navigation hook
     let keyboard_nav = use_keyboard_nav(KeyboardNavConfig {
         sessions: active_sessions.clone(),
@@ -180,6 +186,7 @@ pub fn dashboard_page() -> Html {
         on_activate: focus.on_activate.clone(),
         on_interrupt: focus.on_interrupt.clone(),
         on_show_help,
+        on_new_session,
     });
 
     let close_help = {
@@ -735,6 +742,7 @@ pub fn dashboard_page() -> Html {
                                             <span>{ "↑↓ or jk = navigate" }</span>
                                             <span>{ "1-9 = select" }</span>
                                             <span>{ "w = next waiting" }</span>
+                                            <span>{ "n = new" }</span>
                                             <span>{ "Enter/Esc = edit mode" }</span>
                                             <span>{ "? = shortcuts" }</span>
                                         </>


### PR DESCRIPTION
## Summary
Adds a nav-mode `n` shortcut that opens the launch dialog to start a new session.

- `n` in nav mode → opens the launch dialog (`DashboardUiAction::ToggleLaunchDialog`).
- Nav-mode hint bar now shows `n = new`.
- Keyboard-nav handling now also stands down for `.launch-dialog-backdrop` and `.full-page-modal`, so those modals' own keys win while open.

## Scope
One of three PRs split out of the original combined `feat/keyboard-shortcuts` branch. **This PR is the `n` hotkey only** — no help overlay, no `x` behavior.

## Testing
- `cargo check --target wasm32-unknown-unknown -p frontend` passes.
- Enter nav mode (Esc), press `n` → launch dialog opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)