### PR TITLE
Nav-mode `x` hides/shows the focused session

### DIFF
--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -37,16 +37,14 @@ pub struct KeyboardNavConfig {
     pub focused_index: usize,
     /// Set of hidden session IDs
     pub hidden_sessions: HashSet<Uuid>,
-    /// Set of connected session IDs
-    pub connected_sessions: HashSet<Uuid>,
-    /// Whether inactive sessions are hidden
-    pub inactive_hidden: bool,
     /// Callback when session selection changes
     pub on_select: Callback<usize>,
     /// Callback to activate a session (mark it as having been viewed)
     pub on_activate: Callback<Uuid>,
     /// Callback when triple-Escape interrupt is triggered
     pub on_interrupt: Callback<()>,
+    /// Callback to hide/show a session (nav-mode `x` on the focused session)
+    pub on_toggle_hidden: Callback<Uuid>,
 }
 
 /// Return value from the use_keyboard_nav hook.
@@ -72,6 +70,7 @@ const TRIPLE_ESCAPE_WINDOW_MS: f64 = 600.0;
 /// - Numbers 1-9 select directly
 /// - Enter/Escape/i -> Edit Mode
 /// - w -> next waiting session
+/// - x -> hide/show the focused session
 ///
 /// Triple-Escape (within 600ms) sends an interrupt to the focused session.
 #[hook]
@@ -86,11 +85,10 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let sessions = config.sessions.clone();
         let focused_index = config.focused_index;
         let hidden_sessions = config.hidden_sessions.clone();
-        let connected_sessions = config.connected_sessions.clone();
-        let inactive_hidden = config.inactive_hidden;
         let on_select = config.on_select.clone();
         let on_activate = config.on_activate.clone();
         let on_interrupt = config.on_interrupt.clone();
+        let on_toggle_hidden = config.on_toggle_hidden.clone();
         Callback::from(move |e: KeyboardEvent| {
             // Don't handle keyboard nav when a modal overlay is open
             if gloo::utils::document()
@@ -226,40 +224,34 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                         }
                     }
                     "x" => {
-                        // Placeholder for close session
+                        // Hide/show the focused session (mirrors the rail's
+                        // "Hide Session" action — non-destructive; the session
+                        // keeps running and stays available in the hidden list).
+                        e.prevent_default();
+                        if let Some(session) = sessions.get(focused_index) {
+                            on_toggle_hidden.emit(session.id);
+                        }
                     }
                     key => {
-                        // Number keys 1-9 for direct selection
+                        // Number keys 1-9 select the Nth session *as shown in the
+                        // rail*. The rail (session_rail.rs) numbers the visible
+                        // sessions in `sessions` (already display-sorted) order,
+                        // hiding manually-hidden and cron/scheduled sessions — so
+                        // we must use the exact same order and filter here, or the
+                        // number won't match the badge the user sees.
                         if let Ok(num) = key.parse::<usize>() {
                             if (1..=9).contains(&num) {
-                                // Build visible session indices in display order
-                                let mut visible_indices: Vec<usize> = Vec::new();
-
-                                // Add active sessions first
-                                for (idx, session) in sessions.iter().enumerate() {
-                                    let is_connected = connected_sessions.contains(&session.id);
-                                    let is_hidden = hidden_sessions.contains(&session.id);
-                                    if is_connected && !is_hidden {
-                                        visible_indices.push(idx);
-                                    }
-                                }
-
-                                // Add inactive sessions if not hidden
-                                if !inactive_hidden {
-                                    for (idx, session) in sessions.iter().enumerate() {
-                                        let is_connected = connected_sessions.contains(&session.id);
-                                        let is_hidden = hidden_sessions.contains(&session.id);
-                                        if !is_connected || is_hidden {
-                                            visible_indices.push(idx);
-                                        }
-                                    }
-                                }
-
-                                // Map display number (1-based) to actual index
-                                let display_idx = num - 1;
-                                if display_idx < visible_indices.len() {
+                                let visible_indices: Vec<usize> = sessions
+                                    .iter()
+                                    .enumerate()
+                                    .filter(|(_, s)| {
+                                        !hidden_sessions.contains(&s.id)
+                                            && s.scheduled_task_id.is_none()
+                                    })
+                                    .map(|(idx, _)| idx)
+                                    .collect();
+                                if let Some(&actual_idx) = visible_indices.get(num - 1) {
                                     e.prevent_default();
-                                    let actual_idx = visible_indices[display_idx];
                                     if let Some(session) = sessions.get(actual_idx) {
                                         on_activate.emit(session.id);
                                     }

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -163,16 +163,39 @@ pub fn dashboard_page() -> Html {
         );
     }
 
+    // Toggle a session's hidden state (persisted to localStorage). Shared by
+    // the rail's "Hide Session" action and the nav-mode `x` shortcut.
+    let on_toggle_hidden = {
+        let session_state = session_state.clone();
+        let ui_state = ui_state.clone();
+        Callback::from(move |session_id: Uuid| {
+            let hidden = !session_state.hidden_sessions.contains(&session_id);
+            let mut set = session_state.hidden_sessions.clone();
+            if hidden {
+                set.insert(session_id);
+            } else {
+                set.remove(&session_id);
+            }
+            save_hidden_sessions(&set);
+            session_state.dispatch(DashboardSessionAction::SetHidden { session_id, hidden });
+            // Hiding a session auto-collapses the hidden group so it doesn't
+            // expand in place and leave the user to collapse it manually.
+            if hidden && !ui_state.inactive_hidden {
+                save_inactive_hidden(true);
+                ui_state.dispatch(DashboardUiAction::SetInactiveHidden(true));
+            }
+        })
+    };
+
     // Use the keyboard navigation hook
     let keyboard_nav = use_keyboard_nav(KeyboardNavConfig {
         sessions: active_sessions.clone(),
         focused_index: focus.focused_index,
         hidden_sessions: effective_hidden_sessions.clone(),
-        connected_sessions: session_state.connected_sessions.clone(),
-        inactive_hidden: ui_state.inactive_hidden,
         on_select: focus.on_select_session.clone(),
         on_activate: focus.on_activate.clone(),
         on_interrupt: focus.on_interrupt.clone(),
+        on_toggle_hidden: on_toggle_hidden.clone(),
     });
 
     // Modal open callbacks
@@ -404,21 +427,6 @@ pub fn dashboard_page() -> Html {
                     }
                 }
             });
-        })
-    };
-
-    let on_toggle_hidden = {
-        let session_state = session_state.clone();
-        Callback::from(move |session_id: Uuid| {
-            let hidden = !session_state.hidden_sessions.contains(&session_id);
-            let mut set = session_state.hidden_sessions.clone();
-            if hidden {
-                set.insert(session_id);
-            } else {
-                set.remove(&session_id);
-            }
-            save_hidden_sessions(&set);
-            session_state.dispatch(DashboardSessionAction::SetHidden { session_id, hidden });
         })
     };
 
@@ -723,6 +731,7 @@ pub fn dashboard_page() -> Html {
                                             <span>{ "↑↓ or jk = navigate" }</span>
                                             <span>{ "1-9 = select" }</span>
                                             <span>{ "w = next waiting" }</span>
+                                            <span>{ "x = hide" }</span>
                                             <span>{ "Enter/Esc = edit mode" }</span>
                                         </>
                                     }


### PR DESCRIPTION
## Summary
Wires the nav-mode `x` key to hide/show the focused session.

- `x` in nav mode → toggles the focused session's hidden state, mirroring the rail's non-destructive **Hide Session** action (session keeps running, stays available in the hidden list).
- Hiding auto-collapses the hidden group so it doesn't expand in place and leave the user to collapse it manually.
- Also fixes **1-9 direct-select** to use the exact display order and filter the rail uses (skips manually-hidden and cron/scheduled sessions), so the number matches the badge the user sees. This lets `KeyboardNavConfig` drop its now-unused `connected_sessions` / `inactive_hidden` inputs.
- Nav-mode hint bar now shows `x = hide`.

## ⚠️ Overlap
Per discussion, **another agent is already working on the nav-mode `x` problem.** This PR is split out of the original combined `feat/keyboard-shortcuts` branch for completeness and may duplicate/conflict with that other work — review side-by-side and pick one.

## Scope
One of three PRs split out of the original combined branch. **This PR is the `x` hide/show + the 1-9 order fix only** — no help overlay, no `n` hotkey.

## Testing
- `cargo check --target wasm32-unknown-unknown -p frontend` passes.
- Enter nav mode (Esc), focus a session, press `x` → it hides and the hidden group collapses; press `x` again on it (from the hidden list) to restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)