### PR TITLE
Allow custom session names at launch

### DIFF
--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -50,6 +50,21 @@ pub async fn launch_session(
     // Create a fresh short-lived proxy token for the child process
     let auth_token = mint_launch_token(&app_state, user_id)?;
 
+    // A human-chosen name (when supplied) drives both the display name and,
+    // for worktree launches, the worktree branch. Otherwise fall back to the
+    // working directory's basename.
+    let custom_name = normalize_custom_name(req.name.as_deref());
+    let session_name = custom_name
+        .clone()
+        .unwrap_or_else(|| default_session_name(&req.working_directory));
+    // Name the worktree after the chosen name (launcher sanitizes it to a
+    // git-safe branch); with no name the launcher derives a timestamp default.
+    let worktree_branch = if req.create_worktree {
+        custom_name.clone()
+    } else {
+        None
+    };
+
     let request_id = Uuid::new_v4();
     let session_id = Uuid::new_v4();
     create_desired_session(
@@ -58,6 +73,7 @@ pub async fn launch_session(
             session_id,
             user_id,
             working_directory: req.working_directory.clone(),
+            session_name: session_name.clone(),
             hostname,
             launcher_id: Some(launcher_id),
             client_version: Some(version),
@@ -74,13 +90,13 @@ pub async fn launch_session(
         user_id,
         auth_token,
         working_directory: req.working_directory.clone(),
-        session_name: Some(default_session_name(&req.working_directory)),
+        session_name: Some(session_name),
         claude_args: req.claude_args,
         agent_type: req.agent_type,
         scheduled_task_id: None,
         resume_session_id: Some(session_id),
         create_worktree: req.create_worktree,
-        worktree_branch: req.worktree_branch.clone(),
+        worktree_branch,
     };
 
     if !app_state
@@ -105,6 +121,14 @@ pub async fn launch_session(
     Ok(Json(LaunchResponse { request_id }))
 }
 
+/// Trim a caller-supplied session name, returning `None` when it is absent or
+/// blank so callers fall back to the directory-basename default.
+fn normalize_custom_name(name: Option<&str>) -> Option<String> {
+    name.map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 fn default_session_name(working_directory: &str) -> String {
     std::path::Path::new(working_directory)
         .file_name()
@@ -118,6 +142,7 @@ pub(crate) struct DesiredSessionDraft {
     session_id: Uuid,
     user_id: Uuid,
     working_directory: String,
+    session_name: String,
     hostname: String,
     launcher_id: Option<Uuid>,
     client_version: Option<String>,
@@ -134,11 +159,10 @@ pub(crate) fn create_desired_session(
     use crate::schema::{session_members, sessions};
     use diesel::prelude::*;
 
-    let session_name = default_session_name(&draft.working_directory);
     let new_session = NewSessionWithId {
         id: draft.session_id,
         user_id: draft.user_id,
-        session_name,
+        session_name: draft.session_name,
         session_key: draft.session_id.to_string(),
         working_directory: draft.working_directory,
         status: SessionStatus::Disconnected.as_str().to_string(),
@@ -442,5 +466,28 @@ mod tests {
             resolve_launch_target(&manager, None, Uuid::new_v4()),
             Err(AppError::NotFound("No connected launchers"))
         ));
+    }
+
+    #[test]
+    fn custom_name_is_trimmed_and_blanks_fall_back() {
+        assert_eq!(
+            normalize_custom_name(Some("  api-refactor  ")),
+            Some("api-refactor".to_string())
+        );
+        assert_eq!(normalize_custom_name(Some("   ")), None);
+        assert_eq!(normalize_custom_name(Some("")), None);
+        assert_eq!(normalize_custom_name(None), None);
+    }
+
+    #[test]
+    fn default_session_name_uses_directory_basename() {
+        assert_eq!(
+            default_session_name("/home/ashley/agent-portal"),
+            "agent-portal"
+        );
+        assert_eq!(
+            default_session_name("/home/ashley/agent-portal/"),
+            "agent-portal"
+        );
     }
 }

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -51,18 +51,22 @@ pub async fn launch_session(
     let auth_token = mint_launch_token(&app_state, user_id)?;
 
     // A human-chosen name (when supplied) drives both the display name and,
-    // for worktree launches, the worktree branch. Otherwise fall back to the
-    // working directory's basename.
-    let custom_name = normalize_custom_name(req.name.as_deref());
-    let session_name = custom_name
-        .clone()
-        .unwrap_or_else(|| default_session_name(&req.working_directory));
-    // Name the worktree after the chosen name (launcher sanitizes it to a
-    // git-safe branch); with no name the launcher derives a timestamp default.
-    let worktree_branch = if req.create_worktree {
-        custom_name.clone()
-    } else {
-        None
+    // for worktree launches, the worktree branch. With no name we fall back to
+    // the working directory's basename — except for a worktree launch, where we
+    // mint a `session-<timestamp>` branch and use it as the display name too, so
+    // several unnamed worktree sessions of the same repo stay distinguishable in
+    // the rail instead of all collapsing onto the shared repo basename.
+    let (session_name, worktree_branch) = match (
+        normalize_custom_name(req.name.as_deref()),
+        req.create_worktree,
+    ) {
+        (Some(name), true) => (name.clone(), Some(name)),
+        (Some(name), false) => (name, None),
+        (None, true) => {
+            let branch = default_worktree_branch();
+            (branch.clone(), Some(branch))
+        }
+        (None, false) => (default_session_name(&req.working_directory), None),
     };
 
     let request_id = Uuid::new_v4();
@@ -127,6 +131,14 @@ fn normalize_custom_name(name: Option<&str>) -> Option<String> {
     name.map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string)
+}
+
+/// Timestamped default branch/name for an unnamed worktree launch. Mirrors the
+/// launcher's own fallback format (`session-<YYYYMMDD-HHMMSS>`) so the two paths
+/// stay visually consistent; generating it here lets the display name match the
+/// worktree branch even when the caller supplies no name.
+fn default_worktree_branch() -> String {
+    format!("session-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"))
 }
 
 fn default_session_name(working_directory: &str) -> String {
@@ -489,5 +501,15 @@ mod tests {
             default_session_name("/home/ashley/agent-portal/"),
             "agent-portal"
         );
+    }
+
+    #[test]
+    fn default_worktree_branch_is_timestamped() {
+        let branch = default_worktree_branch();
+        // `session-YYYYMMDD-HHMMSS` — prefix plus a 15-char timestamp.
+        assert!(branch.starts_with("session-"), "got {branch}");
+        let ts = branch.trim_start_matches("session-");
+        assert_eq!(ts.len(), 15, "unexpected timestamp in {branch}");
+        assert!(ts.chars().all(|c| c.is_ascii_digit() || c == '-'));
     }
 }

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -947,9 +947,9 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                         <div class="launch-note">
                             {
                                 if session_name.trim().is_empty() {
-                                    "Worktree branch: session-<timestamp> (set a session name above to name it)".to_string()
+                                    "Worktree branch will be named session-<timestamp> (set a session name above to name it)".to_string()
                                 } else {
-                                    format!("Worktree branch: {}", session_name.trim())
+                                    format!("Worktree branch will be named {}", session_name.trim())
                                 }
                             }
                         </div>

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -324,6 +324,9 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         error: use_state(|| None::<String>),
     };
     let extra_args = use_state(String::new);
+    // Optional human-chosen session name. Drives the dashboard/nav label and,
+    // when a worktree is created, the worktree branch name.
+    let session_name = use_state(String::new);
     let agent_type = use_state(|| shared::AgentType::Claude);
     // Model selector value — the CLI model argument, or "" for the agent's
     // own default. Reset on agent switch since the catalogs don't overlap.
@@ -332,7 +335,6 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     // Opt-in git worktree: when checked, the launcher creates a worktree from
     // the repo containing the chosen directory and runs the session there.
     let create_worktree = use_state(|| false);
-    let worktree_branch = use_state(String::new);
     let launching = use_state(|| false);
     let error_msg = use_state(|| None::<String>);
     let debounce_handle = use_mut_ref(|| None::<Timeout>);
@@ -414,6 +416,15 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         })
     };
 
+    let on_session_name_input = {
+        let session_name = session_name.clone();
+        Callback::from(move |e: InputEvent| {
+            if let Some(input) = e.target_dyn_into::<HtmlInputElement>() {
+                session_name.set(input.value());
+            }
+        })
+    };
+
     let on_agent_type_change = {
         let agent_type = agent_type.clone();
         let model_arg = model_arg.clone();
@@ -453,15 +464,6 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         Callback::from(move |e: Event| {
             if let Some(input) = e.target_dyn_into::<HtmlInputElement>() {
                 create_worktree.set(input.checked());
-            }
-        })
-    };
-
-    let on_worktree_branch_input = {
-        let worktree_branch = worktree_branch.clone();
-        Callback::from(move |e: InputEvent| {
-            if let Some(input) = e.target_dyn_into::<HtmlInputElement>() {
-                worktree_branch.set(input.value());
             }
         })
     };
@@ -525,11 +527,11 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let dir_path = dir.path.clone();
         let home_root = dir.home_root.clone();
         let extra_args = extra_args.clone();
+        let session_name = session_name.clone();
         let agent_type = agent_type.clone();
         let model_arg = model_arg.clone();
         let skip_permissions = skip_permissions.clone();
         let create_worktree = create_worktree.clone();
-        let worktree_branch = worktree_branch.clone();
         let selected_launcher = selected_launcher.clone();
         let launching = launching.clone();
         let error_msg = error_msg.clone();
@@ -573,12 +575,8 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
             let launcher_id = *selected_launcher;
             let selected_agent_type = *agent_type;
             let want_worktree = *create_worktree;
-            let branch = (*worktree_branch).trim().to_string();
-            let branch = if branch.is_empty() {
-                None
-            } else {
-                Some(branch)
-            };
+            let name = (*session_name).trim().to_string();
+            let name = if name.is_empty() { None } else { Some(name) };
             let launching = launching.clone();
             let error_msg = error_msg.clone();
             let on_close = on_close.clone();
@@ -593,8 +591,8 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     launcher_id,
                     claude_args,
                     agent_type: selected_agent_type,
+                    name,
                     create_worktree: want_worktree,
-                    worktree_branch: branch,
                 };
 
                 match Request::post("/api/launch")
@@ -897,6 +895,18 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                         </div>
                     </div>
 
+                    // Session name — shown in the dashboard/nav. Also names the
+                    // worktree branch when one is created.
+                    <div class="launch-field">
+                        <label>{ "Session name (optional)" }</label>
+                        <input
+                            type="text"
+                            placeholder="defaults to the folder name"
+                            value={(*session_name).clone()}
+                            oninput={on_session_name_input}
+                        />
+                    </div>
+
                     // Extra CLI arguments
                     <div class="launch-field">
                         <label>{ "Extra CLI Arguments (optional)" }</label>
@@ -934,14 +944,14 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     </div>
 
                     if *create_worktree {
-                        <div class="launch-field">
-                            <label>{ "Worktree branch (optional)" }</label>
-                            <input
-                                type="text"
-                                placeholder="defaults to session-<timestamp>"
-                                value={(*worktree_branch).clone()}
-                                oninput={on_worktree_branch_input.clone()}
-                            />
+                        <div class="launch-note">
+                            {
+                                if session_name.trim().is_empty() {
+                                    "Worktree branch: session-<timestamp> (set a session name above to name it)".to_string()
+                                } else {
+                                    format!("Worktree branch: {}", session_name.trim())
+                                }
+                            }
                         </div>
                     }
 

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -782,7 +782,7 @@ pub fn dashboard_page() -> Html {
                 if let Some(session_id) = ui_state.pending_delete {
                     let session_name = sessions.iter()
                         .find(|s| s.id == session_id)
-                        .map(|s| utils::extract_folder(&s.working_directory))
+                        .map(|s| s.session_name.as_str())
                         .unwrap_or("this session");
 
                     html! {
@@ -825,7 +825,7 @@ pub fn dashboard_page() -> Html {
                 if let Some(session_id) = ui_state.pending_leave {
                     let session_name = sessions.iter()
                         .find(|s| s.id == session_id)
-                        .map(|s| utils::extract_folder(&s.working_directory))
+                        .map(|s| s.session_name.as_str())
                         .unwrap_or("this session");
 
                     html! {

--- a/frontend/src/pages/dashboard/session_rail/pill.rs
+++ b/frontend/src/pages/dashboard/session_rail/pill.rs
@@ -1,4 +1,3 @@
-use crate::utils;
 use shared::SessionInfo;
 use uuid::Uuid;
 use web_sys::MouseEvent;
@@ -91,7 +90,7 @@ pub(super) fn session_pill(props: &SessionPillProps) -> Html {
             <span class={view.connection_class}>
                 { view.connection_symbol }
             </span>
-            <span class="pill-name" title={session.session_name.clone()}>
+            <span class="pill-name" title={session.working_directory.clone()}>
                 <span class="pill-folder">{ view.folder }</span>
                 <span class="pill-hostname-row">
                     <span class="pill-hostname">{ &session.hostname }</span>
@@ -206,7 +205,9 @@ impl PillViewModel {
             },
             connection_symbol: if props.is_connected { "●" } else { "○" },
             number_annotation,
-            folder: utils::extract_folder(&session.working_directory).to_string(),
+            // Primary pill label: the human-chosen session name (defaults to
+            // the working directory's basename when none was supplied).
+            folder: session.session_name.clone(),
             version_badge,
             vcs,
             agent_badge,

--- a/shared/src/api/launch.rs
+++ b/shared/src/api/launch.rs
@@ -12,6 +12,13 @@ pub struct LaunchRequest {
     pub claude_args: Vec<String>,
     #[serde(default)]
     pub agent_type: crate::AgentType,
+    /// Optional human-chosen session name. When present (non-empty), it becomes
+    /// the session's display name in the dashboard/nav instead of the working
+    /// directory's basename. When `create_worktree` is set, it also names the
+    /// worktree branch (sanitized launcher-side). Additive/opt-in: older
+    /// backends ignore it via `#[serde(default)]`.
+    #[serde(default)]
+    pub name: Option<String>,
     /// When true, the launcher creates a git worktree from the repository that
     /// contains `working_directory` and runs the session inside the new
     /// worktree instead of `working_directory` itself. Requires
@@ -19,10 +26,6 @@ pub struct LaunchRequest {
     /// older launchers ignore it via `#[serde(default)]`.
     #[serde(default)]
     pub create_worktree: bool,
-    /// Optional branch name for the worktree. When omitted, the launcher
-    /// derives a timestamped default (e.g. `session-20260715-143022`).
-    #[serde(default)]
-    pub worktree_branch: Option<String>,
 }
 
 /// Response from GET /api/launchers/:launcher_id/directories?path=…


### PR DESCRIPTION
Sessions were always named after the working directory's basename, so multiple worktree sessions of the same repo showed up as a wall of identical names in the nav rail. This adds a human-chosen name at launch time.

## What it does

- **Session name field** in the launch dialog (optional). When set, it becomes the session's display name in the dashboard/nav.
- **Names the worktree too.** When "Create git worktree" is on, the session name drives the worktree branch (sanitized to a git-safe name launcher-side). The separate "Worktree branch" input is folded into this single field — one knob instead of two.
- **Blank = unchanged.** Falls back to the directory basename, so existing behavior is preserved.
- **Surfaces in the rail.** The nav pill now renders the session name (previously the working-dir basename); the full path moved to the pill tooltip. This is where the custom name delivers its value.

## Scope

Closes the "name at launch time" half of #1357. The rail cards still lead with name-then-machine-then-version; reworking that card layout (lead with name + repo, drop hostname/version, fix name truncation) is tracked separately in #1370. A post-launch rename endpoint (the issue's other nice-to-have) is not included here.

## Testing

- `cargo test -p shared -p backend` — pass; added unit tests for name normalization and the basename default.
- `cargo clippy` clean across shared/backend/frontend; `trunk build` succeeds; `shared` builds for `wasm32-unknown-unknown`.
