### PR TITLE
dev.sh: dual-stack bind, configurable port, scoped stop, optional diesel

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -11,19 +11,20 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# PID file locations
-PID_DIR="/tmp/claude-portal-dev"
-BACKEND_PID_FILE="$PID_DIR/backend.pid"
-
-# Log file locations
-BACKEND_LOG="/tmp/claude-portal-backend.log"
-
 # Network config. Overridable so parallel worktrees don't collide on one port.
 # HOST defaults to dual-stack (::) so IPv6 `localhost` and port-forwards reach
 # the backend — a plain 0.0.0.0 (IPv4-only) bind is missed by forwarders that
 # resolve localhost to ::1.
 PORT="${PORT:-3000}"
 HOST="${HOST:-::}"
+
+# PID file + log locations, keyed by PORT so several instances (one per
+# worktree/branch, on different ports) can run at once without clobbering each
+# other's status/stop tracking. `PORT=3400 ./dev.sh start` runs a second one;
+# `PORT=3400 ./dev.sh stop|status|logs` targets exactly that instance.
+PID_DIR="/tmp/claude-portal-dev"
+BACKEND_PID_FILE="$PID_DIR/backend-$PORT.pid"
+BACKEND_LOG="/tmp/claude-portal-backend-$PORT.log"
 
 log() {
     echo -e "${BLUE}[claude-portal]${NC} $1"
@@ -191,13 +192,24 @@ stop_all() {
         rm -f "$BACKEND_PID_FILE"
     fi
 
-    # Stop database
-    if is_db_running; then
+    # Stop the (shared) database only when no other instances are still using
+    # it — the DB is shared across ports, so tearing it down while another
+    # instance runs would break that instance.
+    local other_live=0
+    for f in "$PID_DIR"/backend-*.pid; do
+        [ -e "$f" ] || continue
+        if kill -0 "$(cat "$f")" 2>/dev/null; then
+            other_live=$((other_live + 1))
+        fi
+    done
+    if [ "$other_live" -gt 0 ]; then
+        warn "Leaving database up — $other_live other backend instance(s) still running."
+    elif is_db_running; then
         docker compose -f docker-compose.test.yml down
         success "Database stopped"
     fi
 
-    success "All services stopped"
+    success "Services stopped (port $PORT)"
 }
 
 # Show status

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -18,6 +18,13 @@ BACKEND_PID_FILE="$PID_DIR/backend.pid"
 # Log file locations
 BACKEND_LOG="/tmp/claude-portal-backend.log"
 
+# Network config. Overridable so parallel worktrees don't collide on one port.
+# HOST defaults to dual-stack (::) so IPv6 `localhost` and port-forwards reach
+# the backend — a plain 0.0.0.0 (IPv4-only) bind is missed by forwarders that
+# resolve localhost to ::1.
+PORT="${PORT:-3000}"
+HOST="${HOST:-::}"
+
 log() {
     echo -e "${BLUE}[claude-portal]${NC} $1"
 }
@@ -95,8 +102,8 @@ run_migrations() {
     export DATABASE_URL="$DEV_DATABASE_URL"
 
     if ! command -v diesel &> /dev/null; then
-        error "diesel CLI not installed. Run: ./scripts/install-deps.sh"
-        return 1
+        warn "diesel CLI not found — skipping explicit migrations (the backend runs pending migrations itself at startup)."
+        return 0
     fi
 
     log "Running database migrations..."
@@ -139,15 +146,18 @@ start_backend() {
 
     export DATABASE_URL="$DEV_DATABASE_URL"
     export DEV_MODE=true
+    export HOST PORT
 
-    log "Starting backend in dev mode..."
-    cargo run -p backend -- --dev-mode > "$BACKEND_LOG" 2>&1 &
+    log "Starting backend in dev mode on ${HOST}:${PORT}..."
+    # Run in its own session/process group (setsid) so `stop` can kill exactly
+    # this backend's group without touching other worktrees' backends.
+    setsid cargo run -p backend -- --dev-mode > "$BACKEND_LOG" 2>&1 &
     local pid=$!
     echo $pid > "$BACKEND_PID_FILE"
 
     log "Waiting for backend to start..."
     for i in {1..30}; do
-        if curl -sf http://localhost:3000/api/health > /dev/null 2>&1; then
+        if curl -sf "http://localhost:$PORT/api/health" > /dev/null 2>&1; then
             success "Backend is ready (PID: $pid)"
             return 0
         fi
@@ -167,18 +177,19 @@ start_backend() {
 stop_all() {
     log "Stopping services..."
 
-    # Stop backend
+    # Stop backend. The backend was started with setsid, so its PID is also its
+    # process-group id; kill the whole group (cargo + the backend child) with a
+    # negative PID. We deliberately DO NOT `pkill -f target/debug/backend` — that
+    # matches every worktree's backend and would reap other developers'/agents'
+    # instances running on this host.
     if [ -f "$BACKEND_PID_FILE" ]; then
         local pid=$(cat "$BACKEND_PID_FILE")
         if kill -0 "$pid" 2>/dev/null; then
-            kill "$pid" 2>/dev/null || true
+            kill -- "-$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
             success "Backend stopped (PID: $pid)"
         fi
         rm -f "$BACKEND_PID_FILE"
     fi
-
-    # Also kill any stray backend processes
-    pkill -f "target/debug/backend" 2>/dev/null || true
 
     # Stop database
     if is_db_running; then
@@ -209,7 +220,7 @@ show_status() {
         echo -e "  Backend:   ${GREEN}running${NC} (PID: $pid)"
 
         # Check if it's actually responding
-        if curl -sf http://localhost:3000/api/health > /dev/null 2>&1; then
+        if curl -sf http://localhost:$PORT/api/health > /dev/null 2>&1; then
             echo -e "  API:       ${GREEN}healthy${NC}"
         else
             echo -e "  API:       ${YELLOW}not responding${NC}"
@@ -220,8 +231,8 @@ show_status() {
 
     echo ""
     echo "URLs:"
-    echo "  Web Interface:  http://localhost:3000/"
-    echo "  Backend API:    http://localhost:3000/api/"
+    echo "  Web Interface:  http://localhost:$PORT/"
+    echo "  Backend API:    http://localhost:$PORT/api/"
     echo ""
     echo "Logs:"
     echo "  Backend: tail -f $BACKEND_LOG"
@@ -267,14 +278,14 @@ do_start() {
     echo "║          ✅ Agent Portal Dev Environment Ready            ║"
     echo "╚═══════════════════════════════════════════════════════════╝"
     echo ""
-    echo "  🌐 Web Interface:  http://localhost:3000/"
-    echo "  📊 Backend API:    http://localhost:3000/api/"
+    echo "  🌐 Web Interface:  http://localhost:$PORT/"
+    echo "  📊 Backend API:    http://localhost:$PORT/api/"
     echo ""
     echo "  🧪 Test Account:   testing@testing.local"
     echo "  ⚠️  DEV MODE:       OAuth bypassed"
     echo ""
     echo "  🔌 To start a portal session:"
-    echo "     1. Open http://localhost:3000/ and generate a setup token"
+    echo "     1. Open http://localhost:$PORT/ and generate a setup token"
     echo "     2. Run the setup command shown in the UI"
     echo ""
     echo "Commands:"


### PR DESCRIPTION
## Summary
Hardens `scripts/dev.sh` so parallel worktrees/agents on one host stop stepping on each other — the friction that made remote-previewing a PR nearly impossible (see #1365, #1369) — and makes running several dev instances at once first-class.

## Changes
- **Scoped stop (the big one):** `stop` no longer runs `pkill -f "target/debug/backend"`, which matched **every** worktree's backend and reaped other developers'/agents' running instances. The backend is now started under `setsid` (its own process group) and stopped with `kill -- -$pid`, killing only its own group.
- **Multiple concurrent instances:** `PORT` is overridable and the PID file + log path are keyed by it (`backend-$PORT.pid`, `claude-portal-backend-$PORT.log`), so several instances can run side by side. `PORT=3400 ./dev.sh start|stop|status|logs` targets exactly that instance. `stop` only tears down the shared dev DB when no other instance is still using it.
- **Dual-stack bind:** `HOST` defaults to `::` so IPv6 `localhost` and `agent-portal forward` reach the backend. A plain `0.0.0.0` (IPv4-only) bind is silently missed by forwarders that resolve `localhost` to `::1`.
- **Optional diesel:** when the `diesel` CLI isn't installed, skip explicit `diesel migration run` with a warning instead of hard-failing — the backend applies pending migrations itself at startup.

## Testing
- `bash -n scripts/dev.sh` passes.
- Verified the process-group teardown kills the `setsid` group cleanly while leaving an unrelated backend on another port untouched.

Refs #1365, #1369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
