### PR TITLE
feat: auto-retry turns killed by transient 529 overload

### DIFF
--- a/backend/migrations/2026-07-16-120000_add_reason_to_session_continuations/down.sql
+++ b/backend/migrations/2026-07-16-120000_add_reason_to_session_continuations/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE session_continuations DROP COLUMN reason;

--- a/backend/migrations/2026-07-16-120000_add_reason_to_session_continuations/up.sql
+++ b/backend/migrations/2026-07-16-120000_add_reason_to_session_continuations/up.sql
@@ -1,0 +1,5 @@
+-- Distinguish why a session continuation was created. Existing rows were all
+-- usage-limit resets (#231/#1260), so they default to 'limit'. Transient-529
+-- overload auto-retries use 'overloaded' (auto-retry killed turns).
+ALTER TABLE session_continuations
+    ADD COLUMN reason VARCHAR(32) NOT NULL DEFAULT 'limit';

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -1,8 +1,8 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use diesel::prelude::*;
 use shared::{
-    ContinuationConfig, PortalMessage, ServerToClient, ServerToLauncher,
-    SessionLimitContinuationFields,
+    AgentType, ContinuationConfig, PortalMessage, ServerToClient, ServerToLauncher,
+    SessionLimitContinuationFields, CONTINUATION_REASON_LIMIT, CONTINUATION_REASON_OVERLOADED,
 };
 use tracing::{error, info, warn};
 use uuid::Uuid;
@@ -16,6 +16,13 @@ const STATUS_PENDING: &str = "pending";
 const STATUS_SCHEDULED: &str = "scheduled";
 const STATUS_FIRED: &str = "fired";
 const STATUS_DROPPED: &str = "dropped";
+
+/// Rolling window used to cap overload auto-retries per session. Counting prior
+/// `overloaded` continuation rows in this window is the whole cap mechanism, so
+/// it survives backend restarts for free (the count is DB-backed).
+const OVERLOAD_RETRY_WINDOW_MINUTES: i64 = 15;
+/// Maximum overload auto-retries within the window before we give up.
+const OVERLOAD_RETRY_ATTEMPT_CAP: i64 = 3;
 
 pub fn handle_session_limit_reached(
     app_state: &AppState,
@@ -84,6 +91,7 @@ pub fn handle_session_limit_reached(
         prompt: fields.prompt,
         status: STATUS_PENDING.to_string(),
         source_message: Some(fields.source_message),
+        reason: CONTINUATION_REASON_LIMIT.to_string(),
     };
 
     let continuation = match diesel::insert_into(session_continuations::table)
@@ -105,6 +113,7 @@ pub fn handle_session_limit_reached(
         continuation.reset_at.to_rfc3339(),
         continuation.status.clone(),
         continuation.source_message.clone().unwrap_or_default(),
+        continuation.reason.clone(),
     );
     let meta = insert_portal_message(&mut conn, &session, &portal).map(|m| m.portal_meta(None));
 
@@ -124,7 +133,12 @@ pub fn handle_session_limit_reached(
         continuation.id, current_session_id, continuation.reset_at
     );
 
-    sync_continuations_for_launcher(app_state, launcher_id, session.user_id);
+    sync_continuations_for_launcher(
+        &app_state.session_manager,
+        &app_state.db_pool,
+        launcher_id,
+        session.user_id,
+    );
 }
 
 pub fn schedule_limit_continuation(
@@ -179,7 +193,12 @@ pub fn schedule_limit_continuation(
             message: Some("Continuation scheduled".to_string()),
         },
     );
-    sync_continuations_for_launcher(app_state, continuation.launcher_id, user_id);
+    sync_continuations_for_launcher(
+        &app_state.session_manager,
+        &app_state.db_pool,
+        continuation.launcher_id,
+        user_id,
+    );
 }
 
 pub fn mark_continuation_fired(
@@ -287,7 +306,12 @@ fn update_terminal_status(
                 }
             }
 
-            sync_continuations_for_launcher(app_state, row.launcher_id, user_id);
+            sync_continuations_for_launcher(
+                &app_state.session_manager,
+                &app_state.db_pool,
+                row.launcher_id,
+                user_id,
+            );
         }
         Err(e) => warn!(
             "Failed to mark continuation {} {} for session {}: {}",
@@ -296,13 +320,15 @@ fn update_terminal_status(
     }
 }
 
-pub fn sync_continuations_for_launcher(app_state: &AppState, launcher_id: Uuid, user_id: Uuid) {
-    let continuations = load_scheduled_continuations(app_state, launcher_id, user_id);
+pub fn sync_continuations_for_launcher(
+    session_manager: &SessionManager,
+    db_pool: &DbPool,
+    launcher_id: Uuid,
+    user_id: Uuid,
+) {
+    let continuations = load_scheduled_continuations(db_pool, launcher_id, user_id);
     let msg = ServerToLauncher::ContinuationSync { continuations };
-    if !app_state
-        .session_manager
-        .send_to_launcher(&launcher_id, msg)
-    {
+    if !session_manager.send_to_launcher(&launcher_id, msg) {
         warn!(
             "Failed to sync continuations to launcher {} for user {}",
             launcher_id, user_id
@@ -311,11 +337,11 @@ pub fn sync_continuations_for_launcher(app_state: &AppState, launcher_id: Uuid, 
 }
 
 pub fn load_scheduled_continuations(
-    app_state: &AppState,
+    db_pool: &DbPool,
     launcher_id: Uuid,
     user_id: Uuid,
 ) -> Vec<ContinuationConfig> {
-    let Ok(mut conn) = app_state.db_pool.get() else {
+    let Ok(mut conn) = db_pool.get() else {
         return Vec::new();
     };
 
@@ -343,9 +369,217 @@ pub fn load_scheduled_continuations(
                 session_name: Some(session.session_name),
                 claude_args,
                 agent_type,
+                reason: row.reason,
             }
         })
         .collect()
+}
+
+/// Conservative signature for a transient provider-overload failure worth an
+/// automatic retry. The CLI surfaces these as an error `Result` whose text is
+/// like `"API Error: 529 Overloaded. This is a server-side issue …"`; the raw
+/// provider form is `overloaded_error`. `api_error_status` is the typed status
+/// from `claude_codes::io::ResultMessage` when present.
+///
+/// Deliberately narrow: it must NOT fire on 4xx, auth failures, or other 5xx —
+/// those aren't safely auto-retryable. We require both an overload token AND a
+/// 529 signal, except for the unambiguous raw `overloaded_error` string.
+pub(crate) fn is_transient_overload(result_text: &str, api_error_status: Option<u16>) -> bool {
+    let lower = result_text.to_ascii_lowercase();
+    if lower.contains("overloaded_error") {
+        return true;
+    }
+    let has_529 = api_error_status == Some(529) || result_text.contains("529");
+    has_529 && lower.contains("overloaded")
+}
+
+/// Count `overloaded` continuations created for `session_id` within the rolling
+/// retry window. This DB-backed count is the entire cap mechanism, so it holds
+/// across backend restarts.
+fn count_recent_overload_retries(conn: &mut diesel::PgConnection, session_id: Uuid) -> i64 {
+    use crate::schema::session_continuations;
+    let window_start =
+        Utc::now().naive_utc() - chrono::Duration::minutes(OVERLOAD_RETRY_WINDOW_MINUTES);
+    session_continuations::table
+        .filter(session_continuations::session_id.eq(session_id))
+        .filter(session_continuations::reason.eq(CONTINUATION_REASON_OVERLOADED))
+        .filter(session_continuations::created_at.gt(window_start))
+        .count()
+        .get_result(conn)
+        .unwrap_or(0)
+}
+
+/// Retry pacing tier from the number of prior `overloaded` retries already made
+/// for this session in the window. Attempt 1 (0 prior) fires immediately — the
+/// CLI already backs off internally, so the portal adds no delay of its own;
+/// attempt 2 waits 60s; attempt 3 waits 300s; beyond that we give up. Returns
+/// `None` once the cap is hit.
+fn overload_retry_delay_secs(prior_attempts: i64) -> Option<i64> {
+    match prior_attempts {
+        0 => Some(0),
+        1 => Some(60),
+        2 => Some(300),
+        _ => None,
+    }
+}
+
+/// Auto-retry a turn that a transient 529 overload killed (detected at the
+/// `Result` path in `message_handlers`). Reuses the usage-limit continuation
+/// machinery verbatim — it inserts an already-`scheduled` `overloaded`
+/// continuation (no user click), the launcher injects `prompt` into the still-
+/// running session, and marks it fired — so Claude resumes the interrupted work.
+///
+/// `result_created_at` is the server timestamp of the failing `Result` row; a
+/// newer user message means a human already stepped in and we stand down.
+pub fn schedule_overloaded_retry(
+    session_manager: &SessionManager,
+    db_pool: &DbPool,
+    session_key: &Option<SessionId>,
+    session_id: Uuid,
+    result_created_at: NaiveDateTime,
+) {
+    // Safety rail: a disconnected proxy can't receive the injected nudge, so a
+    // retry would just sit scheduled. Only retry live sessions.
+    if session_manager
+        .current_connection_gen(&session_id.to_string())
+        .is_none()
+    {
+        info!("Skipping overload auto-retry for {session_id}: no connected proxy");
+        return;
+    }
+
+    let Ok(mut conn) = db_pool.get() else {
+        error!("Failed to get DB connection for overload auto-retry");
+        return;
+    };
+
+    use crate::schema::{messages, session_continuations, sessions};
+
+    let session = match sessions::table.find(session_id).first::<Session>(&mut conn) {
+        Ok(session) => session,
+        Err(e) => {
+            warn!("Skipping overload auto-retry for unknown session {session_id}: {e}");
+            return;
+        }
+    };
+
+    // Claude only — Codex overload semantics are out of scope (see spec).
+    if !matches!(
+        session.agent_type.parse::<AgentType>(),
+        Ok(AgentType::Claude)
+    ) {
+        return;
+    }
+
+    let Some(launcher_id) = session.launcher_id else {
+        info!("Skipping overload auto-retry for {session_id}: no launcher_id");
+        return;
+    };
+
+    // Safety rail: never retry a turn a human already responded to.
+    let newer_user_messages: i64 = messages::table
+        .filter(messages::session_id.eq(session_id))
+        .filter(messages::role.eq("user"))
+        .filter(messages::created_at.gt(result_created_at))
+        .count()
+        .get_result(&mut conn)
+        .unwrap_or(0);
+    if newer_user_messages > 0 {
+        info!("Skipping overload auto-retry for {session_id}: user already responded");
+        return;
+    }
+
+    // Cap: prior `overloaded` retries for this session in the rolling window.
+    let prior_attempts = count_recent_overload_retries(&mut conn, session_id);
+
+    let Some(delay_secs) = overload_retry_delay_secs(prior_attempts) else {
+        // Exhausted the window budget. Leave a visible marker rather than
+        // inventing new push plumbing — `TurnComplete` already fired on this
+        // Result, so the pocketed-phone path is covered.
+        warn!(
+            "Overload auto-retry gave up for session {session_id} after \
+             {prior_attempts} attempt(s) in {OVERLOAD_RETRY_WINDOW_MINUTES}m"
+        );
+        let portal = PortalMessage::text(format!(
+            "Automatic retry gave up after {OVERLOAD_RETRY_ATTEMPT_CAP} attempts following a \
+             transient provider overload (HTTP 529). Please retry manually."
+        ));
+        let meta = insert_portal_message(&mut conn, &session, &portal).map(|m| m.portal_meta(None));
+        if let Some(key) = session_key {
+            session_manager.broadcast_to_web_clients(
+                key,
+                ServerToClient::AgentOutput {
+                    content: portal.to_json(),
+                    agent_type: session.agent_type.parse().unwrap_or_default(),
+                    meta,
+                },
+            );
+        }
+        return;
+    };
+
+    let attempt = prior_attempts + 1;
+    // `reset_at` is the intended fire time; the launcher applies no skew for
+    // `overloaded` continuations, so it fires at exactly this instant.
+    let reset_at = Utc::now() + chrono::Duration::seconds(delay_secs);
+    let source_message = format!(
+        "Turn failed with a transient provider overload (HTTP 529). \
+         Auto-retrying (attempt {attempt}/{OVERLOAD_RETRY_ATTEMPT_CAP})."
+    );
+    let prompt = format!(
+        "Automatic retry after provider overload (attempt {attempt}/{OVERLOAD_RETRY_ATTEMPT_CAP}) \
+         — continue where you left off."
+    );
+
+    // Insert already-`scheduled` (no user action needed) so the existing
+    // launcher fire path picks it up on the next sync.
+    let new_continuation = NewSessionContinuation {
+        session_id,
+        user_id: session.user_id,
+        launcher_id,
+        reset_at,
+        prompt,
+        status: STATUS_SCHEDULED.to_string(),
+        source_message: Some(source_message),
+        reason: CONTINUATION_REASON_OVERLOADED.to_string(),
+    };
+
+    let continuation = match diesel::insert_into(session_continuations::table)
+        .values(&new_continuation)
+        .get_result::<SessionContinuation>(&mut conn)
+    {
+        Ok(row) => row,
+        Err(e) => {
+            error!("Failed to create overload continuation for {session_id}: {e}");
+            return;
+        }
+    };
+
+    let portal = PortalMessage::continuation_prompt(
+        continuation.id,
+        continuation.reset_at.to_rfc3339(),
+        continuation.status.clone(),
+        continuation.source_message.clone().unwrap_or_default(),
+        continuation.reason.clone(),
+    );
+    let meta = insert_portal_message(&mut conn, &session, &portal).map(|m| m.portal_meta(None));
+    if let Some(key) = session_key {
+        session_manager.broadcast_to_web_clients(
+            key,
+            ServerToClient::AgentOutput {
+                content: portal.to_json(),
+                agent_type: session.agent_type.parse().unwrap_or_default(),
+                meta,
+            },
+        );
+    }
+
+    info!(
+        "Scheduled overload auto-retry {} for session {} (attempt {}/{}, +{}s)",
+        continuation.id, session_id, attempt, OVERLOAD_RETRY_ATTEMPT_CAP, delay_secs
+    );
+
+    sync_continuations_for_launcher(session_manager, db_pool, launcher_id, session.user_id);
 }
 
 /// Insert a portal-role message and return the persisted row, so callers can
@@ -376,5 +610,147 @@ fn insert_portal_message(
             error!("Failed to store continuation portal message: {}", e);
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{NewSessionWithId, NewUser, User};
+
+    #[test]
+    fn overload_matcher_accepts_only_transient_529_overloads() {
+        // Positive: the exact user-visible CLI error text.
+        assert!(is_transient_overload(
+            "API Error: 529 Overloaded. This is a server-side issue, usually \
+             temporary — try again in a moment. If it persists, check \
+             https://status.claude.com.",
+            None,
+        ));
+        // Positive: the raw provider form on its own.
+        assert!(is_transient_overload("overloaded_error", None));
+        // Positive: typed 529 status paired with an overload token.
+        assert!(is_transient_overload("Overloaded", Some(529)));
+
+        // Negative: auth, other 4xx/5xx, and generic errors.
+        assert!(!is_transient_overload("401 Unauthorized", None));
+        assert!(!is_transient_overload("Permission denied", None));
+        assert!(!is_transient_overload("Something went wrong", Some(500)));
+        // Negative: an overload word without any 529 signal is not enough.
+        assert!(!is_transient_overload(
+            "the server felt overloaded today",
+            None
+        ));
+        // Negative: a 529 without an overload token stays conservative.
+        assert!(!is_transient_overload("API Error: 529 gateway", Some(529)));
+    }
+
+    #[test]
+    fn retry_delay_tiers() {
+        assert_eq!(overload_retry_delay_secs(0), Some(0));
+        assert_eq!(overload_retry_delay_secs(1), Some(60));
+        assert_eq!(overload_retry_delay_secs(2), Some(300));
+        assert_eq!(overload_retry_delay_secs(3), None);
+        assert_eq!(overload_retry_delay_secs(4), None);
+    }
+
+    fn make_user(conn: &mut diesel::PgConnection) -> User {
+        use crate::schema::users;
+        let nonce = Uuid::new_v4();
+        let new_user = NewUser {
+            google_id: format!("test_overload_{nonce}"),
+            email: format!("test_overload_{nonce}@example.invalid"),
+            name: Some("Overload Test".to_string()),
+            avatar_url: None,
+        };
+        diesel::insert_into(users::table)
+            .values(&new_user)
+            .get_result::<User>(conn)
+            .expect("insert test user")
+    }
+
+    fn make_session(conn: &mut diesel::PgConnection, user_id: Uuid) -> Uuid {
+        use crate::schema::sessions;
+        let session_id = Uuid::new_v4();
+        let new_session = NewSessionWithId {
+            id: session_id,
+            user_id,
+            session_name: "overload-test".to_string(),
+            session_key: session_id.to_string(),
+            working_directory: "/tmp".to_string(),
+            status: shared::SessionStatus::Active.as_str().to_string(),
+            git_branch: None,
+            client_version: None,
+            hostname: "test-host".to_string(),
+            launcher_id: Some(Uuid::new_v4()),
+            agent_type: "claude".to_string(),
+            repo_url: None,
+            scheduled_task_id: None,
+            paused: false,
+            claude_args: serde_json::Value::Array(Vec::new()),
+        };
+        diesel::insert_into(sessions::table)
+            .values(&new_session)
+            .execute(conn)
+            .expect("insert session");
+        session_id
+    }
+
+    fn insert_overloaded_continuation(
+        conn: &mut diesel::PgConnection,
+        session_id: Uuid,
+        user_id: Uuid,
+    ) {
+        use crate::schema::session_continuations;
+        let row = NewSessionContinuation {
+            session_id,
+            user_id,
+            launcher_id: Uuid::new_v4(),
+            reset_at: Utc::now(),
+            prompt: "retry".to_string(),
+            status: STATUS_SCHEDULED.to_string(),
+            source_message: None,
+            reason: CONTINUATION_REASON_OVERLOADED.to_string(),
+        };
+        diesel::insert_into(session_continuations::table)
+            .values(&row)
+            .execute(conn)
+            .expect("insert overloaded continuation");
+    }
+
+    /// 0/1/2/3 prior `overloaded` continuations in the window map to the
+    /// immediate/60s/300s/give-up tiers via the real DB count.
+    #[test]
+    fn tier_selection_counts_recent_overload_retries() {
+        let Some(pool) = crate::test_support::shared_pool() else {
+            return;
+        };
+        let mut conn = pool.get().expect("db conn");
+        let user = make_user(&mut conn);
+        let session_id = make_session(&mut conn, user.id);
+
+        // 0 prior -> immediate.
+        assert_eq!(
+            overload_retry_delay_secs(count_recent_overload_retries(&mut conn, session_id)),
+            Some(0)
+        );
+        // 1 prior -> +60s.
+        insert_overloaded_continuation(&mut conn, session_id, user.id);
+        assert_eq!(
+            overload_retry_delay_secs(count_recent_overload_retries(&mut conn, session_id)),
+            Some(60)
+        );
+        // 2 prior -> +300s.
+        insert_overloaded_continuation(&mut conn, session_id, user.id);
+        assert_eq!(
+            overload_retry_delay_secs(count_recent_overload_retries(&mut conn, session_id)),
+            Some(300)
+        );
+        // 3 prior -> give up.
+        insert_overloaded_continuation(&mut conn, session_id, user.id);
+        assert_eq!(
+            overload_retry_delay_secs(count_recent_overload_retries(&mut conn, session_id)),
+            None
+        );
     }
 }

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -410,8 +410,11 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
         &launcher_name,
     );
 
-    let continuation_configs =
-        super::continuations::load_scheduled_continuations(&app_state, launcher_id, user_id);
+    let continuation_configs = super::continuations::load_scheduled_continuations(
+        &app_state.db_pool,
+        launcher_id,
+        user_id,
+    );
     let _ = tx_for_sync.send(ServerToLauncher::ContinuationSync {
         continuations: continuation_configs,
     });

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -283,6 +283,9 @@ pub fn handle_claude_output(ctx: ClaudeOutputContext<'_>, frame: ClaudeOutputFra
     // Typed portal sidecar for the live broadcast, derived from the persisted
     // row's columns (#portal-meta). `None` when the insert didn't run/failed.
     let mut broadcast_meta: Option<shared::PortalMeta> = None;
+    // Server timestamp of the just-inserted row, used by the overload
+    // auto-retry to detect whether a human has responded since a failed turn.
+    let mut inserted_created_at: Option<chrono::NaiveDateTime> = None;
     if let (Some(session_id), Ok(mut conn)) = (db_session_id, db_pool.get()) {
         use crate::schema::{messages, sessions};
 
@@ -318,6 +321,7 @@ pub fn handle_claude_output(ctx: ClaudeOutputContext<'_>, frame: ClaudeOutputFra
                 .get_result::<crate::models::Message>(&mut conn)
             {
                 Ok(inserted) => {
+                    inserted_created_at = Some(inserted.created_at);
                     // `meta.created_at` becomes the frontend's reconnect
                     // watermark (matches `replay_history`'s `%Y-%m-%dT%H:%M:%S%.f`).
                     broadcast_meta =
@@ -331,6 +335,19 @@ pub fn handle_claude_output(ctx: ClaudeOutputContext<'_>, frame: ClaudeOutputFra
             if role == shared::MessageRole::Result {
                 let subagent_tokens = session_manager.subagent_tokens(session_id);
                 store_result_metadata(&mut conn, session_id, &content, subagent_tokens);
+
+                // A turn killed by a transient 529 provider overload leaves the
+                // session stalled on a user-visible error. Auto-retry it (bounded
+                // + paced) so a human doesn't have to nudge it back to life. The
+                // scheduler takes its own pooled connection (distinct from `conn`).
+                maybe_schedule_overloaded_retry(
+                    session_manager,
+                    session_key,
+                    session_id,
+                    db_pool,
+                    &content,
+                    inserted_created_at,
+                );
 
                 // Turn finished — emit a push (mobile-apps plan §8.1, collapsed
                 // per session by the dispatcher). Suppressed automatically when
@@ -373,6 +390,48 @@ pub fn handle_claude_output(ctx: ClaudeOutputContext<'_>, frame: ClaudeOutputFra
             },
         );
     }
+}
+
+/// Detection point for the transient-529-overload auto-retry. Parses the
+/// `Result` frame with the typed `claude_codes::io::ResultMessage`, and only
+/// when it is an error matching the conservative overload signature does it hand
+/// off to the continuation machinery. `result_created_at` is the server
+/// timestamp of the stored `Result` row (`None` if the insert failed — then we
+/// skip, since the "human already responded" guard has no baseline).
+fn maybe_schedule_overloaded_retry(
+    session_manager: &SessionManager,
+    session_key: &Option<String>,
+    session_id: Uuid,
+    db_pool: &DbPool,
+    content: &serde_json::Value,
+    result_created_at: Option<chrono::NaiveDateTime>,
+) {
+    let Some(result_created_at) = result_created_at else {
+        return;
+    };
+    let Ok(result) = claude_codes::io::ResultMessage::deserialize(content) else {
+        return;
+    };
+    if !result.is_error {
+        return;
+    }
+    // The error text lives in `result` and/or `errors`; join both so the
+    // matcher sees whatever the CLI populated.
+    let mut text = result.result.unwrap_or_default();
+    if !result.errors.is_empty() {
+        text.push('\n');
+        text.push_str(&result.errors.join("\n"));
+    }
+    if !super::continuations::is_transient_overload(&text, result.api_error_status) {
+        return;
+    }
+    super::continuations::schedule_overloaded_retry(
+        session_manager,
+        db_pool,
+        session_key,
+        session_id,
+        result_created_at,
+    );
 }
 
 struct NormalizedOutputContent {

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -413,6 +413,10 @@ pub struct SessionContinuation {
     pub fired_at: Option<NaiveDateTime>,
     pub dropped_at: Option<NaiveDateTime>,
     pub cancelled_at: Option<NaiveDateTime>,
+    /// Why the continuation exists: `"limit"` (usage-limit reset, the historical
+    /// default) or `"overloaded"` (auto-retry after a transient 529). See
+    /// `shared::CONTINUATION_REASON_*`.
+    pub reason: String,
 }
 
 #[derive(Debug, Insertable)]
@@ -425,6 +429,7 @@ pub struct NewSessionContinuation {
     pub prompt: String,
     pub status: String,
     pub source_message: Option<String>,
+    pub reason: String,
 }
 
 // ============================================================================

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -153,6 +153,8 @@ diesel::table! {
         fired_at -> Nullable<Timestamp>,
         dropped_at -> Nullable<Timestamp>,
         cancelled_at -> Nullable<Timestamp>,
+        #[max_length = 32]
+        reason -> Varchar,
     }
 }
 

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -89,6 +89,7 @@ fn render_portal_content(
             reset_at,
             status,
             source_message,
+            reason,
         } => render_continuation_prompt(
             *continuation_id,
             reset_at,
@@ -97,6 +98,7 @@ fn render_portal_content(
                 .map(String::as_str)
                 .unwrap_or(status),
             source_message,
+            reason,
             on_schedule_continuation,
         ),
         shared::PortalContent::AgentMessage { text, .. } => {
@@ -211,21 +213,39 @@ fn render_continuation_prompt(
     reset_at: &str,
     status: &str,
     source_message: &str,
+    reason: &str,
     on_schedule_continuation: Callback<Uuid>,
 ) -> Html {
-    let continuation_label = format_continuation_label(reset_at);
-    let terminal = matches!(
-        status,
-        "scheduled" | "scheduling" | "fired" | "dropped" | "failed"
-    );
+    let overloaded = reason == shared::CONTINUATION_REASON_OVERLOADED;
+    let terminal = overloaded
+        || matches!(
+            status,
+            "scheduled" | "scheduling" | "fired" | "dropped" | "failed"
+        );
     let status_class = status.to_string();
-    let button_label = match status {
-        "scheduled" => "Scheduled",
-        "scheduling" => "Scheduling...",
-        "fired" => "Continued",
-        "dropped" => "Dropped",
-        "failed" => "Failed",
-        _ => "Continue 2 min after limit lifts",
+    // Overload retries are auto-scheduled (no user click), so the button is a
+    // passive status pill and its wording reflects the retry, not a limit reset.
+    let button_label = if overloaded {
+        match status {
+            "fired" => "Retried",
+            "dropped" => "Retry dropped",
+            "failed" => "Retry failed",
+            _ => "Auto-retrying",
+        }
+    } else {
+        match status {
+            "scheduled" => "Scheduled",
+            "scheduling" => "Scheduling...",
+            "fired" => "Continued",
+            "dropped" => "Dropped",
+            "failed" => "Failed",
+            _ => "Continue 2 min after limit lifts",
+        }
+    };
+    let title = if overloaded {
+        "Provider overloaded — auto-retrying"
+    } else {
+        "Claude session limit reached"
     };
     let onclick = {
         let on_schedule_continuation = on_schedule_continuation.clone();
@@ -237,8 +257,10 @@ fn render_continuation_prompt(
     html! {
         <div class="continuation-card">
             <div class="continuation-copy">
-                <div class="continuation-title">{ "Claude session limit reached" }</div>
-                <div class="continuation-detail">{ continuation_label }</div>
+                <div class="continuation-title">{ title }</div>
+                if !overloaded {
+                    <div class="continuation-detail">{ format_continuation_label(reset_at) }</div>
+                }
                 if !source_message.is_empty() {
                     <div class="continuation-source">{ source_message }</div>
                 }

--- a/launcher/src/scheduler.rs
+++ b/launcher/src/scheduler.rs
@@ -11,6 +11,21 @@ use uuid::Uuid;
 const PROMPT_DELAY: Duration = Duration::from_secs(5);
 const CONTINUATION_RESET_SKEW_SECS: i64 = 120;
 
+/// Seconds to wait past a continuation's `reset_at` before firing it.
+///
+/// Usage-limit resets wait `CONTINUATION_RESET_SKEW_SECS`: the reset time Claude
+/// reports is approximate and firing early re-trips the limit. Overload retries
+/// fire with no skew — the backend already encoded the intended (immediate/60s/
+/// 300s) delay in `reset_at`, and the CLI backs off internally, so any extra
+/// wait here would defeat the "retry immediately" intent.
+fn continuation_skew_secs(reason: &str) -> i64 {
+    if reason == shared::CONTINUATION_REASON_OVERLOADED {
+        0
+    } else {
+        CONTINUATION_RESET_SKEW_SECS
+    }
+}
+
 struct ActiveTask {
     config: ScheduledTaskConfig,
     next_fire: Option<DateTime<Utc>>,
@@ -149,7 +164,8 @@ impl Scheduler {
             .iter()
             .filter_map(|c| {
                 DateTime::parse_from_rfc3339(&c.reset_at).ok().map(|dt| {
-                    dt.with_timezone(&Utc) + chrono::Duration::seconds(CONTINUATION_RESET_SKEW_SECS)
+                    dt.with_timezone(&Utc)
+                        + chrono::Duration::seconds(continuation_skew_secs(&c.reason))
                 })
             })
             .map(|next| {
@@ -169,7 +185,8 @@ impl Scheduler {
             let due = DateTime::parse_from_rfc3339(&c.reset_at)
                 .ok()
                 .map(|dt| {
-                    dt.with_timezone(&Utc) + chrono::Duration::seconds(CONTINUATION_RESET_SKEW_SECS)
+                    dt.with_timezone(&Utc)
+                        + chrono::Duration::seconds(continuation_skew_secs(&c.reason))
                         <= now
                 })
                 .unwrap_or(false);
@@ -542,6 +559,10 @@ mod tests {
     }
 
     fn continuation(reset_at: DateTime<Utc>) -> ContinuationConfig {
+        continuation_with_reason(reset_at, shared::CONTINUATION_REASON_LIMIT)
+    }
+
+    fn continuation_with_reason(reset_at: DateTime<Utc>, reason: &str) -> ContinuationConfig {
         ContinuationConfig {
             id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
@@ -551,7 +572,33 @@ mod tests {
             session_name: Some("project".to_string()),
             claude_args: vec!["--model".to_string(), "sonnet".to_string()],
             agent_type: shared::AgentType::Claude,
+            reason: reason.to_string(),
         }
+    }
+
+    #[test]
+    fn overloaded_continuation_fires_at_reset_with_no_skew() {
+        let mut scheduler = Scheduler::new();
+        // reset_at is "now": a limit continuation would wait the skew, but an
+        // overload retry must be due immediately.
+        let due = continuation_with_reason(Utc::now(), shared::CONTINUATION_REASON_OVERLOADED);
+        let id = due.id;
+        scheduler.update_continuations(vec![due]);
+        let ready = scheduler.ready_continuations();
+        assert_eq!(ready.len(), 1, "overloaded continuation should fire now");
+        assert_eq!(ready[0].id, id);
+    }
+
+    #[test]
+    fn limit_continuation_still_waits_skew_at_reset() {
+        let mut scheduler = Scheduler::new();
+        // Same "now" reset_at, but a limit continuation must NOT be due yet.
+        scheduler.update_continuations(vec![continuation_with_reason(
+            Utc::now(),
+            shared::CONTINUATION_REASON_LIMIT,
+        )]);
+        assert!(scheduler.ready_continuations().is_empty());
+        assert!(scheduler.next_continuation_duration() > Some(Duration::ZERO));
     }
 
     #[test]

--- a/shared/src/endpoints/types.rs
+++ b/shared/src/endpoints/types.rs
@@ -3,6 +3,13 @@ use uuid::Uuid;
 
 use crate::{AgentType, PermissionSuggestion};
 
+/// A session continuation created for a usage-limit reset (`#231`/`#1260`).
+pub const CONTINUATION_REASON_LIMIT: &str = "limit";
+/// A session continuation created to auto-retry a turn that a transient 529
+/// overload killed. Fires immediately (no reset skew) — the CLI already backs
+/// off internally, so the portal adds no further delay.
+pub const CONTINUATION_REASON_OVERLOADED: &str = "overloaded";
+
 /// Fields for session registration (shared by proxy and web client).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisterFields {
@@ -87,6 +94,13 @@ pub struct ContinuationConfig {
     pub claude_args: Vec<String>,
     #[serde(default)]
     pub agent_type: AgentType,
+    /// `CONTINUATION_REASON_LIMIT` (default, wire-compatible with older
+    /// launchers/backends that omit it) or `CONTINUATION_REASON_OVERLOADED`.
+    /// The launcher uses this to decide the reset skew: limit resets wait
+    /// `CONTINUATION_RESET_SKEW_SECS` past `reset_at`; overload retries fire at
+    /// `reset_at` with no skew.
+    #[serde(default = "crate::default_continuation_reason")]
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -31,6 +31,13 @@ pub use proxy_tokens::*;
 pub mod endpoints;
 pub use endpoints::*;
 
+/// serde default for continuation `reason` fields: pre-`reason` wire payloads
+/// (older launchers/backends) deserialize as a usage-limit continuation, the
+/// only kind that existed before overload auto-retry.
+pub(crate) fn default_continuation_reason() -> String {
+    CONTINUATION_REASON_LIMIT.to_string()
+}
+
 // Chunked image upload protocol (mixed JSON + binary WS frames)
 pub mod image_upload;
 pub use image_upload::{ImageUploadClientMsg, ImageUploadEndpoint, ImageUploadServerMsg};
@@ -410,12 +417,14 @@ impl PortalMessage {
         reset_at: String,
         status: String,
         source_message: String,
+        reason: String,
     ) -> Self {
         Self::with_content(vec![PortalContent::ContinuationPrompt {
             continuation_id,
             reset_at,
             status,
             source_message,
+            reason,
         }])
     }
 
@@ -501,6 +510,11 @@ pub enum PortalContent {
         reset_at: String,
         status: String,
         source_message: String,
+        /// `CONTINUATION_REASON_LIMIT` (default; omitted by older backends) or
+        /// `CONTINUATION_REASON_OVERLOADED` — lets the card render overload
+        /// auto-retry wording instead of the usage-limit wording.
+        #[serde(default = "default_continuation_reason")]
+        reason: String,
     },
     /// Typed event for an inter-agent message. This replaces UI parsing of
     /// the agent-facing `[message from ...]` text prefix for new messages.
@@ -540,12 +554,14 @@ impl std::fmt::Debug for PortalContent {
                 reset_at,
                 status,
                 source_message,
+                reason,
             } => f
                 .debug_struct("ContinuationPrompt")
                 .field("continuation_id", continuation_id)
                 .field("reset_at", reset_at)
                 .field("status", status)
                 .field("source_message", source_message)
+                .field("reason", reason)
                 .finish(),
             Self::AgentMessage {
                 from_agent_type,
@@ -604,6 +620,44 @@ pub struct AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn continuation_prompt_reason_defaults_to_limit_on_old_wire() {
+        // Wire-compat: a payload from a pre-`reason` backend omits the field; it
+        // must deserialize as a usage-limit card, not fail or render as overload.
+        let json = r#"{"type":"continuationprompt","continuation_id":"11111111-1111-1111-1111-111111111111","reset_at":"2026-07-16T00:00:00Z","status":"pending","source_message":"hi"}"#;
+        let parsed: PortalContent = serde_json::from_str(json).expect("deserialize");
+        let PortalContent::ContinuationPrompt { reason, .. } = parsed else {
+            panic!("expected ContinuationPrompt");
+        };
+        assert_eq!(reason, CONTINUATION_REASON_LIMIT);
+    }
+
+    #[test]
+    fn continuation_prompt_reason_roundtrips_overloaded() {
+        let msg = PortalMessage::continuation_prompt(
+            uuid::Uuid::nil(),
+            "2026-07-16T00:00:00Z".to_string(),
+            "scheduled".to_string(),
+            "src".to_string(),
+            CONTINUATION_REASON_OVERLOADED.to_string(),
+        );
+        let json = serde_json::to_string(&msg).expect("serialize");
+        let back: PortalMessage = serde_json::from_str(&json).expect("deserialize");
+        let PortalContent::ContinuationPrompt { reason, .. } = &back.content[0] else {
+            panic!("expected ContinuationPrompt");
+        };
+        assert_eq!(reason, CONTINUATION_REASON_OVERLOADED);
+    }
+
+    #[test]
+    fn continuation_config_reason_defaults_to_limit_on_old_wire() {
+        // Older launchers/backends omit `reason` on ContinuationConfig; default
+        // to limit so the launcher keeps applying the usual reset skew.
+        let json = r#"{"id":"11111111-1111-1111-1111-111111111111","session_id":"22222222-2222-2222-2222-222222222222","reset_at":"2026-07-16T00:00:00Z","prompt":"go"}"#;
+        let cfg: ContinuationConfig = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(cfg.reason, CONTINUATION_REASON_LIMIT);
+    }
 
     #[test]
     fn version_is_well_formed() {


### PR DESCRIPTION
## Problem

When the Claude CLI exhausts its own retries during a provider overload, the turn dies with a user-visible error:

> API Error: 529 Overloaded. This is a server-side issue, usually temporary — try again in a moment. If it persists, check https://status.claude.com.

The session then sits stalled until a human notices and nudges it. This makes the portal automatically resume the interrupted work.

## What it does

- **Detection (backend, Result path).** An error `Result` whose text matches a conservative transient-overload signature — contains `529` **and** `overloaded`, or the raw provider `overloaded_error` form — triggers a retry. Uses the typed `api_error_status` from `claude-codes` where present. Deliberately narrow: 4xx, auth failures, and other 5xx never match.
- **Immediate first retry, then paced.** The CLI already has an internal retry/backoff loop that moderates request rate, so the portal adds no delay of its own on the first attempt. Subsequent attempts wait 60s, then 300s.
- **Bounded.** At most 3 attempts per session in a rolling 15-minute window, chosen by a plain SQL count of prior `overloaded` continuations — so a sustained outage can't loop forever, and the cap holds across backend restarts (it's DB-backed). After the cap, it stands down and leaves a visible "gave up" message; the existing `TurnComplete` push still fires.
- **Reuses the usage-limit continuation machinery verbatim.** It schedules an already-`scheduled` `overloaded` continuation that the launcher injects into the still-running session, so Claude picks up where it left off. Safety rails: only retry when the session's proxy is still connected, and never when a human already responded after the failure.

## Schema

Adds a `reason` column to `session_continuations` (`VARCHAR(32) NOT NULL DEFAULT 'limit'`) to distinguish `'overloaded'` retries from usage-limit resets. `ContinuationConfig` and the `ContinuationPrompt` portal card gain a wire-compatible `reason` field (serde default `'limit'`), so older launchers/backends interoperate unchanged. The launcher fires `overloaded` continuations with no reset skew (limit resets keep their 2-minute skew), and the frontend card renders "Provider overloaded — auto-retrying" instead of the limit wording.

## Tests

- Signature matcher: positive on the exact CLI message + `overloaded_error`; negative on 401/permission/generic/5xx.
- Retry-delay tiers (0/1/2/3 → immediate/60s/300s/give-up), plus a DB-gated test exercising the real count query.
- Wire-compat serde tests for the new `reason` fields; launcher skew tests (overloaded fires at `reset_at`, limit still waits the skew).