### PR TITLE
Add nav-mode `G` to jump to the latest message

### DIFF
--- a/frontend/src/components/help_overlay.rs
+++ b/frontend/src/components/help_overlay.rs
@@ -93,6 +93,10 @@ const GROUPS: &[ShortcutGroup] = &[
                 description: "Jump to the next waiting session",
             },
             Shortcut {
+                keys: &["G"],
+                description: "Jump to the latest message (resume live tailing)",
+            },
+            Shortcut {
                 keys: &["n"],
                 description: "New session (open the launch dialog)",
             },

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -119,6 +119,9 @@ pub struct KeyboardNavConfig {
     pub on_new_session: Callback<()>,
     /// Callback to delete a session, given its id (nav-mode `d` on the focused session)
     pub on_delete: Callback<Uuid>,
+    /// Callback to jump the focused session's transcript to the newest message
+    /// and resume live tailing (nav-mode `G`).
+    pub on_jump_to_latest: Callback<()>,
 }
 
 /// Return value from the use_keyboard_nav hook.
@@ -170,6 +173,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let on_show_help = config.on_show_help.clone();
         let on_new_session = config.on_new_session.clone();
         let on_delete = config.on_delete.clone();
+        let on_jump_to_latest = config.on_jump_to_latest.clone();
         Callback::from(move |e: KeyboardEvent| {
             // Don't handle keyboard nav when a modal overlay is open. The launch
             // dialog, full-page modals, and help overlay are included so their
@@ -329,6 +333,13 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                         if let Some(session) = sessions.get(focused_index) {
                             on_delete.emit(session.id);
                         }
+                    }
+                    "G" => {
+                        // Jump the focused session's transcript to the newest
+                        // message and resume live tailing. Stays in nav mode
+                        // (like the other nav keys), matching vim's "go to end".
+                        e.prevent_default();
+                        on_jump_to_latest.emit(());
                     }
                     key => {
                         // Number keys 1-9 select the Nth session *as shown in the

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -198,6 +198,7 @@ pub fn dashboard_page() -> Html {
         on_show_help,
         on_new_session,
         on_delete: on_delete.clone(),
+        on_jump_to_latest: focus.on_jump_to_latest.clone(),
     });
 
     // Ctrl+C interrupt: a window capture-phase listener so it fires in every
@@ -723,6 +724,7 @@ pub fn dashboard_page() -> Html {
                                                 on_activity={on_activity.clone()}
                                                 current_user_id={current_user_id.map(|id| id.to_string())}
                                                 interrupt_signal={focus.interrupt_signal}
+                                                jump_to_latest_signal={focus.jump_to_latest_signal}
                                             />
                                         </div>
                                     }

--- a/frontend/src/pages/dashboard/page_focus.rs
+++ b/frontend/src/pages/dashboard/page_focus.rs
@@ -11,6 +11,8 @@ pub(super) struct DashboardFocus {
     pub on_activate: Callback<Uuid>,
     pub on_interrupt: Callback<()>,
     pub interrupt_signal: u32,
+    pub on_jump_to_latest: Callback<()>,
+    pub jump_to_latest_signal: u32,
 }
 
 #[hook]
@@ -122,11 +124,26 @@ pub(super) fn use_dashboard_focus(
         })
     };
 
+    // Jump-to-latest signal counter: incremented by nav-mode `G`, passed to the
+    // focused SessionView which self-dispatches `JumpToLive` on the bump. Uses
+    // the same counter-prop pattern as `interrupt_signal` so the dashboard hook
+    // can reach the focused session's message without holding its dispatcher.
+    let jump_to_latest_signal = use_state(|| 0u32);
+
+    let on_jump_to_latest = {
+        let jump_to_latest_signal = jump_to_latest_signal.clone();
+        Callback::from(move |()| {
+            jump_to_latest_signal.set(*jump_to_latest_signal + 1);
+        })
+    };
+
     DashboardFocus {
         focused_index,
         on_select_session,
         on_activate,
         on_interrupt,
         interrupt_signal: *interrupt_signal,
+        on_jump_to_latest,
+        jump_to_latest_signal: *jump_to_latest_signal,
     }
 }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -65,6 +65,10 @@ pub struct SessionViewProps {
     pub current_user_id: Option<String>,
     #[prop_or(0)]
     pub interrupt_signal: u32,
+    /// Bumped by the dashboard when nav-mode `G` is pressed; the focused session
+    /// jumps its transcript to the newest message and resumes live tailing.
+    #[prop_or(0)]
+    pub jump_to_latest_signal: u32,
 }
 
 fn optimistic_user_message(
@@ -338,6 +342,15 @@ impl Component for SessionView {
             && ctx.props().interrupt_signal > 0
         {
             ctx.link().send_message(SessionViewMsg::Interrupt);
+        }
+
+        // Nav-mode `G` on the focused session: jump to the newest message and
+        // resume live tailing. Same counter-prop pattern as `interrupt_signal`.
+        if ctx.props().focused
+            && ctx.props().jump_to_latest_signal != old_props.jump_to_latest_signal
+            && ctx.props().jump_to_latest_signal > 0
+        {
+            ctx.link().send_message(SessionViewMsg::JumpToLive);
         }
 
         true


### PR DESCRIPTION
When you've scrolled up in a session's transcript, the only way back to the newest message was clicking the "Jump to live ↓" pill. This adds a keyboard path.

## What it does

- **Nav-mode `G`** (reached via `Ctrl/Cmd+K`, matching vim's "go to end") jumps the focused session's transcript to the newest message and resumes live tailing.
- Routes through the existing `SessionViewMsg::JumpToLive` primitive — which sets `should_autoscroll` and snaps to the bottom on the next paint — so tailing state stays consistent (unlike a raw `scroll_top` write).
- The **focused** session is reached with the same counter-prop pattern already used for `interrupt_signal`: the dashboard bumps `jump_to_latest_signal`, and the focused `SessionView` self-dispatches `JumpToLive` on the change — no need to hold the child's dispatcher.
- Listed in the `?` keyboard-shortcuts help overlay.

Closes #1375.

## Testing

- `cargo check --target wasm32-unknown-unknown -p frontend`
- `cargo clippy -p frontend --target wasm32-unknown-unknown --all-targets -- -D warnings`
- `cargo test -p frontend`