### PR TITLE
Fix pressing launcher, forward, focus, and messaging issues

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -54,14 +54,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker
+      - name: Prepare Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=sha,prefix=
-            type=raw,value=latest
+        shell: bash
+        run: |
+          image="${REGISTRY}/${IMAGE_NAME,,}"
+          short_sha="${GITHUB_SHA::7}"
+          created="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          {
+            echo "tags<<EOF"
+            echo "${image}:${short_sha}"
+            echo "${image}:latest"
+            echo "EOF"
+            echo "labels<<EOF"
+            echo "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+            echo "org.opencontainers.image.revision=${GITHUB_SHA}"
+            echo "org.opencontainers.image.created=${created}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -178,8 +178,24 @@ pub async fn send_agent_message(
         user_id, target_id, outcome.seq, outcome.delivered, outcome.persisted
     );
 
+    let pending_inputs = pending_input_count(&mut conn, target_id).unwrap_or(0);
+
     Ok(Json(SendAgentMessageResponse {
         delivered: outcome.delivered,
+        persisted: outcome.persisted,
         seq: outcome.seq,
+        pending_inputs,
     }))
+}
+
+fn pending_input_count(
+    conn: &mut crate::db::DbConnection,
+    session_id: Uuid,
+) -> Result<usize, diesel::result::Error> {
+    use crate::schema::pending_inputs;
+    let count: i64 = pending_inputs::table
+        .filter(pending_inputs::session_id.eq(session_id))
+        .count()
+        .get_result(conn)?;
+    Ok(count.max(0) as usize)
 }

--- a/backend/src/handlers/forwards.rs
+++ b/backend/src/handlers/forwards.rs
@@ -1,6 +1,6 @@
 //! Port-forward registration (docs/PORT_FORWARDING.md): a session has at most
 //! one forwarded port. `session_forwards` holds it; `forward_subdomains` is the
-//! stable label ↔ session lookup the reverse proxy routes by. An agent that
+//! current auto label ↔ session lookup the reverse proxy routes by. An agent that
 //! needs several services fronts them behind its own reverse proxy on the one
 //! forwarded port.
 //!
@@ -18,7 +18,6 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
-use sha2::{Digest, Sha256};
 use tower_cookies::Cookies;
 use tracing::info;
 use uuid::Uuid;
@@ -39,7 +38,7 @@ use crate::AppState;
 const FORWARD_STATUS_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Length of a subdomain label in hex chars (32 bits). Short by design; the
-/// LUT + collision-retry in [`ensure_subdomain_label`] keeps it unambiguous.
+/// LUT + collision-retry in [`rotate_subdomain_label`] keeps it unambiguous.
 const LABEL_HEX_LEN: usize = 8;
 
 /// Public URL for a forward: `{scheme}://{label}.{domain}/`. Errors when
@@ -79,63 +78,57 @@ fn to_forward_info(
     })
 }
 
-/// The `attempt`-th candidate label for a session: the first [`LABEL_HEX_LEN`]
-/// hex chars of `sha256(session_id || attempt)`. Deterministic, so attempt 0 is
-/// stable across calls; later attempts only come into play on a collision.
-fn label_candidate(session_id: Uuid, attempt: u32) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(session_id.as_bytes());
-    hasher.update(attempt.to_le_bytes());
-    let digest = hasher.finalize();
-    hex::encode(digest)[..LABEL_HEX_LEN].to_string()
+fn label_candidate() -> String {
+    hex::encode(Uuid::new_v4().as_bytes())[..LABEL_HEX_LEN].to_string()
 }
 
-/// Return the session's stable subdomain label, allocating one on first use.
-/// Reuses the existing row if present (so the URL is stable across
-/// close/reopen); otherwise inserts the first candidate label that doesn't
-/// collide with another session's, re-deriving with a counter on conflict.
-pub(crate) fn ensure_subdomain_label(
+/// Allocate a fresh auto subdomain label for this active forward. A new label
+/// is minted on every `forward <port>` registration so a stale service worker,
+/// cookie, or browser cache from a previous local app cannot poison the next
+/// forward for the same agent session. Admin custom-subdomain aliases are
+/// stored separately and continue to route to the session.
+fn rotate_subdomain_label(
     conn: &mut crate::db::DbConnection,
     session_id: Uuid,
 ) -> Result<String, AppError> {
     use crate::schema::forward_subdomains as fs;
+    use diesel::result::{DatabaseErrorKind, Error as DieselError};
 
-    if let Some(existing) = fs::table
-        .filter(fs::session_id.eq(session_id))
-        .select(fs::label)
-        .first::<String>(conn)
-        .optional()?
-    {
-        return Ok(existing);
-    }
-
-    for attempt in 0u32..256 {
-        let candidate = label_candidate(session_id, attempt);
-        let inserted = diesel::insert_into(fs::table)
+    for _ in 0..256 {
+        let candidate = label_candidate();
+        let result = diesel::insert_into(fs::table)
             .values(&NewForwardSubdomain {
                 label: candidate.clone(),
                 session_id,
             })
-            .on_conflict_do_nothing()
-            .execute(conn)?;
-        if inserted == 1 {
-            return Ok(candidate);
-        }
-        // Nothing inserted: the label collides with another session's, or this
-        // session got a row concurrently. Re-check the session before trying
-        // the next candidate.
-        if let Some(existing) = fs::table
-            .filter(fs::session_id.eq(session_id))
-            .select(fs::label)
-            .first::<String>(conn)
-            .optional()?
-        {
-            return Ok(existing);
+            .on_conflict(fs::session_id)
+            .do_update()
+            .set((
+                fs::label.eq(candidate.clone()),
+                fs::created_at.eq(diesel::dsl::now),
+            ))
+            .execute(conn);
+
+        match result {
+            Ok(_) => return Ok(candidate),
+            // The random auto label collided with another session's label PK.
+            // Retry with a fresh candidate; all other DB errors are real.
+            Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => continue,
+            Err(e) => return Err(e.into()),
         }
     }
     Err(AppError::Internal(
         "could not allocate a forward subdomain".to_string(),
     ))
+}
+
+/// Return the session's current auto subdomain label, allocating one only when
+/// needed by legacy rows that predate the rotate-on-register behavior.
+pub(crate) fn ensure_subdomain_label(
+    conn: &mut crate::db::DbConnection,
+    session_id: Uuid,
+) -> Result<String, AppError> {
+    existing_label(conn, session_id)?.map_or_else(|| rotate_subdomain_label(conn, session_id), Ok)
 }
 
 /// Map a subdomain label back to its session (the reverse-proxy Host route).
@@ -164,7 +157,7 @@ pub(crate) fn session_for_label(
         .ok_or(AppError::NotFound("forward"))
 }
 
-/// The session's subdomain label, if one has been allocated.
+/// The session's current auto subdomain label, if one has been allocated.
 fn existing_label(
     conn: &mut crate::db::DbConnection,
     session_id: Uuid,
@@ -304,7 +297,7 @@ pub async fn create_forward(
             .filter(session_forwards::session_id.eq(session_id))
             .select(SessionForward::as_select())
             .first(conn)?;
-        let label = ensure_subdomain_label(conn, session_id)?;
+        let label = rotate_subdomain_label(conn, session_id)?;
         Ok((session, row, label, replaced_port))
     })?;
 
@@ -394,7 +387,7 @@ pub async fn list_forwards(
 
 /// DELETE …/sessions/{id}/forwards — revoke the session's forward (owner only).
 /// Drops the row and tells the proxy to close the port and its live streams.
-/// The subdomain label is kept so a re-forward reuses the same URL.
+/// The next registration rotates to a fresh auto subdomain.
 pub async fn delete_forward(
     State(app_state): State<Arc<AppState>>,
     Path(session_id): Path<Uuid>,
@@ -518,4 +511,18 @@ pub async fn set_forward_public(
     );
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_label_candidates_are_short_lower_hex() {
+        let label = label_candidate();
+        assert_eq!(label.len(), LABEL_HEX_LEN);
+        assert!(label
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
 }

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -29,6 +29,7 @@ pub async fn list_launchers(
 #[derive(serde::Serialize)]
 pub struct LaunchResponse {
     pub request_id: Uuid,
+    pub session_id: Uuid,
 }
 
 /// POST /api/launch - Request launching a new session
@@ -46,6 +47,15 @@ pub async fn launch_session(
             .ok_or(AppError::NotFound("Launcher not found"))?;
         (launcher.hostname.clone(), launcher.version.clone())
     };
+    if req.create_worktree
+        && !app_state
+            .session_manager
+            .launcher_supports_capability(launcher_id, shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE)
+    {
+        return Err(AppError::BadRequest(
+            "Selected launcher is too old for git worktree launches. Update agent-portal on that machine and try again.",
+        ));
+    }
 
     // Create a fresh short-lived proxy token for the child process
     let auth_token = mint_launch_token(&app_state, user_id)?;
@@ -122,7 +132,10 @@ pub async fn launch_session(
         request_id, launcher_id, req.working_directory
     );
 
-    Ok(Json(LaunchResponse { request_id }))
+    Ok(Json(LaunchResponse {
+        request_id,
+        session_id,
+    }))
 }
 
 /// Trim a caller-supplied session name, returning `None` when it is absent or
@@ -423,6 +436,7 @@ mod tests {
             running_sessions: Vec::new(),
             working_directory: None,
             version: "test".to_string(),
+            capabilities: vec![shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string()],
             cancel: tokio_util::sync::CancellationToken::new(),
             gen: 0,
             last_seen: std::sync::atomic::AtomicU64::new(0),

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -170,6 +170,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
         user_id,
         working_directory,
         version,
+        capabilities,
         pending_token_refresh,
     ) = loop {
         match ws_receiver.recv().await {
@@ -180,6 +181,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                 hostname,
                 working_directory,
                 version,
+                capabilities,
             })) => {
                 // Authenticate and, for live launcher credentials, opportunistically
                 // rotate legacy non-expiring or half-lived tokens while the
@@ -274,6 +276,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
                     user_id,
                     working_directory,
                     version,
+                    capabilities,
                     pending_token_refresh,
                 );
             }
@@ -341,6 +344,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
             running_sessions: Vec::new(),
             working_directory,
             version: version.unwrap_or_default(),
+            capabilities,
             cancel: cancel.clone(),
             gen: 0, // stamped by try_register_launcher
             last_seen: std::sync::atomic::AtomicU64::new(0), // stamped by try_register_launcher

--- a/backend/src/handlers/websocket/session_manager/launcher_registry.rs
+++ b/backend/src/handlers/websocket/session_manager/launcher_registry.rs
@@ -23,6 +23,7 @@ pub struct LauncherConnection {
     pub running_sessions: Vec<Uuid>,
     pub working_directory: Option<String>,
     pub version: String,
+    pub capabilities: Vec<String>,
     pub cancel: CancellationToken,
     /// Stamped by `try_register_launcher`; caller-supplied values are ignored.
     pub gen: u64,
@@ -138,6 +139,7 @@ impl SessionManager {
                 running_sessions: entry.value().running_sessions.len() as u32,
                 working_directory: entry.value().working_directory.clone(),
                 version: entry.value().version.clone(),
+                capabilities: entry.value().capabilities.clone(),
             })
             .collect()
     }
@@ -148,6 +150,13 @@ impl SessionManager {
                 .get(&id)
                 .map(|launcher| launcher.version.clone())
         })
+    }
+
+    pub fn launcher_supports_capability(&self, launcher_id: Uuid, capability: &str) -> bool {
+        self.launchers
+            .get(&launcher_id)
+            .map(|launcher| launcher.capabilities.iter().any(|c| c == capability))
+            .unwrap_or(false)
     }
 
     pub fn send_to_launcher(&self, launcher_id: &Uuid, msg: ServerToLauncher) -> bool {
@@ -234,6 +243,7 @@ mod tests {
             running_sessions: Vec::new(),
             working_directory: None,
             version: "test".to_string(),
+            capabilities: vec![shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string()],
             cancel: CancellationToken::new(),
             gen: 0,
             last_seen: std::sync::atomic::AtomicU64::new(0),
@@ -293,6 +303,26 @@ mod tests {
         assert_eq!(mgr.launcher_version(None), None);
     }
 
+    #[test]
+    fn launcher_supports_capability_checks_advertised_flags() {
+        let mgr = SessionManager::new();
+        let user_id = Uuid::new_v4();
+        let launcher_id = Uuid::new_v4();
+
+        mgr.try_register_launcher(launcher_id, make_launcher_connection(user_id, "host1"))
+            .expect("register launcher");
+
+        assert!(mgr.launcher_supports_capability(
+            launcher_id,
+            shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE
+        ));
+        assert!(!mgr.launcher_supports_capability(launcher_id, "missing"));
+        assert!(!mgr.launcher_supports_capability(
+            Uuid::new_v4(),
+            shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE
+        ));
+    }
+
     /// The launcher half of #1256: a launcher reconnect reuses the same
     /// `launcher_id`, so the OLD socket's cleanup (running late, after the
     /// new socket registered) must not remove the NEW registration.
@@ -346,6 +376,7 @@ mod tests {
             running_sessions: Vec::new(),
             working_directory: None,
             version: "test".to_string(),
+            capabilities: vec![shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string()],
             cancel: cancel.clone(),
             gen: 0,
             last_seen: std::sync::atomic::AtomicU64::new(0),
@@ -417,6 +448,7 @@ mod tests {
                         running_sessions: Vec::new(),
                         working_directory: None,
                         version: "test".to_string(),
+                        capabilities: vec![shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string()],
                         cancel: CancellationToken::new(),
                         gen: 0,
                         last_seen: std::sync::atomic::AtomicU64::new(0),

--- a/backend/src/handlers/websocket/session_manager/liveness.rs
+++ b/backend/src/handlers/websocket/session_manager/liveness.rs
@@ -152,6 +152,7 @@ mod tests {
             running_sessions: Vec::new(),
             working_directory: None,
             version: "test".to_string(),
+            capabilities: vec![shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string()],
             cancel,
             gen: 0,
             last_seen: std::sync::atomic::AtomicU64::new(0),

--- a/docs/PORT_FORWARDING.md
+++ b/docs/PORT_FORWARDING.md
@@ -21,15 +21,16 @@ long as the session is alive.
 
 ## Design summary
 
-- **One forward per session, on a per-session subdomain**, not path prefixes.
-  Each session gets its own origin: `{label}.{forward domain}`, where `label`
-  is a short opaque hash of the session (not the port). Agent-built apps work
-  unmodified (absolute asset paths, cookies, service workers), and forwarded
-  apps are origin-isolated from the portal and from each other. A session
-  forwards a single port at a time; an agent that needs several services
-  fronts them behind its own reverse proxy on that one port. Because the
-  subdomain identifies the *session*, re-pointing the forward to a different
-  local port keeps the same URL.
+- **One forward per session, on an auto subdomain that rotates per
+  registration**, not path prefixes. Each active forward gets its own origin:
+  `{label}.{forward domain}`, where `label` is a short opaque random value.
+  Agent-built apps work unmodified (absolute asset paths, cookies, service
+  workers), and forwarded apps are origin-isolated from the portal and from
+  each other. A session forwards a single port at a time; an agent that needs
+  several services fronts them behind its own reverse proxy on that one port.
+  Re-registering a forward mints a fresh auto label so stale service workers,
+  cookies, and browser caches from a previous local app cannot poison the next
+  app served by the same session.
 - **One listener.** The backend keeps its single HTTP listener and routes by
   `Host` header. No per-forward port allocation anywhere — which is why the
   CLI takes only a local port, never a remote one.
@@ -59,11 +60,11 @@ browser ──HTTP──▶ backend (Host-routed reverse proxy)
 
 - `label`: either an auto 8-lowercase-hex label (32 bits) or an admin-assigned
   custom label.
-  - **Auto**: allocated per session in the `forward_subdomains` LUT, derived
-    from `sha256(session_id)[..8]`, re-derived with an incrementing counter on
-    the (rare) collision, and stored so the same session always resolves to the
-    same label — stable across close/reopen and independent of which port is
-    forwarded. Doesn't encode the port or leak the raw session UUID.
+  - **Auto**: allocated in the `forward_subdomains` LUT as a random 8-hex
+    label and rotated on every `forward <port>` registration. The current auto
+    label routes to the session's active forward; old auto labels stop
+    resolving after rotation. This avoids cross-app origin state reuse and does
+    not encode the port or leak the raw session UUID.
   - **Custom**: an admin can assign a human-readable alias in the
     `custom_subdomains` table (Admin ▸ Subdomains), which routes to the same
     session *alongside* the auto label. See "Admin custom subdomains" below.
@@ -191,9 +192,9 @@ CREATE TABLE session_forwards (
     UNIQUE (session_id)              -- at most one forward per session
 );
 
--- Subdomain label ↔ session lookup. A short 8-hex label is allocated on first
--- forward (sha256(session_id)[..8], counter-bumped on collision) and kept
--- across close/reopen so the URL stays stable.
+-- Current auto subdomain label ↔ session lookup. A short random 8-hex label
+-- is allocated on each forward registration and atomically replaces the
+-- session's previous auto label.
 CREATE TABLE forward_subdomains (
     label TEXT PRIMARY KEY,
     session_id UUID NOT NULL UNIQUE REFERENCES sessions(id) ON DELETE CASCADE,
@@ -202,8 +203,8 @@ CREATE TABLE forward_subdomains (
 ```
 
 Both tables cascade-delete with the session. A `session_forwards` row is
-deleted when the forward is revoked (its `forward_subdomains` label persists so
-a re-forward reuses the same URL); everything dies with the session.
+deleted when the forward is revoked; the next registration replaces the current
+auto label with a fresh origin. Everything dies with the session.
 
 ### Agent-facing API (bearer token or session cookie, same rails as `/api/agent/*`)
 

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -17,6 +17,11 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::HtmlInputElement;
 use yew::prelude::*;
 
+#[derive(serde::Deserialize)]
+struct LaunchResponse {
+    session_id: Uuid,
+}
+
 /// Sentinel value used in the launcher <select> to represent the "connect new host" option.
 const CONNECT_NEW: &str = "__install__";
 
@@ -298,7 +303,7 @@ fn is_path_home_scoped(path: &str, home_root: Option<&str>) -> bool {
 #[derive(Properties, PartialEq)]
 pub struct LaunchDialogProps {
     pub on_close: Callback<()>,
-    pub on_launched: Callback<()>,
+    pub on_launched: Callback<Uuid>,
     /// Ticks on `ServerToClient::LaunchersChanged` (#710): the dialog
     /// refetches its launcher list live, so a launcher coming online while
     /// the dialog is open appears without reopening it.
@@ -602,6 +607,16 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     .await
                 {
                     Ok(resp) if resp.ok() => {
+                        let launched = match resp.json::<LaunchResponse>().await {
+                            Ok(launched) => launched,
+                            Err(e) => {
+                                error_msg.set(Some(format!(
+                                    "Launch succeeded but response was malformed: {e}"
+                                )));
+                                launching.set(false);
+                                return;
+                            }
+                        };
                         // Remember which machine we launched on, and where on
                         // that machine, so reopening the dialog defaults back to
                         // this launcher + directory next time (#1326).
@@ -609,7 +624,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                             save_last_launcher(lid);
                             save_last_launch_dir_for(lid, &working_dir);
                         }
-                        on_launched.emit(());
+                        on_launched.emit(launched.session_id);
                         on_close.emit(());
                     }
                     Ok(resp) => {

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -340,11 +340,8 @@ pub fn dashboard_page() -> Html {
 
     let on_launch_success = {
         let session_state = session_state.clone();
-        let active_sessions = active_sessions.clone();
-        Callback::from(move |_| {
-            session_state.dispatch(DashboardSessionAction::StoreLaunchSnapshot(
-                active_session_ids(&active_sessions),
-            ));
+        Callback::from(move |session_id: Uuid| {
+            session_state.dispatch(DashboardSessionAction::FocusAndActivate(session_id));
         })
     };
 

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -58,7 +58,6 @@ pub(super) enum DashboardSessionAction {
         hidden: bool,
     },
     MessageSent(Uuid),
-    StoreLaunchSnapshot(Vec<Uuid>),
     FocusNewlyLaunched(Vec<Uuid>),
 }
 
@@ -115,9 +114,6 @@ impl Reducible for DashboardSessionState {
                 if !state.awaiting_sessions.remove(&session_id) {
                     return self;
                 }
-            }
-            DashboardSessionAction::StoreLaunchSnapshot(session_ids) => {
-                state.sessions_at_launch = Some(session_ids.into_iter().collect());
             }
             DashboardSessionAction::FocusNewlyLaunched(session_ids) => {
                 let Some(snapshot) = &state.sessions_at_launch else {
@@ -309,10 +305,9 @@ mod tests {
 
     #[test]
     fn focus_newly_launched_uses_snapshot_delta() {
-        let state = reduce(
-            DashboardSessionState::new(HashSet::new()),
-            DashboardSessionAction::StoreLaunchSnapshot(vec![id(1), id(2)]),
-        );
+        let mut initial = DashboardSessionState::new(HashSet::new());
+        initial.sessions_at_launch = Some(HashSet::from_iter([id(1), id(2)]));
+        let state = Rc::new(initial);
 
         let state = state.reduce(DashboardSessionAction::FocusNewlyLaunched(vec![
             id(1),

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -138,6 +138,7 @@ pub struct InputBar {
     /// One-shot timer that re-applies the initial focus on the next macrotask
     /// after the first render (#1373). Held so it is cancelled on unmount.
     initial_focus_timer: Option<Timeout>,
+    focus_after_render: bool,
     /// Whether opt-in vim editing is enabled (read once from localStorage at
     /// create; takes effect for newly opened sessions / after reload).
     vim_enabled: bool,
@@ -171,6 +172,7 @@ impl Component for InputBar {
             voice_button_ref: NodeRef::default(),
             was_focused: ctx.props().focused,
             initial_focus_timer: None,
+            focus_after_render: ctx.props().focused,
             vim_enabled: load_vim_mode(),
             vim: Rc::new(RefCell::new(VimState::default())),
         }
@@ -181,13 +183,15 @@ impl Component for InputBar {
         let became_focused = now_focused && !self.was_focused;
         self.was_focused = now_focused;
         if became_focused {
-            self.focus_textarea();
+            self.focus_after_render = true;
         }
         true
     }
 
     fn rendered(&mut self, ctx: &Context<Self>, first_render: bool) {
-        if first_render && ctx.props().focused {
+        let first_focused_render = first_render && ctx.props().focused;
+        if first_focused_render || self.focus_after_render {
+            self.focus_after_render = false;
             // Focus immediately for the common case (switching to an
             // already-mounted session). On a fresh page load / new session the
             // focused InputBar mounts with `focused` already true, so the
@@ -199,12 +203,14 @@ impl Component for InputBar {
             // textarea node is stable (uncontrolled, held via `NodeRef`), so
             // this is a genuine post-load focus, not a refocus loop.
             self.focus_textarea();
-            let input_ref = self.input_ref.clone();
-            self.initial_focus_timer = Some(Timeout::new(0, move || {
-                if let Some(input) = input_ref.cast::<HtmlTextAreaElement>() {
-                    let _ = input.focus();
-                }
-            }));
+            if first_focused_render {
+                let input_ref = self.input_ref.clone();
+                self.initial_focus_timer = Some(Timeout::new(0, move || {
+                    if let Some(input) = input_ref.cast::<HtmlTextAreaElement>() {
+                        let _ = input.focus();
+                    }
+                }));
+            }
         }
         // Restore textarea content if it was cleared by a re-render (e.g.
         // WS reconnect): the textarea is uncontrolled (we don't pass `value`

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -96,6 +96,7 @@ pub async fn run_launcher_loop(
                     working_directory: std::env::current_dir()
                         .ok()
                         .map(|p| p.to_string_lossy().to_string()),
+                    capabilities: vec![shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string()],
                 };
                 if ws_sender.send(register).await.is_err() {
                     warn!("Failed to send registration");

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -129,6 +129,10 @@ pub async fn send(agent_id: &str, message: &str) -> Result<()> {
     } else {
         println!("Queued for the session's reconnect (seq {}).", data.seq);
     }
+    if !data.persisted {
+        println!("warning: message was not durably persisted for reconnect replay");
+    }
+    println!("Recipient pending input backlog: {}.", data.pending_inputs);
     Ok(())
 }
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -15,6 +15,10 @@ NC='\033[0m' # No Color
 # HOST defaults to dual-stack (::) so IPv6 `localhost` and port-forwards reach
 # the backend — a plain 0.0.0.0 (IPv4-only) bind is missed by forwarders that
 # resolve localhost to ::1.
+PORT_EXPLICIT=1
+if [ -z "${PORT+x}" ]; then
+    PORT_EXPLICIT=0
+fi
 PORT="${PORT:-3000}"
 HOST="${HOST:-::}"
 
@@ -40,6 +44,55 @@ error() {
 
 warn() {
     echo -e "${YELLOW}⚠${NC} $1"
+}
+
+port_in_use() {
+    local port="$1"
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    elif command -v ss >/dev/null 2>&1; then
+        ss -ltn "( sport = :$port )" | tail -n +2 | grep -q .
+    else
+        return 1
+    fi
+}
+
+describe_port_owner() {
+    local port="$1"
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN || true
+    elif command -v ss >/dev/null 2>&1; then
+        ss -ltnp "( sport = :$port )" || true
+    else
+        echo "No lsof/ss available to identify the listener."
+    fi
+}
+
+choose_available_port() {
+    if ! port_in_use "$PORT"; then
+        return 0
+    fi
+
+    if [ "$PORT_EXPLICIT" -eq 1 ]; then
+        error "PORT=$PORT is already in use."
+        describe_port_owner "$PORT"
+        return 1
+    fi
+
+    local candidate
+    for candidate in $(seq 3001 3099); do
+        if ! port_in_use "$candidate"; then
+            warn "Port $PORT is already in use; using $candidate instead. Set PORT explicitly to require a specific port."
+            PORT="$candidate"
+            BACKEND_PID_FILE="$PID_DIR/backend-$PORT.pid"
+            BACKEND_LOG="/tmp/claude-portal-backend-$PORT.log"
+            return 0
+        fi
+    done
+
+    error "No free dev backend port found in 3000-3099."
+    describe_port_owner 3000
+    return 1
 }
 
 # Ensure PID directory exists
@@ -280,6 +333,7 @@ do_start() {
     echo "╚═══════════════════════════════════════════════════════════╝"
     echo ""
 
+    choose_available_port || exit 1
     start_db || exit 1
     run_migrations || exit 1
     build_frontend || exit 1

--- a/shared/src/api/forwards.rs
+++ b/shared/src/api/forwards.rs
@@ -11,8 +11,8 @@ use uuid::Uuid;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ForwardInfo {
     pub port: u16,
-    /// Fully-formed public URL (`{scheme}://{label}.{domain}/`), stable for
-    /// the session's life regardless of which port it points at.
+    /// Fully-formed public URL (`{scheme}://{label}.{domain}/`). The auto
+    /// label rotates on each registration to avoid stale browser origin state.
     pub url: String,
     /// Registration time, RFC 3339.
     pub created_at: String,

--- a/shared/src/api/sessions.rs
+++ b/shared/src/api/sessions.rs
@@ -140,8 +140,16 @@ pub struct SendAgentMessageResponse {
     /// True if a live proxy received it; false means it was queued for the
     /// session's next reconnect.
     pub delivered: bool,
+    /// True if the backend persisted a pending-input row for replay on proxy
+    /// reconnect. If false and `delivered` is also false, the sender should
+    /// treat the message as not replay-safe.
+    #[serde(default)]
+    pub persisted: bool,
     /// The input sequence number assigned to the injected message.
     pub seq: i64,
+    /// Number of pending input rows for this session after this send.
+    #[serde(default)]
+    pub pending_inputs: usize,
 }
 
 #[cfg(test)]

--- a/shared/src/endpoints/launcher.rs
+++ b/shared/src/endpoints/launcher.rs
@@ -52,6 +52,9 @@ pub enum LauncherToServer {
         /// Working directory where the launcher process is running
         #[serde(default)]
         working_directory: Option<String>,
+        /// Additive feature flags supported by this launcher binary.
+        #[serde(default)]
+        capabilities: Vec<String>,
     },
 
     /// Result of a launch request

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -384,6 +384,7 @@ mod tests {
             hostname: "host1".into(),
             version: Some("1.0".into()),
             working_directory: Some("/home/user/project".into()),
+            capabilities: vec![crate::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string()],
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"LauncherRegister""#));

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -13,6 +13,10 @@ use uuid::Uuid;
 /// placeholder.
 pub const VERSION: &str = env!("PORTAL_VERSION");
 
+/// Launcher capability advertised by versions that honor
+/// `ServerToLauncher::LaunchSession.create_worktree`.
+pub const LAUNCHER_CAPABILITY_CREATE_WORKTREE: &str = "launch.create_worktree";
+
 /// Split [`VERSION`] into `(major, minor, patch)` numeric components.
 /// `None` on the (impossible-by-construction) malformed string.
 pub fn version_parts() -> Option<(u64, u64, u64)> {
@@ -235,6 +239,9 @@ pub struct LauncherInfo {
     /// Launcher binary version
     #[serde(default)]
     pub version: String,
+    /// Additive feature flags advertised by the launcher at registration.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
 }
 
 /// A single open GitHub pull request associated with a session's repository.


### PR DESCRIPTION
## Summary

Fixes the seven pressing open issues batch:

- add launcher capability advertisement and gate `create_worktree` launches so old launchers fail clearly instead of silently ignoring the field
- return `session_id` from launch requests and focus/activate that exact session in the dashboard
- defer composer textarea focus until render on focus flips/reload
- rotate auto forward subdomains on each registration to avoid stale service worker/cache/cookie poisoning, while custom aliases remain stable
- make `scripts/dev.sh` auto-select a free default port in `3001-3099`, while explicit `PORT` fails with listener diagnostics
- include `persisted` and `pending_inputs` in agent-message send responses and surface that in the CLI
- document the new forward-origin rotation semantics

Claude review: approved by session `7615e532` after follow-up fixes for docs and atomic forward-label upsert.

## Validation

- `cargo check --workspace`
- `cargo clippy --workspace`
- `cargo clippy -p frontend --target wasm32-unknown-unknown`
- `cargo test --workspace`
- `cargo build --target wasm32-unknown-unknown -p shared`
- `bash -n scripts/dev.sh`
- `git diff --check`
