### PR TITLE
Block typing into the composer while in Nav mode

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -717,6 +717,7 @@ pub fn dashboard_page() -> Html {
                                             <SessionView
                                                 session={session.clone()}
                                                 focused={is_focused}
+                                                nav_mode={keyboard_nav.nav_mode}
                                                 on_awaiting_change={on_awaiting_change.clone()}
                                                 on_connected_change={on_connected_change.clone()}
                                                 on_message_sent={on_message_sent.clone()}

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -48,6 +48,10 @@ use crate::pages::dashboard::types::{calculate_backoff, MessageData, MessagesRes
 pub struct SessionViewProps {
     pub session: SessionInfo,
     pub focused: bool,
+    /// Whether the dashboard is in keyboard Nav mode. Forwarded to `InputBar` so
+    /// the composer goes `readonly` and stops processing keys while navigating.
+    #[prop_or(false)]
+    pub nav_mode: bool,
     pub on_awaiting_change: Callback<(Uuid, bool)>,
     pub on_connected_change: Callback<(Uuid, bool)>,
     pub on_message_sent: Callback<Uuid>,
@@ -1084,6 +1088,7 @@ impl SessionView {
             <InputBar
                 session_id={ctx.props().session.id}
                 focused={ctx.props().focused}
+                nav_mode={ctx.props().nav_mode}
                 ws_connected={self.ws_connected}
                 {on_register}
                 {on_send_text}

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -41,6 +41,14 @@ pub struct InputBarProps {
     /// Whether the WebSocket is currently connected. Disables the textarea
     /// + send buttons when false.
     pub ws_connected: bool,
+    /// Whether the dashboard is in keyboard Nav mode. While `true` the textarea
+    /// is made `readonly` and its key handler is inert, so keystrokes can't type
+    /// into (or submit from) the composer — otherwise Nav mode is misleading
+    /// because the caret sits in a composer that silently swallows typing. The
+    /// box keeps focus/caret (readonly, not disabled), so leaving Nav lands the
+    /// user ready to type; non-composer keys still bubble to `use_keyboard_nav`.
+    #[prop_or(false)]
+    pub nav_mode: bool,
     /// Fired exactly once on `create`, handing the parent a callback it can
     /// invoke to push inbound events into the bar. Mirrors the
     /// dispatcher-registration pattern used by `PermissionHandler` and
@@ -367,7 +375,15 @@ impl Component for InputBar {
 
         let vim_enabled = self.vim_enabled;
         let vim = self.vim.clone();
+        let nav_mode = ctx.props().nav_mode;
         let handle_keydown = link.callback(move |e: KeyboardEvent| {
+            // In Nav mode the composer is inert: do nothing here (no
+            // prevent_default / stop_propagation) so the key bubbles up to the
+            // dashboard's `use_keyboard_nav` handler, which owns navigation. The
+            // textarea is also `readonly` in this mode, so no character is typed.
+            if nav_mode {
+                return InputBarMsg::Noop;
+            }
             if e.ctrl_key() && e.key().to_lowercase() == "m" {
                 e.prevent_default();
                 return InputBarMsg::ToggleVoice;
@@ -522,6 +538,7 @@ impl Component for InputBar {
                         onkeydown={handle_keydown}
                         onpaste={handle_paste}
                         disabled={!ctx.props().ws_connected}
+                        readonly={ctx.props().nav_mode}
                         rows="1"
                     />
                     { self.render_voice_input(ctx) }


### PR DESCRIPTION
## Problem

In keyboard Nav mode the composer textarea keeps DOM focus (intentional — so leaving Nav via `Ctrl/Cmd+K` lands the caret ready to type). But it also kept *processing* keystrokes: any key that wasn't a nav shortcut (`e`, `a`, Space, Enter, …) was silently typed into — or submitted from — the composer. The result is a misleading Nav mode: text accumulates in a box you believe is inert.

## Fix

Thread the dashboard's `nav_mode` state down through `SessionView` into `InputBar` and make the composer inert while Nav mode is active:

- **`readonly` textarea** — blocks typing and paste, but (unlike `disabled`) keeps focus and the caret, so leaving Nav mode still lands you ready to type.
- **keydown handler early-returns in Nav mode** with no `prevent_default`/`stop_propagation`, so keys bubble up to `use_keyboard_nav` for navigation, and Enter/history/vim/voice no longer fire from the composer.

Together these guarantee Nav mode is purely navigation: `readonly` blocks character insertion (the default action) and the inert key handler stops the composer's own Enter/history/vim behavior.