### PR TITLE
Nav mode: j/k scroll the transcript instead of switching sessions

### DIFF
--- a/frontend/src/components/help_overlay.rs
+++ b/frontend/src/components/help_overlay.rs
@@ -81,8 +81,12 @@ const GROUPS: &[ShortcutGroup] = &[
                 description: "Move between sessions",
             },
             Shortcut {
-                keys: &["h", "j", "k", "l"],
+                keys: &["h", "l"],
                 description: "Move between sessions (vim keys)",
+            },
+            Shortcut {
+                keys: &["j", "k"],
+                description: "Scroll the focused transcript down / up",
             },
             Shortcut {
                 keys: &["1", "–", "9"],

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -30,6 +30,32 @@ fn focus_active_message_input() {
     }
 }
 
+/// Scroll the focused session's transcript ("text window") by a few lines.
+/// Nav-mode `j`/`k` drive this. Only `scrollTop` is moved here: the transcript's
+/// own scroll listener reconciles live tailing afterwards, so scrolling up pauses
+/// the tail and reveals the "Jump to live" pill, and scrolling back to the bottom
+/// resumes it — the same DOM-only approach vim NORMAL uses for the transcript.
+fn scroll_focused_transcript(down: bool) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    // Prefer the focused session's pane; fall back to the only one on screen.
+    let Some(messages) = doc
+        .query_selector(".session-view.focused .session-view-messages")
+        .ok()
+        .flatten()
+        .or_else(|| doc.query_selector(".session-view-messages").ok().flatten())
+    else {
+        return;
+    };
+    // A few lines per press: brisk enough to read through output without the
+    // overshoot of the half-page (Ctrl-d) jumps, and always past the ~50px
+    // at-bottom threshold so a single `k` reliably leaves live tailing.
+    let step = (messages.client_height() / 8).max(60);
+    let delta = if down { step } else { -step };
+    messages.set_scroll_top(messages.scroll_top() + delta);
+}
+
 /// True when there is a live text selection the user is likely trying to copy —
 /// either a document selection (e.g. highlighted transcript text) or a range
 /// inside the focused textarea/input (their selection is separate from the
@@ -146,7 +172,8 @@ pub struct UseKeyboardNav {
 /// - Shift+Tab -> next active session (skips hidden)
 ///
 /// Nav Mode:
-/// - Arrow keys / hjkl navigate sessions
+/// - Arrow keys / `h` / `l` move between sessions
+/// - `j` / `k` scroll the focused session's transcript down / up
 /// - Numbers 1-9 select directly (stays in Nav mode)
 /// - n -> new session (launch dialog)
 /// - d -> delete the focused session (via the confirm modal)
@@ -291,7 +318,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                 // Navigation Mode. Ctrl/Cmd+K (handled above) is the only way
                 // back to edit mode — no key here changes the mode.
                 match e.key().as_str() {
-                    "ArrowUp" | "ArrowLeft" | "k" | "h" => {
+                    "ArrowUp" | "ArrowLeft" | "h" => {
                         e.prevent_default();
                         if let Some(new_idx) = navigate_by_delta(focused_index, -1) {
                             if let Some(session) = sessions.get(new_idx) {
@@ -300,7 +327,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                             on_select.emit(new_idx);
                         }
                     }
-                    "ArrowDown" | "ArrowRight" | "j" | "l" => {
+                    "ArrowDown" | "ArrowRight" | "l" => {
                         e.prevent_default();
                         if let Some(new_idx) = navigate_by_delta(focused_index, 1) {
                             if let Some(session) = sessions.get(new_idx) {
@@ -308,6 +335,18 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                             }
                             on_select.emit(new_idx);
                         }
+                    }
+                    "j" => {
+                        // Scroll the focused transcript down. Session switching
+                        // moved to the arrows / `h` / `l` so the vim-familiar
+                        // `j`/`k` can scroll the text window instead.
+                        e.prevent_default();
+                        scroll_focused_transcript(true);
+                    }
+                    "k" => {
+                        // Scroll the focused transcript up.
+                        e.prevent_default();
+                        scroll_focused_transcript(false);
                     }
                     "w" => {
                         e.prevent_default();

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -746,7 +746,8 @@ pub fn dashboard_page() -> Html {
                                     html! {
                                         <>
                                             <span class="mode-indicator">{ "NAV" }</span>
-                                            <span>{ "↑↓ or jk = navigate" }</span>
+                                            <span>{ "↑↓ hl = navigate" }</span>
+                                            <span>{ "jk = scroll" }</span>
                                             <span>{ "1-9 = select" }</span>
                                             <span>{ "w = next waiting" }</span>
                                             <span>{ "n = new" }</span>


### PR DESCRIPTION
## What

In nav mode, `j`/`k` now scroll the focused session's transcript (the "text window") instead of moving between sessions.

- `j` scrolls the transcript down, `k` scrolls it up, by a few lines per press.
- Session switching stays on the arrow keys and `h`/`l`, plus the `1`-`9` number keys to jump directly — so nothing loses a way to change sessions.
- Only the scroll position is moved, so the transcript's existing scroll listener still pauses live tailing (revealing the "Jump to live" pill) when you scroll up and resumes it when you scroll back to the bottom — the same behavior as vim NORMAL scrolling and the pill.
- The nav-mode hint bar and the `?` shortcuts overlay are updated to match.

## Why

Number keys and the arrows already cover session selection, so binding the vim-familiar `j`/`k` to session switching was the less useful assignment. Scrolling the output while reading a session is the motion people actually reach for, so `j`/`k` now do that.