### PR TITLE
Nav mode: Enter accepts the current pane and returns to edit mode

### DIFF
--- a/frontend/src/components/help_overlay.rs
+++ b/frontend/src/components/help_overlay.rs
@@ -105,6 +105,10 @@ const GROUPS: &[ShortcutGroup] = &[
                 description: "Delete the focused session (with confirmation)",
             },
             Shortcut {
+                keys: &["Enter"],
+                description: "Accept the current pane and return to edit mode",
+            },
+            Shortcut {
                 keys: &["Ctrl/Cmd", "K"],
                 description: "Return to edit mode",
             },

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -151,6 +151,7 @@ pub struct UseKeyboardNav {
 /// - n -> new session (launch dialog)
 /// - d -> delete the focused session (via the confirm modal)
 /// - w -> next waiting session
+/// - Enter -> accept the current pane and return to Edit Mode
 /// - Ctrl/Cmd+K -> back to Edit Mode
 ///
 /// `?` opens the keyboard-shortcuts help overlay whenever focus is not in the
@@ -288,8 +289,9 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
             }
 
             if in_nav_mode {
-                // Navigation Mode. Ctrl/Cmd+K (handled above) is the only way
-                // back to edit mode — no key here changes the mode.
+                // Navigation Mode. Ctrl/Cmd+K (handled above) toggles back to
+                // edit mode from anywhere; Enter (below) also returns to edit
+                // mode once you've landed on a pane.
                 match e.key().as_str() {
                     "ArrowUp" | "ArrowLeft" | "k" | "h" => {
                         e.prevent_default();
@@ -340,6 +342,16 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                         // (like the other nav keys), matching vim's "go to end".
                         e.prevent_default();
                         on_jump_to_latest.emit(());
+                    }
+                    "Enter" => {
+                        // Enter accepts the current pane and drops back to edit
+                        // mode, refocusing the composer — a lighter-weight exit
+                        // than Ctrl/Cmd+K once you've navigated to the pane you
+                        // want. (The composer is inert in nav mode, so this Enter
+                        // never submits a message.)
+                        e.prevent_default();
+                        nav_mode.set(false);
+                        focus_active_message_input();
                     }
                     key => {
                         // Number keys 1-9 select the Nth session *as shown in the

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -750,7 +750,7 @@ pub fn dashboard_page() -> Html {
                                             <span>{ "1-9 = select" }</span>
                                             <span>{ "w = next waiting" }</span>
                                             <span>{ "n = new" }</span>
-                                            <span>{ "Enter/Esc = edit mode" }</span>
+                                            <span>{ "Enter or Ctrl/Cmd+K = edit mode" }</span>
                                             <span>{ "? = shortcuts" }</span>
                                         </>
                                     }


### PR DESCRIPTION
## What

Add `Enter` as a way to leave Nav mode. Previously `Ctrl`/`Cmd`+`K` was the only exit; once you've navigated to the pane you want, `Enter` is the natural "accept and get back to typing" gesture. It drops back to edit mode and refocuses the composer.

Also updates the shortcuts overlay and the on-screen hint bar. The nav hint's stale `Enter/Esc = edit mode` becomes `Enter or Ctrl/Cmd+K = edit mode`, since `Esc` no longer changes modes (as of the Ctrl/Cmd+K rework in #1377).

This works because the composer is inert in Nav mode (landed in #1391), so the `Enter` keypress bubbles to the nav handler instead of submitting a message.

_(Follow-up to #1391; originally stacked on that branch, now rebased directly onto `main`.)_

## Out of scope (flagging)

The **edit-mode** hint still reads `Esc = nav mode`, which is also stale post-#1377 (`Ctrl`/`Cmd`+`K` enters Nav mode now). Left untouched to keep this PR focused.