### PR TITLE
Document durable long-running shell tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "a2",
  "anyhow",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5189,7 +5189,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.0"
+version = "2.13.1"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/claude-session-lib/portal_reminder.md
+++ b/claude-session-lib/portal_reminder.md
@@ -11,3 +11,4 @@ You're running inside the Agent Portal — a web frontend that renders your outp
 - **Session context**: the user sees your working directory, git branch, and PR URL (if one exists) in the session pill next to your output. You don't need to repeat that context unless you're changing it.
 - **Mobile and desktop**: the portal runs on both. Prefer concise answers and avoid extremely wide tables; long horizontal layouts force a horizontal scroll on phones.
 - **Sharing and cron**: the user can share this session read-only with others, and can schedule a prompt to re-run on a cron. Output you produce here may be observed by other users or replayed in a future scheduled run.
+- **Long-running shell tasks**: for processes that must survive portal/service restarts, prefer `systemd-run --user --unit NAME ...` over `nohup ... &`, `disown`, or `setsid`; those shell patterns may still leave the process in the portal session's cgroup.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -158,11 +158,38 @@ claude-portal --session-name "project-b"
 
 ### Long-Running Tasks
 
-For long-running tasks:
+Agent Portal sessions keep running when you close the browser. For ordinary
+commands:
+
 1. Start the task in your session
 2. Close your browser - the session continues running
 3. Check back later from any device
 4. All history is preserved
+
+Processes that must survive a portal restart need a stronger handoff. Shell
+patterns such as `cmd &`, `disown`, `nohup`, or `setsid` detach from the shell,
+but they usually stay in the same systemd control group as the portal session.
+When the service restarts, systemd can still kill every process in that cgroup.
+
+Use `systemd-run --user` to launch the work under the user manager instead:
+
+```bash
+# One-time setup per user, persistent across reboots.
+sudo loginctl enable-linger "$USER"
+
+# Launch the task in its own user service.
+systemd-run --user --unit my-long-task --description "Agent Portal task" \
+  /path/to/command --flag value
+```
+
+The task then lives in the user manager's cgroup, not the individual portal
+session's cgroup. It keeps running across browser closes, session exits, and
+portal service restarts. Logs go to journald by default:
+
+```bash
+journalctl --user -u my-long-task -f
+systemctl --user stop my-long-task
+```
 
 ### Working Directory
 


### PR DESCRIPTION
## Summary

Fixes #844.

- document why nohup/disown/setsid are not enough to survive portal service restarts under systemd cgroups
- add a systemd-run --user recipe with linger setup, journald log viewing, and stop command
- add a concise reminder to the bundled portal reminder
- bump workspace package version to 2.13.1

## Validation

- cargo check -p shared
- git diff --check