### PR TITLE
Stabilize launch directory browser width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "a2",
  "anyhow",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5189,7 +5189,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "anyhow",
  "colored",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.1"
+version = "2.13.2"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -134,7 +134,7 @@ fn dir_entry(is_dir: bool, name: &str, onclick: Option<Callback<MouseEvent>>) ->
     html! {
         <div {class} {onclick}>
             <span class="dir-entry-icon">{ icon }</span>
-            <span class="dir-entry-name">{ name }</span>
+            <span class="dir-entry-name" title={name.to_string()}>{ name }</span>
         </div>
     }
 }

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -352,6 +352,7 @@
     border-radius: 8px;
     box-sizing: border-box;
     padding: 2rem;
+    inline-size: min(540px, calc(100vw - 4rem));
     max-width: 540px;
     max-height: calc(100vh - 4rem);
     overflow-y: auto;
@@ -402,6 +403,7 @@
 
 .launch-field {
     margin-bottom: 1rem;
+    min-width: 0;
 }
 
 .launch-field label {
@@ -557,8 +559,11 @@
     border: 1px solid var(--border);
     border-radius: 6px;
     background: var(--bg-dark);
+    box-sizing: border-box;
+    width: 100%;
     max-height: 240px;
     overflow-y: auto;
+    overflow-x: hidden;
 }
 
 @supports (height: 100dvh) {
@@ -575,6 +580,9 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    box-sizing: border-box;
+    width: 100%;
+    min-width: 0;
     padding: 0.4rem 0.75rem;
     cursor: default;
     font-size: 0.9rem;
@@ -599,6 +607,8 @@
 }
 
 .dir-entry-name {
+    flex: 1 1 auto;
+    min-width: 0;
     color: var(--text-primary);
     font-family: 'Courier New', Consolas, monospace;
     font-size: 0.85rem;

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -489,6 +489,7 @@
     .launch-dialog {
         max-width: 100%;
         width: 95%;
+        inline-size: min(95vw, calc(100vw - 1rem));
         padding: 1.25rem;
         max-height: 85dvh;
         overflow-y: auto;


### PR DESCRIPTION
## Summary

Fixes #1389.

- give the launch dialog and directory browser explicit stable widths
- prevent directory rows and names from contributing intrinsic width during flex layout
- keep long directory entries truncated with ellipsis and expose the full name via title
- bump workspace package version to 2.13.2

## Validation

- cargo check -p frontend --target wasm32-unknown-unknown
- cargo check -p shared
- git diff --check