### PR TITLE
Prioritize session names in rail cards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "a2",
  "anyhow",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5189,7 +5189,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "anyhow",
  "colored",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.2"
+version = "2.13.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.2"
+version = "2.13.3"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -109,45 +109,6 @@ mod tests {
     }
 }
 
-/// Semver staleness level for a proxy client relative to the server.
-enum VersionStaleness {
-    /// Same version or no version info available
-    Current,
-    /// Patch version behind (e.g. 1.3.38 vs 1.3.39)
-    PatchBehind,
-    /// Minor version behind (e.g. 1.2.0 vs 1.3.0)
-    MinorBehind,
-    /// Major version behind (e.g. 0.9.0 vs 1.0.0)
-    MajorBehind,
-}
-
-/// Compare a client version against the server version.
-/// Returns the staleness level.
-fn version_staleness(client: &str, server: &str) -> VersionStaleness {
-    let parse = |s: &str| -> Option<(u64, u64, u64)> {
-        let mut parts = s.split('.');
-        let major = parts.next()?.parse().ok()?;
-        let minor = parts.next()?.parse().ok()?;
-        let patch = parts.next()?.parse().ok()?;
-        Some((major, minor, patch))
-    };
-    let Some((cm, cmi, cp)) = parse(client) else {
-        return VersionStaleness::Current;
-    };
-    let Some((sm, smi, sp)) = parse(server) else {
-        return VersionStaleness::Current;
-    };
-    if cm < sm {
-        VersionStaleness::MajorBehind
-    } else if cmi < smi {
-        VersionStaleness::MinorBehind
-    } else if cp < sp {
-        VersionStaleness::PatchBehind
-    } else {
-        VersionStaleness::Current
-    }
-}
-
 fn sorted_prs(prs: &[PrRef]) -> Vec<PrRef> {
     let mut prs = prs.to_vec();
     prs.sort_by_key(|p| p.number);

--- a/frontend/src/pages/dashboard/session_rail/pill.rs
+++ b/frontend/src/pages/dashboard/session_rail/pill.rs
@@ -1,17 +1,11 @@
+use crate::utils::extract_folder;
 use shared::SessionInfo;
 use uuid::Uuid;
 use web_sys::MouseEvent;
 use yew::prelude::*;
 
+use super::sorted_prs;
 use super::sparkline::{render_activity_sparkline, ActivityRef};
-use super::{sorted_prs, version_staleness, VersionStaleness};
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct VersionBadgeView {
-    class: &'static str,
-    tooltip: String,
-    label: String,
-}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum VcsView {
@@ -27,8 +21,9 @@ struct PillViewModel {
     connection_class: &'static str,
     connection_symbol: &'static str,
     number_annotation: Option<String>,
-    folder: String,
-    version_badge: Option<VersionBadgeView>,
+    session_name: String,
+    repo_label: String,
+    repo_title: String,
     vcs: VcsView,
     agent_badge: Option<(&'static str, &'static str)>,
     hidden_badge: bool,
@@ -90,11 +85,12 @@ pub(super) fn session_pill(props: &SessionPillProps) -> Html {
             <span class={view.connection_class}>
                 { view.connection_symbol }
             </span>
-            <span class="pill-name" title={session.working_directory.clone()}>
-                <span class="pill-folder">{ view.folder }</span>
-                <span class="pill-hostname-row">
-                    <span class="pill-hostname">{ &session.hostname }</span>
-                    { render_version_badge(view.version_badge.as_ref()) }
+            <span class="pill-name" title={view.repo_title.clone()}>
+                <span class="pill-session-name" title={session.session_name.clone()}>
+                    { view.session_name }
+                </span>
+                <span class="pill-repo" title={view.repo_title.clone()}>
+                    { view.repo_label }
                 </span>
                 { render_vcs(&view.vcs) }
             </span>
@@ -160,11 +156,7 @@ impl PillViewModel {
             None
         };
 
-        let version_badge = session
-            .client_version
-            .as_ref()
-            .filter(|_| !props.server_version.is_empty())
-            .map(|client_version| version_badge_view(client_version, &props.server_version));
+        let (repo_label, repo_title) = repo_context(session);
 
         let vcs = {
             let prs = sorted_prs(&session.open_prs);
@@ -205,10 +197,9 @@ impl PillViewModel {
             },
             connection_symbol: if props.is_connected { "●" } else { "○" },
             number_annotation,
-            // Primary pill label: the human-chosen session name (defaults to
-            // the working directory's basename when none was supplied).
-            folder: session.session_name.clone(),
-            version_badge,
+            session_name: session.session_name.clone(),
+            repo_label,
+            repo_title,
             vcs,
             agent_badge,
             hidden_badge: props.is_hidden,
@@ -217,17 +208,16 @@ impl PillViewModel {
     }
 }
 
-fn render_version_badge(version_badge: Option<&VersionBadgeView>) -> Html {
-    if let Some(badge) = version_badge {
-        html! {
-            <span class={classes!("pill-version-badge", badge.class)}
-                title={badge.tooltip.clone()}>
-                { &badge.label }
-            </span>
+fn repo_context(session: &SessionInfo) -> (String, String) {
+    if let Some(repo_url) = session.repo_url.as_deref() {
+        let label = repo_label_from_url(repo_url);
+        if !label.is_empty() {
+            return (label, repo_url.to_string());
         }
-    } else {
-        html! {}
     }
+
+    let fallback = extract_folder(&session.working_directory);
+    (fallback.to_string(), session.working_directory.clone())
 }
 
 fn render_vcs(vcs: &VcsView) -> Html {
@@ -248,27 +238,31 @@ fn render_vcs(vcs: &VcsView) -> Html {
     }
 }
 
-fn version_badge_view(client_version: &str, server_version: &str) -> VersionBadgeView {
-    let staleness = version_staleness(client_version, server_version);
-    let (class, tooltip) = match staleness {
-        VersionStaleness::Current => ("version-current", format!("v{client_version} — up to date")),
-        VersionStaleness::PatchBehind => (
-            "version-patch",
-            format!("v{client_version} → v{server_version} (patch update available)"),
-        ),
-        VersionStaleness::MinorBehind => (
-            "version-minor",
-            format!("v{client_version} → v{server_version} (minor update available)"),
-        ),
-        VersionStaleness::MajorBehind => (
-            "version-major",
-            format!("v{client_version} → v{server_version} (major update available)"),
-        ),
+fn repo_label_from_url(repo_url: &str) -> String {
+    let trimmed = repo_url
+        .trim()
+        .split(['?', '#'])
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .trim_end_matches('/');
+
+    let path = if let Some((_, path)) = trimmed.split_once("://") {
+        path.split_once('/').map(|(_, path)| path).unwrap_or(path)
+    } else if let Some((_, path)) = trimmed.split_once(':') {
+        path
+    } else {
+        trimmed
     };
-    VersionBadgeView {
-        class,
-        tooltip,
-        label: format!("v{client_version}"),
+
+    let parts = path
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    match parts.as_slice() {
+        [.., owner, repo] => format!("{owner}/{repo}"),
+        _ => path.to_string(),
     }
 }
 
@@ -277,12 +271,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_badge_view_reports_patch_update() {
-        let view = version_badge_view("2.12.70", "2.12.73");
+    fn repo_label_from_url_uses_owner_and_repo() {
+        assert_eq!(
+            repo_label_from_url("https://github.com/meawoppl/agent-portal.git"),
+            "meawoppl/agent-portal"
+        );
+        assert_eq!(
+            repo_label_from_url("git@github.com:meawoppl/agent-portal.git"),
+            "meawoppl/agent-portal"
+        );
+    }
 
-        assert_eq!(view.class, "version-patch");
-        assert_eq!(view.label, "v2.12.70");
-        assert!(view.tooltip.contains("patch update available"));
+    #[test]
+    fn repo_label_from_url_strips_query_and_fragment() {
+        assert_eq!(
+            repo_label_from_url("https://github.com/meawoppl/agent-portal.git?tab=readme#main"),
+            "meawoppl/agent-portal"
+        );
     }
 
     #[test]

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -69,11 +69,11 @@
         max-width: 120px;
     }
 
-    .pill-folder {
+    .pill-session-name {
         font-size: 0.8rem;
     }
 
-    .pill-hostname {
+    .pill-repo {
         font-size: 0.65rem;
     }
 
@@ -106,10 +106,6 @@
 
     .pill-hidden-badge {
         font-size: 0.6rem;
-    }
-
-    .pill-version-badge {
-        font-size: 0.55rem;
     }
 
     .pill-menu-toggle {
@@ -558,7 +554,7 @@
         max-width: 90px;
     }
 
-    .pill-folder {
+    .pill-session-name {
         font-size: 0.75rem;
     }
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -226,33 +226,24 @@
     z-index: 1;
 }
 
-.pill-folder {
+.pill-session-name {
     font-size: 0.85rem;
     color: var(--text-primary);
     font-weight: 500;
-    white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-height: 1.18;
+    overflow-wrap: anywhere;
 }
 
-.pill-hostname-row {
-    display: flex;
-    align-items: baseline;
-    gap: 0.3rem;
-    overflow: hidden;
-}
-
-.pill-hostname {
+.pill-repo {
     font-size: 0.7rem;
     color: var(--text-secondary);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-}
-
-.pill-hostname-row .pill-version-badge {
-    font-size: 0.55rem;
-    flex-shrink: 0;
 }
 
 .pill-branch {
@@ -262,7 +253,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 150px;
+    max-width: 100%;
     direction: rtl;
     text-align: left;
 }
@@ -371,8 +362,8 @@
     box-shadow: 0 0 0 2px rgba(127, 132, 156, 0.3);
 }
 
-.session-pill.status-disconnected .pill-folder,
-.session-pill.status-disconnected .pill-hostname,
+.session-pill.status-disconnected .pill-session-name,
+.session-pill.status-disconnected .pill-repo,
 .session-pill.status-disconnected .pill-name {
     color: var(--text-secondary);
 }
@@ -433,36 +424,6 @@
 .pill-agent-badge.paused {
     color: #e0af68;
     background: rgba(224, 175, 104, 0.15);
-}
-
-/* Version staleness badge */
-.pill-version-badge {
-    font-size: 0.6rem;
-    font-weight: 600;
-    padding: 0 0.3rem;
-    border-radius: 3px;
-    flex-shrink: 0;
-}
-
-.pill-version-badge.version-current {
-    color: var(--text-secondary);
-    background: transparent;
-    opacity: 0.5;
-}
-
-.pill-version-badge.version-patch {
-    color: #e0af68;
-    background: rgba(224, 175, 104, 0.15);
-}
-
-.pill-version-badge.version-minor {
-    color: #ff9e64;
-    background: rgba(255, 158, 100, 0.15);
-}
-
-.pill-version-badge.version-major {
-    color: #f7768e;
-    background: rgba(247, 118, 142, 0.15);
 }
 
 /* Token expiry warning badge */


### PR DESCRIPTION
## Summary
- lead session rail cards with the custom session name and allow it to wrap before truncating
- replace hostname/version card metadata with repo context from repo_url, falling back to the working directory basename
- keep branch/PR indicators and remove the now-dead version staleness card helper

Fixes #1370

## Validation
- cargo check -p frontend --target wasm32-unknown-unknown
- cargo check -p shared
- cargo test -p frontend repo_label_from_url
- cargo fmt --check
- git diff --check