### PR TITLE
Add restart-only button for launchers

### DIFF
--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -370,6 +370,53 @@ pub async fn update_launcher(
     Ok(EmptyResponse::OK)
 }
 
+/// POST /api/launchers/:launcher_id/restart - Tell the launcher to restart its
+/// process *without* updating the binary. Gated on
+/// `LAUNCHER_CAPABILITY_RESTART`: launchers too old to decode
+/// `ServerToLauncher::Restart` get a clear 400 instead of a silently-dropped
+/// frame.
+pub async fn restart_launcher(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+    Path(launcher_id): Path<Uuid>,
+) -> Result<EmptyResponse, AppError> {
+    {
+        let launcher = app_state
+            .session_manager
+            .launchers
+            .get(&launcher_id)
+            .ok_or(AppError::NotFound("Launcher not found"))?;
+        if launcher.user_id != user_id {
+            return Err(AppError::Forbidden);
+        }
+    }
+
+    if !app_state
+        .session_manager
+        .launcher_supports_capability(launcher_id, shared::LAUNCHER_CAPABILITY_RESTART)
+    {
+        return Err(AppError::BadRequest(
+            "Launcher too old — update it first, then restart becomes available.",
+        ));
+    }
+
+    // Route through the evicting sender (not a cloned raw sender) so a dead
+    // channel tears the stale connection down instead of lingering.
+    if !app_state
+        .session_manager
+        .send_to_launcher(&launcher_id, ServerToLauncher::Restart)
+    {
+        warn!(
+            "Launcher {} disconnected while sending restart",
+            launcher_id
+        );
+        return Err(AppError::Internal("Launcher disconnected".to_string()));
+    }
+
+    info!("Sent Restart to launcher {}", launcher_id);
+    Ok(EmptyResponse::OK)
+}
+
 /// GET /api/launchers/:launcher_id/probe-agents - Ask the launcher to (re-)scan
 /// its agent CLIs (`claude`, `codex`) and return install state. The frontend
 /// calls this when the launch dialog opens.

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -316,6 +316,10 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             post(handlers::launchers::update_launcher),
         )
         .route(
+            "/api/launchers/{launcher_id}/restart",
+            post(handlers::launchers::restart_launcher),
+        )
+        .route(
             "/api/launchers/{launcher_id}/probe-agents",
             get(handlers::launchers::probe_agents),
         )

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -14,19 +14,35 @@ const UPDATE_TIMEOUT_MS: f64 = 120_000.0;
 /// and the row returns to its resting state.
 const SUCCESS_AUTOCLEAR_MS: f64 = 6_000.0;
 
-/// Per-launcher update lifecycle, driven entirely by live `LaunchersChanged`
-/// pushes (the panel refetches `/api/launchers` on every tick) plus a 1s clock
-/// for elapsed-time display and timeouts.
+/// Which lifecycle a tracked launcher row is in. The two share the same phase
+/// machine, timeout, and phantom-row behavior; they differ only in how a
+/// reappearance on the *same* version is classified:
 ///
-/// State machine (keyed by launcher id, one instance per updating launcher):
+/// - `Update`: same version back = the update likely failed → amber warning.
+/// - `Restart`: same version back = expected (no binary change) → success.
+#[derive(Clone, Copy, PartialEq)]
+enum LifecycleMode {
+    /// "Update & Restart" — pull the latest release, then restart.
+    Update,
+    /// "Restart" — restart the process without touching the binary.
+    Restart,
+}
+
+/// Per-launcher update/restart lifecycle, driven entirely by live
+/// `LaunchersChanged` pushes (the panel refetches `/api/launchers` on every
+/// tick) plus a 1s clock for elapsed-time display and timeouts.
+///
+/// State machine (keyed by launcher id, one instance per in-flight launcher):
 ///
 /// ```text
 ///  click ─▶ Requested ──(drops off list)──▶ Restarting ──(reappears, new ver)──▶ Succeeded ──(6s)──▶ cleared
-///              │                                 │        └(reappears, same ver)─▶ SameVersion
+///              │                                 │        └(reappears, same ver)─▶ SameVersion*
 ///              │(reappears w/ new ver, never     │(120s elapsed)──────────────────▶ TimedOut
-///              │ observed the drop)              │
-///              └────────────▶ Succeeded          └ TimedOut ──(late reconnect)──▶ Succeeded / SameVersion
+///              │ observed the drop; Update only) │
+///              └────────────▶ Succeeded          └ TimedOut ──(late reconnect)──▶ Succeeded / SameVersion*
 /// ```
+/// *`SameVersion` is reachable only in `Update` mode; a `Restart` that comes
+/// back on the same version is `Succeeded`.
 #[derive(Clone, PartialEq)]
 enum UpdatePhase {
     /// POST accepted; the launcher is still in the connected list. Waiting for
@@ -54,6 +70,8 @@ struct UpdateEntry {
     /// The version the launcher reported *before* the update — the baseline the
     /// reconnect is compared against.
     prev_version: String,
+    /// Whether this row is tracking an update-and-restart or a bare restart.
+    mode: LifecycleMode,
     phase: UpdatePhase,
 }
 
@@ -74,24 +92,36 @@ fn version_at_least(current: &str, target: &str) -> bool {
     }
 }
 
-/// Did the launcher come back on a "good" version? Success when the version
-/// changed at all from the pre-update baseline, or when it already sits at/above
-/// the backend's published target (covers a launcher that was already current).
-fn is_successful_return(prev: &str, current: &str, server_version: Option<&str>) -> bool {
-    if current != prev {
-        return true;
+/// Did the launcher come back on a "good" version?
+///
+/// - `Restart` mode: any reappearance is success — the binary is unchanged, so
+///   the version is *expected* to match the baseline.
+/// - `Update` mode: success when the version changed from the pre-update
+///   baseline, or when it already sits at/above the backend's published target
+///   (covers a launcher that was already current).
+fn is_successful_return(
+    mode: LifecycleMode,
+    prev: &str,
+    current: &str,
+    server_version: Option<&str>,
+) -> bool {
+    match mode {
+        LifecycleMode::Restart => true,
+        LifecycleMode::Update => {
+            current != prev || server_version.is_some_and(|s| version_at_least(current, s))
+        }
     }
-    server_version.is_some_and(|s| version_at_least(current, s))
 }
 
-/// Classify a launcher that is present again after (or during) an update.
+/// Classify a launcher that is present again after (or during) a lifecycle.
 fn classify_return(
+    mode: LifecycleMode,
     prev: &str,
     current: &str,
     server_version: Option<&str>,
     now_ms: f64,
 ) -> UpdatePhase {
-    if is_successful_return(prev, current, server_version) {
+    if is_successful_return(mode, prev, current, server_version) {
         UpdatePhase::Succeeded {
             new_version: current.to_string(),
             since_ms: now_ms,
@@ -121,12 +151,18 @@ fn reconcile(
         let present_version = present.get(&id);
 
         let next: Option<UpdatePhase> = match (&entry.phase, present_version) {
-            // Still visible after the request. Catch a restart so fast we never
-            // saw the gap; otherwise keep waiting, but time out an update that
-            // never even takes the launcher down.
+            // Still visible after the request. In Update mode, catch a restart
+            // so fast we never saw the gap (detectable only by a version bump).
+            // In Restart mode the version never changes, so a still-present row
+            // is indistinguishable from "not restarted yet" — we can't fast-path
+            // it and just wait for the drop (or the timeout). Either way, time
+            // out a lifecycle that never even takes the launcher down.
             (UpdatePhase::Requested { since_ms }, Some(v)) => {
-                if is_successful_return(&entry.prev_version, v, server_version) {
+                if entry.mode == LifecycleMode::Update
+                    && is_successful_return(entry.mode, &entry.prev_version, v, server_version)
+                {
                     Some(classify_return(
+                        entry.mode,
                         &entry.prev_version,
                         v,
                         server_version,
@@ -142,8 +178,9 @@ fn reconcile(
             (UpdatePhase::Requested { .. }, None) => {
                 Some(UpdatePhase::Restarting { since_ms: now_ms })
             }
-            // Back after a restart → compare versions.
+            // Back after a restart → classify per mode.
             (UpdatePhase::Restarting { .. }, Some(v)) => Some(classify_return(
+                entry.mode,
                 &entry.prev_version,
                 v,
                 server_version,
@@ -168,6 +205,7 @@ fn reconcile(
             // A timed-out launcher that finally reconnects resolves normally —
             // a reappearing launcher must never stay wedged.
             (UpdatePhase::TimedOut, Some(v)) => Some(classify_return(
+                entry.mode,
                 &entry.prev_version,
                 v,
                 server_version,
@@ -194,73 +232,134 @@ fn elapsed_secs(now_ms: f64, since_ms: f64) -> u64 {
 struct LauncherRowProps {
     launcher: LauncherInfo,
     on_update: Callback<Uuid>,
-    /// The launcher's current update lifecycle phase, if any is in flight.
+    on_restart: Callback<Uuid>,
+    /// Whether the launcher advertises `LAUNCHER_CAPABILITY_RESTART`. When
+    /// false the Restart button is disabled with an "update first" tooltip.
+    restart_supported: bool,
+    /// The launcher's current lifecycle phase, if any is in flight.
     phase: Option<UpdatePhase>,
+    /// Which lifecycle the in-flight phase belongs to (drives the status text).
+    mode: Option<LifecycleMode>,
 }
 
 #[function_component(LauncherRow)]
 fn launcher_row(props: &LauncherRowProps) -> Html {
     let l = &props.launcher;
     let on_update = props.on_update.clone();
+    let on_restart = props.on_restart.clone();
     let launcher_id = l.launcher_id;
 
-    // A restart in progress (Requested/Restarting) locks the button.
+    // A lifecycle in progress (Requested/Restarting) locks BOTH buttons.
     let in_progress = matches!(
         props.phase,
         Some(UpdatePhase::Requested { .. }) | Some(UpdatePhase::Restarting { .. })
     );
 
     // Inline two-step confirm instead of a browser `confirm()` popup, which
-    // doesn't render well on mobile. Keep the action slots stable so the
-    // primary click target doesn't move between the armed/unarmed states.
-    let confirming = use_state(|| false);
+    // doesn't render well on mobile. A single armed slot tracks which action is
+    // primed so only one confirm can be live at a time and the shared Cancel
+    // slot stays stable.
+    let armed = use_state(|| None::<LifecycleMode>);
 
-    let arm = {
-        let confirming = confirming.clone();
-        Callback::from(move |_| confirming.set(true))
+    let arm_update = {
+        let armed = armed.clone();
+        Callback::from(move |_| armed.set(Some(LifecycleMode::Update)))
+    };
+    let arm_restart = {
+        let armed = armed.clone();
+        Callback::from(move |_| armed.set(Some(LifecycleMode::Restart)))
     };
     let cancel = {
-        let confirming = confirming.clone();
-        Callback::from(move |_| confirming.set(false))
+        let armed = armed.clone();
+        Callback::from(move |_| armed.set(None))
     };
-    let confirm = {
+    let confirm_update = {
         let on_update = on_update.clone();
-        let confirming = confirming.clone();
+        let armed = armed.clone();
         Callback::from(move |_| {
-            confirming.set(false);
+            armed.set(None);
             on_update.emit(launcher_id);
         })
     };
+    let confirm_restart = {
+        let on_restart = on_restart.clone();
+        let armed = armed.clone();
+        Callback::from(move |_| {
+            armed.set(None);
+            on_restart.emit(launcher_id);
+        })
+    };
 
-    let primary_label = if in_progress {
-        "Restarting..."
-    } else if *confirming {
-        "Confirm Restart"
+    let update_armed = *armed == Some(LifecycleMode::Update);
+    let restart_armed = *armed == Some(LifecycleMode::Restart);
+    let any_armed = armed.is_some();
+
+    // Update & Restart button.
+    let update_label = if in_progress {
+        "Working..."
+    } else if update_armed {
+        "Confirm Update"
     } else {
         "Update & Restart"
     };
-    let primary_title = if *confirming {
-        "Confirm launcher update and restart"
-    } else {
-        "Pull the latest agent-portal release and restart this launcher"
-    };
-    let primary_class = classes!(
+    let update_class = classes!(
         "update-button",
         "launcher-update-primary",
         if in_progress {
             "stage-3"
-        } else if *confirming {
+        } else if update_armed {
             "confirming"
         } else {
             "stage-0"
         }
     );
-    let primary_onclick = if *confirming { confirm } else { arm };
+    // Can't arm both at once: disable update while restart is armed.
+    let update_disabled = in_progress || restart_armed;
+    let update_onclick = if update_armed {
+        confirm_update
+    } else {
+        arm_update
+    };
+
+    // Restart button. Disabled (with a tooltip) when the launcher is too old to
+    // understand the Restart frame — update it first.
+    let restart_label = if restart_armed {
+        "Confirm Restart"
+    } else {
+        "Restart"
+    };
+    let restart_title = if !props.restart_supported {
+        "launcher too old; update first"
+    } else if restart_armed {
+        "Confirm launcher restart"
+    } else {
+        "Restart this launcher without updating the binary"
+    };
+    let restart_class = classes!(
+        "update-button",
+        "launcher-restart-button",
+        if restart_armed {
+            "confirming"
+        } else {
+            "stage-0"
+        }
+    );
+    let restart_disabled = in_progress || update_armed || !props.restart_supported;
+    let restart_onclick = if restart_armed {
+        confirm_restart
+    } else {
+        arm_restart
+    };
+
     let cancel_class = classes!(
         "cancel-button",
         "launcher-update-secondary",
-        (!*confirming || in_progress).then_some("is-placeholder")
+        (!any_armed || in_progress).then_some("is-placeholder")
     );
+
+    // Whether the in-flight lifecycle is a bare restart — drives the wording of
+    // the transient "requested…" line (Succeeded/SameVersion wording is shared).
+    let is_restart_mode = props.mode == Some(LifecycleMode::Restart);
 
     // Optional status line beneath the row for terminal/transient phases that
     // apply to a launcher that IS present (came back online, or same version).
@@ -281,14 +380,21 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
                 </td>
             </tr>
         }),
-        Some(UpdatePhase::Requested { .. }) => Some(html! {
-            <tr class="launcher-update-status">
-                <td colspan="5" class="launcher-status launcher-status--waiting">
-                    <span class="spinner-small"></span>
-                    { "Update requested — waiting for the launcher to restart…" }
-                </td>
-            </tr>
-        }),
+        Some(UpdatePhase::Requested { .. }) => {
+            let msg = if is_restart_mode {
+                "Restart requested — waiting for the launcher to restart…"
+            } else {
+                "Update requested — waiting for the launcher to restart…"
+            };
+            Some(html! {
+                <tr class="launcher-update-status">
+                    <td colspan="5" class="launcher-status launcher-status--waiting">
+                        <span class="spinner-small"></span>
+                        { msg }
+                    </td>
+                </tr>
+            })
+        }
         _ => None,
     };
 
@@ -302,19 +408,27 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
                 <td class="token-actions">
                     <div class="launcher-update-actions">
                         <button
-                            class={primary_class}
-                            onclick={primary_onclick}
-                            title={primary_title}
-                            disabled={in_progress}
+                            class={update_class}
+                            onclick={update_onclick}
+                            title={"Pull the latest agent-portal release and restart this launcher"}
+                            disabled={update_disabled}
                         >
-                            { primary_label }
+                            { update_label }
+                        </button>
+                        <button
+                            class={restart_class}
+                            onclick={restart_onclick}
+                            title={restart_title}
+                            disabled={restart_disabled}
+                        >
+                            { restart_label }
                         </button>
                         <button
                             class={cancel_class}
                             onclick={cancel}
-                            disabled={!*confirming || in_progress}
-                            aria-hidden={(!*confirming || in_progress).to_string()}
-                            tabindex={if *confirming && !in_progress { "0" } else { "-1" }}
+                            disabled={!any_armed || in_progress}
+                            aria-hidden={(!any_armed || in_progress).to_string()}
+                            tabindex={if any_armed && !in_progress { "0" } else { "-1" }}
                         >
                             { "Cancel" }
                         </button>
@@ -486,13 +600,16 @@ pub fn launchers_panel() -> Html {
         });
     }
 
-    let on_update = {
+    // Shared driver for both lifecycles: optimistically record the Requested
+    // phase (so the row locks and the phantom machinery engages), POST to the
+    // mode's endpoint, and roll the entry back if the request never started.
+    let begin_lifecycle = {
         let request_error = request_error.clone();
         let update_states = update_states.clone();
         let launchers = launchers.clone();
-        Callback::from(move |launcher_id: Uuid| {
-            // Snapshot the pre-update metadata now — we need name/host/version to
-            // render the phantom row once the launcher drops off the list.
+        move |launcher_id: Uuid, mode: LifecycleMode| {
+            // Snapshot the pre-lifecycle metadata now — we need name/host/version
+            // to render the phantom row once the launcher drops off the list.
             let meta = launchers
                 .iter()
                 .find(|l| l.launcher_id == launcher_id)
@@ -508,6 +625,7 @@ pub fn launchers_panel() -> Html {
                     launcher_name: l.launcher_name.clone(),
                     hostname: l.hostname.clone(),
                     prev_version: l.version.clone(),
+                    mode,
                     phase: UpdatePhase::Requested {
                         since_ms: js_sys::Date::now(),
                     },
@@ -516,20 +634,24 @@ pub fn launchers_panel() -> Html {
             update_states.set(states);
             request_error.set(None);
 
+            let (endpoint, verb) = match mode {
+                LifecycleMode::Update => ("update", "Update"),
+                LifecycleMode::Restart => ("restart", "Restart"),
+            };
             let request_error = request_error.clone();
             let update_states = update_states.clone();
             spawn_local(async move {
-                let url = utils::api_url(&format!("/api/launchers/{launcher_id}/update"));
+                let url = utils::api_url(&format!("/api/launchers/{launcher_id}/{endpoint}"));
                 let failure = match Request::post(&url).send().await {
                     Ok(resp) if resp.status() == 200 => None,
                     Ok(resp) => {
                         let text = resp.text().await.unwrap_or_default();
-                        Some(format!("Update failed: {} {}", resp.status(), text))
+                        Some(format!("{verb} failed: {} {}", resp.status(), text))
                     }
-                    Err(e) => Some(format!("Update request failed: {e:?}")),
+                    Err(e) => Some(format!("{verb} request failed: {e:?}")),
                 };
                 if let Some(msg) = failure {
-                    // The update never started — drop the tracked lifecycle so the
+                    // The lifecycle never started — drop the tracked entry so the
                     // row doesn't sit forever in "restarting".
                     let mut states = (*update_states).clone();
                     states.remove(&launcher_id);
@@ -537,7 +659,16 @@ pub fn launchers_panel() -> Html {
                     request_error.set(Some(msg));
                 }
             });
-        })
+        }
+    };
+
+    let on_update = {
+        let begin = begin_lifecycle.clone();
+        Callback::from(move |launcher_id: Uuid| begin(launcher_id, LifecycleMode::Update))
+    };
+    let on_restart = {
+        let begin = begin_lifecycle.clone();
+        Callback::from(move |launcher_id: Uuid| begin(launcher_id, LifecycleMode::Restart))
     };
 
     // Union of connected launchers and any tracked-but-absent (restarting)
@@ -592,15 +723,22 @@ pub fn launchers_panel() -> Html {
                         </thead>
                         <tbody>
                             { for launchers.iter().map(|l| {
-                                let phase = update_states
-                                    .get(&l.launcher_id)
-                                    .map(|e| e.phase.clone());
+                                let entry = update_states.get(&l.launcher_id);
+                                let phase = entry.map(|e| e.phase.clone());
+                                let mode = entry.map(|e| e.mode);
+                                let restart_supported = l
+                                    .capabilities
+                                    .iter()
+                                    .any(|c| c == shared::LAUNCHER_CAPABILITY_RESTART);
                                 html! {
                                     <LauncherRow
                                         key={l.launcher_id.to_string()}
                                         launcher={l.clone()}
                                         on_update={on_update.clone()}
+                                        on_restart={on_restart.clone()}
+                                        restart_supported={restart_supported}
                                         phase={phase}
+                                        mode={mode}
                                     />
                                 }
                             }) }
@@ -626,10 +764,15 @@ mod tests {
     use super::*;
 
     fn entry(prev: &str, phase: UpdatePhase) -> UpdateEntry {
+        entry_mode(LifecycleMode::Update, prev, phase)
+    }
+
+    fn entry_mode(mode: LifecycleMode, prev: &str, phase: UpdatePhase) -> UpdateEntry {
         UpdateEntry {
             launcher_name: "box".into(),
             hostname: "host".into(),
             prev_version: prev.into(),
+            mode,
             phase,
         }
     }
@@ -779,6 +922,75 @@ mod tests {
         states.insert(id, entry("2.5.1", UpdatePhase::Requested { since_ms: 0.0 }));
         // Never saw it leave; it's already back on a new version.
         let next = reconcile(states, &present(&[(id, "2.5.2")]), 500.0, Some("2.5.2"));
+        assert!(matches!(
+            next.get(&id).unwrap().phase,
+            UpdatePhase::Succeeded { .. }
+        ));
+    }
+
+    #[test]
+    fn restart_mode_same_version_return_is_success_not_warning() {
+        let id = Uuid::new_v4();
+        let mut states = HashMap::new();
+        states.insert(
+            id,
+            entry_mode(
+                LifecycleMode::Restart,
+                "2.5.1",
+                UpdatePhase::Restarting { since_ms: 0.0 },
+            ),
+        );
+        // Bare restart: same version back is expected → success, not the amber
+        // "update may have failed" warning that update-mode would show here.
+        let next = reconcile(states, &present(&[(id, "2.5.1")]), 5_000.0, Some("2.5.2"));
+        match &next.get(&id).unwrap().phase {
+            UpdatePhase::Succeeded { new_version, .. } => assert_eq!(new_version, "2.5.1"),
+            _ => panic!("restart-mode same-version return must be Succeeded"),
+        }
+    }
+
+    #[test]
+    fn restart_mode_present_same_version_keeps_waiting_no_fast_path() {
+        let id = Uuid::new_v4();
+        let mut states = HashMap::new();
+        states.insert(
+            id,
+            entry_mode(
+                LifecycleMode::Restart,
+                "2.5.1",
+                UpdatePhase::Requested { since_ms: 0.0 },
+            ),
+        );
+        // Still present on the same version (hasn't dropped yet): must NOT
+        // fast-path to Succeeded — the version can't distinguish "restarted" from
+        // "not restarted yet". Stays Requested until the drop or the timeout.
+        let next = reconcile(states, &present(&[(id, "2.5.1")]), 1_000.0, Some("2.5.2"));
+        assert!(matches!(
+            next.get(&id).unwrap().phase,
+            UpdatePhase::Requested { .. }
+        ));
+    }
+
+    #[test]
+    fn restart_mode_drops_then_returns_succeeds() {
+        let id = Uuid::new_v4();
+        let mut states = HashMap::new();
+        states.insert(
+            id,
+            entry_mode(
+                LifecycleMode::Restart,
+                "2.5.1",
+                UpdatePhase::Requested { since_ms: 0.0 },
+            ),
+        );
+        // Drops off → Restarting.
+        let next = reconcile(states, &present(&[]), 1_000.0, Some("2.5.2"));
+        assert!(matches!(
+            next.get(&id).unwrap().phase,
+            UpdatePhase::Restarting { .. }
+        ));
+        // Comes back on the same version → Succeeded.
+        let next = reconcile(next, &present(&[(id, "2.5.1")]), 2_000.0, Some("2.5.2"));
         assert!(matches!(
             next.get(&id).unwrap().phase,
             UpdatePhase::Succeeded { .. }

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -382,7 +382,7 @@
 /* Update-and-restart button */
 .launcher-update-actions {
     display: grid;
-    grid-template-columns: 11rem 5rem;
+    grid-template-columns: 11rem 7rem 5rem;
     gap: 0.5rem;
     justify-content: end;
     align-items: center;
@@ -399,10 +399,29 @@
     transition: background 0.2s;
 }
 .launcher-update-primary,
+.launcher-restart-button,
 .launcher-update-secondary {
     width: 100%;
     min-height: 2.25rem;
     white-space: nowrap;
+}
+/* Secondary "Restart" action: a subdued outline button distinct from the
+   filled primary "Update & Restart", turning red-to-confirm like the primary. */
+.launcher-restart-button.stage-0 {
+    background: transparent;
+    color: var(--text-secondary, #a9b1d6);
+    border: 1px solid #565f89;
+}
+.launcher-restart-button.stage-0:hover:not([disabled]) {
+    background: #565f89;
+    color: white;
+}
+.launcher-restart-button.confirming {
+    background: var(--error);
+    color: white;
+}
+.launcher-restart-button.confirming:hover {
+    background: #ff5a72;
 }
 .update-button.stage-0 {
     background: #7f849c;

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -96,7 +96,10 @@ pub async fn run_launcher_loop(
                     working_directory: std::env::current_dir()
                         .ok()
                         .map(|p| p.to_string_lossy().to_string()),
-                    capabilities: vec![shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string()],
+                    capabilities: vec![
+                        shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string(),
+                        shared::LAUNCHER_CAPABILITY_RESTART.to_string(),
+                    ],
                 };
                 if ws_sender.send(register).await.is_err() {
                     warn!("Failed to send registration");
@@ -414,6 +417,26 @@ fn probe_agents_for_response() -> Vec<shared::AgentInstall> {
         .collect()
 }
 
+/// Gracefully restart the launcher process. When run under a service manager
+/// (systemd/launchd), sync the unit and ask the manager to restart us (the
+/// manager sends SIGTERM and respawns per the unit's `Restart=`/`KeepAlive`
+/// settings); when unmanaged, exit(0) so an external supervisor respawns.
+/// Shared by the `UpdateAndRestart` (post-download) and `Restart` (no-download)
+/// paths so the restart mechanism lives in exactly one place.
+fn restart_service() {
+    if crate::service::is_installed() {
+        if let Err(e) = crate::service::sync() {
+            error!("Service unit sync failed: {}", e);
+        }
+        if let Err(e) = crate::service::restart() {
+            error!("Service restart failed: {}", e);
+        }
+    } else {
+        info!("Service not installed; exiting so a supervisor can respawn");
+        std::process::exit(0);
+    }
+}
+
 fn list_directory(path: &str, request_id: Uuid) -> LauncherToServer {
     // Resolve ~ to home directory (trailing slash ensures the dir itself is listed,
     // not treated as a filter prefix against its parent)
@@ -687,17 +710,16 @@ async fn handle_message(
                         error!("Update check failed: {}; restarting anyway", e);
                     }
                 }
-                if crate::service::is_installed() {
-                    if let Err(e) = crate::service::sync() {
-                        error!("Service unit sync failed: {}", e);
-                    }
-                    if let Err(e) = crate::service::restart() {
-                        error!("Service restart failed: {}", e);
-                    }
-                } else {
-                    info!("Service not installed; exiting so a supervisor can respawn");
-                    std::process::exit(0);
-                }
+                restart_service();
+            });
+        }
+        ServerToLauncher::Restart => {
+            info!("Received Restart request from dashboard (restart requested via portal)");
+            // Same graceful restart as the post-update path, minus the
+            // download/replace: the service manager (systemd/launchd) respawns
+            // the process, or — when unmanaged — we exit for a supervisor to.
+            tokio::spawn(async move {
+                restart_service();
             });
         }
         ServerToLauncher::TokenRefresh { auth_token } => {

--- a/shared/src/endpoints/launcher.rs
+++ b/shared/src/endpoints/launcher.rs
@@ -276,6 +276,12 @@ pub enum ServerToLauncher {
     /// the agent-portal service. Triggered from the dashboard Launchers panel.
     UpdateAndRestart,
 
+    /// Tell the launcher to restart the agent-portal service *without* updating
+    /// the binary — the same graceful restart as `UpdateAndRestart` minus the
+    /// download/replace. Gated behind `LAUNCHER_CAPABILITY_RESTART` so the
+    /// backend never sends this frame to a launcher too old to decode it.
+    Restart,
+
     /// Ask a live launcher to persist a freshly rotated auth token.
     ///
     /// New launchers reply with `LauncherToServer::TokenRefreshAck` after the

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -17,6 +17,10 @@ pub const VERSION: &str = env!("PORTAL_VERSION");
 /// `ServerToLauncher::LaunchSession.create_worktree`.
 pub const LAUNCHER_CAPABILITY_CREATE_WORKTREE: &str = "launch.create_worktree";
 
+/// Launcher capability advertised by versions that honor
+/// `ServerToLauncher::Restart` (restart the process without updating the binary).
+pub const LAUNCHER_CAPABILITY_RESTART: &str = "launcher.restart";
+
 /// Split [`VERSION`] into `(major, minor, patch)` numeric components.
 /// `None` on the (impossible-by-construction) malformed string.
 pub fn version_parts() -> Option<(u64, u64, u64)> {


### PR DESCRIPTION
Adds a plain **Restart** action next to **Update & Restart** in Settings → Launchers that restarts the launcher process *without* updating the binary.

## What
- **Wire protocol**: new `ServerToLauncher::Restart` variant, gated behind a new `LAUNCHER_CAPABILITY_RESTART` capability. Old launchers that can't decode the frame get a clear 400 ("launcher too old — update it first, then restart becomes available") instead of a silently-dropped message.
- **Launcher**: advertises the capability at registration and, on `Restart`, performs the same graceful service restart as the post-update path **minus** the download/replace. The restart mechanism is factored into a shared `restart_service()` helper (systemd/launchd restart when installed, else `exit(0)` for a supervisor to respawn). Logs "restart requested via portal".
- **Backend**: `POST /api/launchers/:id/restart` mirrors `update_launcher` — auth, ownership check, capability gate, minimal routes diff.
- **Frontend**: reuses the per-launcher reconcile state machine with a `LifecycleMode` split. In **restart** mode, a launcher that reappears on the **same version is success** ("Back online — vX.Y.Z"), not the amber "update may have failed" warning (that stays update-mode only). Timeout and phantom-row behavior are identical. The Restart button is disabled with an "update first" tooltip when the launcher lacks the capability. The pure `reconcile()` and its unit tests were extended for the mode split.

## Why
Sometimes you just need to bounce a launcher (pick up a config/env change, clear a wedged state) without pulling a new release.