### PR TITLE
Keyboard-navigable modals + focus the composer on new session

### DIFF
--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -109,6 +109,9 @@ pub async fn launch_session(
         agent_type: req.agent_type,
         scheduled_task_id: None,
         resume_session_id: Some(session_id),
+        // Brand-new session: the id above was just minted, so the launcher must
+        // create it under that id, not `--resume` (and rotate) it (#1405).
+        resume: Some(false),
         create_worktree: req.create_worktree,
         worktree_branch,
     };

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -316,6 +316,7 @@ pub async fn resume_session(
         resume_session_id: Some(session.id),
         // Resuming an existing session: run in its recorded working directory,
         // never create a new worktree.
+        resume: Some(true),
         create_worktree: false,
         worktree_branch: None,
     };

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -754,6 +754,8 @@ fn handle_launcher_message(
                         agent_type,
                         scheduled_task_id,
                         resume_session_id: last_session_id,
+                        // Scheduler/continuation relaunch of a prior session.
+                        resume: Some(true),
                         create_worktree: false,
                         worktree_branch: None,
                     };
@@ -1095,6 +1097,8 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
             agent_type,
             scheduled_task_id: None,
             resume_session_id: Some(session.id),
+            // Reconcile relaunch of an existing desired session: resume it.
+            resume: Some(true),
             create_worktree: false,
             worktree_branch: None,
         };

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -33,6 +33,7 @@ web-sys = { workspace = true, features = [
     "Window",
     "Document",
     "Element",
+    "NodeList",
     "DomRect",
     "HtmlElement",
     "HtmlInputElement",

--- a/frontend/src/components/confirm_modal.rs
+++ b/frontend/src/components/confirm_modal.rs
@@ -104,10 +104,10 @@ pub fn confirm_modal(props: &ConfirmModalProps) -> Html {
                     <p class="modal-warning">{ warning }</p>
                 }
                 <div class={props.style.actions_class()}>
-                    <button class={props.style.cancel_class()} onclick={props.on_cancel.clone()}>
+                    <button type="button" class={props.style.cancel_class()} onclick={props.on_cancel.clone()}>
                         { "Cancel" }
                     </button>
-                    <button class={props.style.confirm_class()} onclick={props.on_confirm.clone()}>
+                    <button type="button" class={props.style.confirm_class()} onclick={props.on_confirm.clone()}>
                         { &props.confirm_label }
                     </button>
                 </div>

--- a/frontend/src/components/confirm_modal.rs
+++ b/frontend/src/components/confirm_modal.rs
@@ -70,7 +70,7 @@ pub fn confirm_modal(props: &ConfirmModalProps) -> Html {
     // control (Cancel, rendered first — the safer default for a destructive
     // action) on open. Enter/Space activate the focused button natively.
     let container = use_node_ref();
-    let trap_keydown = use_focus_trap(container.clone());
+    use_focus_trap(container.clone());
 
     // Escape cancels. Capture-phase so it never reaches the bubble-phase
     // session-interrupt / nav-mode handlers underneath (mirrors the help
@@ -94,7 +94,6 @@ pub fn confirm_modal(props: &ConfirmModalProps) -> Html {
                 ref={container}
                 class={props.style.container_class()}
                 onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}
-                onkeydown={trap_keydown}
             >
                 if let Some(title) = &props.title {
                     <h2>{ title }</h2>

--- a/frontend/src/components/confirm_modal.rs
+++ b/frontend/src/components/confirm_modal.rs
@@ -1,3 +1,4 @@
+use crate::hooks::{use_escape_capture, use_focus_trap};
 use yew::prelude::*;
 
 /// Visual style of the confirm modal. Each variant maps to an existing CSS
@@ -65,9 +66,36 @@ pub struct ConfirmModalProps {
 
 #[function_component(ConfirmModal)]
 pub fn confirm_modal(props: &ConfirmModalProps) -> Html {
+    // Keyboard access (#1384): trap Tab within the modal and focus its first
+    // control (Cancel, rendered first — the safer default for a destructive
+    // action) on open. Enter/Space activate the focused button natively.
+    let container = use_node_ref();
+    let trap_keydown = use_focus_trap(container.clone());
+
+    // Escape cancels. Capture-phase so it never reaches the bubble-phase
+    // session-interrupt / nav-mode handlers underneath (mirrors the help
+    // overlay). `on_cancel` takes a `MouseEvent`, so synthesize a click for the
+    // keyboard path; the cancel callbacks ignore the event's contents.
+    {
+        let on_cancel = props.on_cancel.clone();
+        use_escape_capture(
+            true,
+            Callback::from(move |()| {
+                if let Ok(ev) = web_sys::MouseEvent::new("click") {
+                    on_cancel.emit(ev);
+                }
+            }),
+        );
+    }
+
     html! {
         <div class="modal-overlay" onclick={props.on_cancel.clone()}>
-            <div class={props.style.container_class()} onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+            <div
+                ref={container}
+                class={props.style.container_class()}
+                onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}
+                onkeydown={trap_keydown}
+            >
                 if let Some(title) = &props.title {
                     <h2>{ title }</h2>
                 }

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -829,6 +829,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     <ProxyTokenSetup />
                     <div class="launch-actions">
                         <button
+                            type="button"
                             class="launch-button-cancel"
                             onclick={
                                 let on_close = props.on_close.clone();
@@ -992,6 +993,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
                     <div class="launch-actions">
                         <button
+                            type="button"
                             class="launch-button-cancel"
                             onclick={
                                 let on_close = props.on_close.clone();
@@ -1001,6 +1003,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                             { "Cancel" }
                         </button>
                         <button
+                            type="button"
                             class="launch-button"
                             onclick={
                                 let launch = launch.clone();

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -661,7 +661,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     // (a no-op for Enter), so a stray Enter can't launch a half-configured
     // session. To launch you Tab to the Launch button and press Enter/Space.
     let dialog_ref = use_node_ref();
-    let trap_keydown = use_focus_trap(dialog_ref.clone());
+    use_focus_trap(dialog_ref.clone());
     use_escape_capture(true, props.on_close.clone());
 
     // Build breadcrumb segments from current path
@@ -818,7 +818,6 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                 ref={dialog_ref}
                 class="launch-dialog"
                 onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}
-                onkeydown={trap_keydown}
             >
                 <h3>{ "Launch Session" }</h3>
 

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -473,6 +473,19 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         })
     };
 
+    // Enter toggles a focused checkbox (#1384). Checkboxes natively toggle on
+    // Space only; wiring Enter to synthesize a click keeps the dialog's "Enter
+    // activates the focused control" model consistent (the change event then
+    // flows through the checkbox's own `onchange`). Space still works natively.
+    let on_checkbox_enter = Callback::from(move |e: KeyboardEvent| {
+        if e.key() == "Enter" {
+            if let Some(input) = e.target_dyn_into::<HtmlInputElement>() {
+                e.prevent_default();
+                input.click();
+            }
+        }
+    });
+
     // navigate_to: Yew's Callback<String> is Rc-backed and cheap to clone,
     // replacing the previous Rc<dyn Fn(String)>. Call sites use .emit(path).
     let navigate_to: Callback<String> = {
@@ -956,6 +969,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                                 type="checkbox"
                                 checked={*skip_permissions}
                                 onchange={on_skip_permissions.clone()}
+                                onkeydown={on_checkbox_enter.clone()}
                             />
                             { format!(" {}", skip_permissions_label(*agent_type)) }
                         </label>
@@ -969,6 +983,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                                 type="checkbox"
                                 checked={*create_worktree}
                                 onchange={on_create_worktree.clone()}
+                                onkeydown={on_checkbox_enter.clone()}
                             />
                             { " Create git worktree (requires a git repo)" }
                         </label>

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -3,7 +3,7 @@
 
 use crate::components::skip_permissions::{skip_permissions_args, skip_permissions_label};
 use crate::components::ProxyTokenSetup;
-use crate::hooks::use_escape;
+use crate::hooks::{use_escape_capture, use_focus_trap};
 use crate::utils::{self, FetchError, On401};
 use claude_codes::ClaudeModel;
 use codex_codes::CodexModel;
@@ -528,7 +528,9 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         })
     };
 
-    let on_launch = {
+    // Primary action, invoked by the Launch button and by Enter from any
+    // non-button field (#1384). `Callback<()>` so both call sites can fire it.
+    let launch: Callback<()> = {
         let dir_path = dir.path.clone();
         let home_root = dir.home_root.clone();
         let extra_args = extra_args.clone();
@@ -542,7 +544,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let error_msg = error_msg.clone();
         let on_close = props.on_close.clone();
         let on_launched = props.on_launched.clone();
-        Callback::from(move |_| {
+        Callback::from(move |_: ()| {
             let working_dir = (*dir_path).clone();
             if working_dir.is_empty() {
                 error_msg.set(Some("Working directory is required".to_string()));
@@ -650,8 +652,17 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         Callback::from(move |_| on_close.emit(()))
     };
 
-    // Close on Escape key
-    use_escape(props.on_close.clone());
+    // Keyboard access (#1384): trap Tab within the dialog and focus its first
+    // field on open. Escape closes it (capture-phase so it doesn't reach the
+    // bubble-phase nav/interrupt handlers underneath).
+    //
+    // Enter activates only the *focused* control (native button/link behavior),
+    // never a dialog-wide submit: opening focus lands on the launcher <select>
+    // (a no-op for Enter), so a stray Enter can't launch a half-configured
+    // session. To launch you Tab to the Launch button and press Enter/Space.
+    let dialog_ref = use_node_ref();
+    let trap_keydown = use_focus_trap(dialog_ref.clone());
+    use_escape_capture(true, props.on_close.clone());
 
     // Build breadcrumb segments from current path
     let path_str = (*dir.path).clone();
@@ -803,7 +814,12 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
     html! {
         <div class="launch-dialog-backdrop" onclick={on_backdrop}>
-            <div class="launch-dialog" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+            <div
+                ref={dialog_ref}
+                class="launch-dialog"
+                onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}
+                onkeydown={trap_keydown}
+            >
                 <h3>{ "Launch Session" }</h3>
 
                 { launcher_select_html }
@@ -986,7 +1002,10 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                         </button>
                         <button
                             class="launch-button"
-                            onclick={on_launch}
+                            onclick={
+                                let launch = launch.clone();
+                                Callback::from(move |_: MouseEvent| launch.emit(()))
+                            }
                             disabled={*launching}
                         >
                             { if *launching { "Launching..." } else { "Launch" } }

--- a/frontend/src/hooks/mod.rs
+++ b/frontend/src/hooks/mod.rs
@@ -4,10 +4,12 @@
 
 mod use_client_websocket;
 mod use_escape;
+mod use_focus_trap;
 mod use_keyboard_nav;
 mod use_sessions;
 
 pub use use_client_websocket::use_client_websocket;
 pub use use_escape::{escape_listener, use_escape, use_escape_capture};
+pub use use_focus_trap::use_focus_trap;
 pub use use_keyboard_nav::{use_interrupt_hotkey, use_keyboard_nav, KeyboardNavConfig};
 pub use use_sessions::use_sessions;

--- a/frontend/src/hooks/use_focus_trap.rs
+++ b/frontend/src/hooks/use_focus_trap.rs
@@ -4,6 +4,7 @@
 //! cycles Tab / Shift+Tab through only the modal's own controls so focus never
 //! escapes into the dashboard behind it.
 
+use gloo::events::{EventListener, EventListenerOptions, EventListenerPhase};
 use wasm_bindgen::JsCast;
 use web_sys::{Element, HtmlElement, Node};
 use yew::prelude::*;
@@ -26,21 +27,26 @@ fn focusable_elements(root: &Element) -> Vec<HtmlElement> {
         .collect()
 }
 
-/// Trap keyboard focus inside `container` while it is mounted.
+/// Trap keyboard focus inside `container` while it is mounted, and move focus
+/// into it on open.
 ///
 /// - On mount, focuses the first focusable descendant. Both modals that use
 ///   this render their intended initial control first (the launch dialog's
 ///   first field; the confirm modal's Cancel button), so "focus the first
 ///   focusable" satisfies the acceptance criteria without extra wiring.
 /// - Tab past the last control wraps to the first; Shift+Tab before the first
-///   wraps to the last. If focus is somehow outside the set, Tab lands on the
-///   first control and Shift+Tab on the last.
+///   wraps to the last. If focus has escaped the modal entirely (e.g. a
+///   re-render swapped out the initially-focused node), the next Tab pulls it
+///   back to the first control and Shift+Tab to the last.
 ///
-/// Returns an `onkeydown` handler to attach to the container element (pass the
-/// same [`NodeRef`]). The handler only acts on Tab, leaving Enter/Escape and
-/// typing to the component.
+/// The Tab handling is a **capture-phase document listener**, not a handler on
+/// the container: a container-scoped `onkeydown` only fires while focus is
+/// already inside it, so it can't recover focus once it has escaped to
+/// `<body>`. Capturing at the document catches Tab wherever focus currently
+/// sits. The listener lives for as long as the modal (this hook's component) is
+/// mounted.
 #[hook]
-pub fn use_focus_trap(container: NodeRef) -> Callback<KeyboardEvent> {
+pub fn use_focus_trap(container: NodeRef) {
     // Move focus into the modal once, after it mounts.
     {
         let container = container.clone();
@@ -54,36 +60,51 @@ pub fn use_focus_trap(container: NodeRef) -> Callback<KeyboardEvent> {
         });
     }
 
-    let container = container.clone();
-    Callback::from(move |e: KeyboardEvent| {
-        if e.key() != "Tab" {
-            return;
-        }
-        let Some(root) = container.cast::<Element>() else {
-            return;
+    // Trap Tab at the document (capture phase) for the modal's lifetime.
+    use_effect_with((), move |_| {
+        let options = EventListenerOptions {
+            phase: EventListenerPhase::Capture,
+            passive: false,
         };
-        let focusables = focusable_elements(&root);
-        let (Some(first), Some(last)) = (focusables.first(), focusables.last()) else {
-            return;
-        };
+        let listener = EventListener::new_with_options(
+            &gloo::utils::document(),
+            "keydown",
+            options,
+            move |event| {
+                let Some(ke) = event.dyn_ref::<web_sys::KeyboardEvent>() else {
+                    return;
+                };
+                if ke.key() != "Tab" {
+                    return;
+                }
+                let Some(root) = container.cast::<Element>() else {
+                    return;
+                };
+                let focusables = focusable_elements(&root);
+                let (Some(first), Some(last)) = (focusables.first(), focusables.last()) else {
+                    return;
+                };
 
-        let active = gloo::utils::document().active_element();
-        let active_in_container = active
-            .as_ref()
-            .map(|a| root.contains(Some(a.unchecked_ref::<Node>())))
-            .unwrap_or(false);
-        let is = |el: &HtmlElement| active.as_ref() == Some(el.unchecked_ref::<Element>());
+                let active = gloo::utils::document().active_element();
+                let active_in_modal = active
+                    .as_ref()
+                    .map(|a| root.contains(Some(a.unchecked_ref::<Node>())))
+                    .unwrap_or(false);
+                let is = |el: &HtmlElement| active.as_ref() == Some(el.unchecked_ref::<Element>());
 
-        if e.shift_key() {
-            // Shift+Tab off the first control (or focus outside the modal) → last.
-            if !active_in_container || is(first) {
-                e.prevent_default();
-                let _ = last.focus();
-            }
-        } else if !active_in_container || is(last) {
-            // Tab off the last control (or focus outside the modal) → first.
-            e.prevent_default();
-            let _ = first.focus();
-        }
-    })
+                if ke.shift_key() {
+                    // Shift+Tab off the first control (or focus outside the modal) → last.
+                    if !active_in_modal || is(first) {
+                        ke.prevent_default();
+                        let _ = last.focus();
+                    }
+                } else if !active_in_modal || is(last) {
+                    // Tab off the last control (or focus outside the modal) → first.
+                    ke.prevent_default();
+                    let _ = first.focus();
+                }
+            },
+        );
+        move || drop(listener)
+    });
 }

--- a/frontend/src/hooks/use_focus_trap.rs
+++ b/frontend/src/hooks/use_focus_trap.rs
@@ -47,16 +47,33 @@ fn focusable_elements(root: &Element) -> Vec<HtmlElement> {
 /// mounted.
 #[hook]
 pub fn use_focus_trap(container: NodeRef) {
-    // Move focus into the modal once, after it mounts.
+    // Move focus into the modal once, after it mounts, and restore it to the
+    // pre-open element when the modal closes. Without the restore, closing the
+    // modal (Cancel / Escape / backdrop) leaves focus on `<body>` — the user
+    // has to click back into the composer to type again (reported on the launch
+    // dialog cancel path, #1384).
     {
         let container = container.clone();
         use_effect_with((), move |_| {
+            let previously_focused = gloo::utils::document()
+                .active_element()
+                .and_then(|el| el.dyn_into::<HtmlElement>().ok());
             if let Some(root) = container.cast::<Element>() {
                 if let Some(first) = focusable_elements(&root).first() {
                     let _ = first.focus();
                 }
             }
-            || ()
+            move || {
+                // Only restore if that element is still in the document (it may
+                // have been removed — e.g. a confirm modal that deleted the
+                // thing its trigger lived in). Refocusing a detached node would
+                // throw / no-op, so guard on `is_connected`.
+                if let Some(el) = previously_focused {
+                    if el.is_connected() {
+                        let _ = el.focus();
+                    }
+                }
+            }
         });
     }
 

--- a/frontend/src/hooks/use_focus_trap.rs
+++ b/frontend/src/hooks/use_focus_trap.rs
@@ -1,0 +1,89 @@
+//! Focus management for modal dialogs (#1384).
+//!
+//! Keeps keyboard focus inside an open modal: moves focus into it on open and
+//! cycles Tab / Shift+Tab through only the modal's own controls so focus never
+//! escapes into the dashboard behind it.
+
+use wasm_bindgen::JsCast;
+use web_sys::{Element, HtmlElement, Node};
+use yew::prelude::*;
+
+/// CSS selector matching the natively focusable controls a modal can contain.
+/// `:not([disabled])` drops disabled inputs/buttons, and `[tabindex='-1']` is
+/// excluded so programmatically-focusable-only nodes aren't part of the cycle.
+const FOCUSABLE: &str = "a[href], button:not([disabled]), input:not([disabled]), \
+     select:not([disabled]), textarea:not([disabled]), \
+     [tabindex]:not([tabindex='-1'])";
+
+/// Collect the focusable descendants of `root` in DOM order.
+fn focusable_elements(root: &Element) -> Vec<HtmlElement> {
+    let Ok(list) = root.query_selector_all(FOCUSABLE) else {
+        return Vec::new();
+    };
+    (0..list.length())
+        .filter_map(|i| list.item(i))
+        .filter_map(|n| n.dyn_into::<HtmlElement>().ok())
+        .collect()
+}
+
+/// Trap keyboard focus inside `container` while it is mounted.
+///
+/// - On mount, focuses the first focusable descendant. Both modals that use
+///   this render their intended initial control first (the launch dialog's
+///   first field; the confirm modal's Cancel button), so "focus the first
+///   focusable" satisfies the acceptance criteria without extra wiring.
+/// - Tab past the last control wraps to the first; Shift+Tab before the first
+///   wraps to the last. If focus is somehow outside the set, Tab lands on the
+///   first control and Shift+Tab on the last.
+///
+/// Returns an `onkeydown` handler to attach to the container element (pass the
+/// same [`NodeRef`]). The handler only acts on Tab, leaving Enter/Escape and
+/// typing to the component.
+#[hook]
+pub fn use_focus_trap(container: NodeRef) -> Callback<KeyboardEvent> {
+    // Move focus into the modal once, after it mounts.
+    {
+        let container = container.clone();
+        use_effect_with((), move |_| {
+            if let Some(root) = container.cast::<Element>() {
+                if let Some(first) = focusable_elements(&root).first() {
+                    let _ = first.focus();
+                }
+            }
+            || ()
+        });
+    }
+
+    let container = container.clone();
+    Callback::from(move |e: KeyboardEvent| {
+        if e.key() != "Tab" {
+            return;
+        }
+        let Some(root) = container.cast::<Element>() else {
+            return;
+        };
+        let focusables = focusable_elements(&root);
+        let (Some(first), Some(last)) = (focusables.first(), focusables.last()) else {
+            return;
+        };
+
+        let active = gloo::utils::document().active_element();
+        let active_in_container = active
+            .as_ref()
+            .map(|a| root.contains(Some(a.unchecked_ref::<Node>())))
+            .unwrap_or(false);
+        let is = |el: &HtmlElement| active.as_ref() == Some(el.unchecked_ref::<Element>());
+
+        if e.shift_key() {
+            // Shift+Tab off the first control (or focus outside the modal) → last.
+            if !active_in_container || is(first) {
+                e.prevent_default();
+                let _ = last.focus();
+            }
+        } else if !active_in_container || is(last) {
+            // Tab off the last control (or focus outside the modal) → first.
+            e.prevent_default();
+            let _ = first.focus();
+        }
+    })
+}

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -150,6 +150,14 @@ pub struct InputBar {
     interim_transcription: Option<String>,
     voice_button_ref: NodeRef,
     was_focused: bool,
+    /// Mirror of the `ws_connected` prop from the previous render. The composer
+    /// textarea is `disabled` until the session's socket is up, and `.focus()`
+    /// on a disabled node is a no-op — so on a freshly launched session the
+    /// mount-time focus attempts (see `rendered`) fire while the textarea is
+    /// still disabled and silently do nothing. Tracking the false→true
+    /// transition lets us re-apply focus the moment the socket connects, if
+    /// this bar belongs to the focused session (#1405).
+    was_ws_connected: bool,
     /// One-shot timer that re-applies the initial focus on the next macrotask
     /// after the first render (#1373). Held so it is cancelled on unmount.
     initial_focus_timer: Option<Timeout>,
@@ -186,6 +194,7 @@ impl Component for InputBar {
             interim_transcription: None,
             voice_button_ref: NodeRef::default(),
             was_focused: ctx.props().focused,
+            was_ws_connected: ctx.props().ws_connected,
             initial_focus_timer: None,
             focus_after_render: ctx.props().focused,
             vim_enabled: load_vim_mode(),
@@ -197,7 +206,17 @@ impl Component for InputBar {
         let now_focused = ctx.props().focused;
         let became_focused = now_focused && !self.was_focused;
         self.was_focused = now_focused;
-        if became_focused {
+
+        // A just-launched session mounts with its socket still down, so the
+        // textarea is `disabled` and the mount-time focus (see `rendered`)
+        // no-ops on a disabled node. Re-apply focus when the socket comes up
+        // while this bar is the focused session's, so the composer is ready to
+        // type in without a stray click (#1405).
+        let now_connected = ctx.props().ws_connected;
+        let became_connected = now_connected && !self.was_ws_connected;
+        self.was_ws_connected = now_connected;
+
+        if became_focused || (became_connected && now_focused) {
             self.focus_after_render = true;
         }
         true

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -645,3 +645,13 @@
     border-color: var(--text-muted);
     color: var(--text-primary);
 }
+
+/* Keyboard focus rings for the launch dialog's buttons and checkboxes (#1384).
+   Inputs/selects already signal focus via their accent border above; buttons
+   and checkboxes need an explicit ring so keyboard users can see the target. */
+.launch-button:focus-visible,
+.launch-button-cancel:focus-visible,
+.launch-checkbox input[type="checkbox"]:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}

--- a/frontend/styles/keyboard.css
+++ b/frontend/styles/keyboard.css
@@ -141,6 +141,14 @@
     border-color: #ff5a72;
 }
 
+/* Keyboard focus ring for the confirm/delete modal buttons (#1384) so the
+   focused (Cancel-by-default) button is visible without the mouse. */
+.modal-cancel:focus-visible,
+.modal-confirm:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
 /* ==========================================================================
    Keyboard Shortcuts Help Overlay (press ?)
    ========================================================================== */

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -538,6 +538,13 @@
     background: #ff5a72;
 }
 
+/* Keyboard focus ring for the panel-style confirm modal buttons (#1384). */
+.cancel-button:focus-visible,
+.confirm-button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
 /* Empty State */
 .tokens-section .empty-state,
 .sessions-section .empty-state {

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -538,6 +538,7 @@ async fn handle_message(
             claude_args,
             agent_type,
             resume_session_id,
+            resume,
             create_worktree,
             worktree_branch,
             ..
@@ -569,6 +570,7 @@ async fn handle_message(
                     agent_type,
                     scheduled_task_id,
                     resume_session_id,
+                    resume,
                     // Scheduler-owned relaunches never create a worktree; the
                     // backend leaves these fields at their defaults for them.
                     create_worktree,

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -102,6 +102,12 @@ pub struct SpawnParams {
     pub agent_type: shared::AgentType,
     pub scheduled_task_id: Option<Uuid>,
     pub resume_session_id: Option<Uuid>,
+    /// Whether `resume_session_id` is an existing session to resume
+    /// (`Some(true)`) or a freshly-assigned id for a brand-new session to
+    /// create (`Some(false)`). `None` (older backend) falls back to the
+    /// historical "any id means resume" behavior. See the field of the same
+    /// name on `ServerToLauncher::LaunchSession` (#1405).
+    pub resume: Option<bool>,
     /// When true, create a git worktree from the repository containing
     /// `working_directory` and run the session inside the new worktree.
     pub create_worktree: bool,
@@ -176,8 +182,17 @@ impl ProcessManager {
             base_dir.to_string_lossy().to_string()
         };
 
+        // A supplied id is resumed only when the backend says it names an
+        // existing session. A brand-new dialog launch supplies its freshly
+        // minted id with `resume: Some(false)` so we create it under that id
+        // (`--session-id`) rather than `--resume`-ing a nonexistent transcript
+        // and rotating to a different id — the rotation changed the id the
+        // dashboard had already focused, dropping composer focus on every new
+        // session (#1405). `None` (older backend) keeps the historical
+        // "any id means resume" behavior. No id at all is always a fresh
+        // session with a random id.
         let (session_id, resume) = match params.resume_session_id {
-            Some(id) => (id, true),
+            Some(id) => (id, params.resume.unwrap_or(true)),
             None => (Uuid::new_v4(), false),
         };
 

--- a/shared/src/endpoints/launcher.rs
+++ b/shared/src/endpoints/launcher.rs
@@ -228,6 +228,17 @@ pub enum ServerToLauncher {
         /// use its local expected-session mapping for backwards compatibility.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         resume_session_id: Option<Uuid>,
+        /// Whether `resume_session_id` names an *existing* session to resume
+        /// (`Some(true)`) or a freshly-assigned id for a *brand-new* session to
+        /// create (`Some(false)`). Dialog launches set `Some(false)` so the
+        /// launcher creates the session under the assigned id (`--session-id`)
+        /// instead of trying to `--resume` a nonexistent transcript and
+        /// rotating to a different id — the rotation silently changed the id the
+        /// dashboard had already focused, dropping composer focus on every new
+        /// session (#1405). Absent (`None`, older backend) → the launcher falls
+        /// back to the historical `resume_session_id.is_some()` behavior.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        resume: Option<bool>,
         /// When true, the launcher creates a git worktree from the repository
         /// that contains `working_directory` and runs the session there.
         /// Additive/opt-in: older launchers ignore it via `#[serde(default)]`.

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -409,6 +409,7 @@ mod tests {
             agent_type: AgentType::Claude,
             scheduled_task_id: None,
             resume_session_id: None,
+            resume: None,
             create_worktree: false,
             worktree_branch: None,
         };


### PR DESCRIPTION
Handles two adjacent focus/keyboard issues in the dashboard.

## Focus the composer when a new session's socket connects (#1405)

Creating a session left the composer unfocused until you clicked it. The composer `<textarea>` is `disabled` until the session's WebSocket is up, and `.focus()` on a disabled node is a no-op — so on a freshly launched session the mount-time focus attempts (first-render + the 0 ms #1373 timer) all fire while the textarea is still disabled and do nothing. When the socket later connects and the textarea enables, nothing re-focuses it.

Fix: track the `ws_connected` prop's false→true transition in `InputBar` and re-apply focus when the socket comes up while this bar belongs to the focused session — mirroring the existing `was_focused` transition handling.

## Keyboard-navigable launch dialog and delete/leave confirmation (#1384)

Once either modal was open you were stranded inside it: no initial focus, no focus trap, no Enter/Escape handling.

- New reusable `use_focus_trap` hook: moves focus into the modal on open (first focusable control) and cycles Tab / Shift+Tab through only the modal's controls.
- **Launch dialog**: focuses the first field on open, traps Tab, submits Launch on Enter from any input/select field (buttons and breadcrumb links keep native activation), and closes on Escape via capture-phase `use_escape` (so Escape doesn't leak to the nav/interrupt handlers underneath).
- **Confirm modal**: focuses Cancel by default (safer for a destructive action), traps Tab, cancels on Escape (capture-phase). Enter/Space activate the focused button natively.
- `:focus-visible` rings on the modals' buttons and checkboxes so keyboard focus is visible.

## Verification

`cargo clippy` (wasm target) clean, `cargo fmt`, `trunk build` succeeds, and `cargo test -p frontend` passes (424 tests). The behavioral changes are in Yew view/component code exercised in the browser; not covered by unit tests.