### PR TITLE
Add model picker to the schedule dialog

### DIFF
--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -1,12 +1,11 @@
 // TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use crate::components::model_select::model_cli_args;
 use crate::components::skip_permissions::{skip_permissions_args, skip_permissions_label};
-use crate::components::ProxyTokenSetup;
+use crate::components::{ModelSelect, ProxyTokenSetup};
 use crate::hooks::use_escape;
 use crate::utils::{self, FetchError, On401};
-use claude_codes::ClaudeModel;
-use codex_codes::CodexModel;
 use gloo::timers::callback::Timeout;
 use gloo_net::http::Request;
 use shared::api::{DirectoryListingResponse, LaunchRequest, ProbeAgentsResponse};
@@ -448,11 +447,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
     let on_model_change = {
         let model_arg = model_arg.clone();
-        Callback::from(move |e: Event| {
-            if let Some(select) = e.target_dyn_into::<web_sys::HtmlSelectElement>() {
-                model_arg.set(select.value());
-            }
-        })
+        Callback::from(move |value: String| model_arg.set(value))
     };
 
     let on_skip_permissions = {
@@ -557,17 +552,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
 
             // Picker args go first so an explicit --model / -c model=… in the
             // extra-args field still wins (both CLIs take the last occurrence).
-            let mut claude_args: Vec<String> = Vec::new();
-            if !model_arg.is_empty() {
-                match *agent_type {
-                    AgentType::Claude => {
-                        claude_args.extend(["--model".to_string(), (*model_arg).clone()]);
-                    }
-                    AgentType::Codex => {
-                        claude_args.extend(["-c".to_string(), format!("model={}", *model_arg)]);
-                    }
-                }
-            }
+            let mut claude_args: Vec<String> = model_cli_args(*agent_type, &model_arg);
             claude_args.extend((*extra_args).split_whitespace().map(|s| s.to_string()));
             if *skip_permissions {
                 claude_args.extend(
@@ -698,41 +683,6 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         AgentType::Codex => "Codex",
     };
 
-    // Model catalog options for the selected agent, from the SDK crates'
-    // known-model tables. Values are the exact CLI model arguments.
-    let model_option = |value: &str, label: &str| -> Html {
-        html! {
-            <option value={value.to_string()} selected={*model_arg == value}>
-                { label }
-            </option>
-        }
-    };
-    let model_options: Html = match *agent_type {
-        AgentType::Claude => html! {
-            <>
-                <optgroup label="Aliases — track the newest model">
-                    { for ClaudeModel::known()
-                        .iter()
-                        .filter(|m| m.is_alias())
-                        .map(|m| model_option(m.cli_arg(), m.display_name())) }
-                </optgroup>
-                <optgroup label="Pinned models">
-                    { for ClaudeModel::known()
-                        .iter()
-                        .filter(|m| !m.is_alias())
-                        .map(|m| model_option(m.cli_arg(), m.display_name())) }
-                </optgroup>
-            </>
-        },
-        AgentType::Codex => html! {
-            // CodexAutoReview is hidden from Codex's own picker; mirror that.
-            { for CodexModel::known()
-                .iter()
-                .filter(|m| !matches!(m, CodexModel::CodexAutoReview))
-                .map(|m| model_option(m.cli_arg(), m.display_name())) }
-        },
-    };
-
     // Pre-compute directory listing HTML
     let dir_listing_html = if *dir.loading {
         html! { <div class="dir-loading">{ "Loading..." }</div> }
@@ -859,12 +809,11 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     // codex-codes crates; "" means the agent's own default.
                     <div class="launch-field">
                         <label>{ "Model" }</label>
-                        <select class="launcher-select" onchange={on_model_change}>
-                            <option value="" selected={model_arg.is_empty()}>
-                                { "Agent default" }
-                            </option>
-                            { model_options.clone() }
-                        </select>
+                        <ModelSelect
+                            agent_type={*agent_type}
+                            value={(*model_arg).clone()}
+                            on_change={on_model_change}
+                        />
                     </div>
 
                     // Directory browser

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -12,6 +12,7 @@ mod help_overlay;
 mod launch_dialog;
 pub(crate) mod markdown;
 pub mod message_renderer;
+mod model_select;
 mod proxy_token_setup;
 mod schedule_dialog;
 mod share_dialog;
@@ -30,6 +31,7 @@ pub use launch_dialog::LaunchDialog;
 pub use message_renderer::{
     group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroupRenderer,
 };
+pub use model_select::ModelSelect;
 pub use proxy_token_setup::ProxyTokenSetup;
 pub use schedule_dialog::ScheduleDialog;
 pub use share_dialog::ShareDialog;

--- a/frontend/src/components/model_select.rs
+++ b/frontend/src/components/model_select.rs
@@ -1,0 +1,268 @@
+//! Shared model picker fed by the SDK model catalogs, used by both the launch
+//! and schedule dialogs.
+//!
+//! The catalog options, the `agent_type` -> CLI-argument mapping, and the
+//! `extract_model_arg` routine that recognizes those args when editing an
+//! existing task all live together so they can't drift apart: `extract_model_arg`
+//! must keep recognizing exactly what `model_cli_args` emits, and it only treats
+//! a value as a model when the picker actually offers it as an option.
+
+use claude_codes::ClaudeModel;
+use codex_codes::CodexModel;
+use shared::AgentType;
+use web_sys::HtmlSelectElement;
+use yew::prelude::*;
+
+/// Build the CLI args that select `model_value` for the given agent. An empty
+/// value means "agent default" and emits no args. Mirrors the mapping used when
+/// launching a session so the two paths stay identical.
+pub fn model_cli_args(agent_type: AgentType, model_value: &str) -> Vec<String> {
+    if model_value.is_empty() {
+        return Vec::new();
+    }
+    match agent_type {
+        AgentType::Claude => vec!["--model".to_string(), model_value.to_string()],
+        AgentType::Codex => vec!["-c".to_string(), format!("model={model_value}")],
+    }
+}
+
+/// `(cli_arg, display_name, is_alias)` tuples that populate the picker for
+/// `agent_type`. The Codex auto-review pseudo-model is hidden, mirroring Codex's
+/// own picker.
+fn model_catalog(agent_type: AgentType) -> Vec<(&'static str, &'static str, bool)> {
+    match agent_type {
+        AgentType::Claude => ClaudeModel::known()
+            .iter()
+            .map(|m| (m.cli_arg(), m.display_name(), m.is_alias()))
+            .collect(),
+        AgentType::Codex => CodexModel::known()
+            .iter()
+            .filter(|m| !matches!(m, CodexModel::CodexAutoReview))
+            .map(|m| (m.cli_arg(), m.display_name(), false))
+            .collect(),
+    }
+}
+
+/// Whether `value` is a model the picker for `agent_type` offers as an option.
+pub fn is_known_model(agent_type: AgentType, value: &str) -> bool {
+    !value.is_empty()
+        && model_catalog(agent_type)
+            .iter()
+            .any(|(cli, _, _)| *cli == value)
+}
+
+/// Pull a picker-selectable model argument out of `args`, returning the model
+/// value (its CLI arg) and the remaining args with that model argument removed.
+///
+/// Recognizes only the forms the picker emits, and only when the value is a
+/// model the picker offers:
+///   * Claude: `--model <value>`
+///   * Codex:  `-c model=<value>`
+///
+/// A malformed form (`--model` with no following value), an unknown model value
+/// (`--model some-future-model`), or the absence of any model argument all yield
+/// `(None, args unchanged)` so the arg is left in the extra-args field untouched
+/// instead of being silently dropped.
+pub fn extract_model_arg(args: &[String], agent_type: AgentType) -> (Option<String>, Vec<String>) {
+    let mut i = 0;
+    while i < args.len() {
+        let matched: Option<String> = match agent_type {
+            AgentType::Claude => {
+                if args[i] == "--model"
+                    && i + 1 < args.len()
+                    && is_known_model(agent_type, &args[i + 1])
+                {
+                    Some(args[i + 1].clone())
+                } else {
+                    None
+                }
+            }
+            AgentType::Codex => {
+                if args[i] == "-c" && i + 1 < args.len() {
+                    args[i + 1]
+                        .strip_prefix("model=")
+                        .filter(|v| is_known_model(agent_type, v))
+                        .map(|v| v.to_string())
+                } else {
+                    None
+                }
+            }
+        };
+
+        if let Some(value) = matched {
+            let mut rest = Vec::with_capacity(args.len() - 2);
+            rest.extend_from_slice(&args[..i]);
+            rest.extend_from_slice(&args[i + 2..]);
+            return (Some(value), rest);
+        }
+        i += 1;
+    }
+    (None, args.to_vec())
+}
+
+#[derive(Properties, PartialEq)]
+pub struct ModelSelectProps {
+    pub agent_type: AgentType,
+    /// Currently selected model CLI arg, or `""` for the agent's own default.
+    pub value: String,
+    /// Fires with the newly selected model CLI arg (`""` = agent default).
+    pub on_change: Callback<String>,
+    /// CSS class for the underlying `<select>`. Defaults to the launcher-select
+    /// styling used by the launch dialog; the schedule dialog passes `""` so it
+    /// inherits `.sched-field select`.
+    #[prop_or_else(|| "launcher-select".to_string())]
+    pub class: String,
+}
+
+/// A `<select>` whose options are the SDK model catalog for `agent_type`.
+/// `""` (the leading "Agent default" option) means the agent's own default.
+///
+/// A `<select>` is inherently focus-stable (no controlled-text-input caret
+/// churn), so no keyed sub-component is needed here.
+#[function_component(ModelSelect)]
+pub fn model_select(props: &ModelSelectProps) -> Html {
+    let onchange = {
+        let on_change = props.on_change.clone();
+        Callback::from(move |e: Event| {
+            if let Some(select) = e.target_dyn_into::<HtmlSelectElement>() {
+                on_change.emit(select.value());
+            }
+        })
+    };
+
+    let selected = props.value.clone();
+    let option = move |cli: &str, label: &str| -> Html {
+        html! {
+            <option value={cli.to_string()} selected={selected == cli}>{ label }</option>
+        }
+    };
+
+    let catalog = model_catalog(props.agent_type);
+    let options: Html = match props.agent_type {
+        AgentType::Claude => html! {
+            <>
+                <optgroup label="Aliases — track the newest model">
+                    { for catalog.iter().filter(|(_, _, alias)| *alias)
+                        .map(|(cli, label, _)| option(cli, label)) }
+                </optgroup>
+                <optgroup label="Pinned models">
+                    { for catalog.iter().filter(|(_, _, alias)| !*alias)
+                        .map(|(cli, label, _)| option(cli, label)) }
+                </optgroup>
+            </>
+        },
+        AgentType::Codex => html! {
+            { for catalog.iter().map(|(cli, label, _)| option(cli, label)) }
+        },
+    };
+
+    html! {
+        <select class={props.class.clone()} {onchange}>
+            <option value="" selected={props.value.is_empty()}>{ "Agent default" }</option>
+            { options }
+        </select>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    /// A model that appears in the Claude catalog (used so the tests don't hard
+    /// code a specific value that may churn as the SDK updates).
+    fn a_known_claude_model() -> String {
+        ClaudeModel::known()[0].cli_arg().to_string()
+    }
+
+    /// A model that appears in the Codex catalog and is offered by the picker.
+    fn a_known_codex_model() -> String {
+        CodexModel::known()
+            .iter()
+            .find(|m| !matches!(m, CodexModel::CodexAutoReview))
+            .unwrap()
+            .cli_arg()
+            .to_string()
+    }
+
+    #[test]
+    fn extract_claude_model_and_strips_it() {
+        let model = a_known_claude_model();
+        let (found, rest) =
+            extract_model_arg(&args(&["--model", &model, "--verbose"]), AgentType::Claude);
+        assert_eq!(found.as_deref(), Some(model.as_str()));
+        assert_eq!(rest, args(&["--verbose"]));
+    }
+
+    #[test]
+    fn extract_codex_model_and_strips_it() {
+        let model = a_known_codex_model();
+        let (found, rest) = extract_model_arg(
+            &args(&["-c", &format!("model={model}"), "-c", "foo=bar"]),
+            AgentType::Codex,
+        );
+        assert_eq!(found.as_deref(), Some(model.as_str()));
+        assert_eq!(rest, args(&["-c", "foo=bar"]));
+    }
+
+    #[test]
+    fn extract_absent_leaves_args_untouched() {
+        let input = args(&["--verbose", "-c", "foo=bar"]);
+        let (found, rest) = extract_model_arg(&input, AgentType::Claude);
+        assert_eq!(found, None);
+        assert_eq!(rest, input);
+    }
+
+    #[test]
+    fn extract_unrecognized_claude_value_is_left_in_args() {
+        // A value the picker doesn't offer must NOT be stripped — it stays in
+        // the extra-args field untouched instead of being silently dropped.
+        let input = args(&["--model", "some-future-model", "--verbose"]);
+        let (found, rest) = extract_model_arg(&input, AgentType::Claude);
+        assert_eq!(found, None);
+        assert_eq!(rest, input);
+    }
+
+    #[test]
+    fn extract_unrecognized_codex_value_is_left_in_args() {
+        let input = args(&["-c", "model=some-future-model"]);
+        let (found, rest) = extract_model_arg(&input, AgentType::Codex);
+        assert_eq!(found, None);
+        assert_eq!(rest, input);
+    }
+
+    #[test]
+    fn extract_dangling_model_flag_is_left_in_args() {
+        // `--model` in trailing position with no value (unrecognized position).
+        let input = args(&["--verbose", "--model"]);
+        let (found, rest) = extract_model_arg(&input, AgentType::Claude);
+        assert_eq!(found, None);
+        assert_eq!(rest, input);
+    }
+
+    #[test]
+    fn round_trips_what_model_cli_args_emits() {
+        let claude = a_known_claude_model();
+        let (found, rest) = extract_model_arg(
+            &model_cli_args(AgentType::Claude, &claude),
+            AgentType::Claude,
+        );
+        assert_eq!(found.as_deref(), Some(claude.as_str()));
+        assert!(rest.is_empty());
+
+        let codex = a_known_codex_model();
+        let (found, rest) =
+            extract_model_arg(&model_cli_args(AgentType::Codex, &codex), AgentType::Codex);
+        assert_eq!(found.as_deref(), Some(codex.as_str()));
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn model_cli_args_empty_is_agent_default() {
+        assert!(model_cli_args(AgentType::Claude, "").is_empty());
+        assert!(model_cli_args(AgentType::Codex, "").is_empty());
+    }
+}

--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -1,9 +1,11 @@
 // TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use crate::components::model_select::{extract_model_arg, model_cli_args};
 use crate::components::skip_permissions::{
     skip_permissions_args, skip_permissions_label, strip_skip_permissions_args,
 };
+use crate::components::ModelSelect;
 use crate::hooks::use_escape;
 use crate::utils::{self, On401};
 use gloo_net::http::Request;
@@ -65,6 +67,8 @@ struct TaskForm {
     timezone: String,
     prompt: String,
     max_runtime_minutes: i32,
+    /// Selected model CLI arg, or "" for the agent's own default.
+    model_arg: String,
     extra_args: String,
     skip_permissions: bool,
 }
@@ -177,13 +181,20 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
             if let Some(task) = tasks.iter().find(|t| t.id == task_id) {
                 let (has_skip, other_args) =
                     strip_skip_permissions_args(&task.fields.claude_args, task.fields.agent_type);
+                // Pull a picker-selectable model out of the remaining args so it
+                // pre-selects in the picker instead of sitting in the extra-args
+                // field (where it would double-apply on save). An unrecognized
+                // model value stays in `extra_args` untouched.
+                let (model_arg, extra_args) =
+                    extract_model_arg(&other_args, task.fields.agent_type);
                 form.set(TaskForm {
                     name: task.fields.name.clone(),
                     cron_expression: task.fields.cron_expression.clone(),
                     timezone: task.fields.timezone.clone(),
                     prompt: task.fields.prompt.clone(),
                     max_runtime_minutes: task.fields.max_runtime_minutes,
-                    extra_args: other_args.join(" "),
+                    model_arg: model_arg.unwrap_or_default(),
+                    extra_args: extra_args.join(" "),
                     skip_permissions: has_skip,
                 });
                 error_msg.set(None);
@@ -221,17 +232,20 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
             }
 
             spawn_local(async move {
-                let mut claude_args: Vec<String> = Vec::new();
+                // Picker args go first so an explicit --model / -c model=… typed
+                // into the extra-args field still wins (both CLIs take the last
+                // occurrence).
+                let mut claude_args: Vec<String> = model_cli_args(agent_type, &data.model_arg);
+                let extra = data.extra_args.trim();
+                if !extra.is_empty() {
+                    claude_args.extend(extra.split_whitespace().map(String::from));
+                }
                 if data.skip_permissions {
                     claude_args.extend(
                         skip_permissions_args(agent_type)
                             .iter()
                             .map(|arg| arg.to_string()),
                     );
-                }
-                let extra = data.extra_args.trim();
-                if !extra.is_empty() {
-                    claude_args.extend(extra.split_whitespace().map(String::from));
                 }
 
                 let result = match mode {
@@ -370,6 +384,15 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
         Callback::from(move |_: Event| {
             let mut f = (*form).clone();
             f.skip_permissions = !f.skip_permissions;
+            form.set(f);
+        })
+    };
+
+    let on_model_change = {
+        let form = form.clone();
+        Callback::from(move |value: String| {
+            let mut f = (*form).clone();
+            f.model_arg = value;
             form.set(f);
         })
     };
@@ -526,11 +549,25 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                                             required=true
                                         />
                                     </div>
+                                    // Model picker — catalogs from the
+                                    // claude-codes / codex-codes crates; ""
+                                    // means the agent's own default. The agent
+                                    // is fixed to this session's agent, so
+                                    // there's no agent switch to reset against.
+                                    <div class="sched-field">
+                                        <label>{ "Model" }</label>
+                                        <ModelSelect
+                                            agent_type={session_agent_type}
+                                            value={form.model_arg.clone()}
+                                            on_change={on_model_change}
+                                            class=""
+                                        />
+                                    </div>
                                     <div class="sched-field">
                                         <label>{ "Extra CLI Arguments (optional)" }</label>
                                         <input
                                             type="text"
-                                            placeholder="--model sonnet --verbose"
+                                            placeholder="--verbose"
                                             value={form.extra_args.clone()}
                                             oninput={set_field(|f, v| f.extra_args = v)}
                                         />

--- a/frontend/styles/schedule-dialog.css
+++ b/frontend/styles/schedule-dialog.css
@@ -247,6 +247,7 @@
 }
 
 .sched-field input,
+.sched-field select,
 .sched-field textarea {
     background: var(--bg-dark);
     border: 1px solid var(--border);
@@ -281,6 +282,7 @@
 }
 
 .sched-field input:focus,
+.sched-field select:focus,
 .sched-field textarea:focus {
     outline: none;
     border-color: var(--accent);


### PR DESCRIPTION
## What

The launch dialog gained a model picker fed by the SDK model catalogs, but the cron/schedule dialog never did — users had to hand-type `--model sonnet` into the extra-args field. This adds the same picker to the schedule dialog.

## How

- **New `ModelSelect` component** (`frontend/src/components/model_select.rs`): props are `agent_type`, `value`, `on_change` (plus an optional `class`). It renders the catalog optgroups exactly as the launch dialog did — Claude aliases (track newest) vs pinned models, Codex minus the hidden auto-review pseudo-model — with `""` meaning the agent's own default. The launch dialog now consumes it with zero behavior change.
- **Shared arg mapping** `model_cli_args(agent_type, value)` (Claude `--model <v>`, Codex `-c model=<v>`) is used by both dialogs.
- **Schedule dialog** gets a Model selector above the extra-args field. Picker args are prepended so an explicit `--model` / `-c model=` typed into extra-args still wins.
- **Editing an existing task**: a pure `extract_model_arg` helper pulls a picker-selectable model out of the stored args, pre-selects it, and strips it from the extra-args text (so it doesn't double-apply). An unrecognized model value (or malformed `--model` position) is left in extra-args untouched. Covered by unit tests (claude/codex forms, absent, unrecognized value, dangling flag, round-trip).

## Verification

- `trunk build`, `cargo build -p backend` (embeds dist)
- `cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings` clean
- `cargo fmt` applied; `cargo test -p frontend` (8 model_select tests pass)