### PR TITLE
Per-task fresh vs continue session mode for scheduled tasks

### DIFF
--- a/backend/migrations/2026-07-17-224833_add_session_mode_to_scheduled_tasks/down.sql
+++ b/backend/migrations/2026-07-17-224833_add_session_mode_to_scheduled_tasks/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE scheduled_tasks DROP COLUMN session_mode;

--- a/backend/migrations/2026-07-17-224833_add_session_mode_to_scheduled_tasks/up.sql
+++ b/backend/migrations/2026-07-17-224833_add_session_mode_to_scheduled_tasks/up.sql
@@ -1,0 +1,4 @@
+-- Per-task session mode: 'fresh' (default, a brand-new session each run) or
+-- 'continue' (each firing resumes the same conversation, accumulating context).
+ALTER TABLE scheduled_tasks
+    ADD COLUMN session_mode VARCHAR(16) NOT NULL DEFAULT 'fresh';

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -36,6 +36,7 @@ fn task_to_fields(t: &ScheduledTask) -> ScheduledTaskFields {
         claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
         agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
         max_runtime_minutes: t.max_runtime_minutes,
+        session_mode: t.session_mode.parse().unwrap_or_default(),
     }
 }
 
@@ -193,6 +194,7 @@ pub async fn create_task_handler(
         claude_args: serde_json::to_value(req.fields.claude_args).unwrap_or_default(),
         agent_type: req.fields.agent_type.as_str().to_string(),
         max_runtime_minutes: req.fields.max_runtime_minutes,
+        session_mode: req.fields.session_mode.as_str().to_string(),
     };
 
     let saved: ScheduledTask = diesel::insert_into(scheduled_tasks::table)
@@ -249,6 +251,7 @@ pub async fn update_task_handler(
         agent_type: req.agent_type.map(|at| at.as_str().to_string()),
         enabled: req.enabled,
         max_runtime_minutes: req.max_runtime_minutes,
+        session_mode: req.session_mode.map(|m| m.as_str().to_string()),
     };
 
     let updated: ScheduledTask = diesel::update(

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -926,6 +926,28 @@ fn handle_launcher_message(
                 return;
             }
 
+            // Continue-mode tasks resume the same conversation on the next
+            // firing, so the session (and, for claude, its on-disk transcript)
+            // must survive completion. Only fresh-mode runs are auto-deleted.
+            let is_continue = {
+                use crate::schema::scheduled_tasks;
+                scheduled_tasks::table
+                    .filter(scheduled_tasks::id.eq(task_id))
+                    .filter(scheduled_tasks::user_id.eq(user_id))
+                    .select(scheduled_tasks::session_mode)
+                    .first::<String>(&mut db_conn)
+                    .ok()
+                    .and_then(|m| m.parse::<shared::SessionMode>().ok())
+                    == Some(shared::SessionMode::Continue)
+            };
+            if is_continue {
+                info!(
+                    "Preserving continue-mode scheduled session {} (task {}) for resume",
+                    session_id, task_id
+                );
+                return;
+            }
+
             if let Err(e) =
                 super::super::helpers::delete_session_with_data(&mut db_conn, &session, true)
             {

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -355,6 +355,7 @@ pub struct ScheduledTask {
     pub last_run_at: Option<NaiveDateTime>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
+    pub session_mode: String,
 }
 
 #[derive(Debug, Insertable)]
@@ -370,6 +371,7 @@ pub struct NewScheduledTask {
     pub claude_args: serde_json::Value,
     pub agent_type: String,
     pub max_runtime_minutes: i32,
+    pub session_mode: String,
 }
 
 /// Partial update for a scheduled task. `None` fields are left unchanged
@@ -388,6 +390,7 @@ pub struct ScheduledTaskChangeset {
     pub agent_type: Option<String>,
     pub enabled: Option<bool>,
     pub max_runtime_minutes: Option<i32>,
+    pub session_mode: Option<String>,
 }
 
 // ============================================================================

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -132,6 +132,8 @@ diesel::table! {
         last_run_at -> Nullable<Timestamp>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        #[max_length = 16]
+        session_mode -> Varchar,
     }
 }
 

--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -71,6 +71,8 @@ struct TaskForm {
     model_arg: String,
     extra_args: String,
     skip_permissions: bool,
+    /// Fresh session each run vs. continue the prior conversation.
+    session_mode: shared::SessionMode,
 }
 
 #[derive(Clone, PartialEq)]
@@ -196,6 +198,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                     model_arg: model_arg.unwrap_or_default(),
                     extra_args: extra_args.join(" "),
                     skip_permissions: has_skip,
+                    session_mode: task.fields.session_mode,
                 });
                 error_msg.set(None);
                 form_mode.set(Some(FormMode::Edit(task_id)));
@@ -260,6 +263,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                                 claude_args: claude_args.clone(),
                                 agent_type,
                                 max_runtime_minutes: data.max_runtime_minutes,
+                                session_mode: data.session_mode,
                             },
                             hostname: host,
                         };
@@ -278,6 +282,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                             max_runtime_minutes: Some(data.max_runtime_minutes),
                             claude_args: Some(claude_args.clone()),
                             agent_type: Some(agent_type),
+                            session_mode: Some(data.session_mode),
                             ..Default::default()
                         };
                         Request::patch(&utils::api_url(&format!("/api/scheduled-tasks/{}", id)))
@@ -397,6 +402,15 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
         })
     };
 
+    let set_session_mode = |mode: shared::SessionMode| {
+        let form = form.clone();
+        Callback::from(move |_: MouseEvent| {
+            let mut f = (*form).clone();
+            f.session_mode = mode;
+            form.set(f);
+        })
+    };
+
     let on_overlay_click = props.on_close.reform(|_| ());
     let on_dialog_click = Callback::from(|e: MouseEvent| e.stop_propagation());
 
@@ -451,6 +465,9 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                                         <code class="sched-task-cron">{ &task.fields.cron_expression }</code>
                                         if task.fields.timezone != "UTC" {
                                             <span class="sched-task-tz">{ &task.fields.timezone }</span>
+                                        }
+                                        if task.fields.session_mode == shared::SessionMode::Continue {
+                                            <span class="sched-task-tz">{ "continue" }</span>
                                         }
                                     </div>
                                     <div class="sched-task-prompt-preview">{ &task.fields.prompt }</div>
@@ -562,6 +579,39 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
                                             on_change={on_model_change}
                                             class=""
                                         />
+                                    </div>
+                                    // Session mode — fresh session each run vs.
+                                    // continue the same conversation (native
+                                    // resume). Works for both claude and codex.
+                                    <div class="sched-field">
+                                        <label>{ "Each run" }</label>
+                                        <div class="sched-mode-toggle">
+                                            <button
+                                                type="button"
+                                                class={classes!(
+                                                    "sched-btn",
+                                                    (form.session_mode == shared::SessionMode::Fresh)
+                                                        .then_some("sched-btn-primary")
+                                                )}
+                                                onclick={set_session_mode(shared::SessionMode::Fresh)}
+                                            >
+                                                { "Fresh session" }
+                                            </button>
+                                            <button
+                                                type="button"
+                                                class={classes!(
+                                                    "sched-btn",
+                                                    (form.session_mode == shared::SessionMode::Continue)
+                                                        .then_some("sched-btn-primary")
+                                                )}
+                                                onclick={set_session_mode(shared::SessionMode::Continue)}
+                                            >
+                                                { "Continue previous" }
+                                            </button>
+                                        </div>
+                                        <span class="sched-hint">
+                                            { "Continue resumes the same conversation each run, accumulating context across firings." }
+                                        </span>
                                     </div>
                                     <div class="sched-field">
                                         <label>{ "Extra CLI Arguments (optional)" }</label>

--- a/launcher/src/scheduler.rs
+++ b/launcher/src/scheduler.rs
@@ -90,6 +90,14 @@ pub struct Scheduler {
     running: HashMap<Uuid, RunningInfo>,
     pending_prompts: Vec<PendingPrompt>,
     continuations: Vec<ContinuationConfig>,
+    /// Last session spawned per task, tracked locally so continue-mode firings
+    /// resume the right conversation even within a single launcher connection.
+    ///
+    /// `ScheduledTaskConfig.last_session_id` only refreshes on `ScheduleSync`
+    /// (task edit / launcher reconnect), so after a run completes the config
+    /// copy is stale until the next sync. This map is updated on every spawn and
+    /// takes precedence, with the config value as the cross-reconnect fallback.
+    last_session_by_task: HashMap<Uuid, Uuid>,
 }
 
 impl Scheduler {
@@ -100,6 +108,7 @@ impl Scheduler {
             running: HashMap::new(),
             pending_prompts: Vec::new(),
             continuations: Vec::new(),
+            last_session_by_task: HashMap::new(),
         }
     }
 
@@ -209,12 +218,26 @@ impl Scheduler {
     }
 
     /// Find and return tasks that are due to fire. Advances next_fire times.
+    ///
+    /// Session-mode decides what a due firing does:
+    /// - `Fresh` (default): launch a brand-new session (`last_session_id: None`).
+    ///   If a prior run is still active, skip this firing (overlap policy).
+    /// - `Continue`: if the task's current session is still active, inject the
+    ///   prompt into it (no new launch). Otherwise relaunch resuming the prior
+    ///   session id when one exists (the agent's native `--resume` / thread
+    ///   resume), or launch fresh on the very first run.
     pub fn fire_due_tasks(&mut self) -> Vec<TaskToFire> {
         let now = Utc::now();
-        let running_task_ids: HashSet<Uuid> = self.running.values().map(|r| r.task_id).collect();
+        // task_id -> session_id of a currently-running run for that task.
+        let active_session_by_task: HashMap<Uuid, Uuid> = self
+            .running
+            .iter()
+            .map(|(session_id, info)| (info.task_id, *session_id))
+            .collect();
 
         let mut to_fire = Vec::new();
         let mut new_pending = Vec::new();
+        let mut new_prompts = Vec::new();
 
         for task in &mut self.tasks {
             let Some(next) = task.next_fire else {
@@ -224,26 +247,70 @@ impl Scheduler {
                 continue;
             }
 
-            if running_task_ids.contains(&task.config.id) {
-                info!(
-                    "Skipping task '{}': previous run still active",
-                    task.config.fields.name
-                );
+            let task_id = task.config.id;
+            let is_continue = task.config.fields.session_mode == shared::SessionMode::Continue;
+            let active_session = active_session_by_task.get(&task_id).copied();
+
+            // Always advance next_fire; whether we launch, inject, or skip below
+            // this firing is consumed either way.
+            let advance = |task: &mut ActiveTask| {
                 task.next_fire = compute_next_fire(
                     &task.config.fields.cron_expression,
                     &task.config.fields.timezone,
                 );
-                continue;
+                if let Some(ref next) = task.next_fire {
+                    info!("Task '{}': next fire at {}", task.config.fields.name, next);
+                }
+            };
+
+            match (is_continue, active_session) {
+                // Continue mode, prior run still active: inject into it instead
+                // of launching a second session.
+                (true, Some(session_id)) => {
+                    info!(
+                        "Continue task '{}': injecting into active session {}",
+                        task.config.fields.name, session_id
+                    );
+                    new_prompts.push(PendingPrompt {
+                        session_id,
+                        task_id,
+                        prompt: task.config.fields.prompt.clone(),
+                        // No spawn delay: the session is already registered.
+                        send_at: Instant::now(),
+                    });
+                    advance(task);
+                    continue;
+                }
+                // Fresh mode with a prior run still active: overlap policy skips.
+                (false, Some(_)) => {
+                    info!(
+                        "Skipping task '{}': previous run still active",
+                        task.config.fields.name
+                    );
+                    advance(task);
+                    continue;
+                }
+                // No active run: launch. Continue mode resumes the prior session
+                // (or launches fresh on the first run); fresh mode always starts
+                // a brand-new session.
+                (_, None) => {}
             }
+
+            let last_session_id = if is_continue {
+                self.last_session_by_task
+                    .get(&task_id)
+                    .copied()
+                    .or(task.config.last_session_id)
+            } else {
+                None
+            };
 
             let request_id = Uuid::new_v4();
             new_pending.push((
                 request_id,
                 PendingLaunch {
-                    kind: PendingLaunchKind::ScheduledTask {
-                        task_id: task.config.id,
-                    },
-                    last_session_id: task.config.last_session_id,
+                    kind: PendingLaunchKind::ScheduledTask { task_id },
+                    last_session_id,
                     prompt: task.config.fields.prompt.clone(),
                 },
             ));
@@ -253,21 +320,22 @@ impl Scheduler {
             });
 
             info!(
-                "Firing task '{}' ({})",
-                task.config.fields.name, task.config.id
+                "Firing task '{}' ({}) [{}{}]",
+                task.config.fields.name,
+                task_id,
+                task.config.fields.session_mode,
+                match last_session_id {
+                    Some(id) => format!(", resuming {id}"),
+                    None => String::new(),
+                }
             );
-            task.next_fire = compute_next_fire(
-                &task.config.fields.cron_expression,
-                &task.config.fields.timezone,
-            );
-            if let Some(ref next) = task.next_fire {
-                info!("Task '{}': next fire at {}", task.config.fields.name, next);
-            }
+            advance(task);
         }
 
         for (request_id, launch) in new_pending {
             self.pending_launches.insert(request_id, launch);
         }
+        self.pending_prompts.extend(new_prompts);
 
         to_fire
     }
@@ -310,6 +378,9 @@ impl Scheduler {
             let PendingLaunchKind::ScheduledTask { task_id } = kind else {
                 return Some(kind);
             };
+            // Remember the session this task just launched so a later
+            // continue-mode firing (within this connection) resumes it.
+            self.last_session_by_task.insert(task_id, session_id);
             self.pending_prompts.push(PendingPrompt {
                 session_id,
                 task_id,
@@ -437,10 +508,16 @@ mod tests {
                 claude_args: vec![],
                 agent_type: AgentType::Claude,
                 max_runtime_minutes: 30,
+                session_mode: shared::SessionMode::Fresh,
             },
             enabled: true,
             last_session_id: None,
         }
+    }
+
+    /// Force a task's `next_fire` into the past so `fire_due_tasks()` sees it due.
+    fn make_due(scheduler: &mut Scheduler) {
+        scheduler.tasks[0].next_fire = Some(Utc::now() - chrono::Duration::seconds(1));
     }
 
     #[test]
@@ -556,6 +633,92 @@ mod tests {
         // Verify running session is tracked
         assert!(scheduler.running.contains_key(&session_id));
         assert_eq!(scheduler.running[&session_id].task_id, task_id);
+    }
+
+    #[test]
+    fn fresh_mode_fires_without_resume() {
+        let mut scheduler = Scheduler::new();
+        let task = make_task("test", "* * * * *"); // Fresh by default
+        scheduler.update_tasks(vec![task]);
+        make_due(&mut scheduler);
+
+        let fired = scheduler.fire_due_tasks();
+        assert_eq!(fired.len(), 1);
+        let info = scheduler
+            .get_pending_launch_info(&fired[0].request_id)
+            .unwrap();
+        // Fresh mode never resumes — a brand-new session each run.
+        assert_eq!(info.last_session_id, None);
+    }
+
+    #[test]
+    fn continue_mode_first_run_launches_fresh() {
+        let mut scheduler = Scheduler::new();
+        let mut task = make_task("test", "* * * * *");
+        task.fields.session_mode = shared::SessionMode::Continue;
+        scheduler.update_tasks(vec![task]);
+        make_due(&mut scheduler);
+
+        let fired = scheduler.fire_due_tasks();
+        assert_eq!(fired.len(), 1);
+        let info = scheduler
+            .get_pending_launch_info(&fired[0].request_id)
+            .unwrap();
+        // No prior session → first run is fresh.
+        assert_eq!(info.last_session_id, None);
+    }
+
+    #[test]
+    fn continue_mode_dead_session_relaunches_with_resume() {
+        let mut scheduler = Scheduler::new();
+        let mut task = make_task("test", "* * * * *");
+        task.fields.session_mode = shared::SessionMode::Continue;
+        scheduler.update_tasks(vec![task]);
+
+        // First run: fires fresh, spawns S1, then S1 exits.
+        make_due(&mut scheduler);
+        let first = scheduler.fire_due_tasks();
+        assert_eq!(first.len(), 1);
+        let s1 = Uuid::new_v4();
+        scheduler.on_session_spawned(first[0].request_id, s1);
+        assert!(scheduler.on_session_exited(&s1).is_some());
+
+        // Second run: prior session is dead → relaunch resuming S1.
+        make_due(&mut scheduler);
+        let second = scheduler.fire_due_tasks();
+        assert_eq!(second.len(), 1);
+        let info = scheduler
+            .get_pending_launch_info(&second[0].request_id)
+            .unwrap();
+        assert_eq!(info.last_session_id, Some(s1));
+    }
+
+    #[test]
+    fn continue_mode_active_session_injects_instead_of_launching() {
+        let mut scheduler = Scheduler::new();
+        let mut task = make_task("test", "* * * * *");
+        task.fields.session_mode = shared::SessionMode::Continue;
+        let task_id = task.id;
+        scheduler.update_tasks(vec![task]);
+
+        // First run spawns S1 and leaves it running.
+        make_due(&mut scheduler);
+        let first = scheduler.fire_due_tasks();
+        let s1 = Uuid::new_v4();
+        scheduler.on_session_spawned(first[0].request_id, s1);
+
+        // Second run while S1 is still active: no new launch, prompt injected.
+        make_due(&mut scheduler);
+        let second = scheduler.fire_due_tasks();
+        assert!(second.is_empty(), "must not launch a second session");
+
+        let ready = scheduler.ready_prompts();
+        assert!(
+            ready
+                .iter()
+                .any(|(sid, tid, _)| *sid == s1 && *tid == task_id),
+            "prompt should be queued for the active session"
+        );
     }
 
     fn continuation(reset_at: DateTime<Utc>) -> ContinuationConfig {

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -484,6 +484,7 @@ mod tests {
             claude_args: vec!["--verbose".to_string()],
             agent_type: crate::AgentType::Claude,
             max_runtime_minutes: 30,
+            session_mode: crate::SessionMode::Fresh,
         }
     }
 
@@ -507,7 +508,8 @@ mod tests {
                 "prompt": "Check deps",
                 "claude_args": ["--verbose"],
                 "agent_type": "claude",
-                "max_runtime_minutes": 30
+                "max_runtime_minutes": 30,
+                "session_mode": "fresh"
             }"#,
         )
         .unwrap();
@@ -532,6 +534,8 @@ mod tests {
         assert_eq!(parsed.fields.max_runtime_minutes, 30);
         assert!(parsed.fields.claude_args.is_empty());
         assert_eq!(parsed.fields.agent_type, crate::AgentType::Claude);
+        // Omitted session_mode defaults to Fresh (historical behavior).
+        assert_eq!(parsed.fields.session_mode, crate::SessionMode::Fresh);
     }
 
     /// Pins the ScheduledTaskInfo wire shape, including the always-serialized
@@ -561,6 +565,7 @@ mod tests {
                 "agent_type": "claude",
                 "enabled": true,
                 "max_runtime_minutes": 30,
+                "session_mode": "fresh",
                 "last_session_id": null,
                 "last_run_at": "2026-01-01T00:00:00+00:00",
                 "created_at": "2026-01-01T00:00:00+00:00",

--- a/shared/src/api/scheduled_tasks.rs
+++ b/shared/src/api/scheduled_tasks.rs
@@ -33,6 +33,8 @@ pub struct UpdateScheduledTaskRequest {
     pub enabled: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_runtime_minutes: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_mode: Option<crate::SessionMode>,
 }
 
 /// Info about a scheduled task (returned by list/create endpoints)

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -12,7 +12,7 @@ pub use ws_bridge::WsEndpoint;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AgentType, SendMode};
+    use crate::{AgentType, SendMode, SessionMode};
     use uuid::Uuid;
 
     #[test]
@@ -511,6 +511,7 @@ mod tests {
                     claude_args: vec![],
                     agent_type: AgentType::Claude,
                     max_runtime_minutes: 30,
+                    session_mode: SessionMode::Fresh,
                 },
                 enabled: true,
                 last_session_id: None,
@@ -544,6 +545,7 @@ mod tests {
                 claude_args: vec!["--verbose".into()],
                 agent_type: AgentType::Claude,
                 max_runtime_minutes: 30,
+                session_mode: SessionMode::Continue,
             },
             enabled: true,
             last_session_id: None,
@@ -559,7 +561,8 @@ mod tests {
                 "claude_args": ["--verbose"],
                 "agent_type": "claude",
                 "enabled": true,
-                "max_runtime_minutes": 30
+                "max_runtime_minutes": 30,
+                "session_mode": "continue"
             }"#,
         )
         .unwrap();
@@ -582,6 +585,8 @@ mod tests {
         let parsed: ScheduledTaskConfig = serde_json::from_str(old_wire).unwrap();
         assert_eq!(parsed.fields.name, "nightly audit");
         assert_eq!(parsed.fields.max_runtime_minutes, 30);
+        // Omitted session_mode defaults to Fresh (old-launcher wire compat).
+        assert_eq!(parsed.fields.session_mode, SessionMode::Fresh);
         assert!(parsed.enabled);
         assert_eq!(
             parsed.last_session_id,

--- a/shared/src/endpoints/types.rs
+++ b/shared/src/endpoints/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{AgentType, PermissionSuggestion};
+use crate::{AgentType, PermissionSuggestion, SessionMode};
 
 /// A session continuation created for a usage-limit reset (`#231`/`#1260`).
 pub const CONTINUATION_REASON_LIMIT: &str = "limit";
@@ -57,6 +57,10 @@ pub struct ScheduledTaskFields {
     pub agent_type: AgentType,
     #[serde(default = "default_max_runtime_minutes")]
     pub max_runtime_minutes: i32,
+    /// Whether each firing starts fresh or continues the prior conversation.
+    /// Defaults to `Fresh` so payloads from older clients keep today's behavior.
+    #[serde(default)]
+    pub session_mode: SessionMode,
 }
 
 fn default_timezone() -> String {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -150,6 +150,52 @@ impl std::str::FromStr for AgentType {
     }
 }
 
+/// How a scheduled task treats the conversation across firings.
+///
+/// - `Fresh` (default): each firing launches a brand-new session/conversation,
+///   the historical behavior. The prior run's session is auto-deleted on
+///   completion.
+/// - `Continue`: each firing continues the same conversation, accumulating
+///   context across runs (a standup bot that remembers, a monitor that knows
+///   what it said last time). The session is preserved between runs and resumed
+///   via the agent's native mechanism (`claude --resume` / codex `thread/resume`).
+///
+/// Serializes lowercase and defaults to `Fresh` so older wire payloads that omit
+/// the field keep today's behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionMode {
+    #[default]
+    Fresh,
+    Continue,
+}
+
+impl SessionMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SessionMode::Fresh => "fresh",
+            SessionMode::Continue => "continue",
+        }
+    }
+}
+
+impl std::fmt::Display for SessionMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for SessionMode {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "fresh" => Ok(SessionMode::Fresh),
+            "continue" => Ok(SessionMode::Continue),
+            other => Err(format!("unknown session mode: {}", other)),
+        }
+    }
+}
+
 /// Cost and token usage information for a single session
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SessionCost {
@@ -631,6 +677,26 @@ pub struct AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_mode_serde_and_default() {
+        // Lowercase wire form round-trips.
+        assert_eq!(
+            serde_json::to_string(&SessionMode::Fresh).unwrap(),
+            r#""fresh""#
+        );
+        assert_eq!(
+            serde_json::to_string(&SessionMode::Continue).unwrap(),
+            r#""continue""#
+        );
+        assert_eq!(
+            serde_json::from_str::<SessionMode>(r#""continue""#).unwrap(),
+            SessionMode::Continue
+        );
+        // Default is Fresh so omitted/older payloads keep today's behavior.
+        assert_eq!(SessionMode::default(), SessionMode::Fresh);
+        assert_eq!("fresh".parse::<SessionMode>().unwrap(), SessionMode::Fresh);
+    }
 
     #[test]
     fn continuation_prompt_reason_defaults_to_limit_on_old_wire() {


### PR DESCRIPTION
## What

Adds a per-task **session mode** to scheduled tasks:

- **Fresh** (default, today's behavior): each firing launches a brand-new session/conversation; the prior run is auto-deleted on completion.
- **Continue**: each firing continues the same conversation, accumulating context across runs — a daily standup bot that remembers, a monitor that knows what it said last time.

## How it works

Scheduled tasks fire launcher-side. The firing path is: launcher `Scheduler::fire_due_tasks` → `LauncherToServer::RequestLaunch` → backend `LaunchSession` → `ProcessManager::spawn` (in-process session via `claude-session-lib`), with the prompt injected as input ~5s after spawn (`InjectInput` → `pending_inputs`).

Continue mode reuses the machinery that already backs usage-limit continuations — passing a prior session id as `resume_session_id` reuses the same `session_id` with `resume=true`, which becomes `claude --resume <id>` (`claude-session-lib/src/spawn.rs`) or codex `thread/resume` (`codex-session-lib`, thread id persisted per session on disk).

Per-task decision, all resolved in `fire_due_tasks`:
- **Continue + prior session still active** → inject the prompt into it (queued pending prompt), no new launch.
- **Continue + prior session dead** → relaunch resuming the prior session id (the scheduler tracks the last spawned session per task locally, with the DB-synced `last_session_id` as the cross-reconnect fallback).
- **Continue + no prior session** → launch fresh (first run).
- **Fresh** → always a new session; overlap policy unchanged (skip if a prior run is still active).

For continue mode to actually resume, continue-mode sessions are **preserved** on `ScheduledRunCompleted` (fresh-mode runs are still auto-deleted). Failure honesty: if a resume target's transcript/thread is gone, `run_session_task` already rotates to a fresh session rather than skipping the run.

## Codex

Supported. Codex resume (app-server `thread/resume`, thread id persisted per session id to disk) is already plumbed and works run-over-run since continue mode reuses the session id. No dialog gating needed.

## Changes

- `shared`: `SessionMode` enum (serde lowercase, `#[serde(default)]` → `Fresh` for wire compat) on `ScheduledTaskFields` + `UpdateScheduledTaskRequest`.
- `backend`: `session_mode` column (migration, model, CRUD); preserve continue-mode sessions on completion.
- `launcher`: fresh/continue firing logic + per-task last-session tracking.
- `frontend`: "Each run: Fresh session / Continue previous" toggle in the schedule dialog + a continue badge in the task list.

## Tests

- Scheduler unit tests: fresh fires without resume; continue first-run fresh; continue dead-session relaunches with resume; continue active-session injects instead of launching.
- Shared serde: `SessionMode` round-trip + default; wire-compat tests updated (omitted field defaults to `fresh`).

Verified: `cargo fmt --check`, clippy (workspace `--exclude frontend` + frontend wasm target, both `-D warnings`), `cargo test -p backend -p shared`, `trunk build`, `cargo build -p backend -p agent-portal`.