### PR TITLE
Replace shared-session role strings with SessionRole

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.3"
+version = "2.13.4"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -5,7 +5,7 @@ use axum::{
 use diesel::prelude::*;
 use serde::Deserialize;
 use shared::api::{DirectoryListingResponse, LaunchRequest, ProbeAgentsResponse};
-use shared::{LauncherInfo, LauncherToServer, ServerToLauncher, SessionStatus};
+use shared::{LauncherInfo, LauncherToServer, ServerToLauncher, SessionRole, SessionStatus};
 use std::sync::Arc;
 use tracing::{error, info, warn};
 use uuid::Uuid;
@@ -214,7 +214,7 @@ pub(crate) fn create_desired_session(
         .values(NewSessionMember {
             session_id: draft.session_id,
             user_id: draft.user_id,
-            role: "owner".to_string(),
+            role: SessionRole::Owner.as_str().to_string(),
         })
         .execute(&mut conn)?;
 

--- a/backend/src/handlers/session_access.rs
+++ b/backend/src/handlers/session_access.rs
@@ -17,6 +17,7 @@
 use crate::errors::AppError;
 use crate::AppState;
 use diesel::prelude::*;
+use shared::SessionRole;
 use tracing::{error, warn};
 use uuid::Uuid;
 
@@ -69,7 +70,7 @@ pub fn verify_session_owner(
         .inner_join(session_members::table.on(session_members::session_id.eq(sessions::id)))
         .filter(sessions::id.eq(session_id))
         .filter(session_members::user_id.eq(user_id))
-        .filter(session_members::role.eq("owner"))
+        .filter(session_members::role.eq(SessionRole::Owner.as_str()))
         .select(crate::models::Session::as_select())
         .first::<crate::models::Session>(conn)
         .optional()?
@@ -90,7 +91,7 @@ pub fn verify_owner_membership(
     session_members::table
         .filter(session_members::session_id.eq(session_id))
         .filter(session_members::user_id.eq(user_id))
-        .filter(session_members::role.eq("owner"))
+        .filter(session_members::role.eq(SessionRole::Owner.as_str()))
         .select(session_members::user_id)
         .first::<Uuid>(conn)
         .optional()?
@@ -129,8 +130,8 @@ pub fn verify_session_mutator(
         .filter(session_members::user_id.eq(user_id))
         .filter(
             session_members::role
-                .eq("owner")
-                .or(session_members::role.eq("editor")),
+                .eq(SessionRole::Owner.as_str())
+                .or(session_members::role.eq(SessionRole::Editor.as_str())),
         )
         .select(crate::models::Session::as_select())
         .first::<crate::models::Session>(conn)

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -8,7 +8,7 @@ use shared::api::{
     AddMemberRequest, ResolveProxySessionRequest, ResolveProxySessionResponse, SessionMemberInfo,
     SessionMembersResponse, UpdateMemberRoleRequest,
 };
-use shared::SessionStatus;
+use shared::{SessionRole, SessionStatus};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -23,7 +23,7 @@ use crate::{
 /// Session with the current user's role included.
 ///
 /// Serializes via `#[serde(flatten)]` of the full `Session` row plus a
-/// `my_role` string — this is the on-wire shape consumed by the frontend.
+/// typed `my_role` — this is the on-wire shape consumed by the frontend.
 /// The frontend deserializes the same bytes into `shared::api::SessionsResponse`
 /// (whose `sessions` field is `Vec<shared::SessionInfo>`); `SessionInfo`
 /// silently drops the per-row stats fields it doesn't care about
@@ -33,7 +33,7 @@ use crate::{
 pub struct SessionWithRole {
     #[serde(flatten)]
     pub session: Session,
-    pub my_role: String,
+    pub my_role: SessionRole,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub launcher_version: Option<String>,
 }
@@ -66,7 +66,7 @@ pub async fn list_sessions(
                 .session_manager
                 .launcher_version(session.launcher_id),
             session,
-            my_role: role,
+            my_role: role.parse().unwrap_or(SessionRole::Unknown),
         })
         .collect();
 
@@ -371,8 +371,8 @@ struct UserBasicInfo {
 }
 
 /// Validate a member role supplied by the caller
-fn validate_member_role(role: &str) -> Result<(), AppError> {
-    if role != "editor" && role != "viewer" {
+fn validate_member_role(role: SessionRole) -> Result<(), AppError> {
+    if !role.is_assignable_member_role() {
         return Err(AppError::BadRequest("Invalid role"));
     }
     Ok(())
@@ -410,7 +410,7 @@ pub async fn list_session_members(
             user_id: user.id,
             email: user.email,
             name: user.name,
-            role: member.role,
+            role: member.role.parse().unwrap_or(SessionRole::Unknown),
             created_at: member.created_at,
         })
         .collect();
@@ -427,7 +427,7 @@ pub async fn add_session_member(
     Path(session_id): Path<Uuid>,
     Json(req): Json<AddMemberRequest>,
 ) -> Result<EmptyResponse, AppError> {
-    validate_member_role(&req.role)?;
+    validate_member_role(req.role)?;
 
     let mut conn = app_state.conn()?;
 
@@ -459,7 +459,7 @@ pub async fn add_session_member(
     let new_member = NewSessionMember {
         session_id,
         user_id: target_user_id,
-        role: req.role,
+        role: req.role.as_str().to_string(),
     };
 
     diesel::insert_into(session_members::table)
@@ -487,7 +487,10 @@ pub async fn remove_session_member(
         .optional()?
         .ok_or(AppError::NotFound("Session not found"))?;
 
-    let is_owner = current_membership.role == "owner";
+    let is_owner = current_membership
+        .role
+        .parse::<SessionRole>()
+        .is_ok_and(SessionRole::can_manage_members);
 
     if !is_owner && current_user_id != target_user_id {
         return Err(AppError::Forbidden);
@@ -518,7 +521,7 @@ pub async fn update_session_member_role(
     Path((session_id, target_user_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<UpdateMemberRoleRequest>,
 ) -> Result<EmptyResponse, AppError> {
-    validate_member_role(&req.role)?;
+    validate_member_role(req.role)?;
 
     let mut conn = app_state.conn()?;
 
@@ -539,7 +542,7 @@ pub async fn update_session_member_role(
             .filter(session_members::session_id.eq(session_id))
             .filter(session_members::user_id.eq(target_user_id)),
     )
-    .set(session_members::role.eq(&req.role))
+    .set(session_members::role.eq(req.role.as_str()))
     .execute(&mut conn)?;
 
     if updated == 0 {

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -1,7 +1,7 @@
 use crate::models::{NewSessionMember, NewSessionWithId};
 use crate::AppState;
 use diesel::prelude::*;
-use shared::{AgentType, SessionStatus};
+use shared::{AgentType, SessionRole, SessionStatus};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -301,7 +301,7 @@ fn create_new_session(
             let new_member = NewSessionMember {
                 session_id: session.id,
                 user_id,
-                role: "owner".to_string(),
+                role: SessionRole::Owner.as_str().to_string(),
             };
             if let Err(e) = diesel::insert_into(session_members::table)
                 .values(&new_member)

--- a/frontend/src/components/share_dialog.rs
+++ b/frontend/src/components/share_dialog.rs
@@ -6,6 +6,7 @@ use gloo_net::http::Request;
 use shared::api::{
     AddMemberRequest, SessionMemberInfo, SessionMembersResponse, UpdateMemberRoleRequest,
 };
+use shared::SessionRole;
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::HtmlInputElement;
@@ -24,13 +25,13 @@ pub enum ShareDialogMsg {
     LoadMembers,
     MembersLoaded(Vec<SessionMemberInfo>),
     UpdateEmail(String),
-    UpdateRole(String),
+    UpdateRole(SessionRole),
     AddMember,
     MemberAdded,
     RemoveMember(Uuid),
     MemberRemoved(Uuid),
-    ChangeRole(Uuid, String),
-    RoleChanged(Uuid, String),
+    ChangeRole(Uuid, SessionRole),
+    RoleChanged(Uuid, SessionRole),
     SetError(String),
 }
 
@@ -38,7 +39,7 @@ pub struct ShareDialog {
     members: Vec<SessionMemberInfo>,
     loading: bool,
     email_input: String,
-    new_role: String,
+    new_role: SessionRole,
     error: Option<String>,
     // RAII guard — must be held to keep the Escape listener active
     _escape_listener: Option<EventListener>,
@@ -61,7 +62,7 @@ impl Component for ShareDialog {
             members: Vec::new(),
             loading: true,
             email_input: String::new(),
-            new_role: "viewer".to_string(),
+            new_role: SessionRole::Viewer,
             error: None,
             _escape_listener: Some(listener),
         }
@@ -109,7 +110,7 @@ impl Component for ShareDialog {
                 }
                 let session_id = ctx.props().session_id;
                 let email = self.email_input.trim().to_string();
-                let role = self.new_role.clone();
+                let role = self.new_role;
                 let link = ctx.link().clone();
 
                 spawn_local(async move {
@@ -183,13 +184,13 @@ impl Component for ShareDialog {
             ShareDialogMsg::ChangeRole(user_id, new_role) => {
                 let session_id = ctx.props().session_id;
                 let link = ctx.link().clone();
-                let role = new_role.clone();
+                let role = new_role;
                 spawn_local(async move {
                     let url = utils::api_url(&format!(
                         "/api/sessions/{}/members/{}",
                         session_id, user_id
                     ));
-                    let body = UpdateMemberRoleRequest { role: role.clone() };
+                    let body = UpdateMemberRoleRequest { role };
                     match Request::patch(&url).json(&body).unwrap().send().await {
                         Ok(response) if response.ok() => {
                             link.send_message(ShareDialogMsg::RoleChanged(user_id, role));
@@ -240,7 +241,7 @@ impl Component for ShareDialog {
 
         let on_role_change = ctx.link().callback(|e: Event| {
             let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
-            ShareDialogMsg::UpdateRole(select.value())
+            ShareDialogMsg::UpdateRole(select.value().parse().unwrap_or(SessionRole::Viewer))
         });
 
         let on_add_click = ctx.link().callback(|_| ShareDialogMsg::AddMember);
@@ -283,7 +284,7 @@ impl Component for ShareDialog {
                             oninput={on_email_input}
                             onkeypress={on_keypress}
                         />
-                        <select value={self.new_role.clone()} onchange={on_role_change}>
+                        <select value={self.new_role.as_str()} onchange={on_role_change}>
                             <option value="viewer">{ "Viewer" }</option>
                             <option value="editor">{ "Editor" }</option>
                         </select>
@@ -313,7 +314,7 @@ impl Component for ShareDialog {
 
 impl ShareDialog {
     fn view_member(&self, ctx: &Context<Self>, member: &SessionMemberInfo) -> Html {
-        let is_owner = member.role == "owner";
+        let is_owner = member.role == SessionRole::Owner;
         let user_id = member.user_id;
         let display_name = member
             .name
@@ -329,7 +330,10 @@ impl ShareDialog {
             let link = ctx.link().clone();
             Callback::from(move |e: Event| {
                 let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
-                link.send_message(ShareDialogMsg::ChangeRole(user_id, select.value()));
+                link.send_message(ShareDialogMsg::ChangeRole(
+                    user_id,
+                    select.value().parse().unwrap_or(SessionRole::Viewer),
+                ));
             })
         };
 
@@ -342,9 +346,9 @@ impl ShareDialog {
                     } else {
                         html! {
                             <>
-                                <select class="member-role-select" value={member.role.clone()} onchange={on_role_change}>
-                                    <option value="viewer" selected={member.role == "viewer"}>{ "Viewer" }</option>
-                                    <option value="editor" selected={member.role == "editor"}>{ "Editor" }</option>
+                                <select class="member-role-select" value={member.role.as_str()} onchange={on_role_change}>
+                                    <option value="viewer" selected={member.role == SessionRole::Viewer}>{ "Viewer" }</option>
+                                    <option value="editor" selected={member.role == SessionRole::Editor}>{ "Editor" }</option>
                                 </select>
                                 <button class="member-remove" onclick={on_remove} title="Remove member">
                                     { "×" }

--- a/frontend/src/pages/dashboard/session_order.rs
+++ b/frontend/src/pages/dashboard/session_order.rs
@@ -101,7 +101,7 @@ pub(super) fn resolve_focus_index(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use shared::{AgentType, SessionInfo, SessionStatus};
+    use shared::{AgentType, SessionInfo, SessionRole, SessionStatus};
 
     fn session(id: Uuid, dir: &str, host: &str, branch: Option<&str>) -> SessionInfo {
         SessionInfo {
@@ -115,7 +115,7 @@ mod tests {
             created_at: String::new(),
             updated_at: String::new(),
             git_branch: branch.map(|b| b.to_string()),
-            my_role: "owner".to_string(),
+            my_role: SessionRole::Owner,
             hostname: host.to_string(),
             launcher_id: None,
             launcher_version: None,

--- a/frontend/src/pages/dashboard/session_rail/menu.rs
+++ b/frontend/src/pages/dashboard/session_rail/menu.rs
@@ -1,7 +1,7 @@
 // TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use shared::SessionInfo;
+use shared::{SessionInfo, SessionRole};
 use uuid::Uuid;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::MouseEvent;
@@ -138,7 +138,7 @@ fn render_menu_content(session: &SessionInfo, props: &SessionRailMenuProps) -> H
         )
     };
 
-    let pause_option = if session.my_role != "viewer" {
+    let pause_option = if session.my_role != SessionRole::Viewer {
         let (pause_label, pause_hint) = if is_paused {
             ("Resume Session", "Restart from saved session")
         } else {
@@ -212,7 +212,7 @@ fn render_menu_content(session: &SessionInfo, props: &SessionRailMenuProps) -> H
     };
     let short_id = &session.id.to_string()[..8];
 
-    let leave_option = if session.my_role != "owner" {
+    let leave_option = if session.my_role != SessionRole::Owner {
         menu_option(
             classes!("leave"),
             "Leave Session",
@@ -225,7 +225,7 @@ fn render_menu_content(session: &SessionInfo, props: &SessionRailMenuProps) -> H
 
     let repo_option = repo_pr_submenu(session);
 
-    let share_option = if session.my_role == "owner" {
+    let share_option = if session.my_role == SessionRole::Owner {
         let on_share = close_then(props.on_close.clone(), {
             let on_share = props.on_share.clone();
             move || on_share.emit(session_id)
@@ -240,7 +240,7 @@ fn render_menu_content(session: &SessionInfo, props: &SessionRailMenuProps) -> H
         html! {}
     };
 
-    let delete_option = if session.my_role == "owner" {
+    let delete_option = if session.my_role == SessionRole::Owner {
         menu_option(
             classes!("stop"),
             "Delete Session",
@@ -251,7 +251,7 @@ fn render_menu_content(session: &SessionInfo, props: &SessionRailMenuProps) -> H
         html! {}
     };
 
-    let schedule_option = if session.my_role == "owner" {
+    let schedule_option = if session.my_role == SessionRole::Owner {
         menu_option(
             classes!("schedule"),
             "Schedule Task",

--- a/frontend/src/pages/dashboard/session_rail/pill.rs
+++ b/frontend/src/pages/dashboard/session_rail/pill.rs
@@ -112,7 +112,7 @@ pub(super) fn session_pill(props: &SessionPillProps) -> Html {
             }
             {
                 if let Some(role_class) = view.role_badge_class {
-                    html! { <span class={role_class}>{ &session.my_role }</span> }
+                    html! { <span class={role_class}>{ session.my_role.as_str() }</span> }
                 } else {
                     html! {}
                 }
@@ -181,8 +181,8 @@ impl PillViewModel {
             None
         };
 
-        let role_badge_class = (session.my_role != "owner")
-            .then(|| format!("pill-role-badge role-{}", session.my_role));
+        let role_badge_class = (session.my_role != shared::SessionRole::Owner)
+            .then(|| format!("pill-role-badge role-{}", session.my_role.as_str()));
 
         Self {
             pill_classes,

--- a/frontend/src/pages/settings/sessions_panel.rs
+++ b/frontend/src/pages/settings/sessions_panel.rs
@@ -40,7 +40,7 @@ fn session_row(props: &SessionRowProps) -> Html {
     let project = utils::extract_folder(&session.working_directory);
     let hostname = &session.hostname;
 
-    let is_owner = session.my_role == "owner";
+    let is_owner = session.my_role == shared::SessionRole::Owner;
 
     let short_id = &session.id.to_string()[..8];
 

--- a/shared/src/api/sessions.rs
+++ b/shared/src/api/sessions.rs
@@ -4,7 +4,7 @@ use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::SessionInfo;
+use crate::{SessionInfo, SessionRole};
 
 /// Response from GET /api/sessions — sessions visible to the current user.
 ///
@@ -62,7 +62,7 @@ pub struct SessionMemberInfo {
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]
-    pub role: String,
+    pub role: SessionRole,
     pub created_at: NaiveDateTime,
 }
 

--- a/shared/src/api/users.rs
+++ b/shared/src/api/users.rs
@@ -3,6 +3,8 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::SessionRole;
+
 /// Request to update a user's admin/ban settings (admin endpoint)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UpdateUserRequest {
@@ -44,13 +46,13 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddMemberRequest {
     pub email: String,
-    pub role: String,
+    pub role: SessionRole,
 }
 
 /// Request to update a session member's role
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateMemberRoleRequest {
-    pub role: String,
+    pub role: SessionRole,
 }
 
 /// Response from GET /api/auth/me — the currently authenticated user.

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -231,6 +231,61 @@ impl SessionStatus {
     }
 }
 
+/// Current user's role within a shared session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionRole {
+    Owner,
+    Editor,
+    #[default]
+    Viewer,
+    #[serde(other)]
+    Unknown,
+}
+
+impl SessionRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Owner => "owner",
+            Self::Editor => "editor",
+            Self::Viewer => "viewer",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub fn can_mutate(self) -> bool {
+        matches!(self, Self::Owner | Self::Editor)
+    }
+
+    pub fn can_manage_members(self) -> bool {
+        matches!(self, Self::Owner)
+    }
+
+    pub fn is_assignable_member_role(self) -> bool {
+        matches!(self, Self::Editor | Self::Viewer)
+    }
+}
+
+impl std::fmt::Display for SessionRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for SessionRole {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "owner" => Ok(Self::Owner),
+            "editor" => Ok(Self::Editor),
+            "viewer" => Ok(Self::Viewer),
+            "unknown" => Ok(Self::Unknown),
+            other => Err(format!("unknown session role: {}", other)),
+        }
+    }
+}
+
 impl SendMode {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -323,7 +378,7 @@ pub struct SessionInfo {
     #[serde(default)]
     pub git_branch: Option<String>,
     /// The current user's role in this session (owner, editor, viewer)
-    pub my_role: String,
+    pub my_role: SessionRole,
     /// Hostname of the machine running the session
     #[serde(default)]
     pub hostname: String,
@@ -760,6 +815,34 @@ mod tests {
 
         let replaced: SessionStatus = serde_json::from_str("\"replaced\"").unwrap();
         assert_eq!(replaced, SessionStatus::Replaced);
+    }
+
+    #[test]
+    fn session_role_wire_and_capabilities() {
+        assert_eq!(SessionRole::Owner.as_str(), "owner");
+        assert_eq!(SessionRole::Editor.as_str(), "editor");
+        assert_eq!(SessionRole::Viewer.as_str(), "viewer");
+
+        assert!(SessionRole::Owner.can_manage_members());
+        assert!(SessionRole::Owner.can_mutate());
+        assert!(SessionRole::Editor.can_mutate());
+        assert!(!SessionRole::Editor.can_manage_members());
+        assert!(!SessionRole::Viewer.can_mutate());
+
+        assert!(SessionRole::Editor.is_assignable_member_role());
+        assert!(SessionRole::Viewer.is_assignable_member_role());
+        assert!(!SessionRole::Owner.is_assignable_member_role());
+
+        let json = serde_json::to_string(&SessionRole::Editor).unwrap();
+        assert_eq!(json, "\"editor\"");
+        assert_eq!(
+            serde_json::from_str::<SessionRole>("\"owner\"").unwrap(),
+            SessionRole::Owner
+        );
+        assert_eq!(
+            " viewer ".parse::<SessionRole>().unwrap(),
+            SessionRole::Viewer
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a shared `SessionRole` enum with serde lowercase wire format and role capability helpers.
- Uses `SessionRole` in session member request/response DTOs and session `my_role` wire data.
- Converts backend/frontend role checks to enum comparisons while keeping DB columns as text at the persistence boundary.

Closes #1415.

## Validation
- `cargo test -p shared`
- `cargo check -p backend`
- `cargo check -p frontend --target wasm32-unknown-unknown`
- `cargo fmt --check`
- `git diff --check`
