### PR TITLE
Use AgentType for turn metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "a2",
  "anyhow",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5189,7 +5189,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "colored",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "hex",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.3"
+version = "2.13.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.4"
+version = "2.13.5"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/turn_metrics.rs
+++ b/backend/src/handlers/turn_metrics.rs
@@ -28,6 +28,7 @@ use diesel::prelude::*;
 use diesel::sql_types::{BigInt, Double, Nullable, Text, Timestamptz};
 use serde::Deserialize;
 use shared::api::{MetricBucket, MetricBucketsResponse, TurnMetricsResponse};
+use shared::AgentType;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -382,7 +383,7 @@ pub async fn list_aggregated_turn_metrics(
             let stop_reason_counts = reason_index.remove(&key).unwrap_or_default();
             MetricBucket {
                 bucket_start: row.bucket_start,
-                agent_type: row.agent_type,
+                agent_type: row.agent_type.parse().unwrap_or(AgentType::Claude),
                 model: row.model,
                 service_tier: row.service_tier,
                 turn_count: row.turn_count,
@@ -475,7 +476,7 @@ mod tests {
         let resp = MetricBucketsResponse {
             buckets: vec![MetricBucket {
                 bucket_start: Utc.with_ymd_and_hms(2026, 5, 27, 0, 0, 0).unwrap(),
-                agent_type: "claude".to_string(),
+                agent_type: AgentType::Claude,
                 model: Some("claude-opus-4-7".to_string()),
                 service_tier: Some("standard".to_string()),
                 turn_count: 12,

--- a/backend/src/handlers/websocket/turn_metrics.rs
+++ b/backend/src/handlers/websocket/turn_metrics.rs
@@ -78,7 +78,7 @@ pub fn handle_turn_metrics_report(
         session_id,
         user_id: owner_id,
         user_message_id: metrics.user_message_id,
-        agent_type: metrics.agent_type.clone(),
+        agent_type: metrics.agent_type.as_str().to_string(),
         model: metrics.model.clone(),
         service_tier: metrics.service_tier.clone(),
         started_at: metrics.started_at,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -557,7 +557,7 @@ impl TurnMetric {
             // session is gone. Freshly inserted rows always carry one.
             session_id: self.session_id.unwrap_or_default(),
             user_message_id: self.user_message_id,
-            agent_type: self.agent_type,
+            agent_type: self.agent_type.parse().unwrap_or(shared::AgentType::Claude),
             model: self.model,
             service_tier: self.service_tier,
             started_at: self.started_at,

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -462,7 +462,7 @@ pub(crate) async fn claude_io_task(
                             let usage = r.usage.as_ref();
                             let model = current_model.clone();
                             let outcome = TurnOutcome {
-                                agent_type: shared::AgentType::Claude.as_str().to_string(),
+                                agent_type: shared::AgentType::Claude,
                                 model,
                                 service_tier: current_service_tier.clone().or_else(|| {
                                     usage

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -369,9 +369,7 @@ pub(crate) async fn codex_io_task(
                                     .or_else(|| thread_model.clone())
                                     .or_else(|| configured_model_fallback.clone());
                                 let outcome = TurnOutcome {
-                                    agent_type: shared::AgentType::Codex
-                                        .as_str()
-                                        .to_string(),
+                                    agent_type: shared::AgentType::Codex,
                                     model,
                                     service_tier: None,
                                     input_tokens: usage

--- a/frontend/src/components/message_renderer/turn_metrics_footer.rs
+++ b/frontend/src/components/message_renderer/turn_metrics_footer.rs
@@ -234,6 +234,7 @@ pub fn render_turn_metrics_footer(metrics: Option<&TurnMetrics>) -> Html {
 mod tests {
     use super::*;
     use chrono::Utc;
+    use shared::AgentType;
     use uuid::Uuid;
 
     // ---- compact_count ----
@@ -405,7 +406,7 @@ mod tests {
             id: Some(Uuid::nil()),
             session_id: Uuid::nil(),
             user_message_id: None,
-            agent_type: "claude".to_string(),
+            agent_type: AgentType::Claude,
             model: Some("claude-opus-4-7".to_string()),
             service_tier: Some("standard".to_string()),
             started_at: Utc::now(),
@@ -465,7 +466,7 @@ mod tests {
             id: Some(Uuid::nil()),
             session_id: Uuid::nil(),
             user_message_id: None,
-            agent_type: "codex".to_string(),
+            agent_type: AgentType::Codex,
             model: None,
             service_tier: None,
             started_at: Utc::now(),

--- a/frontend/src/components/turn_metrics_pill.rs
+++ b/frontend/src/components/turn_metrics_pill.rs
@@ -294,6 +294,7 @@ pub fn turn_metrics_header_pill(props: &TurnMetricsHeaderPillProps) -> Html {
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
+    use shared::AgentType;
     use uuid::Uuid;
 
     fn mk(model: Option<&str>, tier: Option<&str>, idx: i64) -> TurnMetrics {
@@ -320,7 +321,7 @@ mod tests {
             is_error: false,
             tool_call_count: 0,
             stream_restarts: 0,
-            agent_type: "claude".to_string(),
+            agent_type: AgentType::Claude,
             model: model.map(|s| s.to_string()),
             service_tier: tier.map(|s| s.to_string()),
             total_cost_usd: Some(0.012),

--- a/frontend/src/hooks/client_websocket_events.rs
+++ b/frontend/src/hooks/client_websocket_events.rs
@@ -100,6 +100,7 @@ pub(crate) fn insert_recent_metric(
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
+    use shared::AgentType;
     use uuid::Uuid;
 
     /// Build a minimal `TurnMetrics` with the fields the recent-buffer
@@ -109,7 +110,7 @@ mod tests {
             id,
             session_id: Uuid::nil(),
             user_message_id: None,
-            agent_type: "claude".to_string(),
+            agent_type: AgentType::Claude,
             model: None,
             service_tier: None,
             started_at: Utc.timestamp_opt(started_secs, 0).unwrap(),

--- a/frontend/src/pages/dashboard/session_view/state.rs
+++ b/frontend/src/pages/dashboard/session_view/state.rs
@@ -55,6 +55,7 @@ pub(super) fn sort_turn_metrics_by_start(metrics: &mut [TurnMetrics]) {
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
+    use shared::AgentType;
     use uuid::Uuid;
 
     fn metric(id: Option<Uuid>, started_secs: i64, output_tokens: i64) -> TurnMetrics {
@@ -62,7 +63,7 @@ mod tests {
             id,
             session_id: Uuid::nil(),
             user_message_id: None,
-            agent_type: "claude".to_string(),
+            agent_type: AgentType::Claude,
             model: None,
             service_tier: None,
             started_at: Utc.timestamp_opt(started_secs, 0).unwrap(),

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -87,7 +87,7 @@ pub fn performance_panel() -> Html {
 mod tests {
     use super::*;
     use chrono::{DateTime, TimeZone, Utc};
-    use shared::api::MetricBucket;
+    use shared::{api::MetricBucket, AgentType};
     use std::collections::BTreeMap;
 
     use super::model::{
@@ -112,7 +112,7 @@ mod tests {
         }
         MetricBucket {
             bucket_start: ts,
-            agent_type: "claude".to_string(),
+            agent_type: AgentType::Claude,
             model: model.map(|s| s.to_string()),
             service_tier: tier.map(|s| s.to_string()),
             turn_count: 1,
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn pair_label_appends_non_standard_tier() {
         let label = pair_label(&(
-            "claude".to_string(),
+            AgentType::Claude,
             Some("claude-opus-4-7".to_string()),
             Some("priority".to_string()),
         ));
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn pair_label_drops_standard_tier() {
         let label = pair_label(&(
-            "claude".to_string(),
+            AgentType::Claude,
             Some("claude-opus-4-7".to_string()),
             Some("standard".to_string()),
         ));
@@ -187,13 +187,13 @@ mod tests {
 
     #[test]
     fn pair_label_codex_when_no_model() {
-        let label = pair_label(&("codex".to_string(), None, None));
+        let label = pair_label(&(AgentType::Codex, None, None));
         assert_eq!(label, "Codex");
     }
 
     #[test]
     fn pair_label_unknown_when_no_claude_model() {
-        let label = pair_label(&("claude".to_string(), None, None));
+        let label = pair_label(&(AgentType::Claude, None, None));
         assert_eq!(label, "claude unknown");
     }
 
@@ -206,7 +206,7 @@ mod tests {
     #[test]
     fn group_by_key_roundtrips_through_string() {
         let pairs = vec![(
-            "claude".to_string(),
+            AgentType::Claude,
             Some("claude-opus-4-7".to_string()),
             Some("standard".to_string()),
         )];

--- a/frontend/src/pages/settings/performance_panel/model.rs
+++ b/frontend/src/pages/settings/performance_panel/model.rs
@@ -2,12 +2,13 @@
 
 use chrono::{DateTime, Utc};
 use shared::api::MetricBucket;
+use shared::AgentType;
 
 /// (agent_type, model, service_tier) tuple used as the group-by key. Codex
 /// currently reports no model or tier; keeping the agent in the key lets the
 /// UI label that shape explicitly without colliding with missing Claude
 /// metadata.
-pub(super) type GroupKey = (String, Option<String>, Option<String>);
+pub(super) type GroupKey = (AgentType, Option<String>, Option<String>);
 
 /// Pure helper: list the distinct (agent, model, tier) groups present in the
 /// bucket list.
@@ -21,7 +22,7 @@ pub(super) fn distinct_pairs(buckets: &[MetricBucket]) -> Vec<GroupKey> {
 
 pub(super) fn bucket_group_key(bucket: &MetricBucket) -> GroupKey {
     (
-        bucket.agent_type.clone(),
+        bucket.agent_type,
         bucket.model.clone(),
         bucket.service_tier.clone(),
     )
@@ -34,11 +35,10 @@ pub(super) fn bucket_group_key(bucket: &MetricBucket) -> GroupKey {
 /// shows the full model id (no vendor-prefix shortening), keeps the tier's
 /// original case, and adds codex / agent-without-model handling.
 pub(super) fn pair_label(pair: &GroupKey) -> String {
-    let base = match (pair.0.as_str(), pair.1.as_deref()) {
-        ("codex", None) => "Codex".to_string(),
+    let base = match (pair.0, pair.1.as_deref()) {
+        (AgentType::Codex, None) => "Codex".to_string(),
         (_, Some(model)) => model.to_string(),
-        (agent, None) if !agent.is_empty() => format!("{agent} unknown"),
-        _ => "unknown".to_string(),
+        (agent, None) => format!("{agent} unknown"),
     };
     match pair.2.as_deref() {
         Some(t) if !t.is_empty() && !t.eq_ignore_ascii_case("standard") => {

--- a/session-lib/src/turn_tracker.rs
+++ b/session-lib/src/turn_tracker.rs
@@ -14,7 +14,7 @@
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
-use shared::TurnMetrics;
+use shared::{AgentType, TurnMetrics};
 use uuid::Uuid;
 
 /// Running state of the current turn.
@@ -241,7 +241,7 @@ impl TurnTracker {
 /// `TurnCompleted` frame.
 #[derive(Debug, Clone, Default)]
 pub struct TurnOutcome {
-    pub agent_type: String,
+    pub agent_type: AgentType,
     pub model: Option<String>,
     pub service_tier: Option<String>,
     pub input_tokens: i64,
@@ -276,7 +276,7 @@ mod tests {
 
     fn outcome() -> TurnOutcome {
         TurnOutcome {
-            agent_type: "claude".to_string(),
+            agent_type: AgentType::Claude,
             model: Some("claude-opus-4-7".to_string()),
             service_tier: Some("standard".to_string()),
             input_tokens: 100,
@@ -392,7 +392,7 @@ mod tests {
         tracker.start(t0, Utc::now());
         tracker.record_content_frame(t0 + Duration::from_millis(80));
         let outcome = TurnOutcome {
-            agent_type: "codex".to_string(),
+            agent_type: AgentType::Codex,
             model: None,
             service_tier: None,
             input_tokens: 42,
@@ -408,7 +408,7 @@ mod tests {
         let m = tracker
             .finalize(t0 + Duration::from_millis(400), Utc::now(), outcome)
             .unwrap();
-        assert_eq!(m.agent_type, "codex");
+        assert_eq!(m.agent_type, AgentType::Codex);
         assert!(m.total_cost_usd.is_none());
         assert!(m.model.is_none());
         assert_eq!(m.input_tokens, 42);

--- a/shared/src/api/metrics.rs
+++ b/shared/src/api/metrics.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use uuid::Uuid;
 
+use crate::AgentType;
+
 /// Per-model usage / cost breakdown carried by Claude's
 /// `ResultMessage.modelUsage` field.
 pub use claude_codes::io::ModelUsageEntry;
@@ -49,7 +51,7 @@ pub struct TurnMetrics {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_message_id: Option<Uuid>,
 
-    pub agent_type: String,
+    pub agent_type: AgentType,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -141,7 +143,7 @@ pub struct TurnMetricsResponse {
 pub struct MetricBucket {
     /// Bucket start timestamp (UTC). `date_trunc('hour' | 'day', started_at)`.
     pub bucket_start: DateTime<Utc>,
-    pub agent_type: String,
+    pub agent_type: AgentType,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -287,7 +287,7 @@ mod tests {
             id: None,
             session_id: Uuid::nil(),
             user_message_id: None,
-            agent_type: "claude".to_string(),
+            agent_type: crate::AgentType::Claude,
             model: Some("claude-opus-4-7".to_string()),
             service_tier: Some("standard".to_string()),
             started_at: started,
@@ -326,7 +326,7 @@ mod tests {
             id: None,
             session_id: Uuid::nil(),
             user_message_id: None,
-            agent_type: "claude".to_string(),
+            agent_type: crate::AgentType::Claude,
             model: Some("claude-opus-4-7".to_string()),
             service_tier: None,
             started_at: Utc::now(),
@@ -374,7 +374,7 @@ mod tests {
         counts.insert("max_tokens".to_string(), 1);
         let bucket = MetricBucket {
             bucket_start,
-            agent_type: "claude".to_string(),
+            agent_type: crate::AgentType::Claude,
             model: Some("claude-opus-4-7".to_string()),
             service_tier: Some("standard".to_string()),
             turn_count: 6,
@@ -405,7 +405,7 @@ mod tests {
     fn metric_buckets_response_roundtrip() {
         let bucket = MetricBucket {
             bucket_start: chrono::Utc::now(),
-            agent_type: "codex".to_string(),
+            agent_type: crate::AgentType::Codex,
             model: None,
             service_tier: None,
             turn_count: 3,
@@ -444,7 +444,7 @@ mod tests {
             id: None,
             session_id: Uuid::nil(),
             user_message_id: None,
-            agent_type: "codex".to_string(),
+            agent_type: crate::AgentType::Codex,
             model: None,
             service_tier: None,
             started_at: started,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -116,7 +116,9 @@ pub fn is_compaction_boundary(sys: &SystemMessage) -> bool {
 }
 
 /// Which agent CLI backs a session
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum AgentType {
     #[default]
@@ -125,7 +127,7 @@ pub enum AgentType {
 }
 
 impl AgentType {
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(self) -> &'static str {
         match self {
             AgentType::Claude => "claude",
             AgentType::Codex => "codex",
@@ -142,7 +144,7 @@ impl std::fmt::Display for AgentType {
 impl std::str::FromStr for AgentType {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.trim().to_ascii_lowercase().as_str() {
             "claude" => Ok(AgentType::Claude),
             "codex" => Ok(AgentType::Codex),
             other => Err(format!("unknown agent type: {}", other)),


### PR DESCRIPTION
Closes #1416.

## Summary
- Change turn metrics wire structs to use shared::AgentType instead of raw strings.
- Parse persisted metric rows into AgentType at the backend boundary.
- Update frontend grouping/labels and turn tracker tests to use the typed enum.

## Validation
- cargo fmt --check
- cargo test -p shared -p session-lib
- mkdir -p frontend/dist && cargo check -p backend
- cargo check -p frontend --target wasm32-unknown-unknown
- cargo check -p claude-session-lib -p codex-session-lib -p claude-portal -p agent-portal