### PR TITLE
Cover backend validation error mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "a2",
  "anyhow",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5189,7 +5189,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "anyhow",
  "colored",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "anyhow",
  "hex",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.5"
+version = "2.13.6"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -54,6 +54,14 @@ fn task_to_info(t: ScheduledTask) -> ScheduledTaskInfo {
     }
 }
 
+fn validate_cron_expression(cron_expression: &str) -> Result<(), AppError> {
+    let cron_fields: Vec<&str> = cron_expression.split_whitespace().collect();
+    if cron_fields.len() != 5 {
+        return Err(AppError::BadRequest("Invalid cron expression"));
+    }
+    Ok(())
+}
+
 /// Convert a ScheduledTask model to a ScheduledTaskConfig protocol message.
 pub(crate) fn task_to_config(t: &ScheduledTask) -> ScheduledTaskConfig {
     ScheduledTaskConfig {
@@ -172,11 +180,9 @@ pub async fn create_task_handler(
     CurrentUserId(user_id): CurrentUserId,
     Json(req): Json<CreateScheduledTaskRequest>,
 ) -> Result<Json<ScheduledTaskInfo>, AppError> {
-    // Basic cron validation: must have 5 space-separated fields
-    let cron_fields: Vec<&str> = req.fields.cron_expression.split_whitespace().collect();
-    if cron_fields.len() != 5 {
+    if let Err(err) = validate_cron_expression(&req.fields.cron_expression) {
         warn!("Invalid cron expression: {}", req.fields.cron_expression);
-        return Err(AppError::BadRequest("Invalid cron expression"));
+        return Err(err);
     }
 
     let mut conn = app_state.conn()?;
@@ -228,10 +234,9 @@ pub async fn update_task_handler(
 
     // Validate cron if provided
     if let Some(ref cron) = req.cron_expression {
-        let fields: Vec<&str> = cron.split_whitespace().collect();
-        if fields.len() != 5 {
+        if let Err(err) = validate_cron_expression(cron) {
             warn!("Invalid cron expression in update: {}", cron);
-            return Err(AppError::BadRequest("Invalid cron expression"));
+            return Err(err);
         }
     }
 
@@ -326,4 +331,23 @@ pub async fn list_runs_handler(
         .load(&mut conn)?;
 
     Ok(Json(runs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_cron_validation_is_bad_request() {
+        let err = validate_cron_expression("* * *").unwrap_err();
+        assert!(matches!(
+            err,
+            AppError::BadRequest("Invalid cron expression")
+        ));
+    }
+
+    #[test]
+    fn valid_cron_validation_accepts_five_fields() {
+        validate_cron_expression("*/5 * * * *").unwrap();
+    }
 }

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -378,6 +378,34 @@ fn validate_member_role(role: SessionRole) -> Result<(), AppError> {
     Ok(())
 }
 
+fn ensure_member_not_existing(member_exists: bool) -> Result<(), AppError> {
+    if member_exists {
+        return Err(AppError::BadRequest("User is already a member"));
+    }
+    Ok(())
+}
+
+fn ensure_owner_not_self_removal(
+    is_owner: bool,
+    current_user_id: Uuid,
+    target_user_id: Uuid,
+) -> Result<(), AppError> {
+    if is_owner && current_user_id == target_user_id {
+        return Err(AppError::BadRequest("Owner cannot remove themselves"));
+    }
+    Ok(())
+}
+
+fn ensure_not_self_role_change(
+    current_user_id: Uuid,
+    target_user_id: Uuid,
+) -> Result<(), AppError> {
+    if current_user_id == target_user_id {
+        return Err(AppError::BadRequest("Cannot change own role"));
+    }
+    Ok(())
+}
+
 /// List all members of a session
 pub async fn list_session_members(
     State(app_state): State<Arc<AppState>>,
@@ -452,9 +480,7 @@ pub async fn add_session_member(
         .first::<SessionMember>(&mut conn)
         .optional()?;
 
-    if existing.is_some() {
-        return Err(AppError::BadRequest("User is already a member"));
-    }
+    ensure_member_not_existing(existing.is_some())?;
 
     let new_member = NewSessionMember {
         session_id,
@@ -496,9 +522,7 @@ pub async fn remove_session_member(
         return Err(AppError::Forbidden);
     }
 
-    if is_owner && current_user_id == target_user_id {
-        return Err(AppError::BadRequest("Owner cannot remove themselves"));
-    }
+    ensure_owner_not_self_removal(is_owner, current_user_id, target_user_id)?;
 
     let deleted = diesel::delete(
         session_members::table
@@ -533,9 +557,7 @@ pub async fn update_session_member_role(
         current_user_id,
     )?;
 
-    if current_user_id == target_user_id {
-        return Err(AppError::BadRequest("Cannot change own role"));
-    }
+    ensure_not_self_role_change(current_user_id, target_user_id)?;
 
     let updated = diesel::update(
         session_members::table
@@ -550,4 +572,44 @@ pub async fn update_session_member_role(
     }
 
     Ok(EmptyResponse::OK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_member_role_validation_is_bad_request() {
+        let err = validate_member_role(SessionRole::Owner).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest("Invalid role")));
+    }
+
+    #[test]
+    fn duplicate_member_validation_is_bad_request() {
+        let err = ensure_member_not_existing(true).unwrap_err();
+        assert!(matches!(
+            err,
+            AppError::BadRequest("User is already a member")
+        ));
+    }
+
+    #[test]
+    fn owner_self_removal_validation_is_bad_request() {
+        let user_id = Uuid::nil();
+        let err = ensure_owner_not_self_removal(true, user_id, user_id).unwrap_err();
+        assert!(matches!(
+            err,
+            AppError::BadRequest("Owner cannot remove themselves")
+        ));
+    }
+
+    #[test]
+    fn self_role_change_validation_is_bad_request() {
+        let user_id = Uuid::nil();
+        let err = ensure_not_self_role_change(user_id, user_id).unwrap_err();
+        assert!(matches!(
+            err,
+            AppError::BadRequest("Cannot change own role")
+        ));
+    }
 }


### PR DESCRIPTION
Closes #1419.

## Summary
- Centralize scheduled-task cron validation so create/update share the same BadRequest mapping.
- Add small session-member validation helpers for duplicate member and owner/self constraints.
- Add focused tests for invalid cron, invalid member role, duplicate member, owner self-removal, and self role-change mappings.

## Validation
- cargo fmt --check && git diff --check
- mkdir -p frontend/dist && cargo test -p backend validation_is_bad_request
- mkdir -p frontend/dist && cargo check -p backend