### PR TITLE
Deduplicate turn metrics display helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "a2",
  "anyhow",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5189,7 +5189,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "anyhow",
  "colored",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "anyhow",
  "hex",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.6"
+version = "2.13.7"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/count_up.rs
+++ b/frontend/src/components/count_up.rs
@@ -91,7 +91,7 @@ pub fn count_up(props: &CountUpProps) -> Html {
     }
 
     let shown = if props.compact {
-        crate::components::message_renderer::turn_metrics_footer::compact_count(*value)
+        crate::components::turn_metrics_display::compact_count(*value)
     } else {
         value.to_string()
     };

--- a/frontend/src/components/message_renderer/turn_metrics_footer.rs
+++ b/frontend/src/components/message_renderer/turn_metrics_footer.rs
@@ -48,89 +48,9 @@
 use shared::TurnMetrics;
 use yew::prelude::*;
 
-/// Compact integer for "2.1k in / 547 out" chips.
-///
-/// Values `< 1000` render as integers; values `≥ 1000` render as a
-/// one-decimal-k abbreviation (`1500` → `"1.5k"`, `1_000_000` → `"1000.0k"`).
-/// We deliberately don't introduce an `M` suffix — a single turn that emits
-/// 1M tokens is so far out of distribution that a long, easy-to-eyeball
-/// `1000.0k` is preferable to an opaque `1.0M`.
-pub fn compact_count(n: i64) -> String {
-    if n < 1000 {
-        n.to_string()
-    } else {
-        format!("{:.1}k", n as f64 / 1000.0)
-    }
-}
-
-/// Tokens-per-second chip text, e.g. `"47.2 tok/s"`.
-///
-/// Returns `None` when `generation_duration_ms` is `None` or `0` — both
-/// happen on error paths (turn aborted before any content frame, Codex
-/// failed-turn frames with missing duration) and rendering "inf tok/s" or
-/// dividing by zero would be misleading.
-pub fn format_tok_per_sec(
-    output_tokens: i64,
-    generation_duration_ms: Option<i64>,
-) -> Option<String> {
-    let gen_ms = generation_duration_ms?;
-    if gen_ms <= 0 {
-        return None;
-    }
-    let tok_per_sec = output_tokens as f64 / (gen_ms as f64 / 1000.0);
-    Some(format!("{:.1} tok/s", tok_per_sec))
-}
-
-/// TTFT chip text, e.g. `"TTFT 1.31s"`. Returns `None` if `ttft_ms` is
-/// `None` (turn errored before any content frame).
-pub fn format_ttft(ttft_ms: Option<i64>) -> Option<String> {
-    let ms = ttft_ms?;
-    Some(format!("TTFT {:.2}s", ms as f64 / 1000.0))
-}
-
-/// Cache-hit-% chip text, e.g. `"cache 84% hit"`.
-///
-/// Denominator is `input + cache_read + cache_creation` — the total prompt
-/// tokens this turn could plausibly have come from cache. Returns `None`
-/// when all three are zero (no prompt at all, or Codex turn that doesn't
-/// expose the cache breakdown — both should hide the chip rather than
-/// render a misleading "0% hit").
-pub fn format_cache_hit(input: i64, cache_read: i64, cache_creation: i64) -> Option<String> {
-    let total = input + cache_read + cache_creation;
-    if total <= 0 {
-        return None;
-    }
-    let pct = (cache_read as f64 / total as f64) * 100.0;
-    Some(format!("cache {:.0}% hit", pct))
-}
-
-/// Max-gap chip text, e.g. `"max gap 1.5s"`.
-///
-/// Only renders when the gap exceeds 1000ms — sub-1s inter-token gaps are
-/// the normal streaming heartbeat and showing them would just clutter every
-/// successful turn's chip strip. The 1000ms threshold matches the eyeball
-/// "I noticed a stall" line for a streaming UI.
-pub fn format_max_gap(max_inter_token_gap_ms: Option<i64>) -> Option<String> {
-    let ms = max_inter_token_gap_ms?;
-    if ms <= 1000 {
-        return None;
-    }
-    Some(format!("max gap {:.1}s", ms as f64 / 1000.0))
-}
-
-/// Cost chip text, e.g. `"$0.014"` for sub-$1 and `"$1.23"` for $1+.
-///
-/// Returns `None` when `total_cost_usd` is `None` — Codex turns don't
-/// surface cost on their wire today, so the chip vanishes naturally for
-/// codex sessions.
-pub fn format_cost(total_cost_usd: Option<f64>) -> Option<String> {
-    let cost = total_cost_usd?;
-    if cost.abs() < 1.0 {
-        Some(format!("${:.3}", cost))
-    } else {
-        Some(format!("${:.2}", cost))
-    }
-}
+use crate::components::turn_metrics_display::{
+    compact_count, format_cache_hit, format_cost, format_max_gap, format_tok_per_sec, format_ttft,
+};
 
 /// Build the full chip list for a `TurnMetrics` row, in render order. Each
 /// `Some(text)` chip becomes one `<span class="turn-metric-chip">` in the

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -20,6 +20,7 @@ pub mod skip_permissions;
 pub mod sparkline;
 pub mod time_ago;
 mod tool_renderers;
+pub(crate) mod turn_metrics_display;
 mod turn_metrics_pill;
 mod voice_input;
 

--- a/frontend/src/components/turn_metrics_display.rs
+++ b/frontend/src/components/turn_metrics_display.rs
@@ -1,0 +1,120 @@
+//! Shared display helpers for turn-metrics UI surfaces.
+
+use shared::AgentType;
+
+/// Compact integer for `"2.1k in / 547 out"` chips.
+pub(crate) fn compact_count(n: i64) -> String {
+    if n < 1000 {
+        n.to_string()
+    } else {
+        format!("{:.1}k", n as f64 / 1000.0)
+    }
+}
+
+pub(crate) fn compact_metric_count(value: f64) -> String {
+    if value < 1000.0 {
+        format!("{value:.0}")
+    } else {
+        format!("{:.1}k", value / 1000.0)
+    }
+}
+
+/// Strip a vendor prefix and trailing dated suffix so a model name fits a
+/// compact dashboard chip.
+pub(crate) fn compact_model_label(model: &str) -> String {
+    let trimmed = model
+        .strip_prefix("claude-")
+        .or_else(|| model.strip_prefix("gpt-"))
+        .or_else(|| model.strip_prefix("o"))
+        .unwrap_or(model);
+    let mut parts: Vec<&str> = trimmed.split('-').collect();
+    if let Some(last) = parts.last() {
+        if last.len() == 8 && last.chars().all(|c| c.is_ascii_digit()) {
+            parts.pop();
+        }
+    }
+    parts.join("-")
+}
+
+/// Build the compact dashboard label for a model/tier pair.
+pub(crate) fn format_compact_model_tier_label(
+    model: &Option<String>,
+    tier: &Option<String>,
+) -> String {
+    let short_model = model
+        .as_deref()
+        .map(compact_model_label)
+        .unwrap_or_else(|| "unknown".to_string());
+    append_nonstandard_tier(short_model, tier.as_deref())
+}
+
+/// Build the full settings-panel label for an agent/model/tier group.
+pub(crate) fn format_agent_model_tier_label(
+    agent_type: AgentType,
+    model: &Option<String>,
+    tier: &Option<String>,
+) -> String {
+    let base = match (agent_type, model.as_deref()) {
+        (AgentType::Codex, None) => "Codex".to_string(),
+        (_, Some(model)) => model.to_string(),
+        (agent, None) => format!("{agent} unknown"),
+    };
+    append_nonstandard_tier(base, tier.as_deref())
+}
+
+fn append_nonstandard_tier(base: String, tier: Option<&str>) -> String {
+    match tier {
+        Some(t) if !t.is_empty() && !t.eq_ignore_ascii_case("standard") => {
+            format!("{base} {}", t.to_ascii_lowercase())
+        }
+        _ => base,
+    }
+}
+
+/// Tokens-per-second chip text, e.g. `"47.2 tok/s"`.
+pub(crate) fn format_tok_per_sec(
+    output_tokens: i64,
+    generation_duration_ms: Option<i64>,
+) -> Option<String> {
+    let gen_ms = generation_duration_ms?;
+    if gen_ms <= 0 {
+        return None;
+    }
+    let tok_per_sec = output_tokens as f64 / (gen_ms as f64 / 1000.0);
+    Some(format!("{:.1} tok/s", tok_per_sec))
+}
+
+/// TTFT chip text, e.g. `"TTFT 1.31s"`.
+pub(crate) fn format_ttft(ttft_ms: Option<i64>) -> Option<String> {
+    let ms = ttft_ms?;
+    Some(format!("TTFT {:.2}s", ms as f64 / 1000.0))
+}
+
+/// Cache-hit-% chip text, e.g. `"cache 84% hit"`.
+pub(crate) fn format_cache_hit(input: i64, cache_read: i64, cache_creation: i64) -> Option<String> {
+    let total = input + cache_read + cache_creation;
+    if total <= 0 {
+        return None;
+    }
+    let pct = (cache_read as f64 / total as f64) * 100.0;
+    Some(format!("cache {:.0}% hit", pct))
+}
+
+/// Max-gap chip text, e.g. `"max gap 1.5s"`.
+pub(crate) fn format_max_gap(max_inter_token_gap_ms: Option<i64>) -> Option<String> {
+    let ms = max_inter_token_gap_ms?;
+    if ms <= 1000 {
+        return None;
+    }
+    Some(format!("max gap {:.1}s", ms as f64 / 1000.0))
+}
+
+/// Cost chip text, e.g. `"$0.014"` for sub-$1 and `"$1.23"` for $1+.
+pub(crate) fn format_cost(total_cost_usd: Option<f64>) -> Option<String> {
+    let cost = total_cost_usd?;
+    if cost.abs() < 1.0 {
+        Some(format!("${:.3}", cost))
+    } else {
+        Some(format!("${:.2}", cost))
+    }
+}

--- a/frontend/src/components/turn_metrics_pill.rs
+++ b/frontend/src/components/turn_metrics_pill.rs
@@ -13,6 +13,7 @@ use web_sys::Element;
 use yew::prelude::*;
 
 use super::sparkline::Sparkline;
+use super::turn_metrics_display::{compact_metric_count, format_compact_model_tier_label};
 
 /// Which metric the sparkline plots. Selectable via the dropdown.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,36 +75,7 @@ pub(crate) fn pick_most_recent_model_tier(
 /// when present and not `"standard"` (the default tier is never worth
 /// chip space).
 pub(crate) fn format_model_tier_label(model: &Option<String>, tier: &Option<String>) -> String {
-    let short_model = model
-        .as_deref()
-        .map(compact_model_label)
-        .unwrap_or_else(|| "unknown".to_string());
-    match tier.as_deref() {
-        Some(t) if !t.is_empty() && !t.eq_ignore_ascii_case("standard") => {
-            format!("{short_model} {}", t.to_ascii_lowercase())
-        }
-        _ => short_model,
-    }
-}
-
-/// Strip a vendor prefix + trailing dated suffix so a model name fits the
-/// chip. `claude-opus-4-5-20260301` → `opus-4-5`; `gpt-5-mini` → `5-mini`.
-/// Named distinctly from `message_renderer::shorten_model_name` (which
-/// produces display names like "Opus 4.5") to avoid import mix-ups.
-fn compact_model_label(model: &str) -> String {
-    let trimmed = model
-        .strip_prefix("claude-")
-        .or_else(|| model.strip_prefix("gpt-"))
-        .or_else(|| model.strip_prefix("o"))
-        .unwrap_or(model);
-    // Drop a trailing -YYYYMMDD if present (Anthropic dated checkpoints).
-    let mut parts: Vec<&str> = trimmed.split('-').collect();
-    if let Some(last) = parts.last() {
-        if last.len() == 8 && last.chars().all(|c| c.is_ascii_digit()) {
-            parts.pop();
-        }
-    }
-    parts.join("-")
+    format_compact_model_tier_label(model, tier)
 }
 
 /// Filter the buffer to turns that match the chosen (model, tier) pair,
@@ -175,14 +147,6 @@ fn format_current_value(metric: SparklineMetric, value: f64) -> String {
         SparklineMetric::CacheHit => format!("cache {:.0}%", value),
         SparklineMetric::Thinking => format!("{} thinking", compact_metric_count(value)),
         SparklineMetric::Subagent => format!("{} subagent", compact_metric_count(value)),
-    }
-}
-
-fn compact_metric_count(value: f64) -> String {
-    if value < 1000.0 {
-        format!("{value:.0}")
-    } else {
-        format!("{:.1}k", value / 1000.0)
     }
 }
 
@@ -293,6 +257,7 @@ pub fn turn_metrics_header_pill(props: &TurnMetricsHeaderPillProps) -> Html {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::components::turn_metrics_display::compact_model_label;
     use chrono::{TimeZone, Utc};
     use shared::AgentType;
     use uuid::Uuid;

--- a/frontend/src/pages/settings/performance_panel/model.rs
+++ b/frontend/src/pages/settings/performance_panel/model.rs
@@ -4,6 +4,8 @@ use chrono::{DateTime, Utc};
 use shared::api::MetricBucket;
 use shared::AgentType;
 
+use crate::components::turn_metrics_display::format_agent_model_tier_label;
+
 /// (agent_type, model, service_tier) tuple used as the group-by key. Codex
 /// currently reports no model or tier; keeping the agent in the key lets the
 /// UI label that shape explicitly without colliding with missing Claude
@@ -35,17 +37,7 @@ pub(super) fn bucket_group_key(bucket: &MetricBucket) -> GroupKey {
 /// shows the full model id (no vendor-prefix shortening), keeps the tier's
 /// original case, and adds codex / agent-without-model handling.
 pub(super) fn pair_label(pair: &GroupKey) -> String {
-    let base = match (pair.0, pair.1.as_deref()) {
-        (AgentType::Codex, None) => "Codex".to_string(),
-        (_, Some(model)) => model.to_string(),
-        (agent, None) => format!("{agent} unknown"),
-    };
-    match pair.2.as_deref() {
-        Some(t) if !t.is_empty() && !t.eq_ignore_ascii_case("standard") => {
-            format!("{base} {t}")
-        }
-        _ => base,
-    }
+    format_agent_model_tier_label(pair.0, &pair.1, &pair.2)
 }
 
 /// Pick a stable color from the Tokyo-Night palette. We cycle through a


### PR DESCRIPTION
Closes #1418.\n\n## Summary\n- centralize compact count, model/tier label, and metric-chip formatters in a shared frontend helper module\n- reuse the helpers from the turn metrics footer, metrics pill, settings performance grouping, and CountUp compact display\n- keep existing formatter test coverage while removing duplicate implementations\n\n## Validation\n- cargo fmt --check && git diff --check\n- cargo check -p frontend --target wasm32-unknown-unknown\n- cargo test -p frontend turn_metrics