### PR TITLE
Centralize portal message metadata helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "a2",
  "anyhow",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5189,7 +5189,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "anyhow",
  "colored",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "anyhow",
  "hex",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.7"
+version = "2.13.8"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.7"
+version = "2.13.8"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -79,8 +79,8 @@ pub(super) fn replay_history(
 
     // Surface the server-assigned `created_at` for the latest row so the
     // frontend can use it directly as its reconnect-replay watermark
-    // without re-parsing the per-message `_created_at` injection below
-    // (closes #784). History is ordered ASC, so `last()` is the newest.
+    // without re-parsing per-message content. History is ordered ASC, so
+    // `last()` is the newest.
     let last_created_at: Option<String> = history
         .last()
         .map(|msg| msg.created_at.format("%Y-%m-%dT%H:%M:%S%.6f").to_string());
@@ -92,23 +92,7 @@ pub(super) fn replay_history(
             // rides here — `content` stays raw (no `_`-key injection; see
             // docs/PORTAL_META_SIDECAR.md).
             let meta = Some(msg.portal_meta(user_names.get(&msg.user_id).cloned()));
-            // Fallback when the DB row content isn't valid JSON: wrap the raw
-            // string in a typed envelope so the frontend's `ClaudeMessage`
-            // dispatch still finds a `type` and `content`.
-            #[derive(serde::Serialize)]
-            struct FallbackMessageContent<'a> {
-                #[serde(rename = "type")]
-                message_type: &'a str,
-                content: &'a str,
-            }
-            let content =
-                serde_json::from_str::<serde_json::Value>(&msg.content).unwrap_or_else(|_| {
-                    serde_json::to_value(FallbackMessageContent {
-                        message_type: &msg.role,
-                        content: &msg.content,
-                    })
-                    .unwrap_or(serde_json::Value::Null)
-                });
+            let content = shared::content_value_or_fallback(&msg.role, &msg.content);
             shared::HistoryEntry { content, meta }
         })
         .collect();

--- a/frontend/src/components/message_renderer/group_renderer.rs
+++ b/frontend/src/components/message_renderer/group_renderer.rs
@@ -1,6 +1,6 @@
 use super::dispatch;
 use super::grouping::{
-    extract_raw_iso, thinking_tokens_estimate, visible_group_indices, GroupCategory, MessageGroup,
+    thinking_tokens_estimate, visible_group_indices, GroupCategory, MessageGroup,
 };
 use super::local_timestamp;
 use std::collections::HashMap;
@@ -48,8 +48,8 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
         } => {
             let ts = messages
                 .first()
-                .and_then(extract_raw_iso)
-                .and_then(|iso| local_timestamp(&iso));
+                .and_then(|message| message.raw_iso())
+                .and_then(local_timestamp);
 
             // A run of `thinking_tokens` markers collapses to a single compact
             // chip: the `thinking` badge plus an odometer climbing to the run's
@@ -77,7 +77,10 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                 };
             }
 
-            let last_iso = messages.last().and_then(extract_raw_iso);
+            let last_iso = messages
+                .last()
+                .and_then(|message| message.raw_iso())
+                .map(str::to_string);
             let wrapper_class = match category {
                 GroupCategory::User => "user-message",
                 GroupCategory::Portal => "portal-message",
@@ -100,7 +103,7 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                     <div class="message-body grouped-message-body">
                         { for visible.iter().map(|&i| {
                             let message = &messages[i];
-                            let key = extract_raw_iso(message)
+                            let key = message.raw_iso()
                                 .map(|iso| format!("m-{}", iso))
                                 .unwrap_or_else(|| format!("m{}", i));
                             html! { <div {key} class="grouped-message-part">{ dispatch::render_identity_group_part(message, props.agent_type, props.session_id, &props.continuation_statuses, props.on_schedule_continuation.clone()) }</div> }

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -3,12 +3,6 @@ use crate::components::agent_frame::{AgentFrame, AgentFrameKind, AgentFrameRegis
 use super::renderers::assistant_label;
 use super::types::{ClaudeMessage, RenderedMessage};
 
-/// Extract the raw created-at ISO string from the typed message sidecar, for
-/// use with the live-updating TimeAgo component.
-pub(super) fn extract_raw_iso(message: &RenderedMessage) -> Option<String> {
-    message.raw_iso().map(str::to_string)
-}
-
 /// Category for a run of consecutive related messages — drives both the
 /// grouping decision (`classify`) and the wrapper style on the rendered
 /// group (`MessageGroupRenderer`).
@@ -90,7 +84,7 @@ impl MessageGroup {
                 }
             },
         };
-        match extract_raw_iso(first) {
+        match first.raw_iso() {
             Some(iso) => yew::virtual_dom::Key::from(format!("{}-{}", prefix, iso)),
             None => yew::virtual_dom::Key::from(format!("{}{}", prefix, index)),
         }

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -14,14 +14,13 @@ use dispatch::FrameRenderContext;
 pub use group_renderer::MessageGroupRenderer;
 #[cfg(test)]
 use grouping::classify;
-use grouping::extract_raw_iso;
 pub use grouping::{group_is_turn_terminator, group_messages, thinking_chip_starts};
 #[cfg(test)]
 use grouping::{visible_group_indices, GroupCategory, MessageGroup};
 
 /// Format an already-extracted `PortalMeta.created_at` ISO string as local time.
-/// Takes the `extract_raw_iso` result rather than the raw JSON so the
-/// message string is parsed once per render, not once per consumer.
+/// Takes an already-extracted `PortalMeta.created_at` value rather than raw
+/// message JSON so the renderer only reads the typed sidecar once.
 pub(super) fn local_timestamp(iso: &str) -> Option<String> {
     let ms = js_sys::Date::parse(iso);
     if ms.is_nan() {
@@ -60,14 +59,14 @@ pub struct MessageRendererProps {
 
 #[function_component(MessageRenderer)]
 pub fn message_renderer(props: &MessageRendererProps) -> Html {
-    let raw_iso = extract_raw_iso(&props.message);
-    let ts = raw_iso.as_deref().and_then(local_timestamp);
+    let raw_iso = props.message.raw_iso();
+    let ts = raw_iso.and_then(local_timestamp);
     dispatch::render_frame(FrameRenderContext {
         message: &props.message,
         agent_type: props.agent_type,
         session_id: props.session_id,
         timestamp: ts.as_deref(),
-        raw_iso: raw_iso.as_deref(),
+        raw_iso,
         current_user_id: props.current_user_id.as_deref(),
         turn_metrics: props.turn_metrics.as_ref(),
         continuation_statuses: &props.continuation_statuses,

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -19,7 +19,7 @@ impl RenderedMessage {
     }
 
     pub fn raw_iso(&self) -> Option<&str> {
-        self.meta.as_ref()?.created_at.as_deref()
+        shared::created_at_iso(self.meta.as_ref())
     }
 
     pub fn delivery(&self) -> Option<&shared::DeliveryMeta> {
@@ -27,7 +27,7 @@ impl RenderedMessage {
     }
 
     pub fn source(&self) -> Option<&shared::MessageSource> {
-        self.meta.as_ref()?.source.as_ref()
+        self.meta.as_ref()?.source()
     }
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -39,6 +39,10 @@ pub use proxy_tokens::*;
 pub mod endpoints;
 pub use endpoints::*;
 
+// Portal metadata sidecar helpers
+pub mod message_metadata;
+pub use message_metadata::{content_value_or_fallback, created_at_iso};
+
 /// serde default for continuation `reason` fields: pre-`reason` wire payloads
 /// (older launchers/backends) deserialize as a usage-limit continuation, the
 /// only kind that existed before overload auto-retry.

--- a/shared/src/message_metadata.rs
+++ b/shared/src/message_metadata.rs
@@ -1,0 +1,121 @@
+//! Helpers for the typed portal metadata sidecar that travels beside raw agent
+//! message content.
+
+use crate::{HistoryEntry, MessageSource, PortalMeta};
+
+/// Extract the server-created timestamp from an optional metadata sidecar.
+pub fn created_at_iso(meta: Option<&PortalMeta>) -> Option<&str> {
+    meta.and_then(PortalMeta::created_at_iso)
+}
+
+/// Parse stored message content as JSON, falling back to a typed envelope when
+/// the persisted row predates strict JSON storage or contains raw text.
+pub fn content_value_or_fallback(role: &str, content: &str) -> serde_json::Value {
+    #[derive(serde::Serialize)]
+    struct FallbackMessageContent<'a> {
+        #[serde(rename = "type")]
+        message_type: &'a str,
+        content: &'a str,
+    }
+
+    serde_json::from_str::<serde_json::Value>(content).unwrap_or_else(|_| {
+        serde_json::to_value(FallbackMessageContent {
+            message_type: role,
+            content,
+        })
+        .unwrap_or(serde_json::Value::Null)
+    })
+}
+
+impl PortalMeta {
+    /// Server-assigned persisted-row timestamp as an ISO string.
+    pub fn created_at_iso(&self) -> Option<&str> {
+        self.created_at.as_deref()
+    }
+
+    /// Typed origin/attribution for this message, when it is not the session's
+    /// own agent output.
+    pub fn source(&self) -> Option<&MessageSource> {
+        self.source.as_ref()
+    }
+}
+
+impl HistoryEntry {
+    /// Server-assigned timestamp from this historical row's metadata sidecar.
+    pub fn created_at_iso(&self) -> Option<&str> {
+        created_at_iso(self.meta.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn created_at_iso_reads_present_timestamp() {
+        let meta = PortalMeta {
+            created_at: Some("2026-07-19T00:00:00.000000".to_string()),
+            ..PortalMeta::default()
+        };
+
+        assert_eq!(
+            created_at_iso(Some(&meta)),
+            Some("2026-07-19T00:00:00.000000")
+        );
+        assert_eq!(meta.created_at_iso(), Some("2026-07-19T00:00:00.000000"));
+    }
+
+    #[test]
+    fn created_at_iso_handles_missing_metadata() {
+        assert_eq!(created_at_iso(None), None);
+        assert_eq!(PortalMeta::default().created_at_iso(), None);
+    }
+
+    #[test]
+    fn source_reads_sender_metadata() {
+        let account_id = Uuid::from_u128(42);
+        let meta = PortalMeta {
+            source: Some(MessageSource::Human {
+                account_id,
+                name: "Matt".to_string(),
+            }),
+            ..PortalMeta::default()
+        };
+
+        assert_eq!(
+            meta.source(),
+            Some(&MessageSource::Human {
+                account_id,
+                name: "Matt".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn content_value_or_fallback_preserves_valid_json() {
+        let value = content_value_or_fallback("assistant", r#"{"type":"assistant","ok":true}"#);
+        assert_eq!(value["type"], "assistant");
+        assert_eq!(value["ok"], true);
+    }
+
+    #[test]
+    fn content_value_or_fallback_wraps_malformed_json() {
+        let value = content_value_or_fallback("portal", "raw text");
+        assert_eq!(value["type"], "portal");
+        assert_eq!(value["content"], "raw text");
+    }
+
+    #[test]
+    fn history_entry_exposes_created_at_iso() {
+        let entry = HistoryEntry {
+            content: serde_json::Value::Null,
+            meta: Some(PortalMeta {
+                created_at: Some("2026-07-19T01:02:03.000000".to_string()),
+                ..PortalMeta::default()
+            }),
+        };
+
+        assert_eq!(entry.created_at_iso(), Some("2026-07-19T01:02:03.000000"));
+    }
+}


### PR DESCRIPTION
Closes #1417.\n\n## Summary\n- add shared portal metadata helpers for created-at/source access and malformed-content fallback envelopes\n- use the shared fallback helper in backend replay instead of a local ad-hoc struct\n- route frontend rendered-message timestamp/source reads through the shared metadata API and remove the local extract_raw_iso wrapper\n\n## Validation\n- cargo fmt --check && git diff --check\n- cargo test -p shared message_metadata\n- cargo check -p frontend --target wasm32-unknown-unknown\n- cargo test -p backend replay_tests