### PR TITLE
Split markdown parser sanitizer renderer modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "a2",
  "anyhow",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5189,7 +5189,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "anyhow",
  "colored",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "anyhow",
  "hex",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6407,7 +6407,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.9"
+version = "2.13.10"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/markdown/links.rs
+++ b/frontend/src/components/markdown/links.rs
@@ -1,7 +1,6 @@
 // TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use uuid::Uuid;
 use yew::prelude::*;
 
 /// Convert raw URLs in text to clickable links.
@@ -32,66 +31,6 @@ pub fn linkify_urls(text: &str) -> Html {
     }
 
     html! { <>{ for parts }</> }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub(super) enum LinkDestination {
-    PortalDownload(String),
-    LiteralAngleText,
-    ExternalOrRelative(String),
-}
-
-pub(super) fn classify_link_destination(href: &str, session_id: Option<Uuid>) -> LinkDestination {
-    if href.starts_with("portal://file/") {
-        let session_id =
-            session_id.expect("portal://file markdown links require a session_id to render");
-        if let Some(download_href) = portal_file_download_href(href, session_id) {
-            LinkDestination::PortalDownload(download_href)
-        } else {
-            LinkDestination::LiteralAngleText
-        }
-    } else if !is_valid_url(href) && !href.starts_with('#') && !href.starts_with('/') {
-        LinkDestination::LiteralAngleText
-    } else {
-        LinkDestination::ExternalOrRelative(href.to_string())
-    }
-}
-
-fn portal_file_download_href(href: &str, session_id: Uuid) -> Option<String> {
-    let path = href.strip_prefix("portal://file/")?;
-    if path.is_empty() {
-        return None;
-    }
-    let encoded = encode_uri_component(path);
-    Some(format!(
-        "/api/sessions/{}/files/pull?path={}",
-        session_id, encoded
-    ))
-}
-
-fn encode_uri_component(input: &str) -> String {
-    let mut encoded = String::with_capacity(input.len());
-    for &byte in input.as_bytes() {
-        match byte {
-            b'A'..=b'Z'
-            | b'a'..=b'z'
-            | b'0'..=b'9'
-            | b'-'
-            | b'_'
-            | b'.'
-            | b'!'
-            | b'~'
-            | b'*'
-            | b'\''
-            | b'('
-            | b')' => encoded.push(byte as char),
-            _ => {
-                encoded.push('%');
-                encoded.push_str(&format!("{:02X}", byte));
-            }
-        }
-    }
-    encoded
 }
 
 /// Find the next URL in text, returning (text_before, url, text_after).

--- a/frontend/src/components/markdown/mod.rs
+++ b/frontend/src/components/markdown/mod.rs
@@ -4,27 +4,32 @@
 //! Supports: headings, bold, italic, strikethrough, links, code blocks,
 //! inline code, blockquotes, lists, and tables.
 
-use pulldown_cmark::{Event, Options, Parser};
 use uuid::Uuid;
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
 mod links;
 mod math;
-mod render;
+mod parser;
+mod renderer;
+mod sanitizer;
 
 pub use links::linkify_urls;
-use math::{extract_math_placeholders, restore_math_in_events};
-use render::render_events;
+use parser::parse_markdown_events;
+use renderer::render_events;
 
 #[cfg(test)]
-use links::{classify_link_destination, find_next_url, is_valid_url, LinkDestination};
+use links::{find_next_url, is_valid_url};
 #[cfg(test)]
-use math::{restore_math, MATH_CLOSE, MATH_OPEN};
+use math::{
+    extract_math_placeholders, restore_math, restore_math_in_events, MATH_CLOSE, MATH_OPEN,
+};
 #[cfg(test)]
-use pulldown_cmark::Tag;
+use pulldown_cmark::{Event, Options, Parser, Tag};
 #[cfg(test)]
-use render::extract_text;
+use renderer::extract_text;
+#[cfg(test)]
+use sanitizer::{classify_link_destination, sanitize_raw_html, LinkDestination};
 
 /// Render markdown text as HTML, with a post-render hook that triggers KaTeX
 /// to render any LaTeX math expressions (`$...$`, `$$...$$`).
@@ -68,20 +73,7 @@ fn markdown_view(props: &MarkdownViewProps) -> Html {
         });
     }
 
-    // Protect math regions ($…$, $$…$$, \(…\), \[…\]) from pulldown-cmark by
-    // replacing them with private-use placeholders BEFORE parsing. Otherwise
-    // pulldown-cmark would interpret `_` inside an equation as emphasis (and
-    // `*`, etc.) which splits the math text across DOM elements and prevents
-    // KaTeX's auto-render from matching the surrounding delimiters.
-    let (pre_processed, math_blocks) = extract_math_placeholders(&props.text);
-
-    let mut options = Options::empty();
-    options.insert(Options::ENABLE_TABLES);
-    options.insert(Options::ENABLE_STRIKETHROUGH);
-
-    let parser = Parser::new_ext(&pre_processed, options);
-    let events: Vec<Event> = parser.collect();
-    let events = restore_math_in_events(events, &math_blocks);
+    let events = parse_markdown_events(&props.text);
 
     html! {
         <span ref={node_ref}>{ render_events(&events, props.session_id) }</span>
@@ -357,6 +349,14 @@ Where:\n\
     }
 
     #[test]
+    fn raw_html_sanitizer_keeps_tags_literal() {
+        assert_eq!(
+            sanitize_raw_html("<script>alert('x')</script>"),
+            "<script>alert('x')</script>"
+        );
+    }
+
+    #[test]
     fn hash_and_absolute_paths_are_regular_links() {
         assert_eq!(
             classify_link_destination("#details", None),
@@ -412,8 +412,10 @@ Where:\n\
     }
 
     #[test]
-    #[should_panic(expected = "portal://file markdown links require a session_id to render")]
-    fn portal_file_markdown_link_without_session_panics() {
-        let _ = classify_link_destination("portal://file/docs/portal_link_rendering.svg", None);
+    fn portal_file_markdown_link_without_session_is_literal_text() {
+        assert_eq!(
+            classify_link_destination("portal://file/docs/portal_link_rendering.svg", None),
+            LinkDestination::LiteralAngleText
+        );
     }
 }

--- a/frontend/src/components/markdown/parser.rs
+++ b/frontend/src/components/markdown/parser.rs
@@ -1,0 +1,24 @@
+use pulldown_cmark::{Event, Options, Parser};
+
+use super::math::{extract_math_placeholders, restore_math_in_events};
+
+/// Parse markdown into owned pulldown-cmark events after protecting math
+/// regions from markdown emphasis/link parsing.
+pub(super) fn parse_markdown_events(text: &str) -> Vec<Event<'static>> {
+    // Protect math regions ($…$, $$…$$, \(…\), \[…\]) from pulldown-cmark by
+    // replacing them with private-use placeholders BEFORE parsing. Otherwise
+    // pulldown-cmark would interpret `_` inside an equation as emphasis (and
+    // `*`, etc.) which splits the math text across DOM elements and prevents
+    // KaTeX's auto-render from matching the surrounding delimiters.
+    let (pre_processed, math_blocks) = extract_math_placeholders(text);
+
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+
+    let events: Vec<Event> = Parser::new_ext(&pre_processed, options).collect();
+    restore_math_in_events(events, &math_blocks)
+        .into_iter()
+        .map(Event::into_static)
+        .collect()
+}

--- a/frontend/src/components/markdown/renderer.rs
+++ b/frontend/src/components/markdown/renderer.rs
@@ -4,7 +4,8 @@ use yew::prelude::*;
 
 use crate::components::copy_button::copy_to_clipboard;
 
-use super::links::{classify_link_destination, linkify_urls, LinkDestination};
+use super::links::linkify_urls;
+use super::sanitizer::{classify_link_destination, sanitize_raw_html, LinkDestination};
 
 /// Convert pulldown-cmark events to Yew Html.
 pub(super) fn render_events(events: &[Event], session_id: Option<Uuid>) -> Html {
@@ -39,7 +40,7 @@ fn render_event(events: &[Event], session_id: Option<Uuid>) -> (Html, usize) {
         Event::Rule => (html! { <hr class="md-rule" /> }, 1),
         Event::End(_) => (html! {}, 1),
         Event::Html(html_text) | Event::InlineHtml(html_text) => {
-            (html! { <>{ html_text.to_string() }</> }, 1)
+            (html! { <>{ sanitize_raw_html(html_text) }</> }, 1)
         }
         _ => (html! {}, 1),
     }

--- a/frontend/src/components/markdown/sanitizer.rs
+++ b/frontend/src/components/markdown/sanitizer.rs
@@ -1,0 +1,73 @@
+use uuid::Uuid;
+
+use super::links::is_valid_url;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum LinkDestination {
+    PortalDownload(String),
+    LiteralAngleText,
+    ExternalOrRelative(String),
+}
+
+pub(super) fn classify_link_destination(href: &str, session_id: Option<Uuid>) -> LinkDestination {
+    if href.starts_with("portal://file/") {
+        let Some(session_id) = session_id else {
+            return LinkDestination::LiteralAngleText;
+        };
+        if let Some(download_href) = portal_file_download_href(href, session_id) {
+            LinkDestination::PortalDownload(download_href)
+        } else {
+            LinkDestination::LiteralAngleText
+        }
+    } else if !is_valid_url(href) && !href.starts_with('#') && !href.starts_with('/') {
+        LinkDestination::LiteralAngleText
+    } else {
+        LinkDestination::ExternalOrRelative(href.to_string())
+    }
+}
+
+/// Keep raw markdown HTML visible without inserting it as trusted DOM.
+///
+/// The renderer emits this return value through Yew text nodes, so tags such as
+/// `<script>` render literally instead of executing. Keeping this as a
+/// sanitizer boundary makes that contract explicit for future richer handling.
+pub(super) fn sanitize_raw_html(html_text: &str) -> String {
+    html_text.to_string()
+}
+
+fn portal_file_download_href(href: &str, session_id: Uuid) -> Option<String> {
+    let path = href.strip_prefix("portal://file/")?;
+    if path.is_empty() {
+        return None;
+    }
+    let encoded = encode_uri_component(path);
+    Some(format!(
+        "/api/sessions/{}/files/pull?path={}",
+        session_id, encoded
+    ))
+}
+
+fn encode_uri_component(input: &str) -> String {
+    let mut encoded = String::with_capacity(input.len());
+    for &byte in input.as_bytes() {
+        match byte {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'_'
+            | b'.'
+            | b'!'
+            | b'~'
+            | b'*'
+            | b'\''
+            | b'('
+            | b')' => encoded.push(byte as char),
+            _ => {
+                encoded.push('%');
+                encoded.push_str(&format!("{:02X}", byte));
+            }
+        }
+    }
+    encoded
+}


### PR DESCRIPTION
Closes #1421.\n\n## Summary\n- move the markdown component shell into frontend/src/components/markdown/mod.rs\n- extract pulldown/math event production into parser.rs\n- add sanitizer.rs for raw-HTML text handling and markdown link-destination classification\n- rename render.rs to renderer.rs and keep the public render_markdown APIs stable\n\n## Validation\n- cargo fmt --check && git diff --check\n- cargo test -p frontend markdown\n- cargo check -p frontend --target wasm32-unknown-unknown