### PR TITLE
Add health timer and restore last active session

### DIFF
--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -38,6 +38,7 @@ web-sys = { workspace = true, features = [
     "HtmlElement",
     "HtmlInputElement",
     "HtmlSelectElement",
+    "HtmlTextAreaElement",
     "Location",
     "Storage",
     "Navigator",

--- a/frontend/src/health_timer.rs
+++ b/frontend/src/health_timer.rs
@@ -1,0 +1,280 @@
+//! Local health-break timer.
+//!
+//! Settings live entirely in browser localStorage. The app-level reminder
+//! listens for same-window and cross-window storage changes so editing Settings
+//! takes effect immediately without a backend round trip.
+
+use gloo::events::EventListener;
+use gloo::timers::callback::Timeout;
+use serde::{Deserialize, Serialize};
+use yew::prelude::*;
+
+use crate::hooks::use_focus_trap;
+
+pub const STORAGE_KEY: &str = "agent_portal.health_timer.v1";
+
+const SETTINGS_CHANGED_EVENT: &str = "agent-portal-health-timer-settings-changed";
+const DEFAULT_CADENCE_MINUTES: u32 = 30;
+const DEFAULT_MESSAGE: &str = "Time for a quick break.";
+const MINUTE_MS: f64 = 60_000.0;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HealthTimerSettings {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_cadence_minutes")]
+    pub cadence_minutes: u32,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default = "current_timestamp")]
+    pub last_confirmed_at: String,
+}
+
+impl Default for HealthTimerSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            cadence_minutes: DEFAULT_CADENCE_MINUTES,
+            message: String::new(),
+            last_confirmed_at: current_timestamp(),
+        }
+    }
+}
+
+impl HealthTimerSettings {
+    pub fn normalized(mut self) -> Self {
+        self.cadence_minutes = self.cadence_minutes.max(1);
+        if timestamp_to_ms(&self.last_confirmed_at).is_none() {
+            self.last_confirmed_at = current_timestamp();
+        }
+        self
+    }
+
+    pub fn reminder_message(&self) -> &str {
+        let trimmed = self.message.trim();
+        if trimmed.is_empty() {
+            DEFAULT_MESSAGE
+        } else {
+            trimmed
+        }
+    }
+
+    fn reset_from_now(mut self) -> Self {
+        self.last_confirmed_at = current_timestamp();
+        self.normalized()
+    }
+}
+
+pub fn load_health_timer_settings() -> HealthTimerSettings {
+    let Some(storage) = local_storage() else {
+        return HealthTimerSettings::default();
+    };
+    let Ok(Some(raw)) = storage.get_item(STORAGE_KEY) else {
+        return HealthTimerSettings::default();
+    };
+    serde_json::from_str::<HealthTimerSettings>(&raw)
+        .map(HealthTimerSettings::normalized)
+        .unwrap_or_default()
+}
+
+pub fn save_health_timer_settings(settings: &HealthTimerSettings) {
+    if let Some(storage) = local_storage() {
+        if let Ok(raw) = serde_json::to_string(&settings.clone().normalized()) {
+            let _ = storage.set_item(STORAGE_KEY, &raw);
+        }
+    }
+    notify_settings_changed();
+}
+
+pub fn save_health_timer_settings_reset(settings: &HealthTimerSettings) {
+    save_health_timer_settings(&settings.clone().reset_from_now());
+}
+
+fn default_cadence_minutes() -> u32 {
+    DEFAULT_CADENCE_MINUTES
+}
+
+fn local_storage() -> Option<web_sys::Storage> {
+    web_sys::window().and_then(|w| w.local_storage().ok().flatten())
+}
+
+#[cfg(not(test))]
+fn current_timestamp() -> String {
+    js_sys::Date::new_0()
+        .to_iso_string()
+        .as_string()
+        .unwrap_or_else(|| "1970-01-01T00:00:00.000Z".to_string())
+}
+
+#[cfg(test)]
+fn current_timestamp() -> String {
+    "2026-07-19T00:00:00.000Z".to_string()
+}
+
+fn now_ms() -> f64 {
+    js_sys::Date::now()
+}
+
+fn timestamp_to_ms(value: &str) -> Option<f64> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.timestamp_millis() as f64)
+}
+
+fn delay_until_due_ms(settings: &HealthTimerSettings, now: f64) -> u32 {
+    let cadence_ms = f64::from(settings.cadence_minutes.max(1)) * MINUTE_MS;
+    let last = timestamp_to_ms(&settings.last_confirmed_at).unwrap_or(now);
+    let due = last + cadence_ms;
+    let delay = (due - now).max(0.0);
+    delay.min(f64::from(u32::MAX)).round() as u32
+}
+
+fn notify_settings_changed() {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Ok(event) = web_sys::Event::new(SETTINGS_CHANGED_EVENT) else {
+        return;
+    };
+    let _ = window.dispatch_event(&event);
+}
+
+#[function_component(HealthTimerReminder)]
+pub fn health_timer_reminder() -> Html {
+    let settings = use_state(load_health_timer_settings);
+    let showing = use_state(|| false);
+
+    {
+        let settings = settings.clone();
+        let showing = showing.clone();
+        use_effect_with((), move |_| {
+            let listeners = web_sys::window().map(|window| {
+                let same_window = {
+                    let settings = settings.clone();
+                    let showing = showing.clone();
+                    EventListener::new(&window, SETTINGS_CHANGED_EVENT, move |_| {
+                        let loaded = load_health_timer_settings();
+                        if !loaded.enabled {
+                            showing.set(false);
+                        }
+                        settings.set(loaded);
+                    })
+                };
+                let cross_window = {
+                    let settings = settings.clone();
+                    let showing = showing.clone();
+                    EventListener::new(&window, "storage", move |_| {
+                        let loaded = load_health_timer_settings();
+                        if !loaded.enabled {
+                            showing.set(false);
+                        }
+                        settings.set(loaded);
+                    })
+                };
+
+                (same_window, cross_window)
+            });
+
+            move || drop(listeners)
+        });
+    }
+
+    {
+        let settings_value = (*settings).clone();
+        let is_showing = *showing;
+        let showing = showing.clone();
+        use_effect_with(
+            (settings_value, is_showing),
+            move |(settings, is_showing)| {
+                let timeout = if settings.enabled && !*is_showing {
+                    let delay = delay_until_due_ms(settings, now_ms());
+                    Some(Timeout::new(delay, move || showing.set(true)))
+                } else {
+                    None
+                };
+                move || drop(timeout)
+            },
+        );
+    }
+
+    if !settings.enabled || !*showing {
+        return html! {};
+    }
+
+    let message = settings.reminder_message().to_string();
+    let on_confirm = {
+        let settings = settings.clone();
+        let showing = showing.clone();
+        Callback::from(move |_: MouseEvent| {
+            let next = (*settings).clone().reset_from_now();
+            save_health_timer_settings(&next);
+            settings.set(next);
+            showing.set(false);
+        })
+    };
+    let dialog_ref = use_node_ref();
+    use_focus_trap(dialog_ref.clone());
+
+    html! {
+        <div class="health-timer-overlay" role="presentation">
+            <section
+                ref={dialog_ref}
+                class="health-timer-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="health-timer-title"
+            >
+                <h2 id="health-timer-title">{ "Health timer" }</h2>
+                <p>{ message }</p>
+                <button type="button" class="health-timer-confirm" onclick={on_confirm}>
+                    { "Confirm" }
+                </button>
+            </section>
+        </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_normalize_clamps_cadence_and_repairs_timestamp() {
+        let settings = HealthTimerSettings {
+            enabled: true,
+            cadence_minutes: 0,
+            message: String::new(),
+            last_confirmed_at: "not a timestamp".to_string(),
+        }
+        .normalized();
+
+        assert_eq!(settings.cadence_minutes, 1);
+        assert!(timestamp_to_ms(&settings.last_confirmed_at).is_some());
+    }
+
+    #[test]
+    fn blank_message_uses_default() {
+        let settings = HealthTimerSettings {
+            message: "   ".to_string(),
+            ..HealthTimerSettings::default()
+        };
+
+        assert_eq!(settings.reminder_message(), DEFAULT_MESSAGE);
+    }
+
+    #[test]
+    fn due_delay_counts_from_last_confirmation() {
+        let settings = HealthTimerSettings {
+            enabled: true,
+            cadence_minutes: 15,
+            message: String::new(),
+            last_confirmed_at: "2026-07-19T12:00:00.000Z".to_string(),
+        };
+
+        let now = timestamp_to_ms("2026-07-19T12:10:00.000Z").unwrap();
+        assert_eq!(delay_until_due_ms(&settings, now), 5 * 60 * 1000);
+
+        let overdue = timestamp_to_ms("2026-07-19T12:16:00.000Z").unwrap();
+        assert_eq!(delay_until_due_ms(&settings, overdue), 0);
+    }
+}

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -239,7 +239,8 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
             if gloo::utils::document()
                 .query_selector(
                     ".sched-overlay, .share-dialog-overlay, .help-overlay, \
-                     .launch-dialog-backdrop, .modal-overlay, .full-page-modal",
+                     .launch-dialog-backdrop, .modal-overlay, .full-page-modal, \
+                     .health-timer-overlay",
                 )
                 .ok()
                 .flatten()

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audio;
 mod components;
+mod health_timer;
 mod hooks;
 mod pages;
 pub mod utils;
@@ -8,6 +9,7 @@ pub mod utils;
 /// (see `shared::VERSION` / `shared/build.rs`, issue #1096).
 pub const VERSION: &str = shared::VERSION;
 
+use health_timer::HealthTimerReminder;
 use pages::{
     access_denied::AccessDeniedPage, admin::AdminPage, agent_messaging::AgentMessagingPage,
     banned::BannedPage, dashboard::DashboardPage, settings::SettingsPage, splash::SplashPage,
@@ -70,6 +72,7 @@ fn app() -> Html {
     html! {
         <BrowserRouter>
             <Switch<Route> render={switch} />
+            <HealthTimerReminder />
         </BrowserRouter>
     }
 }

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -514,6 +514,19 @@ pub fn dashboard_page() -> Html {
         .iter()
         .filter(|id| !effective_hidden_sessions.contains(id))
         .count();
+    // SessionView creation starts each session websocket subscription. Keep the
+    // rail order stable, but mount the focused session first so a reload gives
+    // the last-active session the first subscription attempt before background
+    // sessions connect.
+    let session_view_order: Vec<usize> = if active_sessions.is_empty() {
+        Vec::new()
+    } else {
+        let focused_index = focus.focused_index.min(active_sessions.len() - 1);
+        let mut indices = Vec::with_capacity(active_sessions.len());
+        indices.push(focused_index);
+        indices.extend((0..active_sessions.len()).filter(|index| *index != focused_index));
+        indices
+    };
 
     // Update browser tab title
     {
@@ -702,10 +715,11 @@ pub fn dashboard_page() -> Html {
                     // Session views
                     <div class={classes!("session-views-container", if keyboard_nav.nav_mode { Some("nav-mode") } else { None })}>
                         {
-                            active_sessions.iter().enumerate().map(|(index, session)| {
+                            session_view_order.iter().filter_map(|&index| {
+                                let session = active_sessions.get(index)?;
                                 let is_focused = index == focus.focused_index;
                                 let is_activated = session_state.activated_sessions.contains(&session.id);
-                                if is_activated {
+                                Some(if is_activated {
                                     html! {
                                         <div
                                             key={session.id.to_string()}
@@ -732,7 +746,7 @@ pub fn dashboard_page() -> Html {
                                             class="session-view-wrapper hidden"
                                         />
                                     }
-                                }
+                                })
                             }).collect::<Html>()
                         }
                     </div>

--- a/frontend/src/pages/dashboard/page_focus.rs
+++ b/frontend/src/pages/dashboard/page_focus.rs
@@ -1,5 +1,6 @@
 use super::page_state::{active_session_ids, DashboardSessionAction, DashboardSessionState};
 use super::session_order;
+use super::types::{load_last_active_session, save_last_active_session};
 use shared::SessionInfo;
 use std::collections::HashSet;
 use uuid::Uuid;
@@ -55,29 +56,64 @@ pub(super) fn use_dashboard_focus(
             ),
             move |(sessions, hidden_sessions, is_loading)| {
                 if !*is_loading && !sessions.is_empty() {
-                    // Focus the first non-hidden session by id (falls through to
+                    let visible = |session: &&SessionInfo| !hidden_sessions.contains(&session.id);
+                    let saved_focus = load_last_active_session().and_then(|saved_id| {
+                        sessions
+                            .iter()
+                            .find(|s| s.id == saved_id && !hidden_sessions.contains(&s.id))
+                            .map(|s| s.id)
+                    });
+                    // Prefer the last active session from this browser, then
+                    // fall back to the first non-hidden session by id (then
                     // the first session if all are hidden).
-                    let first_focus = sessions
-                        .iter()
-                        .find(|s| !hidden_sessions.contains(&s.id))
-                        .or_else(|| sessions.first())
-                        .map(|s| s.id);
+                    let focus_id = saved_focus.or_else(|| {
+                        sessions
+                            .iter()
+                            .find(visible)
+                            .or_else(|| sessions.first())
+                            .map(|s| s.id)
+                    });
 
-                    // Activate all non-hidden sessions so they load in background.
-                    let activate_ids = sessions
-                        .iter()
-                        .filter(|s| !hidden_sessions.contains(&s.id))
-                        .map(|s| s.id)
-                        .collect();
+                    let mut activate_ids: Vec<Uuid> = focus_id.into_iter().collect();
+                    activate_ids.extend(
+                        sessions
+                            .iter()
+                            .filter(visible)
+                            .map(|s| s.id)
+                            .filter(|id| Some(*id) != focus_id),
+                    );
+                    if activate_ids.is_empty() {
+                        activate_ids.extend(sessions.iter().map(|s| s.id));
+                    }
 
+                    if let Some(id) = focus_id {
+                        save_last_active_session(id);
+                    }
+
+                    // Activate the preferred session first. The reducer stores
+                    // a set, but the dashboard render also prioritizes the
+                    // focused id so the saved session's websocket starts
+                    // before background sessions on reload.
                     session_state.dispatch(DashboardSessionAction::InitializeFocus {
-                        focus_id: first_focus,
+                        focus_id,
                         activate_ids,
                     });
                 }
                 || ()
             },
         );
+    }
+
+    // Persist focus changes from every path that updates the reducer
+    // (keyboard/rail selection, notification deep link, newly launched session).
+    {
+        let focused_id = session_state.focused_id;
+        use_effect_with(focused_id, move |focused_id| {
+            if let Some(id) = focused_id {
+                save_last_active_session(*id);
+            }
+            || ()
+        });
     }
 
     // Auto-focus newly launched session when it appears in the session list.
@@ -102,6 +138,7 @@ pub(super) fn use_dashboard_focus(
             crate::audio::ensure_audio_context();
             crate::audio::play_sound(crate::audio::SoundEvent::SessionSwap);
             if let Some(session) = active_sessions.get(index) {
+                save_last_active_session(session.id);
                 session_state.dispatch(DashboardSessionAction::FocusAndActivate(session.id));
             }
         })

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -22,6 +22,9 @@ pub const SHOW_COST_STORAGE_KEY: &str = "claude-portal-show-cost";
 /// Storage key for session rail orientation in localStorage
 pub const RAIL_ORIENTATION_STORAGE_KEY: &str = "claude-portal-rail-orientation";
 
+/// Storage key for the last actively focused session in localStorage
+pub const LAST_ACTIVE_SESSION_STORAGE_KEY: &str = "claude-portal-last-active-session";
+
 /// Storage key for the opt-in vim editing mode in localStorage
 pub const VIM_MODE_STORAGE_KEY: &str = "claude-portal-vim-mode";
 
@@ -191,6 +194,16 @@ pub fn load_rail_position() -> RailPosition {
 /// Save rail position preference to localStorage.
 pub fn save_rail_position(position: RailPosition) {
     storage_set(RAIL_ORIENTATION_STORAGE_KEY, position.as_str());
+}
+
+/// Load the last actively focused session from localStorage.
+pub fn load_last_active_session() -> Option<Uuid> {
+    storage_get(LAST_ACTIVE_SESSION_STORAGE_KEY).and_then(|value| Uuid::parse_str(&value).ok())
+}
+
+/// Save the last actively focused session to localStorage.
+pub fn save_last_active_session(session_id: Uuid) {
+    storage_set(LAST_ACTIVE_SESSION_STORAGE_KEY, &session_id.to_string());
 }
 
 /// Load hidden session IDs from localStorage

--- a/frontend/src/pages/settings/health_timer_panel.rs
+++ b/frontend/src/pages/settings/health_timer_panel.rs
@@ -1,0 +1,96 @@
+use crate::health_timer::{
+    load_health_timer_settings, save_health_timer_settings_reset, HealthTimerSettings,
+};
+use yew::prelude::*;
+
+#[function_component(HealthTimerPanel)]
+pub fn health_timer_panel() -> Html {
+    let settings = use_state(load_health_timer_settings);
+
+    let persist = {
+        let settings = settings.clone();
+        Callback::from(move |next: HealthTimerSettings| {
+            save_health_timer_settings_reset(&next);
+            settings.set(next.normalized());
+        })
+    };
+
+    let on_enabled_change = {
+        let settings = settings.clone();
+        let persist = persist.clone();
+        Callback::from(move |e: Event| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            let mut next = (*settings).clone();
+            next.enabled = input.checked();
+            persist.emit(next);
+        })
+    };
+
+    let on_cadence_change = {
+        let settings = settings.clone();
+        let persist = persist.clone();
+        Callback::from(move |e: Event| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            let mut next = (*settings).clone();
+            next.cadence_minutes = input.value().parse::<u32>().unwrap_or(1).max(1);
+            persist.emit(next);
+        })
+    };
+
+    let on_message_change = {
+        let settings = settings.clone();
+        let persist = persist.clone();
+        Callback::from(move |e: web_sys::InputEvent| {
+            let textarea: web_sys::HtmlTextAreaElement = e.target_unchecked_into();
+            let mut next = (*settings).clone();
+            next.message = textarea.value();
+            persist.emit(next);
+        })
+    };
+
+    html! {
+        <section class="health-settings-section">
+            <div class="section-header">
+                <h2>{ "Health timer" }</h2>
+                <p class="section-description">
+                    { "Periodic local reminders. Saved in this browser." }
+                </p>
+            </div>
+
+            <div class="health-settings-card">
+                <label class="toggle-label health-toggle">
+                    <input
+                        type="checkbox"
+                        checked={settings.enabled}
+                        onchange={on_enabled_change}
+                    />
+                    <span>{ if settings.enabled { "Enabled" } else { "Disabled" } }</span>
+                </label>
+
+                <label class="health-setting-field">
+                    <span>{ "Reminder interval" }</span>
+                    <div class="health-minutes-input">
+                        <input
+                            type="number"
+                            min="1"
+                            step="1"
+                            value={settings.cadence_minutes.to_string()}
+                            onchange={on_cadence_change}
+                        />
+                        <span>{ "minutes" }</span>
+                    </div>
+                </label>
+
+                <label class="health-setting-field">
+                    <span>{ "Reminder message" }</span>
+                    <textarea
+                        rows="4"
+                        placeholder="Stop/stretch and take a break"
+                        value={settings.message.clone()}
+                        oninput={on_message_change}
+                    />
+                </label>
+            </div>
+        </section>
+    }
+}

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -1,5 +1,6 @@
 mod appearance_panel;
 mod forwarding_panel;
+mod health_timer_panel;
 mod launchers_panel;
 mod notifications_panel;
 mod performance_panel;
@@ -10,6 +11,7 @@ mod tokens_panel;
 use crate::utils;
 use appearance_panel::AppearancePanel;
 use forwarding_panel::ForwardingPanel;
+use health_timer_panel::HealthTimerPanel;
 use launchers_panel::LaunchersPanel;
 use notifications_panel::NotificationsPanel;
 use performance_panel::PerformancePanel;
@@ -27,6 +29,7 @@ enum SettingsTab {
     Forwarding,
     Sounds,
     Notifications,
+    HealthTimer,
     Performance,
     Appearance,
 }
@@ -70,6 +73,7 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
     let on_forwarding_tab = make_tab_handler(SettingsTab::Forwarding);
     let on_sounds_tab = make_tab_handler(SettingsTab::Sounds);
     let on_notifications_tab = make_tab_handler(SettingsTab::Notifications);
+    let on_health_timer_tab = make_tab_handler(SettingsTab::HealthTimer);
     let on_performance_tab = make_tab_handler(SettingsTab::Performance);
     let on_appearance_tab = make_tab_handler(SettingsTab::Appearance);
 
@@ -132,6 +136,12 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                     { "Notifications" }
                 </button>
                 <button
+                    class={classes!("tab-button", (*active_tab == SettingsTab::HealthTimer).then_some("active"))}
+                    onclick={on_health_timer_tab}
+                >
+                    { "Health Timer" }
+                </button>
+                <button
                     class={classes!("tab-button", (*active_tab == SettingsTab::Performance).then_some("active"))}
                     onclick={on_performance_tab}
                 >
@@ -160,6 +170,9 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                 }
                 if *active_tab == SettingsTab::Notifications {
                     <NotificationsPanel />
+                }
+                if *active_tab == SettingsTab::HealthTimer {
+                    <HealthTimerPanel />
                 }
                 if *active_tab == SettingsTab::Sessions {
                     <SessionsPanel on_sessions_loaded={on_sessions_loaded} />

--- a/frontend/styles/dashboard.css
+++ b/frontend/styles/dashboard.css
@@ -103,6 +103,67 @@
     margin: 0;
 }
 
+/* Health timer reminder */
+.health-timer-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1300;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    background: rgba(0, 0, 0, 0.68);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    animation: fadeIn 0.2s ease-out;
+}
+
+.health-timer-dialog {
+    width: min(92vw, 460px);
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+    text-align: center;
+    animation: scaleIn 0.2s ease-out;
+}
+
+.health-timer-dialog h2 {
+    margin: 0 0 0.75rem;
+    color: var(--text-primary);
+    font-size: 1.25rem;
+}
+
+.health-timer-dialog p {
+    margin: 0 0 1.25rem;
+    color: var(--text-primary);
+    font-size: 1rem;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.health-timer-confirm {
+    background: var(--accent);
+    border: none;
+    color: #fff;
+    padding: 0.6rem 1.35rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.health-timer-confirm:hover {
+    background: var(--accent-hover);
+}
+
+.health-timer-confirm:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
 @keyframes fadeIn {
     from {
         opacity: 0;
@@ -539,4 +600,3 @@
     color: var(--accent, #7aa2f7);
     font-weight: 600;
 }
-

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -697,6 +697,77 @@
     color: var(--text-primary);
 }
 
+/* Health timer */
+.health-settings-section {
+    max-width: 760px;
+}
+
+.health-settings-card {
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.health-toggle {
+    align-self: flex-start;
+}
+
+.health-setting-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.health-setting-field > span {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.health-minutes-input {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.health-minutes-input input,
+.health-setting-field textarea {
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    border-radius: 4px;
+    font: inherit;
+}
+
+.health-minutes-input input {
+    width: 7rem;
+    padding: 0.45rem 0.55rem;
+}
+
+.health-setting-field textarea {
+    width: 100%;
+    max-width: 620px;
+    min-height: 6rem;
+    padding: 0.65rem 0.75rem;
+    resize: vertical;
+    line-height: 1.4;
+}
+
+.health-minutes-input input:focus,
+.health-setting-field textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.health-minutes-input span {
+    color: var(--text-secondary);
+}
+
 .sound-event-cards {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary\n- add a browser-local health timer with Settings controls for enabled state, cadence, and message\n- show an app-wide blocking reminder modal with only a Confirm action\n- persist the last active dashboard session in localStorage and restore it on reload\n- mount the focused session view first so its websocket subscription starts before background sessions\n\n## Version\nThis will be active under runtime version 2.13.1050 after squash merge, based on current origin/main commit count 1049 + 1.\n\n## Tests\n- cargo fmt --check\n- cargo test -p frontend health_timer\n- cargo test -p frontend dashboard\n- cargo check -p frontend --target wasm32-unknown-unknown\n- cargo clippy -p frontend --target wasm32-unknown-unknown -- -D warnings