### PR TITLE
Group session rail by host (opt-in)

### DIFF
--- a/frontend/src/pages/dashboard/mod.rs
+++ b/frontend/src/pages/dashboard/mod.rs
@@ -19,5 +19,6 @@ mod types;
 
 pub use page::DashboardPage;
 pub use types::{
-    load_rail_position, load_vim_mode, save_rail_position, save_vim_mode, RailPosition,
+    load_group_by_host, load_rail_position, load_vim_mode, save_group_by_host, save_rail_position,
+    save_vim_mode, RailPosition,
 };

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -11,8 +11,8 @@ use super::session_order;
 use super::session_rail::{ActivityRef, AgentMessageBroadcast, BroadcastRef, SessionRail};
 use super::session_view::SessionView;
 use super::types::{
-    load_hidden_sessions, load_inactive_hidden, load_rail_position, load_show_cost,
-    save_hidden_sessions, save_inactive_hidden, save_show_cost,
+    load_group_by_host, load_hidden_sessions, load_inactive_hidden, load_rail_position,
+    load_show_cost, save_hidden_sessions, save_inactive_hidden, save_show_cost,
 };
 use crate::components::{
     ConfirmModal, ConfirmModalStyle, HelpOverlay, LaunchDialog, TurnMetricsHeaderPill,
@@ -91,6 +91,7 @@ pub fn dashboard_page() -> Html {
             load_inactive_hidden(),
             load_show_cost(),
             load_rail_position(),
+            load_group_by_host(),
         )
     });
     // Focus is tracked by `session_id` (the source of truth), not by array
@@ -132,7 +133,18 @@ pub fn dashboard_page() -> Html {
         // Total, deterministic order keyed down to the unique session id, so
         // the displayed order is a pure function of the session *set* and never
         // depends on the order `/api/sessions` happened to return (issue #1094).
-        sorted.sort_by(session_order::session_display_cmp);
+        //
+        // When the "group rail by host" pref is on we swap in the host-first
+        // comparator. Both are *total* orders over the same vec, and this vec is
+        // the single source of truth for focus resolution, nav-mode numbering,
+        // and `j`/`k` traversal — so the logical order always matches the
+        // visible top-to-bottom rail (grouped when the pref is on). The rail's
+        // host headers are inserted purely visually and carry no display index.
+        if ui_state.group_by_host {
+            sorted.sort_by(session_order::session_display_cmp_grouped);
+        } else {
+            sorted.sort_by(session_order::session_display_cmp);
+        }
         sorted
     };
 
@@ -254,6 +266,7 @@ pub fn dashboard_page() -> Html {
             // localStorage so the dashboard picks up the new value when
             // the user navigates back.
             ui_state.dispatch(DashboardUiAction::SetRailPosition(load_rail_position()));
+            ui_state.dispatch(DashboardUiAction::SetGroupByHost(load_group_by_host()));
             ui_state.dispatch(DashboardUiAction::CloseSettings);
         })
     };
@@ -733,6 +746,7 @@ pub fn dashboard_page() -> Html {
                         awaiting_sessions={session_state.awaiting_sessions.clone()}
                         hidden_sessions={effective_hidden_sessions.clone()}
                         inactive_hidden={ui_state.inactive_hidden}
+                        group_by_host={ui_state.group_by_host}
                         connected_sessions={session_state.connected_sessions.clone()}
                         nav_mode={keyboard_nav.nav_mode}
                         activity_timestamps={(*activity_timestamps).clone()}

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -156,12 +156,19 @@ pub(super) struct DashboardUiState {
     pub inactive_hidden: bool,
     pub show_cost: bool,
     pub rail_position: RailPosition,
+    /// Opt-in: group the session rail's pills into per-host sections.
+    pub group_by_host: bool,
     pub pending_leave: Option<Uuid>,
     pub pending_delete: Option<Uuid>,
 }
 
 impl DashboardUiState {
-    pub fn new(inactive_hidden: bool, show_cost: bool, rail_position: RailPosition) -> Self {
+    pub fn new(
+        inactive_hidden: bool,
+        show_cost: bool,
+        rail_position: RailPosition,
+        group_by_host: bool,
+    ) -> Self {
         Self {
             show_launch_dialog: false,
             show_admin: false,
@@ -170,6 +177,7 @@ impl DashboardUiState {
             inactive_hidden,
             show_cost,
             rail_position,
+            group_by_host,
             pending_leave: None,
             pending_delete: None,
         }
@@ -189,6 +197,7 @@ pub(super) enum DashboardUiAction {
     SetInactiveHidden(bool),
     SetShowCost(bool),
     SetRailPosition(RailPosition),
+    SetGroupByHost(bool),
     RequestLeave(Uuid),
     ClearPendingLeave,
     RequestDelete(Uuid),
@@ -234,6 +243,9 @@ impl Reducible for DashboardUiState {
             }
             DashboardUiAction::SetRailPosition(position) => {
                 state.rail_position = position;
+            }
+            DashboardUiAction::SetGroupByHost(enabled) => {
+                state.group_by_host = enabled;
             }
             DashboardUiAction::RequestLeave(session_id) => {
                 state.pending_leave = Some(session_id);
@@ -353,7 +365,7 @@ mod tests {
 
     #[test]
     fn ui_reducer_controls_modal_visibility() {
-        let state = DashboardUiState::new(false, false, RailPosition::Top);
+        let state = DashboardUiState::new(false, false, RailPosition::Top, false);
         let state = reduce_ui(state, DashboardUiAction::ToggleLaunchDialog);
         assert!(state.show_launch_dialog);
 
@@ -378,19 +390,21 @@ mod tests {
 
     #[test]
     fn ui_reducer_tracks_preferences() {
-        let state = DashboardUiState::new(false, false, RailPosition::Top);
+        let state = DashboardUiState::new(false, false, RailPosition::Top, false);
         let state = reduce_ui(state, DashboardUiAction::SetInactiveHidden(true));
         let state = state.reduce(DashboardUiAction::SetShowCost(true));
         let state = state.reduce(DashboardUiAction::SetRailPosition(RailPosition::Left));
+        let state = state.reduce(DashboardUiAction::SetGroupByHost(true));
 
         assert!(state.inactive_hidden);
         assert!(state.show_cost);
         assert_eq!(state.rail_position, RailPosition::Left);
+        assert!(state.group_by_host);
     }
 
     #[test]
     fn ui_reducer_tracks_pending_confirmations() {
-        let state = DashboardUiState::new(false, false, RailPosition::Top);
+        let state = DashboardUiState::new(false, false, RailPosition::Top, false);
         let state = reduce_ui(state, DashboardUiAction::RequestLeave(id(1)));
         let state = state.reduce(DashboardUiAction::RequestDelete(id(2)));
 

--- a/frontend/src/pages/dashboard/session_order.rs
+++ b/frontend/src/pages/dashboard/session_order.rs
@@ -50,6 +50,49 @@ pub(super) fn session_display_cmp(a: &SessionInfo, b: &SessionInfo) -> Ordering 
     display_sort_key(a).cmp(&display_sort_key(b))
 }
 
+/// Label shown for the "no hostname" bucket in the grouped rail.
+pub(super) const UNKNOWN_HOST_LABEL: &str = "unknown host";
+
+/// Group-membership label for a session's host section. Whitespace-only /
+/// empty hostnames collapse into a single [`UNKNOWN_HOST_LABEL`] bucket;
+/// otherwise the trimmed hostname (original case preserved for display).
+pub(super) fn host_group_label(s: &SessionInfo) -> String {
+    let host = s.hostname.trim();
+    if host.is_empty() {
+        UNKNOWN_HOST_LABEL.to_string()
+    } else {
+        host.to_string()
+    }
+}
+
+/// Sort key that places a session into its host *section*. Named hosts sort
+/// alphabetically (case-insensitively); the empty/unknown-host bucket sorts
+/// last via the leading `is_unknown` flag. This is intentionally coarser than
+/// [`display_sort_key`] — it only decides which section a session lands in, not
+/// its order *within* the section.
+fn host_group_key(s: &SessionInfo) -> (bool, String) {
+    let host = s.hostname.trim();
+    (host.is_empty(), host.to_lowercase())
+}
+
+/// Grouped (by-host) display comparator used when the "group rail by host"
+/// preference is on. Keys the host *section* first, then falls back to the
+/// standard total order [`session_display_cmp`] within each section. This means:
+///
+/// - host sections are alphabetical, with the empty/unknown-host bucket last;
+/// - sessions **within** a section keep the exact relative order they'd have
+///   ungrouped (so activity-driven polls don't reshuffle within a group);
+/// - the order stays *total* (the inner key ends in the unique `id`), so — like
+///   [`session_display_cmp`] — the displayed sequence is a pure function of the
+///   session set. That totality is what lets nav-mode numbering, `j`/`k`
+///   traversal, and [`resolve_focus_index`] all consume the same vector and
+///   agree with the visible top-to-bottom order.
+pub(super) fn session_display_cmp_grouped(a: &SessionInfo, b: &SessionInfo) -> Ordering {
+    host_group_key(a)
+        .cmp(&host_group_key(b))
+        .then_with(|| session_display_cmp(a, b))
+}
+
 /// Resolve the focused session's index in the *currently displayed* order.
 ///
 /// Focus is stored by `session_id` (the source of truth), so a reorder or a
@@ -292,6 +335,113 @@ mod tests {
 
         // Next refresh brings the session back; focus resolves by id again.
         assert_eq!(resolve_focus_index(&full, Some(launched), &hidden, 1), 2);
+    }
+
+    /// Grouped ordering sorts sessions into alphabetical host sections, and the
+    /// section a session lands in is independent of the poll's input order.
+    #[test]
+    fn grouped_orders_sections_alphabetically_by_host() {
+        let a = Uuid::from_u128(1);
+        let b = Uuid::from_u128(2);
+        let c = Uuid::from_u128(3);
+        let mk = || {
+            vec![
+                session(a, "/repo", "zeta", None),
+                session(b, "/repo", "alpha", None),
+                session(c, "/repo", "mid", None),
+            ]
+        };
+
+        let mut forward = mk();
+        forward.sort_by(session_display_cmp_grouped);
+        let mut reversed = mk();
+        reversed.reverse();
+        reversed.sort_by(session_display_cmp_grouped);
+
+        let hosts = |v: &[SessionInfo]| v.iter().map(|s| s.hostname.clone()).collect::<Vec<_>>();
+        // alpha < mid < zeta, regardless of input order.
+        assert_eq!(hosts(&forward), vec!["alpha", "mid", "zeta"]);
+        assert_eq!(hosts(&forward), hosts(&reversed));
+    }
+
+    /// Within a single host section, grouped order matches the ungrouped total
+    /// order (folder, then agent, then id) — grouping only reorders *across*
+    /// hosts, never within one.
+    #[test]
+    fn grouped_keeps_within_host_order_stable() {
+        let a = Uuid::from_u128(10);
+        let b = Uuid::from_u128(20);
+        let c = Uuid::from_u128(30);
+        let mk = || {
+            vec![
+                session(c, "/home/me/charlie", "host", None),
+                session(a, "/home/me/alpha", "host", None),
+                session(b, "/home/me/bravo", "host", None),
+            ]
+        };
+
+        let mut grouped = mk();
+        grouped.sort_by(session_display_cmp_grouped);
+        let mut ungrouped = mk();
+        ungrouped.sort_by(session_display_cmp);
+
+        let ids = |v: &[SessionInfo]| v.iter().map(|s| s.id).collect::<Vec<_>>();
+        // Single host → grouped is identical to ungrouped, i.e. folder order.
+        assert_eq!(ids(&grouped), ids(&ungrouped));
+        assert_eq!(ids(&grouped), vec![a, b, c]);
+    }
+
+    /// Sessions with an empty (or whitespace-only) hostname collapse into one
+    /// `unknown host` bucket that sorts *after* every named host.
+    #[test]
+    fn grouped_buckets_unknown_host_last() {
+        let named = Uuid::from_u128(1);
+        let blank = Uuid::from_u128(2);
+        let spaces = Uuid::from_u128(3);
+        let mut v = [
+            session(blank, "/repo", "", None),
+            session(named, "/repo", "web-01", None),
+            session(spaces, "/repo", "   ", None),
+        ];
+        v.sort_by(session_display_cmp_grouped);
+
+        // Named host first; the two empty/whitespace hosts share the trailing
+        // unknown bucket (ordered among themselves by the total inner key).
+        assert_eq!(v[0].id, named);
+        assert_eq!(host_group_label(&v[0]), "web-01");
+        assert_eq!(host_group_label(&v[1]), UNKNOWN_HOST_LABEL);
+        assert_eq!(host_group_label(&v[2]), UNKNOWN_HOST_LABEL);
+    }
+
+    /// Focus resolution runs against the grouped order exactly as it does for the
+    /// ungrouped order: focus stays pinned to its session id even though grouping
+    /// moves that session to a different display index. This is the guarantee
+    /// that nav numbers / `j`/`k` line up with the visible grouped rail.
+    #[test]
+    fn focus_resolves_against_grouped_order() {
+        let a = Uuid::from_u128(1);
+        let b = Uuid::from_u128(2);
+        let c = Uuid::from_u128(3);
+        let hidden = HashSet::new();
+
+        // Distinct hosts so grouping reorders relative to insertion order.
+        let mut sessions = vec![
+            session(a, "/repo", "zeta", None),
+            session(b, "/repo", "alpha", None),
+            session(c, "/repo", "mid", None),
+        ];
+        sessions.sort_by(session_display_cmp_grouped);
+        // Grouped order is alpha(b), mid(c), zeta(a).
+        assert_eq!(
+            sessions.iter().map(|s| s.id).collect::<Vec<_>>(),
+            vec![b, c, a]
+        );
+
+        // Focused session `a` (host zeta) resolves to its grouped index 2, not
+        // its pre-sort index 0.
+        assert_eq!(resolve_focus_index(&sessions, Some(a), &hidden, 0), 2);
+        assert_eq!(resolve_focus_index(&sessions, Some(b), &hidden, 0), 0);
+        assert_eq!(resolve_focus_index(&sessions, Some(c), &hidden, 0), 1);
     }
 
     /// The transient-miss hold must never index past the end of the list.

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -128,6 +128,78 @@ fn repo_pr_menu_hint(repo_url: Option<&str>, pr_count: usize) -> &'static str {
     }
 }
 
+/// Render one contiguous run of pills (visible or hidden section) into the rail,
+/// optionally prefixed with per-host header rows.
+///
+/// `entries` is the slice of `(index_in_sorted_sessions, session)` pairs to
+/// render; `number_offset` is the nav-mode display-number base for the first
+/// pill in this run. When `props.group_by_host` is on, a non-focusable header
+/// row is emitted before the first pill of each new host group. Headers carry
+/// **no** `data-index` or `display_number`, so keyboard numbering / `j`/`k`
+/// traversal skip them entirely and stay aligned with the sorted session vec.
+///
+/// Headers and pills are pushed as *flat siblings* into one keyed list (never
+/// nested in fragments) so Yew's keyed reconciliation still preserves each pill
+/// instance across reorders — the same guarantee the ungrouped rail relies on.
+/// With `group_by_host` off, the emitted list is exactly the keyed pills, i.e.
+/// identical to the pre-grouping render path.
+fn render_pill_section(
+    props: &SessionRailProps,
+    entries: &[(usize, &SessionInfo)],
+    number_offset: usize,
+    broadcast_active_ids: (&[Uuid], &[Uuid]),
+    render_time: f64,
+    on_toggle_menu: &Callback<(Uuid, MouseEvent)>,
+    section_key: &str,
+) -> Html {
+    let (broadcast_senders, broadcast_receivers) = broadcast_active_ids;
+    let mut nodes: Vec<Html> = Vec::with_capacity(entries.len());
+    let mut prev_label: Option<String> = None;
+    for (display_idx, (index, session)) in entries.iter().enumerate() {
+        if props.group_by_host {
+            let label = super::session_order::host_group_label(session);
+            if prev_label.as_deref() != Some(label.as_str()) {
+                prev_label = Some(label.clone());
+                let count = entries
+                    .iter()
+                    .filter(|(_, s)| super::session_order::host_group_label(s) == label)
+                    .count();
+                nodes.push(html! {
+                    <div
+                        key={format!("{section_key}-host-{label}")}
+                        class="session-rail-host-header"
+                        title={format!("{label} — {count} session(s)")}
+                    >
+                        <span class="host-header-name">{ label }</span>
+                        <span class="host-header-count">{ count }</span>
+                    </div>
+                });
+            }
+        }
+        nodes.push(html! {
+            <SessionPill
+                key={session.id.to_string()}
+                index={*index}
+                display_number={Some(number_offset + display_idx)}
+                session={(*session).clone()}
+                is_focused={*index == props.focused_index}
+                is_awaiting={props.awaiting_sessions.contains(&session.id)}
+                is_hidden={props.hidden_sessions.contains(&session.id)}
+                is_connected={props.connected_sessions.contains(&session.id)}
+                nav_mode={props.nav_mode}
+                server_version={props.server_version.clone()}
+                activity_timestamps={props.activity_timestamps.clone()}
+                is_broadcast_sender={broadcast_senders.contains(&session.id)}
+                is_broadcast_receiver={broadcast_receivers.contains(&session.id)}
+                render_time={render_time}
+                on_select={props.on_select.clone()}
+                on_toggle_menu={on_toggle_menu.clone()}
+            />
+        });
+    }
+    nodes.into_iter().collect::<Html>()
+}
+
 /// Props for the SessionRail component
 #[derive(Properties, PartialEq)]
 pub struct SessionRailProps {
@@ -136,6 +208,10 @@ pub struct SessionRailProps {
     pub awaiting_sessions: HashSet<Uuid>,
     pub hidden_sessions: HashSet<Uuid>,
     pub inactive_hidden: bool,
+    /// Opt-in: render per-host section headers between pill groups. The order
+    /// itself is grouped upstream (see `page.rs`); this flag only controls the
+    /// visual header rows so the rail stays in lockstep with nav numbering.
+    pub group_by_host: bool,
     pub connected_sessions: HashSet<Uuid>,
     pub nav_mode: bool,
     #[prop_or_default]
@@ -393,28 +469,17 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     html! {
         <div class="session-rail-container" onclick={on_container_click}>
             <div class="session-rail" ref={rail_ref} onwheel={on_wheel}>
-                { visible_indices.iter().enumerate().map(|(display_idx, (index, session))| {
-                    html! {
-                        <SessionPill
-                            key={session.id.to_string()}
-                            index={*index}
-                            display_number={Some(display_idx)}
-                            session={(*session).clone()}
-                            is_focused={*index == props.focused_index}
-                            is_awaiting={props.awaiting_sessions.contains(&session.id)}
-                            is_hidden={props.hidden_sessions.contains(&session.id)}
-                            is_connected={props.connected_sessions.contains(&session.id)}
-                            nav_mode={props.nav_mode}
-                            server_version={props.server_version.clone()}
-                            activity_timestamps={props.activity_timestamps.clone()}
-                            is_broadcast_sender={broadcast_senders.contains(&session.id)}
-                            is_broadcast_receiver={broadcast_receivers.contains(&session.id)}
-                            render_time={*render_time}
-                            on_select={props.on_select.clone()}
-                            on_toggle_menu={on_toggle_pill_menu.clone()}
-                        />
-                    }
-                }).collect::<Html>() }
+                {
+                    render_pill_section(
+                        props,
+                        &visible_indices,
+                        0,
+                        (&broadcast_senders, &broadcast_receivers),
+                        *render_time,
+                        &on_toggle_pill_menu,
+                        "visible",
+                    )
+                }
 
                 {
                     if hidden_count > 0 {
@@ -441,28 +506,15 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
 
                 {
                     if !props.inactive_hidden {
-                        hidden_indices.iter().enumerate().map(|(display_idx, (index, session))| {
-                            html! {
-                                <SessionPill
-                                    key={session.id.to_string()}
-                                    index={*index}
-                                    display_number={Some(visible_count + display_idx)}
-                                    session={(*session).clone()}
-                                    is_focused={*index == props.focused_index}
-                                    is_awaiting={props.awaiting_sessions.contains(&session.id)}
-                                    is_hidden={props.hidden_sessions.contains(&session.id)}
-                                    is_connected={props.connected_sessions.contains(&session.id)}
-                                    nav_mode={props.nav_mode}
-                                    server_version={props.server_version.clone()}
-                                    activity_timestamps={props.activity_timestamps.clone()}
-                                    is_broadcast_sender={broadcast_senders.contains(&session.id)}
-                                    is_broadcast_receiver={broadcast_receivers.contains(&session.id)}
-                                    render_time={*render_time}
-                                    on_select={props.on_select.clone()}
-                                    on_toggle_menu={on_toggle_pill_menu.clone()}
-                                />
-                            }
-                        }).collect::<Html>()
+                        render_pill_section(
+                            props,
+                            &hidden_indices,
+                            visible_count,
+                            (&broadcast_senders, &broadcast_receivers),
+                            *render_time,
+                            &on_toggle_pill_menu,
+                            "hidden",
+                        )
                     } else {
                         html! {}
                     }

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -25,6 +25,9 @@ pub const RAIL_ORIENTATION_STORAGE_KEY: &str = "claude-portal-rail-orientation";
 /// Storage key for the last actively focused session in localStorage
 pub const LAST_ACTIVE_SESSION_STORAGE_KEY: &str = "claude-portal-last-active-session";
 
+/// Storage key for the opt-in "group session rail by host" preference.
+pub const SESSION_RAIL_GROUP_BY_HOST_STORAGE_KEY: &str = "claude-portal-session-rail-group-by-host";
+
 /// Storage key for the opt-in vim editing mode in localStorage
 pub const VIM_MODE_STORAGE_KEY: &str = "claude-portal-vim-mode";
 
@@ -182,6 +185,16 @@ impl RailPosition {
             Self::Right => "rail-right",
         }
     }
+}
+
+/// Load the "group session rail by host" preference (default: off).
+pub fn load_group_by_host() -> bool {
+    load_bool_pref(SESSION_RAIL_GROUP_BY_HOST_STORAGE_KEY)
+}
+
+/// Save the "group session rail by host" preference to localStorage.
+pub fn save_group_by_host(enabled: bool) {
+    save_bool_pref(SESSION_RAIL_GROUP_BY_HOST_STORAGE_KEY, enabled);
 }
 
 /// Load rail position preference from localStorage (default: top).

--- a/frontend/src/pages/settings/appearance_panel.rs
+++ b/frontend/src/pages/settings/appearance_panel.rs
@@ -1,5 +1,6 @@
 use crate::pages::dashboard::{
-    load_rail_position, load_vim_mode, save_rail_position, save_vim_mode, RailPosition,
+    load_group_by_host, load_rail_position, load_vim_mode, save_group_by_host, save_rail_position,
+    save_vim_mode, RailPosition,
 };
 use yew::prelude::*;
 
@@ -14,6 +15,17 @@ const ALL_POSITIONS: &[(RailPosition, &str)] = &[
 pub fn appearance_panel() -> Html {
     let position = use_state(load_rail_position);
     let vim_enabled = use_state(load_vim_mode);
+    let group_by_host = use_state(load_group_by_host);
+
+    let on_toggle_group_by_host = {
+        let group_by_host = group_by_host.clone();
+        Callback::from(move |e: Event| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            let enabled = input.checked();
+            save_group_by_host(enabled);
+            group_by_host.set(enabled);
+        })
+    };
 
     let on_toggle_vim = {
         let vim_enabled = vim_enabled.clone();
@@ -61,6 +73,24 @@ pub fn appearance_panel() -> Html {
                         }
                     })}
                 </div>
+            </div>
+
+            <div class="appearance-setting">
+                <h3>{ "Group session rail by host" }</h3>
+                <p class="setting-description">
+                    { "Split the session rail into sections by the machine each \
+                       session runs on. Sections are ordered alphabetically by \
+                       hostname; sessions with no hostname group under \
+                       \"unknown host\". Off by default." }
+                </p>
+                <label class="toggle-label">
+                    <input
+                        type="checkbox"
+                        checked={*group_by_host}
+                        onchange={on_toggle_group_by_host}
+                    />
+                    <span>{ if *group_by_host { "Enabled" } else { "Disabled" } }</span>
+                </label>
             </div>
 
             <div class="appearance-setting">

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -148,6 +148,62 @@
     background: rgba(0, 0, 0, 0.2);
 }
 
+/* Per-host section header (opt-in "group rail by host"). Non-interactive
+   label rendered inline among the pills. In the horizontal (top/bottom) rail
+   it reads as a compact chip that precedes each host's pills; in the vertical
+   (left/right) rail it spans the column as a full-width section heading. */
+.session-rail-host-header {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    flex-shrink: 0;
+    padding: 0.15rem 0.5rem;
+    align-self: center;
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+}
+
+.session-rail-host-header .host-header-name {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.session-rail-host-header .host-header-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.1rem;
+    padding: 0 0.3rem;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid var(--border);
+    font-size: 0.65rem;
+    font-weight: 600;
+}
+
+/* Vertical rail: host headers become full-width section rows with a subtle
+   top rule so groups read as stacked sections rather than inline chips. */
+.dashboard-body.rail-left .session-rail-host-header,
+.dashboard-body.rail-right .session-rail-host-header {
+    align-self: stretch;
+    width: 100%;
+    justify-content: space-between;
+    padding: 0.35rem 0.25rem 0.15rem;
+    border-top: 1px solid var(--border);
+    margin-top: 0.15rem;
+}
+
+/* The first header in a vertical rail shouldn't carry a top rule/margin. */
+.dashboard-body.rail-left .session-rail-host-header:first-child,
+.dashboard-body.rail-right .session-rail-host-header:first-child {
+    border-top: none;
+    margin-top: 0;
+}
+
 .session-pill {
     --pill-visual-height: 2.5rem;
 


### PR DESCRIPTION
## What

Adds an opt-in Appearance setting that groups the dashboard session rail into per-host sections. Off by default; the rail is unchanged when the toggle is off.

When enabled:
- Sessions are grouped into sections by `SessionInfo.hostname`.
- Sections are ordered alphabetically by hostname; sessions with an empty/whitespace-only hostname bucket last under an "unknown host" section.
- Within a group, sessions keep their existing relative order (so activity-driven polls don't reshuffle inside a host).
- Each group is preceded by a compact, non-focusable host header (hostname + session count).
- Works in both horizontal (top/bottom) and vertical (left/right) rail orientations.
- Persisted per browser in localStorage (like the rail-orientation pref); takes effect on returning to the dashboard, no reload.

## How nav-order stays consistent

Grouping is done in the *canonical sort* (`session_display_cmp_grouped`) that produces the single `active_sessions` vector. That one vector drives focus resolution (`resolve_focus_index`), nav-mode numbering, and `j`/`k` traversal — so the logical order always matches the visible grouped rail. Both comparators are *total* (keyed down to the unique session id). The rail's host headers are inserted purely visually and carry no `data-index`/`display_number`, so keyboard numbering and traversal skip them. Header and pill VNodes are emitted as flat, keyed siblings (not nested in fragments) so Yew's keyed reconciliation still preserves pill instances across reorders.

## Tests

Extended `session_order` unit tests: grouped alphabetical host ordering (input-order independent), stable within-group order, unknown-host bucketing, and focus resolution against the grouped order. Added a `SetGroupByHost` reducer assertion.

Verified: `trunk build`, `cargo clippy -p frontend --target wasm32-unknown-unknown -D warnings`, `cargo test -p frontend`, `cargo build -p backend` (embeds dist).