### PR TITLE
Animate inter-agent messages across session pills

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -8,7 +8,7 @@ use super::page_state::{
     DashboardUiState,
 };
 use super::session_order;
-use super::session_rail::{ActivityRef, SessionRail};
+use super::session_rail::{ActivityRef, AgentMessageBroadcast, BroadcastRef, SessionRail};
 use super::session_view::SessionView;
 use super::types::{
     load_hidden_sessions, load_inactive_hidden, load_rail_position, load_show_cost,
@@ -101,6 +101,7 @@ pub fn dashboard_page() -> Html {
     // Activity buffer: mutations don't trigger page re-renders.
     // SessionRail reads this on its own 100 ms tick instead.
     let activity_timestamps = use_memo((), |_| ActivityRef::default());
+    let agent_message_broadcasts = use_memo((), |_| BroadcastRef::default());
     let spend_animation = use_spend_badge_animation(total_user_spend);
 
     // Get DB-authoritative sessions in a total, deterministic display order
@@ -485,6 +486,19 @@ pub fn dashboard_page() -> Html {
         )
     };
 
+    let on_agent_message = {
+        let broadcasts = (*agent_message_broadcasts).clone();
+        Callback::from(
+            move |(from_session_id, to_session_id, timestamp): (Uuid, Uuid, f64)| {
+                broadcasts.push(AgentMessageBroadcast {
+                    from_session_id,
+                    to_session_id,
+                    timestamp,
+                });
+            },
+        )
+    };
+
     let on_branch_change = {
         let set_sessions = sessions_hook.set_sessions.clone();
         let sessions = sessions.clone();
@@ -702,6 +716,8 @@ pub fn dashboard_page() -> Html {
                         connected_sessions={session_state.connected_sessions.clone()}
                         nav_mode={keyboard_nav.nav_mode}
                         activity_timestamps={(*activity_timestamps).clone()}
+                        broadcasts={(*agent_message_broadcasts).clone()}
+                        rail_position={ui_state.rail_position}
                         server_version={server_version.clone()}
                         on_select={focus.on_select_session.clone()}
                         on_leave={on_leave.clone()}
@@ -733,6 +749,7 @@ pub fn dashboard_page() -> Html {
                                                 on_message_sent={on_message_sent.clone()}
                                                 on_branch_change={on_branch_change.clone()}
                                                 on_activity={on_activity.clone()}
+                                                on_agent_message={on_agent_message.clone()}
                                                 current_user_id={current_user_id.map(|id| id.to_string())}
                                                 interrupt_signal={focus.interrupt_signal}
                                                 jump_to_latest_signal={focus.jump_to_latest_signal}

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -13,10 +13,13 @@ use wasm_bindgen::JsCast;
 use web_sys::{Element, HtmlElement, WheelEvent};
 use yew::prelude::*;
 
+mod broadcast;
 mod hooks;
 mod menu;
 mod pill;
 mod sparkline;
+use broadcast::{render_broadcasts, RailAxis};
+pub use broadcast::{AgentMessageBroadcast, BroadcastRef};
 use hooks::use_scheduled_task_blocker;
 use menu::SessionRailMenu;
 use pill::SessionPill;
@@ -137,6 +140,9 @@ pub struct SessionRailProps {
     pub nav_mode: bool,
     #[prop_or_default]
     pub activity_timestamps: ActivityRef,
+    #[prop_or_default]
+    pub broadcasts: BroadcastRef,
+    pub rail_position: crate::pages::dashboard::RailPosition,
     /// Server version string for comparing against client versions
     #[prop_or_default]
     pub server_version: String,
@@ -349,6 +355,21 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
 
     let hidden_count = hidden_indices.len();
     let visible_count = visible_indices.len();
+    let mut rendered_session_ids: Vec<Uuid> = visible_indices
+        .iter()
+        .map(|(_, session)| session.id)
+        .collect();
+    if !props.inactive_hidden {
+        rendered_session_ids.extend(hidden_indices.iter().map(|(_, session)| session.id));
+    }
+    let (broadcast_senders, broadcast_receivers) =
+        props.broadcasts.active_session_ids(*render_time);
+    let rail_axis = match props.rail_position {
+        crate::pages::dashboard::RailPosition::Top
+        | crate::pages::dashboard::RailPosition::Bottom => RailAxis::Horizontal,
+        crate::pages::dashboard::RailPosition::Left
+        | crate::pages::dashboard::RailPosition::Right => RailAxis::Vertical,
+    };
 
     // Container with position:relative holds the rail + dropdown.
     // Dropdown uses position:fixed to escape rail overflow clipping.
@@ -382,6 +403,8 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                             nav_mode={props.nav_mode}
                             server_version={props.server_version.clone()}
                             activity_timestamps={props.activity_timestamps.clone()}
+                            is_broadcast_sender={broadcast_senders.contains(&session.id)}
+                            is_broadcast_receiver={broadcast_receivers.contains(&session.id)}
                             render_time={*render_time}
                             on_select={props.on_select.clone()}
                             on_toggle_menu={on_toggle_pill_menu.clone()}
@@ -428,6 +451,8 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                                     nav_mode={props.nav_mode}
                                     server_version={props.server_version.clone()}
                                     activity_timestamps={props.activity_timestamps.clone()}
+                                    is_broadcast_sender={broadcast_senders.contains(&session.id)}
+                                    is_broadcast_receiver={broadcast_receivers.contains(&session.id)}
                                     render_time={*render_time}
                                     on_select={props.on_select.clone()}
                                     on_toggle_menu={on_toggle_pill_menu.clone()}
@@ -439,6 +464,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     }
                 }
             </div>
+            { render_broadcasts(&props.broadcasts, &rendered_session_ids, rail_axis, *render_time) }
             <SessionRailMenu
                 session={open_session}
                 position={*menu_pos}

--- a/frontend/src/pages/dashboard/session_rail/broadcast.rs
+++ b/frontend/src/pages/dashboard/session_rail/broadcast.rs
@@ -1,0 +1,224 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use uuid::Uuid;
+use yew::prelude::*;
+
+const BROADCAST_WINDOW_MS: f64 = 2_400.0;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AgentMessageBroadcast {
+    pub from_session_id: Uuid,
+    pub to_session_id: Uuid,
+    pub timestamp: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RailAxis {
+    Horizontal,
+    Vertical,
+}
+
+impl RailAxis {
+    fn class(self) -> &'static str {
+        match self {
+            Self::Horizontal => "horizontal",
+            Self::Vertical => "vertical",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct BroadcastView {
+    pub from_session_id: Uuid,
+    pub to_session_id: Uuid,
+    pub timestamp: f64,
+    pub start_pct: f64,
+    pub end_pct: f64,
+    pub reverse: bool,
+}
+
+#[derive(Clone)]
+pub struct BroadcastRef(Rc<RefCell<Vec<AgentMessageBroadcast>>>);
+
+impl BroadcastRef {
+    pub fn push(&self, event: AgentMessageBroadcast) {
+        let cutoff = event.timestamp - BROADCAST_WINDOW_MS;
+        let mut events = self.0.borrow_mut();
+        events.retain(|e| e.timestamp > cutoff);
+        events.push(event);
+    }
+
+    pub(super) fn active_session_ids(&self, now: f64) -> (Vec<Uuid>, Vec<Uuid>) {
+        let cutoff = now - BROADCAST_WINDOW_MS;
+        let mut senders = Vec::new();
+        let mut receivers = Vec::new();
+        for event in self.0.borrow().iter().filter(|e| e.timestamp > cutoff) {
+            push_unique(&mut senders, event.from_session_id);
+            push_unique(&mut receivers, event.to_session_id);
+        }
+        (senders, receivers)
+    }
+
+    pub(super) fn view_for(&self, rendered_session_ids: &[Uuid], now: f64) -> Vec<BroadcastView> {
+        if rendered_session_ids.len() < 2 {
+            return Vec::new();
+        }
+
+        let cutoff = now - BROADCAST_WINDOW_MS;
+        self.0
+            .borrow()
+            .iter()
+            .filter(|event| event.timestamp > cutoff)
+            .filter_map(|event| {
+                let from_idx = rendered_session_ids
+                    .iter()
+                    .position(|id| *id == event.from_session_id)?;
+                let to_idx = rendered_session_ids
+                    .iter()
+                    .position(|id| *id == event.to_session_id)?;
+                if from_idx == to_idx {
+                    return None;
+                }
+                let from_pct = slot_pct(from_idx, rendered_session_ids.len());
+                let to_pct = slot_pct(to_idx, rendered_session_ids.len());
+                Some(BroadcastView {
+                    from_session_id: event.from_session_id,
+                    to_session_id: event.to_session_id,
+                    timestamp: event.timestamp,
+                    start_pct: from_pct.min(to_pct),
+                    end_pct: from_pct.max(to_pct),
+                    reverse: from_pct > to_pct,
+                })
+            })
+            .collect()
+    }
+}
+
+impl PartialEq for BroadcastRef {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Default for BroadcastRef {
+    fn default() -> Self {
+        Self(Rc::new(RefCell::new(Vec::new())))
+    }
+}
+
+pub(super) fn render_broadcasts(
+    broadcasts: &BroadcastRef,
+    rendered_session_ids: &[Uuid],
+    axis: RailAxis,
+    render_time: f64,
+) -> Html {
+    let views = broadcasts.view_for(rendered_session_ids, render_time);
+    if views.is_empty() {
+        return html! {};
+    }
+
+    html! {
+        <div class={classes!("agent-broadcast-layer", axis.class())} aria-hidden="true">
+            { for views.into_iter().map(|view| {
+                let span = (view.end_pct - view.start_pct).max(1.0);
+                let style = match axis {
+                    RailAxis::Horizontal => {
+                        format!("left: {:.2}%; width: {:.2}%;", view.start_pct, span)
+                    }
+                    RailAxis::Vertical => {
+                        format!("top: {:.2}%; height: {:.2}%;", view.start_pct, span)
+                    }
+                };
+                html! {
+                    <span
+                        key={format!("{}-{}-{:.0}", view.from_session_id, view.to_session_id, view.timestamp)}
+                        class={classes!("agent-broadcast-path", view.reverse.then_some("reverse"))}
+                        {style}
+                    >
+                        <span class="agent-broadcast-packet" />
+                    </span>
+                }
+            }) }
+        </div>
+    }
+}
+
+fn slot_pct(index: usize, total: usize) -> f64 {
+    ((index as f64) + 0.5) / (total as f64) * 100.0
+}
+
+fn push_unique(values: &mut Vec<Uuid>, id: Uuid) {
+    if !values.contains(&id) {
+        values.push(id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    #[test]
+    fn broadcast_view_maps_visible_sender_and_receiver_to_slots() {
+        let events = BroadcastRef::default();
+        events.push(AgentMessageBroadcast {
+            from_session_id: id(1),
+            to_session_id: id(3),
+            timestamp: 1_000.0,
+        });
+
+        let view = events.view_for(&[id(1), id(2), id(3)], 1_200.0);
+        assert_eq!(view.len(), 1);
+        assert!((view[0].start_pct - 16.666).abs() < 0.01);
+        assert!((view[0].end_pct - 83.333).abs() < 0.01);
+        assert!(!view[0].reverse);
+    }
+
+    #[test]
+    fn broadcast_view_marks_reverse_direction() {
+        let events = BroadcastRef::default();
+        events.push(AgentMessageBroadcast {
+            from_session_id: id(3),
+            to_session_id: id(1),
+            timestamp: 1_000.0,
+        });
+
+        let view = events.view_for(&[id(1), id(2), id(3)], 1_200.0);
+        assert_eq!(view.len(), 1);
+        assert!(view[0].reverse);
+    }
+
+    #[test]
+    fn broadcast_view_omits_events_when_sender_is_not_rendered() {
+        let events = BroadcastRef::default();
+        events.push(AgentMessageBroadcast {
+            from_session_id: id(9),
+            to_session_id: id(1),
+            timestamp: 1_000.0,
+        });
+
+        assert!(events.view_for(&[id(1), id(2)], 1_200.0).is_empty());
+    }
+
+    #[test]
+    fn active_session_ids_expires_old_events() {
+        let events = BroadcastRef::default();
+        events.push(AgentMessageBroadcast {
+            from_session_id: id(1),
+            to_session_id: id(2),
+            timestamp: 1_000.0,
+        });
+
+        let (senders, receivers) = events.active_session_ids(1_100.0);
+        assert_eq!(senders, vec![id(1)]);
+        assert_eq!(receivers, vec![id(2)]);
+
+        let (senders, receivers) = events.active_session_ids(4_000.0);
+        assert!(senders.is_empty());
+        assert!(receivers.is_empty());
+    }
+}

--- a/frontend/src/pages/dashboard/session_rail/pill.rs
+++ b/frontend/src/pages/dashboard/session_rail/pill.rs
@@ -42,6 +42,8 @@ pub(super) struct SessionPillProps {
     pub nav_mode: bool,
     pub server_version: String,
     pub activity_timestamps: ActivityRef,
+    pub is_broadcast_sender: bool,
+    pub is_broadcast_receiver: bool,
     pub render_time: f64,
     pub on_select: Callback<usize>,
     pub on_toggle_menu: Callback<(Uuid, MouseEvent)>,
@@ -142,6 +144,12 @@ impl PillViewModel {
         }
         if props.nav_mode {
             pill_classes.push("nav-mode");
+        }
+        if props.is_broadcast_sender {
+            pill_classes.push("broadcast-sender");
+        }
+        if props.is_broadcast_receiver {
+            pill_classes.push("broadcast-receiver");
         }
         if is_status_disconnected {
             pill_classes.push("status-disconnected");

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -62,6 +62,8 @@ pub struct SessionViewProps {
     #[prop_or_default]
     pub on_activity: Callback<(Uuid, ActivityTag, f64)>,
     #[prop_or_default]
+    pub on_agent_message: Callback<(Uuid, Uuid, f64)>,
+    #[prop_or_default]
     pub current_user_id: Option<String>,
     #[prop_or(0)]
     pub interrupt_signal: u32,
@@ -981,6 +983,13 @@ impl SessionView {
 
     fn handle_received_output(&mut self, ctx: &Context<Self>, output: RenderedMessage) -> bool {
         let tag = classify_output_msg_type(&output.content);
+        if let Some(shared::MessageSource::Agent { session_id, .. }) = output.source() {
+            ctx.props().on_agent_message.emit((
+                *session_id,
+                ctx.props().session.id,
+                js_sys::Date::now(),
+            ));
+        }
         if let Ok(claude_msg) = serde_json::from_str::<shared::ClaudeOutput>(&output.content) {
             // Live task events: the `created_at` field isn't part of the
             // live wire envelope, so the panel falls back to `Date.now()`

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -64,6 +64,10 @@
 .dashboard-body.rail-left  > .session-rail-container { border-right: 1px solid var(--border); }
 .dashboard-body.rail-right > .session-rail-container { border-left:  1px solid var(--border); }
 
+.session-rail-container {
+    position: relative;
+}
+
 .dashboard-body.rail-left .session-rail,
 .dashboard-body.rail-right .session-rail {
     flex: 1;
@@ -205,6 +209,204 @@
        glyph alone signals "still waiting". */
     border-color: var(--accent);
     background: rgba(122, 162, 247, 0.18);
+}
+
+.session-pill.broadcast-sender,
+.session-pill.broadcast-receiver {
+    overflow: visible;
+}
+
+.session-pill.broadcast-sender::before,
+.session-pill.broadcast-receiver::before {
+    content: "";
+    position: absolute;
+    top: -8px;
+    right: 18px;
+    width: 14px;
+    height: 14px;
+    border-top: 2px solid #bb9af7;
+    border-left: 2px solid #bb9af7;
+    border-radius: 50% 0 0 0;
+    transform: rotate(45deg);
+    opacity: 0;
+    pointer-events: none;
+    z-index: 4;
+    animation: agent-antenna-pop 900ms ease-out;
+}
+
+.session-pill.broadcast-receiver::before {
+    border-top-color: #7dcfff;
+    border-left-color: #7dcfff;
+}
+
+.session-pill.broadcast-sender::after,
+.session-pill.broadcast-receiver::after {
+    content: "";
+    position: absolute;
+    top: -11px;
+    right: 13px;
+    width: 24px;
+    height: 24px;
+    border: 1px solid rgba(187, 154, 247, 0.65);
+    border-radius: 50%;
+    opacity: 0;
+    pointer-events: none;
+    z-index: 3;
+    animation: agent-radio-ring 900ms ease-out;
+}
+
+.session-pill.broadcast-receiver::after {
+    border-color: rgba(125, 207, 255, 0.65);
+}
+
+.agent-broadcast-layer {
+    position: absolute;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.agent-broadcast-layer.horizontal {
+    left: 0;
+    right: 0;
+    top: 0.65rem;
+    height: 20px;
+}
+
+.agent-broadcast-layer.vertical {
+    top: 0;
+    bottom: 0;
+    left: 0.65rem;
+    width: 20px;
+}
+
+.agent-broadcast-path {
+    position: absolute;
+    display: block;
+    opacity: 0;
+    animation: agent-path-fade 1.35s ease-out;
+}
+
+.agent-broadcast-layer.horizontal .agent-broadcast-path {
+    top: 0;
+    height: 20px;
+    border-top: 1px dashed rgba(187, 154, 247, 0.55);
+}
+
+.agent-broadcast-layer.vertical .agent-broadcast-path {
+    left: 0;
+    width: 20px;
+    border-left: 1px dashed rgba(187, 154, 247, 0.55);
+}
+
+.agent-broadcast-packet {
+    position: absolute;
+    display: block;
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+    background: #bb9af7;
+    box-shadow: 0 0 10px rgba(187, 154, 247, 0.85);
+}
+
+.agent-broadcast-layer.horizontal .agent-broadcast-packet {
+    top: -5px;
+    left: 0;
+    animation: agent-packet-x 1.05s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+}
+
+.agent-broadcast-layer.horizontal .agent-broadcast-path.reverse .agent-broadcast-packet {
+    animation-name: agent-packet-x-reverse;
+}
+
+.agent-broadcast-layer.vertical .agent-broadcast-packet {
+    top: 0;
+    left: -4px;
+    animation: agent-packet-y 1.05s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+}
+
+.agent-broadcast-layer.vertical .agent-broadcast-path.reverse .agent-broadcast-packet {
+    animation-name: agent-packet-y-reverse;
+}
+
+@keyframes agent-antenna-pop {
+    0% {
+        opacity: 0;
+        transform: rotate(45deg) scale(0.7);
+    }
+    20%,
+    65% {
+        opacity: 1;
+        transform: rotate(45deg) scale(1);
+    }
+    100% {
+        opacity: 0;
+        transform: rotate(45deg) scale(0.85);
+    }
+}
+
+@keyframes agent-radio-ring {
+    0% {
+        opacity: 0.8;
+        transform: scale(0.35);
+    }
+    100% {
+        opacity: 0;
+        transform: scale(1.4);
+    }
+}
+
+@keyframes agent-path-fade {
+    0%,
+    12% {
+        opacity: 0;
+    }
+    22%,
+    72% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+
+@keyframes agent-packet-x {
+    from { left: 0; }
+    to { left: calc(100% - 8px); }
+}
+
+@keyframes agent-packet-x-reverse {
+    from { left: calc(100% - 8px); }
+    to { left: 0; }
+}
+
+@keyframes agent-packet-y {
+    from { top: 0; }
+    to { top: calc(100% - 8px); }
+}
+
+@keyframes agent-packet-y-reverse {
+    from { top: calc(100% - 8px); }
+    to { top: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .session-pill.broadcast-sender::before,
+    .session-pill.broadcast-receiver::before,
+    .session-pill.broadcast-sender::after,
+    .session-pill.broadcast-receiver::after,
+    .agent-broadcast-path,
+    .agent-broadcast-packet {
+        animation: none;
+    }
+
+    .session-pill.broadcast-sender,
+    .session-pill.broadcast-receiver {
+        box-shadow: 0 0 0 2px rgba(187, 154, 247, 0.35);
+    }
+
+    .agent-broadcast-layer {
+        display: none;
+    }
 }
 
 .pill-indicator {


### PR DESCRIPTION
## Summary
- surface live inter-agent messages as transient broadcasts between sender and receiver session pills
- add sender/receiver pill antenna states plus rail-level packet animation for horizontal and vertical rails
- keep broadcast state local to the dashboard and ignore history replay so only new agent-to-agent traffic animates

## Testing
- cargo fmt --check
- cargo test -p frontend broadcast
- cargo test -p frontend session_rail
- cargo check -p frontend --target wasm32-unknown-unknown

Stacked on #1433.