### PR TITLE
Show the session model number in the pill watermark

### DIFF
--- a/backend/migrations/2026-07-19-192252_add_last_model_to_sessions/down.sql
+++ b/backend/migrations/2026-07-19-192252_add_last_model_to_sessions/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN last_model;

--- a/backend/migrations/2026-07-19-192252_add_last_model_to_sessions/up.sql
+++ b/backend/migrations/2026-07-19-192252_add_last_model_to_sessions/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN last_model VARCHAR(128);

--- a/backend/src/handlers/websocket/turn_metrics.rs
+++ b/backend/src/handlers/websocket/turn_metrics.rs
@@ -55,15 +55,16 @@ pub fn handle_turn_metrics_report(
     // Resolve the session's owner so the metric carries its own ownership.
     // `turn_metrics.user_id` is what the Performance queries filter on, which
     // lets a row outlive its session (`session_id` is `ON DELETE SET NULL`)
-    // and still be attributed to the right user.
-    let owner_id: Uuid = {
+    // and still be attributed to the right user. We fetch `last_model` in the
+    // same round-trip so we can change-gate the write below.
+    let (owner_id, stored_model): (Uuid, Option<String>) = {
         use crate::schema::sessions;
         match sessions::table
             .find(session_id)
-            .select(sessions::user_id)
-            .first::<Uuid>(&mut conn)
+            .select((sessions::user_id, sessions::last_model))
+            .first::<(Uuid, Option<String>)>(&mut conn)
         {
-            Ok(uid) => uid,
+            Ok(row) => row,
             Err(e) => {
                 error!(
                     "Failed to resolve owner for session {} (turn metrics insert): {}",
@@ -73,6 +74,32 @@ pub fn handle_turn_metrics_report(
             }
         }
     };
+
+    // Record the session's most recent model so the dashboard rail can render
+    // a compact model watermark on the pill. Last observed wins, but we only
+    // write when the value actually changes (a Fable 5 session that falls back
+    // to Opus 4.8 flips the stored id) — an unchanged model writes nothing,
+    // keeping this off the hot path for the common every-turn case. The live
+    // flip on already-open dashboards rides the existing per-turn
+    // `ServerToClient::TurnMetrics` fanout below (which carries `model`); this
+    // write is what a fresh page load / `/api/sessions` poll reads back.
+    if should_persist_model(stored_model.as_deref(), metrics.model.as_deref()) {
+        use crate::schema::sessions;
+        if let Err(e) = diesel::update(sessions::table.find(session_id))
+            .set(sessions::last_model.eq(&metrics.model))
+            .execute(&mut conn)
+        {
+            error!(
+                "Failed to update sessions.last_model for session {}: {}",
+                session_id, e
+            );
+        } else {
+            info!(
+                "Updated sessions.last_model for session {}: {:?} -> {:?}",
+                session_id, stored_model, metrics.model
+            );
+        }
+    }
 
     let new_row = NewTurnMetric {
         session_id,
@@ -160,8 +187,60 @@ pub fn handle_turn_metrics_report(
     }
 }
 
-// No unit tests here — the persist/broadcast round-trip needs a real
-// Postgres connection (no in-process Diesel sqlite fallback is set up in
-// this repo). The `TurnTracker` finalize path is exercised via
-// `session_lib::turn_tracker` unit tests; the wire shape is exercised via
-// `shared::api::tests::turn_metrics_*_roundtrip`.
+/// Whether an observed model warrants an `UPDATE` of `sessions.last_model`.
+///
+/// Gates the write so an already-open dashboard doesn't take a redundant DB
+/// write on every identical turn, and a `None`/unknown observation never
+/// clears a previously-known value:
+///   * `observed = Some(m)` and `m != stored`  → write (model changed)
+///   * `observed = Some(m)` and `m == stored`  → skip (unchanged)
+///   * `observed = None`                        → skip (don't clobber)
+///
+/// Pure so the changed-vs-unchanged decision is unit-testable without a live
+/// Postgres connection (the persist/broadcast round-trip itself still needs
+/// one — see below).
+fn should_persist_model(stored: Option<&str>, observed: Option<&str>) -> bool {
+    match observed {
+        Some(m) => stored != Some(m),
+        None => false,
+    }
+}
+
+// The persist/broadcast round-trip needs a real Postgres connection (no
+// in-process Diesel sqlite fallback is set up in this repo). The `TurnTracker`
+// finalize path is exercised via `session_lib::turn_tracker` unit tests; the
+// wire shape is exercised via `shared::api::tests::turn_metrics_*_roundtrip`.
+#[cfg(test)]
+mod tests {
+    use super::should_persist_model;
+
+    #[test]
+    fn writes_when_model_changes() {
+        // Fable 5 → Opus 4.8 fallback: the stored id must be replaced.
+        assert!(should_persist_model(
+            Some("claude-fable-5"),
+            Some("claude-opus-4-8")
+        ));
+    }
+
+    #[test]
+    fn writes_first_observation_from_null() {
+        assert!(should_persist_model(None, Some("claude-opus-4-8")));
+    }
+
+    #[test]
+    fn skips_when_model_unchanged() {
+        // The common every-turn case: no redundant write.
+        assert!(!should_persist_model(
+            Some("claude-opus-4-8"),
+            Some("claude-opus-4-8")
+        ));
+    }
+
+    #[test]
+    fn skips_when_observation_absent() {
+        // A None observation never clears a previously-known model.
+        assert!(!should_persist_model(Some("claude-opus-4-8"), None));
+        assert!(!should_persist_model(None, None));
+    }
+}

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -70,6 +70,12 @@ pub struct Session {
     /// `None` = never; the sweep re-archives when `last_activity` advances
     /// past this.
     pub archived_at: Option<NaiveDateTime>,
+    /// Most recently observed model id for this session (last turn wins), e.g.
+    /// `"claude-opus-4-8"`. Written from the per-turn metrics path when it
+    /// changes so the dashboard rail can render a compact model watermark on
+    /// the session pill. `None` until the first turn with a known model. See
+    /// `handlers::websocket::turn_metrics`.
+    pub last_model: Option<String>,
 }
 
 /// Insertable session that specifies the ID (so we can use Claude's session ID)

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -222,6 +222,8 @@ diesel::table! {
         launch_lease_until -> Nullable<Timestamp>,
         open_prs -> Jsonb,
         archived_at -> Nullable<Timestamp>,
+        #[max_length = 128]
+        last_model -> Nullable<Varchar>,
     }
 }
 

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -26,7 +26,7 @@ use crate::utils;
 use gloo_net::http::Request;
 use serde::Deserialize;
 use shared::SessionInfo;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::MouseEvent;
@@ -107,8 +107,28 @@ pub fn dashboard_page() -> Html {
     // Get DB-authoritative sessions in a total, deterministic display order
     // (see `session_order`). A disconnected, unpaused session is
     // desired-running and should stay visible while the launcher reconciles it.
+    // Live model overlay for the pill's model watermark. The dashboard already
+    // receives every session's per-turn `TurnMetrics` (which carries `model`)
+    // on the user channel, so a mid-session model change — e.g. a Fable 5
+    // session falling back to Opus 4.8 — flips the pill's watermark instantly,
+    // before the next `/api/sessions` poll reads the persisted `last_model`
+    // back. Latest turn wins: the buffer is ordered oldest→newest, so a plain
+    // `collect` lets later entries overwrite earlier ones per session.
+    let live_models: HashMap<Uuid, String> = ws_hook
+        .recent_turn_metrics
+        .iter()
+        .filter_map(|m| m.model.clone().map(|model| (m.session_id, model)))
+        .collect();
+
     let active_sessions: Vec<SessionInfo> = {
         let mut sorted: Vec<SessionInfo> = sessions.to_vec();
+        // Overlay the live model onto the polled row so the watermark reflects
+        // the current turn without waiting for the poll to catch up.
+        for session in sorted.iter_mut() {
+            if let Some(model) = live_models.get(&session.id) {
+                session.last_model = Some(model.clone());
+            }
+        }
         // Total, deterministic order keyed down to the unique session id, so
         // the displayed order is a pure function of the session *set* and never
         // depends on the order `/api/sessions` happened to return (issue #1094).

--- a/frontend/src/pages/dashboard/session_order.rs
+++ b/frontend/src/pages/dashboard/session_order.rs
@@ -127,6 +127,7 @@ mod tests {
             scheduled_task_id: None,
             paused: false,
             claude_args: Vec::new(),
+            last_model: None,
         }
     }
 

--- a/frontend/src/pages/dashboard/session_rail/pill.rs
+++ b/frontend/src/pages/dashboard/session_rail/pill.rs
@@ -18,6 +18,9 @@ enum VcsView {
 struct PillViewModel {
     pill_classes: Vec<&'static str>,
     watermark_class: &'static str,
+    /// Compact model version (e.g. `"4.8"`) rendered as a faint watermark next
+    /// to the agent logo, or `None` when the session has no known model yet.
+    model_watermark: Option<String>,
     connection_class: &'static str,
     connection_symbol: &'static str,
     number_annotation: Option<String>,
@@ -77,6 +80,13 @@ pub(super) fn session_pill(props: &SessionPillProps) -> Html {
             data-index={props.index.to_string()}
         >
             <span class={view.watermark_class} aria-hidden="true" />
+            {
+                if let Some(model) = &view.model_watermark {
+                    html! { <span class="pill-model-watermark" aria-hidden="true">{ model }</span> }
+                } else {
+                    html! {}
+                }
+            }
             {
                 if let Some(num) = &view.number_annotation {
                     html! { <span class="pill-number">{ num }</span> }
@@ -198,6 +208,10 @@ impl PillViewModel {
                 shared::AgentType::Claude => "pill-watermark claude",
                 shared::AgentType::Codex => "pill-watermark codex",
             },
+            model_watermark: session
+                .last_model
+                .as_deref()
+                .and_then(shared::compact_model_version),
             connection_class: if props.is_connected {
                 "pill-status connected"
             } else {

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -189,6 +189,26 @@
 .pill-watermark.claude { background-image: url('/anthropic-mark.svg'); }
 .pill-watermark.codex  { background-image: url('/openai-mark.png'); }
 
+/* Model-version watermark — the session's compact model number (e.g. "4.8")
+   rendered in the same faint grey/opacity treatment as the agent logo, anchored
+   to the pill's bottom-right corner (opposite the left-anchored logo). Sits at
+   z-index 0 behind the foreground text (same as the logo), so it never collides
+   with the pill name/branch at any rail width — the text always paints on top.
+   Bottom offset clears the 5px activity sparkline. */
+.pill-model-watermark {
+    position: absolute;
+    right: 6px;
+    bottom: 6px;
+    pointer-events: none;
+    font-size: 0.95rem;
+    font-weight: 700;
+    font-family: monospace;
+    line-height: 1;
+    color: var(--text-primary);
+    opacity: 0.22;
+    z-index: 0;
+}
+
 .session-pill:hover {
     border-color: var(--accent);
     background: rgba(122, 162, 247, 0.1);

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -63,6 +63,10 @@ pub mod fmt;
 // Timezone canonicalization (abbreviation -> IANA) shared across crates
 pub mod timezone;
 
+// Compact model-version extraction for the session-pill watermark
+pub mod model_version;
+pub use model_version::compact_model_version;
+
 // API client types and trait
 pub mod api;
 pub use api::{
@@ -424,6 +428,14 @@ pub struct SessionInfo {
     /// Arguments used when launching the agent CLI.
     #[serde(default)]
     pub claude_args: Vec<String>,
+    /// Most recently observed model id for this session (last turn wins), e.g.
+    /// `"claude-opus-4-8"`. Populated from `sessions.last_model` on the wire;
+    /// the rail renders a compact version of it (see
+    /// [`compact_model_version`]) as a watermark on the pill. `None` until the
+    /// session has completed a turn with a known model. `#[serde(default)]`
+    /// keeps older proxies/clients wire-compatible.
+    #[serde(default)]
+    pub last_model: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/shared/src/model_version.rs
+++ b/shared/src/model_version.rs
@@ -1,0 +1,165 @@
+//! Compact model-version extraction for the session-pill watermark.
+//!
+//! The dashboard rail renders a faint model number next to the agent logo on
+//! each session pill so a glance distinguishes, say, an Opus 4.8 session from
+//! a Fable 5 one. This module turns a full model **id** (as it arrives from the
+//! agent's per-turn result, e.g. `"claude-opus-4-8"` or `"gpt-5.5-codex"`) into
+//! a compact token like `"4.8"` / `"5.5"`.
+//!
+//! Why digit-pattern extraction rather than the SDK model catalogs
+//! (`claude_codes::ClaudeModel` / `codex_codes::CodexModel`): the catalogs key
+//! on picker **cli args** (`"opus"`, `"sonnet"`, aliases) — not the fully
+//! qualified id string the runtime reports on each turn — so they can't map
+//! `"claude-haiku-4-5-20251001"` back to a version. The id form always carries
+//! the version as a dash- or dot-separated run of small numbers, optionally
+//! followed by a date/build suffix (`20251001`), so we extract that directly.
+//! This also gracefully handles ids the catalog has never heard of (a
+//! newly-shipped model): as long as it follows the `family-<version>` shape we
+//! still get a sensible token, and anything unrecognizable yields `None` (the
+//! caller renders the logo alone — never the raw id).
+
+/// Extract a compact display version from a model id string.
+///
+/// Returns `None` when no plausible version can be found, so the caller renders
+/// the logo watermark alone rather than an ugly raw id.
+///
+/// Examples:
+/// ```
+/// use shared::compact_model_version;
+/// assert_eq!(compact_model_version("claude-opus-4-8").as_deref(), Some("4.8"));
+/// assert_eq!(compact_model_version("claude-fable-5").as_deref(), Some("5"));
+/// assert_eq!(compact_model_version("claude-sonnet-5").as_deref(), Some("5"));
+/// assert_eq!(
+///     compact_model_version("claude-haiku-4-5-20251001").as_deref(),
+///     Some("4.5")
+/// );
+/// assert_eq!(compact_model_version("gpt-5.5-codex").as_deref(), Some("5.5"));
+/// assert_eq!(compact_model_version("garbled-nonsense"), None);
+/// ```
+pub fn compact_model_version(model_id: &str) -> Option<String> {
+    // Version components are short numbers. A pure-digit run of 4+ digits is a
+    // date/build snapshot (`20251001`, `1106`), not a version part, so we treat
+    // it as a terminator rather than a component.
+    const MAX_VERSION_PART_DIGITS: usize = 3;
+
+    #[derive(PartialEq)]
+    enum Kind {
+        /// A version component, e.g. `4`, `8`, or `5.5` (dotted is always one).
+        Version,
+        /// A date/build suffix like `20251001` — terminates the version run.
+        DateOrBuild,
+        /// Anything else (a family word like `opus`, `codex`).
+        Other,
+    }
+
+    fn classify(tok: &str) -> Kind {
+        if tok.is_empty() {
+            return Kind::Other;
+        }
+        // Numeric-ish: digits with optional internal dots (`5`, `5.5`).
+        let numeric_ish = tok
+            .split('.')
+            .all(|seg| !seg.is_empty() && seg.bytes().all(|b| b.is_ascii_digit()));
+        if !numeric_ish {
+            return Kind::Other;
+        }
+        if tok.contains('.') {
+            // A dotted number is unambiguously a version ("5.5").
+            Kind::Version
+        } else if tok.len() <= MAX_VERSION_PART_DIGITS {
+            Kind::Version
+        } else {
+            Kind::DateOrBuild
+        }
+    }
+
+    let mut parts: Vec<&str> = Vec::new();
+    for tok in model_id.split('-') {
+        match classify(tok) {
+            Kind::Version => parts.push(tok),
+            // Once the version run has started, any non-version token ends it
+            // (so a trailing date or family suffix isn't mixed in). Before it
+            // starts, skip leading family words.
+            Kind::DateOrBuild | Kind::Other => {
+                if parts.is_empty() {
+                    continue;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("."))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compact_model_version;
+
+    #[test]
+    fn claude_dashed_major_minor() {
+        assert_eq!(
+            compact_model_version("claude-opus-4-8").as_deref(),
+            Some("4.8")
+        );
+    }
+
+    #[test]
+    fn claude_single_component() {
+        assert_eq!(
+            compact_model_version("claude-fable-5").as_deref(),
+            Some("5")
+        );
+        assert_eq!(
+            compact_model_version("claude-sonnet-5").as_deref(),
+            Some("5")
+        );
+    }
+
+    #[test]
+    fn claude_with_date_suffix_dropped() {
+        assert_eq!(
+            compact_model_version("claude-haiku-4-5-20251001").as_deref(),
+            Some("4.5")
+        );
+    }
+
+    #[test]
+    fn codex_dotted_version() {
+        assert_eq!(
+            compact_model_version("gpt-5.5-codex").as_deref(),
+            Some("5.5")
+        );
+    }
+
+    #[test]
+    fn codex_trailing_family_word_stops_run() {
+        // The `-codex` suffix must not leak into the token.
+        assert_eq!(compact_model_version("gpt-5-codex").as_deref(), Some("5"));
+    }
+
+    #[test]
+    fn unknown_or_garbled_yields_none() {
+        assert_eq!(compact_model_version(""), None);
+        assert_eq!(compact_model_version("garbled-nonsense"), None);
+        assert_eq!(compact_model_version("claude"), None);
+        // A bare uuid-ish token has no small numeric run.
+        assert_eq!(compact_model_version("abc123def"), None);
+    }
+
+    #[test]
+    fn date_only_after_family_is_none() {
+        // No version parts before the date suffix → nothing to show.
+        assert_eq!(compact_model_version("some-model-20251001"), None);
+    }
+
+    #[test]
+    fn three_component_version_joins_all() {
+        assert_eq!(compact_model_version("foo-1-2-3").as_deref(), Some("1.2.3"));
+    }
+}


### PR DESCRIPTION
## What

Session pills in the dashboard rail render a faint agent-logo watermark. This adds the session's **compact model number** — `4.8`, `5`, `5.5` — next to that logo in the same faint grey tone and weight, so a glance distinguishes an Opus 4.8 session from a Fable 5 one.

## How

- **Model source:** none existed on the rail today. `SessionInfo` had no model field; the backend only learned the per-turn model in the `turn_metrics` path. Added a nullable `sessions.last_model` column, written **change-gated** from that same path (last observed model wins; only writes when the value actually changes, so it stays off the hot path for the common every-turn case).
- **Wire:** `SessionInfo.last_model` (`#[serde(default)]` for compatibility) flows to the rail via the existing `/api/sessions` shape.
- **Display:** a pure `shared::compact_model_version` helper turns a model id into a compact token via digit-pattern extraction (the SDK catalogs key on picker cli-args, not the full id the runtime reports, so they can't map it back). Unknown/garbled ids render nothing — never a raw id. The pill renders it bottom-right (opposite the left-anchored logo), reusing the logo's grey/opacity and sitting behind the text so it never collides at any rail width.
- **Live auto-update:** the dashboard already receives every session's per-turn `TurnMetrics` (which carries `model`) on the user channel. A mid-session model change — e.g. a Fable 5 session falling back to Opus 4.8 — flips the watermark instantly by overlaying the live model onto the polled row. No new wire message, no reload.
- **No model yet:** logo only, exactly as before.

## Tests

- `compact_model_version`: `claude-opus-4-8`→`4.8`, `claude-fable-5`→`5`, `claude-sonnet-5`→`5`, `claude-haiku-4-5-20251001`→`4.5`, `gpt-5.5-codex`→`5.5`, garbled→none (+ doctest).
- `should_persist_model` gating: changed → write, first-observation → write, unchanged → skip, `None` observation → skip.