### PR TITLE
Brighten inter-agent broadcast strands

### DIFF
--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -251,10 +251,12 @@
 
 .pill-broadcast-strand {
     width: 46px;
-    height: 1px;
+    height: 2px;
     transform-origin: center;
-    background: linear-gradient(90deg, transparent, rgba(187, 154, 247, 0.95), transparent);
-    box-shadow: 0 0 9px rgba(187, 154, 247, 0.65);
+    background: linear-gradient(90deg, transparent, #d8b4ff 18%, #bb9af7 50%, #d8b4ff 82%, transparent);
+    box-shadow:
+        0 0 7px rgba(216, 180, 255, 0.95),
+        0 0 15px rgba(187, 154, 247, 0.78);
 }
 
 .pill-broadcast-core {
@@ -311,16 +313,14 @@
 }
 
 .session-pill.broadcast-receiver .pill-broadcast-strand {
-    background: linear-gradient(90deg, transparent, rgba(125, 207, 255, 0.95), transparent);
-    box-shadow: 0 0 9px rgba(125, 207, 255, 0.62);
     animation: pill-strands-release 980ms cubic-bezier(0.25, 0.8, 0.25, 1) 520ms forwards;
 }
 
 .session-pill.broadcast-receiver .pill-broadcast-core {
-    border-color: rgba(125, 207, 255, 0.85);
+    border-color: rgba(216, 180, 255, 0.92);
     box-shadow:
-        inset 0 0 8px rgba(125, 207, 255, 0.22),
-        0 0 14px rgba(125, 207, 255, 0.36);
+        inset 0 0 10px rgba(216, 180, 255, 0.32),
+        0 0 18px rgba(187, 154, 247, 0.55);
     animation: pill-core-release 980ms cubic-bezier(0.25, 0.8, 0.25, 1) 520ms forwards;
 }
 
@@ -353,14 +353,72 @@
     animation: agent-path-fade 1.35s ease-out;
 }
 
+.agent-broadcast-path::before,
+.agent-broadcast-path::after {
+    content: "";
+    position: absolute;
+    display: block;
+    opacity: 0;
+    pointer-events: none;
+    background: linear-gradient(90deg, transparent, rgba(216, 180, 255, 0.95), #bb9af7, rgba(216, 180, 255, 0.95), transparent);
+    box-shadow:
+        0 0 8px rgba(216, 180, 255, 0.9),
+        0 0 18px rgba(187, 154, 247, 0.72);
+}
+
 .agent-broadcast-layer.horizontal .agent-broadcast-path {
     top: 0;
     height: 34px;
 }
 
+.agent-broadcast-layer.horizontal .agent-broadcast-path::before,
+.agent-broadcast-layer.horizontal .agent-broadcast-path::after {
+    left: 0;
+    width: 42px;
+    height: 2px;
+    animation: agent-strand-x 1.35s cubic-bezier(0.2, 0.75, 0.18, 1) forwards;
+}
+
+.agent-broadcast-layer.horizontal .agent-broadcast-path::before {
+    top: 11px;
+}
+
+.agent-broadcast-layer.horizontal .agent-broadcast-path::after {
+    top: 21px;
+    animation-delay: 90ms;
+}
+
+.agent-broadcast-layer.horizontal .agent-broadcast-path.reverse::before,
+.agent-broadcast-layer.horizontal .agent-broadcast-path.reverse::after {
+    animation-name: agent-strand-x-reverse;
+}
+
 .agent-broadcast-layer.vertical .agent-broadcast-path {
     left: 0;
     width: 34px;
+}
+
+.agent-broadcast-layer.vertical .agent-broadcast-path::before,
+.agent-broadcast-layer.vertical .agent-broadcast-path::after {
+    top: 0;
+    width: 2px;
+    height: 42px;
+    background: linear-gradient(180deg, transparent, rgba(216, 180, 255, 0.95), #bb9af7, rgba(216, 180, 255, 0.95), transparent);
+    animation: agent-strand-y 1.35s cubic-bezier(0.2, 0.75, 0.18, 1) forwards;
+}
+
+.agent-broadcast-layer.vertical .agent-broadcast-path::before {
+    left: 11px;
+}
+
+.agent-broadcast-layer.vertical .agent-broadcast-path::after {
+    left: 21px;
+    animation-delay: 90ms;
+}
+
+.agent-broadcast-layer.vertical .agent-broadcast-path.reverse::before,
+.agent-broadcast-layer.vertical .agent-broadcast-path.reverse::after {
+    animation-name: agent-strand-y-reverse;
 }
 
 .agent-broadcast-packet {
@@ -369,12 +427,13 @@
     place-items: center;
     width: 26px;
     height: 18px;
-    border: 1px solid rgba(187, 154, 247, 0.9);
+    border: 1px solid rgba(216, 180, 255, 0.98);
     border-radius: 4px;
     background: rgba(26, 27, 38, 0.9);
     box-shadow:
-        inset 0 0 8px rgba(187, 154, 247, 0.2),
-        0 0 18px rgba(187, 154, 247, 0.58);
+        inset 0 0 10px rgba(216, 180, 255, 0.26),
+        0 0 18px rgba(216, 180, 255, 0.75),
+        0 0 28px rgba(187, 154, 247, 0.5);
 }
 
 .agent-broadcast-packet::before,
@@ -383,8 +442,8 @@
     position: absolute;
     top: 50%;
     width: 18px;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(187, 154, 247, 0.9));
+    height: 2px;
+    background: linear-gradient(90deg, transparent, #d8b4ff, #bb9af7);
     opacity: 0;
     transform: translateY(-50%) scaleX(0.25);
     animation: packet-strand-pulse 1.35s ease-out forwards;
@@ -547,6 +606,78 @@
     }
 }
 
+@keyframes agent-strand-x {
+    0% {
+        left: 0;
+        opacity: 0;
+        scale: 0.2 1;
+    }
+    18%,
+    76% {
+        opacity: 1;
+        scale: 1 1;
+    }
+    100% {
+        left: calc(100% - 42px);
+        opacity: 0;
+        scale: 0.45 1;
+    }
+}
+
+@keyframes agent-strand-x-reverse {
+    0% {
+        left: calc(100% - 42px);
+        opacity: 0;
+        scale: 0.2 1;
+    }
+    18%,
+    76% {
+        opacity: 1;
+        scale: 1 1;
+    }
+    100% {
+        left: 0;
+        opacity: 0;
+        scale: 0.45 1;
+    }
+}
+
+@keyframes agent-strand-y {
+    0% {
+        top: 0;
+        opacity: 0;
+        scale: 1 0.2;
+    }
+    18%,
+    76% {
+        opacity: 1;
+        scale: 1 1;
+    }
+    100% {
+        top: calc(100% - 42px);
+        opacity: 0;
+        scale: 1 0.45;
+    }
+}
+
+@keyframes agent-strand-y-reverse {
+    0% {
+        top: calc(100% - 42px);
+        opacity: 0;
+        scale: 1 0.2;
+    }
+    18%,
+    76% {
+        opacity: 1;
+        scale: 1 1;
+    }
+    100% {
+        top: 0;
+        opacity: 0;
+        scale: 1 0.45;
+    }
+}
+
 @keyframes agent-packet-x {
     0% {
         left: 0;
@@ -623,6 +754,8 @@
     .pill-broadcast-strand,
     .pill-broadcast-core,
     .agent-broadcast-path,
+    .agent-broadcast-path::before,
+    .agent-broadcast-path::after,
     .agent-broadcast-packet,
     .agent-broadcast-packet::before,
     .agent-broadcast-packet::after {


### PR DESCRIPTION
## Summary
- make sender and receiver pill strands use the same brighter purple treatment
- thicken strand strokes and increase glow/contrast around pill gather/release effects
- add animated purple filaments across the rail gap so the message motion is visible between pills, not only on the framed packet

## Testing
- cargo fmt --check
- cargo test -p frontend session_rail
- cargo check -p frontend --target wasm32-unknown-unknown
- npm ci && npm run lint:css from frontend/lint (passes locally; npm warns because local Node is v18 while package wants Node >=20, CI uses Node 20)