### PR TITLE
Align pill model number watermark

### DIFF
--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -149,6 +149,8 @@
 }
 
 .session-pill {
+    --pill-visual-height: 2.5rem;
+
     position: relative;
     display: flex;
     align-items: center;
@@ -190,17 +192,16 @@
 .pill-watermark.codex  { background-image: url('/openai-mark.png'); }
 
 /* Model-version watermark — the session's compact model number (e.g. "4.8")
-   rendered in the same faint grey/opacity treatment as the agent logo, anchored
-   to the pill's bottom-right corner (opposite the left-anchored logo). Sits at
-   z-index 0 behind the foreground text (same as the logo), so it never collides
-   with the pill name/branch at any rail width — the text always paints on top.
-   Bottom offset clears the 5px activity sparkline. */
+   rendered in the same faint grey/opacity treatment as the agent logo. The
+   number shares the logo-side anchor, is vertically centered in the pill, and
+   scales to 3/5 of the pill's visual height. */
 .pill-model-watermark {
     position: absolute;
-    right: 6px;
-    bottom: 6px;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
     pointer-events: none;
-    font-size: 0.95rem;
+    font-size: calc(var(--pill-visual-height) * 0.6);
     font-weight: 700;
     font-family: monospace;
     line-height: 1;


### PR DESCRIPTION
## Summary
- move the model-number watermark from the bottom-right to the logo-side edge
- vertically center it within the pill
- size it to 3/5 of the pill visual height via a pill-scoped CSS variable

## Tests
- cargo fmt --check
- cargo test -p frontend session_rail
- cargo check -p frontend --target wasm32-unknown-unknown
- npm ci && npm run lint:css (frontend/lint; npm emitted Node 20 engine warnings under Node 18)