### PR TITLE
Centralize operational log markers in a source-of-truth module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,15 +248,32 @@ To avoid it:
 - **Don't restore partial/mismatched DB snapshots** (a snapshot of the migrations table without the corresponding columns produces exactly this drift).
 - **Symptom → fix:** a `column "…" does not exist` at runtime on a table whose migration *is* recorded means recorded-but-not-applied drift. Fix by applying the column directly (`ALTER TABLE … ADD COLUMN IF NOT EXISTS …` matching the migration's `up.sql`); the migrations table already records it, so future restarts stay consistent.
 
-### Schema-drift alerting
+### Operational log markers
 
-DB write failures on the input path are **swallowed** (logged, then delivery continues) so a transient DB hiccup never drops a live message. The downside is drift can hide in the logs. Both write paths emit a stable marker — alert on it:
+Some failures are deliberately **logged-and-continued** rather than propagated —
+dropping a durable message or crashing a background sweep would be worse than the
+failure itself. Each such site emits a **stable SCREAMING_SNAKE marker** as the
+first token of its log line so you can alert on the substring.
 
-```
-PENDING_INPUT_PERSIST_FAILED   # pending_inputs INSERT failed (web + agent paths)
-```
+**`backend/src/markers.rs` is the single source of truth.** Every marker is a
+`pub const &str` there (value == name), each emit site references the const (so a
+rename is compile-time and repo-wide), and a unit test enforces uniqueness +
+naming + that each const is wired to an emit site. **New alertable
+logged-and-continue failure? Add a const in `markers.rs` (with the doc treatment)
+and a row here.**
 
-A recurring `PENDING_INPUT_PERSIST_FAILED` right after a deploy almost always means schema drift (a migration recorded-but-not-applied) — see above. A one-off is likely a transient DB blip.
+| Marker | Emitted by (when) | Recurring burst means | Action |
+|--------|-------------------|-----------------------|--------|
+| `PENDING_INPUT_PERSIST_FAILED` | Input enqueue (`input_queue.rs`) when the `pending_inputs` row can't be written — INSERT failed *or* no DB connection (web + agent paths) | Schema drift after a deploy (migration recorded-but-not-applied); every INSERT fails and inputs sent while a proxy bounces can be lost | Diff live schema vs. latest migration (`\d pending_inputs`); `ALTER TABLE … ADD COLUMN IF NOT EXISTS …` the missing column |
+| `INPUT_SEQ_BUMP_FAILED` | Input enqueue when bumping `sessions.input_seq` fails (falls back to seq `1`) | Same schema-drift / DB-degradation signal, scoped to `input_seq`; replay ordering unreliable for affected sessions | Same as above — reconcile schema drift / check DB health |
+| `PUSH_DISPATCH_FAILED` | Push dispatcher (`push/dispatcher.rs`) on any swallowed delivery-path failure | Systemic push fault — VAPID/APNs/FCM misconfig or credential expiry, or DB problem resolving recipients; users stop getting pushes | Verify push credentials (`PORTAL_VAPID_*`/`PORTAL_APNS_*`/`PORTAL_FCM_*`) + DB health; a low trickle of dead endpoints is normal |
+| `SESSION_ARCHIVE_FAILED` | Archive sweep (`background.rs`) when archiving one session fails | Archive backend unhealthy (bad `PORTAL_SESSION_ARCHIVE_*`, S3 creds/permissions, full local root); retention held, hot DB grows | Check archive-backend reachability, credentials/permissions, and config |
+| `ARCHIVE_SWEEP_FAILED` | Archive sweep task returning an error before processing any sessions (e.g. no DB connection) | Persistent DB/archive-subsystem problem; nothing archived, retention globally held | Check DB-pool health + archive backend; sweep self-recovers |
+| `RETENTION_TRIM_HELD` | Retention cleanup (`background.rs`) when it holds sessions' trims because their pre-trim archive didn't succeed | An archive outage is silently blocking retention; watch hot-DB size (expect alongside the archive markers) | Treat a rising count as an archive incident; retention drains once archiving succeeds (empty when archive disabled — normal) |
+
+A recurring `PENDING_INPUT_PERSIST_FAILED` right after a deploy almost always
+means schema drift (a migration recorded-but-not-applied) — see above. A one-off
+of any marker is usually a transient DB/network blip.
 
 ### Adding a New API Endpoint
 

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use crate::db::DbPool;
 use crate::handlers;
 use crate::handlers::websocket::SessionManager;
+use crate::markers::{ARCHIVE_SWEEP_FAILED, RETENTION_TRIM_HELD, SESSION_ARCHIVE_FAILED};
 use crate::models;
 use crate::schema;
 use crate::AppState;
@@ -133,7 +134,7 @@ pub async fn run_archive_sweep(app_state: Arc<AppState>) {
                 );
             }
         }
-        Ok(Err(e)) => tracing::error!("ARCHIVE_SWEEP_FAILED: {e}"),
+        Ok(Err(e)) => tracing::error!("{ARCHIVE_SWEEP_FAILED}: {e}"),
         Err(e) => tracing::error!("archive sweep task panicked: {e}"),
     }
 }
@@ -475,7 +476,7 @@ fn ensure_session_archived(
         }
         Err(e) => {
             runtime.stats.record_failure(&e.to_string());
-            tracing::error!("SESSION_ARCHIVE_FAILED session={}: {e}", session.id);
+            tracing::error!("{SESSION_ARCHIVE_FAILED} session={}: {e}", session.id);
             false
         }
     }
@@ -646,7 +647,7 @@ pub async fn run_retention_cleanup(app_state: Arc<AppState>) {
         // Stable marker aligned with SESSION_ARCHIVE_FAILED: alert on this to
         // catch an archive outage that is silently blocking retention.
         tracing::warn!(
-            "RETENTION_TRIM_HELD {} sessions pending archive",
+            "{RETENTION_TRIM_HELD} {} sessions pending archive",
             held_ids.len()
         );
     }

--- a/backend/src/handlers/websocket/session_manager/input_queue.rs
+++ b/backend/src/handlers/websocket/session_manager/input_queue.rs
@@ -18,6 +18,8 @@ use shared::{SendMode, ServerToProxy};
 use tracing::error;
 use uuid::Uuid;
 
+use crate::markers::{INPUT_SEQ_BUMP_FAILED, PENDING_INPUT_PERSIST_FAILED};
+
 use crate::db::DbPool;
 use crate::models::NewPendingInput;
 
@@ -61,7 +63,7 @@ impl SessionManager {
                 {
                     Ok(s) => s,
                     Err(e) => {
-                        error!("INPUT_SEQ_BUMP_FAILED session={}: {}", session_id, e);
+                        error!("{INPUT_SEQ_BUMP_FAILED} session={}: {}", session_id, e);
                         1
                     }
                 };
@@ -79,14 +81,20 @@ impl SessionManager {
                 {
                     Ok(_) => persisted = true,
                     Err(e) => {
-                        error!("PENDING_INPUT_PERSIST_FAILED session={}: {}", session_id, e)
+                        error!(
+                            "{PENDING_INPUT_PERSIST_FAILED} session={}: {}",
+                            session_id, e
+                        )
                     }
                 }
                 next_seq
             }
             Err(e) => {
+                // No DB connection ⇒ the pending-input row is never written and
+                // the sequence is never assigned: same durable-loss outcome as a
+                // failed INSERT, so it carries the same marker (see markers.rs).
                 error!(
-                    "Failed to get DB connection to enqueue input for session {}: {}",
+                    "{PENDING_INPUT_PERSIST_FAILED} no DB connection to enqueue input for session {}: {}",
                     session_id, e
                 );
                 0

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -17,6 +17,7 @@ pub mod db;
 pub mod errors;
 pub mod handlers;
 pub mod jwt;
+pub mod markers;
 pub mod models;
 pub mod push;
 pub mod routes;

--- a/backend/src/markers.rs
+++ b/backend/src/markers.rs
@@ -1,0 +1,178 @@
+//! Stable, operationally-alertable log markers.
+//!
+//! Some failures are deliberately **logged-and-continued** rather than
+//! propagated: dropping a durable message or crashing a background sweep would
+//! be worse than the failure itself. To stay observable, each such site emits a
+//! **stable SCREAMING_SNAKE marker** as the first token of its log line so
+//! operators can alert on the substring (e.g. a Loki/CloudWatch match).
+//!
+//! This module is the **single source of truth** for those markers. Rules:
+//!
+//! - Every alertable marker is a `pub const &str` here whose **value equals its
+//!   name**. Emit sites reference the const (never a bare string literal) so a
+//!   rename is a compile-time, repo-wide change — and so the value stays
+//!   byte-identical to whatever existing alerts already match on.
+//! - Each const carries a doc comment covering (a) **what emits it and when**,
+//!   (b) what a **recurring burst vs a one-off** indicates, and (c) the
+//!   **operator action**.
+//! - Adding a new logged-and-continue failure on a durable-loss path? Add a
+//!   const here (with the doc treatment) *and* a row to the marker table in
+//!   `CLAUDE.md` ("Operational log markers"). The `markers` unit test enforces
+//!   uniqueness and naming.
+
+/// Emitted when a browser/agent input could **not be persisted** to the
+/// `pending_inputs` table — either the INSERT failed or no DB connection was
+/// available to attempt it. The message may still reach a live proxy, but the
+/// durable copy that replays on proxy reconnect is missing, so an input sent
+/// while the proxy is bouncing can be silently lost.
+///
+/// - **Recurring burst right after a deploy:** almost always schema drift — a
+///   migration recorded in `__diesel_schema_migrations` but not physically
+///   applied (see CLAUDE.md "Migration hygiene"). Every INSERT fails until the
+///   column is reconciled.
+/// - **One-off:** a transient DB blip (pool exhaustion, failover). Self-heals.
+/// - **Action:** on a burst, diff the live schema against the latest migration
+///   (`\d pending_inputs`) and apply any missing column with
+///   `ALTER TABLE … ADD COLUMN IF NOT EXISTS …`; the migrations table already
+///   records it, so restarts stay consistent.
+pub const PENDING_INPUT_PERSIST_FAILED: &str = "PENDING_INPUT_PERSIST_FAILED";
+
+/// Emitted when bumping a session's monotonic `input_seq` fails; the enqueue
+/// falls back to sequence `1`. A wrong/duplicate sequence number can corrupt
+/// replay ordering on the affected session, so this shares the durable-input
+/// blast radius with [`PENDING_INPUT_PERSIST_FAILED`].
+///
+/// - **Recurring:** same schema-drift / DB-degradation signals as
+///   `PENDING_INPUT_PERSIST_FAILED`, scoped to the `sessions` table's
+///   `input_seq` column; ordering for those sessions is unreliable until fixed.
+/// - **One-off:** a transient DB blip on a single enqueue. Tolerable.
+/// - **Action:** same as `PENDING_INPUT_PERSIST_FAILED` — reconcile schema
+///   drift; otherwise investigate DB health.
+pub const INPUT_SEQ_BUMP_FAILED: &str = "INPUT_SEQ_BUMP_FAILED";
+
+/// Emitted by the push dispatcher (`push/dispatcher.rs`) for every real
+/// delivery-path failure it swallows: resolving the recipient, loading
+/// subscriptions, delivering to an endpoint, or recording delivery state. A
+/// missed push is intentionally never fatal to the request that triggered it.
+///
+/// - **Recurring burst:** a systemic push fault — VAPID/APNs/FCM
+///   misconfiguration or credential expiry, or a DB problem resolving
+///   recipients. Users stop receiving notifications while it persists.
+/// - **One-off:** a single dead/rotated endpoint or a transient network error;
+///   dead endpoints are auto-disabled and expected in small numbers.
+/// - **Action:** on a burst, verify push credentials
+///   (`PORTAL_VAPID_*`, `PORTAL_APNS_*`, `PORTAL_FCM_*`) and DB health; a low
+///   trickle needs no action.
+pub const PUSH_DISPATCH_FAILED: &str = "PUSH_DISPATCH_FAILED";
+
+/// Emitted when archiving a single eligible session fails during the archive
+/// sweep (`background.rs`). Archive-first is the retention invariant, so a
+/// failure here also **holds** that session's retention trim (see
+/// [`RETENTION_TRIM_HELD`]) — the hot DB keeps its data rather than losing the
+/// unarchived delta.
+///
+/// - **Recurring burst:** the archive backend is unhealthy — bad
+///   `PORTAL_SESSION_ARCHIVE_*` config, S3 credential/permission failure, or a
+///   full/unwritable local root. Retention is blocked for those sessions and
+///   the hot DB grows until it recovers.
+/// - **One-off:** a transient backend hiccup on a single session; retried next
+///   sweep.
+/// - **Action:** on a burst, check archive-backend reachability and
+///   credentials/permissions and the `PORTAL_SESSION_ARCHIVE_*` settings.
+pub const SESSION_ARCHIVE_FAILED: &str = "SESSION_ARCHIVE_FAILED";
+
+/// Emitted when the whole archive sweep task returns an error before it can
+/// process sessions (e.g. it could not get a DB connection). Distinct from
+/// [`SESSION_ARCHIVE_FAILED`], which is per-session; this means the sweep as a
+/// whole did no useful work this cycle.
+///
+/// - **Recurring:** a persistent problem reaching the DB or the archive
+///   subsystem; no sessions are being archived, so retention is globally held.
+/// - **One-off:** a transient DB-pool checkout failure for one cycle; the next
+///   scheduled sweep retries.
+/// - **Action:** on a burst, check DB-pool health and the archive backend; the
+///   sweep is idempotent and self-recovers once the dependency is healthy.
+pub const ARCHIVE_SWEEP_FAILED: &str = "ARCHIVE_SWEEP_FAILED";
+
+/// Emitted when the retention cleanup cycle **holds** one or more sessions'
+/// trims because their pre-trim archive did not succeed this cycle (archive-first
+/// invariant). Held sessions are excluded from both delete paths and retried
+/// next cycle, so no unarchived data is lost — but their hot-DB rows keep
+/// growing until the archive recovers.
+///
+/// - **Recurring/growing count:** an archive outage is silently blocking
+///   retention; expect this alongside [`SESSION_ARCHIVE_FAILED`] /
+///   [`ARCHIVE_SWEEP_FAILED`], and watch hot-DB size.
+/// - **One-off / small count:** a session or two briefly behind the archive;
+///   clears on its own next cycle.
+/// - **Action:** treat a sustained/rising count as an archive-backend incident —
+///   restore the backend; retention drains automatically once archiving
+///   succeeds. (An empty held set when archiving is disabled is normal.)
+pub const RETENTION_TRIM_HELD: &str = "RETENTION_TRIM_HELD";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registry of every stable marker. New markers MUST be added here so
+    /// the tests below can enforce uniqueness, naming, and that each is wired to
+    /// a real emit site.
+    const ALL_MARKERS: &[&str] = &[
+        PENDING_INPUT_PERSIST_FAILED,
+        INPUT_SEQ_BUMP_FAILED,
+        PUSH_DISPATCH_FAILED,
+        SESSION_ARCHIVE_FAILED,
+        ARCHIVE_SWEEP_FAILED,
+        RETENTION_TRIM_HELD,
+    ];
+
+    #[test]
+    fn markers_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for m in ALL_MARKERS {
+            assert!(seen.insert(*m), "duplicate marker value: {m}");
+        }
+    }
+
+    #[test]
+    fn markers_are_screaming_snake() {
+        for m in ALL_MARKERS {
+            assert!(!m.is_empty(), "empty marker");
+            assert!(
+                m.chars()
+                    .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'),
+                "marker not SCREAMING_SNAKE: {m}"
+            );
+            assert!(
+                m.starts_with(|c: char| c.is_ascii_uppercase()),
+                "marker must start with an uppercase letter: {m}"
+            );
+            assert!(!m.contains("__"), "marker has doubled underscore: {m}");
+            assert!(
+                !m.starts_with('_') && !m.ends_with('_'),
+                "marker has leading/trailing underscore: {m}"
+            );
+        }
+    }
+
+    /// Guards against a marker defined but never wired to an emit site: every
+    /// const's value must appear somewhere in a known emit-site source other
+    /// than its own definition in this module. Uses `include_str!` on sibling
+    /// files so no build hacks are required.
+    #[test]
+    fn every_marker_is_referenced_by_an_emit_site() {
+        let sources: &[&str] = &[
+            include_str!("background.rs"),
+            include_str!("push/dispatcher.rs"),
+            include_str!("handlers/websocket/session_manager/input_queue.rs"),
+        ];
+        for m in ALL_MARKERS {
+            let referenced = sources.iter().any(|s| s.contains(m));
+            assert!(
+                referenced,
+                "marker {m} is not referenced by any known emit-site source; \
+                 wire it up or remove it"
+            );
+        }
+    }
+}

--- a/backend/src/push/dispatcher.rs
+++ b/backend/src/push/dispatcher.rs
@@ -21,16 +21,11 @@ use tracing::{debug, error};
 use uuid::Uuid;
 
 use crate::db::DbConnection;
+use crate::markers::PUSH_DISPATCH_FAILED;
 use crate::models::PushSubscription;
 use crate::push::transport::{PushTransport, SendOutcome};
 use crate::push::{ConfiguredTransport, NotificationEvent};
 use crate::AppState;
-
-/// Stable log marker for a real (non-dead-endpoint) delivery failure. Alert on
-/// this: a recurring burst right after a deploy usually means a transport
-/// misconfiguration, mirroring the `PENDING_INPUT_PERSIST_FAILED` convention
-/// (CLAUDE.md "Schema-drift alerting").
-const PUSH_DISPATCH_FAILED: &str = "PUSH_DISPATCH_FAILED";
 
 /// Spawn the dispatcher task. Consumes the receiver end of the notification
 /// channel; runs until the channel closes (backend shutdown).


### PR DESCRIPTION
## What

Operationally-alertable log markers were scattered as ad-hoc string literals (and one local `const`), with only `PENDING_INPUT_PERSIST_FAILED` documented — the retention-fix author literally found no doc home for `RETENTION_TRIM_HELD`.

This collects them into `backend/src/markers.rs` as the single source of truth:

- Each marker is a `pub const &str` whose value equals its name, with a doc comment covering (a) what emits it and when, (b) recurring-burst vs one-off meaning, (c) the operator action.
- Every emit site now references the const. **Emitted strings are byte-identical**, so any existing alerts keep matching.
- A unit test asserts the markers are unique, SCREAMING_SNAKE, and that each const is wired to a real emit site (via `include_str!` on the emit-site sources — no build hacks).
- `CLAUDE.md`'s "Schema-drift alerting" section is replaced by an "Operational log markers" table listing all markers (name | emitted by | recurring means | action) and naming `markers.rs` as the source of truth; new alertable failures must add a const + a table row.

## Marker inventory

`PENDING_INPUT_PERSIST_FAILED`, `INPUT_SEQ_BUMP_FAILED`, `PUSH_DISPATCH_FAILED`, `SESSION_ARCHIVE_FAILED`, `ARCHIVE_SWEEP_FAILED`, `RETENTION_TRIM_HELD`.

## New marker coverage added

While auditing, one durable-loss path was unmarked: when input enqueue **can't get a DB connection**, the `pending_inputs` row is never written and the sequence is never assigned — the same durable-loss outcome as a failed INSERT, but it only logged a generic message. It now emits `PENDING_INPUT_PERSIST_FAILED`, closing an alerting gap on the input path.

(`INPUT_SEQ_BUMP_FAILED` already existed as a bare string on the same enqueue path; it is now a documented const rather than a new marker.)

## Verification

- `cargo fmt --check` clean
- `cargo clippy --workspace --exclude frontend --all-targets -- -D warnings` clean
- `cargo test -p backend` — 231 unit + 4 harness tests pass (incl. the 3 new marker tests)