### PR TITLE
Extract pure state machines from the session-lib io_task loops

### DIFF
--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -208,56 +208,192 @@ fn plain_user_echo_text(output: &ClaudeOutput) -> Option<String> {
     saw_text.then_some(text)
 }
 
-fn should_drop_claude_user_echo(
-    output: &ClaudeOutput,
-    pending_echo_drops: &mut VecDeque<EchoDropMarker>,
-) -> bool {
-    let Some(echoed_text) = plain_user_echo_text(output) else {
-        return false;
-    };
-
-    if is_system_reminder_text(&echoed_text) {
-        tracing::debug!("Dropping system-reminder user echo from transcript");
-        return true;
-    }
-
-    if echoed_text.trim().is_empty() {
-        tracing::debug!("Dropping empty user echo from transcript");
-        return true;
-    }
-
-    if let Some(marker) = pending_echo_drops.pop_front() {
-        if marker.expected_text != echoed_text {
-            tracing::warn!(
-                "Dropping Claude user echo with mismatched text; expected={}, echoed={}",
-                truncate_for_log(&marker.expected_text),
-                truncate_for_log(&echoed_text)
-            );
-        }
-        return true;
-    }
-
-    false
-}
-
-fn clear_stale_echo_markers_at_turn_boundary(pending_echo_drops: &mut VecDeque<EchoDropMarker>) {
-    let count = pending_echo_drops.len();
-    if count == 0 {
-        return;
-    }
-    pending_echo_drops.clear();
-    tracing::warn!(
-        "Cleared {} pending Claude user echo drop marker(s) at turn boundary",
-        count
-    );
-}
-
 fn truncate_for_log(text: &str) -> String {
     const LIMIT: usize = 120;
     if text.chars().count() <= LIMIT {
         return text.to_string();
     }
     format!("{}...", text.chars().take(LIMIT).collect::<String>())
+}
+
+// Detector for the upstream-429 turn shape. When Anthropic's API rate-limits a
+// request, `claude --print` doesn't fail — it streams an assistant message
+// whose first text block starts with this prefix, then emits a Result with
+// is_error=true. We retry that turn for the user with full-jitter exponential
+// backoff.
+const RATE_LIMIT_TEXT_PREFIX: &str = "API Error: Server is temporarily limiting requests";
+const MAX_RATE_LIMIT_RETRIES: u32 = 30;
+const RATE_LIMIT_BACKOFF_CAP_SECS: u64 = 60;
+
+/// Decision produced at a rate-limited turn's error terminator. The RNG-drawn
+/// backoff delay is intentionally left to the caller (the state machine stays
+/// deterministic); it only reports the backoff *window* to draw from.
+#[derive(Debug)]
+enum RateLimitDecision {
+    /// No prior input to re-issue — do nothing.
+    NoInput,
+    /// Retry budget exhausted after `attempts` consecutive rate-limited turns;
+    /// the caller surfaces the give-up notice. The counter has been reset.
+    GiveUp { attempts: u32 },
+    /// Re-issue `input` after a full-jitter backoff drawn from `[0, exp_cap]`
+    /// seconds; `attempt`/`max` are for the user-facing retry notice.
+    Retry {
+        input: Box<ClaudeInput>,
+        exp_cap: u64,
+        attempt: u32,
+        max: u32,
+    },
+}
+
+/// Mutable driver state for a Claude session's I/O loop, gathered out of the
+/// select-loop so the rate-limit retry machine and the stdin-echo-drop
+/// bookkeeping have pure, unit-testable transition methods (issue #917). The
+/// loop keeps only channel recv, effect execution, and claude-client I/O.
+///
+/// Deliberately excludes the metrics/token trackers (`TurnTracker`, the
+/// subagent rollup, model/tier latches): those are already cohesive and their
+/// updates are interleaved with client reads, so folding them in would not add
+/// testability.
+#[derive(Default)]
+struct ClaudeIoState {
+    /// The most recent user input we sent — kept so we can re-issue it on a
+    /// rate-limited turn without bothering the user.
+    last_input: Option<ClaudeInput>,
+    /// Consecutive rate-limited turns. Reset on success, on fresh user input,
+    /// and after a max-out give-up.
+    rate_limit_attempts: u32,
+    /// Set while an assistant frame in the current turn matched the rate-limit
+    /// text prefix. Latched until the turn's Result frame so we can classify the
+    /// whole turn on its terminator.
+    current_turn_was_rate_limited: bool,
+    /// Parsed `(reset_at_rfc3339, source_message)` when the current turn hit the
+    /// weekly session limit; consumed on the error terminator.
+    pending_session_limit: Option<(String, String)>,
+    /// FIFO markers for CLI stdin echoes we expect to drop from the transcript
+    /// (claude re-emits each user message we send it as a `user` frame).
+    pending_echo_drops: VecDeque<EchoDropMarker>,
+}
+
+impl ClaudeIoState {
+    fn set_last_input(&mut self, input: ClaudeInput) {
+        self.last_input = Some(input);
+    }
+
+    fn current_turn_was_rate_limited(&self) -> bool {
+        self.current_turn_was_rate_limited
+    }
+
+    fn has_pending_session_limit(&self) -> bool {
+        self.pending_session_limit.is_some()
+    }
+
+    /// An assistant frame's first text block matched the upstream-429 prefix.
+    fn note_rate_limited_turn(&mut self) {
+        self.current_turn_was_rate_limited = true;
+    }
+
+    /// An assistant frame carried a parseable weekly-session-limit banner.
+    fn note_session_limit(&mut self, reset_at: String, source_message: String) {
+        self.pending_session_limit = Some((reset_at, source_message));
+    }
+
+    /// Clear the per-turn retry/limit latches. Shared by fresh user input, a
+    /// successful (non-error) Result, and retry cancellation (a new command
+    /// arriving mid-backoff) — all of which reset the same three fields.
+    fn reset_turn_retry_state(&mut self) {
+        self.rate_limit_attempts = 0;
+        self.current_turn_was_rate_limited = false;
+        self.pending_session_limit = None;
+    }
+
+    /// Consume the pending session-limit banner (emitted once on the error
+    /// terminator).
+    fn take_session_limit(&mut self) -> Option<(String, String)> {
+        self.pending_session_limit.take()
+    }
+
+    /// Decide what to do at a rate-limited turn's error terminator. Only called
+    /// when the turn's error Result was rate-limited; clears the per-turn
+    /// rate-limit latch, then advances the retry budget.
+    fn on_rate_limit_terminator(&mut self) -> RateLimitDecision {
+        self.current_turn_was_rate_limited = false;
+        let Some(input) = self.last_input.clone() else {
+            return RateLimitDecision::NoInput;
+        };
+        if self.rate_limit_attempts >= MAX_RATE_LIMIT_RETRIES {
+            let attempts = self.rate_limit_attempts;
+            self.rate_limit_attempts = 0;
+            return RateLimitDecision::GiveUp { attempts };
+        }
+        self.rate_limit_attempts += 1;
+        // Full-jitter exponential backoff:
+        //   delay ∈ [0, min(cap, 2^attempt)] seconds.
+        // attempt=1 -> [0,2]; 2 -> [0,4]; 3 -> [0,8]; 4 -> [0,16]; the cap
+        // saturates by attempt 5 but we max-out before that.
+        let exp_cap = 2u64
+            .saturating_pow(self.rate_limit_attempts)
+            .min(RATE_LIMIT_BACKOFF_CAP_SECS);
+        RateLimitDecision::Retry {
+            input: Box::new(input),
+            exp_cap,
+            attempt: self.rate_limit_attempts,
+            max: MAX_RATE_LIMIT_RETRIES,
+        }
+    }
+
+    /// Record that we sent `text` on stdin — claude will echo it back as a
+    /// `user` frame we must drop from the transcript.
+    fn push_echo_drop(&mut self, expected_text: String) {
+        self.pending_echo_drops
+            .push_back(EchoDropMarker { expected_text });
+    }
+
+    /// Whether an inbound `user` frame is a CLI echo of stdin we should drop.
+    /// Consumes the matching pending marker (FIFO); unconditional drops
+    /// (system-reminders, empty) don't consume a marker.
+    fn should_drop_user_echo(&mut self, output: &ClaudeOutput) -> bool {
+        let Some(echoed_text) = plain_user_echo_text(output) else {
+            return false;
+        };
+
+        if is_system_reminder_text(&echoed_text) {
+            tracing::debug!("Dropping system-reminder user echo from transcript");
+            return true;
+        }
+
+        if echoed_text.trim().is_empty() {
+            tracing::debug!("Dropping empty user echo from transcript");
+            return true;
+        }
+
+        if let Some(marker) = self.pending_echo_drops.pop_front() {
+            if marker.expected_text != echoed_text {
+                tracing::warn!(
+                    "Dropping Claude user echo with mismatched text; expected={}, echoed={}",
+                    truncate_for_log(&marker.expected_text),
+                    truncate_for_log(&echoed_text)
+                );
+            }
+            return true;
+        }
+
+        false
+    }
+
+    /// Drop any echo markers that never matched by the turn boundary — the CLI
+    /// coalesced/omitted the echo, so a stale marker would wrongly swallow the
+    /// next real user frame.
+    fn clear_stale_echo_markers(&mut self) {
+        let count = self.pending_echo_drops.len();
+        if count == 0 {
+            return;
+        }
+        self.pending_echo_drops.clear();
+        tracing::warn!(
+            "Cleared {} pending Claude user echo drop marker(s) at turn boundary",
+            count
+        );
+    }
 }
 
 /// Background task that owns the Claude process and handles all I/O.
@@ -274,29 +410,12 @@ pub(crate) async fn claude_io_task(
     mut command_rx: mpsc::UnboundedReceiver<IoCommand>,
     event_tx: mpsc::UnboundedSender<IoEvent>,
 ) {
-    // Detector for the upstream-429 turn shape. When Anthropic's API rate-
-    // limits a request, `claude --print` doesn't fail — it streams an
-    // assistant message whose first text block starts with this prefix, then
-    // emits a Result with is_error=true. We retry that turn for the user
-    // with full-jitter exponential backoff.
-    const RATE_LIMIT_TEXT_PREFIX: &str = "API Error: Server is temporarily limiting requests";
-    const MAX_RATE_LIMIT_RETRIES: u32 = 30;
-    const RATE_LIMIT_BACKOFF_CAP_SECS: u64 = 60;
-
     // Take stderr so we can read it if Claude exits unexpectedly.
     let mut stderr_reader = client.take_stderr();
 
-    // The most recent user input we sent — kept so we can re-issue it on
-    // a rate-limited turn without bothering the user.
-    let mut last_input: Option<ClaudeInput> = None;
-    // Consecutive rate-limited turns. Resets on success, on a new user
-    // input, and after a max-out give-up.
-    let mut rate_limit_attempts: u32 = 0;
-    // Set while an assistant frame in the current turn matched the
-    // rate-limit text prefix. Latched until the turn's Result frame so we
-    // can classify the whole turn on its terminator.
-    let mut current_turn_was_rate_limited = false;
-    let mut pending_session_limit: Option<(String, String)> = None;
+    // Rate-limit retry machine + stdin-echo-drop bookkeeping, gathered into a
+    // state struct with pure transition methods (issue #917).
+    let mut state = ClaudeIoState::default();
 
     // Per-turn performance metrics tracker. `start`ed on each user input,
     // `record_content_frame`d on assistant/text frames, finalized on
@@ -316,7 +435,6 @@ pub(crate) async fn claude_io_task(
     // first turn starts land outside every turn window.
     let mut subagent_rollup = claude_codes::SubagentUsageRollup::default();
     let mut subagent_tokens_at_turn_start: i64 = 0;
-    let mut pending_echo_drops: VecDeque<EchoDropMarker> = VecDeque::new();
 
     loop {
         tokio::select! {
@@ -329,9 +447,7 @@ pub(crate) async fn claude_io_task(
                         display_event,
                     } => {
                         // Each fresh user input gets its own retry budget.
-                        rate_limit_attempts = 0;
-                        current_turn_was_rate_limited = false;
-                        pending_session_limit = None;
+                        state.reset_turn_retry_state();
                         subagent_tokens_at_turn_start = subagent_rollup.subagent_tokens as i64;
                         // Begin per-turn metrics capture. Wall-clock UTC is
                         // chrono::Utc::now(); the monotonic instant is the
@@ -344,12 +460,12 @@ pub(crate) async fn claude_io_task(
                             delivered,
                             display_event,
                             event_tx: &event_tx,
-                            pending_echo_drops: &mut pending_echo_drops,
+                            pending_echo_drops: &mut state.pending_echo_drops,
                             synthesize_visible_echo: true,
                         })
                         .await;
                         if let Ok(input) = &r {
-                            last_input = Some(input.clone());
+                            state.set_last_input(input.clone());
                         }
                         r.map(|_| ())
                     }
@@ -376,7 +492,7 @@ pub(crate) async fn claude_io_task(
             result = client.receive() => {
                 match result {
                     Ok(output) => {
-                        if should_drop_claude_user_echo(&output, &mut pending_echo_drops) {
+                        if state.should_drop_user_echo(&output) {
                             continue;
                         }
 
@@ -435,19 +551,16 @@ pub(crate) async fn claude_io_task(
                                     });
                                 if let Some(text) = first_text {
                                     if text.starts_with(RATE_LIMIT_TEXT_PREFIX) {
-                                        current_turn_was_rate_limited = true;
+                                        state.note_rate_limited_turn();
                                     }
                                     if let Some(reset_at) = parse_session_limit_reset(text) {
-                                        pending_session_limit =
-                                            Some((reset_at, text.to_string()));
+                                        state.note_session_limit(reset_at, text.to_string());
                                     }
                                 }
                             }
                             ClaudeOutput::Result(r) if !r.is_error => {
                                 // Successful turn — clear consecutive-failure state.
-                                rate_limit_attempts = 0;
-                                current_turn_was_rate_limited = false;
-                                pending_session_limit = None;
+                                state.reset_turn_retry_state();
                             }
                             _ => {}
                         }
@@ -458,7 +571,7 @@ pub(crate) async fn claude_io_task(
                         // turn (which will get its own row when `start` runs
                         // again).
                         if let ClaudeOutput::Result(ref r) = output {
-                            clear_stale_echo_markers_at_turn_boundary(&mut pending_echo_drops);
+                            state.clear_stale_echo_markers();
                             let usage = r.usage.as_ref();
                             let model = current_model.clone();
                             let outcome = TurnOutcome {
@@ -510,14 +623,12 @@ pub(crate) async fn claude_io_task(
                             }
                         }
 
-                        let is_rate_limit_terminator = matches!(
-                            &output,
-                            ClaudeOutput::Result(r) if r.is_error
-                        ) && current_turn_was_rate_limited;
-                        let is_session_limit_terminator = matches!(
-                            &output,
-                            ClaudeOutput::Result(r) if r.is_error
-                        ) && pending_session_limit.is_some();
+                        let terminator_is_error =
+                            matches!(&output, ClaudeOutput::Result(r) if r.is_error);
+                        let is_rate_limit_terminator =
+                            terminator_is_error && state.current_turn_was_rate_limited();
+                        let is_session_limit_terminator =
+                            terminator_is_error && state.has_pending_session_limit();
 
                         // Classify the frame into neutral decisions here (the
                         // boundary that keeps `Session` free of `ClaudeOutput`)
@@ -538,7 +649,7 @@ pub(crate) async fn claude_io_task(
                         }
 
                         if is_session_limit_terminator {
-                            if let Some((reset_at, source_message)) = pending_session_limit.take() {
+                            if let Some((reset_at, source_message)) = state.take_session_limit() {
                                 let _ = event_tx.send(IoEvent::SessionLimitReached {
                                     session_id,
                                     reset_at,
@@ -552,39 +663,39 @@ pub(crate) async fn claude_io_task(
                             continue;
                         }
 
-                        current_turn_was_rate_limited = false;
-                        let Some(input) = last_input.clone() else {
-                            continue;
-                        };
-
-                        if rate_limit_attempts >= MAX_RATE_LIMIT_RETRIES {
-                            let _ = event_tx.send(IoEvent::RawOutput(
-                                PortalMessage::text(format!(
-                                    "Rate-limited by upstream API {} times in a row \u{2014} not retrying. Send your message again to try once more.",
-                                    rate_limit_attempts
-                                ))
-                                .to_json(),
-                            ));
-                            rate_limit_attempts = 0;
-                            continue;
-                        }
-
-                        rate_limit_attempts += 1;
-                        // Full-jitter exponential backoff:
-                        //   delay ∈ [0, min(cap, 2^attempt)] seconds.
-                        // attempt=1 -> [0,2]; 2 -> [0,4]; 3 -> [0,8]; 4 -> [0,16];
-                        // the cap saturates by attempt 5 but we max-out before that.
-                        let exp_cap = 2u64
-                            .saturating_pow(rate_limit_attempts)
-                            .min(RATE_LIMIT_BACKOFF_CAP_SECS);
-                        let delay_secs = {
-                            let mut rng = rand::thread_rng();
-                            rng.gen_range(0.0..=exp_cap as f64)
+                        // Advance the retry machine on the rate-limited error
+                        // terminator; the loop executes the resulting effect.
+                        let (input, delay_secs, attempt, max) = match state
+                            .on_rate_limit_terminator()
+                        {
+                            RateLimitDecision::NoInput => continue,
+                            RateLimitDecision::GiveUp { attempts } => {
+                                let _ = event_tx.send(IoEvent::RawOutput(
+                                    PortalMessage::text(format!(
+                                        "Rate-limited by upstream API {} times in a row \u{2014} not retrying. Send your message again to try once more.",
+                                        attempts
+                                    ))
+                                    .to_json(),
+                                ));
+                                continue;
+                            }
+                            RateLimitDecision::Retry {
+                                input,
+                                exp_cap,
+                                attempt,
+                                max,
+                            } => {
+                                let delay_secs = {
+                                    let mut rng = rand::thread_rng();
+                                    rng.gen_range(0.0..=exp_cap as f64)
+                                };
+                                (input, delay_secs, attempt, max)
+                            }
                         };
                         let _ = event_tx.send(IoEvent::RawOutput(
                             PortalMessage::text(format!(
                                 "Rate-limited by upstream API. Retrying in {:.1}s (attempt {}/{}).",
-                                delay_secs, rate_limit_attempts, MAX_RATE_LIMIT_RETRIES
+                                delay_secs, attempt, max
                             ))
                             .to_json(),
                         ));
@@ -607,9 +718,7 @@ pub(crate) async fn claude_io_task(
                                         SessionError::Agent(e.to_string()),
                                     ));
                                 } else if let Some(expected_text) = plain_input_text(&input) {
-                                    pending_echo_drops.push_back(EchoDropMarker {
-                                        expected_text,
-                                    });
+                                    state.push_echo_drop(expected_text);
                                 }
                             }
                             Some(cmd) = command_rx.recv() => {
@@ -621,9 +730,10 @@ pub(crate) async fn claude_io_task(
                                     } => {
                                         // User typed something while we were waiting
                                         // — honor that, abandon the retry, and reset
-                                        // the budget for the new prompt.
-                                        rate_limit_attempts = 0;
-                                        pending_session_limit = None;
+                                        // the budget for the new prompt. (The
+                                        // rate-limit latch was already cleared by
+                                        // `on_rate_limit_terminator`.)
+                                        state.reset_turn_retry_state();
                                         subagent_tokens_at_turn_start = subagent_rollup.subagent_tokens as i64;
                                         turn_tracker.start(Instant::now(), chrono::Utc::now());
                                         let r = send_claude_user_input(ClaudeUserInputSend {
@@ -633,13 +743,13 @@ pub(crate) async fn claude_io_task(
                                             delivered,
                                             display_event,
                                             event_tx: &event_tx,
-                                            pending_echo_drops: &mut pending_echo_drops,
+                                            pending_echo_drops: &mut state.pending_echo_drops,
                                             synthesize_visible_echo: true,
                                         })
                                         .await;
                                         match r {
                                             Ok(new_input) => {
-                                                last_input = Some(new_input);
+                                                state.set_last_input(new_input);
                                             }
                                             Err(e) => {
                                                 let _ = event_tx.send(IoEvent::Error(
@@ -667,8 +777,7 @@ pub(crate) async fn claude_io_task(
                                         // rate-limited turn: abandon the retry
                                         // and cancel (a no-op on the CLI if the
                                         // turn isn't running).
-                                        rate_limit_attempts = 0;
-                                        pending_session_limit = None;
+                                        state.reset_turn_retry_state();
                                         if let Err(e) =
                                             client.send(&interrupt_input()).await
                                         {
@@ -1020,98 +1129,72 @@ mod tests {
         assert!(synthetic_user_echo_value("   \n\t", None, Uuid::nil()).is_none());
     }
 
+    fn state_with_drops(texts: &[&str]) -> ClaudeIoState {
+        ClaudeIoState {
+            pending_echo_drops: texts
+                .iter()
+                .map(|t| EchoDropMarker {
+                    expected_text: t.to_string(),
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn pending_echo_drop_markers_are_fifo() {
-        let mut pending = VecDeque::from([
-            EchoDropMarker {
-                expected_text: "first".to_string(),
-            },
-            EchoDropMarker {
-                expected_text: "second".to_string(),
-            },
-        ]);
+        let mut state = state_with_drops(&["first", "second"]);
 
-        assert!(should_drop_claude_user_echo(
-            &text_user_output("first"),
-            &mut pending
-        ));
-        assert_eq!(pending.len(), 1);
-        assert!(should_drop_claude_user_echo(
-            &text_user_output("second"),
-            &mut pending
-        ));
-        assert!(pending.is_empty());
+        assert!(state.should_drop_user_echo(&text_user_output("first")));
+        assert_eq!(state.pending_echo_drops.len(), 1);
+        assert!(state.should_drop_user_echo(&text_user_output("second")));
+        assert!(state.pending_echo_drops.is_empty());
     }
 
     #[test]
     fn pending_echo_marker_drops_mismatched_plain_echo_but_not_future_frames() {
-        let mut pending = VecDeque::from([EchoDropMarker {
-            expected_text: "expected".to_string(),
-        }]);
+        let mut state = state_with_drops(&["expected"]);
 
-        assert!(should_drop_claude_user_echo(
-            &text_user_output("changed by cli"),
-            &mut pending
-        ));
-        assert!(pending.is_empty());
-        assert!(!should_drop_claude_user_echo(
-            &text_user_output("future legitimate user frame"),
-            &mut pending
-        ));
+        assert!(state.should_drop_user_echo(&text_user_output("changed by cli")));
+        assert!(state.pending_echo_drops.is_empty());
+        assert!(!state.should_drop_user_echo(&text_user_output("future legitimate user frame")));
     }
 
     #[test]
     fn stale_echo_markers_clear_at_turn_boundary() {
-        let mut pending = VecDeque::from([EchoDropMarker {
-            expected_text: "never echoed".to_string(),
-        }]);
-        clear_stale_echo_markers_at_turn_boundary(&mut pending);
-        assert!(pending.is_empty());
+        let mut state = state_with_drops(&["never echoed"]);
+        state.clear_stale_echo_markers();
+        assert!(state.pending_echo_drops.is_empty());
     }
 
     #[test]
     fn system_reminder_and_empty_user_echoes_drop_without_marker() {
-        let mut pending = VecDeque::new();
-        assert!(should_drop_claude_user_echo(
-            &text_user_output("<system-reminder>hidden</system-reminder>"),
-            &mut pending
-        ));
-        assert!(should_drop_claude_user_echo(
-            &text_user_output(" \n\t "),
-            &mut pending
-        ));
+        let mut state = ClaudeIoState::default();
+        assert!(state.should_drop_user_echo(&text_user_output(
+            "<system-reminder>hidden</system-reminder>"
+        )));
+        assert!(state.should_drop_user_echo(&text_user_output(" \n\t ")));
     }
 
     #[test]
     fn unconditional_echo_drops_do_not_consume_pending_marker() {
-        let mut pending = VecDeque::from([EchoDropMarker {
-            expected_text: "real prompt".to_string(),
-        }]);
+        let mut state = state_with_drops(&["real prompt"]);
 
-        assert!(should_drop_claude_user_echo(
-            &text_user_output(" \n\t "),
-            &mut pending
-        ));
-        assert_eq!(pending.len(), 1);
+        assert!(state.should_drop_user_echo(&text_user_output(" \n\t ")));
+        assert_eq!(state.pending_echo_drops.len(), 1);
 
-        assert!(should_drop_claude_user_echo(
-            &text_user_output("<system-reminder>hidden</system-reminder>"),
-            &mut pending
-        ));
-        assert_eq!(pending.len(), 1);
+        assert!(state.should_drop_user_echo(&text_user_output(
+            "<system-reminder>hidden</system-reminder>"
+        )));
+        assert_eq!(state.pending_echo_drops.len(), 1);
 
-        assert!(should_drop_claude_user_echo(
-            &text_user_output("real prompt"),
-            &mut pending
-        ));
-        assert!(pending.is_empty());
+        assert!(state.should_drop_user_echo(&text_user_output("real prompt")));
+        assert!(state.pending_echo_drops.is_empty());
     }
 
     #[test]
     fn structured_user_frames_are_not_plain_echoes() {
-        let mut pending = VecDeque::from([EchoDropMarker {
-            expected_text: "next prompt".to_string(),
-        }]);
+        let mut state = state_with_drops(&["next prompt"]);
         let tool_result = user_output_with_content(serde_json::json!([
             {
                 "type": "tool_result",
@@ -1119,12 +1202,114 @@ mod tests {
                 "content": "ok"
             }
         ]));
-        assert!(!should_drop_claude_user_echo(&tool_result, &mut pending));
-        assert_eq!(pending.len(), 1);
+        assert!(!state.should_drop_user_echo(&tool_result));
+        assert_eq!(state.pending_echo_drops.len(), 1);
 
         let no_blocks = user_output_with_content(serde_json::json!([]));
-        assert!(!should_drop_claude_user_echo(&no_blocks, &mut pending));
-        assert_eq!(pending.len(), 1);
+        assert!(!state.should_drop_user_echo(&no_blocks));
+        assert_eq!(state.pending_echo_drops.len(), 1);
+    }
+
+    #[test]
+    fn rate_limit_retry_counter_advances_then_resets_on_fresh_input() {
+        // The retry machine, previously buried in the select-loop, is now a
+        // pure transition. A fresh user input must reset the retry budget.
+        let mut state = ClaudeIoState::default();
+        state.set_last_input(ClaudeInput::user_message(
+            "do the thing".to_string(),
+            Uuid::nil(),
+        ));
+
+        // First rate-limited terminator → attempt 1, backoff window [0, 2].
+        state.note_rate_limited_turn();
+        match state.on_rate_limit_terminator() {
+            RateLimitDecision::Retry {
+                exp_cap,
+                attempt,
+                max,
+                ..
+            } => {
+                assert_eq!(attempt, 1);
+                assert_eq!(exp_cap, 2);
+                assert_eq!(max, MAX_RATE_LIMIT_RETRIES);
+            }
+            other => panic!("expected Retry, got {other:?}"),
+        }
+        // The latch was cleared by the terminator.
+        assert!(!state.current_turn_was_rate_limited());
+
+        // Second consecutive rate-limited terminator → attempt 2, window [0, 4].
+        state.note_rate_limited_turn();
+        match state.on_rate_limit_terminator() {
+            RateLimitDecision::Retry {
+                exp_cap, attempt, ..
+            } => {
+                assert_eq!(attempt, 2);
+                assert_eq!(exp_cap, 4);
+            }
+            other => panic!("expected Retry, got {other:?}"),
+        }
+
+        // A fresh user input resets the budget: the next rate-limited
+        // terminator restarts at attempt 1.
+        state.reset_turn_retry_state();
+        state.note_rate_limited_turn();
+        match state.on_rate_limit_terminator() {
+            RateLimitDecision::Retry { attempt, .. } => assert_eq!(attempt, 1),
+            other => panic!("expected Retry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rate_limit_terminator_without_prior_input_does_nothing() {
+        let mut state = ClaudeIoState::default();
+        assert!(matches!(
+            state.on_rate_limit_terminator(),
+            RateLimitDecision::NoInput
+        ));
+    }
+
+    #[test]
+    fn rate_limit_gives_up_after_max_retries_then_resets_counter() {
+        let mut state = ClaudeIoState::default();
+        state.set_last_input(ClaudeInput::user_message(
+            "retry me".to_string(),
+            Uuid::nil(),
+        ));
+
+        // Exhaust the budget: attempts climb from 1 to MAX.
+        for _ in 0..MAX_RATE_LIMIT_RETRIES {
+            assert!(matches!(
+                state.on_rate_limit_terminator(),
+                RateLimitDecision::Retry { .. }
+            ));
+        }
+        // Now at the cap → give up, reporting the attempt count, and reset.
+        match state.on_rate_limit_terminator() {
+            RateLimitDecision::GiveUp { attempts } => {
+                assert_eq!(attempts, MAX_RATE_LIMIT_RETRIES);
+            }
+            other => panic!("expected GiveUp, got {other:?}"),
+        }
+        // Counter reset: a subsequent terminator retries from attempt 1 again.
+        match state.on_rate_limit_terminator() {
+            RateLimitDecision::Retry { attempt, .. } => assert_eq!(attempt, 1),
+            other => panic!("expected Retry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn successful_result_clears_session_limit_and_rate_limit_latches() {
+        let mut state = ClaudeIoState::default();
+        state.note_rate_limited_turn();
+        state.note_session_limit("2026-01-01T00:00:00Z".to_string(), "banner".to_string());
+        assert!(state.current_turn_was_rate_limited());
+        assert!(state.has_pending_session_limit());
+
+        state.reset_turn_retry_state();
+        assert!(!state.current_turn_was_rate_limited());
+        assert!(!state.has_pending_session_limit());
+        assert!(state.take_session_limit().is_none());
     }
 
     #[test]

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -98,6 +98,95 @@ fn route_user_input(turn_active: bool, current_turn_id: Option<&str>) -> InputRo
     }
 }
 
+/// Mutable driver state for a Codex session's I/O loop, gathered out of the
+/// select-loop so the turn / queue / approval bookkeeping has pure,
+/// unit-testable transition methods (issue #917). The loop keeps only channel
+/// recv, effect execution, and app-server I/O; every decision about *whether a
+/// turn is active*, *how to route a fresh input*, *which approval-response
+/// shape a request expects*, and *what to drain at turn end* lives here.
+///
+/// Deliberately excludes the metrics/token trackers (`TurnTracker`,
+/// `CodexSubagentTokenTracker`, the usage latches): those are already cohesive
+/// structs and their updates are interleaved with app-server reads, so folding
+/// them in would not add testability.
+#[derive(Default)]
+struct CodexIoState {
+    /// Whether a turn is currently being driven (a `turn/start` has been
+    /// dispatched and its `turn/completed` not yet observed).
+    turn_active: bool,
+    /// The active turn's id, captured from `turn/started`; required (non-empty)
+    /// to steer or interrupt. `None` until observed; cleared on `turn/completed`.
+    current_turn_id: Option<String>,
+    /// User prompts that arrived while a turn was active but un-steerable;
+    /// drained one-per-turn-end in FIFO order.
+    queued_prompts: VecDeque<QueuedPrompt>,
+    /// Per-request approval-response shape, latched when the server→client
+    /// approval request arrives and consumed when the user's decision returns.
+    pending_approval_kinds: HashMap<String, CodexApprovalResponseKind>,
+}
+
+impl CodexIoState {
+    fn turn_active(&self) -> bool {
+        self.turn_active
+    }
+
+    fn set_turn_active(&mut self, active: bool) {
+        self.turn_active = active;
+    }
+
+    fn current_turn_id(&self) -> Option<&str> {
+        self.current_turn_id.as_deref()
+    }
+
+    /// Latch the active turn id from any notification that names a turn
+    /// (`turn/started` and every later turn-scoped frame).
+    fn set_turn_id(&mut self, turn_id: &str) {
+        self.current_turn_id = Some(turn_id.to_string());
+    }
+
+    /// Clear the active turn id at `turn/completed`.
+    fn clear_turn_id(&mut self) {
+        self.current_turn_id = None;
+    }
+
+    /// Decide how to deliver a fresh user input given the current turn state.
+    fn route_input(&self) -> InputRouting {
+        route_user_input(self.turn_active, self.current_turn_id.as_deref())
+    }
+
+    /// Queue a prompt for the next turn-end drain (a turn is active but
+    /// un-steerable, or a `turn/steer` attempt failed).
+    fn queue_prompt(&mut self, prompt: QueuedPrompt) {
+        self.queued_prompts.push_back(prompt);
+    }
+
+    /// Count of prompts currently queued (for log messages).
+    fn queued_len(&self) -> usize {
+        self.queued_prompts.len()
+    }
+
+    /// A turn ended: mark idle and hand back the next queued prompt to start,
+    /// if any. Pops at most one — the remainder wait for the next turn end,
+    /// exactly as the pre-extraction loop did.
+    fn on_turn_ended(&mut self) -> Option<QueuedPrompt> {
+        self.turn_active = false;
+        self.queued_prompts.pop_front()
+    }
+
+    /// Latch the approval-response shape for a server→client approval request.
+    fn record_approval_request(&mut self, request_id: String, kind: CodexApprovalResponseKind) {
+        self.pending_approval_kinds.insert(request_id, kind);
+    }
+
+    /// Consume the approval-response shape for a request id, defaulting to the
+    /// v2 accept/decline family when the request was never latched.
+    fn take_approval_kind(&mut self, request_id: &str) -> CodexApprovalResponseKind {
+        self.pending_approval_kinds
+            .remove(request_id)
+            .unwrap_or(CodexApprovalResponseKind::AcceptDecline)
+    }
+}
+
 /// Background task for Codex sessions.
 pub(crate) async fn codex_io_task(
     config: SessionConfig,
@@ -244,14 +333,13 @@ pub(crate) async fn codex_io_task(
         &thread_id,
     ))));
 
-    let mut turn_active = false;
-    let mut queued_prompts: VecDeque<QueuedPrompt> = VecDeque::new();
-    // Track the turn currently being driven so we can name it on
-    // `turn/interrupt` requests (codex-codes 0.129.3 made both
-    // `thread_id` and `turn_id` required on `TurnInterruptParams`).
-    // Set when a `turn/started` notification arrives; cleared when
-    // `turn/completed` arrives.
-    let mut current_turn_id: Option<String> = None;
+    // Turn/queue/approval bookkeeping, gathered into a state struct with pure
+    // transition methods (issue #917). `current_turn_id` tracks the turn being
+    // driven so we can name it on `turn/interrupt` requests (codex-codes
+    // 0.129.3 made both `thread_id` and `turn_id` required on
+    // `TurnInterruptParams`): set when a `turn/started` notification arrives,
+    // cleared when `turn/completed` arrives.
+    let mut state = CodexIoState::default();
     let mut latest_token_usage: Option<(String, CodexUsageEvent)> = None;
     // Per-turn metrics tracker. `start`ed inside `start_codex_turn`,
     // updated as `ItemStarted` / `ItemCompleted` notifications come in,
@@ -262,18 +350,16 @@ pub(crate) async fn codex_io_task(
     let mut current_turn_usage: Option<codex_codes::TokenUsageBreakdown> = None;
     let mut current_turn_model: Option<String> = None;
     let mut subagent_token_tracker = CodexSubagentTokenTracker::new(thread_id.clone());
-    let mut pending_approval_response_kinds: HashMap<String, CodexApprovalResponseKind> =
-        HashMap::new();
 
     loop {
-        if turn_active {
+        if state.turn_active() {
             // Turn is active: drain server messages AND accept approval responses.
             tokio::select! {
                 result = client.next_message() => {
                     match result {
                         Ok(Some(msg)) => {
                             if let Some((request_id, kind)) = approval_response_kind(&msg) {
-                                pending_approval_response_kinds.insert(request_id, kind);
+                                state.record_approval_request(request_id, kind);
                             }
 
                             // Peek for turn lifecycle so we can name the
@@ -283,7 +369,7 @@ pub(crate) async fn codex_io_task(
                             // because it consumes the message.
                             if let codex_codes::ServerMessage::Notification(notif) = &msg {
                                 if let codex_codes::Notification::TurnStarted(p) = notif {
-                                    current_turn_id = Some(p.turn.id.clone());
+                                    state.set_turn_id(&p.turn.id);
                                     current_turn_model = thread_model.clone();
                                     subagent_token_tracker.start_parent_turn();
                                 }
@@ -294,8 +380,8 @@ pub(crate) async fn codex_io_task(
                                     );
                                 }
                                 if let codex_codes::Notification::ModelRerouted(p) = notif {
-                                    let matches_current_turn = current_turn_id
-                                        .as_deref()
+                                    let matches_current_turn = state
+                                        .current_turn_id()
                                         .is_some_and(|turn_id| turn_id == p.turn_id);
                                     if p.thread_id == thread_id && matches_current_turn {
                                         current_turn_model =
@@ -310,8 +396,8 @@ pub(crate) async fn codex_io_task(
                                     notif
                                 {
                                     let is_current_main_turn = p.thread_id == thread_id
-                                        && current_turn_id
-                                            .as_deref()
+                                        && state
+                                            .current_turn_id()
                                             .is_some_and(|turn_id| turn_id == p.turn_id);
                                     if is_current_main_turn {
                                         latest_token_usage = Some((
@@ -365,10 +451,10 @@ pub(crate) async fn codex_io_task(
                                     }
                                 }
                                 if let Some(turn_id) = notif.turn_id() {
-                                    current_turn_id = Some(turn_id.to_string());
+                                    state.set_turn_id(turn_id);
                                 }
                                 if matches!(notif, codex_codes::Notification::TurnCompleted(_)) {
-                                    current_turn_id = None;
+                                    state.clear_turn_id();
                                 }
                             }
 
@@ -464,13 +550,14 @@ pub(crate) async fn codex_io_task(
                                     latest_usage_for_msg,
                                 );
                             if turn_ended {
-                                turn_active = false;
+                                // Turn ended: `on_turn_ended` marks the state
+                                // idle and drains at most one queued prompt.
                                 if let Some((prompt, delivered, display_event)) =
-                                    queued_prompts.pop_front()
+                                    state.on_turn_ended()
                                 {
                                     turn_tracker
                                         .start(Instant::now(), chrono::Utc::now());
-                                    turn_active = start_codex_turn(
+                                    let started = start_codex_turn(
                                         &mut client,
                                         &thread_id,
                                         prompt,
@@ -479,6 +566,7 @@ pub(crate) async fn codex_io_task(
                                         &event_tx,
                                     )
                                     .await;
+                                    state.set_turn_active(started);
                                 }
                             }
                             if !ok {
@@ -555,7 +643,10 @@ pub(crate) async fn codex_io_task(
 
                             let interrupt_params = TurnInterruptParams {
                                 thread_id: thread_id.clone(),
-                                turn_id: current_turn_id.clone().unwrap_or_default(),
+                                turn_id: state
+                                    .current_turn_id()
+                                    .unwrap_or_default()
+                                    .to_string(),
                             };
                             if let Err(e) = client.turn_interrupt(&interrupt_params).await {
                                 tracing::error!(
@@ -563,7 +654,7 @@ pub(crate) async fn codex_io_task(
                                      \u{2014} forcing turn_active=false to unwedge",
                                     e
                                 );
-                                turn_active = false;
+                                state.set_turn_active(false);
                             }
                             continue;
                         }
@@ -582,9 +673,7 @@ pub(crate) async fn codex_io_task(
                             decision,
                         } => {
                             let rid = parse_request_id(&request_id);
-                            let kind = pending_approval_response_kinds
-                                .remove(&request_id)
-                                .unwrap_or(CodexApprovalResponseKind::AcceptDecline);
+                            let kind = state.take_approval_kind(&request_id);
                             let result = codex_approval_result(&decision, kind);
                             if let Err(e) = client.respond(rid, &result).await {
                                 tracing::error!("Failed to send Codex approval: {}", e);
@@ -600,7 +689,7 @@ pub(crate) async fn codex_io_task(
                                     let _ = delivered.send(Ok(()));
                                 }
                             } else {
-                                match route_user_input(true, current_turn_id.as_deref()) {
+                                match state.route_input() {
                                     // Deliver mid-turn via `turn/steer` so the
                                     // input joins the ACTIVE turn's pending-input
                                     // queue (parity with claude, which steers
@@ -612,9 +701,10 @@ pub(crate) async fn codex_io_task(
                                     InputRouting::Steer => {
                                         // `Steer` is only returned with a known,
                                         // non-empty turn id.
-                                        let turn_id = current_turn_id
-                                            .clone()
-                                            .expect("Steer routing implies a known turn id");
+                                        let turn_id = state
+                                            .current_turn_id()
+                                            .expect("Steer routing implies a known turn id")
+                                            .to_string();
                                         match steer_codex_turn(
                                             &mut client,
                                             &thread_id,
@@ -656,9 +746,9 @@ pub(crate) async fn codex_io_task(
                                                     "turn/steer into turn {} failed ({}); queueing for turn end ({} pending)",
                                                     turn_id,
                                                     e,
-                                                    queued_prompts.len() + 1
+                                                    state.queued_len() + 1
                                                 );
-                                                queued_prompts.push_back((
+                                                state.queue_prompt((
                                                     text,
                                                     delivered,
                                                     display_event,
@@ -672,9 +762,9 @@ pub(crate) async fn codex_io_task(
                                     InputRouting::Queue | InputRouting::StartTurn => {
                                         tracing::debug!(
                                             "Codex input during active turn without a known turn id; queueing ({} pending)",
-                                            queued_prompts.len() + 1
+                                            state.queued_len() + 1
                                         );
-                                        queued_prompts.push_back((text, delivered, display_event));
+                                        state.queue_prompt((text, delivered, display_event));
                                     }
                                 }
                             }
@@ -683,10 +773,10 @@ pub(crate) async fn codex_io_task(
                             // Cancel the in-flight turn. `turn/interrupt` needs
                             // both thread_id and turn_id; skip if we haven't seen
                             // a `turn/started` yet (nothing to name/cancel).
-                            if let Some(turn_id) = current_turn_id.clone() {
+                            if let Some(turn_id) = state.current_turn_id() {
                                 let params = TurnInterruptParams {
                                     thread_id: thread_id.clone(),
-                                    turn_id,
+                                    turn_id: turn_id.to_string(),
                                 };
                                 if let Err(e) = client.turn_interrupt(&params).await {
                                     tracing::error!("Failed to interrupt Codex turn: {}", e);
@@ -711,7 +801,7 @@ pub(crate) async fn codex_io_task(
                         continue;
                     }
                     turn_tracker.start(Instant::now(), chrono::Utc::now());
-                    turn_active = start_codex_turn(
+                    let started = start_codex_turn(
                         &mut client,
                         &thread_id,
                         text,
@@ -720,6 +810,7 @@ pub(crate) async fn codex_io_task(
                         &event_tx,
                     )
                     .await;
+                    state.set_turn_active(started);
                 }
                 Some(IoCommand::Permission { .. }) => {
                     tracing::warn!("Codex approval response with no active turn");
@@ -1246,6 +1337,97 @@ mod tests {
         assert_eq!(route_user_input(true, None), InputRouting::Queue);
         // An empty turn id is unusable as expectedTurnId (required non-empty).
         assert_eq!(route_user_input(true, Some("")), InputRouting::Queue);
+    }
+
+    fn queued_prompt(text: &str) -> QueuedPrompt {
+        (text.to_string(), None, None)
+    }
+
+    #[test]
+    fn state_route_input_mirrors_route_user_input() {
+        let mut state = CodexIoState::default();
+        // Idle → start.
+        assert_eq!(state.route_input(), InputRouting::StartTurn);
+        // Active but no observed turn id → queue.
+        state.set_turn_active(true);
+        assert_eq!(state.route_input(), InputRouting::Queue);
+        // Active with a known, non-empty turn id → steer.
+        state.set_turn_id("turn-1");
+        assert_eq!(state.route_input(), InputRouting::Steer);
+        // Empty turn id is unusable as expectedTurnId → queue.
+        state.set_turn_id("");
+        assert_eq!(state.route_input(), InputRouting::Queue);
+    }
+
+    #[test]
+    fn state_clear_turn_id_forces_queue_until_next_turn_started() {
+        let mut state = CodexIoState::default();
+        state.set_turn_active(true);
+        state.set_turn_id("turn-1");
+        assert_eq!(state.route_input(), InputRouting::Steer);
+        // turn/completed clears the id; a still-active follow-on turn with no
+        // observed id must queue rather than steer against a stale id.
+        state.clear_turn_id();
+        assert_eq!(state.current_turn_id(), None);
+        assert_eq!(state.route_input(), InputRouting::Queue);
+    }
+
+    #[test]
+    fn state_take_approval_kind_consumes_latched_kind_then_defaults() {
+        let mut state = CodexIoState::default();
+        state.record_approval_request(
+            "7".to_string(),
+            CodexApprovalResponseKind::ExecApprovedDenied,
+        );
+        // First take returns the latched kind and consumes it.
+        assert_eq!(
+            state.take_approval_kind("7"),
+            CodexApprovalResponseKind::ExecApprovedDenied
+        );
+        // Second take (or an unknown id) defaults to the v2 accept/decline family.
+        assert_eq!(
+            state.take_approval_kind("7"),
+            CodexApprovalResponseKind::AcceptDecline
+        );
+        assert_eq!(
+            state.take_approval_kind("never-seen"),
+            CodexApprovalResponseKind::AcceptDecline
+        );
+    }
+
+    #[test]
+    fn state_steer_failure_then_turn_end_drains_queue_exactly_once() {
+        // Reproduces the interleaving that was previously untestable: a turn is
+        // active, a `turn/steer` attempt fails so the input is queued, then the
+        // turn ends. The queued prompt must drain exactly once — and a second,
+        // still-queued prompt waits for the *next* turn end.
+        let mut state = CodexIoState::default();
+        state.set_turn_active(true);
+        state.set_turn_id("turn-1");
+
+        // Two steer attempts fail and fall back to the queue.
+        state.queue_prompt(queued_prompt("first"));
+        state.queue_prompt(queued_prompt("second"));
+        assert_eq!(state.queued_len(), 2);
+
+        // First turn end drains exactly one (FIFO) and marks idle.
+        let drained = state.on_turn_ended().expect("first prompt drains");
+        assert_eq!(drained.0, "first");
+        assert!(!state.turn_active());
+        assert_eq!(state.queued_len(), 1);
+
+        // The just-drained prompt starts a new turn; the second stays queued.
+        state.set_turn_active(true);
+        // A redundant turn-end (no new turn started meanwhile) must not
+        // double-drain: it hands back the one remaining prompt, once.
+        let drained = state.on_turn_ended().expect("second prompt drains");
+        assert_eq!(drained.0, "second");
+        assert_eq!(state.queued_len(), 0);
+
+        // Nothing left to drain.
+        state.set_turn_active(true);
+        assert!(state.on_turn_ended().is_none());
+        assert!(!state.turn_active());
     }
 
     #[test]


### PR DESCRIPTION
## What

Both `claude-session-lib/src/io_task.rs` and `codex-session-lib/src/io_task.rs` were single giant `select!`-loops interleaving turn tracking, echo-drop markers, rate-limit retry, prompt queueing/steer routing, approval bookkeeping, and metrics. Every recent change had to bolt a standalone pure function onto the side to be testable. This applies issue #917's thesis to the two worst files: the implicit driver state is gathered into a per-crate struct with **pure transition methods** that return explicit effect values; each select-loop now keeps only channel recv, effect execution, and client I/O.

Pure refactor — **zero behavior change**.

### `CodexIoState`
Gathers `turn_active`, the current turn id, the queued-prompt FIFO, and the pending approval-response kinds. Methods: `route_input` (Steer/Queue/StartTurn), `set_turn_id`/`clear_turn_id`, `queue_prompt`, `on_turn_ended` (turn-end drain — pops at most one), `record_approval_request`/`take_approval_kind`. `route_user_input` folds in as `route_input`.

### `ClaudeIoState`
Gathers `last_input`, the consecutive rate-limit attempt counter, the per-turn rate-limit latch, the pending session-limit banner, and the stdin-echo-drop queue. The rate-limit terminator becomes `on_rate_limit_terminator -> RateLimitDecision` (`NoInput` / `GiveUp { attempts }` / `Retry { input, exp_cap, attempt, max }`) — the RNG-drawn backoff delay is left to the caller so the machine stays deterministic and testable. The freestanding echo helpers (`should_drop_claude_user_echo`, `clear_stale_echo_markers_at_turn_boundary`) fold into methods so there's one organizational scheme, not two.

## Tests

Existing unit tests migrated onto the new structs and kept green; added transition tests for previously-untestable interleavings:
- codex: `route_input` mirror, `clear_turn_id` forces queue, `take_approval_kind` consume-then-default, and **steer-fails-then-turn-ends drains the queue exactly once**.
- claude: **rate-limit retry counter advances then resets on fresh input**, give-up-then-reset at the cap, no-input terminator is a no-op, successful result clears the latches.

io_task test count: claude 18 → 22, codex 17 → 21.

## Verification
- `cargo fmt --check` clean
- `cargo clippy --workspace --exclude frontend --all-targets -- -D warnings` clean
- `cargo test -p claude-session-lib -p codex-session-lib -p session-lib -p agent-portal -p backend` all pass
- `cargo build -p agent-portal` green (Session<A> Sync constraint preserved)