### PR TITLE
Consolidate AppState test construction into a shared builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "a2",
  "anyhow",
  "axum",
+ "backend",
  "base64 0.22.1",
  "chrono",
  "clap",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -94,7 +94,17 @@ memory-serve = "2.1"
 [lints]
 workspace = true
 
+[features]
+# Exposes `test_support` (shared test pool + canonical `AppState` builder) to
+# consumers that link the lib without `cfg(test)` — i.e. the integration-test
+# binaries under `tests/`. Off by default, so `cargo build`/release never
+# compiles the test scaffolding; only the self dev-dependency below turns it on.
+test-support = []
+
 [dev-dependencies]
+# Self dev-dependency: enables `test-support` on our own lib for the duration of
+# the test build (`cargo test`/`--all-targets`) without leaking it into release.
+backend = { path = ".", features = ["test-support"] }
 ws-bridge = { workspace = true, features = ["native-client"] }
 uuid = { workspace = true }
 tempfile = "3"

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -150,14 +150,10 @@ impl FromRequestParts<Arc<AppState>> for CurrentUserId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::handlers::images::ImageStore;
     use crate::handlers::proxy_tokens::{issue_proxy_token_with_type, TokenPersist};
-    use crate::handlers::websocket::SessionManager;
     use crate::models::NewUser;
     use crate::schema::{proxy_auth_tokens, users};
     use axum::http::{header::AUTHORIZATION, HeaderValue};
-    use std::time::Duration;
-    use tower_cookies::cookie::Key;
     use tower_cookies::Cookie;
 
     fn user(disabled: bool) -> User {
@@ -189,33 +185,6 @@ mod tests {
             reject_disabled_user(user(true)),
             Err(AppError::Forbidden)
         ));
-    }
-
-    fn test_state(pool: crate::db::DbPool) -> AppState {
-        AppState {
-            dev_mode: false,
-            db_pool: pool,
-            session_manager: SessionManager::new(),
-            oauth_basic_client: None,
-            device_flow_store: None,
-            public_url: "http://localhost:3000".to_string(),
-            cookie_key: Key::generate(),
-            jwt_secret: "test-secret-key-at-least-32-bytes".to_string(),
-            app_title: "Agent Portal Test".to_string(),
-            splash_text: None,
-            allowed_email_domain: None,
-            allowed_emails: None,
-            message_retention_count: 100,
-            message_retention_days: 30,
-            session_max_age_days: 14,
-            max_image_mb: 10,
-            image_store: ImageStore::new(1024 * 1024, Duration::from_secs(60)),
-            forward_domain: None,
-            archive: None,
-            notifications: crate::push::channel().0,
-            vapid_public_key: None,
-            mobile_app_links: crate::config::MobileAppLinksConfig::default(),
-        }
     }
 
     fn insert_user(conn: &mut PgConnection, disabled: bool) -> User {
@@ -284,7 +253,7 @@ mod tests {
         let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
-        let app_state = test_state(pool);
+        let app_state = crate::test_support::test_app_state(pool);
         let mut conn = app_state.conn().expect("conn");
         let user = insert_user(&mut conn, false);
         let cookies = signed_cookie(&app_state, user.id);
@@ -298,7 +267,7 @@ mod tests {
         let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
-        let app_state = test_state(pool);
+        let app_state = crate::test_support::test_app_state(pool);
         let mut conn = app_state.conn().expect("conn");
         let user = insert_user(&mut conn, true);
         let cookies = signed_cookie(&app_state, user.id);
@@ -314,7 +283,7 @@ mod tests {
         let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
-        let app_state = test_state(pool);
+        let app_state = crate::test_support::test_app_state(pool);
         let cookies = Cookies::default();
 
         assert!(matches!(
@@ -328,7 +297,7 @@ mod tests {
         let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
-        let app_state = test_state(pool);
+        let app_state = crate::test_support::test_app_state(pool);
         let mut conn = app_state.conn().expect("conn");
         let user = insert_user(&mut conn, false);
         let (_row_id, token) = issue_mobile_token(&app_state, &mut conn, user.id);
@@ -344,7 +313,7 @@ mod tests {
         let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
-        let app_state = test_state(pool);
+        let app_state = crate::test_support::test_app_state(pool);
         let mut conn = app_state.conn().expect("conn");
         let user = insert_user(&mut conn, false);
         let (row_id, token) = issue_mobile_token(&app_state, &mut conn, user.id);
@@ -367,7 +336,7 @@ mod tests {
         let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
-        let app_state = test_state(pool);
+        let app_state = crate::test_support::test_app_state(pool);
         let mut conn = app_state.conn().expect("conn");
         let user = insert_user(&mut conn, false);
         let (row_id, token) = issue_mobile_token(&app_state, &mut conn, user.id);
@@ -388,7 +357,7 @@ mod tests {
         let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
-        let app_state = test_state(pool);
+        let app_state = crate::test_support::test_app_state(pool);
         let mut conn = app_state.conn().expect("conn");
         let user = insert_user(&mut conn, true);
         let (_row_id, token) = issue_mobile_token(&app_state, &mut conn, user.id);
@@ -405,7 +374,7 @@ mod tests {
         let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
-        let app_state = test_state(pool);
+        let app_state = crate::test_support::test_app_state(pool);
         let mut conn = app_state.conn().expect("conn");
         let user = insert_user(&mut conn, false);
         let cookies = signed_cookie(&app_state, user.id);

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -596,13 +596,9 @@ fn encode_query_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::handlers::images::ImageStore;
-    use crate::handlers::websocket::SessionManager;
     use crate::models::{NewUser, ProxyAuthToken};
     use crate::schema::{proxy_auth_tokens, users};
     use axum::http::{header::AUTHORIZATION, HeaderValue};
-    use std::time::Duration;
-    use tower_cookies::cookie::Key;
 
     #[test]
     fn auth_user_error_preserves_forbidden_and_database_errors() {
@@ -662,30 +658,7 @@ mod tests {
     }
 
     fn test_state(pool: crate::db::DbPool) -> Arc<AppState> {
-        Arc::new(AppState {
-            dev_mode: false,
-            db_pool: pool,
-            session_manager: SessionManager::new(),
-            oauth_basic_client: None,
-            device_flow_store: None,
-            public_url: "http://localhost:3000".to_string(),
-            cookie_key: Key::generate(),
-            jwt_secret: "test-secret-key-at-least-32-bytes".to_string(),
-            app_title: "Agent Portal Test".to_string(),
-            splash_text: None,
-            allowed_email_domain: None,
-            allowed_emails: None,
-            message_retention_count: 100,
-            message_retention_days: 30,
-            session_max_age_days: 14,
-            max_image_mb: 10,
-            image_store: ImageStore::new(1024 * 1024, Duration::from_secs(60)),
-            forward_domain: None,
-            archive: None,
-            notifications: crate::push::channel().0,
-            vapid_public_key: None,
-            mobile_app_links: crate::config::MobileAppLinksConfig::default(),
-        })
+        Arc::new(crate::test_support::test_app_state(pool))
     }
 
     fn insert_user(conn: &mut diesel::PgConnection) -> User {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -22,7 +22,12 @@ pub mod push;
 pub mod routes;
 pub mod schema;
 
-#[cfg(test)]
+// Visible to the crate's own `#[cfg(test)]` modules AND to the separate
+// integration-test binaries (e.g. `tests/harness.rs`), which link the lib
+// *without* `cfg(test)`. The `test-support` feature is enabled only via the
+// crate's self dev-dependency in `Cargo.toml`, so this module is never
+// compiled into `cargo build`/release binaries.
+#[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 
 use crate::db::DbPool;

--- a/backend/src/test_support.rs
+++ b/backend/src/test_support.rs
@@ -12,11 +12,62 @@
 //! parallelism.
 
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use diesel::pg::PgConnection;
 use diesel::r2d2::{ConnectionManager, Pool};
+use tower_cookies::Key;
 
+use crate::config::MobileAppLinksConfig;
 use crate::db::DbPool;
+use crate::handlers::images::ImageStore;
+use crate::handlers::websocket::SessionManager;
+use crate::AppState;
+
+/// Build the canonical test [`AppState`] wired to `pool`.
+///
+/// WHY this exists: every DB-gated test module used to hand-write the full
+/// ~20-field `AppState { .. }` literal (unit tests in `auth.rs` /
+/// `handlers/auth.rs`, plus the integration harness in `tests/harness.rs`).
+/// That made **every new `AppState` field a change to every one of those
+/// literals** — during the push work three fields landed in a single day
+/// (`notifications`, `vapid_public_key`, and the VAPID transport rework), and
+/// each meant editing four identical literals plus eating the resulting rebase
+/// conflicts across parallel PRs. Centralizing construction here means a new
+/// field is one default in one place; call sites that don't care never change.
+///
+/// The defaults are the canonical *unit-test* configuration (dev mode off, no
+/// OAuth, a tiny in-memory image store, every optional `None`). Call sites that
+/// need something different mutate the returned struct before `Arc`-wrapping —
+/// e.g. `let mut s = test_app_state(pool); s.dev_mode = true;`. That direct-
+/// mutation override is deliberate: it needs no builder scaffolding and, unlike
+/// a literal, names only the fields a given test actually cares about.
+pub fn test_app_state(pool: DbPool) -> AppState {
+    AppState {
+        dev_mode: false,
+        db_pool: pool,
+        session_manager: SessionManager::new(),
+        oauth_basic_client: None,
+        device_flow_store: None,
+        public_url: "http://localhost:3000".to_string(),
+        cookie_key: Key::generate(),
+        jwt_secret: "test-secret-key-at-least-32-bytes".to_string(),
+        app_title: "Agent Portal Test".to_string(),
+        splash_text: None,
+        allowed_email_domain: None,
+        allowed_emails: None,
+        message_retention_count: 100,
+        message_retention_days: 30,
+        session_max_age_days: 14,
+        max_image_mb: 10,
+        image_store: ImageStore::new(1024 * 1024, Duration::from_secs(60)),
+        forward_domain: None,
+        archive: None,
+        notifications: crate::push::channel().0,
+        vapid_public_key: None,
+        mobile_app_links: MobileAppLinksConfig::default(),
+    }
+}
 
 /// Max connections the shared test pool may open.
 ///

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -15,10 +15,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use backend::config::ServerConfig;
 use backend::handlers::device_flow::DeviceFlowStore;
-use backend::handlers::images::ImageStore;
-use backend::handlers::websocket::SessionManager;
+use backend::test_support::test_app_state;
 use backend::AppState;
 use shared::endpoints::SessionEndpoint;
 use shared::{AgentType, ProxyToServer, RegisterFields, ServerToProxy};
@@ -50,41 +48,16 @@ fn test_pool() -> backend::db::DbPool {
 }
 
 /// Boot the backend (dev mode) on an ephemeral port; returns its address.
-/// Mirrors `backend::run`'s state construction, minus the background tasks.
+/// Uses the shared canonical [`test_app_state`] builder (see
+/// `backend::test_support`) with dev mode enabled so the `/ws/session` register
+/// path resolves the seeded dev user without a real auth token. No dispatcher
+/// is spawned, so notification emits are silently no-ops.
 async fn spawn_test_app() -> SocketAddr {
-    let pool = test_pool();
+    let mut state = test_app_state(test_pool());
+    state.dev_mode = true;
+    state.device_flow_store = Some(DeviceFlowStore::default());
 
-    let config = ServerConfig::from_env(true).expect("parse server config");
-    let oauth = backend::config::build_google_oauth_client(true).expect("oauth client");
-
-    let state = Arc::new(AppState {
-        dev_mode: true,
-        db_pool: pool,
-        session_manager: SessionManager::new(),
-        oauth_basic_client: oauth,
-        device_flow_store: Some(DeviceFlowStore::default()),
-        public_url: config.public_url,
-        cookie_key: config.cookie_key,
-        jwt_secret: config.jwt_secret,
-        app_title: config.app_title,
-        splash_text: config.splash_text,
-        allowed_email_domain: config.allowed_email_domain,
-        allowed_emails: config.allowed_emails,
-        message_retention_count: config.message_retention_count,
-        message_retention_days: config.message_retention_days,
-        session_max_age_days: config.session_max_age_days,
-        max_image_mb: config.max_image_mb,
-        image_store: ImageStore::new(config.image_store_max_bytes, config.image_store_ttl),
-        forward_domain: config.forward_domain,
-        archive: None,
-        // No dispatcher is spawned in the harness; the receiver drops
-        // immediately, so emits are silently no-ops (see NotificationSender).
-        notifications: backend::push::channel().0,
-        vapid_public_key: config.vapid_public_key,
-        mobile_app_links: config.mobile_app_links,
-    });
-
-    let app = backend::routes::build_router(state);
+    let app = backend::routes::build_router(Arc::new(state));
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind ephemeral port");
@@ -316,36 +289,13 @@ async fn archive_sweep_persists_and_is_idempotent() {
 /// archive runtime and a 1-day age-retention window. Used by the held-trim
 /// test to drive `background::run_retention_cleanup` directly.
 fn retention_test_state(archive: Option<Arc<backend::archive::ArchiveRuntime>>) -> Arc<AppState> {
-    let mut config = ServerConfig::from_env(true).expect("parse server config");
+    let mut state = test_app_state(test_pool());
     // A short age window so backdated messages are trim-eligible; a high
     // per-session cap so only the age path (not truncation) is exercised.
-    config.message_retention_days = 1;
-    config.message_retention_count = 100_000;
-    let oauth = backend::config::build_google_oauth_client(true).expect("oauth client");
-    Arc::new(AppState {
-        dev_mode: true,
-        db_pool: test_pool(),
-        session_manager: SessionManager::new(),
-        oauth_basic_client: oauth,
-        device_flow_store: Some(DeviceFlowStore::default()),
-        public_url: config.public_url,
-        cookie_key: config.cookie_key,
-        jwt_secret: config.jwt_secret,
-        app_title: config.app_title,
-        splash_text: config.splash_text,
-        allowed_email_domain: config.allowed_email_domain,
-        allowed_emails: config.allowed_emails,
-        message_retention_count: config.message_retention_count,
-        message_retention_days: config.message_retention_days,
-        session_max_age_days: config.session_max_age_days,
-        max_image_mb: config.max_image_mb,
-        image_store: ImageStore::new(config.image_store_max_bytes, config.image_store_ttl),
-        forward_domain: config.forward_domain,
-        archive,
-        notifications: backend::push::channel().0,
-        vapid_public_key: config.vapid_public_key,
-        mobile_app_links: config.mobile_app_links,
-    })
+    state.message_retention_days = 1;
+    state.message_retention_count = 100_000;
+    state.archive = archive;
+    Arc::new(state)
 }
 
 /// #1258 phase 2: retention holds the message trim for a session whose


### PR DESCRIPTION
## What

Adds `test_support::test_app_state(pool)` — one canonical constructor for the test `AppState` — and converts every hand-written literal to it.

Consolidated **four** duplicated constructions:
- `backend/src/auth.rs` — `test_state` helper (deleted; call sites use the builder directly)
- `backend/src/handlers/auth.rs` — `test_state` helper (now a one-line `Arc::new(test_app_state(..))` delegate)
- `backend/tests/harness.rs` — `spawn_test_app` and `retention_test_state` (both now build canonical + mutate the handful of fields they care about)

## Why

Every DB-gated test module hand-wrote the full ~20-field `AppState { .. }` literal, so **every new `AppState` field meant editing all four identical literals** and eating the resulting rebase conflicts across parallel PRs — three fields (`notifications`, `vapid_public_key`, VAPID transport) landed this way in a single day during the push work. Adding a field is now one default in one place; call sites that don't care never change.

## Harness visibility mechanism

`test_support` was `#[cfg(test)]`-gated, so the integration-test binary (which links the lib **without** `cfg(test)`) couldn't see it — that's why the harness previously duplicated everything inline. It's now gated behind `#[cfg(any(test, feature = "test-support"))]`, with the feature enabled via a **self dev-dependency** (`backend = { path = ".", features = ["test-support"] }`). With `resolver = "2"` this keeps the module out of normal/release builds.

Verified: `cargo build -p backend --release` resolves the `test-support` feature empty (normal-edge `cargo tree`) and the `test_app_state` symbol is absent from the release binary.

## Verification

- `cargo fmt` clean
- `cargo clippy --workspace --exclude frontend --all-targets -- -D warnings` clean
- `cargo test -p backend` — 228 unit + 4 harness tests pass
- `cargo build -p backend --release` succeeds; test scaffolding not compiled