### PR TITLE
Push typed enums through to the storage boundary

### DIFF
--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -604,7 +604,7 @@ mod tests {
             owner_name: None,
             session_name: "s".into(),
             agent_type: "claude".into(),
-            status: "disconnected".into(),
+            status: shared::SessionStatus::Disconnected.as_str().into(),
             working_directory: "/w".into(),
             hostname: "h".into(),
             git_branch: None,

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 use shared::api::{
     AgentSessionInfo, AgentSessionsResponse, SendAgentMessageRequest, SendAgentMessageResponse,
 };
+use shared::SessionStatus;
 
 use crate::errors::AppError;
 use crate::models::Session;
@@ -68,7 +69,7 @@ pub async fn list_agent_sessions(
     let rows: Vec<Session> = sessions::table
         .inner_join(session_members::table.on(session_members::session_id.eq(sessions::id)))
         .filter(session_members::user_id.eq(user_id))
-        .filter(sessions::status.ne("replaced"))
+        .filter(sessions::status.ne(SessionStatus::Replaced.as_str()))
         .filter(sessions::scheduled_task_id.is_null())
         .select(Session::as_select())
         .order(sessions::last_activity.desc())

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -12,10 +12,37 @@ use crate::db::DbPool;
 use crate::models::{NewMessage, NewSessionContinuation, Session, SessionContinuation};
 use crate::AppState;
 
-const STATUS_PENDING: &str = "pending";
-const STATUS_SCHEDULED: &str = "scheduled";
-const STATUS_FIRED: &str = "fired";
-const STATUS_DROPPED: &str = "dropped";
+/// Lifecycle state stored in `session_continuations.status`.
+///
+/// Backend-local: the column never crosses the wire as a typed value — the
+/// `ServerToClient::ContinuationStatus` notification carries a broader string
+/// set (it also emits a transient `"failed"` that is never persisted). The
+/// wire/DB string is [`ContinuationStatus::as_str`], so stored values stay
+/// byte-identical while interior branches match on the enum exhaustively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContinuationStatus {
+    Pending,
+    Scheduled,
+    Fired,
+    Dropped,
+}
+
+impl ContinuationStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            ContinuationStatus::Pending => "pending",
+            ContinuationStatus::Scheduled => "scheduled",
+            ContinuationStatus::Fired => "fired",
+            ContinuationStatus::Dropped => "dropped",
+        }
+    }
+}
+
+impl std::fmt::Display for ContinuationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// Rolling window used to cap overload auto-retries per session. Counting prior
 /// `overloaded` continuation rows in this window is the whole cap mechanism, so
@@ -89,7 +116,7 @@ pub fn handle_session_limit_reached(
         launcher_id,
         reset_at,
         prompt: fields.prompt,
-        status: STATUS_PENDING.to_string(),
+        status: ContinuationStatus::Pending.as_str().to_string(),
         source_message: Some(fields.source_message),
         reason: CONTINUATION_REASON_LIMIT.to_string(),
     };
@@ -158,10 +185,10 @@ pub fn schedule_limit_continuation(
             .filter(session_continuations::id.eq(continuation_id))
             .filter(session_continuations::session_id.eq(session_id))
             .filter(session_continuations::user_id.eq(user_id))
-            .filter(session_continuations::status.eq(STATUS_PENDING)),
+            .filter(session_continuations::status.eq(ContinuationStatus::Pending.as_str())),
     )
     .set((
-        session_continuations::status.eq(STATUS_SCHEDULED),
+        session_continuations::status.eq(ContinuationStatus::Scheduled.as_str()),
         session_continuations::scheduled_at.eq(diesel::dsl::now),
         session_continuations::updated_at.eq(diesel::dsl::now),
     ))
@@ -189,7 +216,7 @@ pub fn schedule_limit_continuation(
         &session_id.to_string(),
         ServerToClient::ContinuationStatus {
             continuation_id,
-            status: STATUS_SCHEDULED.to_string(),
+            status: ContinuationStatus::Scheduled.as_str().to_string(),
             message: Some("Continuation scheduled".to_string()),
         },
     );
@@ -214,7 +241,7 @@ pub fn mark_continuation_fired(
         user_id,
         continuation_id,
         session_id,
-        STATUS_FIRED,
+        ContinuationStatus::Fired,
         None,
     );
 }
@@ -233,7 +260,7 @@ pub fn mark_continuation_dropped(
         user_id,
         continuation_id,
         session_id,
-        STATUS_DROPPED,
+        ContinuationStatus::Dropped,
         Some(reason),
     );
 }
@@ -244,7 +271,7 @@ fn update_terminal_status(
     user_id: Uuid,
     continuation_id: Uuid,
     session_id: Uuid,
-    status: &str,
+    status: ContinuationStatus,
     reason: Option<String>,
 ) {
     let Ok(mut conn) = app_state.db_pool.get() else {
@@ -260,15 +287,15 @@ fn update_terminal_status(
             .filter(session_continuations::launcher_id.eq(launcher_id)),
     )
     .set((
-        session_continuations::status.eq(status),
+        session_continuations::status.eq(status.as_str()),
         session_continuations::last_error.eq(reason.clone()),
         session_continuations::updated_at.eq(diesel::dsl::now),
-        session_continuations::fired_at.eq(if status == STATUS_FIRED {
+        session_continuations::fired_at.eq(if status == ContinuationStatus::Fired {
             Some(chrono::Utc::now().naive_utc())
         } else {
             None
         }),
-        session_continuations::dropped_at.eq(if status == STATUS_DROPPED {
+        session_continuations::dropped_at.eq(if status == ContinuationStatus::Dropped {
             Some(chrono::Utc::now().naive_utc())
         } else {
             None
@@ -282,12 +309,12 @@ fn update_terminal_status(
                 &session_id.to_string(),
                 ServerToClient::ContinuationStatus {
                     continuation_id,
-                    status: status.to_string(),
+                    status: status.as_str().to_string(),
                     message: reason.clone(),
                 },
             );
 
-            if status == STATUS_DROPPED {
+            if status == ContinuationStatus::Dropped {
                 if let Ok(session) = sessions::table.find(session_id).first::<Session>(&mut conn) {
                     let portal = PortalMessage::text(
                         "Continuation was not sent because the local Claude process was no longer running when the session limit reset."
@@ -350,7 +377,7 @@ pub fn load_scheduled_continuations(
         .inner_join(sessions::table.on(sessions::id.eq(session_continuations::session_id)))
         .filter(session_continuations::launcher_id.eq(launcher_id))
         .filter(session_continuations::user_id.eq(user_id))
-        .filter(session_continuations::status.eq(STATUS_SCHEDULED))
+        .filter(session_continuations::status.eq(ContinuationStatus::Scheduled.as_str()))
         .order(session_continuations::reset_at.asc())
         .select((SessionContinuation::as_select(), Session::as_select()))
         .load::<(SessionContinuation, Session)>(&mut conn)
@@ -539,7 +566,7 @@ pub fn schedule_overloaded_retry(
         launcher_id,
         reset_at,
         prompt,
-        status: STATUS_SCHEDULED.to_string(),
+        status: ContinuationStatus::Scheduled.as_str().to_string(),
         source_message: Some(source_message),
         reason: CONTINUATION_REASON_OVERLOADED.to_string(),
     };
@@ -708,7 +735,7 @@ mod tests {
             launcher_id: Uuid::new_v4(),
             reset_at: Utc::now(),
             prompt: "retry".to_string(),
-            status: STATUS_SCHEDULED.to_string(),
+            status: ContinuationStatus::Scheduled.as_str().to_string(),
             source_message: None,
             reason: CONTINUATION_REASON_OVERLOADED.to_string(),
         };

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -230,6 +230,24 @@ pub struct PushSubscription {
     pub disabled_at: Option<DateTime<Utc>>,
 }
 
+impl PushSubscription {
+    /// Parse the stored `platform` string into the typed [`PushPlatform`].
+    ///
+    /// This is the single read-side conversion boundary for the `platform`
+    /// column: interior code (transport dispatch, per-transport guards) matches
+    /// on the returned enum rather than re-parsing the raw string, so a typo can
+    /// no longer silently miss.
+    ///
+    /// **Unknown-value policy:** returns `None` for a value that is not one of
+    /// the known platforms. Rows are only ever written from a typed
+    /// [`PushPlatform`], so `None` means legacy/corrupt data; callers
+    /// skip-with-log (fall through to the log transport) rather than panicking —
+    /// matching the historical fallthrough behavior.
+    pub fn platform_kind(&self) -> Option<shared::api::PushPlatform> {
+        shared::api::PushPlatform::from_wire(&self.platform)
+    }
+}
+
 #[derive(Debug, Insertable)]
 #[diesel(table_name = crate::schema::push_subscriptions)]
 pub struct NewPushSubscription {
@@ -672,5 +690,36 @@ mod tests {
         assert!(meta.source.is_some());
         // Delivery is frontend-owned — the backend never sets it.
         assert!(meta.delivery.is_none());
+    }
+
+    fn push_sub(platform: &str) -> PushSubscription {
+        PushSubscription {
+            id: Uuid::nil(),
+            user_id: Uuid::nil(),
+            platform: platform.to_string(),
+            endpoint_or_token: "e".to_string(),
+            p256dh: None,
+            auth: None,
+            device_label: None,
+            created_at: chrono::Utc::now(),
+            last_success_at: None,
+            disabled_at: None,
+        }
+    }
+
+    #[test]
+    fn platform_kind_parses_every_known_platform() {
+        use shared::api::PushPlatform;
+        for p in [PushPlatform::Webpush, PushPlatform::Apns, PushPlatform::Fcm] {
+            assert_eq!(push_sub(p.as_wire()).platform_kind(), Some(p));
+        }
+    }
+
+    #[test]
+    fn platform_kind_returns_none_for_legacy_or_corrupt_value() {
+        // Unknown-value policy: never panic — hand back None so the dispatcher
+        // skips-with-log rather than mis-routing a legacy/corrupt row.
+        assert_eq!(push_sub("mms").platform_kind(), None);
+        assert_eq!(push_sub("").platform_kind(), None);
     }
 }

--- a/backend/src/push/apns.rs
+++ b/backend/src/push/apns.rs
@@ -14,8 +14,7 @@ use serde::Serialize;
 use crate::models::PushSubscription;
 use crate::push::transport::{PushError, PushTransport, SendOutcome};
 use crate::push::{ApnsTransportConfig, PushPayload};
-
-const APNS_PLATFORM: &str = "apns";
+use shared::api::PushPlatform;
 
 #[derive(Debug, Serialize)]
 struct ApnsCustomData<'a> {
@@ -54,7 +53,9 @@ impl ApnsTransport {
         sub: &'a PushSubscription,
         payload: &'a PushPayload,
     ) -> Result<a2::request::payload::Payload<'a>, PushError> {
-        if sub.platform != APNS_PLATFORM {
+        // Reject non-APNs rows (and any legacy/unknown platform) before building
+        // the payload. `platform_kind()` is the typed read boundary.
+        if sub.platform_kind() != Some(PushPlatform::Apns) {
             return Err(PushError::Transport(format!(
                 "ApnsTransport cannot deliver to platform {:?} (subscription {})",
                 sub.platform, sub.id
@@ -208,7 +209,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
             bundle_id: "io.txcl.agentportal".to_string(),
         };
         let payload = payload();
-        let sub = sub(APNS_PLATFORM);
+        let sub = sub(PushPlatform::Apns.as_wire());
         let notification = transport
             .build_payload(&sub, &payload)
             .expect("payload builds");

--- a/backend/src/push/fcm.rs
+++ b/backend/src/push/fcm.rs
@@ -15,8 +15,8 @@ use tokio::sync::Mutex;
 use crate::models::PushSubscription;
 use crate::push::transport::{PushError, PushTransport, SendOutcome};
 use crate::push::{FcmTransportConfig, PushPayload};
+use shared::api::PushPlatform;
 
-const FCM_PLATFORM: &str = "fcm";
 const FCM_SCOPE: &str = "https://www.googleapis.com/auth/firebase.messaging";
 const FCM_TOKEN_REFRESH_SLOP: Duration = Duration::from_secs(60);
 
@@ -139,7 +139,9 @@ impl FcmTransport {
         sub: &PushSubscription,
         payload: &PushPayload,
     ) -> Result<FcmRequest, PushError> {
-        if sub.platform != FCM_PLATFORM {
+        // Reject non-FCM rows (and any legacy/unknown platform) before building
+        // the request. `platform_kind()` is the typed read boundary.
+        if sub.platform_kind() != Some(PushPlatform::Fcm) {
             return Err(PushError::Transport(format!(
                 "FcmTransport cannot deliver to platform {:?} (subscription {})",
                 sub.platform, sub.id
@@ -302,8 +304,8 @@ mod tests {
     #[test]
     fn fcm_request_serializes_typed_payload_and_collapse_key() {
         let payload = payload();
-        let request =
-            FcmTransport::build_request(&sub(FCM_PLATFORM), &payload).expect("request builds");
+        let request = FcmTransport::build_request(&sub(PushPlatform::Fcm.as_wire()), &payload)
+            .expect("request builds");
         let json = serde_json::to_value(&request).expect("serialize");
         assert_eq!(json["message"]["token"], "fcm-registration-token");
         assert_eq!(json["message"]["notification"]["title"], payload.title);

--- a/backend/src/push/mod.rs
+++ b/backend/src/push/mod.rs
@@ -23,7 +23,7 @@ pub use transport::{LogTransport, PushError, PushTransport, SendOutcome};
 pub use webpush::WebPushTransport;
 
 use crate::models::PushSubscription;
-use shared::api::{NotificationContentDetail, NotificationPrefs};
+use shared::api::{NotificationContentDetail, NotificationPrefs, PushPlatform};
 use std::path::PathBuf;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
@@ -121,20 +121,33 @@ impl PushTransport for ConfiguredTransport {
                 webpush,
                 apns,
                 fcm,
-            } => match sub.platform.as_str() {
-                "webpush" => match webpush {
+            } => match sub.platform_kind() {
+                // Exhaustive over the closed `PushPlatform` set: adding a
+                // transport variant upstream forces a compile error here rather
+                // than silently routing to the log fallback.
+                Some(PushPlatform::Webpush) => match webpush {
                     Some(t) => t.send(sub, payload).await,
                     None => log.send(sub, payload).await,
                 },
-                "apns" => match apns {
+                Some(PushPlatform::Apns) => match apns {
                     Some(t) => t.send(sub, payload).await,
                     None => log.send(sub, payload).await,
                 },
-                "fcm" => match fcm {
+                Some(PushPlatform::Fcm) => match fcm {
                     Some(t) => t.send(sub, payload).await,
                     None => log.send(sub, payload).await,
                 },
-                _ => log.send(sub, payload).await,
+                // Legacy/corrupt platform string (see
+                // `PushSubscription::platform_kind`): skip-with-log, matching the
+                // historical fallthrough-to-log behavior.
+                None => {
+                    tracing::warn!(
+                        "push subscription {} has unknown platform {:?}; routing to log transport",
+                        sub.id,
+                        sub.platform
+                    );
+                    log.send(sub, payload).await
+                }
             },
         }
     }

--- a/backend/src/push/webpush.rs
+++ b/backend/src/push/webpush.rs
@@ -24,11 +24,7 @@ use web_push::{
 use crate::models::PushSubscription;
 use crate::push::transport::{PushError, PushTransport, SendOutcome};
 use crate::push::PushPayload;
-
-/// The `platform` column value for browser Web Push subscriptions. APNs/FCM
-/// rows carry different values and are handled by native transports (C7); this
-/// transport skips them with a clear error rather than mis-sending.
-const WEBPUSH_PLATFORM: &str = "webpush";
+use shared::api::PushPlatform;
 
 /// Time-to-live handed to the push service: how long it should retain the
 /// notification for an offline device before dropping it. One day matches the
@@ -77,7 +73,10 @@ impl WebPushTransport {
         sub: &PushSubscription,
         payload: &PushPayload,
     ) -> Result<WebPushMessage, PushError> {
-        if sub.platform != WEBPUSH_PLATFORM {
+        // Web Push only handles browser subscriptions; APNs/FCM rows (and any
+        // legacy/unknown platform string) are rejected before we build a
+        // message. `platform_kind()` is the typed read boundary.
+        if sub.platform_kind() != Some(PushPlatform::Webpush) {
             return Err(PushError::Transport(format!(
                 "WebPushTransport cannot deliver to platform {:?} (subscription {}); \
                  native APNs/FCM is C7",

--- a/launcher/src/scheduler.rs
+++ b/launcher/src/scheduler.rs
@@ -19,10 +19,12 @@ const CONTINUATION_RESET_SKEW_SECS: i64 = 120;
 /// 300s) delay in `reset_at`, and the CLI backs off internally, so any extra
 /// wait here would defeat the "retry immediately" intent.
 fn continuation_skew_secs(reason: &str) -> i64 {
-    if reason == shared::CONTINUATION_REASON_OVERLOADED {
-        0
-    } else {
-        CONTINUATION_RESET_SKEW_SECS
+    match shared::ContinuationReason::from_wire(reason) {
+        Some(shared::ContinuationReason::Overloaded) => 0,
+        // `Limit` and any legacy/unknown reason wait the full skew — matches the
+        // historical `else` default (see `ContinuationReason`'s unknown-value
+        // policy).
+        Some(shared::ContinuationReason::Limit) | None => CONTINUATION_RESET_SKEW_SECS,
     }
 }
 

--- a/shared/src/endpoints/types.rs
+++ b/shared/src/endpoints/types.rs
@@ -3,12 +3,66 @@ use uuid::Uuid;
 
 use crate::{AgentType, PermissionSuggestion, SessionMode};
 
+/// Why a session continuation was created.
+///
+/// Stored in `session_continuations.reason` and carried on the wire in
+/// [`ContinuationConfig::reason`] (backend → launcher), so this enum lives in
+/// `shared`. The launcher uses it to decide the reset skew (see
+/// [`ContinuationConfig::reason`]).
+///
+/// The wire/DB representation is the snake-case string emitted by
+/// [`ContinuationReason::as_wire`] — the same values serde produces — so the
+/// column and JSON stay in lockstep.
+///
+/// **Unknown-value policy:** [`ContinuationReason::from_wire`] returns `None`
+/// for an unrecognized string rather than panicking. Consumers treat an unknown
+/// reason as the neutral `Limit` default (the historical fallthrough), so a
+/// legacy or newer-launcher value never breaks scheduling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContinuationReason {
+    /// A usage-limit reset (`#231`/`#1260`). Waits the full reset skew.
+    Limit,
+    /// Auto-retry of a turn a transient 529 overload killed. Fires immediately
+    /// (no reset skew) — the CLI already backs off internally, so the portal
+    /// adds no further delay.
+    Overloaded,
+}
+
+impl ContinuationReason {
+    /// The wire/DB string for this reason — identical to the serde encoding, so
+    /// the `session_continuations.reason` column stays in lockstep with JSON.
+    pub const fn as_wire(self) -> &'static str {
+        match self {
+            ContinuationReason::Limit => "limit",
+            ContinuationReason::Overloaded => "overloaded",
+        }
+    }
+
+    /// Parse a stored/wire reason string. Returns `None` for an unrecognized
+    /// value so callers can apply the `Limit`-default fallthrough (see the type
+    /// doc's unknown-value policy) rather than panicking on legacy/corrupt data.
+    pub fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "limit" => Some(ContinuationReason::Limit),
+            "overloaded" => Some(ContinuationReason::Overloaded),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ContinuationReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_wire())
+    }
+}
+
 /// A session continuation created for a usage-limit reset (`#231`/`#1260`).
-pub const CONTINUATION_REASON_LIMIT: &str = "limit";
+pub const CONTINUATION_REASON_LIMIT: &str = ContinuationReason::Limit.as_wire();
 /// A session continuation created to auto-retry a turn that a transient 529
 /// overload killed. Fires immediately (no reset skew) — the CLI already backs
 /// off internally, so the portal adds no further delay.
-pub const CONTINUATION_REASON_OVERLOADED: &str = "overloaded";
+pub const CONTINUATION_REASON_OVERLOADED: &str = ContinuationReason::Overloaded.as_wire();
 
 /// Fields for session registration (shared by proxy and web client).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -249,4 +303,48 @@ pub struct FileDownloadResponseFields {
     pub data_base64: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod continuation_reason_tests {
+    use super::*;
+
+    #[test]
+    fn as_wire_and_serde_agree() {
+        for reason in [ContinuationReason::Limit, ContinuationReason::Overloaded] {
+            // The wire string, the serde encoding, and Display must all match.
+            assert_eq!(serde_json::to_value(reason).unwrap(), reason.as_wire());
+            assert_eq!(reason.to_string(), reason.as_wire());
+        }
+    }
+
+    #[test]
+    fn from_wire_round_trips_every_variant() {
+        for reason in [ContinuationReason::Limit, ContinuationReason::Overloaded] {
+            assert_eq!(
+                ContinuationReason::from_wire(reason.as_wire()),
+                Some(reason)
+            );
+        }
+    }
+
+    #[test]
+    fn from_wire_returns_none_for_unknown() {
+        // Unknown-value policy: never panic, hand back None so callers apply the
+        // Limit-default fallthrough.
+        assert_eq!(ContinuationReason::from_wire("bogus"), None);
+        assert_eq!(ContinuationReason::from_wire(""), None);
+    }
+
+    #[test]
+    fn legacy_consts_match_enum_wire() {
+        assert_eq!(
+            CONTINUATION_REASON_LIMIT,
+            ContinuationReason::Limit.as_wire()
+        );
+        assert_eq!(
+            CONTINUATION_REASON_OVERLOADED,
+            ContinuationReason::Overloaded.as_wire()
+        );
+    }
 }


### PR DESCRIPTION
Shared typed enums existed but stopped at the DB layer — interior code matched raw stringly-typed column values, where a typo compiles and silently never matches. This threads the enums all the way in, so each column has exactly one conversion boundary (parse on DB read / serialize on DB write + wire edges) and interior matches are exhaustive over the closed set. No schema/migration changes — storage stays strings.

## Columns / enums

- **`push_subscriptions.platform`** — new `PushSubscription::platform_kind()` (backend model method) is the single read boundary, parsing the shared `PushPlatform::from_wire`. `ConfiguredTransport::send` now matches exhaustively on the enum with an explicit `None` arm; the per-transport WebPush/APNs/FCM guards compare the typed value instead of module string consts (removed).
- **`session_continuations.reason`** — new shared `ContinuationReason` enum (`Limit`/`Overloaded`) with `as_wire`/`from_wire`/`Display`; the legacy `CONTINUATION_REASON_*` consts are now derived from it. The launcher's reset-skew decision matches the enum exhaustively instead of `reason == const`.
- **`session_continuations.status`** — backend-local `ContinuationStatus` enum replaces the four `STATUS_*` string consts; `update_terminal_status` takes the enum so the fired/dropped branches are exhaustive.
- **`sessions.status`** — replaced the last two raw `"replaced"`/`"disconnected"` literals with `SessionStatus::as_str()` (the rest of the codebase already routed through the enum).

## Unknown-value policy (behavior-preserving)

- `PushPlatform::from_wire` → `None`: dispatcher skip-with-log (routes to the log transport, matching the historical fallthrough); per-transport guards reject. Documented on `platform_kind`.
- `ContinuationReason::from_wire` → `None`: treated as the neutral `Limit` default (matches the old `else` branch). Documented on the enum.
- `ContinuationStatus` / `SessionStatus`: only ever written from the typed value, so no read-parse fallback needed.

Valid values are byte-identical on the wire and in the DB. Round-trip (every variant to/from string) and unknown-value tests added per enum.

## Left stringly (deliberately)

- The `ServerToClient::ContinuationStatus.status` wire field stays a `String` — it carries a broader set than the DB column (a transient `"failed"` never persisted), so it isn't the same closed set as `ContinuationStatus`.
- `sessions.status` on the `Session` model stays a `String` column: it flows straight to the wire via serde flatten and every interior comparison already goes through `SessionStatus::as_str()`, so there is no read-boundary parse to add.
- `scheduled_tasks.session_mode` was already fully typed on `origin/main` (parsed via `SessionMode::from_str`, written via `as_str`); no change needed.

Verified: `cargo fmt --check`, `cargo clippy --workspace --exclude frontend --all-targets -D warnings`, `cargo test -p backend -p shared` and `-p agent-portal`, plus `cargo build --target wasm32-unknown-unknown -p shared`.