### PR TITLE
Fix inter-agent broadcast rail geometry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "a2",
  "anyhow",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5190,7 +5190,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "colored",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "hex",
@@ -6331,7 +6331,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.10"
+version = "2.13.11"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -468,7 +468,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
 
     html! {
         <div class="session-rail-container" onclick={on_container_click}>
-            <div class="session-rail" ref={rail_ref} onwheel={on_wheel}>
+            <div class="session-rail" ref={rail_ref.clone()} onwheel={on_wheel}>
                 {
                     render_pill_section(
                         props,
@@ -520,7 +520,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     }
                 }
             </div>
-            { render_broadcasts(&props.broadcasts, &rendered_sessions, rail_axis, *render_time) }
+            { render_broadcasts(&props.broadcasts, &rail_ref, &rendered_sessions, rail_axis, *render_time) }
             <SessionRailMenu
                 session={open_session}
                 position={*menu_pos}

--- a/frontend/src/pages/dashboard/session_rail/broadcast.rs
+++ b/frontend/src/pages/dashboard/session_rail/broadcast.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use shared::AgentType;
 use uuid::Uuid;
+use web_sys::Element;
 use yew::prelude::*;
 
 const BROADCAST_WINDOW_MS: f64 = 2_400.0;
@@ -34,10 +35,24 @@ pub(super) struct BroadcastView {
     pub from_session_id: Uuid,
     pub to_session_id: Uuid,
     pub timestamp: f64,
-    pub start_pct: f64,
-    pub end_pct: f64,
+    pub start: f64,
+    pub end: f64,
+    pub units: BroadcastUnits,
     pub reverse: bool,
     pub agent_type: AgentType,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum BroadcastUnits {
+    Percent,
+    Pixels,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct RenderedSessionPosition {
+    pub id: Uuid,
+    pub agent_type: AgentType,
+    pub center: f64,
 }
 
 #[derive(Clone)]
@@ -102,13 +117,52 @@ impl BroadcastRef {
                     from_session_id: event.from_session_id,
                     to_session_id: event.to_session_id,
                     timestamp: event.timestamp,
-                    start_pct: from_pct.min(to_pct),
-                    end_pct: from_pct.max(to_pct),
+                    start: from_pct.min(to_pct),
+                    end: from_pct.max(to_pct),
+                    units: BroadcastUnits::Percent,
                     reverse: from_pct > to_pct,
                     agent_type: rendered_sessions
                         .get(from_idx)
                         .map(|(_, agent_type)| *agent_type)
                         .unwrap_or_default(),
+                })
+            })
+            .collect()
+    }
+
+    pub(super) fn view_for_positions(
+        &self,
+        rendered_positions: &[RenderedSessionPosition],
+        now: f64,
+    ) -> Vec<BroadcastView> {
+        if rendered_positions.len() < 2 {
+            return Vec::new();
+        }
+
+        let cutoff = now - BROADCAST_WINDOW_MS;
+        self.0
+            .borrow()
+            .iter()
+            .filter(|event| event.timestamp > cutoff)
+            .filter_map(|event| {
+                let from = rendered_positions
+                    .iter()
+                    .find(|pos| pos.id == event.from_session_id)?;
+                let to = rendered_positions
+                    .iter()
+                    .find(|pos| pos.id == event.to_session_id)?;
+                if from.id == to.id {
+                    return None;
+                }
+                Some(BroadcastView {
+                    from_session_id: event.from_session_id,
+                    to_session_id: event.to_session_id,
+                    timestamp: event.timestamp,
+                    start: from.center.min(to.center),
+                    end: from.center.max(to.center),
+                    units: BroadcastUnits::Pixels,
+                    reverse: from.center > to.center,
+                    agent_type: from.agent_type,
                 })
             })
             .collect()
@@ -129,11 +183,14 @@ impl Default for BroadcastRef {
 
 pub(super) fn render_broadcasts(
     broadcasts: &BroadcastRef,
+    rail_ref: &NodeRef,
     rendered_sessions: &[(Uuid, AgentType)],
     axis: RailAxis,
     render_time: f64,
 ) -> Html {
-    let views = broadcasts.view_for_sessions(rendered_sessions, render_time);
+    let views = measure_rendered_positions(rail_ref, rendered_sessions, axis)
+        .map(|positions| broadcasts.view_for_positions(&positions, render_time))
+        .unwrap_or_else(|| broadcasts.view_for_sessions(rendered_sessions, render_time));
     if views.is_empty() {
         return html! {};
     }
@@ -141,13 +198,14 @@ pub(super) fn render_broadcasts(
     html! {
         <div class={classes!("agent-broadcast-layer", axis.class())} aria-hidden="true">
             { for views.into_iter().map(|view| {
-                let span = (view.end_pct - view.start_pct).max(1.0);
+                let span = (view.end - view.start).max(1.0);
+                let unit = view.units.css_unit();
                 let style = match axis {
                     RailAxis::Horizontal => {
-                        format!("left: {:.2}%; width: {:.2}%;", view.start_pct, span)
+                        format!("left: {:.2}{unit}; width: {:.2}{unit};", view.start, span)
                     }
                     RailAxis::Vertical => {
-                        format!("top: {:.2}%; height: {:.2}%;", view.start_pct, span)
+                        format!("top: {:.2}{unit}; height: {:.2}{unit};", view.start, span)
                     }
                 };
                 let packet_class = match view.agent_type {
@@ -168,6 +226,46 @@ pub(super) fn render_broadcasts(
             }) }
         </div>
     }
+}
+
+impl BroadcastUnits {
+    fn css_unit(self) -> &'static str {
+        match self {
+            Self::Percent => "%",
+            Self::Pixels => "px",
+        }
+    }
+}
+
+fn measure_rendered_positions(
+    rail_ref: &NodeRef,
+    rendered_sessions: &[(Uuid, AgentType)],
+    axis: RailAxis,
+) -> Option<Vec<RenderedSessionPosition>> {
+    let rail = rail_ref.cast::<Element>()?;
+    let container = rail.parent_element()?;
+    let container_rect = container.get_bounding_client_rect();
+    let origin = match axis {
+        RailAxis::Horizontal => container_rect.left(),
+        RailAxis::Vertical => container_rect.top(),
+    };
+
+    let mut positions = Vec::with_capacity(rendered_sessions.len());
+    for (id, agent_type) in rendered_sessions {
+        let selector = format!("[data-session-id=\"{id}\"]");
+        let pill = rail.query_selector(&selector).ok().flatten()?;
+        let rect = pill.get_bounding_client_rect();
+        let center = match axis {
+            RailAxis::Horizontal => (rect.left() + rect.right()) / 2.0 - origin,
+            RailAxis::Vertical => (rect.top() + rect.bottom()) / 2.0 - origin,
+        };
+        positions.push(RenderedSessionPosition {
+            id: *id,
+            agent_type: *agent_type,
+            center,
+        });
+    }
+    Some(positions)
 }
 
 fn slot_pct(index: usize, total: usize) -> f64 {
@@ -199,8 +297,9 @@ mod tests {
 
         let view = events.view_for(&[id(1), id(2), id(3)], 1_200.0);
         assert_eq!(view.len(), 1);
-        assert!((view[0].start_pct - 16.666).abs() < 0.01);
-        assert!((view[0].end_pct - 83.333).abs() < 0.01);
+        assert!((view[0].start - 16.666).abs() < 0.01);
+        assert!((view[0].end - 83.333).abs() < 0.01);
+        assert_eq!(view[0].units, BroadcastUnits::Percent);
         assert!(!view[0].reverse);
     }
 
@@ -237,6 +336,44 @@ mod tests {
         );
 
         assert_eq!(view.len(), 1);
+        assert_eq!(view[0].agent_type, AgentType::Codex);
+    }
+
+    #[test]
+    fn broadcast_view_uses_measured_pill_centers_when_available() {
+        let events = BroadcastRef::default();
+        events.push(AgentMessageBroadcast {
+            from_session_id: id(3),
+            to_session_id: id(1),
+            timestamp: 1_000.0,
+        });
+
+        let view = events.view_for_positions(
+            &[
+                RenderedSessionPosition {
+                    id: id(1),
+                    agent_type: AgentType::Claude,
+                    center: 120.0,
+                },
+                RenderedSessionPosition {
+                    id: id(2),
+                    agent_type: AgentType::Codex,
+                    center: 310.0,
+                },
+                RenderedSessionPosition {
+                    id: id(3),
+                    agent_type: AgentType::Codex,
+                    center: 575.0,
+                },
+            ],
+            1_200.0,
+        );
+
+        assert_eq!(view.len(), 1);
+        assert_eq!(view[0].start, 120.0);
+        assert_eq!(view[0].end, 575.0);
+        assert_eq!(view[0].units, BroadcastUnits::Pixels);
+        assert!(view[0].reverse);
         assert_eq!(view[0].agent_type, AgentType::Codex);
     }
 

--- a/frontend/src/pages/dashboard/session_rail/pill.rs
+++ b/frontend/src/pages/dashboard/session_rail/pill.rs
@@ -78,6 +78,7 @@ pub(super) fn session_pill(props: &SessionPillProps) -> Html {
             onclick={on_click}
             key={session.id.to_string()}
             data-index={props.index.to_string()}
+            data-session-id={session.id.to_string()}
         >
             <span class={view.watermark_class} aria-hidden="true" />
             <span class="pill-broadcast-effect" aria-hidden="true">


### PR DESCRIPTION
## Summary
- measure actual rendered pill centers for inter-agent broadcast paths
- keep the old slot-percentage geometry as a fallback before DOM refs are available
- add a stable data-session-id on session pills and cover measured geometry with a unit test
- bump workspace version to 2.13.11

## Tests
- cargo fmt --check
- cargo test -p frontend broadcast_view
- cargo check -p frontend --target wasm32-unknown-unknown
- cargo clippy -p frontend --target wasm32-unknown-unknown --all-targets -- -D warnings