### PR TITLE
Render Claude tool progress messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "a2",
  "anyhow",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5190,7 +5190,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "colored",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "hex",
@@ -6331,7 +6331,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.10"
+version = "2.13.11"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/frontend/src/components/agent_frame.rs
+++ b/frontend/src/components/agent_frame.rs
@@ -30,6 +30,7 @@ pub enum AgentFrameKind {
     ClaudeUser,
     ClaudeError,
     ClaudeRateLimitEvent,
+    ClaudeToolProgress,
     Portal,
     OptimisticUser,
     CodexThreadStarted,
@@ -106,6 +107,7 @@ impl FrameRenderer {
             | AgentFrameKind::ClaudeUser
             | AgentFrameKind::ClaudeError
             | AgentFrameKind::ClaudeRateLimitEvent
+            | AgentFrameKind::ClaudeToolProgress
             | AgentFrameKind::Portal
             | AgentFrameKind::OptimisticUser => Self::Claude,
             AgentFrameKind::CodexThreadStarted
@@ -138,6 +140,7 @@ impl ClaudeMessage {
             Self::Error(_) => AgentFrameKind::ClaudeError,
             Self::Portal(_) => AgentFrameKind::Portal,
             Self::RateLimitEvent(_) => AgentFrameKind::ClaudeRateLimitEvent,
+            Self::ToolProgress(_) => AgentFrameKind::ClaudeToolProgress,
             Self::OptimisticUser(_) => AgentFrameKind::OptimisticUser,
             Self::Unknown => AgentFrameKind::RawJson,
         }
@@ -229,6 +232,28 @@ mod tests {
         );
 
         assert_eq!(frame.kind(), AgentFrameKind::OptimisticUser);
+        assert_eq!(
+            AgentFrameRegistry::renderer_for(&frame),
+            FrameRenderer::Claude
+        );
+    }
+
+    #[test]
+    fn parses_claude_tool_progress_frame_to_claude_renderer() {
+        let frame = parse_for(
+            shared::AgentType::Claude,
+            serde_json::json!({
+                "type": "tool_progress",
+                "tool_use_id": "toolu_011pEiJk5V6SMz5Lv5u4broE-heartbeat-0",
+                "tool_name": "Bash",
+                "parent_tool_use_id": "toolu_011pEiJk5V6SMz5Lv5u4broE",
+                "elapsed_time_seconds": 30.0,
+                "uuid": "5ee5161f-f634-4187-be5a-6a58fac0935d",
+                "session_id": "e5cf12a9-db74-4a5a-b103-75ab55a10ccc"
+            }),
+        );
+
+        assert_eq!(frame.kind(), AgentFrameKind::ClaudeToolProgress);
         assert_eq!(
             AgentFrameRegistry::renderer_for(&frame),
             FrameRenderer::Claude

--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -87,6 +87,9 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
             AgentFrame::Claude(ClaudeMessage::RateLimitEvent(msg)) => {
                 renderers::render_rate_limit_event(&msg, ctx.timestamp)
             }
+            AgentFrame::Claude(ClaudeMessage::ToolProgress(msg)) => {
+                renderers::render_tool_progress_message(&msg, ctx.timestamp)
+            }
             AgentFrame::Claude(ClaudeMessage::Unknown)
             | AgentFrame::Codex(_)
             | AgentFrame::RawJson => render_raw_json(json),

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -329,6 +329,42 @@ pub fn render_rate_limit_event(msg: &shared::RateLimitEvent, timestamp: Option<&
     }
 }
 
+pub fn render_tool_progress_message(
+    msg: &shared::ToolProgressMessage,
+    timestamp: Option<&str>,
+) -> Html {
+    let elapsed_ms = (msg.elapsed_time_seconds.max(0.0) * 1000.0).round() as u64;
+    let elapsed = format_duration(elapsed_ms);
+    let tooltip = format!(
+        "{} has been running for {}",
+        msg.tool_name,
+        format_duration(elapsed_ms)
+    );
+
+    html! {
+        <div class="claude-message tool-progress-message">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
+                <span class="message-type-badge tool-progress">{ "Tool Progress" }</span>
+                <span class="tool-progress-inline" title={tooltip}>
+                    <span class="tool-progress-tool">{ &msg.tool_name }</span>
+                    <span class="tool-progress-detail">{ elapsed }</span>
+                    if let Some(parent_id) = &msg.parent_tool_use_id {
+                        <span class="tool-progress-detail monospace" title={parent_id.clone()}>
+                            { format!("parent {}", shared::fmt::truncate_str(parent_id, 18)) }
+                        </span>
+                    }
+                    if let Some(task_id) = &msg.task_id {
+                        <span class="tool-progress-detail monospace" title={task_id.clone()}>
+                            { format!("task {}", shared::fmt::truncate_str(task_id, 18)) }
+                        </span>
+                    }
+                </span>
+                <CopyButton text={msg.tool_use_id.clone()} title="Copy tool use ID" />
+            </div>
+        </div>
+    }
+}
+
 const ALLOWED_IMAGE_MEDIA_TYPES: &[&str] = &[
     "image/png",
     "image/jpeg",

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -40,6 +40,7 @@ pub enum ClaudeMessage {
     Error(shared::AnthropicError),
     Portal(PortalMessage),
     RateLimitEvent(shared::RateLimitEvent),
+    ToolProgress(shared::ToolProgressMessage),
     OptimisticUser(OptimisticUserMessage),
     Unknown,
 }
@@ -65,9 +66,10 @@ impl ClaudeMessage {
                 shared::ClaudeOutput::Result(msg) => Self::Result(msg),
                 shared::ClaudeOutput::Error(msg) => Self::Error(msg),
                 shared::ClaudeOutput::RateLimitEvent(msg) => Self::RateLimitEvent(msg),
+                shared::ClaudeOutput::ToolProgress(msg) => Self::ToolProgress(msg),
                 // Wildcard: control frames plus the 2.1.160 wire additions
-                // (stream_event, tool_progress, transcript variants, …) that
-                // have no dedicated renderer yet.
+                // (stream_event, transcript variants, …) that have no
+                // dedicated renderer yet.
                 _ => Self::Unknown,
             });
         }
@@ -90,9 +92,10 @@ impl<'de> Deserialize<'de> for ClaudeMessage {
                 shared::ClaudeOutput::Result(msg) => Self::Result(msg),
                 shared::ClaudeOutput::Error(msg) => Self::Error(msg),
                 shared::ClaudeOutput::RateLimitEvent(msg) => Self::RateLimitEvent(msg),
+                shared::ClaudeOutput::ToolProgress(msg) => Self::ToolProgress(msg),
                 // Wildcard: control frames plus the 2.1.160 wire additions
-                // (stream_event, tool_progress, transcript variants, …) that
-                // have no dedicated renderer yet.
+                // (stream_event, transcript variants, …) that have no
+                // dedicated renderer yet.
                 _ => Self::Unknown,
             });
         }

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -192,6 +192,7 @@ pub(super) fn message_type_tag(m: &ClaudeMessage) -> ActivityTag {
         ClaudeMessage::Error(_) => ActivityTag::Error,
         ClaudeMessage::Portal(_) => ActivityTag::Portal,
         ClaudeMessage::RateLimitEvent(_) => ActivityTag::RateLimit,
+        ClaudeMessage::ToolProgress(_) => ActivityTag::System,
         ClaudeMessage::Unknown => ActivityTag::Unknown,
     }
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1228,6 +1228,51 @@
     margin-right: 0.35rem;
 }
 
+/* ==========================================================================
+   Tool Progress Message
+   ========================================================================== */
+
+.tool-progress-message {
+    border-left: 3px solid #bb9af7;
+    background: rgba(187, 154, 247, 0.05);
+}
+
+.tool-progress-message .message-header {
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.message-type-badge.tool-progress {
+    background: rgba(187, 154, 247, 0.2);
+    color: #bb9af7;
+}
+
+.tool-progress-inline {
+    align-items: center;
+    color: var(--text-secondary);
+    display: inline-flex;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+    gap: 0.35rem;
+    min-width: 0;
+}
+
+.tool-progress-tool {
+    color: #bb9af7;
+    font-weight: 600;
+}
+
+.tool-progress-detail::before {
+    color: var(--text-muted);
+    content: "·";
+    margin-right: 0.35rem;
+}
+
+.tool-progress-detail.monospace {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+}
+
 .utilization-row {
     display: flex;
     align-items: center;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -96,7 +96,8 @@ pub use claude_codes::io::{
 pub use claude_codes::io::{
     AnthropicError, AssistantMessage, AssistantUsage, MessageContent, RateLimitEvent,
     ResultMessage, ServerToolUse, SystemMessage, SystemSubtype, TaskNotificationMessage,
-    TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType, TaskUsage, UserMessage,
+    TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType, TaskUsage, ToolProgressMessage,
+    UserMessage,
 };
 pub use claude_codes::CacheCreationDetails;
 pub use claude_codes::ClaudeOutput;


### PR DESCRIPTION
## Summary
- route typed Claude `tool_progress` frames through the Claude renderer instead of the raw unknown fallback
- add a compact tool-progress status row showing tool name, elapsed time, parent/task ids, and copyable tool-use id
- re-export the SDK `ToolProgressMessage` type through `shared` and add a regression test for the reported Bash heartbeat payload
- bump workspace version to 2.13.11

## Verification
- `cargo test -p frontend parses_claude_tool_progress_frame_to_claude_renderer`
- `cargo fmt --check`
- `cargo check -p frontend --target wasm32-unknown-unknown`
- `cargo clippy -p frontend --target wasm32-unknown-unknown --all-targets -- -D warnings`
- `python3 ./scripts/check-no-json-macro.py`
- `cd frontend/lint && npm ci && npm run lint:css`