### PR TITLE
Backfill session model watermarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agent-portal-mobile"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "agent-portal-mobile-status-notification",
  "reqwest 0.12.28",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "backend"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "a2",
  "anyhow",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "claude-portal"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "claude-session-lib"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "codex-session-lib"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "chrono",
  "claude-codes",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5190,7 +5190,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portal-auth"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "colored",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "portal-update"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "hex",
@@ -6331,7 +6331,7 @@ dependencies = [
 
 [[package]]
 name = "session-lib"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # `major.minor.{git commit count}`, derived at build time by `shared/build.rs`
 # so no PR ever edits a version line (issue #1096). Runtime version =
 # `shared::VERSION`.
-version = "2.13.10"
+version = "2.13.11"
 edition = "2021"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
 

--- a/backend/migrations/2026-07-21-090000_backfill_session_last_model/down.sql
+++ b/backend/migrations/2026-07-21-090000_backfill_session_last_model/down.sql
@@ -1,0 +1,3 @@
+-- Data-only backfill. Intentionally no-op on rollback: clearing
+-- sessions.last_model would destroy model observations written after this
+-- migration ran.

--- a/backend/migrations/2026-07-21-090000_backfill_session_last_model/up.sql
+++ b/backend/migrations/2026-07-21-090000_backfill_session_last_model/up.sql
@@ -1,0 +1,23 @@
+-- Populate sessions.last_model for sessions that already had turn metrics
+-- before the last_model column was added. New turns keep this column current
+-- through backend/src/handlers/websocket/turn_metrics.rs.
+WITH latest_model AS (
+    SELECT DISTINCT ON (tm.session_id)
+        tm.session_id,
+        LEFT(tm.model, 128) AS model
+    FROM turn_metrics tm
+    WHERE tm.session_id IS NOT NULL
+      AND tm.model IS NOT NULL
+      AND btrim(tm.model) <> ''
+      AND lower(btrim(tm.model)) <> 'unknown'
+    ORDER BY
+        tm.session_id,
+        COALESCE(tm.completed_at, tm.started_at) DESC,
+        tm.started_at DESC,
+        tm.id DESC
+)
+UPDATE sessions s
+SET last_model = latest_model.model
+FROM latest_model
+WHERE s.id = latest_model.session_id
+  AND s.last_model IS NULL;


### PR DESCRIPTION
## Summary
- add a data-only migration that backfills `sessions.last_model` from each session's latest non-null `turn_metrics.model`
- preserve existing `sessions.last_model` values so live/newer observations are not overwritten
- leave rollback as a no-op to avoid deleting legitimate post-migration model observations
- bump workspace version to 2.13.11

## Verification
- `./scripts/check-migration-names.sh`
- `cargo test -p shared model_version`
- `env -u NO_COLOR -u CLICOLOR -u CLICOLOR_FORCE trunk build` from `frontend/`
- `cargo test -p backend turn_metrics`
- `cargo fmt --check`
- `git diff --check`