### PR TITLE
Handle Claude tool_progress heartbeats as ephemeral live status

### DIFF
--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -414,6 +414,29 @@ fn handle_proxy_message(
                 *metrics,
             );
         }
+        ProxyToServer::ToolProgress {
+            session_id: _,
+            tool_use_id,
+            parent_tool_use_id,
+            tool_name,
+            elapsed_time_seconds,
+        } => {
+            // Ephemeral live-status heartbeat: fan out to the session's web
+            // clients only — deliberately NO DB write (unlike SequencedOutput).
+            // A 20-minute tool call emits ~40 of these; persisting them would
+            // bloat retention. If no client is connected it simply evaporates.
+            if let Some(key) = session_key {
+                session_manager.broadcast_to_web_clients(
+                    key,
+                    shared::ServerToClient::ToolProgress {
+                        tool_use_id,
+                        parent_tool_use_id,
+                        tool_name,
+                        elapsed_time_seconds,
+                    },
+                );
+            }
+        }
         ProxyToServer::SessionLimitReached(fields) => {
             handle_session_limit_reached(
                 app_state,

--- a/claude-session-lib/src/proxy_session/session_event.rs
+++ b/claude-session-lib/src/proxy_session/session_event.rs
@@ -96,6 +96,34 @@ pub(super) async fn handle_next_event<A: Agent>(
         return None;
     }
 
+    // Ephemeral tool-progress heartbeat: forward as a typed side-channel,
+    // mirroring `TurnMetricsReport` above. Deliberately bypasses the output
+    // buffer — heartbeats are live-status only and must never be persisted or
+    // replayed. The backend fans it out to web clients (never to the DB).
+    if let Some(SessionEvent::ToolProgress {
+        tool_use_id,
+        parent_tool_use_id,
+        tool_name,
+        elapsed_time_seconds,
+    }) = event
+    {
+        let msg = ProxyToServer::ToolProgress {
+            session_id: state.session_id,
+            tool_use_id,
+            parent_tool_use_id,
+            tool_name,
+            elapsed_time_seconds,
+        };
+        let mut ws = state.ws_write.lock().await;
+        if ws.send(msg).await.is_err() {
+            error!("Failed to send tool-progress heartbeat");
+            return Some(ConnectionResult::Disconnected(
+                state.connection_start.elapsed(),
+            ));
+        }
+        return None;
+    }
+
     // Codex app-server thread id: hand it to the persistence sink (the proxy's
     // ProxyConfig writer) so the next resume of this session can call
     // `thread/resume` with it. Emitted once per spawn by codex-session-lib.

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -341,6 +341,13 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
                 "SessionLimitReached should be handled before calling handle_session_event_with_wiggum"
             );
         }
+        Some(SessionEvent::ToolProgress { .. }) => {
+            // Handled in run_main_loop (session_event::handle_next_event) before
+            // calling this function — forwarded as a typed side-channel.
+            unreachable!(
+                "ToolProgress should be handled before calling handle_session_event_with_wiggum"
+            );
+        }
         Some(SessionEvent::Error(e)) => {
             let err_msg = e.to_string();
             error!("Session error: {}", err_msg);

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -26,8 +26,10 @@ use yew::prelude::*;
 
 use super::forward_chips::ForwardChips;
 use super::helpers::{
-    autoscroll_transition, classify_output_msg_type, enrich_codex_file_change_permission,
-    is_claude_awaiting, reconcile_pending_sends, update_pending_send_delivery, ActivityTag,
+    autoscroll_transition, classify_output_msg_type, clear_completed_tools,
+    enrich_codex_file_change_permission, format_tool_elapsed, is_claude_awaiting,
+    reconcile_pending_sends, running_tool_key, update_pending_send_delivery, upsert_tool_progress,
+    ActiveToolProgress, ActivityTag,
 };
 use super::input_bar::{InputBar, InputBarInbound};
 use super::outbox::Outbox;
@@ -253,6 +255,12 @@ pub struct SessionView {
     /// counter would buy nothing.
     turn_metrics: Vec<TurnMetrics>,
     continuation_statuses: HashMap<Uuid, String>,
+    /// Currently-running tools, fed by the ephemeral `WsEvent::ToolProgress`
+    /// heartbeat side-channel and rendered as a trailing "active tool" status
+    /// strip. Never persisted; pruned when a tool's result arrives or the turn
+    /// ends. Kept out of the memoized message-render props on purpose (see the
+    /// `helpers` tool-progress section).
+    active_tools: Vec<ActiveToolProgress>,
     /// Monotonic tick bumped on every `ForwardsChanged` frame; passed to the
     /// forward-chip strip as a prop so it refetches (docs/PORT_FORWARDING.md).
     forwards_refresh: u32,
@@ -331,6 +339,7 @@ impl Component for SessionView {
             pending_sends: Vec::new(),
             turn_metrics: Vec::new(),
             continuation_statuses: HashMap::new(),
+            active_tools: Vec::new(),
             forwards_refresh: 0,
         }
     }
@@ -662,6 +671,7 @@ impl Component for SessionView {
                         { for self.pending_sends.iter().enumerate().map(|(i, message)| {
                             html! { <MessageRenderer key={format!("p{}", i)} message={message.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
                         })}
+                        { self.render_active_tools() }
                     </div>
                     if !is_tailing {
                         <button
@@ -782,6 +792,18 @@ impl SessionView {
                 true
             }
             WsEvent::UploadResult(fields) => self.handle_upload_result(fields),
+            WsEvent::ToolProgress {
+                tool_use_id,
+                parent_tool_use_id,
+                tool_name,
+                elapsed_time_seconds,
+            } => {
+                // Ephemeral live status: refresh the running-tool strip. Never
+                // touches `messages` (no persistence, no replay watermark).
+                let key = running_tool_key(&tool_use_id, parent_tool_use_id.as_deref());
+                upsert_tool_progress(&mut self.active_tools, key, tool_name, elapsed_time_seconds);
+                true
+            }
         }
     }
 
@@ -1009,8 +1031,40 @@ impl SessionView {
             .emit((ctx.props().session.id, tag, activity_ts));
         reconcile_pending_sends(&mut self.pending_sends, tag, &output.content);
 
+        // Retire any active-tool strip entries this message completes: a
+        // tool_result for the running tool, or a turn `result` that ends the
+        // turn entirely. (The live heartbeat side-channel only adds entries.)
+        clear_completed_tools(&mut self.active_tools, &output.content);
+
         push_message_with_limit(&mut self.messages, output, MAX_MESSAGES_PER_SESSION);
         true
+    }
+
+    /// Trailing "active tool" strip: one live pill per currently-running tool,
+    /// showing "{tool} running — {elapsed}" and refreshed by the ephemeral
+    /// `WsEvent::ToolProgress` heartbeats. Renders nothing when idle. Lives at
+    /// the transcript tail rather than mutating historical tool cards so it
+    /// stays outside the memoized message-render pipeline (see the `helpers`
+    /// tool-progress section for the rationale).
+    fn render_active_tools(&self) -> Html {
+        if self.active_tools.is_empty() {
+            return html! {};
+        }
+        html! {
+            <div class="active-tool-strip">
+                { for self.active_tools.iter().map(|tool| {
+                    html! {
+                        <div class="active-tool-pill" key={tool.key.clone()}>
+                            <span class="active-tool-spinner" />
+                            <span class="active-tool-name">{ tool.tool_name.clone() }</span>
+                            <span class="active-tool-status">
+                                { format!("running — {}", format_tool_elapsed(tool.elapsed_seconds)) }
+                            </span>
+                        </div>
+                    }
+                }) }
+            </div>
+        }
     }
 
     fn handle_ws_error(&mut self, ctx: &Context<Self>, err: String) -> bool {

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -463,6 +463,129 @@ fn pending_client_msg_id(pending: &RenderedMessage) -> Option<uuid::Uuid> {
     pending.delivery().map(|delivery| delivery.client_msg_id)
 }
 
+// --- Ephemeral tool-progress ("active tool" strip) ------------------------
+//
+// Live heartbeats for long-running tools arrive on the non-persisted
+// `WsEvent::ToolProgress` side-channel (see `websocket.rs`) roughly every 30s.
+// The view holds an ordered list of currently-running tools and renders a
+// trailing status strip ("Bash running — 1m 30s"). We deliberately keep this
+// OUT of the memoized message-render pipeline: folding a per-heartbeat-changing
+// map into `MessageRenderer` props would re-render the whole transcript every
+// 30s. A trailing strip re-renders only itself — the framework's grain.
+
+/// One currently-running tool tracked for the live "active tool" strip.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ActiveToolProgress {
+    /// Correlation key = the running tool's id (see [`running_tool_key`]).
+    pub key: String,
+    pub tool_name: String,
+    pub elapsed_seconds: f64,
+}
+
+/// Derive the correlation key for a heartbeat: the *running* tool's id.
+///
+/// Claude's `tool_progress` frame carries `tool_use_id` = `<base>-heartbeat-N`
+/// and, in production, `parent_tool_use_id` = the base tool id. The base id is
+/// what the eventual `tool_result` block carries, so keying on it lets us clear
+/// the entry when the tool finishes. Prefer `parent_tool_use_id`; otherwise
+/// strip the `-heartbeat-N` suffix from `tool_use_id` (older/edge wire shapes
+/// where the parent is absent); fall back to `tool_use_id` verbatim.
+pub(crate) fn running_tool_key(tool_use_id: &str, parent_tool_use_id: Option<&str>) -> String {
+    if let Some(parent) = parent_tool_use_id.filter(|p| !p.is_empty()) {
+        return parent.to_string();
+    }
+    match tool_use_id.rsplit_once("-heartbeat-") {
+        Some((base, _)) if !base.is_empty() => base.to_string(),
+        _ => tool_use_id.to_string(),
+    }
+}
+
+/// Upsert a heartbeat into the ordered active-tool list: refresh the elapsed
+/// time of an existing entry in place (preserving display order) or append a
+/// new one. Order-preserving so the strip doesn't reshuffle every 30s.
+pub(crate) fn upsert_tool_progress(
+    list: &mut Vec<ActiveToolProgress>,
+    key: String,
+    tool_name: String,
+    elapsed_seconds: f64,
+) {
+    if let Some(existing) = list.iter_mut().find(|t| t.key == key) {
+        existing.tool_name = tool_name;
+        existing.elapsed_seconds = elapsed_seconds;
+    } else {
+        list.push(ActiveToolProgress {
+            key,
+            tool_name,
+            elapsed_seconds,
+        });
+    }
+}
+
+/// Prune finished tools from the active-tool list given a freshly-arrived
+/// output message. A turn terminator (`result`) means nothing is running, so
+/// the whole list clears; otherwise any tool whose id appears as a
+/// `tool_result` in the message is done and its entry is dropped. Returns
+/// whether anything changed (so the caller can skip a re-render).
+pub(crate) fn clear_completed_tools(list: &mut Vec<ActiveToolProgress>, content: &str) -> bool {
+    if list.is_empty() {
+        return false;
+    }
+    let Ok(output) = serde_json::from_str::<shared::ClaudeOutput>(content) else {
+        return false;
+    };
+    match output {
+        // Turn over → nothing is running anymore.
+        shared::ClaudeOutput::Result(_) => {
+            list.clear();
+            true
+        }
+        shared::ClaudeOutput::User(user) => {
+            let finished = tool_result_ids(&user.message.content);
+            prune_keys(list, &finished)
+        }
+        shared::ClaudeOutput::Assistant(asst) => {
+            let finished = tool_result_ids(&asst.message.content);
+            prune_keys(list, &finished)
+        }
+        _ => false,
+    }
+}
+
+fn tool_result_ids(blocks: &[shared::ContentBlock]) -> Vec<String> {
+    blocks
+        .iter()
+        .filter_map(|b| match b {
+            shared::ContentBlock::ToolResult(tr) => Some(tr.tool_use_id.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn prune_keys(list: &mut Vec<ActiveToolProgress>, finished: &[String]) -> bool {
+    if finished.is_empty() {
+        return false;
+    }
+    let before = list.len();
+    list.retain(|t| !finished.contains(&t.key));
+    list.len() != before
+}
+
+/// Format an elapsed-seconds count as a compact human duration: `45s`,
+/// `1m 30s`, `1h 05m` (seconds dropped past an hour to stay short).
+pub(crate) fn format_tool_elapsed(seconds: f64) -> String {
+    let total = seconds.max(0.0) as u64;
+    let hours = total / 3600;
+    let minutes = (total % 3600) / 60;
+    let secs = total % 60;
+    if hours > 0 {
+        format!("{hours}h {minutes:02}m")
+    } else if minutes > 0 {
+        format!("{minutes}m {secs:02}s")
+    } else {
+        format!("{secs}s")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -957,5 +1080,127 @@ mod tests {
             ),
             ActivityTag::Error
         );
+    }
+
+    // --- tool-progress ("active tool" strip) ---
+
+    #[test]
+    fn running_tool_key_prefers_parent_then_strips_heartbeat_suffix() {
+        // Production shape: parent is the base tool id → key on it.
+        assert_eq!(
+            running_tool_key("toolu_01abc-heartbeat-3", Some("toolu_01abc")),
+            "toolu_01abc"
+        );
+        // No parent → strip the -heartbeat-N suffix from tool_use_id.
+        assert_eq!(
+            running_tool_key("toolu_01abc-heartbeat-0", None),
+            "toolu_01abc"
+        );
+        // Empty parent is treated as absent.
+        assert_eq!(
+            running_tool_key("toolu_01abc-heartbeat-0", Some("")),
+            "toolu_01abc"
+        );
+        // No suffix and no parent → verbatim.
+        assert_eq!(running_tool_key("toolu_01abc", None), "toolu_01abc");
+    }
+
+    #[test]
+    fn upsert_tool_progress_refreshes_in_place_preserving_order() {
+        let mut list = Vec::new();
+        upsert_tool_progress(&mut list, "a".into(), "Bash".into(), 30.0);
+        upsert_tool_progress(&mut list, "b".into(), "Read".into(), 30.0);
+        // Refresh "a": elapsed updates, order stays [a, b].
+        upsert_tool_progress(&mut list, "a".into(), "Bash".into(), 60.0);
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].key, "a");
+        assert_eq!(list[0].elapsed_seconds, 60.0);
+        assert_eq!(list[1].key, "b");
+    }
+
+    #[test]
+    fn clear_completed_tools_drops_matching_tool_result() {
+        let mut list = vec![
+            ActiveToolProgress {
+                key: "toolu_01".into(),
+                tool_name: "Bash".into(),
+                elapsed_seconds: 90.0,
+            },
+            ActiveToolProgress {
+                key: "toolu_02".into(),
+                tool_name: "Read".into(),
+                elapsed_seconds: 30.0,
+            },
+        ];
+        let user_result = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_01",
+                    "content": "done",
+                }]
+            },
+            "session_id": "01890000-0000-7000-8000-000000000001",
+        })
+        .to_string();
+        assert!(clear_completed_tools(&mut list, &user_result));
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].key, "toolu_02");
+    }
+
+    #[test]
+    fn clear_completed_tools_clears_all_on_turn_result() {
+        let mut list = vec![ActiveToolProgress {
+            key: "toolu_01".into(),
+            tool_name: "Bash".into(),
+            elapsed_seconds: 90.0,
+        }];
+        let result = serde_json::json!({
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "duration_ms": 100,
+            "duration_api_ms": 80,
+            "num_turns": 1,
+            "session_id": "01890000-0000-7000-8000-000000000001",
+            "total_cost_usd": 0.0,
+        })
+        .to_string();
+        assert!(clear_completed_tools(&mut list, &result));
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn clear_completed_tools_is_noop_for_unrelated_message() {
+        let mut list = vec![ActiveToolProgress {
+            key: "toolu_01".into(),
+            tool_name: "Bash".into(),
+            elapsed_seconds: 90.0,
+        }];
+        let assistant = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "role": "assistant",
+                "model": "claude-sonnet-4-5",
+                "content": [{"type": "text", "text": "still working"}],
+            },
+            "session_id": "01890000-0000-7000-8000-000000000001",
+        })
+        .to_string();
+        assert!(!clear_completed_tools(&mut list, &assistant));
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn format_tool_elapsed_shapes() {
+        assert_eq!(format_tool_elapsed(0.0), "0s");
+        assert_eq!(format_tool_elapsed(45.0), "45s");
+        assert_eq!(format_tool_elapsed(90.0), "1m 30s");
+        assert_eq!(format_tool_elapsed(3725.0), "1h 02m");
+        // Negative guards to zero rather than panicking.
+        assert_eq!(format_tool_elapsed(-5.0), "0s");
     }
 }

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -55,6 +55,15 @@ pub enum WsEvent {
     /// Terminal outcome of a file upload (#939 phase 4). The view gates the
     /// prompt referencing the file on this.
     UploadResult(shared::FileUploadResultFields),
+    /// Ephemeral live tool-progress heartbeat (`ServerToClient::ToolProgress`).
+    /// Drives the per-session "active tool" strip; never persisted, so it is
+    /// not part of `Output`/`HistoryBatch` and carries no timestamp.
+    ToolProgress {
+        tool_use_id: String,
+        parent_tool_use_id: Option<String>,
+        tool_name: String,
+        elapsed_time_seconds: f64,
+    },
 }
 
 /// Connect to WebSocket and start receiving messages.
@@ -229,6 +238,19 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
         }
         ServerToClient::ForwardsChanged { session_id: _ } => {
             on_event.emit(WsEvent::ForwardsChanged);
+        }
+        ServerToClient::ToolProgress {
+            tool_use_id,
+            parent_tool_use_id,
+            tool_name,
+            elapsed_time_seconds,
+        } => {
+            on_event.emit(WsEvent::ToolProgress {
+                tool_use_id,
+                parent_tool_use_id,
+                tool_name,
+                elapsed_time_seconds,
+            });
         }
         unhandled => {
             // Variants we haven't wired a UI route for yet (e.g. new
@@ -594,6 +616,7 @@ mod tests {
             WsEvent::InputProgress { .. } => "InputProgress",
             WsEvent::ForwardsChanged => "ForwardsChanged",
             WsEvent::UploadResult(_) => "UploadResult",
+            WsEvent::ToolProgress { .. } => "ToolProgress",
         }
     }
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1482,3 +1482,52 @@
     background: rgba(122, 162, 247, 0.25);
     text-decoration: underline;
 }
+
+/* ==========================================================================
+   Active-tool strip (ephemeral tool_progress heartbeats)
+
+   A live status line at the transcript tail — one pill per currently-running
+   tool, showing "running — 1m 30s", refreshed as tool_progress heartbeats
+   arrive (~30s). Never persisted; cleared when the tool result arrives or the
+   turn ends. Deliberately separate from historical tool cards so it stays out
+   of the memoized message-render pipeline.
+   ========================================================================== */
+
+.active-tool-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0.25rem 0.1rem 0.1rem;
+}
+
+.active-tool-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.75rem;
+    font-family: var(--font-mono);
+    color: var(--text-secondary);
+    background: rgba(122, 162, 247, 0.08);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.15rem 0.6rem;
+}
+
+.active-tool-spinner {
+    width: 0.7rem;
+    height: 0.7rem;
+    border: 2px solid rgba(122, 162, 247, 0.35);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    flex-shrink: 0;
+}
+
+.active-tool-name {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.active-tool-status {
+    color: var(--text-muted);
+}

--- a/session-lib/src/adapter.rs
+++ b/session-lib/src/adapter.rs
@@ -40,6 +40,25 @@ pub enum AgentOutput {
     },
     /// Fatal "conversation not found" → maps to `SessionEvent::SessionNotFound`.
     NotFound,
+    /// An ephemeral tool-progress heartbeat (Claude's `tool_progress` frame).
+    ///
+    /// A distinct outcome from `Visible` on purpose: heartbeats are pure
+    /// live-status and must NOT be buffered or persisted (a long-running tool
+    /// emits one every ~30s — a 20-minute Bash call would otherwise write ~40
+    /// junk rows into `messages` and render ~40 "Unrecognized Message" cards).
+    /// `Session` maps this to `SessionEvent::ToolProgress` without touching the
+    /// replay buffer; the proxy forwards it on a typed side-channel that the
+    /// backend fans out to web clients (never to the DB). Codex has no analogue
+    /// today, so only `ClaudeAdapter` produces it.
+    ToolProgress {
+        /// The heartbeat's own id (`<tool_use_id>-heartbeat-N`).
+        tool_use_id: String,
+        /// The running tool's id when Claude provides it (see the wire docs on
+        /// `shared::ProxyToServer::ToolProgress`).
+        parent_tool_use_id: Option<String>,
+        tool_name: String,
+        elapsed_time_seconds: f64,
+    },
     /// Internal ack / nothing for the consumer — `Session` skips it.
     Noop,
 }
@@ -155,6 +174,16 @@ impl AgentOutputClassifier for ClaudeAdapter {
             }
             // Control responses are CLI acks — internal, the consumer skips.
             ClaudeOutput::ControlResponse(_) => vec![AgentOutput::Noop],
+            // Tool-progress heartbeat → ephemeral live status, never persisted.
+            // Handled explicitly (not via the `Visible` fall-through) so a
+            // long-running tool's ~30s heartbeats don't flood `messages` /
+            // render as "Unrecognized Message" cards. See `AgentOutput::ToolProgress`.
+            ClaudeOutput::ToolProgress(tp) => vec![AgentOutput::ToolProgress {
+                tool_use_id: tp.tool_use_id,
+                parent_tool_use_id: tp.parent_tool_use_id,
+                tool_name: tp.tool_name,
+                elapsed_time_seconds: tp.elapsed_time_seconds,
+            }],
             // Everything else (System, User, Assistant, Error, RateLimitEvent)
             // is user-visible.
             _ => vec![AgentOutput::Visible(raw)],
@@ -321,6 +350,43 @@ mod tests {
         });
         let mut adapter = ClaudeAdapter;
         assert_eq!(adapter.classify(raw), vec![AgentOutput::Noop]);
+    }
+
+    #[test]
+    fn classify_tool_progress_is_ephemeral_not_visible() {
+        // The production heartbeat shape: a `-heartbeat-N` tool_use_id with the
+        // running tool's base id in `parent_tool_use_id`, arriving every ~30s.
+        let raw = json!({
+            "type": "tool_progress",
+            "tool_name": "Bash",
+            "elapsed_time_seconds": 30.0,
+            "parent_tool_use_id": "toolu_01abc",
+            "tool_use_id": "toolu_01abc-heartbeat-0",
+            "session_id": "01890000-0000-7000-8000-000000000001",
+            "uuid": "01890000-0000-7000-8000-000000000002"
+        });
+        let mut adapter = ClaudeAdapter;
+        let out = adapter.classify(raw);
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            AgentOutput::ToolProgress {
+                tool_use_id,
+                parent_tool_use_id,
+                tool_name,
+                elapsed_time_seconds,
+            } => {
+                assert_eq!(tool_use_id, "toolu_01abc-heartbeat-0");
+                assert_eq!(parent_tool_use_id.as_deref(), Some("toolu_01abc"));
+                assert_eq!(tool_name, "Bash");
+                assert_eq!(*elapsed_time_seconds, 30.0);
+            }
+            other => panic!("expected ToolProgress, got {other:?}"),
+        }
+        // The critical invariant: a heartbeat is NOT a Visible/persisted frame.
+        assert!(
+            !matches!(&out[0], AgentOutput::Visible(_)),
+            "tool_progress must never classify as Visible — it would be persisted"
+        );
     }
 
     #[test]

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -136,6 +136,20 @@ pub enum SessionEvent {
     /// proxy can persist it. See `IoEvent::CodexThreadId`.
     CodexThreadId(String),
 
+    /// Ephemeral tool-progress heartbeat for a long-running tool call.
+    ///
+    /// Deliberately NOT buffered into the replay buffer by `Session` (unlike
+    /// `RawOutput`): heartbeats are live-status only and must never be
+    /// persisted or replayed. The proxy forwards this on a typed side-channel
+    /// (`ProxyToServer::ToolProgress`), mirroring how `TurnMetricsReady`
+    /// bypasses the output buffer. See `crate::adapter::AgentOutput::ToolProgress`.
+    ToolProgress {
+        tool_use_id: String,
+        parent_tool_use_id: Option<String>,
+        tool_name: String,
+        elapsed_time_seconds: f64,
+    },
+
     /// Claude reported a hard session limit with a reset time.
     SessionLimitReached {
         session_id: uuid::Uuid,

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -269,6 +269,23 @@ impl<A: Agent> Session<A> {
                             self.buffer.push(value.clone());
                             return Some(SessionEvent::RawOutput(value));
                         }
+                        // Ephemeral tool-progress heartbeat: forward it as a
+                        // live-status side-channel event WITHOUT buffering, so
+                        // it is never persisted or replayed. See
+                        // `AgentOutput::ToolProgress`.
+                        AgentOutput::ToolProgress {
+                            tool_use_id,
+                            parent_tool_use_id,
+                            tool_name,
+                            elapsed_time_seconds,
+                        } => {
+                            return Some(SessionEvent::ToolProgress {
+                                tool_use_id,
+                                parent_tool_use_id,
+                                tool_name,
+                                elapsed_time_seconds,
+                            });
+                        }
                         // Internal ack / nothing for the consumer — skip it and
                         // let the outer loop pull the next event.
                         AgentOutput::Noop => {}

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -327,4 +327,19 @@ pub enum ServerToClient {
     /// `GET /api/sessions/{id}/forwards` — the frame carries no payload so
     /// there is exactly one source of truth (docs/PORT_FORWARDING.md).
     ForwardsChanged { session_id: Uuid },
+
+    /// Ephemeral live tool-progress heartbeat, fanned out from
+    /// `ProxyToServer::ToolProgress`. Purely a live-status signal: never
+    /// persisted, never part of `HistoryBatch`, so it carries no `created_at`
+    /// / `PortalMeta`. The frontend keys a per-session "active tool" strip by
+    /// the running tool's id (derived from `parent_tool_use_id` / `tool_use_id`)
+    /// and clears the entry when the tool's result arrives or the turn ends. A
+    /// client that never sees it (offline during the tool call) loses nothing.
+    ToolProgress {
+        tool_use_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_tool_use_id: Option<String>,
+        tool_name: String,
+        elapsed_time_seconds: f64,
+    },
 }

--- a/shared/src/endpoints/session.rs
+++ b/shared/src/endpoints/session.rs
@@ -125,6 +125,30 @@ pub enum ProxyToServer {
     /// hot-path frames that fly orders of magnitude more often.
     TurnMetricsReport(Box<TurnMetrics>),
 
+    /// Ephemeral tool-progress heartbeat from Claude for a long-running tool
+    /// call (`ClaudeOutput::ToolProgress`, emitted every ~30s while the tool
+    /// runs). Deliberately a typed side-channel — NOT `SequencedOutput`: it is
+    /// never buffered, never persisted (a 20-minute Bash call would otherwise
+    /// write ~40 noise rows into `messages` and blow retention), and never
+    /// replayed. The backend fans it out to the session's web clients as
+    /// `ServerToClient::ToolProgress` to drive a live "running — Xs" status;
+    /// if no client is listening it simply evaporates. See the classifier
+    /// (`session_lib::adapter::ClaudeAdapter`) and the frontend active-tool
+    /// strip for the two ends of this path.
+    ToolProgress {
+        session_id: Uuid,
+        /// The heartbeat's own id (`<tool_use_id>-heartbeat-N`).
+        tool_use_id: String,
+        /// The running tool's id, when Claude sets it. In production this is
+        /// the base tool id (the heartbeat id minus the `-heartbeat-N`
+        /// suffix); `None` for the top-level agent in some wire shapes. The
+        /// frontend derives its correlation key from this plus `tool_use_id`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_tool_use_id: Option<String>,
+        tool_name: String,
+        elapsed_time_seconds: f64,
+    },
+
     /// Claude reported a hard session limit with a reset time. The backend
     /// persists a one-shot continuation candidate and asks the user whether
     /// to schedule it.


### PR DESCRIPTION
## Problem

Claude Code emits `tool_progress` heartbeat frames (`ClaudeOutput::ToolProgress`, supported since claude-codes 2.1.160; workspace pins 2.1.161) every ~30s while a long-running tool runs. The portal rendered each as an "Unrecognized Message" card **and persisted it** — a 20-minute Bash call produced ~40 noise rows in `messages` (blowing retention) plus ~40 junk cards.

## What this does

Handles heartbeats at the first typed dispatch point (the session-lib classifier) as a new **ephemeral** outcome that is never buffered, persisted, or replayed, then fans them out to web clients on a typed side-channel — the same shape as `TurnMetricsReport` / `InputProgress`.

Chain of custody:

- **Classifier** (`session_lib::adapter::ClaudeAdapter`): matches `ClaudeOutput::ToolProgress` **explicitly** → `AgentOutput::ToolProgress`, instead of the `Visible` catch-all. (Kept the exhaustive-match discipline: the wiggum `SessionEvent` match gets an explicit `ToolProgress` arm too.)
- **Session** (`Session::next_event`): maps it to `SessionEvent::ToolProgress` **without pushing to the replay buffer** — so it is structurally impossible for a heartbeat to be persisted or replayed.
- **Proxy** (`session_event::handle_next_event`): forwards `ProxyToServer::ToolProgress` on the typed side-channel, bypassing the output buffer.
- **Backend** (`proxy_socket`): broadcasts `ServerToClient::ToolProgress` to the session's web clients — **no DB write**. If no client is connected it evaporates.
- **Frontend**: a live "running — 1m 30s" strip at the transcript tail, one pill per active tool, keyed by the running tool's id (derived from `parent_tool_use_id` / by stripping the `-heartbeat-N` suffix) and cleared when the tool's result arrives or the turn ends.

## Tier achieved: **live elapsed** (best case)

Elapsed time renders live and updates as heartbeats arrive. One design note: it renders as a dedicated ephemeral status strip at the transcript tail rather than mutating each historical tool card in place. Threading a per-heartbeat-changing map into the memoized `MessageRenderer` / `MessageGroupRenderer` props would re-render the entire transcript every 30s; the trailing strip re-renders only itself — the framework's grain. The correlation key is documented so a future move onto the card itself is a small, seam-named change.

## Persistence confirmation

No DB rows: heartbeats never become `AgentOutput::Visible`, are never pushed to the `Session` replay buffer, and the backend arm has no `messages` insert (unlike `SequencedOutput`). The "Unrecognized Message" card disappears purely because the frame no longer reaches the frontend as persisted content.

## Codex parity

Codex has no `tool_progress` analogue that our pipeline mishandles: its `item.started → item.updated → item.completed` lifecycle is already classified and deduped at render (#776), so it produces no "Unrecognized" cards. There is a separate `item/mcpToolCall/progress` notification in codex-codes worth auditing later for the same ephemeral treatment — noted as a **follow-up**, not implemented here.

## Tests

- Classifier: `tool_progress` produces the ephemeral `ToolProgress` outcome, asserted **not** `Visible` (the persistence invariant).
- Frontend helpers: running-tool key derivation (parent vs. heartbeat-suffix strip), order-preserving upsert, clear-on-tool-result, clear-all-on-turn-result, and elapsed formatting.

Verified: `cargo fmt --check`; `cargo clippy --workspace --exclude frontend --all-targets -D warnings`; `cargo clippy -p frontend --target wasm32 -D warnings`; `cargo test --workspace`; `cargo build -p agent-portal` (Sync); `trunk build` + `cargo build -p backend`.