### PR TITLE
Add launcher and archiver provenance to session archive manifests

### DIFF
--- a/backend/migrations/2026-07-23-023050_add_launcher_version_to_sessions/down.sql
+++ b/backend/migrations/2026-07-23-023050_add_launcher_version_to_sessions/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN launcher_version;

--- a/backend/migrations/2026-07-23-023050_add_launcher_version_to_sessions/up.sql
+++ b/backend/migrations/2026-07-23-023050_add_launcher_version_to_sessions/up.sql
@@ -1,0 +1,6 @@
+-- Persist the launching launcher's reported version onto the session row so
+-- it survives into long-term archive manifests (#1258 provenance). The live
+-- version lives only in the in-memory launcher registry, which is gone by the
+-- time the archival sweep runs; capturing it at session-create time is the
+-- only durable source. NULL for non-launcher (proxy-direct) sessions.
+ALTER TABLE sessions ADD COLUMN launcher_version VARCHAR(32);

--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -278,6 +278,45 @@ pub struct SessionArchiveManifest {
     /// contract [`ARCHIVE_SCHEMA_VERSION`] guards, so it is **not** bumped.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub media: Option<Vec<MediaEntry>>,
+
+    // --- Provenance (all additive within schema v1) ---
+    //
+    // These follow the same additive-compat contract as `media` above:
+    // each is `#[serde(default, skip_serializing_if = …)]`, so a manifest
+    // written before the field existed deserializes to the empty value and
+    // a manifest without the datum re-serializes byte-identically (key
+    // omitted). No existing field or the object layout changes, so
+    // [`ARCHIVE_SCHEMA_VERSION`] is **not** bumped.
+    /// The launcher that spawned this session (`sessions.launcher_id`), or
+    /// `None` for proxy-direct sessions. Pairs with `launcher_version`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launcher_id: Option<Uuid>,
+    /// The launcher's self-reported version at launch time
+    /// (`sessions.launcher_version`), captured when the session row was
+    /// created. **Last-known-at-launch**: a mid-session launcher
+    /// auto-update does not refresh it. `None` for non-launcher sessions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launcher_version: Option<String>,
+    /// The scheduled (cron) task that spawned this session
+    /// (`sessions.scheduled_task_id`), linking an archived session back to
+    /// the automation that created it. `None` for interactively-launched
+    /// sessions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduled_task_id: Option<Uuid>,
+    /// Extra CLI arguments the agent binary was launched with
+    /// (`sessions.claude_args`), e.g. `["--model", "opus"]`. Reveals model
+    /// pinning and other launch-time behavior knobs. These are agent CLI
+    /// flags only — portal auth travels via a separate proxy token, never
+    /// here — so they carry no transport/auth secrets. Empty (and thus
+    /// omitted) for sessions launched with no extra args.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub claude_args: Vec<String>,
+    /// `shared::VERSION` of the backend that performed this archive write.
+    /// **Per-write**: a re-archive by a newer backend stamps the newer
+    /// version, so this records who last wrote the object, not who first
+    /// created the session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_by_version: Option<String>,
 }
 
 /// One archived media blob referenced from a manifest. The bytes live at
@@ -768,6 +807,11 @@ mod tests {
             turns: ArchiveTurnStats::default(),
             transcript: None,
             media: None,
+            launcher_id: None,
+            launcher_version: None,
+            scheduled_task_id: None,
+            claude_args: Vec::new(),
+            archived_by_version: None,
         }
     }
 
@@ -1109,6 +1153,71 @@ mod tests {
         assert!(value.as_object_mut().unwrap().remove("media").is_none());
         let parsed: SessionArchiveManifest = serde_json::from_value(value).unwrap();
         assert_eq!(parsed.media, None);
+    }
+
+    #[test]
+    fn manifest_provenance_fields_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArchiveStore::Local(LocalArchiveStore {
+            root: tmp.path().to_path_buf(),
+        });
+        let (u, s) = (Uuid::from_u128(4), Uuid::from_u128(5));
+        let mut manifest = manifest(u, s);
+        manifest.launcher_id = Some(Uuid::from_u128(6));
+        manifest.launcher_version = Some("2.13.42".into());
+        manifest.scheduled_task_id = Some(Uuid::from_u128(7));
+        manifest.claude_args = vec!["--model".into(), "opus".into()];
+        manifest.archived_by_version = Some("2.13.99".into());
+        let bundle = SessionArchiveBundle {
+            manifest: manifest.clone(),
+            transcript_ndjson: None,
+        };
+        store.put_session_archive(&bundle).unwrap();
+        let got = store.get_session_manifest(u, s).unwrap().expect("manifest");
+        assert_eq!(got, manifest);
+    }
+
+    #[test]
+    fn old_manifest_without_provenance_fields_parses() {
+        // A manifest written before the provenance fields existed must still
+        // deserialize (each is additive/optional → empty default), and a
+        // manifest with none of them set must omit every key (byte-compat).
+        let u = Uuid::from_u128(1);
+        let s = Uuid::from_u128(2);
+        let m = manifest(u, s);
+        let json = serde_json::to_string(&m).unwrap();
+        for key in [
+            "launcher_id",
+            "launcher_version",
+            "scheduled_task_id",
+            "claude_args",
+            "archived_by_version",
+        ] {
+            assert!(
+                !json.contains(&format!("\"{key}\"")),
+                "provenance-less manifest must omit `{key}`: {json}"
+            );
+        }
+
+        // Simulate an old writer: strip the keys entirely and confirm the
+        // manifest still round-trips to empty defaults.
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        for key in [
+            "launcher_id",
+            "launcher_version",
+            "scheduled_task_id",
+            "claude_args",
+            "archived_by_version",
+        ] {
+            assert!(obj.remove(key).is_none());
+        }
+        let parsed: SessionArchiveManifest = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.launcher_id, None);
+        assert_eq!(parsed.launcher_version, None);
+        assert_eq!(parsed.scheduled_task_id, None);
+        assert!(parsed.claude_args.is_empty());
+        assert_eq!(parsed.archived_by_version, None);
     }
 
     fn walk(dir: &Path) -> Vec<PathBuf> {

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -360,6 +360,15 @@ fn archive_one_session(
             turns,
             transcript: transcript_info,
             media,
+            launcher_id: session.launcher_id,
+            launcher_version: session.launcher_version.clone(),
+            scheduled_task_id: session.scheduled_task_id,
+            // `claude_args` is stored as a JSONB string array; recover it as
+            // Vec<String>, tolerating a malformed/absent value as empty.
+            claude_args: serde_json::from_value(session.claude_args.clone()).unwrap_or_default(),
+            // Per-write provenance: whichever backend runs this sweep stamps
+            // its own version, so a re-archive reflects the newer writer.
+            archived_by_version: Some(shared::VERSION.to_string()),
         },
         transcript_ndjson,
     };

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -204,6 +204,12 @@ pub(crate) fn create_desired_session(
         paused: false,
         claude_args: serde_json::to_value(&draft.claude_args)
             .unwrap_or_else(|_| serde_json::Value::Array(Vec::new())),
+        // Stamp the launcher's live version now — the registry entry that
+        // holds it is gone by archive time (see
+        // `NewSessionWithId::launcher_version`).
+        launcher_version: app_state
+            .session_manager
+            .launcher_version(draft.launcher_id),
     };
 
     diesel::insert_into(sessions::table)

--- a/backend/src/handlers/media_archive.rs
+++ b/backend/src/handlers/media_archive.rs
@@ -344,6 +344,7 @@ mod tests {
                 scheduled_task_id: None,
                 paused: false,
                 claude_args: serde_json::Value::Array(vec![]),
+                launcher_version: None,
             })
             .execute(&mut conn)
             .expect("insert session");

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -323,6 +323,7 @@ mod db_tests {
             scheduled_task_id: None,
             paused: false,
             claude_args: serde_json::Value::Array(Vec::new()),
+            launcher_version: None,
         };
         diesel::insert_into(sessions::table)
             .values(&new_session)

--- a/backend/src/handlers/session_access.rs
+++ b/backend/src/handlers/session_access.rs
@@ -229,6 +229,7 @@ mod db_tests {
             scheduled_task_id: None,
             paused: false,
             claude_args: serde_json::Value::Array(Vec::new()),
+            launcher_version: None,
         };
         diesel::insert_into(sessions::table)
             .values(&new_session)

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -715,6 +715,7 @@ mod tests {
             scheduled_task_id: None,
             paused: false,
             claude_args: serde_json::Value::Array(Vec::new()),
+            launcher_version: None,
         };
         diesel::insert_into(sessions::table)
             .values(&new_session)

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -218,7 +218,16 @@ pub fn register_or_update_session(
             );
         }
 
-        create_new_session(&mut conn, requesting_user_id, params)
+        // Resolve the launcher's live version from the in-memory registry
+        // *now*, at create time — it's the only moment the connection is
+        // guaranteed present. It won't be available at archive time (the
+        // registry entry is long gone), so we persist it onto the row. See
+        // `NewSessionWithId::launcher_version` for the last-known-at-launch
+        // semantics.
+        let launcher_version = app_state
+            .session_manager
+            .launcher_version(params.launcher_id);
+        create_new_session(&mut conn, requesting_user_id, params, launcher_version)
     };
 
     // Bind the auth token to the session it just registered, and revoke any
@@ -271,6 +280,7 @@ fn create_new_session(
     conn: &mut diesel::PgConnection,
     user_id: Uuid,
     params: &RegistrationParams,
+    launcher_version: Option<String>,
 ) -> RegistrationResult {
     use crate::schema::{session_members, sessions};
 
@@ -291,6 +301,7 @@ fn create_new_session(
         paused: false,
         claude_args: serde_json::to_value(params.claude_args)
             .unwrap_or_else(|_| serde_json::Value::Array(Vec::new())),
+        launcher_version,
     };
 
     match diesel::insert_into(sessions::table)
@@ -514,5 +525,66 @@ mod tests {
                 "SESSION_NOT_FOUND_ERROR (`{SESSION_NOT_FOUND_ERROR}`) leaks rejection cause via substring `{forbidden}`"
             );
         }
+    }
+
+    /// The launcher-version capture wiring end-to-end at the DB layer: a
+    /// session created with a `launcher_version` must read back with it
+    /// intact (migration + schema + model round-trip), so the value is
+    /// durable for the archive sweep that runs long after the launcher's
+    /// in-memory registry entry is gone. Skips when no test DB is available.
+    #[test]
+    fn launcher_version_persists_on_session_row() {
+        use crate::models::{NewSessionWithId, NewUser, Session, User};
+        use crate::schema::{sessions, users};
+
+        let Some(pool) = crate::test_support::shared_pool() else {
+            return;
+        };
+        let mut conn = pool.get().expect("conn");
+
+        let nonce = Uuid::new_v4();
+        let user = diesel::insert_into(users::table)
+            .values(&NewUser {
+                google_id: format!("test_launcher_version_{nonce}"),
+                email: format!("test_launcher_version_{nonce}@example.invalid"),
+                name: Some("Launcher Version Test".to_string()),
+                avatar_url: None,
+            })
+            .get_result::<User>(&mut conn)
+            .expect("insert test user");
+
+        let session_id = Uuid::new_v4();
+        let created = diesel::insert_into(sessions::table)
+            .values(&NewSessionWithId {
+                id: session_id,
+                user_id: user.id,
+                session_name: format!("launcher-version-{session_id}"),
+                session_key: session_id.to_string(),
+                working_directory: "/tmp".to_string(),
+                status: SessionStatus::Active.as_str().to_string(),
+                git_branch: None,
+                client_version: None,
+                hostname: "test-host".to_string(),
+                launcher_id: Some(Uuid::new_v4()),
+                agent_type: "claude".to_string(),
+                repo_url: None,
+                scheduled_task_id: None,
+                paused: false,
+                claude_args: serde_json::Value::Array(Vec::new()),
+                launcher_version: Some("2.13.42".to_string()),
+            })
+            .get_result::<Session>(&mut conn)
+            .expect("insert session");
+
+        assert_eq!(created.launcher_version.as_deref(), Some("2.13.42"));
+
+        let fetched = sessions::table
+            .find(session_id)
+            .first::<Session>(&mut conn)
+            .expect("fetch session");
+        assert_eq!(fetched.launcher_version.as_deref(), Some("2.13.42"));
+
+        let _ = diesel::delete(sessions::table.find(session_id)).execute(&mut conn);
+        let _ = diesel::delete(users::table.find(user.id)).execute(&mut conn);
     }
 }

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -148,6 +148,7 @@ mod replay_tests {
             scheduled_task_id: None,
             paused: false,
             claude_args: serde_json::Value::Array(Vec::new()),
+            launcher_version: None,
         };
         diesel::insert_into(sessions::table)
             .values(&new_session)

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -76,6 +76,10 @@ pub struct Session {
     /// the session pill. `None` until the first turn with a known model. See
     /// `handlers::websocket::turn_metrics`.
     pub last_model: Option<String>,
+    /// Version reported by the launcher that spawned this session, captured
+    /// at session-create time (see `NewSessionWithId::launcher_version`).
+    /// `None` for proxy-direct (non-launcher) sessions.
+    pub launcher_version: Option<String>,
 }
 
 /// Insertable session that specifies the ID (so we can use Claude's session ID)
@@ -97,6 +101,16 @@ pub struct NewSessionWithId {
     pub scheduled_task_id: Option<Uuid>,
     pub paused: bool,
     pub claude_args: serde_json::Value,
+    /// The launcher's self-reported version at the moment this session was
+    /// created, resolved from the in-memory launcher registry
+    /// (`LauncherConnection.version`). Captured here — alongside `launcher_id`
+    /// — because the registry entry is gone by the time the archival sweep
+    /// runs, so the session row is the only durable carrier for launcher
+    /// provenance. Semantics: **last-known-at-launch**. If the launcher later
+    /// auto-updates and restarts mid-session, this value is *not* refreshed;
+    /// it records the version that actually spawned the proxy. `None` for
+    /// non-launcher sessions or if the launcher is somehow not in the registry.
+    pub launcher_version: Option<String>,
 }
 
 #[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]

--- a/backend/src/push/dispatcher.rs
+++ b/backend/src/push/dispatcher.rs
@@ -310,6 +310,7 @@ mod db_tests {
             scheduled_task_id: None,
             paused: false,
             claude_args: serde_json::Value::Array(Vec::new()),
+            launcher_version: None,
         };
         diesel::insert_into(sessions::table)
             .values(&new_session)

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -224,6 +224,8 @@ diesel::table! {
         archived_at -> Nullable<Timestamp>,
         #[max_length = 128]
         last_model -> Nullable<Varchar>,
+        #[max_length = 32]
+        launcher_version -> Nullable<Varchar>,
     }
 }
 

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -181,6 +181,7 @@ async fn archive_sweep_persists_and_is_idempotent() {
             scheduled_task_id: None,
             paused: false,
             claude_args: serde_json::Value::Array(vec![]),
+            launcher_version: None,
         })
         .execute(&mut conn)
         .expect("insert session");
@@ -345,6 +346,7 @@ async fn retention_holds_trim_when_archive_fails() {
             scheduled_task_id: None,
             paused: false,
             claude_args: serde_json::Value::Array(vec![]),
+            launcher_version: None,
         })
         .execute(&mut conn)
         .expect("insert session");
@@ -467,6 +469,7 @@ async fn rearchive_after_trim_merges_transcript() {
             scheduled_task_id: None,
             paused: false,
             claude_args: serde_json::Value::Array(vec![]),
+            launcher_version: None,
         })
         .execute(&mut conn)
         .expect("insert session");


### PR DESCRIPTION
## What

Archived sessions now carry full launch-and-write provenance — who/what/which versions — closing the gaps in `SessionArchiveManifest` after the media work.

### New manifest fields (all optional, additive within `ARCHIVE_SCHEMA_VERSION` 1)
Same compat contract as the media section: each is `#[serde(default, skip_serializing_if = …)]`, so old manifests deserialize to empty defaults and a manifest without the datum re-serializes byte-identically (key omitted). The schema version is **not** bumped.

- **`launcher_id`** / **`launcher_version`** — which launcher spawned the session and its version.
- **`scheduled_task_id`** — links a session back to the cron/scheduled task that spawned it.
- **`claude_args`** — the agent CLI flags the session was launched with (reveals model pinning etc.).
- **`archived_by_version`** — `shared::VERSION` of the backend performing the archive write (per-write; a re-archive by a newer backend stamps the newer version).

### `sessions.launcher_version` capture
The launcher's version lived only in the in-memory launcher registry (`LauncherConnection.version`), which is gone by the time the archival sweep runs. A new nullable `sessions.launcher_version` column (migration + regenerated `schema.rs`) captures it durably.

**Where capture lands:** at the two points a launcher-launched session row is created and the registry still holds the launcher connection:
- `create_new_session` (proxy `Register` path) — resolves `session_manager.launcher_version(launcher_id)` at create time.
- `create_desired_session` (desired-session / `RequestLaunch` path) — same resolution.

**Semantics:** last-known-at-launch. If the launcher auto-updates and restarts mid-session, the value is *not* refreshed — it records the version that actually spawned the proxy. NULL for proxy-direct (non-launcher) sessions. Documented in a doc-comment on the model field.

## Provenance audit — added vs skipped

**Added** (cheaply in hand on the `sessions` row, provenance-relevant): `launcher_id`, `launcher_version`, `scheduled_task_id`, `claude_args`, `archived_by_version`.

**Skipped:**
- `last_model` — model provenance is already covered by `turns.models` (the full distinct-model set observed), which is strictly more complete than the single "final model" watermark; `last_model` is a live-dashboard convenience derivable from the transcript.
- `open_prs` — mutable current-state (refreshed as PRs open/close), not launch-time provenance; the authoritative `pr_url` is already in the manifest.

## `claude_args` secrets verdict — clean, included

`claude_args` are extra CLI flags for the agent binary (e.g. `["--model", "opus"]`, `--verbose`, `--permission-mode`), sourced from the launcher config / launch request and passed to claude/codex as `extra_args`. The portal auth token travels on a **separate** proxy token (`auth_token`), never through `claude_args`, and the claude CLI does not take API keys as args. No transport/auth material flows here, so it is safe to archive.

## Tests
- `manifest_provenance_fields_roundtrip` — all new fields survive a store round-trip.
- `old_manifest_without_provenance_fields_parses` — pins old-manifest compat (keys absent on serialize, parse to empty defaults on deserialize), matching the media-section test pattern.
- `launcher_version_persists_on_session_row` — DB-backed round-trip of the new column (migration + schema + model wiring), gated on the shared test pool.

## Verify
`cargo fmt --check`, `cargo clippy --workspace --exclude frontend --all-targets -- -D warnings`, `cargo test -p backend -p shared` (all green), `trunk build`, `cargo build -p backend -p agent-portal`, migration-name check all pass.