### PR TITLE
Fix duplicate launcher_version key that empties the session list

### DIFF
--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -34,8 +34,6 @@ pub struct SessionWithRole {
     #[serde(flatten)]
     pub session: Session,
     pub my_role: SessionRole,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub launcher_version: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -61,12 +59,21 @@ pub async fn list_sessions(
 
     let sessions_with_role = results
         .into_iter()
-        .map(|(session, role)| SessionWithRole {
-            launcher_version: app_state
+        .map(|(mut session, role)| {
+            // `Session::launcher_version` (the DB column added in #1454) holds
+            // the launcher version captured at session-create time. This wire
+            // shape has always exposed the *live* launcher version, so replace
+            // the flattened value with the currently-connected one. Carrying
+            // both a flattened and a separate explicit `launcher_version` field
+            // produced a duplicate JSON key that failed frontend deserialization
+            // (emptying the whole session list) whenever a launcher was online.
+            session.launcher_version = app_state
                 .session_manager
-                .launcher_version(session.launcher_id),
-            session,
-            my_role: role.parse().unwrap_or(SessionRole::Unknown),
+                .launcher_version(session.launcher_id);
+            SessionWithRole {
+                session,
+                my_role: role.parse().unwrap_or(SessionRole::Unknown),
+            }
         })
         .collect();
 


### PR DESCRIPTION
## Problem

The dashboard shows the "No Sessions Connected" splash even with active sessions. Console:

```
Failed to fetch sessions: failed to parse response: duplicate field `launcher_version` at line 1 column 2151
```

## Root cause

#1454 added a `launcher_version` column to the `Session` model (`backend/src/models.rs`). `SessionWithRole` exposes `Session` on the `/api/sessions` wire shape via `#[serde(flatten)]`, and `list_sessions` *also* set an explicit top-level `launcher_version` (the live launcher version from the session registry). The response therefore serialized the `launcher_version` key **twice** whenever a launcher was connected. serde rejects the whole payload on the duplicate key, so `use_sessions` never populates the list and the dashboard renders the empty-state splash. Launchers menu / metrics / per-session sockets use other endpoints, so only the session list was affected.

## Fix

Overwrite the flattened `Session::launcher_version` with the live launcher version and drop the redundant explicit field, restoring the single-key wire shape `shared::SessionInfo` expects. The at-launch value stays in the DB for the archive-provenance path; nothing consumes it on this endpoint.