### PR TITLE
Refine host group headers in the session rail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ screenlog.*
 /*.patch
 parsing-dump/
 /image.png
+builds/

--- a/dropps-vs-allfreeclear-venn.svg
+++ b/dropps-vs-allfreeclear-venn.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 790" font-family="system-ui, -apple-system, sans-serif">
+  <!-- transparent background for dark portal theme -->
+  <text x="450" y="34" text-anchor="middle" fill="#c0caf5" font-size="18" font-weight="700">Ingredient Venn — laundry detergents</text>
+  <text x="450" y="56" text-anchor="middle" fill="#565f89" font-size="13">Dropps 4-in-1 Plus Oxi pods (Free &amp; Clear)  vs  all® free clear liquid (current label)</text>
+
+  <!-- circles -->
+  <circle cx="330" cy="400" r="280" fill="#7aa2f7" fill-opacity="0.09" stroke="#7aa2f7" stroke-width="2"/>
+  <circle cx="665" cy="400" r="205" fill="#9ece6a" fill-opacity="0.09" stroke="#9ece6a" stroke-width="2"/>
+
+  <!-- circle labels -->
+  <text x="215" y="145" text-anchor="middle" fill="#7aa2f7" font-size="15" font-weight="700">DROPPS 4-in-1 (22)</text>
+  <text x="745" y="215" text-anchor="middle" fill="#9ece6a" font-size="15" font-weight="700">all free clear (8)</text>
+
+  <!-- ===== Dropps-only ===== -->
+  <g font-size="12.5" fill="#a9b1d6">
+    <text x="150" y="205" fill="#7aa2f7" font-size="11" font-weight="700">SURFACTANTS &amp; SOAP</text>
+    <text x="150" y="223">alkyl glucoside</text>
+    <text x="150" y="240">MEA-LAS</text>
+    <text x="150" y="257">MEA-cocoate (soap) †</text>
+
+    <text x="138" y="284" fill="#7aa2f7" font-size="11" font-weight="700">SOLVENTS</text>
+    <text x="138" y="302">glycerin</text>
+    <text x="138" y="319">propylene glycol</text>
+
+    <text x="130" y="346" fill="#7aa2f7" font-size="11" font-weight="700">ENZYMES</text>
+    <text x="130" y="364">subtilisin (protein stains)</text>
+    <text x="130" y="381">amylase (starches)</text>
+    <text x="130" y="398">lipase (oils)</text>
+    <text x="130" y="415">pectate lyase (produce)</text>
+    <text x="130" y="432">mannanase (gums)</text>
+
+    <text x="134" y="459" fill="#7aa2f7" font-size="11" font-weight="700">FABRIC &amp; ODOR CARE</text>
+    <text x="134" y="477">nonionic polyester (soil release)</text>
+    <text x="134" y="494">zinc ricinoleate (odor)</text>
+    <text x="134" y="511">wheat-protein/silicone quat</text>
+
+    <text x="150" y="538" fill="#7aa2f7" font-size="11" font-weight="700">CHELANT · STABILIZERS · SAFETY</text>
+    <text x="150" y="556">GLDA chelant †</text>
+    <text x="150" y="573">citric acid · sodium sulfite</text>
+    <text x="150" y="590">denatonium benzoate (bitterant)</text>
+    <text x="150" y="607">polyvinyl alcohol (pod film)</text>
+  </g>
+
+  <!-- ===== Shared (intersection) ===== -->
+  <g font-size="12.5" fill="#7dcfff" text-anchor="middle">
+    <text x="527" y="352" font-size="11" font-weight="700" fill="#7dcfff">SHARED</text>
+    <text x="527" y="374">water</text>
+    <text x="527" y="396">sodium laureth</text>
+    <text x="527" y="411">sulfate</text>
+    <text x="527" y="433">alcohol</text>
+    <text x="527" y="448">ethoxylates *</text>
+  </g>
+
+  <!-- ===== All-only ===== -->
+  <g font-size="12.5" fill="#a9b1d6">
+    <text x="628" y="330" fill="#9ece6a" font-size="11" font-weight="700">BUILDER</text>
+    <text x="628" y="348">sodium carbonate</text>
+    <text x="628" y="375" fill="#9ece6a" font-size="11" font-weight="700">CHELANT &amp; SOAP</text>
+    <text x="628" y="393">MGDA chelant †</text>
+    <text x="628" y="410">sodium C8-18 soap †</text>
+    <text x="628" y="437" fill="#9ece6a" font-size="11" font-weight="700">POLYMER &amp; PRESERVATIVE</text>
+    <text x="628" y="455">sodium polyacrylate</text>
+    <text x="628" y="472">benzisothiazolinone</text>
+  </g>
+
+  <!-- footnotes -->
+  <g font-size="11.5" fill="#565f89">
+    <text x="60" y="712">* same molecule class, different chain length: Dropps uses C12-14, all uses C12-15 ethoxylated alcohols — functionally interchangeable nonionics.</text>
+    <text x="60" y="730">† cross-product functional analogs, different molecules: MEA-cocoate ↔ sodium C8-18 soap; GLDA ↔ MGDA (both aminocarboxylate chelants).</text>
+    <text x="60" y="748">EWG's Free &amp; Clear entry also lists "fragrance" — Dropps markets it perfume-free; likely carryover from the scented variant, excluded above.</text>
+    <text x="60" y="766">"all" list = current official label (8 ingredients, CAS-verified). Older label revisions also listed Fluorescent Brightener 28 and sodium chloride.</text>
+  </g>
+</svg>

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -171,7 +171,7 @@ fn render_pill_section(
                         title={format!("{label} — {count} session(s)")}
                     >
                         <span class="host-header-name">{ label }</span>
-                        <span class="host-header-count">{ count }</span>
+                        <span class="host-header-count">{ format!("({count})") }</span>
                     </div>
                 });
             }

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -152,17 +152,20 @@
    label rendered inline among the pills. In the horizontal (top/bottom) rail
    it reads as a compact chip that precedes each host's pills; in the vertical
    (left/right) rail it spans the column as a full-width section heading. */
+/* A thin, small-text section header sitting in the sliver of space above each
+   host's pills: muted uppercase hostname plus a plain "(n)" parenthetical —
+   deliberately not a chip/badge, so it reads as a label, not a control. */
 .session-rail-host-header {
     display: flex;
-    align-items: center;
-    gap: 0.35rem;
+    align-items: baseline;
+    gap: 0.3rem;
     flex-shrink: 0;
-    padding: 0.15rem 0.5rem;
+    padding: 0.1rem 0.5rem;
     align-self: center;
     color: var(--text-secondary);
-    font-size: 0.7rem;
+    font-size: 0.65rem;
     text-transform: uppercase;
-    letter-spacing: 0.03em;
+    letter-spacing: 0.05em;
     white-space: nowrap;
 }
 
@@ -173,28 +176,20 @@
 }
 
 .session-rail-host-header .host-header-count {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 1.1rem;
-    padding: 0 0.3rem;
-    border-radius: 999px;
-    background: rgba(0, 0, 0, 0.3);
-    border: 1px solid var(--border);
-    font-size: 0.65rem;
-    font-weight: 600;
+    font-weight: 400;
+    opacity: 0.75;
 }
 
-/* Vertical rail: host headers become full-width section rows with a subtle
-   top rule so groups read as stacked sections rather than inline chips. */
+/* Vertical rail: the header becomes a full-width row with a hairline rule and
+   a thin gap above it, so each host group reads as a stacked section. */
 .dashboard-body.rail-left .session-rail-host-header,
 .dashboard-body.rail-right .session-rail-host-header {
     align-self: stretch;
     width: 100%;
-    justify-content: space-between;
-    padding: 0.35rem 0.25rem 0.15rem;
+    justify-content: flex-start;
+    padding: 0.4rem 0.25rem 0.1rem;
     border-top: 1px solid var(--border);
-    margin-top: 0.15rem;
+    margin-top: 0.35rem;
 }
 
 /* The first header in a vertical rail shouldn't carry a top rule/margin. */


### PR DESCRIPTION
Per Matt: the group-by-host headers become thin, small-text section labels sitting in the space above each host's pills — muted uppercase hostname + a plain "(n)" parenthetical count (previously a chip-style badge). Vertical rail keeps the hairline top rule with a slightly airier gap; horizontal rail keeps inline placement. Left-aligned in vertical mode; first header carries no rule (unchanged). Verified with trunk build + frontend wasm clippy.