### PR TITLE
Extract archive format and stores into a shared archive-format crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "archive-format"
+version = "2.13.10"
+dependencies = [
+ "chrono",
+ "object_store",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
+ "zstd",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +523,7 @@ version = "2.13.10"
 dependencies = [
  "a2",
  "anyhow",
+ "archive-format",
  "axum",
  "backend",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "shared",
+    "archive-format",
     "backend",
     "frontend",
     "proxy",

--- a/archive-format/Cargo.toml
+++ b/archive-format/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "archive-format"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+# Native-only crate: the on-disk/on-S3 format for long-term session archives
+# (#1258), shared by the backend (writer) and a standalone archive/history
+# viewer (reader) so the viewer never has to link the backend crate. NOT in
+# `shared/` — it uses `object_store`/`tokio`/`std::fs`, none of which are
+# WASM-compatible.
+
+[dependencies]
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+zstd = "0.13"
+object_store = { version = "0.14.0", features = ["aws"] }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/archive-format/src/lib.rs
+++ b/archive-format/src/lib.rs
@@ -1,0 +1,499 @@
+//! Long-term session archive format (#1258).
+//!
+//! This crate is the *format* layer for the session archive: the serde types
+//! (manifests, transcript lines, media sidecars), the deterministic object-key
+//! derivation, the zstd transcript codec, and the read-side store
+//! (local filesystem + S3-compatible `object_store`). It is shared by two
+//! consumers so neither has to link the other:
+//!
+//! * the **backend** writes archives from the archival sweep, and
+//! * a standalone **archive/history viewer** reads them back.
+//!
+//! Backend-only glue (the sweep, DB-facing bundle assembly, `ArchiveRuntime`
+//! wiring, stats, and marker emissions) stays in the backend crate.
+//!
+//! ## Object layout (schema v1)
+//!
+//! ```text
+//! v1/users/{user_id}/sessions/{session_id}/manifest.json
+//! v1/users/{user_id}/sessions/{session_id}/messages.ndjson.zst
+//! ```
+//!
+//! Transcripts are always zstd-compressed — they are text-heavy NDJSON
+//! and shrink dramatically; there is deliberately no plaintext option.
+//! Manifests stay plain JSON so external tools can list/scan them cheaply.
+//!
+//! Keys are deterministic (stable ids only, no user-controlled segments),
+//! so re-archiving a session overwrites in place — the sweep re-archives
+//! whenever `sessions.last_activity` advances past `sessions.archived_at`,
+//! making the whole pipeline idempotent.
+//!
+//! ## Trust model
+//!
+//! The archive backend is operator-controlled infrastructure: anyone with
+//! access to the root path (or, later, the bucket) already holds
+//! deployment-level access. Raw message bodies are archived deliberately —
+//! the feature exists to make provider-bound content auditable — but
+//! transport/auth material (tokens, cookies, secrets) is never part of
+//! session content and must never be added to manifests.
+
+pub mod store;
+pub use store::*;
+
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+/// Bump when the manifest shape or object layout changes incompatibly.
+pub const ARCHIVE_SCHEMA_VERSION: u32 = 1;
+
+/// zstd level for transcript bodies. Archival is write-once/read-rare and
+/// runs on the blocking pool, so a higher-than-default level is a good
+/// trade: noticeably smaller objects for a little more CPU.
+const ZSTD_LEVEL: i32 = 9;
+
+/// The manifest's `transcript.compression` value. Fixed — transcripts are
+/// always zstd; the field exists so external viewers stay self-describing
+/// if a future schema version ever changes the codec.
+pub const TRANSCRIPT_COMPRESSION: &str = "zstd";
+
+/// zstd-compress a transcript body at the archive's fixed [`ZSTD_LEVEL`].
+/// Centralized here so writer (backend) and reader (viewer) share one codec.
+pub fn zstd_encode(bytes: &[u8]) -> std::io::Result<Vec<u8>> {
+    zstd::encode_all(bytes, ZSTD_LEVEL)
+}
+
+/// Decompress a zstd transcript body.
+pub fn zstd_decode(bytes: &[u8]) -> std::io::Result<Vec<u8>> {
+    zstd::decode_all(bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Manifest / bundle types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ArchiveTokenTotals {
+    pub input: i64,
+    pub output: i64,
+    pub cache_creation: i64,
+    pub cache_read: i64,
+    pub thinking: i64,
+    pub subagent: i64,
+}
+
+/// Turn-level aggregates for the manifest, sourced from `turn_metrics`.
+///
+/// Known v1 gaps, documented deliberately: **rate-limit event counts and
+/// reconnect counts have no durable DB source today** (limit events are
+/// transient wire frames; reconnects live only in logs), so they cannot
+/// appear in manifests until something persists them. `errored` counts
+/// turns with `is_error`, which subsumes limit-terminated turns.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ArchiveTurnStats {
+    pub count: i64,
+    pub errored: i64,
+    /// Stop-reason histogram (BTreeMap for deterministic serialization).
+    pub stop_reasons: BTreeMap<String, i64>,
+    /// Distinct models observed, sorted.
+    pub models: Vec<String>,
+    /// Service-tier histogram (e.g. "standard" / "priority").
+    pub service_tiers: BTreeMap<String, i64>,
+    /// Total tool invocations across all turns.
+    pub tool_calls: i64,
+    /// Total stream restarts (auto-retried turns) across all turns.
+    pub stream_restarts: i64,
+    /// Sum of per-turn wall-clock durations, milliseconds.
+    pub total_duration_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ArchiveTranscriptInfo {
+    pub object_key: String,
+    pub compression: String,
+    pub message_count: i64,
+    pub bytes: u64,
+}
+
+/// The per-session archive manifest (schema v1). Analytics and admin
+/// surfaces read this; they must never need the transcript body.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SessionArchiveManifest {
+    pub schema_version: u32,
+    pub session_id: Uuid,
+    pub user_id: Uuid,
+    /// Raw email deliberately included for admin reporting (see module
+    /// docs on the trust model).
+    pub owner_email: String,
+    pub owner_name: Option<String>,
+    pub session_name: String,
+    pub agent_type: String,
+    pub status: String,
+    pub working_directory: String,
+    pub hostname: String,
+    pub git_branch: Option<String>,
+    pub repo_url: Option<String>,
+    pub pr_url: Option<String>,
+    pub client_version: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub last_activity: NaiveDateTime,
+    pub archived_at: NaiveDateTime,
+    /// Message-count histogram by role (user/assistant/...).
+    pub message_counts: BTreeMap<String, i64>,
+    pub tokens: ArchiveTokenTotals,
+    pub total_cost_usd: f64,
+    pub turns: ArchiveTurnStats,
+    /// Present iff transcript archival is enabled and messages existed.
+    pub transcript: Option<ArchiveTranscriptInfo>,
+    /// Media blobs (`agent-portal show`) whose bytes were written through to
+    /// the archive for this session, one entry per surviving blob.
+    ///
+    /// **Schema-compat (why this stays v1):** the field is additive and
+    /// optional — `#[serde(default, skip_serializing_if = "Option::is_none")]`
+    /// means an old manifest written before this field existed deserializes
+    /// with `media == None`, and a manifest with no media re-serializes
+    /// byte-identically to the old shape (the key is omitted). Neither the
+    /// object layout nor any existing field changes, so external viewers that
+    /// don't know the field are unaffected. That is exactly the additive-change
+    /// contract [`ARCHIVE_SCHEMA_VERSION`] guards, so it is **not** bumped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media: Option<Vec<MediaEntry>>,
+
+    // --- Provenance (all additive within schema v1) ---
+    //
+    // These follow the same additive-compat contract as `media` above:
+    // each is `#[serde(default, skip_serializing_if = …)]`, so a manifest
+    // written before the field existed deserializes to the empty value and
+    // a manifest without the datum re-serializes byte-identically (key
+    // omitted). No existing field or the object layout changes, so
+    // [`ARCHIVE_SCHEMA_VERSION`] is **not** bumped.
+    /// The launcher that spawned this session (`sessions.launcher_id`), or
+    /// `None` for proxy-direct sessions. Pairs with `launcher_version`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launcher_id: Option<Uuid>,
+    /// The launcher's self-reported version at launch time
+    /// (`sessions.launcher_version`), captured when the session row was
+    /// created. **Last-known-at-launch**: a mid-session launcher
+    /// auto-update does not refresh it. `None` for non-launcher sessions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launcher_version: Option<String>,
+    /// The scheduled (cron) task that spawned this session
+    /// (`sessions.scheduled_task_id`), linking an archived session back to
+    /// the automation that created it. `None` for interactively-launched
+    /// sessions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduled_task_id: Option<Uuid>,
+    /// Extra CLI arguments the agent binary was launched with
+    /// (`sessions.claude_args`), e.g. `["--model", "opus"]`. Reveals model
+    /// pinning and other launch-time behavior knobs. These are agent CLI
+    /// flags only — portal auth travels via a separate proxy token, never
+    /// here — so they carry no transport/auth secrets. Empty (and thus
+    /// omitted) for sessions launched with no extra args.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub claude_args: Vec<String>,
+    /// `shared::VERSION` of the backend that performed this archive write.
+    /// **Per-write**: a re-archive by a newer backend stamps the newer
+    /// version, so this records who last wrote the object, not who first
+    /// created the session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_by_version: Option<String>,
+}
+
+/// One archived media blob referenced from a manifest. The bytes live at
+/// [`media_key`]; `bytes`/`content_type`/`uploaded_at` are copied from the
+/// blob's sidecar ([`ArchivedMediaMeta`]), which is the authoritative record
+/// that the blob exists in the archive.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MediaEntry {
+    pub media_id: Uuid,
+    /// `"image"` or `"video"`.
+    pub kind: String,
+    pub content_type: String,
+    pub bytes: u64,
+    pub object_key: String,
+    pub uploaded_at: NaiveDateTime,
+}
+
+/// Sidecar record stored next to each written-through media blob
+/// (`{media_key}.meta.json`). It carries the content type and original
+/// filename so a read-through fetch can set response headers **before** the
+/// session's manifest exists (write-through happens at upload time; the
+/// manifest is only written at the much-later archive sweep). Writing the
+/// bytes first and the sidecar last means "sidecar present" implies
+/// "bytes complete" — the same ordering invariant as transcript-then-manifest.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ArchivedMediaMeta {
+    pub media_id: Uuid,
+    pub kind: String,
+    pub content_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    pub bytes: u64,
+    pub uploaded_at: NaiveDateTime,
+}
+
+/// One transcript line, serialized as NDJSON. `content` is the raw stored
+/// message JSON, embedded as a JSON value so the archive round-trips the
+/// wire content byte-for-byte semantically.
+///
+/// `id` is the message row's UUID — the merge key that lets a re-archive
+/// UNION the existing archived transcript with whatever remains in the hot
+/// DB (phase 2 trims hot messages after archival; a later re-archive must
+/// never shrink the archived transcript).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ArchiveMessageLine {
+    pub id: Uuid,
+    pub role: String,
+    pub created_at: NaiveDateTime,
+    pub agent_type: String,
+    pub content: serde_json::Value,
+}
+
+/// Everything needed to write one session's archive.
+pub struct SessionArchiveBundle {
+    pub manifest: SessionArchiveManifest,
+    /// NDJSON transcript body (uncompressed); `None` in metadata-only mode.
+    pub transcript_ndjson: Option<Vec<u8>>,
+}
+
+// ---------------------------------------------------------------------------
+// Object keys
+// ---------------------------------------------------------------------------
+
+pub fn manifest_key(user_id: Uuid, session_id: Uuid) -> String {
+    format!("v1/users/{user_id}/sessions/{session_id}/manifest.json")
+}
+
+pub fn transcript_key(user_id: Uuid, session_id: Uuid) -> String {
+    format!("v1/users/{user_id}/sessions/{session_id}/messages.ndjson.zst")
+}
+
+/// Key for a media blob's raw bytes. Co-located under the session prefix (like
+/// the manifest/transcript) so a session's whole archive lives at one prefix.
+/// `media_id` is the served id from `/api/images/{id}` or `/api/media/{id}`.
+pub fn media_key(user_id: Uuid, session_id: Uuid, media_id: Uuid) -> String {
+    format!("v1/users/{user_id}/sessions/{session_id}/media/{media_id}")
+}
+
+/// Key for a media blob's JSON sidecar ([`ArchivedMediaMeta`]).
+pub fn media_meta_key(user_id: Uuid, session_id: Uuid, media_id: Uuid) -> String {
+    format!("v1/users/{user_id}/sessions/{session_id}/media/{media_id}.meta.json")
+}
+
+// ---------------------------------------------------------------------------
+// Transcript merge / parse
+// ---------------------------------------------------------------------------
+
+/// Union an existing archived transcript with the messages currently in the
+/// hot DB, keyed by message id (#1258 phase 2). Retention may have trimmed
+/// hot rows that only exist in the archive, and the DB may hold rows newer
+/// than the archive — the merge keeps both, ordered by `created_at` (id as
+/// a deterministic tiebreaker). A re-archive can therefore never shrink an
+/// archived transcript.
+pub fn merge_transcript_lines(
+    existing: Vec<ArchiveMessageLine>,
+    current: Vec<ArchiveMessageLine>,
+) -> Vec<ArchiveMessageLine> {
+    let mut by_id: BTreeMap<Uuid, ArchiveMessageLine> = BTreeMap::new();
+    for line in existing {
+        by_id.insert(line.id, line);
+    }
+    // Current DB rows win on id collision (content is immutable in
+    // practice; this just prefers the freshest serialization).
+    for line in current {
+        by_id.insert(line.id, line);
+    }
+    let mut merged: Vec<ArchiveMessageLine> = by_id.into_values().collect();
+    merged.sort_by_key(|line| (line.created_at, line.id));
+    merged
+}
+
+/// Parse an uncompressed NDJSON transcript body into typed lines.
+pub fn parse_transcript_ndjson(ndjson: &[u8]) -> std::io::Result<Vec<ArchiveMessageLine>> {
+    String::from_utf8_lossy(ndjson)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str(l).map_err(|e| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, format!("bad line: {e}"))
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub(crate) fn manifest(user_id: Uuid, session_id: Uuid) -> SessionArchiveManifest {
+        let t = chrono::NaiveDate::from_ymd_opt(2026, 7, 11)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        SessionArchiveManifest {
+            schema_version: ARCHIVE_SCHEMA_VERSION,
+            session_id,
+            user_id,
+            owner_email: "t@t".into(),
+            owner_name: None,
+            session_name: "s".into(),
+            agent_type: "claude".into(),
+            status: "disconnected".into(),
+            working_directory: "/w".into(),
+            hostname: "h".into(),
+            git_branch: None,
+            repo_url: None,
+            pr_url: None,
+            client_version: None,
+            created_at: t,
+            last_activity: t,
+            archived_at: t,
+            message_counts: BTreeMap::from([("user".into(), 2)]),
+            tokens: ArchiveTokenTotals::default(),
+            total_cost_usd: 0.5,
+            turns: ArchiveTurnStats::default(),
+            transcript: None,
+            media: None,
+            launcher_id: None,
+            launcher_version: None,
+            scheduled_task_id: None,
+            claude_args: Vec::new(),
+            archived_by_version: None,
+        }
+    }
+
+    #[test]
+    fn keys_are_deterministic_and_partitioned() {
+        let u = Uuid::from_u128(1);
+        let s = Uuid::from_u128(2);
+        assert_eq!(
+            manifest_key(u, s),
+            format!("v1/users/{u}/sessions/{s}/manifest.json")
+        );
+        assert_eq!(
+            transcript_key(u, s),
+            format!("v1/users/{u}/sessions/{s}/messages.ndjson.zst")
+        );
+    }
+
+    /// #1258 phase 2: the merge is a union by message id, ordered by
+    /// (created_at, id), with current DB rows winning id collisions — a
+    /// re-archive can only grow a transcript, never shrink it.
+    #[test]
+    fn merge_never_shrinks_and_orders_deterministically() {
+        let t0 = chrono::NaiveDate::from_ymd_opt(2026, 7, 11)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        let line = |id: u128, secs: u32, text: &str| ArchiveMessageLine {
+            id: Uuid::from_u128(id),
+            role: "user".into(),
+            created_at: t0 + chrono::Duration::seconds(secs as i64),
+            agent_type: "claude".into(),
+            content: serde_json::json!({ "text": text }),
+        };
+
+        // Archive holds 1,2 (retention later trimmed them from the DB);
+        // DB holds 2 (fresher serialization) and 3 (new).
+        let existing = vec![line(1, 0, "one"), line(2, 10, "two-old")];
+        let current = vec![line(2, 10, "two-new"), line(3, 20, "three")];
+
+        let merged = merge_transcript_lines(existing, current);
+        let texts: Vec<&str> = merged
+            .iter()
+            .map(|l| l.content["text"].as_str().unwrap())
+            .collect();
+        assert_eq!(texts, vec!["one", "two-new", "three"]);
+
+        // Idempotent: merging the result with itself changes nothing.
+        let again = merge_transcript_lines(
+            merged.iter().map(clone_line).collect(),
+            merged.iter().map(clone_line).collect(),
+        );
+        assert_eq!(again.len(), merged.len());
+    }
+
+    pub(crate) fn clone_line(l: &ArchiveMessageLine) -> ArchiveMessageLine {
+        ArchiveMessageLine {
+            id: l.id,
+            role: l.role.clone(),
+            created_at: l.created_at,
+            agent_type: l.agent_type.clone(),
+            content: l.content.clone(),
+        }
+    }
+
+    #[test]
+    fn zstd_transcript_roundtrips() {
+        let body = b"{\"id\":1}\n{\"id\":2}\n";
+        let encoded = zstd_encode(body).unwrap();
+        assert_eq!(&encoded[..4], &[0x28, 0xb5, 0x2f, 0xfd], "zstd magic bytes");
+        assert_eq!(zstd_decode(&encoded).unwrap(), body);
+    }
+
+    #[test]
+    fn old_manifest_without_media_field_parses() {
+        // A manifest serialized before the `media` field existed must still
+        // deserialize (additive optional field → defaults to None), and a
+        // media-less manifest must not emit the key (byte-compat).
+        let u = Uuid::from_u128(1);
+        let s = Uuid::from_u128(2);
+        let m = manifest(u, s);
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(
+            !json.contains("\"media\""),
+            "media-less manifest must omit the key: {json}"
+        );
+
+        // Hand-build a manifest JSON object with the `media` key entirely
+        // absent (simulating an old writer) and confirm it round-trips.
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value.as_object_mut().unwrap().remove("media").is_none());
+        let parsed: SessionArchiveManifest = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.media, None);
+    }
+
+    #[test]
+    fn old_manifest_without_provenance_fields_parses() {
+        // A manifest written before the provenance fields existed must still
+        // deserialize (each is additive/optional → empty default), and a
+        // manifest with none of them set must omit every key (byte-compat).
+        let u = Uuid::from_u128(1);
+        let s = Uuid::from_u128(2);
+        let m = manifest(u, s);
+        let json = serde_json::to_string(&m).unwrap();
+        for key in [
+            "launcher_id",
+            "launcher_version",
+            "scheduled_task_id",
+            "claude_args",
+            "archived_by_version",
+        ] {
+            assert!(
+                !json.contains(&format!("\"{key}\"")),
+                "provenance-less manifest must omit `{key}`: {json}"
+            );
+        }
+
+        // Simulate an old writer: strip the keys entirely and confirm the
+        // manifest still round-trips to empty defaults.
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        for key in [
+            "launcher_id",
+            "launcher_version",
+            "scheduled_task_id",
+            "claude_args",
+            "archived_by_version",
+        ] {
+            assert!(obj.remove(key).is_none());
+        }
+        let parsed: SessionArchiveManifest = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.launcher_id, None);
+        assert_eq!(parsed.launcher_version, None);
+        assert_eq!(parsed.scheduled_task_id, None);
+        assert!(parsed.claude_args.is_empty());
+        assert_eq!(parsed.archived_by_version, None);
+    }
+}

--- a/archive-format/src/store.rs
+++ b/archive-format/src/store.rs
@@ -1,0 +1,604 @@
+//! Archive store: config parsing plus the local-filesystem and
+//! S3-compatible (`object_store`) backends, shared by the backend (writer)
+//! and the standalone archive viewer (reader).
+
+use std::path::{Path, PathBuf};
+
+use object_store::ObjectStoreExt as _;
+use uuid::Uuid;
+
+use crate::{
+    manifest_key, media_key, media_meta_key, parse_transcript_ndjson, transcript_key, zstd_decode,
+    zstd_encode, ArchiveMessageLine, ArchivedMediaMeta, SessionArchiveBundle,
+    SessionArchiveManifest,
+};
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Which object store the archive lives in.
+#[derive(Debug, Clone)]
+pub enum ArchiveBackendConfig {
+    Local {
+        root: PathBuf,
+    },
+    /// S3-compatible object storage. Credentials, region, and endpoint
+    /// come from the standard `AWS_*` environment variables (validated at
+    /// startup when the store is built).
+    S3 {
+        bucket: String,
+        /// Optional key prefix inside the bucket (no trailing slash).
+        prefix: Option<String>,
+    },
+}
+
+/// Validated archive configuration. `None` anywhere upstream means the
+/// feature is disabled (the default, including on hosted deployments).
+#[derive(Debug, Clone)]
+pub struct ArchiveConfig {
+    pub backend: ArchiveBackendConfig,
+    /// When false, only manifests are archived (metadata/rollup mode);
+    /// transcripts stay subject to normal DB retention.
+    pub transcripts: bool,
+    /// When true (the default whenever the archive is enabled), media shown via
+    /// `agent-portal show` is written through to the archive at upload time and
+    /// read back through on a served-store miss (#1450 blobs are ephemeral —
+    /// TTL/size bounded — so an archived transcript otherwise permanently shows
+    /// "media expired"). Gates both the write-through and the read-through.
+    pub media: bool,
+}
+
+/// Parse archive settings from the environment. Fail-fast: partial or
+/// contradictory config is an error at startup, not a silent fallback.
+pub fn archive_config_from_env() -> Result<Option<ArchiveConfig>, String> {
+    if std::env::var("PORTAL_SESSION_ARCHIVE_COMPRESS").is_ok() {
+        return Err(
+            "PORTAL_SESSION_ARCHIVE_COMPRESS has been removed; transcripts are \
+             always zstd-compressed — unset it"
+                .to_string(),
+        );
+    }
+    let backend =
+        std::env::var("PORTAL_SESSION_ARCHIVE_BACKEND").unwrap_or_else(|_| "disabled".to_string());
+    let backend = match backend.as_str() {
+        "disabled" => return Ok(None),
+        "local" => {
+            let root = std::env::var("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT").map_err(|_| {
+                "PORTAL_SESSION_ARCHIVE_BACKEND=local requires \
+                 PORTAL_SESSION_ARCHIVE_LOCAL_ROOT to be set"
+                    .to_string()
+            })?;
+            if root.trim().is_empty() {
+                return Err("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT must not be empty".to_string());
+            }
+            ArchiveBackendConfig::Local {
+                root: PathBuf::from(root),
+            }
+        }
+        "s3" => {
+            let bucket = std::env::var("PORTAL_SESSION_ARCHIVE_S3_BUCKET").map_err(|_| {
+                "PORTAL_SESSION_ARCHIVE_BACKEND=s3 requires \
+                 PORTAL_SESSION_ARCHIVE_S3_BUCKET to be set"
+                    .to_string()
+            })?;
+            if bucket.trim().is_empty() {
+                return Err("PORTAL_SESSION_ARCHIVE_S3_BUCKET must not be empty".to_string());
+            }
+            let prefix = match std::env::var("PORTAL_SESSION_ARCHIVE_S3_PREFIX") {
+                Ok(p) => {
+                    let p = p.trim().trim_matches('/').to_string();
+                    if p.is_empty() {
+                        return Err(
+                            "PORTAL_SESSION_ARCHIVE_S3_PREFIX must not be empty (unset it \
+                             to archive at the bucket root)"
+                                .to_string(),
+                        );
+                    }
+                    Some(p)
+                }
+                Err(_) => None,
+            };
+            ArchiveBackendConfig::S3 { bucket, prefix }
+        }
+        other => {
+            return Err(format!(
+                "PORTAL_SESSION_ARCHIVE_BACKEND must be `disabled`, `local`, or `s3`, got `{other}`"
+            ))
+        }
+    };
+    let transcripts = match std::env::var("PORTAL_SESSION_ARCHIVE_TRANSCRIPTS")
+        .unwrap_or_else(|_| "true".to_string())
+        .as_str()
+    {
+        "true" => true,
+        "false" => false,
+        other => {
+            return Err(format!(
+                "PORTAL_SESSION_ARCHIVE_TRANSCRIPTS must be `true` or `false`, got `{other}`"
+            ))
+        }
+    };
+    let media = match std::env::var("PORTAL_SESSION_ARCHIVE_MEDIA")
+        .unwrap_or_else(|_| "true".to_string())
+        .as_str()
+    {
+        "true" => true,
+        "false" => false,
+        other => {
+            return Err(format!(
+                "PORTAL_SESSION_ARCHIVE_MEDIA must be `true` or `false`, got `{other}`"
+            ))
+        }
+    };
+    Ok(Some(ArchiveConfig {
+        backend,
+        transcripts,
+        media,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/// Typed archive store. An enum (not a trait object) so backends stay a
+/// closed, exhaustively-matched set.
+pub enum ArchiveStore {
+    Local(LocalArchiveStore),
+    /// S3-compatible object storage in production; any `ObjectStore`
+    /// implementation (e.g. in-memory) in tests.
+    Object(ObjectArchiveStore),
+}
+
+impl ArchiveStore {
+    pub fn from_config(config: &ArchiveConfig) -> Result<Self, String> {
+        match &config.backend {
+            ArchiveBackendConfig::Local { root } => {
+                Ok(Self::Local(LocalArchiveStore { root: root.clone() }))
+            }
+            ArchiveBackendConfig::S3 { bucket, prefix } => Ok(Self::Object(
+                ObjectArchiveStore::s3_from_env(bucket, prefix.clone())?,
+            )),
+        }
+    }
+
+    /// Write a session's archive: transcript first, manifest last — a
+    /// manifest's existence implies its transcript object is complete.
+    pub fn put_session_archive(&self, bundle: &SessionArchiveBundle) -> std::io::Result<()> {
+        match self {
+            Self::Local(store) => store.put_session_archive(bundle),
+            Self::Object(store) => store.put_session_archive(bundle),
+        }
+    }
+
+    pub fn get_session_manifest(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+    ) -> std::io::Result<Option<SessionArchiveManifest>> {
+        match self {
+            Self::Local(store) => store.get_session_manifest(user_id, session_id),
+            Self::Object(store) => store.get_session_manifest(user_id, session_id),
+        }
+    }
+
+    /// Read an archived transcript's lines, or `None` if no transcript
+    /// object exists yet. Used by the merge-on-rearchive path and the viewer.
+    pub fn read_transcript_lines(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+    ) -> std::io::Result<Option<Vec<ArchiveMessageLine>>> {
+        let raw = match self.get_object(&transcript_key(user_id, session_id))? {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
+        parse_transcript_ndjson(&zstd_decode(&raw)?).map(Some)
+    }
+
+    /// Write a raw object at `key` (overwrites; deterministic keys make this
+    /// idempotent).
+    pub fn put_object(&self, key: &str, bytes: Vec<u8>) -> std::io::Result<()> {
+        match self {
+            Self::Local(store) => store.write_atomic(key, &bytes),
+            Self::Object(store) => store.put_bytes(key, bytes),
+        }
+    }
+
+    /// Read a raw object at `key`, or `None` if it does not exist.
+    pub fn get_object(&self, key: &str) -> std::io::Result<Option<Vec<u8>>> {
+        match self {
+            Self::Local(store) => match std::fs::read(store.object_path(key)) {
+                Ok(bytes) => Ok(Some(bytes)),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                Err(e) => Err(e),
+            },
+            Self::Object(store) => store.get_bytes(key),
+        }
+    }
+
+    /// Write a media blob and its sidecar. Bytes first, sidecar last — so a
+    /// present sidecar implies the bytes are complete (mirrors
+    /// transcript-then-manifest).
+    pub fn put_media(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+        meta: &ArchivedMediaMeta,
+        bytes: &[u8],
+    ) -> std::io::Result<()> {
+        self.put_object(
+            &media_key(user_id, session_id, meta.media_id),
+            bytes.to_vec(),
+        )?;
+        let meta_json = serde_json::to_vec(meta)?;
+        self.put_object(
+            &media_meta_key(user_id, session_id, meta.media_id),
+            meta_json,
+        )
+    }
+
+    /// Read a media blob's sidecar, or `None` if it was never written through.
+    /// Sidecar presence is the archive's record that the blob's bytes exist.
+    pub fn get_media_meta(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+        media_id: Uuid,
+    ) -> std::io::Result<Option<ArchivedMediaMeta>> {
+        match self.get_object(&media_meta_key(user_id, session_id, media_id))? {
+            Some(bytes) => Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("corrupt media sidecar for {media_id}: {e}"),
+                )
+            })?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Read a media blob's raw bytes, or `None` if absent.
+    pub fn get_media_bytes(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+        media_id: Uuid,
+    ) -> std::io::Result<Option<Vec<u8>>> {
+        self.get_object(&media_key(user_id, session_id, media_id))
+    }
+
+    // -- Read/list surface (viewer-facing; #1288) ---------------------------
+
+    /// List the user ids present in the archive (`v1/users/{uuid}/`).
+    /// Non-UUID entries are ignored (defensive against stray files).
+    pub fn list_users(&self) -> std::io::Result<Vec<Uuid>> {
+        match self {
+            Self::Local(store) => store.list_uuid_dirs(Path::new("v1/users")),
+            Self::Object(store) => store.list_uuid_prefixes("v1/users"),
+        }
+    }
+
+    /// List the session ids archived for `user_id`.
+    pub fn list_sessions(&self, user_id: Uuid) -> std::io::Result<Vec<Uuid>> {
+        let prefix = format!("v1/users/{user_id}/sessions");
+        match self {
+            Self::Local(store) => store.list_uuid_dirs(Path::new(&prefix)),
+            Self::Object(store) => store.list_uuid_prefixes(&prefix),
+        }
+    }
+}
+
+/// S3-compatible (or any `object_store`) backend. Store methods are sync —
+/// they run on the blocking pool alongside the DB work — so each call
+/// blocks on the async client via the captured runtime handle.
+pub struct ObjectArchiveStore {
+    store: std::sync::Arc<dyn object_store::ObjectStore>,
+    /// Key prefix inside the bucket (no trailing slash).
+    prefix: Option<String>,
+    handle: tokio::runtime::Handle,
+}
+
+impl ObjectArchiveStore {
+    /// Build over any `object_store` implementation (e.g. in-memory in
+    /// tests). `prefix` is an optional key prefix (no trailing slash);
+    /// `handle` is the tokio runtime the sync methods block on.
+    pub fn new(
+        store: std::sync::Arc<dyn object_store::ObjectStore>,
+        prefix: Option<String>,
+        handle: tokio::runtime::Handle,
+    ) -> Self {
+        Self {
+            store,
+            prefix,
+            handle,
+        }
+    }
+
+    /// Build against S3. Bucket/prefix come from portal config; region,
+    /// credentials, and custom endpoints come from the standard `AWS_*`
+    /// environment variables (`object_store`'s `from_env`).
+    fn s3_from_env(bucket: &str, prefix: Option<String>) -> Result<Self, String> {
+        let handle = tokio::runtime::Handle::try_current().map_err(|_| {
+            "archive S3 store must be constructed inside the tokio runtime".to_string()
+        })?;
+        let s3 = object_store::aws::AmazonS3Builder::from_env()
+            .with_bucket_name(bucket)
+            .build()
+            .map_err(|e| format!("invalid S3 archive configuration: {e}"))?;
+        Ok(Self {
+            store: std::sync::Arc::new(s3),
+            prefix,
+            handle,
+        })
+    }
+
+    fn object_path(&self, key: &str) -> object_store::path::Path {
+        match &self.prefix {
+            Some(prefix) => object_store::path::Path::from(format!("{prefix}/{key}")),
+            None => object_store::path::Path::from(key),
+        }
+    }
+
+    fn put_bytes(&self, key: &str, bytes: Vec<u8>) -> std::io::Result<()> {
+        let path = self.object_path(key);
+        self.handle
+            .block_on(self.store.put(&path, bytes.into()))
+            .map(|_| ())
+            .map_err(std::io::Error::from)
+    }
+
+    fn get_bytes(&self, key: &str) -> std::io::Result<Option<Vec<u8>>> {
+        let path = self.object_path(key);
+        let result = self
+            .handle
+            .block_on(async { self.store.get(&path).await?.bytes().await });
+        match result {
+            Ok(bytes) => Ok(Some(bytes.to_vec())),
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(e) => Err(std::io::Error::from(e)),
+        }
+    }
+
+    /// List the immediate child "directories" of `key_prefix` whose final
+    /// segment parses as a UUID (delimiter listing → common prefixes).
+    fn list_uuid_prefixes(&self, key_prefix: &str) -> std::io::Result<Vec<Uuid>> {
+        let path = self.object_path(key_prefix);
+        let listing = self
+            .handle
+            .block_on(self.store.list_with_delimiter(Some(&path)))
+            .map_err(std::io::Error::from)?;
+        let mut ids: Vec<Uuid> = listing
+            .common_prefixes
+            .iter()
+            .filter_map(|p| p.parts().next_back())
+            .filter_map(|part| Uuid::parse_str(part.as_ref()).ok())
+            .collect();
+        ids.sort();
+        Ok(ids)
+    }
+
+    fn put_session_archive(&self, bundle: &SessionArchiveBundle) -> std::io::Result<()> {
+        let m = &bundle.manifest;
+        if let Some(ndjson) = &bundle.transcript_ndjson {
+            let body = zstd_encode(ndjson.as_slice())?;
+            self.put_bytes(&transcript_key(m.user_id, m.session_id), body)?;
+        }
+        let manifest_json = serde_json::to_vec_pretty(&bundle.manifest)?;
+        self.put_bytes(&manifest_key(m.user_id, m.session_id), manifest_json)
+    }
+
+    fn get_session_manifest(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+    ) -> std::io::Result<Option<SessionArchiveManifest>> {
+        match self.get_bytes(&manifest_key(user_id, session_id))? {
+            Some(bytes) => Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("corrupt manifest for session {session_id}: {e}"),
+                )
+            })?)),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Local-filesystem backend. Objects are plain files under `root`; writes
+/// are atomic (temp file in the destination directory + rename).
+pub struct LocalArchiveStore {
+    pub(crate) root: PathBuf,
+}
+
+impl LocalArchiveStore {
+    /// Build over a local filesystem root.
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    fn object_path(&self, key: &str) -> PathBuf {
+        // Keys are built exclusively by the key fns in this crate from UUIDs
+        // and fixed literals — no user-controlled segments.
+        self.root.join(key)
+    }
+
+    fn write_atomic(&self, key: &str, bytes: &[u8]) -> std::io::Result<()> {
+        let path = self.object_path(key);
+        // Keys are built exclusively by this crate's key fns, so a parent and
+        // file name always exist; map defensively rather than panicking.
+        let (dir, file_name) = match (path.parent(), path.file_name()) {
+            (Some(dir), Some(name)) => (dir, name),
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("malformed object key: {key}"),
+                ))
+            }
+        };
+        std::fs::create_dir_all(dir)?;
+        let tmp = dir.join(format!(".{}.tmp", file_name.to_string_lossy()));
+        std::fs::write(&tmp, bytes)?;
+        std::fs::rename(&tmp, &path)
+    }
+
+    /// List the immediate child directories of `prefix` whose names parse as
+    /// UUIDs. A missing prefix directory is an empty archive, not an error.
+    fn list_uuid_dirs(&self, prefix: &Path) -> std::io::Result<Vec<Uuid>> {
+        let dir = self.root.join(prefix);
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e),
+        };
+        let mut ids = Vec::new();
+        for entry in entries {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                if let Ok(id) = Uuid::parse_str(&entry.file_name().to_string_lossy()) {
+                    ids.push(id);
+                }
+            }
+        }
+        ids.sort();
+        Ok(ids)
+    }
+
+    fn put_session_archive(&self, bundle: &SessionArchiveBundle) -> std::io::Result<()> {
+        let m = &bundle.manifest;
+        if let Some(ndjson) = &bundle.transcript_ndjson {
+            let body = zstd_encode(ndjson.as_slice())?;
+            self.write_atomic(&transcript_key(m.user_id, m.session_id), &body)?;
+        }
+        let manifest_json = serde_json::to_vec_pretty(&bundle.manifest)?;
+        self.write_atomic(&manifest_key(m.user_id, m.session_id), &manifest_json)
+    }
+
+    fn get_session_manifest(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+    ) -> std::io::Result<Option<SessionArchiveManifest>> {
+        let path = self.object_path(&manifest_key(user_id, session_id));
+        match std::fs::read(&path) {
+            Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("corrupt manifest at {}: {e}", path.display()),
+                )
+            })?)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Decompress + parse an archived transcript (test/inspection helper).
+pub fn read_transcript(
+    root: &Path,
+    user_id: Uuid,
+    session_id: Uuid,
+) -> std::io::Result<Vec<ArchiveMessageLine>> {
+    let raw = std::fs::read(root.join(transcript_key(user_id, session_id)))?;
+    parse_transcript_ndjson(&zstd_decode(&raw)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::manifest;
+
+    fn local_store(root: &Path) -> ArchiveStore {
+        ArchiveStore::Local(LocalArchiveStore {
+            root: root.to_path_buf(),
+        })
+    }
+
+    #[test]
+    fn put_get_roundtrip_and_listing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = local_store(dir.path());
+
+        let u1 = Uuid::from_u128(1);
+        let u2 = Uuid::from_u128(2);
+        let s1 = Uuid::from_u128(10);
+        let s2 = Uuid::from_u128(11);
+
+        for (u, s) in [(u1, s1), (u1, s2), (u2, s1)] {
+            let bundle = SessionArchiveBundle {
+                manifest: manifest(u, s),
+                transcript_ndjson: Some(b"{\"id\":\"01890000-0000-7000-8000-000000000001\",\"role\":\"user\",\"created_at\":\"2026-07-11T00:00:00\",\"agent_type\":\"claude\",\"content\":{}}\n".to_vec()),
+            };
+            store.put_session_archive(&bundle).unwrap();
+        }
+
+        assert_eq!(store.list_users().unwrap(), vec![u1, u2]);
+        assert_eq!(store.list_sessions(u1).unwrap(), vec![s1, s2]);
+        assert_eq!(store.list_sessions(u2).unwrap(), vec![s1]);
+        assert_eq!(
+            store.list_sessions(Uuid::from_u128(99)).unwrap(),
+            Vec::<Uuid>::new()
+        );
+
+        let m = store.get_session_manifest(u1, s1).unwrap().unwrap();
+        assert_eq!(m.session_id, s1);
+        let lines = store.read_transcript_lines(u1, s1).unwrap().unwrap();
+        assert_eq!(lines.len(), 1);
+        assert!(store
+            .get_session_manifest(Uuid::from_u128(99), s1)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn media_sidecar_roundtrip_and_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = local_store(dir.path());
+        let (u, s, m) = (Uuid::from_u128(1), Uuid::from_u128(2), Uuid::from_u128(3));
+
+        let meta = ArchivedMediaMeta {
+            media_id: m,
+            kind: "image".into(),
+            content_type: "image/png".into(),
+            filename: Some("plot.png".into()),
+            bytes: 4,
+            uploaded_at: chrono::NaiveDate::from_ymd_opt(2026, 7, 11)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+        };
+        store.put_media(u, s, &meta, b"png!").unwrap();
+
+        assert_eq!(store.get_media_meta(u, s, m).unwrap().unwrap(), meta);
+        assert_eq!(
+            store.get_media_bytes(u, s, m).unwrap().unwrap(),
+            b"png!".to_vec()
+        );
+        assert!(store
+            .get_media_meta(u, s, Uuid::from_u128(9))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn env_config_rejects_partial_and_unknown() {
+        // Note: env-var tests mutate process env; keep them in ONE test so
+        // they can't race each other under parallel execution.
+        std::env::remove_var("PORTAL_SESSION_ARCHIVE_BACKEND");
+        assert!(archive_config_from_env().unwrap().is_none());
+
+        std::env::set_var("PORTAL_SESSION_ARCHIVE_BACKEND", "gopher");
+        assert!(archive_config_from_env().is_err());
+
+        std::env::set_var("PORTAL_SESSION_ARCHIVE_BACKEND", "local");
+        std::env::remove_var("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT");
+        assert!(archive_config_from_env().is_err());
+
+        std::env::set_var("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT", "/tmp/x");
+        let cfg = archive_config_from_env().unwrap().unwrap();
+        assert!(cfg.transcripts && cfg.media);
+
+        std::env::remove_var("PORTAL_SESSION_ARCHIVE_BACKEND");
+        std::env::remove_var("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT");
+    }
+}

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -8,6 +8,9 @@ authors.workspace = true
 # Shared types
 shared = { path = "../shared" }
 
+# Long-term session archive format + read-side store (#1258)
+archive-format = { path = "../archive-format" }
+
 # Async runtime
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -32,15 +32,19 @@
 //! transport/auth material (tokens, cookies, secrets) is never part of
 //! session content and must never be added to manifests.
 
-use chrono::NaiveDateTime;
-use object_store::ObjectStoreExt as _;
-use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
-use uuid::Uuid;
+// ---------------------------------------------------------------------------
+// Format + store layer — moved to the `archive-format` crate (#1288) so the
+// standalone archive viewer reads archives without linking the backend.
+// Re-exported here so every existing `crate::archive::X` path keeps working.
+// ---------------------------------------------------------------------------
 
-/// Bump when the manifest shape or object layout changes incompatibly.
-pub const ARCHIVE_SCHEMA_VERSION: u32 = 1;
+pub use archive_format::{
+    archive_config_from_env, manifest_key, media_key, media_meta_key, merge_transcript_lines,
+    read_transcript, transcript_key, zstd_decode, zstd_encode, ArchiveBackendConfig, ArchiveConfig,
+    ArchiveMessageLine, ArchiveStore, ArchiveTokenTotals, ArchiveTranscriptInfo, ArchiveTurnStats,
+    ArchivedMediaMeta, LocalArchiveStore, MediaEntry, ObjectArchiveStore, SessionArchiveBundle,
+    SessionArchiveManifest, ARCHIVE_SCHEMA_VERSION, TRANSCRIPT_COMPRESSION,
+};
 
 /// How often the archival sweep runs.
 pub const ARCHIVE_SWEEP_INTERVAL_SECS: u64 = 300;
@@ -52,353 +56,6 @@ pub const ARCHIVE_IDLE_SECS: i64 = 3600;
 
 /// Sessions archived per sweep tick, so one sweep can't monopolize the DB.
 pub const ARCHIVE_SWEEP_BATCH: i64 = 25;
-
-/// zstd level for transcript bodies. Archival is write-once/read-rare and
-/// runs on the blocking pool, so a higher-than-default level is a good
-/// trade: noticeably smaller objects for a little more CPU.
-const ZSTD_LEVEL: i32 = 9;
-
-/// The manifest's `transcript.compression` value. Fixed — transcripts are
-/// always zstd; the field exists so external viewers stay self-describing
-/// if a future schema version ever changes the codec.
-pub const TRANSCRIPT_COMPRESSION: &str = "zstd";
-
-// ---------------------------------------------------------------------------
-// Configuration
-// ---------------------------------------------------------------------------
-
-/// Which object store the archive writes to.
-#[derive(Debug, Clone)]
-pub enum ArchiveBackendConfig {
-    Local {
-        root: PathBuf,
-    },
-    /// S3-compatible object storage. Credentials, region, and endpoint
-    /// come from the standard `AWS_*` environment variables (validated at
-    /// startup when the store is built).
-    S3 {
-        bucket: String,
-        /// Optional key prefix inside the bucket (no trailing slash).
-        prefix: Option<String>,
-    },
-}
-
-/// Validated archive configuration. `None` anywhere upstream means the
-/// feature is disabled (the default, including on hosted deployments).
-#[derive(Debug, Clone)]
-pub struct ArchiveConfig {
-    pub backend: ArchiveBackendConfig,
-    /// When false, only manifests are archived (metadata/rollup mode);
-    /// transcripts stay subject to normal DB retention.
-    pub transcripts: bool,
-    /// When true (the default whenever the archive is enabled), media shown via
-    /// `agent-portal show` is written through to the archive at upload time and
-    /// read back through on a served-store miss (#1450 blobs are ephemeral —
-    /// TTL/size bounded — so an archived transcript otherwise permanently shows
-    /// "media expired"). Gates both the write-through and the read-through.
-    pub media: bool,
-}
-
-/// Parse archive settings from the environment. Fail-fast: partial or
-/// contradictory config is an error at startup, not a silent fallback.
-pub fn archive_config_from_env() -> Result<Option<ArchiveConfig>, String> {
-    if std::env::var("PORTAL_SESSION_ARCHIVE_COMPRESS").is_ok() {
-        return Err(
-            "PORTAL_SESSION_ARCHIVE_COMPRESS has been removed; transcripts are \
-             always zstd-compressed — unset it"
-                .to_string(),
-        );
-    }
-    let backend =
-        std::env::var("PORTAL_SESSION_ARCHIVE_BACKEND").unwrap_or_else(|_| "disabled".to_string());
-    let backend = match backend.as_str() {
-        "disabled" => return Ok(None),
-        "local" => {
-            let root = std::env::var("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT").map_err(|_| {
-                "PORTAL_SESSION_ARCHIVE_BACKEND=local requires \
-                 PORTAL_SESSION_ARCHIVE_LOCAL_ROOT to be set"
-                    .to_string()
-            })?;
-            if root.trim().is_empty() {
-                return Err("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT must not be empty".to_string());
-            }
-            ArchiveBackendConfig::Local {
-                root: PathBuf::from(root),
-            }
-        }
-        "s3" => {
-            let bucket = std::env::var("PORTAL_SESSION_ARCHIVE_S3_BUCKET").map_err(|_| {
-                "PORTAL_SESSION_ARCHIVE_BACKEND=s3 requires \
-                 PORTAL_SESSION_ARCHIVE_S3_BUCKET to be set"
-                    .to_string()
-            })?;
-            if bucket.trim().is_empty() {
-                return Err("PORTAL_SESSION_ARCHIVE_S3_BUCKET must not be empty".to_string());
-            }
-            let prefix = match std::env::var("PORTAL_SESSION_ARCHIVE_S3_PREFIX") {
-                Ok(p) => {
-                    let p = p.trim().trim_matches('/').to_string();
-                    if p.is_empty() {
-                        return Err(
-                            "PORTAL_SESSION_ARCHIVE_S3_PREFIX must not be empty (unset it \
-                             to archive at the bucket root)"
-                                .to_string(),
-                        );
-                    }
-                    Some(p)
-                }
-                Err(_) => None,
-            };
-            ArchiveBackendConfig::S3 { bucket, prefix }
-        }
-        other => {
-            return Err(format!(
-                "PORTAL_SESSION_ARCHIVE_BACKEND must be `disabled`, `local`, or `s3`, got `{other}`"
-            ))
-        }
-    };
-    let transcripts = match std::env::var("PORTAL_SESSION_ARCHIVE_TRANSCRIPTS")
-        .unwrap_or_else(|_| "true".to_string())
-        .as_str()
-    {
-        "true" => true,
-        "false" => false,
-        other => {
-            return Err(format!(
-                "PORTAL_SESSION_ARCHIVE_TRANSCRIPTS must be `true` or `false`, got `{other}`"
-            ))
-        }
-    };
-    let media = match std::env::var("PORTAL_SESSION_ARCHIVE_MEDIA")
-        .unwrap_or_else(|_| "true".to_string())
-        .as_str()
-    {
-        "true" => true,
-        "false" => false,
-        other => {
-            return Err(format!(
-                "PORTAL_SESSION_ARCHIVE_MEDIA must be `true` or `false`, got `{other}`"
-            ))
-        }
-    };
-    Ok(Some(ArchiveConfig {
-        backend,
-        transcripts,
-        media,
-    }))
-}
-
-// ---------------------------------------------------------------------------
-// Manifest / bundle types
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
-pub struct ArchiveTokenTotals {
-    pub input: i64,
-    pub output: i64,
-    pub cache_creation: i64,
-    pub cache_read: i64,
-    pub thinking: i64,
-    pub subagent: i64,
-}
-
-/// Turn-level aggregates for the manifest, sourced from `turn_metrics`.
-///
-/// Known v1 gaps, documented deliberately: **rate-limit event counts and
-/// reconnect counts have no durable DB source today** (limit events are
-/// transient wire frames; reconnects live only in logs), so they cannot
-/// appear in manifests until something persists them. `errored` counts
-/// turns with `is_error`, which subsumes limit-terminated turns.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
-pub struct ArchiveTurnStats {
-    pub count: i64,
-    pub errored: i64,
-    /// Stop-reason histogram (BTreeMap for deterministic serialization).
-    pub stop_reasons: BTreeMap<String, i64>,
-    /// Distinct models observed, sorted.
-    pub models: Vec<String>,
-    /// Service-tier histogram (e.g. "standard" / "priority").
-    pub service_tiers: BTreeMap<String, i64>,
-    /// Total tool invocations across all turns.
-    pub tool_calls: i64,
-    /// Total stream restarts (auto-retried turns) across all turns.
-    pub stream_restarts: i64,
-    /// Sum of per-turn wall-clock durations, milliseconds.
-    pub total_duration_ms: i64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ArchiveTranscriptInfo {
-    pub object_key: String,
-    pub compression: String,
-    pub message_count: i64,
-    pub bytes: u64,
-}
-
-/// The per-session archive manifest (schema v1). Analytics and admin
-/// surfaces read this; they must never need the transcript body.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct SessionArchiveManifest {
-    pub schema_version: u32,
-    pub session_id: Uuid,
-    pub user_id: Uuid,
-    /// Raw email deliberately included for admin reporting (see module
-    /// docs on the trust model).
-    pub owner_email: String,
-    pub owner_name: Option<String>,
-    pub session_name: String,
-    pub agent_type: String,
-    pub status: String,
-    pub working_directory: String,
-    pub hostname: String,
-    pub git_branch: Option<String>,
-    pub repo_url: Option<String>,
-    pub pr_url: Option<String>,
-    pub client_version: Option<String>,
-    pub created_at: NaiveDateTime,
-    pub last_activity: NaiveDateTime,
-    pub archived_at: NaiveDateTime,
-    /// Message-count histogram by role (user/assistant/...).
-    pub message_counts: BTreeMap<String, i64>,
-    pub tokens: ArchiveTokenTotals,
-    pub total_cost_usd: f64,
-    pub turns: ArchiveTurnStats,
-    /// Present iff transcript archival is enabled and messages existed.
-    pub transcript: Option<ArchiveTranscriptInfo>,
-    /// Media blobs (`agent-portal show`) whose bytes were written through to
-    /// the archive for this session, one entry per surviving blob.
-    ///
-    /// **Schema-compat (why this stays v1):** the field is additive and
-    /// optional — `#[serde(default, skip_serializing_if = "Option::is_none")]`
-    /// means an old manifest written before this field existed deserializes
-    /// with `media == None`, and a manifest with no media re-serializes
-    /// byte-identically to the old shape (the key is omitted). Neither the
-    /// object layout nor any existing field changes, so external viewers that
-    /// don't know the field are unaffected. That is exactly the additive-change
-    /// contract [`ARCHIVE_SCHEMA_VERSION`] guards, so it is **not** bumped.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub media: Option<Vec<MediaEntry>>,
-
-    // --- Provenance (all additive within schema v1) ---
-    //
-    // These follow the same additive-compat contract as `media` above:
-    // each is `#[serde(default, skip_serializing_if = …)]`, so a manifest
-    // written before the field existed deserializes to the empty value and
-    // a manifest without the datum re-serializes byte-identically (key
-    // omitted). No existing field or the object layout changes, so
-    // [`ARCHIVE_SCHEMA_VERSION`] is **not** bumped.
-    /// The launcher that spawned this session (`sessions.launcher_id`), or
-    /// `None` for proxy-direct sessions. Pairs with `launcher_version`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub launcher_id: Option<Uuid>,
-    /// The launcher's self-reported version at launch time
-    /// (`sessions.launcher_version`), captured when the session row was
-    /// created. **Last-known-at-launch**: a mid-session launcher
-    /// auto-update does not refresh it. `None` for non-launcher sessions.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub launcher_version: Option<String>,
-    /// The scheduled (cron) task that spawned this session
-    /// (`sessions.scheduled_task_id`), linking an archived session back to
-    /// the automation that created it. `None` for interactively-launched
-    /// sessions.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub scheduled_task_id: Option<Uuid>,
-    /// Extra CLI arguments the agent binary was launched with
-    /// (`sessions.claude_args`), e.g. `["--model", "opus"]`. Reveals model
-    /// pinning and other launch-time behavior knobs. These are agent CLI
-    /// flags only — portal auth travels via a separate proxy token, never
-    /// here — so they carry no transport/auth secrets. Empty (and thus
-    /// omitted) for sessions launched with no extra args.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub claude_args: Vec<String>,
-    /// `shared::VERSION` of the backend that performed this archive write.
-    /// **Per-write**: a re-archive by a newer backend stamps the newer
-    /// version, so this records who last wrote the object, not who first
-    /// created the session.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub archived_by_version: Option<String>,
-}
-
-/// One archived media blob referenced from a manifest. The bytes live at
-/// [`media_key`]; `bytes`/`content_type`/`uploaded_at` are copied from the
-/// blob's sidecar ([`ArchivedMediaMeta`]), which is the authoritative record
-/// that the blob exists in the archive.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct MediaEntry {
-    pub media_id: Uuid,
-    /// `"image"` or `"video"`.
-    pub kind: String,
-    pub content_type: String,
-    pub bytes: u64,
-    pub object_key: String,
-    pub uploaded_at: NaiveDateTime,
-}
-
-/// Sidecar record stored next to each written-through media blob
-/// (`{media_key}.meta.json`). It carries the content type and original
-/// filename so a read-through fetch can set response headers **before** the
-/// session's manifest exists (write-through happens at upload time; the
-/// manifest is only written at the much-later archive sweep). Writing the
-/// bytes first and the sidecar last means "sidecar present" implies
-/// "bytes complete" — the same ordering invariant as transcript-then-manifest.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ArchivedMediaMeta {
-    pub media_id: Uuid,
-    pub kind: String,
-    pub content_type: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub filename: Option<String>,
-    pub bytes: u64,
-    pub uploaded_at: NaiveDateTime,
-}
-
-/// One transcript line, serialized as NDJSON. `content` is the raw stored
-/// message JSON, embedded as a JSON value so the archive round-trips the
-/// wire content byte-for-byte semantically.
-///
-/// `id` is the message row's UUID — the merge key that lets a re-archive
-/// UNION the existing archived transcript with whatever remains in the hot
-/// DB (phase 2 trims hot messages after archival; a later re-archive must
-/// never shrink the archived transcript).
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ArchiveMessageLine {
-    pub id: Uuid,
-    pub role: String,
-    pub created_at: NaiveDateTime,
-    pub agent_type: String,
-    pub content: serde_json::Value,
-}
-
-/// Everything needed to write one session's archive.
-pub struct SessionArchiveBundle {
-    pub manifest: SessionArchiveManifest,
-    /// NDJSON transcript body (uncompressed); `None` in metadata-only mode.
-    pub transcript_ndjson: Option<Vec<u8>>,
-}
-
-// ---------------------------------------------------------------------------
-// Object keys
-// ---------------------------------------------------------------------------
-
-pub fn manifest_key(user_id: Uuid, session_id: Uuid) -> String {
-    format!("v1/users/{user_id}/sessions/{session_id}/manifest.json")
-}
-
-pub fn transcript_key(user_id: Uuid, session_id: Uuid) -> String {
-    format!("v1/users/{user_id}/sessions/{session_id}/messages.ndjson.zst")
-}
-
-/// Key for a media blob's raw bytes. Co-located under the session prefix (like
-/// the manifest/transcript) so a session's whole archive lives at one prefix.
-/// `media_id` is the served id from `/api/images/{id}` or `/api/media/{id}`.
-pub fn media_key(user_id: Uuid, session_id: Uuid, media_id: Uuid) -> String {
-    format!("v1/users/{user_id}/sessions/{session_id}/media/{media_id}")
-}
-
-/// Key for a media blob's JSON sidecar ([`ArchivedMediaMeta`]).
-pub fn media_meta_key(user_id: Uuid, session_id: Uuid, media_id: Uuid) -> String {
-    format!("v1/users/{user_id}/sessions/{session_id}/media/{media_id}.meta.json")
-}
 
 // ---------------------------------------------------------------------------
 // Store
@@ -452,331 +109,12 @@ impl ArchiveStats {
     }
 }
 
-/// Union an existing archived transcript with the messages currently in the
-/// hot DB, keyed by message id (#1258 phase 2). Retention may have trimmed
-/// hot rows that only exist in the archive, and the DB may hold rows newer
-/// than the archive — the merge keeps both, ordered by `created_at` (id as
-/// a deterministic tiebreaker). A re-archive can therefore never shrink an
-/// archived transcript.
-pub fn merge_transcript_lines(
-    existing: Vec<ArchiveMessageLine>,
-    current: Vec<ArchiveMessageLine>,
-) -> Vec<ArchiveMessageLine> {
-    let mut by_id: BTreeMap<Uuid, ArchiveMessageLine> = BTreeMap::new();
-    for line in existing {
-        by_id.insert(line.id, line);
-    }
-    // Current DB rows win on id collision (content is immutable in
-    // practice; this just prefers the freshest serialization).
-    for line in current {
-        by_id.insert(line.id, line);
-    }
-    let mut merged: Vec<ArchiveMessageLine> = by_id.into_values().collect();
-    merged.sort_by_key(|line| (line.created_at, line.id));
-    merged
-}
-
-/// Typed archive store. An enum (not a trait object) so backends stay a
-/// closed, compiler-checked set.
-pub enum ArchiveStore {
-    Local(LocalArchiveStore),
-    /// S3-compatible object storage in production; any `ObjectStore`
-    /// implementation (e.g. in-memory) in tests.
-    Object(ObjectArchiveStore),
-}
-
-impl ArchiveStore {
-    pub fn from_config(config: &ArchiveConfig) -> Result<Self, String> {
-        match &config.backend {
-            ArchiveBackendConfig::Local { root } => {
-                Ok(Self::Local(LocalArchiveStore { root: root.clone() }))
-            }
-            ArchiveBackendConfig::S3 { bucket, prefix } => Ok(Self::Object(
-                ObjectArchiveStore::s3_from_env(bucket, prefix.clone())?,
-            )),
-        }
-    }
-
-    /// Write a session's archive: transcript first, manifest last — a
-    /// manifest's existence implies its transcript object is complete.
-    pub fn put_session_archive(&self, bundle: &SessionArchiveBundle) -> std::io::Result<()> {
-        match self {
-            Self::Local(store) => store.put_session_archive(bundle),
-            Self::Object(store) => store.put_session_archive(bundle),
-        }
-    }
-
-    pub fn get_session_manifest(
-        &self,
-        user_id: Uuid,
-        session_id: Uuid,
-    ) -> std::io::Result<Option<SessionArchiveManifest>> {
-        match self {
-            Self::Local(store) => store.get_session_manifest(user_id, session_id),
-            Self::Object(store) => store.get_session_manifest(user_id, session_id),
-        }
-    }
-
-    /// Read an archived transcript's lines, or `None` if no transcript
-    /// object exists yet. Used by the merge-on-rearchive path.
-    pub fn read_transcript_lines(
-        &self,
-        user_id: Uuid,
-        session_id: Uuid,
-    ) -> std::io::Result<Option<Vec<ArchiveMessageLine>>> {
-        let raw = match self {
-            Self::Local(store) => {
-                match std::fs::read(store.object_path(&transcript_key(user_id, session_id))) {
-                    Ok(bytes) => bytes,
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-                    Err(e) => return Err(e),
-                }
-            }
-            Self::Object(store) => match store.get_bytes(&transcript_key(user_id, session_id)) {
-                Ok(Some(bytes)) => bytes,
-                Ok(None) => return Ok(None),
-                Err(e) => return Err(e),
-            },
-        };
-        parse_transcript_ndjson(&zstd::decode_all(raw.as_slice())?).map(Some)
-    }
-
-    /// Write a raw object at `key` (overwrites; deterministic keys make this
-    /// idempotent). Backend-dispatched; used by the media write-through.
-    pub fn put_object(&self, key: &str, bytes: Vec<u8>) -> std::io::Result<()> {
-        match self {
-            Self::Local(store) => store.write_atomic(key, &bytes),
-            Self::Object(store) => store.put_bytes(key, bytes),
-        }
-    }
-
-    /// Read a raw object at `key`, or `None` if it does not exist.
-    pub fn get_object(&self, key: &str) -> std::io::Result<Option<Vec<u8>>> {
-        match self {
-            Self::Local(store) => match std::fs::read(store.object_path(key)) {
-                Ok(bytes) => Ok(Some(bytes)),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-                Err(e) => Err(e),
-            },
-            Self::Object(store) => store.get_bytes(key),
-        }
-    }
-
-    /// Write a media blob and its sidecar. Bytes first, sidecar last — so a
-    /// present sidecar implies the bytes are complete (mirrors
-    /// transcript-then-manifest).
-    pub fn put_media(
-        &self,
-        user_id: Uuid,
-        session_id: Uuid,
-        meta: &ArchivedMediaMeta,
-        bytes: &[u8],
-    ) -> std::io::Result<()> {
-        self.put_object(
-            &media_key(user_id, session_id, meta.media_id),
-            bytes.to_vec(),
-        )?;
-        let meta_json = serde_json::to_vec(meta)?;
-        self.put_object(
-            &media_meta_key(user_id, session_id, meta.media_id),
-            meta_json,
-        )
-    }
-
-    /// Read a media blob's sidecar, or `None` if it was never written through.
-    /// Sidecar presence is the archive's record that the blob's bytes exist.
-    pub fn get_media_meta(
-        &self,
-        user_id: Uuid,
-        session_id: Uuid,
-        media_id: Uuid,
-    ) -> std::io::Result<Option<ArchivedMediaMeta>> {
-        match self.get_object(&media_meta_key(user_id, session_id, media_id))? {
-            Some(bytes) => Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("corrupt media sidecar for {media_id}: {e}"),
-                )
-            })?)),
-            None => Ok(None),
-        }
-    }
-
-    /// Read a media blob's raw bytes, or `None` if absent.
-    pub fn get_media_bytes(
-        &self,
-        user_id: Uuid,
-        session_id: Uuid,
-        media_id: Uuid,
-    ) -> std::io::Result<Option<Vec<u8>>> {
-        self.get_object(&media_key(user_id, session_id, media_id))
-    }
-}
-
-/// S3-compatible (or any `object_store`) backend. Store methods are sync —
-/// they run on the blocking pool alongside the DB work — so each call
-/// blocks on the async client via the captured runtime handle.
-pub struct ObjectArchiveStore {
-    store: std::sync::Arc<dyn object_store::ObjectStore>,
-    /// Key prefix inside the bucket (no trailing slash).
-    prefix: Option<String>,
-    handle: tokio::runtime::Handle,
-}
-
-impl ObjectArchiveStore {
-    /// Build against S3. Bucket/prefix come from portal config; region,
-    /// credentials, and custom endpoints come from the standard `AWS_*`
-    /// environment variables (`object_store`'s `from_env`).
-    fn s3_from_env(bucket: &str, prefix: Option<String>) -> Result<Self, String> {
-        let handle = tokio::runtime::Handle::try_current().map_err(|_| {
-            "archive S3 store must be constructed inside the tokio runtime".to_string()
-        })?;
-        let s3 = object_store::aws::AmazonS3Builder::from_env()
-            .with_bucket_name(bucket)
-            .build()
-            .map_err(|e| format!("invalid S3 archive configuration: {e}"))?;
-        Ok(Self {
-            store: std::sync::Arc::new(s3),
-            prefix,
-            handle,
-        })
-    }
-
-    fn object_path(&self, key: &str) -> object_store::path::Path {
-        match &self.prefix {
-            Some(prefix) => object_store::path::Path::from(format!("{prefix}/{key}")),
-            None => object_store::path::Path::from(key),
-        }
-    }
-
-    fn put_bytes(&self, key: &str, bytes: Vec<u8>) -> std::io::Result<()> {
-        let path = self.object_path(key);
-        self.handle
-            .block_on(self.store.put(&path, bytes.into()))
-            .map(|_| ())
-            .map_err(std::io::Error::from)
-    }
-
-    fn get_bytes(&self, key: &str) -> std::io::Result<Option<Vec<u8>>> {
-        let path = self.object_path(key);
-        let result = self
-            .handle
-            .block_on(async { self.store.get(&path).await?.bytes().await });
-        match result {
-            Ok(bytes) => Ok(Some(bytes.to_vec())),
-            Err(object_store::Error::NotFound { .. }) => Ok(None),
-            Err(e) => Err(std::io::Error::from(e)),
-        }
-    }
-
-    fn put_session_archive(&self, bundle: &SessionArchiveBundle) -> std::io::Result<()> {
-        let m = &bundle.manifest;
-        if let Some(ndjson) = &bundle.transcript_ndjson {
-            let body = zstd::encode_all(ndjson.as_slice(), ZSTD_LEVEL)?;
-            self.put_bytes(&transcript_key(m.user_id, m.session_id), body)?;
-        }
-        let manifest_json = serde_json::to_vec_pretty(&bundle.manifest)?;
-        self.put_bytes(&manifest_key(m.user_id, m.session_id), manifest_json)
-    }
-
-    fn get_session_manifest(
-        &self,
-        user_id: Uuid,
-        session_id: Uuid,
-    ) -> std::io::Result<Option<SessionArchiveManifest>> {
-        match self.get_bytes(&manifest_key(user_id, session_id))? {
-            Some(bytes) => Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("corrupt manifest for session {session_id}: {e}"),
-                )
-            })?)),
-            None => Ok(None),
-        }
-    }
-}
-
-/// Local-filesystem backend. Objects are plain files under `root`; writes
-/// are atomic (temp file in the destination directory + rename).
-pub struct LocalArchiveStore {
-    root: PathBuf,
-}
-
-impl LocalArchiveStore {
-    fn object_path(&self, key: &str) -> PathBuf {
-        // Keys are built exclusively by `manifest_key`/`transcript_key`
-        // from UUIDs and fixed literals — no user-controlled segments.
-        self.root.join(key)
-    }
-
-    fn write_atomic(&self, key: &str, bytes: &[u8]) -> std::io::Result<()> {
-        let path = self.object_path(key);
-        let dir = path.parent().expect("object keys always have a parent");
-        std::fs::create_dir_all(dir)?;
-        let tmp = dir.join(format!(
-            ".{}.tmp",
-            path.file_name()
-                .expect("object keys always have a file name")
-                .to_string_lossy()
-        ));
-        std::fs::write(&tmp, bytes)?;
-        std::fs::rename(&tmp, &path)
-    }
-
-    fn put_session_archive(&self, bundle: &SessionArchiveBundle) -> std::io::Result<()> {
-        let m = &bundle.manifest;
-        if let Some(ndjson) = &bundle.transcript_ndjson {
-            let body = zstd::encode_all(ndjson.as_slice(), ZSTD_LEVEL)?;
-            self.write_atomic(&transcript_key(m.user_id, m.session_id), &body)?;
-        }
-        let manifest_json = serde_json::to_vec_pretty(&bundle.manifest)?;
-        self.write_atomic(&manifest_key(m.user_id, m.session_id), &manifest_json)
-    }
-
-    fn get_session_manifest(
-        &self,
-        user_id: Uuid,
-        session_id: Uuid,
-    ) -> std::io::Result<Option<SessionArchiveManifest>> {
-        let path = self.object_path(&manifest_key(user_id, session_id));
-        match std::fs::read(&path) {
-            Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("corrupt manifest at {}: {e}", path.display()),
-                )
-            })?)),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(e) => Err(e),
-        }
-    }
-}
-
-/// Decompress + parse an archived transcript (test/inspection helper).
-pub fn read_transcript(
-    root: &Path,
-    user_id: Uuid,
-    session_id: Uuid,
-) -> std::io::Result<Vec<ArchiveMessageLine>> {
-    let raw = std::fs::read(root.join(transcript_key(user_id, session_id)))?;
-    parse_transcript_ndjson(&zstd::decode_all(raw.as_slice())?)
-}
-
-fn parse_transcript_ndjson(ndjson: &[u8]) -> std::io::Result<Vec<ArchiveMessageLine>> {
-    String::from_utf8_lossy(ndjson)
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .map(|l| {
-            serde_json::from_str(l).map_err(|e| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, format!("bad line: {e}"))
-            })
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+    use uuid::Uuid;
 
     fn manifest(user_id: Uuid, session_id: Uuid) -> SessionArchiveManifest {
         let t = chrono::NaiveDate::from_ymd_opt(2026, 7, 11)
@@ -859,9 +197,7 @@ mod tests {
     #[test]
     fn local_roundtrip_and_idempotent_overwrite() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = ArchiveStore::Local(LocalArchiveStore {
-            root: tmp.path().to_path_buf(),
-        });
+        let store = ArchiveStore::Local(LocalArchiveStore::new(tmp.path().to_path_buf()));
         let (u, s) = (Uuid::from_u128(7), Uuid::from_u128(9));
         let (m, bundle) = bundle_with_one_line(u, s);
 
@@ -897,11 +233,11 @@ mod tests {
     #[test]
     fn object_store_roundtrip_and_missing_reads() {
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let store = ArchiveStore::Object(ObjectArchiveStore {
-            store: std::sync::Arc::new(object_store::memory::InMemory::new()),
-            prefix: Some("portal-archive".into()),
-            handle: rt.handle().clone(),
-        });
+        let store = ArchiveStore::Object(ObjectArchiveStore::new(
+            std::sync::Arc::new(object_store::memory::InMemory::new()),
+            Some("portal-archive".into()),
+            rt.handle().clone(),
+        ));
         let (u, s) = (Uuid::from_u128(7), Uuid::from_u128(9));
 
         assert!(store.get_session_manifest(u, s).unwrap().is_none());
@@ -973,9 +309,7 @@ mod tests {
     #[test]
     fn missing_manifest_reads_as_none() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = ArchiveStore::Local(LocalArchiveStore {
-            root: tmp.path().to_path_buf(),
-        });
+        let store = ArchiveStore::Local(LocalArchiveStore::new(tmp.path().to_path_buf()));
         assert!(store
             .get_session_manifest(Uuid::from_u128(1), Uuid::from_u128(2))
             .unwrap()
@@ -1079,16 +413,14 @@ mod tests {
     fn media_roundtrip_local_and_object() {
         // Local backend.
         let tmp = tempfile::tempdir().unwrap();
-        let local = ArchiveStore::Local(LocalArchiveStore {
-            root: tmp.path().to_path_buf(),
-        });
+        let local = ArchiveStore::Local(LocalArchiveStore::new(tmp.path().to_path_buf()));
         // Object (S3) backend via the in-memory store.
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let object = ArchiveStore::Object(ObjectArchiveStore {
-            store: std::sync::Arc::new(object_store::memory::InMemory::new()),
-            prefix: Some("portal-archive".into()),
-            handle: rt.handle().clone(),
-        });
+        let object = ArchiveStore::Object(ObjectArchiveStore::new(
+            std::sync::Arc::new(object_store::memory::InMemory::new()),
+            Some("portal-archive".into()),
+            rt.handle().clone(),
+        ));
 
         for store in [&local, &object] {
             let (u, s, m) = (Uuid::from_u128(7), Uuid::from_u128(9), Uuid::from_u128(42));
@@ -1109,9 +441,7 @@ mod tests {
     #[test]
     fn manifest_media_section_roundtrips() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = ArchiveStore::Local(LocalArchiveStore {
-            root: tmp.path().to_path_buf(),
-        });
+        let store = ArchiveStore::Local(LocalArchiveStore::new(tmp.path().to_path_buf()));
         let (u, s) = (Uuid::from_u128(1), Uuid::from_u128(2));
         let m = Uuid::from_u128(3);
         let mut manifest = manifest(u, s);
@@ -1158,9 +488,7 @@ mod tests {
     #[test]
     fn manifest_provenance_fields_roundtrip() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = ArchiveStore::Local(LocalArchiveStore {
-            root: tmp.path().to_path_buf(),
-        });
+        let store = ArchiveStore::Local(LocalArchiveStore::new(tmp.path().to_path_buf()));
         let (u, s) = (Uuid::from_u128(4), Uuid::from_u128(5));
         let mut manifest = manifest(u, s);
         manifest.launcher_id = Some(Uuid::from_u128(6));


### PR DESCRIPTION
PR 1 of the archive/history viewer series (#1288). Moves the format layer (manifest + all sub-structs incl. media/provenance, transcript lines, sidecar meta, key fns, zstd codec, merge) and the store layer (config/env parsing, local + S3 backends) into a new native-only `archive-format` crate, and adds the read/list surface the viewer needs (`list_users`/`list_sessions`, delimiter-listing on S3, read_dir locally, non-UUID entries ignored).

Backend becomes re-exports + backend-only glue (ArchiveRuntime/Stats, sweep consts) — every `crate::archive::X` path and all existing tests unchanged; behavior byte-identical. New store constructors replace private-field struct literals. 8 new crate tests (roundtrip/listing/media/env-config) + full backend suite green.