### PR TITLE
Add portal-archive archive/history viewer CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "archive-viewer"
+version = "2.13.10"
+dependencies = [
+ "anyhow",
+ "archive-format",
+ "chrono",
+ "clap",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "shared",
     "archive-format",
+    "archive-viewer",
     "backend",
     "frontend",
     "proxy",

--- a/archive-viewer/Cargo.toml
+++ b/archive-viewer/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "archive-viewer"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+# Standalone archive/history viewer (#1288). Produces the `portal-archive`
+# binary that reads back session archives written by the backend's archival
+# sweep. It links only the `archive-format` crate (the shared read/write
+# format), never the backend, so it stays a small, self-contained CLI.
+
+[[bin]]
+name = "portal-archive"
+path = "src/main.rs"
+
+[dependencies]
+archive-format = { path = "../archive-format" }
+anyhow = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
+clap = { version = "4.5", features = ["derive", "env"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# The S3 read path blocks on a captured tokio runtime handle, so the binary
+# needs a runtime even though it is otherwise synchronous.
+tokio = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/archive-viewer/README.md
+++ b/archive-viewer/README.md
@@ -1,0 +1,84 @@
+# archive-viewer (`portal-archive`)
+
+A standalone CLI for browsing and summarizing agent-portal's long-term session
+archive — the objects written by the backend's archival sweep, whose on-disk /
+on-S3 format lives in the `archive-format` crate. It links only
+`archive-format`, never the backend, so it can run anywhere the archive is
+reachable: a local filesystem root or an S3-compatible bucket.
+
+## Build
+
+```bash
+cargo build -p archive-viewer            # produces target/debug/portal-archive
+```
+
+## Target selection
+
+Every command reads from one archive target, resolved in this order:
+
+1. `--local-root <path>` — a local filesystem archive root.
+2. `--s3-bucket <bucket> [--s3-prefix <prefix>]` — an S3 (or S3-compatible)
+   bucket; region/credentials/endpoint come from the standard `AWS_*`
+   environment variables.
+3. Otherwise the `PORTAL_SESSION_ARCHIVE_*` environment variables (the same
+   ones the backend uses) are read.
+
+If none resolve, the command exits with a clear error.
+
+## Commands
+
+```bash
+# List archived sessions (one row each), most-recently-active first.
+# Manifest-only — transcripts are never read.
+portal-archive --local-root /srv/archive list
+portal-archive --local-root /srv/archive list \
+    --user alice --agent claude \
+    --from 2026-07-01 --to 2026-07-31 --name refactor
+
+# Aggregate manifest metrics into a grouped table.
+portal-archive --local-root /srv/archive rollup --group-by user   # or agent | model
+portal-archive --local-root /srv/archive rollup --from 2026-07-01
+
+# Export every flattened manifest row (all fields, incl. provenance).
+portal-archive --local-root /srv/archive export --format csv -o sessions.csv
+portal-archive --local-root /srv/archive export --format json
+
+# Print a readable transcript digest for one session (short id prefix ok).
+portal-archive --local-root /srv/archive cat aaaaaaaa
+portal-archive --local-root /srv/archive cat aaaaaaaa --raw   # dump NDJSON verbatim
+```
+
+### `list`
+
+Columns: session id (short), name, agent, status, user email, hostname,
+created, last activity, message count, cost, models, media count. Sorted by
+last activity, descending. Filters: `--user` (email substring or session/user
+UUID prefix), `--agent`, `--name` (substring), and `--from`/`--to` (RFC3339 or
+`YYYY-MM-DD`, matched against last activity).
+
+### `rollup`
+
+Aggregates from manifests alone. `--group-by user|agent|model` (default
+`user`) with the same date filters. A session that used multiple models
+contributes its full totals to *each* model's row (manifests carry no per-model
+token split), so per-model totals can exceed the grand total.
+
+### `export`
+
+A full dump (no filters) of every manifest row as CSV (default) or JSON,
+including the token breakdown, turn stats, and provenance (`client_version`,
+`launcher_id`/`launcher_version`, `scheduled_task_id`, `archived_by_version`).
+Writes to stdout, or to a file with `-o`.
+
+### `cat`
+
+Resolves a session by full id or unique short prefix across all users, then
+prints a one-line-per-message digest (local-time timestamp, role, and a compact
+content summary; `thinking` blocks are skipped). `--raw` dumps the stored
+NDJSON transcript verbatim instead.
+
+## Graceful degradation
+
+A corrupt manifest is warned about on stderr and skipped; a session with no
+archived transcript reports so plainly; an empty archive prints a friendly
+message rather than an empty table.

--- a/archive-viewer/src/cat.rs
+++ b/archive-viewer/src/cat.rs
@@ -1,0 +1,108 @@
+//! `cat` — print a readable transcript digest (or the raw NDJSON) for one
+//! archived session.
+
+use anyhow::{anyhow, Result};
+use archive_format::{transcript_key, zstd_decode, ArchiveMessageLine, ArchiveStore};
+use chrono::{Local, TimeZone, Utc};
+use uuid::Uuid;
+
+use crate::summarize::summarize_content;
+
+/// Read the session's transcript and render it. With `raw`, dumps the stored
+/// NDJSON verbatim; otherwise renders the one-line-per-message digest. Missing
+/// transcripts return a friendly note rather than an error.
+pub fn run(store: &ArchiveStore, user_id: Uuid, session_id: Uuid, raw: bool) -> Result<String> {
+    if raw {
+        return match store
+            .get_object(&transcript_key(user_id, session_id))
+            .map_err(|e| anyhow!("failed to read transcript: {e}"))?
+        {
+            Some(bytes) => {
+                let ndjson = zstd_decode(&bytes)
+                    .map_err(|e| anyhow!("failed to decompress transcript: {e}"))?;
+                Ok(String::from_utf8_lossy(&ndjson).trim_end().to_string())
+            }
+            None => Ok("(no transcript archived for this session)".to_string()),
+        };
+    }
+
+    match store
+        .read_transcript_lines(user_id, session_id)
+        .map_err(|e| anyhow!("failed to read transcript: {e}"))?
+    {
+        Some(lines) if !lines.is_empty() => Ok(digest(&lines)),
+        Some(_) => Ok("(transcript archived but empty)".to_string()),
+        None => Ok("(no transcript archived for this session)".to_string()),
+    }
+}
+
+/// Render a full digest: one line per message.
+pub fn digest(lines: &[ArchiveMessageLine]) -> String {
+    lines.iter().map(digest_line).collect::<Vec<_>>().join("\n")
+}
+
+/// One digest line: `local-timestamp  role  summary`. The stored timestamp is
+/// UTC-naive; it is converted to the viewer's local timezone for display.
+fn digest_line(line: &ArchiveMessageLine) -> String {
+    let ts = Utc
+        .from_utc_datetime(&line.created_at)
+        .with_timezone(&Local)
+        .format("%Y-%m-%d %H:%M:%S");
+    format!(
+        "{ts}  {:<9}  {}",
+        line.role,
+        summarize_content(&line.content)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+    use serde_json::json;
+
+    fn line(role: &str, content: serde_json::Value) -> ArchiveMessageLine {
+        ArchiveMessageLine {
+            id: Uuid::new_v4(),
+            role: role.to_string(),
+            created_at: NaiveDate::from_ymd_opt(2026, 7, 11)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+            agent_type: "claude".to_string(),
+            content,
+        }
+    }
+
+    #[test]
+    fn digest_has_one_line_per_message_with_role_and_summary() {
+        let lines = vec![
+            line("user", json!("please refactor this")),
+            line(
+                "assistant",
+                json!({"content": [{"type": "text", "text": "on it"},
+                                   {"type": "tool_use", "name": "Edit"}]}),
+            ),
+        ];
+        let out = digest(&lines);
+        let rendered: Vec<&str> = out.lines().collect();
+        assert_eq!(rendered.len(), 2);
+        assert!(rendered[0].contains("user"));
+        assert!(rendered[0].contains("please refactor this"));
+        assert!(rendered[1].contains("assistant"));
+        assert!(rendered[1].contains("on it"));
+        assert!(rendered[1].contains("[tool_use: Edit]"));
+    }
+
+    #[test]
+    fn digest_skips_thinking_in_summary() {
+        let lines = vec![line(
+            "assistant",
+            json!([{"type": "thinking", "thinking": "hidden"},
+                   {"type": "text", "text": "shown"}]),
+        )];
+        let out = digest(&lines);
+        assert!(out.contains("shown"));
+        assert!(!out.contains("hidden"));
+    }
+}

--- a/archive-viewer/src/export.rs
+++ b/archive-viewer/src/export.rs
@@ -1,0 +1,310 @@
+//! `export` — flatten every manifest row (all fields, including provenance)
+//! to CSV or JSON. Same row shape as `list`, plus the full token/turn
+//! breakdown and provenance columns.
+
+use serde::Serialize;
+
+use crate::rows::FlatRow;
+
+/// Output format for `export`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum Format {
+    Csv,
+    Json,
+}
+
+/// A fully-flattened manifest row. Every field is a scalar (or a small joined
+/// string) so it serializes cleanly to both CSV and JSON. `Option` renders as
+/// an empty CSV cell / JSON `null`.
+#[derive(Serialize)]
+pub struct ExportRow {
+    pub session_id: String,
+    pub user_id: String,
+    pub owner_email: String,
+    pub owner_name: Option<String>,
+    pub session_name: String,
+    pub agent_type: String,
+    pub status: String,
+    pub working_directory: String,
+    pub hostname: String,
+    pub git_branch: Option<String>,
+    pub repo_url: Option<String>,
+    pub pr_url: Option<String>,
+    pub created_at: String,
+    pub last_activity: String,
+    pub archived_at: String,
+    pub message_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub thinking_tokens: i64,
+    pub subagent_tokens: i64,
+    pub total_cost_usd: f64,
+    pub turn_count: i64,
+    pub turn_errored: i64,
+    pub tool_calls: i64,
+    pub stream_restarts: i64,
+    pub total_duration_ms: i64,
+    /// Distinct models, joined with `|`.
+    pub models: String,
+    pub media_count: usize,
+    pub media_bytes: u64,
+    // --- Provenance ---
+    pub client_version: Option<String>,
+    pub launcher_id: Option<String>,
+    pub launcher_version: Option<String>,
+    pub scheduled_task_id: Option<String>,
+    /// Extra agent CLI args, joined with a space.
+    pub claude_args: String,
+    pub archived_by_version: Option<String>,
+}
+
+impl ExportRow {
+    pub fn from_row(row: &FlatRow) -> Self {
+        let m = &row.manifest;
+        Self {
+            session_id: m.session_id.to_string(),
+            user_id: m.user_id.to_string(),
+            owner_email: m.owner_email.clone(),
+            owner_name: m.owner_name.clone(),
+            session_name: m.session_name.clone(),
+            agent_type: m.agent_type.clone(),
+            status: m.status.clone(),
+            working_directory: m.working_directory.clone(),
+            hostname: m.hostname.clone(),
+            git_branch: m.git_branch.clone(),
+            repo_url: m.repo_url.clone(),
+            pr_url: m.pr_url.clone(),
+            created_at: fmt(&m.created_at),
+            last_activity: fmt(&m.last_activity),
+            archived_at: fmt(&m.archived_at),
+            message_count: row.message_count(),
+            input_tokens: m.tokens.input,
+            output_tokens: m.tokens.output,
+            cache_creation_tokens: m.tokens.cache_creation,
+            cache_read_tokens: m.tokens.cache_read,
+            thinking_tokens: m.tokens.thinking,
+            subagent_tokens: m.tokens.subagent,
+            total_cost_usd: m.total_cost_usd,
+            turn_count: m.turns.count,
+            turn_errored: m.turns.errored,
+            tool_calls: m.turns.tool_calls,
+            stream_restarts: m.turns.stream_restarts,
+            total_duration_ms: m.turns.total_duration_ms,
+            models: m.turns.models.join("|"),
+            media_count: row.media_count(),
+            media_bytes: row.media_bytes(),
+            client_version: m.client_version.clone(),
+            launcher_id: m.launcher_id.map(|id| id.to_string()),
+            launcher_version: m.launcher_version.clone(),
+            scheduled_task_id: m.scheduled_task_id.map(|id| id.to_string()),
+            claude_args: m.claude_args.join(" "),
+            archived_by_version: m.archived_by_version.clone(),
+        }
+    }
+
+    /// CSV cells in `CSV_HEADERS` order.
+    fn csv_cells(&self) -> Vec<String> {
+        vec![
+            self.session_id.clone(),
+            self.user_id.clone(),
+            self.owner_email.clone(),
+            opt(&self.owner_name),
+            self.session_name.clone(),
+            self.agent_type.clone(),
+            self.status.clone(),
+            self.working_directory.clone(),
+            self.hostname.clone(),
+            opt(&self.git_branch),
+            opt(&self.repo_url),
+            opt(&self.pr_url),
+            self.created_at.clone(),
+            self.last_activity.clone(),
+            self.archived_at.clone(),
+            self.message_count.to_string(),
+            self.input_tokens.to_string(),
+            self.output_tokens.to_string(),
+            self.cache_creation_tokens.to_string(),
+            self.cache_read_tokens.to_string(),
+            self.thinking_tokens.to_string(),
+            self.subagent_tokens.to_string(),
+            format!("{:.6}", self.total_cost_usd),
+            self.turn_count.to_string(),
+            self.turn_errored.to_string(),
+            self.tool_calls.to_string(),
+            self.stream_restarts.to_string(),
+            self.total_duration_ms.to_string(),
+            self.models.clone(),
+            self.media_count.to_string(),
+            self.media_bytes.to_string(),
+            opt(&self.client_version),
+            opt(&self.launcher_id),
+            opt(&self.launcher_version),
+            opt(&self.scheduled_task_id),
+            self.claude_args.clone(),
+            opt(&self.archived_by_version),
+        ]
+    }
+}
+
+pub const CSV_HEADERS: &[&str] = &[
+    "session_id",
+    "user_id",
+    "owner_email",
+    "owner_name",
+    "session_name",
+    "agent_type",
+    "status",
+    "working_directory",
+    "hostname",
+    "git_branch",
+    "repo_url",
+    "pr_url",
+    "created_at",
+    "last_activity",
+    "archived_at",
+    "message_count",
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_tokens",
+    "cache_read_tokens",
+    "thinking_tokens",
+    "subagent_tokens",
+    "total_cost_usd",
+    "turn_count",
+    "turn_errored",
+    "tool_calls",
+    "stream_restarts",
+    "total_duration_ms",
+    "models",
+    "media_count",
+    "media_bytes",
+    "client_version",
+    "launcher_id",
+    "launcher_version",
+    "scheduled_task_id",
+    "claude_args",
+    "archived_by_version",
+];
+
+/// Serialize `rows` in `format`. JSON is a pretty array; CSV is RFC4180 with a
+/// header line. Returns an error only if JSON serialization somehow fails.
+pub fn render(rows: &[FlatRow], format: Format) -> anyhow::Result<String> {
+    let export: Vec<ExportRow> = rows.iter().map(ExportRow::from_row).collect();
+    match format {
+        Format::Json => Ok(serde_json::to_string_pretty(&export)?),
+        Format::Csv => Ok(render_csv(&export)),
+    }
+}
+
+fn render_csv(rows: &[ExportRow]) -> String {
+    let mut out = String::new();
+    out.push_str(
+        &CSV_HEADERS
+            .iter()
+            .map(|h| escape_csv(h))
+            .collect::<Vec<_>>()
+            .join(","),
+    );
+    for row in rows {
+        out.push('\n');
+        out.push_str(
+            &row.csv_cells()
+                .iter()
+                .map(|c| escape_csv(c))
+                .collect::<Vec<_>>()
+                .join(","),
+        );
+    }
+    out
+}
+
+/// RFC4180 field escaping: quote when the field contains a comma, quote,
+/// CR, or LF; internal quotes are doubled.
+fn escape_csv(field: &str) -> String {
+    if field.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", field.replace('"', "\"\""))
+    } else {
+        field.to_string()
+    }
+}
+
+fn opt(v: &Option<String>) -> String {
+    v.clone().unwrap_or_default()
+}
+
+fn fmt(dt: &chrono::NaiveDateTime) -> String {
+    dt.format("%Y-%m-%dT%H:%M:%S").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rows::test_support::manifest;
+    use crate::rows::FlatRow;
+    use chrono::NaiveDate;
+    use uuid::Uuid;
+
+    fn dt() -> chrono::NaiveDateTime {
+        NaiveDate::from_ymd_opt(2026, 7, 11)
+            .unwrap()
+            .and_hms_opt(9, 30, 0)
+            .unwrap()
+    }
+
+    fn sample_row() -> FlatRow {
+        let mut m = manifest(
+            Uuid::from_u128(1),
+            Uuid::from_u128(2),
+            "dev@x.io",
+            "name, with comma",
+            "claude",
+            dt(),
+        );
+        m.tokens.input = 100;
+        m.total_cost_usd = 1.25;
+        m.turns.models = vec!["opus".to_string(), "sonnet".to_string()];
+        m.client_version = Some("2.13.5".to_string());
+        m.archived_by_version = Some("2.13.9".to_string());
+        FlatRow {
+            user_id: Uuid::from_u128(1),
+            manifest: m,
+        }
+    }
+
+    #[test]
+    fn csv_has_header_and_quotes_commas() {
+        let out = render(&[sample_row()], Format::Csv).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines[0], CSV_HEADERS.join(","));
+        assert_eq!(lines.len(), 2);
+        // The comma-containing name must be quoted.
+        assert!(lines[1].contains("\"name, with comma\""));
+        // Joined models and provenance are present.
+        assert!(lines[1].contains("opus|sonnet"));
+        assert!(lines[1].contains("2.13.5"));
+        assert!(lines[1].contains("2.13.9"));
+    }
+
+    #[test]
+    fn json_is_array_of_objects_with_expected_fields() {
+        let out = render(&[sample_row()], Format::Json).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let obj = &arr[0];
+        assert_eq!(obj["owner_email"], "dev@x.io");
+        assert_eq!(obj["input_tokens"], 100);
+        assert_eq!(obj["models"], "opus|sonnet");
+        assert_eq!(obj["client_version"], "2.13.5");
+        // Unset provenance is JSON null.
+        assert!(obj["launcher_id"].is_null());
+    }
+
+    #[test]
+    fn escape_csv_doubles_internal_quotes() {
+        assert_eq!(escape_csv("a\"b"), "\"a\"\"b\"");
+        assert_eq!(escape_csv("plain"), "plain");
+    }
+}

--- a/archive-viewer/src/fixture_tests.rs
+++ b/archive-viewer/src/fixture_tests.rs
@@ -1,0 +1,281 @@
+//! End-to-end tests over a real fixture archive built in a tempdir through
+//! `archive-format`'s own put paths (`put_session_archive` / `put_media`), so
+//! the viewer is exercised against genuinely-written objects rather than
+//! hand-mocked rows. Covers multi-user / multi-session, media sidecars, and
+//! one media-less older-style manifest.
+
+use archive_format::{
+    ArchiveMessageLine, ArchiveStore, ArchivedMediaMeta, LocalArchiveStore, SessionArchiveBundle,
+};
+use chrono::{NaiveDate, NaiveDateTime};
+use serde_json::json;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use crate::export::{self, Format};
+use crate::rollup::{self, GroupBy};
+use crate::rows::test_support::{manifest, media_entry};
+use crate::rows::{collect_rows, filter_and_sort, resolve_session, Filters};
+use crate::{cat, list};
+
+const USER_A: u128 = 0xAAAA_0000_0000_0000_0000_0000_0000_000A;
+const USER_B: u128 = 0xBBBB_0000_0000_0000_0000_0000_0000_000B;
+const SESSION_A1: u128 = 0x1111_0000_0000_0000_0000_0000_0000_0001;
+const SESSION_A2: u128 = 0x2222_0000_0000_0000_0000_0000_0000_0002;
+const SESSION_B1: u128 = 0x3333_0000_0000_0000_0000_0000_0000_0003;
+
+fn day(d: u32) -> NaiveDateTime {
+    NaiveDate::from_ymd_opt(2026, 7, d)
+        .unwrap()
+        .and_hms_opt(12, 0, 0)
+        .unwrap()
+}
+
+fn ndjson(lines: &[ArchiveMessageLine]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for l in lines {
+        buf.extend_from_slice(serde_json::to_string(l).unwrap().as_bytes());
+        buf.push(b'\n');
+    }
+    buf
+}
+
+fn msg(role: &str, day_of_month: u32, content: serde_json::Value) -> ArchiveMessageLine {
+    ArchiveMessageLine {
+        id: Uuid::new_v4(),
+        role: role.to_string(),
+        created_at: day(day_of_month),
+        agent_type: "claude".to_string(),
+        content,
+    }
+}
+
+/// Build the fixture archive and return the tempdir (kept alive) + store.
+fn build_fixture() -> (TempDir, ArchiveStore) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = ArchiveStore::Local(LocalArchiveStore::new(dir.path().to_path_buf()));
+
+    let (user_a, user_b) = (Uuid::from_u128(USER_A), Uuid::from_u128(USER_B));
+
+    // --- User A, session 1: claude, media in manifest + written-through. ---
+    let mut a1 = manifest(
+        user_a,
+        Uuid::from_u128(SESSION_A1),
+        "alice@example.com",
+        "refactor the rail",
+        "claude",
+        day(14),
+    );
+    a1.message_counts
+        .extend([("user".to_string(), 2), ("assistant".to_string(), 1)]);
+    a1.tokens.input = 100;
+    a1.tokens.output = 50;
+    a1.tokens.cache_creation = 10;
+    a1.tokens.cache_read = 5;
+    a1.tokens.thinking = 3;
+    a1.total_cost_usd = 0.10;
+    a1.turns.count = 2;
+    a1.turns.tool_calls = 4;
+    a1.turns.models = vec!["opus".to_string()];
+    let media_id = Uuid::new_v4();
+    a1.media = Some(vec![media_entry(media_id, 2048)]);
+    store
+        .put_session_archive(&SessionArchiveBundle {
+            manifest: a1,
+            transcript_ndjson: Some(ndjson(&[
+                msg("user", 14, json!("please refactor the rail")),
+                msg(
+                    "assistant",
+                    14,
+                    json!({"content": [
+                        {"type": "thinking", "thinking": "hidden reasoning"},
+                        {"type": "text", "text": "starting the refactor"},
+                        {"type": "tool_use", "name": "Edit", "input": {}},
+                    ]}),
+                ),
+                msg("user", 14, json!("thanks")),
+            ])),
+        })
+        .unwrap();
+    let meta = ArchivedMediaMeta {
+        media_id,
+        kind: "image".to_string(),
+        content_type: "image/png".to_string(),
+        filename: Some("plot.png".to_string()),
+        bytes: 2048,
+        uploaded_at: day(14),
+    };
+    store
+        .put_media(user_a, Uuid::from_u128(SESSION_A1), &meta, &vec![0u8; 2048])
+        .unwrap();
+
+    // --- User A, session 2: media-less, older-style manifest (media = None). ---
+    let mut a2 = manifest(
+        user_a,
+        Uuid::from_u128(SESSION_A2),
+        "alice@example.com",
+        "docs pass",
+        "claude",
+        day(12),
+    );
+    a2.message_counts.insert("user".to_string(), 1);
+    a2.tokens.input = 200;
+    a2.tokens.output = 100;
+    a2.total_cost_usd = 0.20;
+    a2.turns.count = 1;
+    a2.turns.tool_calls = 1;
+    a2.turns.models = vec!["sonnet".to_string()];
+    assert!(a2.media.is_none(), "a2 is the media-less older-style row");
+    store
+        .put_session_archive(&SessionArchiveBundle {
+            manifest: a2,
+            transcript_ndjson: Some(ndjson(&[msg("user", 12, json!("update the docs"))])),
+        })
+        .unwrap();
+
+    // --- User B, session 1: codex, media. ---
+    let mut b1 = manifest(
+        user_b,
+        Uuid::from_u128(SESSION_B1),
+        "bob@example.com",
+        "codex spike",
+        "codex",
+        day(13),
+    );
+    b1.tokens.input = 300;
+    b1.total_cost_usd = 0.30;
+    b1.turns.count = 3;
+    b1.turns.models = vec!["gpt-5".to_string()];
+    b1.media = Some(vec![media_entry(Uuid::new_v4(), 4096)]);
+    store
+        .put_session_archive(&SessionArchiveBundle {
+            manifest: b1,
+            transcript_ndjson: Some(ndjson(&[msg("user", 13, json!("spike a codex flow"))])),
+        })
+        .unwrap();
+
+    (dir, store)
+}
+
+#[test]
+fn collects_all_three_sessions_across_two_users() {
+    let (_dir, store) = build_fixture();
+    let rows = collect_rows(&store).unwrap();
+    assert_eq!(rows.len(), 3);
+}
+
+#[test]
+fn list_filters_by_agent_and_user() {
+    let (_dir, store) = build_fixture();
+    let rows = collect_rows(&store).unwrap();
+
+    let codex = filter_and_sort(
+        collect_rows(&store).unwrap(),
+        &Filters {
+            agent: Some("codex".to_string()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(codex.len(), 1);
+    assert_eq!(codex[0].manifest.owner_email, "bob@example.com");
+
+    let alice = filter_and_sort(
+        rows,
+        &Filters {
+            user: Some("alice".to_string()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(alice.len(), 2);
+    // Sorted by last_activity desc: the day-14 session comes first.
+    assert_eq!(alice[0].manifest.session_name, "refactor the rail");
+
+    // The rendered table names the media-bearing and media-less rows.
+    let out = list::render(&alice);
+    assert!(out.contains("refactor the rail"));
+    assert!(out.contains("docs pass"));
+}
+
+#[test]
+fn rollup_by_user_sums_manifest_metrics() {
+    let (_dir, store) = build_fixture();
+    let rows = filter_and_sort(collect_rows(&store).unwrap(), &Filters::default());
+    let out = rollup::render(&rows, GroupBy::User);
+
+    let alice = out
+        .lines()
+        .find(|l| l.starts_with("alice@example.com"))
+        .unwrap();
+    // alice: 2 sessions, turns 2+1=3, input 100+200=300, output 50+100=150,
+    // cache (10+5)+0=15, thinking 3, cost 0.30, tools 4+1=5, media 2048.
+    assert!(alice.contains("300"), "input sum: {alice}");
+    assert!(alice.contains("150"), "output sum: {alice}");
+    assert!(alice.contains("$0.3000"), "cost sum: {alice}");
+    assert!(alice.contains("2048"), "media bytes: {alice}");
+
+    let bob = out
+        .lines()
+        .find(|l| l.starts_with("bob@example.com"))
+        .unwrap();
+    assert!(bob.contains("4096"), "bob media bytes: {bob}");
+}
+
+#[test]
+fn export_csv_and_json_have_expected_shape() {
+    let (_dir, store) = build_fixture();
+    let rows = filter_and_sort(collect_rows(&store).unwrap(), &Filters::default());
+
+    let csv = export::render(&rows, Format::Csv).unwrap();
+    let csv_lines: Vec<&str> = csv.lines().collect();
+    assert_eq!(csv_lines[0], export::CSV_HEADERS.join(","));
+    assert_eq!(csv_lines.len(), 1 + 3, "header + 3 rows");
+    assert!(csv.contains("alice@example.com"));
+    assert!(csv.contains("opus"));
+
+    let jsonv: serde_json::Value =
+        serde_json::from_str(&export::render(&rows, Format::Json).unwrap()).unwrap();
+    let arr = jsonv.as_array().unwrap();
+    assert_eq!(arr.len(), 3);
+    assert!(arr.iter().any(|r| r["owner_email"] == "bob@example.com"));
+    // The media-less A2 row reports zero media, provenance null.
+    let a2 = arr
+        .iter()
+        .find(|r| r["session_name"] == "docs pass")
+        .unwrap();
+    assert_eq!(a2["media_count"], 0);
+    assert!(a2["launcher_id"].is_null());
+}
+
+#[test]
+fn cat_resolves_short_prefix_and_renders_digest() {
+    let (_dir, store) = build_fixture();
+    let rows = collect_rows(&store).unwrap();
+
+    // "1111" uniquely identifies session A1.
+    let row = resolve_session("1111", &rows).unwrap();
+    assert_eq!(row.manifest.session_id, Uuid::from_u128(SESSION_A1));
+
+    let digest = cat::run(&store, row.user_id, row.manifest.session_id, false).unwrap();
+    let lines: Vec<&str> = digest.lines().collect();
+    assert_eq!(lines.len(), 3, "one line per message");
+    assert!(lines[0].contains("please refactor the rail"));
+    assert!(lines[1].contains("starting the refactor"));
+    assert!(lines[1].contains("[tool_use: Edit]"));
+    // Thinking blocks are omitted from the digest.
+    assert!(!digest.contains("hidden reasoning"));
+
+    // Raw mode dumps the stored NDJSON verbatim (3 lines, valid JSON each).
+    let raw = cat::run(&store, row.user_id, row.manifest.session_id, true).unwrap();
+    assert_eq!(raw.lines().count(), 3);
+    for l in raw.lines() {
+        let _: serde_json::Value = serde_json::from_str(l).unwrap();
+    }
+}
+
+#[test]
+fn cat_missing_transcript_is_friendly() {
+    let (_dir, store) = build_fixture();
+    // A session id that was never archived -> resolve fails cleanly.
+    let rows = collect_rows(&store).unwrap();
+    assert!(resolve_session("ffffffff", &rows).is_err());
+}

--- a/archive-viewer/src/list.rs
+++ b/archive-viewer/src/list.rs
@@ -1,0 +1,101 @@
+//! `list` — one table row per archived session, manifest-only.
+
+use crate::rows::FlatRow;
+use crate::table;
+
+const HEADERS: &[&str] = &[
+    "SESSION", "NAME", "AGENT", "STATUS", "USER", "HOST", "CREATED", "ACTIVITY", "MSGS", "COST",
+    "MODELS", "MEDIA",
+];
+
+/// Render the list table for `rows` (already filtered and sorted). Returns a
+/// friendly message instead of an empty table when there is nothing to show.
+pub fn render(rows: &[FlatRow]) -> String {
+    if rows.is_empty() {
+        return "No archived sessions match.".to_string();
+    }
+    let table_rows: Vec<Vec<String>> = rows.iter().map(row_cells).collect();
+    table::render(HEADERS, &table_rows)
+}
+
+fn row_cells(row: &FlatRow) -> Vec<String> {
+    let m = &row.manifest;
+    vec![
+        row.short_id(),
+        truncate(&m.session_name, 30),
+        m.agent_type.clone(),
+        m.status.clone(),
+        truncate(&m.owner_email, 24),
+        truncate(&m.hostname, 16),
+        fmt_dt(&m.created_at),
+        fmt_dt(&m.last_activity),
+        row.message_count().to_string(),
+        format!("${:.4}", m.total_cost_usd),
+        if m.turns.models.is_empty() {
+            "-".to_string()
+        } else {
+            m.turns.models.join(",")
+        },
+        row.media_count().to_string(),
+    ]
+}
+
+/// Format a manifest timestamp (stored UTC-naive) as `YYYY-MM-DD HH:MM`.
+pub fn fmt_dt(dt: &chrono::NaiveDateTime) -> String {
+    dt.format("%Y-%m-%d %H:%M").to_string()
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let kept: String = s.chars().take(max.saturating_sub(1)).collect();
+    format!("{kept}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rows::test_support::manifest;
+    use crate::rows::FlatRow;
+    use chrono::NaiveDate;
+    use uuid::Uuid;
+
+    fn dt() -> chrono::NaiveDateTime {
+        NaiveDate::from_ymd_opt(2026, 7, 11)
+            .unwrap()
+            .and_hms_opt(9, 30, 0)
+            .unwrap()
+    }
+
+    #[test]
+    fn empty_is_friendly() {
+        assert_eq!(render(&[]), "No archived sessions match.");
+    }
+
+    #[test]
+    fn row_shows_short_id_name_agent_and_cost() {
+        let mut m = manifest(
+            Uuid::from_u128(1),
+            Uuid::from_u128(0xabcdef12),
+            "dev@x.io",
+            "my session",
+            "claude",
+            dt(),
+        );
+        m.total_cost_usd = 1.5;
+        m.turns.models = vec!["opus".to_string(), "sonnet".to_string()];
+        let rows = vec![FlatRow {
+            user_id: Uuid::from_u128(1),
+            manifest: m,
+        }];
+        let out = render(&rows);
+        assert!(out.contains("my session"));
+        assert!(out.contains("claude"));
+        assert!(out.contains("dev@x.io"));
+        assert!(out.contains("$1.5000"));
+        assert!(out.contains("opus,sonnet"));
+        // Short id is the first 8 hex chars of the simple form.
+        assert!(out.contains(&Uuid::from_u128(0xabcdef12).simple().to_string()[..8]));
+    }
+}

--- a/archive-viewer/src/main.rs
+++ b/archive-viewer/src/main.rs
@@ -1,0 +1,236 @@
+//! `portal-archive` — standalone archive/history viewer (#1288).
+//!
+//! Reads back the long-term session archive written by the backend's archival
+//! sweep (`archive-format` crate) and offers a small CLI over it: `list`,
+//! `rollup`, `export`, and `cat`. It links only `archive-format`, never the
+//! backend.
+//!
+//! The whole tool is synchronous, but the S3 backend's store methods block on
+//! a captured tokio runtime handle, so the entrypoint is `#[tokio::main]` to
+//! guarantee a runtime exists when the store is constructed.
+
+mod cat;
+mod export;
+mod list;
+mod rollup;
+mod rows;
+mod summarize;
+mod table;
+
+#[cfg(test)]
+mod fixture_tests;
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use archive_format::{archive_config_from_env, ArchiveBackendConfig, ArchiveConfig, ArchiveStore};
+use clap::{Args as ClapArgs, Parser, Subcommand};
+
+use crate::export::Format;
+use crate::rollup::GroupBy;
+use crate::rows::{collect_rows, filter_and_sort, parse_date_arg, resolve_session, Filters};
+
+#[derive(Parser, Debug)]
+#[command(name = "portal-archive")]
+#[command(about = "Browse and summarize the long-term session archive")]
+#[command(
+    after_help = "Target selection: pass --local-root or --s3-bucket, else the \
+                  PORTAL_SESSION_ARCHIVE_* environment variables are used.\n  \
+                  Source & issues: https://github.com/meawoppl/agent-portal"
+)]
+struct Args {
+    #[command(flatten)]
+    target: TargetArgs,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+/// Global archive-target selection flags (usable before or after the
+/// subcommand).
+#[derive(ClapArgs, Debug)]
+struct TargetArgs {
+    /// Read from a local filesystem archive rooted at this path.
+    #[arg(long, global = true, conflicts_with = "s3_bucket")]
+    local_root: Option<PathBuf>,
+
+    /// Read from this S3 (or S3-compatible) bucket. Region/credentials/endpoint
+    /// come from the standard AWS_* environment variables.
+    #[arg(long, global = true)]
+    s3_bucket: Option<String>,
+
+    /// Key prefix inside the S3 bucket (requires --s3-bucket).
+    #[arg(long, global = true, requires = "s3_bucket")]
+    s3_prefix: Option<String>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// List archived sessions (one row each), most-recently-active first.
+    List(ListArgs),
+    /// Aggregate manifest metrics into a grouped table.
+    Rollup(RollupArgs),
+    /// Export flattened manifest rows (all fields) as CSV or JSON.
+    Export(ExportArgs),
+    /// Print a readable transcript digest for one session.
+    Cat(CatArgs),
+}
+
+#[derive(ClapArgs, Debug)]
+struct ListArgs {
+    /// Filter by user: an email substring or a session/user UUID prefix.
+    #[arg(long)]
+    user: Option<String>,
+    /// Filter by agent type (e.g. claude, codex).
+    #[arg(long)]
+    agent: Option<String>,
+    /// Only sessions last active on/after this RFC3339 datetime or YYYY-MM-DD.
+    #[arg(long)]
+    from: Option<String>,
+    /// Only sessions last active on/before this RFC3339 datetime or YYYY-MM-DD.
+    #[arg(long)]
+    to: Option<String>,
+    /// Filter by a substring of the session name (case-insensitive).
+    #[arg(long)]
+    name: Option<String>,
+}
+
+#[derive(ClapArgs, Debug)]
+struct RollupArgs {
+    /// What to group rows by.
+    #[arg(long, value_enum, default_value_t = GroupBy::User)]
+    group_by: GroupBy,
+    /// Only sessions last active on/after this RFC3339 datetime or YYYY-MM-DD.
+    #[arg(long)]
+    from: Option<String>,
+    /// Only sessions last active on/before this RFC3339 datetime or YYYY-MM-DD.
+    #[arg(long)]
+    to: Option<String>,
+}
+
+#[derive(ClapArgs, Debug)]
+struct ExportArgs {
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = Format::Csv)]
+    format: Format,
+    /// Write to this file instead of stdout.
+    #[arg(short = 'o', long)]
+    output: Option<PathBuf>,
+}
+
+#[derive(ClapArgs, Debug)]
+struct CatArgs {
+    /// Session id or unique short prefix.
+    session: String,
+    /// Dump the raw NDJSON transcript instead of the digest.
+    #[arg(long)]
+    raw: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    // Keep CLI errors to a single clean stderr line (no anyhow backtrace).
+    if let Err(e) = run() {
+        eprintln!("error: {e:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let args = Args::parse();
+    let config = resolve_config(&args.target)?;
+    let store = ArchiveStore::from_config(&config)
+        .map_err(|e| anyhow!("failed to open archive store: {e}"))?;
+
+    match args.command {
+        Command::List(a) => run_list(&store, a),
+        Command::Rollup(a) => run_rollup(&store, a),
+        Command::Export(a) => run_export(&store, a),
+        Command::Cat(a) => run_cat(&store, a),
+    }
+}
+
+/// Resolve the archive target from flags, falling back to the environment.
+fn resolve_config(target: &TargetArgs) -> Result<ArchiveConfig> {
+    if let Some(root) = &target.local_root {
+        return Ok(ArchiveConfig {
+            backend: ArchiveBackendConfig::Local { root: root.clone() },
+            transcripts: true,
+            media: true,
+        });
+    }
+    if let Some(bucket) = &target.s3_bucket {
+        return Ok(ArchiveConfig {
+            backend: ArchiveBackendConfig::S3 {
+                bucket: bucket.clone(),
+                prefix: target.s3_prefix.clone(),
+            },
+            transcripts: true,
+            media: true,
+        });
+    }
+    match archive_config_from_env().map_err(|e| anyhow!(e))? {
+        Some(config) => Ok(config),
+        None => Err(anyhow!(
+            "no archive target: pass --local-root <path> or --s3-bucket <bucket>, \
+             or set the PORTAL_SESSION_ARCHIVE_* environment variables"
+        )),
+    }
+}
+
+fn build_filters(
+    user: Option<String>,
+    agent: Option<String>,
+    name: Option<String>,
+    from: Option<String>,
+    to: Option<String>,
+) -> Result<Filters> {
+    Ok(Filters {
+        user,
+        agent,
+        name,
+        from: from
+            .as_deref()
+            .map(|s| parse_date_arg(s, false))
+            .transpose()?,
+        to: to.as_deref().map(|s| parse_date_arg(s, true)).transpose()?,
+    })
+}
+
+fn run_list(store: &ArchiveStore, a: ListArgs) -> Result<()> {
+    let filters = build_filters(a.user, a.agent, a.name, a.from, a.to)?;
+    let rows = filter_and_sort(collect_rows(store)?, &filters);
+    println!("{}", list::render(&rows));
+    Ok(())
+}
+
+fn run_rollup(store: &ArchiveStore, a: RollupArgs) -> Result<()> {
+    let filters = build_filters(None, None, None, a.from, a.to)?;
+    let rows = filter_and_sort(collect_rows(store)?, &filters);
+    println!("{}", rollup::render(&rows, a.group_by));
+    Ok(())
+}
+
+fn run_export(store: &ArchiveStore, a: ExportArgs) -> Result<()> {
+    // Export mirrors `list`'s default ordering but applies no filters — it is
+    // a full dump of every archived manifest row.
+    let rows = filter_and_sort(collect_rows(store)?, &Filters::default());
+    let rendered = export::render(&rows, a.format)?;
+    match a.output {
+        Some(path) => {
+            std::fs::write(&path, rendered)
+                .with_context(|| format!("failed to write {}", path.display()))?;
+            eprintln!("Wrote {} rows to {}", rows.len(), path.display());
+        }
+        None => println!("{rendered}"),
+    }
+    Ok(())
+}
+
+fn run_cat(store: &ArchiveStore, a: CatArgs) -> Result<()> {
+    let rows = collect_rows(store)?;
+    let row = resolve_session(&a.session, &rows)?;
+    let out = cat::run(store, row.user_id, row.manifest.session_id, a.raw)?;
+    println!("{out}");
+    Ok(())
+}

--- a/archive-viewer/src/rollup.rs
+++ b/archive-viewer/src/rollup.rs
@@ -1,0 +1,194 @@
+//! `rollup` — aggregate manifest metrics into a grouped table.
+
+use std::collections::BTreeMap;
+
+use crate::rows::FlatRow;
+use crate::table;
+
+/// What to group rows by.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum GroupBy {
+    /// Group by owner email.
+    User,
+    /// Group by agent type (`claude` / `codex`).
+    Agent,
+    /// Group by model. A session that used multiple models contributes its
+    /// full totals to *each* model's row (manifests carry no per-model token
+    /// split), so per-model sessions/tokens can exceed the grand total.
+    Model,
+}
+
+#[derive(Default)]
+struct Agg {
+    sessions: i64,
+    turns: i64,
+    input: i64,
+    output: i64,
+    cache: i64,
+    thinking: i64,
+    cost: f64,
+    tool_calls: i64,
+    media_bytes: u64,
+}
+
+impl Agg {
+    fn add(&mut self, row: &FlatRow) {
+        let m = &row.manifest;
+        self.sessions += 1;
+        self.turns += m.turns.count;
+        self.input += m.tokens.input;
+        self.output += m.tokens.output;
+        self.cache += row.cache_tokens();
+        self.thinking += m.tokens.thinking;
+        self.cost += m.total_cost_usd;
+        self.tool_calls += m.turns.tool_calls;
+        self.media_bytes += row.media_bytes();
+    }
+}
+
+const HEADERS: &[&str] = &[
+    "GROUP",
+    "SESSIONS",
+    "TURNS",
+    "INPUT",
+    "OUTPUT",
+    "CACHE",
+    "THINKING",
+    "COST",
+    "TOOLS",
+    "MEDIA_BYTES",
+];
+
+/// Aggregate `rows` by `group_by` and render the table. Returns a friendly
+/// message when there is nothing to aggregate.
+pub fn render(rows: &[FlatRow], group_by: GroupBy) -> String {
+    if rows.is_empty() {
+        return "No archived sessions to roll up.".to_string();
+    }
+    let mut groups: BTreeMap<String, Agg> = BTreeMap::new();
+    for row in rows {
+        for key in group_keys(row, group_by) {
+            groups.entry(key).or_default().add(row);
+        }
+    }
+
+    let table_rows: Vec<Vec<String>> = groups
+        .iter()
+        .map(|(key, a)| {
+            vec![
+                key.clone(),
+                a.sessions.to_string(),
+                a.turns.to_string(),
+                a.input.to_string(),
+                a.output.to_string(),
+                a.cache.to_string(),
+                a.thinking.to_string(),
+                format!("${:.4}", a.cost),
+                a.tool_calls.to_string(),
+                a.media_bytes.to_string(),
+            ]
+        })
+        .collect();
+    table::render(HEADERS, &table_rows)
+}
+
+/// The group key(s) a row belongs to. Only `Model` can yield more than one.
+fn group_keys(row: &FlatRow, group_by: GroupBy) -> Vec<String> {
+    let m = &row.manifest;
+    match group_by {
+        GroupBy::User => vec![m.owner_email.clone()],
+        GroupBy::Agent => vec![m.agent_type.clone()],
+        GroupBy::Model => {
+            if m.turns.models.is_empty() {
+                vec!["(no model)".to_string()]
+            } else {
+                m.turns.models.clone()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rows::test_support::manifest;
+    use crate::rows::FlatRow;
+    use chrono::NaiveDate;
+    use uuid::Uuid;
+
+    fn dt() -> chrono::NaiveDateTime {
+        NaiveDate::from_ymd_opt(2026, 7, 11)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+    }
+
+    fn row(email: &str, agent: &str, models: &[&str]) -> FlatRow {
+        let mut m = manifest(Uuid::new_v4(), Uuid::new_v4(), email, "s", agent, dt());
+        m.turns.count = 3;
+        m.turns.tool_calls = 5;
+        m.tokens.input = 100;
+        m.tokens.output = 40;
+        m.tokens.cache_creation = 10;
+        m.tokens.cache_read = 20;
+        m.tokens.thinking = 7;
+        m.total_cost_usd = 0.25;
+        m.turns.models = models.iter().map(|s| s.to_string()).collect();
+        m.media = Some(vec![crate::rows::test_support::media_entry(
+            Uuid::new_v4(),
+            1024,
+        )]);
+        FlatRow {
+            user_id: Uuid::new_v4(),
+            manifest: m,
+        }
+    }
+
+    #[test]
+    fn groups_by_user_and_sums() {
+        let rows = vec![
+            row("a@x", "claude", &["opus"]),
+            row("a@x", "claude", &["opus"]),
+            row("b@x", "codex", &["gpt-5"]),
+        ];
+        let out = render(&rows, GroupBy::User);
+        let lines: Vec<&str> = out.lines().collect();
+        // a@x: 2 sessions, input 200, cache 60, cost 0.50, media 2048.
+        let a_line = lines.iter().find(|l| l.starts_with("a@x")).unwrap();
+        assert!(a_line.contains(" 2 "), "sessions: {a_line}");
+        assert!(a_line.contains("200"), "input: {a_line}");
+        assert!(a_line.contains("60"), "cache: {a_line}");
+        assert!(a_line.contains("$0.5000"), "cost: {a_line}");
+        assert!(a_line.contains("2048"), "media bytes: {a_line}");
+    }
+
+    #[test]
+    fn groups_by_agent() {
+        let rows = vec![
+            row("a@x", "claude", &["opus"]),
+            row("b@x", "codex", &["gpt-5"]),
+        ];
+        let out = render(&rows, GroupBy::Agent);
+        assert!(out.lines().any(|l| l.starts_with("claude")));
+        assert!(out.lines().any(|l| l.starts_with("codex")));
+    }
+
+    #[test]
+    fn multi_model_session_counts_in_each_model() {
+        let rows = vec![row("a@x", "claude", &["opus", "sonnet"])];
+        let out = render(&rows, GroupBy::Model);
+        let opus = out.lines().find(|l| l.starts_with("opus")).unwrap();
+        let sonnet = out.lines().find(|l| l.starts_with("sonnet")).unwrap();
+        // The single session contributes its full turn count to both models.
+        assert!(opus.contains(" 3 "), "{opus}");
+        assert!(sonnet.contains(" 3 "), "{sonnet}");
+    }
+
+    #[test]
+    fn empty_is_friendly() {
+        assert_eq!(
+            render(&[], GroupBy::User),
+            "No archived sessions to roll up."
+        );
+    }
+}

--- a/archive-viewer/src/rows.rs
+++ b/archive-viewer/src/rows.rs
@@ -1,0 +1,461 @@
+//! Manifest collection, flattening, filtering, and session-id resolution.
+//!
+//! Everything downstream (list / rollup / export / cat) works off a
+//! `Vec<FlatRow>` gathered here. Collection is manifest-only — transcripts are
+//! never read to build a row — and degrades gracefully: a corrupt manifest or
+//! an unreadable user prefix is warned about on stderr and skipped rather than
+//! aborting the whole scan.
+
+use anyhow::{anyhow, Result};
+use archive_format::{ArchiveStore, SessionArchiveManifest};
+use chrono::{DateTime, NaiveDate, NaiveDateTime};
+use uuid::Uuid;
+
+/// Short session-id length used in tables, matching the launcher CLI.
+pub const SHORT_ID_LEN: usize = 8;
+
+/// One archived session, flattened to the (user, manifest) pair every command
+/// reads from.
+#[derive(Debug)]
+pub struct FlatRow {
+    pub user_id: Uuid,
+    pub manifest: SessionArchiveManifest,
+}
+
+impl FlatRow {
+    pub fn short_id(&self) -> String {
+        self.manifest
+            .session_id
+            .simple()
+            .to_string()
+            .chars()
+            .take(SHORT_ID_LEN)
+            .collect()
+    }
+
+    /// Total messages across all roles.
+    pub fn message_count(&self) -> i64 {
+        self.manifest.message_counts.values().sum()
+    }
+
+    /// Number of archived media blobs.
+    pub fn media_count(&self) -> usize {
+        self.manifest.media.as_ref().map_or(0, Vec::len)
+    }
+
+    /// Total archived media bytes.
+    pub fn media_bytes(&self) -> u64 {
+        self.manifest
+            .media
+            .as_ref()
+            .map_or(0, |m| m.iter().map(|e| e.bytes).sum())
+    }
+
+    /// Combined cache tokens (creation + read).
+    pub fn cache_tokens(&self) -> i64 {
+        self.manifest.tokens.cache_creation + self.manifest.tokens.cache_read
+    }
+}
+
+/// Walk the archive and collect every readable manifest. Corrupt manifests
+/// and unreadable per-user listings are logged to stderr and skipped; only a
+/// failure to list users at all is fatal (nothing can be done without it).
+pub fn collect_rows(store: &ArchiveStore) -> Result<Vec<FlatRow>> {
+    let users = store
+        .list_users()
+        .map_err(|e| anyhow!("failed to list archive users: {e}"))?;
+
+    let mut rows = Vec::new();
+    for user_id in users {
+        let sessions = match store.list_sessions(user_id) {
+            Ok(sessions) => sessions,
+            Err(e) => {
+                eprintln!("warning: skipping user {user_id}: cannot list sessions: {e}");
+                continue;
+            }
+        };
+        for session_id in sessions {
+            match store.get_session_manifest(user_id, session_id) {
+                Ok(Some(manifest)) => rows.push(FlatRow { user_id, manifest }),
+                // Missing manifest under a listed session dir: a partial or
+                // in-progress write; nothing to show, skip silently.
+                Ok(None) => {}
+                Err(e) => {
+                    eprintln!(
+                        "warning: skipping corrupt manifest for session {session_id} \
+                         (user {user_id}): {e}"
+                    );
+                }
+            }
+        }
+    }
+    Ok(rows)
+}
+
+/// Filters shared by `list` (and applied at collection time). All are
+/// optional; an unset filter matches everything.
+#[derive(Default)]
+pub struct Filters {
+    /// Substring match against `owner_email`, or a session/user UUID prefix.
+    pub user: Option<String>,
+    /// Exact agent-type match (`claude` / `codex`).
+    pub agent: Option<String>,
+    /// Substring match against `session_name` (case-insensitive).
+    pub name: Option<String>,
+    /// Activity window (matched against `last_activity`, the sort key).
+    pub from: Option<NaiveDateTime>,
+    pub to: Option<NaiveDateTime>,
+}
+
+impl Filters {
+    pub fn matches(&self, row: &FlatRow) -> bool {
+        let m = &row.manifest;
+        if let Some(user) = &self.user {
+            let needle = user.to_ascii_lowercase();
+            let email_hit = m.owner_email.to_ascii_lowercase().contains(&needle);
+            let uuid_hit = matches_uuid_prefix(m.user_id, &needle)
+                || matches_uuid_prefix(m.session_id, &needle);
+            if !email_hit && !uuid_hit {
+                return false;
+            }
+        }
+        if let Some(agent) = &self.agent {
+            if !m.agent_type.eq_ignore_ascii_case(agent) {
+                return false;
+            }
+        }
+        if let Some(name) = &self.name {
+            if !m
+                .session_name
+                .to_ascii_lowercase()
+                .contains(&name.to_ascii_lowercase())
+            {
+                return false;
+            }
+        }
+        if let Some(from) = self.from {
+            if m.last_activity < from {
+                return false;
+            }
+        }
+        if let Some(to) = self.to {
+            if m.last_activity > to {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// True when `id`'s hyphen-free hex rendering starts with `prefix` (already
+/// lowercased, hyphens allowed and stripped).
+fn matches_uuid_prefix(id: Uuid, prefix: &str) -> bool {
+    let prefix = prefix.replace('-', "");
+    if prefix.is_empty() || !prefix.chars().all(|c| c.is_ascii_hexdigit()) {
+        return false;
+    }
+    id.simple().to_string().starts_with(&prefix)
+}
+
+/// Apply filters and sort by `last_activity` descending (most recent first).
+pub fn filter_and_sort(rows: Vec<FlatRow>, filters: &Filters) -> Vec<FlatRow> {
+    let mut kept: Vec<FlatRow> = rows.into_iter().filter(|r| filters.matches(r)).collect();
+    kept.sort_by(|a, b| b.manifest.last_activity.cmp(&a.manifest.last_activity));
+    kept
+}
+
+/// Parse a `--from`/`--to` argument: RFC3339 (any offset, normalized to UTC)
+/// or a bare `YYYY-MM-DD`. A bare date becomes start-of-day for `--from` and
+/// end-of-day for `--to` (`end_of_day = true`) so a single date is an
+/// inclusive full-day bound.
+pub fn parse_date_arg(input: &str, end_of_day: bool) -> Result<NaiveDateTime> {
+    let input = input.trim();
+    if let Ok(dt) = DateTime::parse_from_rfc3339(input) {
+        return Ok(dt.naive_utc());
+    }
+    if let Ok(date) = NaiveDate::parse_from_str(input, "%Y-%m-%d") {
+        let time = if end_of_day {
+            date.and_hms_opt(23, 59, 59)
+        } else {
+            date.and_hms_opt(0, 0, 0)
+        };
+        return time.ok_or_else(|| anyhow!("invalid date `{input}`"));
+    }
+    Err(anyhow!(
+        "invalid date `{input}`: expected RFC3339 (e.g. 2026-07-11T10:00:00Z) or YYYY-MM-DD"
+    ))
+}
+
+/// Resolve a session-id prefix (hex, hyphens optional) across all collected
+/// rows. Mirrors the launcher's `resolve_session_id`: unique prefix wins,
+/// empty match errors, ambiguous match lists the candidates.
+pub fn resolve_session<'a>(input: &str, rows: &'a [FlatRow]) -> Result<&'a FlatRow> {
+    let prefix = normalize_prefix(input)?;
+    let matches: Vec<&FlatRow> = rows
+        .iter()
+        .filter(|r| {
+            r.manifest
+                .session_id
+                .simple()
+                .to_string()
+                .starts_with(&prefix)
+        })
+        .collect();
+    match matches.as_slice() {
+        [row] => Ok(row),
+        [] => Err(anyhow!("no archived session matches `{}`", input.trim())),
+        many => {
+            let ids = many
+                .iter()
+                .map(|r| r.manifest.session_id.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(anyhow!(
+                "session id prefix `{}` is ambiguous; use more characters or a full id \
+                 (matches: {ids})",
+                input.trim()
+            ))
+        }
+    }
+}
+
+fn normalize_prefix(input: &str) -> Result<String> {
+    let prefix = input.trim().replace('-', "").to_ascii_lowercase();
+    if prefix.is_empty() {
+        return Err(anyhow!("session id prefix cannot be empty"));
+    }
+    if !prefix.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(anyhow!(
+            "session id prefix `{}` must contain only hex digits",
+            input.trim()
+        ));
+    }
+    Ok(prefix)
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use archive_format::{
+        ArchiveTokenTotals, ArchiveTurnStats, MediaEntry, SessionArchiveManifest,
+        ARCHIVE_SCHEMA_VERSION,
+    };
+    use chrono::NaiveDateTime;
+    use std::collections::BTreeMap;
+    use uuid::Uuid;
+
+    /// Build a manifest with sensible defaults; callers override fields.
+    pub fn manifest(
+        user_id: Uuid,
+        session_id: Uuid,
+        owner_email: &str,
+        session_name: &str,
+        agent_type: &str,
+        last_activity: NaiveDateTime,
+    ) -> SessionArchiveManifest {
+        SessionArchiveManifest {
+            schema_version: ARCHIVE_SCHEMA_VERSION,
+            session_id,
+            user_id,
+            owner_email: owner_email.to_string(),
+            owner_name: None,
+            session_name: session_name.to_string(),
+            agent_type: agent_type.to_string(),
+            status: "disconnected".to_string(),
+            working_directory: "/repo".to_string(),
+            hostname: "host-1".to_string(),
+            git_branch: None,
+            repo_url: None,
+            pr_url: None,
+            client_version: None,
+            created_at: last_activity,
+            last_activity,
+            archived_at: last_activity,
+            message_counts: BTreeMap::new(),
+            tokens: ArchiveTokenTotals::default(),
+            total_cost_usd: 0.0,
+            turns: ArchiveTurnStats::default(),
+            transcript: None,
+            media: None,
+            launcher_id: None,
+            launcher_version: None,
+            scheduled_task_id: None,
+            claude_args: Vec::new(),
+            archived_by_version: None,
+        }
+    }
+
+    pub fn media_entry(media_id: Uuid, bytes: u64) -> MediaEntry {
+        MediaEntry {
+            media_id,
+            kind: "image".to_string(),
+            content_type: "image/png".to_string(),
+            bytes,
+            object_key: format!("media/{media_id}"),
+            uploaded_at: chrono::NaiveDate::from_ymd_opt(2026, 7, 11)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::manifest;
+    use super::*;
+    use chrono::{Datelike, NaiveDate};
+
+    fn dt(day: u32) -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(2026, 7, day)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap()
+    }
+
+    // Put the day in the top nibble so each session id has a distinct leading
+    // hex digit (small `from_u128` values are all leading zeros → ambiguous).
+    fn session_for(day: u32) -> Uuid {
+        Uuid::from_u128((day as u128) << 124)
+    }
+
+    fn row(email: &str, name: &str, agent: &str, day: u32) -> FlatRow {
+        FlatRow {
+            user_id: Uuid::from_u128(day as u128),
+            manifest: manifest(
+                Uuid::from_u128(day as u128),
+                session_for(day),
+                email,
+                name,
+                agent,
+                dt(day),
+            ),
+        }
+    }
+
+    fn sample() -> Vec<FlatRow> {
+        vec![
+            row("alice@x.io", "refactor rail", "claude", 10),
+            row("bob@y.io", "codex spike", "codex", 12),
+            row("alice@x.io", "docs pass", "claude", 11),
+        ]
+    }
+
+    #[test]
+    fn sorts_by_last_activity_desc() {
+        let out = filter_and_sort(sample(), &Filters::default());
+        let days: Vec<u32> = out
+            .iter()
+            .map(|r| r.manifest.last_activity.date().day())
+            .collect();
+        assert_eq!(days, vec![12, 11, 10]);
+    }
+
+    #[test]
+    fn filter_by_user_email_substring() {
+        let filters = Filters {
+            user: Some("alice".to_string()),
+            ..Default::default()
+        };
+        let out = filter_and_sort(sample(), &filters);
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|r| r.manifest.owner_email == "alice@x.io"));
+    }
+
+    #[test]
+    fn filter_by_agent() {
+        let filters = Filters {
+            agent: Some("codex".to_string()),
+            ..Default::default()
+        };
+        let out = filter_and_sort(sample(), &filters);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].manifest.agent_type, "codex");
+    }
+
+    #[test]
+    fn filter_by_name_substring_case_insensitive() {
+        let filters = Filters {
+            name: Some("REFACTOR".to_string()),
+            ..Default::default()
+        };
+        let out = filter_and_sort(sample(), &filters);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].manifest.session_name, "refactor rail");
+    }
+
+    #[test]
+    fn filter_by_date_window_inclusive() {
+        let filters = Filters {
+            from: Some(parse_date_arg("2026-07-11", false).unwrap()),
+            to: Some(parse_date_arg("2026-07-11", true).unwrap()),
+            ..Default::default()
+        };
+        let out = filter_and_sort(sample(), &filters);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].manifest.session_name, "docs pass");
+    }
+
+    #[test]
+    fn filter_by_user_uuid_prefix() {
+        let rows = sample();
+        // The day-12 (codex) session has a distinct leading hex nibble.
+        let target = session_for(12).simple().to_string();
+        let filters = Filters {
+            user: Some(target[..4].to_string()),
+            ..Default::default()
+        };
+        let out = filter_and_sort(rows, &filters);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].manifest.agent_type, "codex");
+    }
+
+    #[test]
+    fn parse_date_rfc3339_and_plain() {
+        assert_eq!(
+            parse_date_arg("2026-07-11T10:30:00Z", false).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 11)
+                .unwrap()
+                .and_hms_opt(10, 30, 0)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_date_arg("2026-07-11", true).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 11)
+                .unwrap()
+                .and_hms_opt(23, 59, 59)
+                .unwrap()
+        );
+        assert!(parse_date_arg("not-a-date", false).is_err());
+    }
+
+    fn row_with_session(session: Uuid) -> FlatRow {
+        FlatRow {
+            user_id: Uuid::from_u128(1),
+            manifest: manifest(Uuid::from_u128(1), session, "a@a", "s", "claude", dt(10)),
+        }
+    }
+
+    #[test]
+    fn resolve_unique_prefix() {
+        let rows = sample();
+        let full = session_for(10).simple().to_string();
+        let resolved = resolve_session(&full[..4], &rows).unwrap();
+        assert_eq!(resolved.manifest.session_id, session_for(10));
+    }
+
+    #[test]
+    fn resolve_missing_prefix_errors() {
+        assert!(resolve_session("ffffffff", &sample()).is_err());
+    }
+
+    #[test]
+    fn resolve_ambiguous_prefix_errors() {
+        // Two ids sharing the leading hex nibble `1...`.
+        let rows = vec![
+            row_with_session(Uuid::from_u128(0x1000_0000_0000_0000_0000_0000_0000_0001)),
+            row_with_session(Uuid::from_u128(0x1000_0000_0000_0000_0000_0000_0000_0002)),
+        ];
+        let err = resolve_session("1000", &rows).unwrap_err().to_string();
+        assert!(err.contains("ambiguous"), "got: {err}");
+    }
+}

--- a/archive-viewer/src/summarize.rs
+++ b/archive-viewer/src/summarize.rs
@@ -1,0 +1,188 @@
+//! Pure, dependency-free summarizer over a transcript line's raw `content`
+//! JSON. Both Claude and Codex store their message body as an opaque JSON
+//! value in [`archive_format::ArchiveMessageLine::content`]; this collapses
+//! whichever shape it is into one short human-readable line for `cat`'s
+//! digest view. It is deliberately defensive (never panics, handles unknown
+//! shapes) and pure (no I/O), so it is cheap to unit-test.
+
+use serde_json::Value;
+
+/// Max characters in a summarized line before it is truncated with an
+/// ellipsis. Keeps `cat`'s digest to roughly one terminal line per message.
+pub const SUMMARY_MAX_CHARS: usize = 200;
+
+/// Summarize a message's raw `content` JSON into a compact single line.
+///
+/// Handles the common shapes:
+/// * a bare string,
+/// * `{ "text": "..." }`,
+/// * `{ "content": <blocks> }` or a bare array of content blocks, where each
+///   block is either a string or `{ "type": ..., ... }` (text / tool_use /
+///   tool_result / image / thinking).
+///
+/// `thinking` blocks are skipped. Anything unrecognized falls back to a
+/// compact JSON rendering. The result is whitespace-collapsed and truncated
+/// to [`SUMMARY_MAX_CHARS`].
+pub fn summarize_content(content: &Value) -> String {
+    let raw = render(content);
+    truncate(&collapse_ws(&raw), SUMMARY_MAX_CHARS)
+}
+
+/// Render the content to a (possibly long) string, before whitespace
+/// collapsing/truncation.
+fn render(content: &Value) -> String {
+    match content {
+        Value::String(s) => s.clone(),
+        Value::Array(blocks) => render_blocks(blocks),
+        Value::Object(map) => {
+            // A message envelope with a nested content array/string.
+            if let Some(inner) = map.get("content") {
+                match inner {
+                    Value::Array(blocks) => return render_blocks(blocks),
+                    Value::String(s) => return s.clone(),
+                    _ => {}
+                }
+            }
+            // A single block object, or a `{ "text": ... }` shape.
+            if let Some(rendered) = render_block(content) {
+                return rendered;
+            }
+            compact(content)
+        }
+        _ => compact(content),
+    }
+}
+
+/// Render an array of content blocks, joining the non-empty pieces.
+fn render_blocks(blocks: &[Value]) -> String {
+    blocks
+        .iter()
+        .filter_map(render_block)
+        .filter(|piece| !piece.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Render one content block. Returns `None` for blocks that contribute
+/// nothing to the summary (e.g. `thinking`).
+fn render_block(block: &Value) -> Option<String> {
+    match block {
+        Value::String(s) => Some(s.clone()),
+        Value::Object(map) => {
+            let kind = map.get("type").and_then(Value::as_str);
+            match kind {
+                Some("thinking") | Some("redacted_thinking") => None,
+                Some("text") => map
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .or(Some(String::new())),
+                Some("tool_use") => {
+                    let name = map.get("name").and_then(Value::as_str).unwrap_or("unknown");
+                    Some(format!("[tool_use: {name}]"))
+                }
+                Some("tool_result") => Some("[tool_result]".to_string()),
+                Some("image") => Some("[image]".to_string()),
+                // No `type` but a bare `text` field (common for user turns).
+                None => map.get("text").and_then(Value::as_str).map(str::to_string),
+                // A typed block we don't special-case: name it.
+                Some(other) => Some(format!("[{other}]")),
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Compact JSON fallback (single line, no pretty printing).
+fn compact(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "<unrenderable>".to_string())
+}
+
+/// Collapse all runs of ASCII whitespace (including newlines) to single
+/// spaces and trim the ends.
+fn collapse_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Truncate to `max` characters (by `char`, so we never split a UTF-8
+/// codepoint), appending an ellipsis when we cut.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let kept: String = s.chars().take(max.saturating_sub(1)).collect();
+    format!("{kept}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn bare_string() {
+        assert_eq!(summarize_content(&json!("hello world")), "hello world");
+    }
+
+    #[test]
+    fn text_field_object() {
+        assert_eq!(summarize_content(&json!({"text": "hi there"})), "hi there");
+    }
+
+    #[test]
+    fn content_blocks_text_and_tool_use() {
+        let v = json!({
+            "content": [
+                {"type": "text", "text": "let me check"},
+                {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+            ]
+        });
+        assert_eq!(summarize_content(&v), "let me check [tool_use: Bash]");
+    }
+
+    #[test]
+    fn thinking_blocks_are_skipped() {
+        let v = json!([
+            {"type": "thinking", "thinking": "secret reasoning that is long"},
+            {"type": "text", "text": "visible answer"},
+        ]);
+        assert_eq!(summarize_content(&v), "visible answer");
+    }
+
+    #[test]
+    fn tool_result_and_image() {
+        let v = json!([
+            {"type": "tool_result", "content": "output"},
+            {"type": "image", "source": {}},
+        ]);
+        assert_eq!(summarize_content(&v), "[tool_result] [image]");
+    }
+
+    #[test]
+    fn whitespace_is_collapsed() {
+        assert_eq!(
+            summarize_content(&json!("line one\n\n   line   two")),
+            "line one line two"
+        );
+    }
+
+    #[test]
+    fn long_text_is_truncated_with_ellipsis() {
+        let long = "x".repeat(500);
+        let out = summarize_content(&json!(long));
+        assert_eq!(out.chars().count(), SUMMARY_MAX_CHARS);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn unknown_shape_falls_back_to_compact_json() {
+        let v = json!({"weird": 42});
+        assert_eq!(summarize_content(&v), "{\"weird\":42}");
+    }
+
+    #[test]
+    fn tool_use_without_name_is_safe() {
+        let v = json!([{"type": "tool_use"}]);
+        assert_eq!(summarize_content(&v), "[tool_use: unknown]");
+    }
+}

--- a/archive-viewer/src/table.rs
+++ b/archive-viewer/src/table.rs
@@ -1,0 +1,69 @@
+//! Minimal aligned plain-text table renderer, shared by `list` and `rollup`.
+//! No dependency on a table crate — columns are left-aligned and padded to the
+//! widest cell (header included), separated by two spaces.
+
+/// Render `headers` + `rows` as an aligned table string (no trailing newline).
+/// Every row is expected to have `headers.len()` cells; short rows are padded
+/// with blanks and extra cells are ignored, so a caller mismatch degrades to a
+/// readable table rather than a panic.
+pub fn render(headers: &[&str], rows: &[Vec<String>]) -> String {
+    let cols = headers.len();
+    let mut widths: Vec<usize> = headers.iter().map(|h| h.chars().count()).collect();
+    for row in rows {
+        for (i, cell) in row.iter().take(cols).enumerate() {
+            widths[i] = widths[i].max(cell.chars().count());
+        }
+    }
+
+    let mut out = String::new();
+    push_row(
+        &mut out,
+        &widths,
+        &headers.iter().map(|h| h.to_string()).collect::<Vec<_>>(),
+    );
+    for row in rows {
+        out.push('\n');
+        push_row(&mut out, &widths, row);
+    }
+    out
+}
+
+fn push_row(out: &mut String, widths: &[usize], cells: &[String]) {
+    let empty = String::new();
+    let parts: Vec<String> = widths
+        .iter()
+        .enumerate()
+        .map(|(i, &w)| {
+            let cell = cells.get(i).unwrap_or(&empty);
+            let pad = w.saturating_sub(cell.chars().count());
+            format!("{cell}{}", " ".repeat(pad))
+        })
+        .collect();
+    out.push_str(parts.join("  ").trim_end());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aligns_columns_to_widest_cell() {
+        let out = render(
+            &["a", "bbb"],
+            &[
+                vec!["xx".to_string(), "y".to_string()],
+                vec!["z".to_string(), "wwww".to_string()],
+            ],
+        );
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines[0], "a   bbb");
+        assert_eq!(lines[1], "xx  y");
+        assert_eq!(lines[2], "z   wwww");
+    }
+
+    #[test]
+    fn short_rows_are_padded_not_panicking() {
+        let out = render(&["a", "b", "c"], &[vec!["1".to_string()]]);
+        assert_eq!(out.lines().next_back(), Some("1"));
+    }
+}


### PR DESCRIPTION
Adds a new workspace crate `archive-viewer` producing the `portal-archive`
binary: a standalone reader over the long-term session archive. It links only
the `archive-format` crate (the shared on-disk/on-S3 format), never the
backend, so it can run anywhere the archive is reachable.

## Target selection

A global `--local-root <path>` or `--s3-bucket <bucket> [--s3-prefix <p>]`
selects the archive; otherwise the `PORTAL_SESSION_ARCHIVE_*` environment
variables are used. A clear error is printed when none resolve.

## Subcommands

- **`list`** — one manifest-only row per session (short id, name, agent,
  status, user, host, created/activity, msgs, cost, models, media count),
  sorted by last activity. Filters: `--user` (email substring or session/user
  UUID prefix), `--agent`, `--name`, `--from`/`--to` (RFC3339 or `YYYY-MM-DD`).
- **`rollup`** — aggregates from manifests alone, `--group-by user|agent|model`
  (default `user`) with the same date filters. Columns: sessions, turns,
  input/output/cache/thinking tokens, cost, tool calls, media bytes.
- **`export`** — full CSV (default) or JSON dump of flattened manifest rows,
  including the token/turn breakdown and provenance (`client_version`,
  `launcher_id`/`launcher_version`, `scheduled_task_id`, `archived_by_version`).
  Writes stdout or `-o <file>`.
- **`cat <id-or-prefix>`** — resolves a session across users by full id or
  unique short prefix, then prints a one-line-per-message transcript digest
  (local-time timestamp, role, compact content summary; `thinking` blocks
  skipped) or, with `--raw`, the stored NDJSON verbatim.

## Robustness

Corrupt manifests are warned about on stderr and skipped; a session with no
archived transcript reports so plainly; an empty archive prints a friendly
message.

## Tests

Unit tests cover the pure content summarizer, filters, rollup math, export
shape, table alignment, and prefix resolution. An end-to-end suite builds a
fixture archive in a tempdir through `archive-format`'s put paths (multi-user,
multi-session, media sidecars, and one media-less older-style manifest) and
exercises list/rollup/export/cat against genuinely-written objects.

Usage is documented in `archive-viewer/README.md`.