### PR TITLE
Add the archive session viewer WASM UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,24 @@ jobs:
       - name: Build frontend
         run: cd frontend && trunk build
 
+  build-viewer-frontend:
+    name: Build Viewer Frontend (WASM)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key: "viewer-frontend"
+          targets: wasm32-unknown-unknown
+          trunk: "true"
+
+      - name: Build viewer frontend
+        run: cd viewer-frontend && trunk build
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ target
 
 # Frontend build artifacts
 frontend/dist/
+viewer-frontend/dist/
 
 # Database
 *.db

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7975,6 +7975,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "viewer-frontend"
+version = "2.13.10"
+dependencies = [
+ "chrono",
+ "frontend",
+ "gloo-net 0.6.0",
+ "log",
+ "serde",
+ "serde_json",
+ "shared",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-logger",
+ "web-sys",
+ "yew",
+ "yew-router",
+]
+
+[[package]]
 name = "vswhom"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "shared",
     "backend",
     "frontend",
+    "viewer-frontend",
     "proxy",
     "session-lib",
     "claude-session-lib",

--- a/viewer-frontend/Cargo.toml
+++ b/viewer-frontend/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "viewer-frontend"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+# Standalone archive-viewer WASM app (#1288, PR 3a). A second Yew app that
+# renders archived transcripts with the *real* portal renderers by linking the
+# `frontend` crate as an rlib through its `viewer_api` facade. It is a workspace
+# member like `frontend` — both are Yew apps that also compile on the host
+# target (web-sys/js-sys are no-op stubs natively), so `cargo build/clippy
+# --workspace` covers it and `trunk build` produces the WASM bundle. The
+# `portal-archive serve` subcommand (PR 3b) embeds this crate's `dist/` and
+# serves the JSON API it fetches.
+
+[[bin]]
+name = "viewer-frontend"
+path = "src/main.rs"
+
+[dependencies]
+# Shared, WASM-compatible portal types (SessionArchiveManifest is redefined
+# locally against the pinned JSON contract; shared gives us PortalMeta /
+# AgentType used by the renderer facade).
+shared = { path = "../shared" }
+
+# The portal frontend, linked as an rlib purely for its presentation-only
+# `viewer_api` facade (RenderedMessage / group_messages / MessageGroupRenderer).
+frontend = { path = "../frontend" }
+
+# Yew framework
+yew = { workspace = true }
+yew-router = { workspace = true }
+
+# WASM bindings
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+
+# Web APIs — just what the viewer touches (location for hash routing).
+web-sys = { workspace = true, features = ["Window", "Location"] }
+
+# HTTP fetch
+gloo-net = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+uuid = { workspace = true }
+chrono = { workspace = true, features = ["wasmbind"] }
+
+# Logging in WASM
+wasm-logger = "0.2"
+log = "0.4"
+
+[lints]
+workspace = true

--- a/viewer-frontend/Trunk.toml
+++ b/viewer-frontend/Trunk.toml
@@ -1,0 +1,4 @@
+[build]
+# Assets are served at root. The `portal-archive serve` subcommand (PR 3b)
+# embeds this dist/ and serves the JSON API from the same origin.
+public_url = "/"

--- a/viewer-frontend/index.html
+++ b/viewer-frontend/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Agent Portal — Archive Viewer</title>
+    <meta name="theme-color" content="#1a1b26" />
+    <meta name="description" content="Read-only viewer for archived Agent Portal sessions." />
+
+    <!-- KaTeX for rendering LaTeX math in messages (DOM-level auto-render, same
+         as the live portal). Optional; transcripts render fine without it. -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"
+          integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous" />
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"
+            integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
+            integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>
+
+    <style>
+        #loading {
+            display: flex; flex-direction: column; align-items: center; justify-content: center;
+            height: 100vh; background: #1a1b26; color: #7f849c;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; font-size: 0.95rem; gap: 1.2rem;
+        }
+        .spinner {
+            width: 36px; height: 36px; border: 3px solid #292e42; border-top-color: #7aa2f7;
+            border-radius: 50%; animation: spin 0.8s linear infinite;
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+    </style>
+
+    <link data-trunk rel="rust" data-wasm-opt="z" />
+
+    <!-- Reuse the portal's real stylesheets so archived transcripts look like
+         the live app. Referenced from ../frontend/styles/ (single source of
+         truth) rather than duplicated. base.css carries the Tokyo-Night theme
+         variables the message renderers depend on. -->
+    <link data-trunk rel="css" href="../frontend/styles/base.css" />
+    <link data-trunk rel="css" href="../frontend/styles/components.css" />
+    <link data-trunk rel="css" href="../frontend/styles/messages.css" />
+    <link data-trunk rel="css" href="../frontend/styles/markdown.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/base.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/askuserquestion.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/bash.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/diff.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/exitplanmode.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/read.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/search.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/task.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/todowrite.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/webfetch.css" />
+    <link data-trunk rel="css" href="../frontend/styles/tools/websearch.css" />
+
+    <!-- Viewer-only chrome (browser table, filters, manifest card). -->
+    <link data-trunk rel="css" href="styles/viewer.css" />
+
+    <!-- Same KaTeX bootstrap helper the live portal uses. -->
+    <link data-trunk rel="copy-file" href="../frontend/katex-helper.js" />
+    <script defer src="/katex-helper.js"></script>
+</head>
+<body>
+    <div id="loading">
+        <div class="spinner"></div>
+        <p>Loading&hellip;</p>
+    </div>
+</body>
+</html>

--- a/viewer-frontend/src/api.rs
+++ b/viewer-frontend/src/api.rs
@@ -1,0 +1,290 @@
+//! Typed models and fetch helpers for the archive-viewer JSON API.
+//!
+//! Field shapes track the pinned #1288 contract (see the crate docs). Manifest
+//! fields mirror `backend/src/archive.rs::SessionArchiveManifest` — the
+//! `/manifest` endpoint returns that struct's raw JSON — but are redefined here
+//! (rather than depending on the native `backend` crate) with `#[serde(default)]`
+//! throughout so schema-additive manifests keep deserializing.
+
+use serde::Deserialize;
+
+/// Error surfaced by every fetch, rendered inline by the calling component.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FetchError {
+    /// Transport failure (offline, DNS, CORS, connection refused).
+    Network(String),
+    /// Non-2xx HTTP status.
+    Status(u16),
+    /// 2xx body that failed to decode into the expected shape.
+    Decode(String),
+}
+
+impl std::fmt::Display for FetchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FetchError::Network(e) => write!(f, "network error: {e}"),
+            FetchError::Status(404) => write!(f, "not found (404) — archive missing or moved"),
+            FetchError::Status(s) => write!(f, "server returned HTTP {s}"),
+            FetchError::Decode(e) => write!(f, "could not parse server response: {e}"),
+        }
+    }
+}
+
+/// `GET /api/users` row.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct UserSummary {
+    pub user_id: String,
+    #[serde(default)]
+    pub owner_email: Option<String>,
+    #[serde(default)]
+    pub owner_name: Option<String>,
+    #[serde(default)]
+    pub session_count: i64,
+}
+
+impl UserSummary {
+    /// Best available human label for a user (name, else email, else id).
+    pub fn label(&self) -> String {
+        self.owner_name
+            .clone()
+            .filter(|s| !s.is_empty())
+            .or_else(|| self.owner_email.clone().filter(|s| !s.is_empty()))
+            .unwrap_or_else(|| self.user_id.clone())
+    }
+}
+
+/// `GET /api/sessions` summary row.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub user_id: String,
+    #[serde(default)]
+    pub session_name: String,
+    #[serde(default)]
+    pub agent_type: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub hostname: String,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub last_activity: String,
+    #[serde(default)]
+    pub total_cost_usd: f64,
+    #[serde(default)]
+    pub message_count: i64,
+    #[serde(default)]
+    pub media_count: i64,
+    #[serde(default)]
+    pub models: Vec<String>,
+}
+
+/// `GET /api/rollup?group_by=user` row (compact top strip).
+///
+/// The rollup endpoint (PR 3b) must emit these field names.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct RollupRow {
+    /// The group key value (e.g. the user id when `group_by=user`).
+    #[serde(default)]
+    pub group: String,
+    /// Human label for the group, when the server can resolve one.
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub session_count: i64,
+    #[serde(default)]
+    pub message_count: i64,
+    #[serde(default)]
+    pub total_cost_usd: f64,
+}
+
+impl RollupRow {
+    pub fn display_label(&self) -> String {
+        self.label
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| self.group.clone())
+    }
+}
+
+/// Token totals sub-object of the manifest (mirrors `ArchiveTokenTotals`).
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+pub struct TokenTotals {
+    #[serde(default)]
+    pub input: i64,
+    #[serde(default)]
+    pub output: i64,
+    #[serde(default)]
+    pub cache_creation: i64,
+    #[serde(default)]
+    pub cache_read: i64,
+    #[serde(default)]
+    pub thinking: i64,
+    #[serde(default)]
+    pub subagent: i64,
+}
+
+impl TokenTotals {
+    pub fn total(&self) -> i64 {
+        self.input + self.output + self.cache_creation + self.cache_read
+    }
+}
+
+/// Raw manifest JSON (`GET /api/sessions/{user}/{session}/manifest`).
+///
+/// A permissive subset of `SessionArchiveManifest`: every field is
+/// `#[serde(default)]` and unknown fields are ignored, so newer/older manifest
+/// schemas still populate the header card.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+pub struct Manifest {
+    #[serde(default)]
+    pub session_id: String,
+    #[serde(default)]
+    pub user_id: String,
+    #[serde(default)]
+    pub owner_email: String,
+    #[serde(default)]
+    pub owner_name: Option<String>,
+    #[serde(default)]
+    pub session_name: String,
+    #[serde(default)]
+    pub agent_type: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub working_directory: String,
+    #[serde(default)]
+    pub hostname: String,
+    #[serde(default)]
+    pub git_branch: Option<String>,
+    #[serde(default)]
+    pub repo_url: Option<String>,
+    #[serde(default)]
+    pub pr_url: Option<String>,
+    #[serde(default)]
+    pub client_version: Option<String>,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub last_activity: String,
+    #[serde(default)]
+    pub archived_at: String,
+    #[serde(default)]
+    pub tokens: TokenTotals,
+    #[serde(default)]
+    pub total_cost_usd: f64,
+    #[serde(default)]
+    pub launcher_version: Option<String>,
+    #[serde(default)]
+    pub archived_by_version: Option<String>,
+}
+
+/// One transcript line from the NDJSON stream
+/// (`GET /api/sessions/{user}/{session}/messages`).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct MessageLine {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub role: String,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub agent_type: String,
+    /// Raw stored message content, embedded as a JSON value.
+    #[serde(default)]
+    pub content: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// Fetch helpers
+// ---------------------------------------------------------------------------
+
+/// GET a path and decode a JSON body into `T`.
+pub async fn fetch_json<T: serde::de::DeserializeOwned>(path: &str) -> Result<T, FetchError> {
+    let response = gloo_net::http::Request::get(path)
+        .send()
+        .await
+        .map_err(|e| FetchError::Network(e.to_string()))?;
+    if !response.ok() {
+        return Err(FetchError::Status(response.status()));
+    }
+    response
+        .json::<T>()
+        .await
+        .map_err(|e| FetchError::Decode(e.to_string()))
+}
+
+/// GET the NDJSON messages stream and parse each non-empty line.
+///
+/// At v1 scale the whole body is buffered then split; malformed lines are
+/// skipped rather than failing the whole transcript.
+pub async fn fetch_messages(user: &str, session: &str) -> Result<Vec<MessageLine>, FetchError> {
+    let path = format!("/api/sessions/{user}/{session}/messages");
+    let response = gloo_net::http::Request::get(&path)
+        .send()
+        .await
+        .map_err(|e| FetchError::Network(e.to_string()))?;
+    if !response.ok() {
+        return Err(FetchError::Status(response.status()));
+    }
+    let body = response
+        .text()
+        .await
+        .map_err(|e| FetchError::Decode(e.to_string()))?;
+
+    Ok(parse_ndjson(&body))
+}
+
+/// Parse an NDJSON body into message lines, skipping blank/unparseable lines.
+pub fn parse_ndjson(body: &str) -> Vec<MessageLine> {
+    body.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| serde_json::from_str::<MessageLine>(line).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ndjson_skips_blank_and_bad_lines() {
+        let body = "\
+{\"id\":\"a\",\"role\":\"user\",\"created_at\":\"t1\",\"agent_type\":\"claude\",\"content\":{\"type\":\"user\"}}
+
+not json
+{\"id\":\"b\",\"role\":\"assistant\",\"created_at\":\"t2\",\"agent_type\":\"claude\",\"content\":{}}
+";
+        let lines = parse_ndjson(body);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].id, "a");
+        assert_eq!(lines[1].role, "assistant");
+    }
+
+    #[test]
+    fn user_label_prefers_name_then_email_then_id() {
+        let with_name = UserSummary {
+            user_id: "id".into(),
+            owner_email: Some("e@x.com".into()),
+            owner_name: Some("Matt".into()),
+            session_count: 1,
+        };
+        assert_eq!(with_name.label(), "Matt");
+
+        let with_email = UserSummary {
+            owner_name: None,
+            ..with_name.clone()
+        };
+        assert_eq!(with_email.label(), "e@x.com");
+
+        let bare = UserSummary {
+            owner_name: None,
+            owner_email: None,
+            ..with_name
+        };
+        assert_eq!(bare.label(), "id");
+    }
+}

--- a/viewer-frontend/src/browser.rs
+++ b/viewer-frontend/src/browser.rs
@@ -1,0 +1,276 @@
+//! Session browser (`#/`): rollup strip, filter controls, session table.
+
+use std::collections::HashMap;
+
+use wasm_bindgen_futures::spawn_local;
+use web_sys::{HtmlInputElement, HtmlSelectElement};
+use yew::prelude::*;
+
+use crate::api::{self, FetchError, RollupRow, SessionSummary, UserSummary};
+use crate::filters::{filter_and_sort, SessionFilter};
+
+/// `None` = in flight; `Some(Ok/Err)` = settled.
+type Load<T> = Option<Result<T, FetchError>>;
+
+#[function_component(SessionBrowser)]
+pub fn session_browser() -> Html {
+    let users = use_state(|| None as Load<Vec<UserSummary>>);
+    let sessions = use_state(|| None as Load<Vec<SessionSummary>>);
+    let rollup = use_state(|| None as Load<Vec<RollupRow>>);
+    let filter = use_state(SessionFilter::default);
+
+    {
+        let users = users.clone();
+        let sessions = sessions.clone();
+        let rollup = rollup.clone();
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                users.set(Some(
+                    api::fetch_json::<Vec<UserSummary>>("/api/users").await,
+                ));
+            });
+            spawn_local(async move {
+                sessions.set(Some(
+                    api::fetch_json::<Vec<SessionSummary>>("/api/sessions").await,
+                ));
+            });
+            spawn_local(async move {
+                rollup.set(Some(
+                    api::fetch_json::<Vec<RollupRow>>("/api/rollup?group_by=user").await,
+                ));
+            });
+            || ()
+        });
+    }
+
+    let user_labels: HashMap<String, String> = match &*users {
+        Some(Ok(list)) => list
+            .iter()
+            .map(|u| (u.user_id.clone(), u.label()))
+            .collect(),
+        _ => HashMap::new(),
+    };
+
+    html! {
+        <div class="viewer-root">
+            <header class="viewer-header">
+                <h1>{ "Agent Portal — Session Archive" }</h1>
+            </header>
+            { rollup_strip(&rollup) }
+            { filter_controls(&users, &filter) }
+            { session_table(&sessions, &filter, &user_labels) }
+        </div>
+    }
+}
+
+fn rollup_strip(rollup: &Load<Vec<RollupRow>>) -> Html {
+    match rollup {
+        None => html! { <div class="viewer-rollup viewer-loading">{ "Loading totals…" }</div> },
+        Some(Err(e)) => html! {
+            <div class="viewer-rollup viewer-error">{ format!("Totals unavailable: {e}") }</div>
+        },
+        Some(Ok(rows)) if rows.is_empty() => Html::default(),
+        Some(Ok(rows)) => {
+            let total_sessions: i64 = rows.iter().map(|r| r.session_count).sum();
+            let total_cost: f64 = rows.iter().map(|r| r.total_cost_usd).sum();
+            html! {
+                <div class="viewer-rollup">
+                    <div class="rollup-tile">
+                        <span class="rollup-value">{ total_sessions }</span>
+                        <span class="rollup-label">{ "sessions" }</span>
+                    </div>
+                    <div class="rollup-tile">
+                        <span class="rollup-value">{ format!("${total_cost:.2}") }</span>
+                        <span class="rollup-label">{ "total spend" }</span>
+                    </div>
+                    { for rows.iter().map(|r| html! {
+                        <div class="rollup-tile rollup-user">
+                            <span class="rollup-value">{ format!("${:.2}", r.total_cost_usd) }</span>
+                            <span class="rollup-label">
+                                { format!("{} ({} sess)", r.display_label(), r.session_count) }
+                            </span>
+                        </div>
+                    }) }
+                </div>
+            }
+        }
+    }
+}
+
+fn filter_controls(users: &Load<Vec<UserSummary>>, filter: &UseStateHandle<SessionFilter>) -> Html {
+    let on_user = {
+        let filter = filter.clone();
+        Callback::from(move |e: Event| {
+            let value = e.target_unchecked_into::<HtmlSelectElement>().value();
+            let mut next = (*filter).clone();
+            next.user_id = (!value.is_empty()).then_some(value);
+            filter.set(next);
+        })
+    };
+    let on_agent = {
+        let filter = filter.clone();
+        Callback::from(move |e: Event| {
+            let value = e.target_unchecked_into::<HtmlSelectElement>().value();
+            let mut next = (*filter).clone();
+            next.agent_type = (!value.is_empty()).then_some(value);
+            filter.set(next);
+        })
+    };
+    let on_from = {
+        let filter = filter.clone();
+        Callback::from(move |e: InputEvent| {
+            let value = e.target_unchecked_into::<HtmlInputElement>().value();
+            let mut next = (*filter).clone();
+            next.from = (!value.is_empty()).then_some(value);
+            filter.set(next);
+        })
+    };
+    let on_to = {
+        let filter = filter.clone();
+        Callback::from(move |e: InputEvent| {
+            let value = e.target_unchecked_into::<HtmlInputElement>().value();
+            let mut next = (*filter).clone();
+            next.to = (!value.is_empty()).then_some(value);
+            filter.set(next);
+        })
+    };
+    // Uncontrolled (no `value` binding) so the node is never recreated on the
+    // parent re-render each keystroke triggers — focus and caret stay put.
+    let on_query = {
+        let filter = filter.clone();
+        Callback::from(move |e: InputEvent| {
+            let value = e.target_unchecked_into::<HtmlInputElement>().value();
+            let mut next = (*filter).clone();
+            next.query = (!value.is_empty()).then_some(value);
+            filter.set(next);
+        })
+    };
+
+    let user_options = match users {
+        Some(Ok(list)) => list
+            .iter()
+            .map(|u| html! { <option value={u.user_id.clone()}>{ u.label() }</option> })
+            .collect::<Html>(),
+        _ => Html::default(),
+    };
+
+    html! {
+        <div class="viewer-filters">
+            <label>
+                { "User" }
+                <select onchange={on_user}>
+                    <option value="">{ "All users" }</option>
+                    { user_options }
+                </select>
+            </label>
+            <label>
+                { "Agent" }
+                <select onchange={on_agent}>
+                    <option value="">{ "All agents" }</option>
+                    <option value="claude">{ "Claude" }</option>
+                    <option value="codex">{ "Codex" }</option>
+                </select>
+            </label>
+            <label>
+                { "From" }
+                <input type="date" oninput={on_from} />
+            </label>
+            <label>
+                { "To" }
+                <input type="date" oninput={on_to} />
+            </label>
+            <label class="viewer-filter-search">
+                { "Name" }
+                <input type="text" placeholder="substring…" oninput={on_query} />
+            </label>
+        </div>
+    }
+}
+
+fn session_table(
+    sessions: &Load<Vec<SessionSummary>>,
+    filter: &SessionFilter,
+    user_labels: &HashMap<String, String>,
+) -> Html {
+    match sessions {
+        None => html! { <div class="viewer-loading">{ "Loading sessions…" }</div> },
+        Some(Err(e)) => html! {
+            <div class="viewer-error">{ format!("Could not load sessions: {e}") }</div>
+        },
+        Some(Ok(list)) => {
+            let rows = filter_and_sort(list, filter);
+            if rows.is_empty() {
+                return html! {
+                    <div class="viewer-empty">{ "No sessions match these filters." }</div>
+                };
+            }
+            html! {
+                <table class="viewer-table">
+                    <thead>
+                        <tr>
+                            <th>{ "Name" }</th>
+                            <th>{ "Agent" }</th>
+                            <th>{ "User" }</th>
+                            <th>{ "Host" }</th>
+                            <th>{ "Created" }</th>
+                            <th>{ "Last activity" }</th>
+                            <th class="num">{ "Msgs" }</th>
+                            <th class="num">{ "Cost" }</th>
+                            <th>{ "Models" }</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        { for rows.iter().map(|s| session_row(s, user_labels)) }
+                    </tbody>
+                </table>
+            }
+        }
+    }
+}
+
+fn session_row(s: &SessionSummary, user_labels: &HashMap<String, String>) -> Html {
+    let href = format!("#/session/{}/{}", s.user_id, s.session_id);
+    let user_label = user_labels
+        .get(&s.user_id)
+        .cloned()
+        .unwrap_or_else(|| s.user_id.clone());
+    let name = if s.session_name.is_empty() {
+        s.session_id.clone()
+    } else {
+        s.session_name.clone()
+    };
+    let models = s.models.join(", ");
+    html! {
+        <tr class="viewer-row" onclick={navigate(&href)}>
+            <td class="cell-name"><a href={href.clone()}>{ name }</a></td>
+            <td>{ &s.agent_type }</td>
+            <td>{ user_label }</td>
+            <td>{ &s.hostname }</td>
+            <td class="cell-date">{ short_date(&s.created_at) }</td>
+            <td class="cell-date">{ short_date(&s.last_activity) }</td>
+            <td class="num">{ s.message_count }</td>
+            <td class="num">{ format!("${:.2}", s.total_cost_usd) }</td>
+            <td class="cell-models">{ models }</td>
+        </tr>
+    }
+}
+
+/// Navigate on row click. Anchor already handles keyboard/middle-click; this
+/// makes the whole row clickable.
+fn navigate(href: &str) -> Callback<MouseEvent> {
+    let href = href.to_string();
+    Callback::from(move |_| {
+        if let Some(win) = web_sys::window() {
+            let _ = win.location().set_hash(href.trim_start_matches('#'));
+        }
+    })
+}
+
+/// Trim an ISO timestamp to `YYYY-MM-DD HH:MM` for compact table display.
+fn short_date(iso: &str) -> String {
+    let trimmed = iso.replace('T', " ");
+    match trimmed.char_indices().nth(16) {
+        Some((idx, _)) => trimmed[..idx].to_string(),
+        None => trimmed,
+    }
+}

--- a/viewer-frontend/src/filters.rs
+++ b/viewer-frontend/src/filters.rs
@@ -1,0 +1,172 @@
+//! Client-side filtering and sorting for the session browser.
+//!
+//! At v1 archive scale the whole session list is fetched once and filtered in
+//! the browser (the pinned contract also accepts server-side query params, but
+//! doing it client-side keeps the browser responsive while typing).
+
+use crate::api::SessionSummary;
+
+/// Active filter selections from the browser controls. Empty/`None` fields are
+/// "no constraint".
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SessionFilter {
+    /// Exact `user_id` match.
+    pub user_id: Option<String>,
+    /// Exact `agent_type` match (e.g. "claude", "codex").
+    pub agent_type: Option<String>,
+    /// Inclusive lower bound on `last_activity` (ISO date/datetime prefix).
+    pub from: Option<String>,
+    /// Inclusive upper bound on `last_activity` (ISO date prefix; compared as
+    /// `< from_next_day` via a trailing high sentinel so a bare `YYYY-MM-DD`
+    /// upper bound includes that whole day).
+    pub to: Option<String>,
+    /// Case-insensitive substring match on `session_name`.
+    pub query: Option<String>,
+}
+
+impl SessionFilter {
+    fn matches(&self, s: &SessionSummary) -> bool {
+        if let Some(user) = non_empty(&self.user_id) {
+            if s.user_id != *user {
+                return false;
+            }
+        }
+        if let Some(agent) = non_empty(&self.agent_type) {
+            if s.agent_type != *agent {
+                return false;
+            }
+        }
+        if let Some(from) = non_empty(&self.from) {
+            if s.last_activity.as_str() < from.as_str() {
+                return false;
+            }
+        }
+        if let Some(to) = non_empty(&self.to) {
+            // Treat a date-only upper bound inclusively: everything on that day
+            // sorts before "<date>~" (`~` > any ISO time char).
+            let upper = format!("{to}~");
+            if s.last_activity.as_str() >= upper.as_str() {
+                return false;
+            }
+        }
+        if let Some(q) = non_empty(&self.query) {
+            if !s.session_name.to_lowercase().contains(&q.to_lowercase()) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+fn non_empty(opt: &Option<String>) -> Option<&String> {
+    opt.as_ref().filter(|s| !s.trim().is_empty())
+}
+
+/// Filter then sort by `last_activity` descending (newest first). Ties break on
+/// `session_name` for a stable, human-predictable order.
+pub fn filter_and_sort(sessions: &[SessionSummary], filter: &SessionFilter) -> Vec<SessionSummary> {
+    let mut out: Vec<SessionSummary> = sessions
+        .iter()
+        .filter(|s| filter.matches(s))
+        .cloned()
+        .collect();
+    out.sort_by(|a, b| {
+        b.last_activity
+            .cmp(&a.last_activity)
+            .then_with(|| a.session_name.cmp(&b.session_name))
+    });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(name: &str, user: &str, agent: &str, last: &str) -> SessionSummary {
+        SessionSummary {
+            session_id: format!("sess-{name}"),
+            user_id: user.into(),
+            session_name: name.into(),
+            agent_type: agent.into(),
+            status: "archived".into(),
+            hostname: "host".into(),
+            created_at: last.into(),
+            last_activity: last.into(),
+            total_cost_usd: 0.0,
+            message_count: 0,
+            media_count: 0,
+            models: vec![],
+        }
+    }
+
+    fn corpus() -> Vec<SessionSummary> {
+        vec![
+            session("alpha", "u1", "claude", "2026-07-01T10:00:00"),
+            session("beta", "u2", "codex", "2026-07-03T10:00:00"),
+            session("gamma", "u1", "codex", "2026-07-02T10:00:00"),
+        ]
+    }
+
+    #[test]
+    fn sorts_by_last_activity_desc() {
+        let out = filter_and_sort(&corpus(), &SessionFilter::default());
+        let names: Vec<_> = out.iter().map(|s| s.session_name.as_str()).collect();
+        assert_eq!(names, vec!["beta", "gamma", "alpha"]);
+    }
+
+    #[test]
+    fn filters_by_user() {
+        let filter = SessionFilter {
+            user_id: Some("u1".into()),
+            ..Default::default()
+        };
+        let out = filter_and_sort(&corpus(), &filter);
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|s| s.user_id == "u1"));
+    }
+
+    #[test]
+    fn filters_by_agent() {
+        let filter = SessionFilter {
+            agent_type: Some("codex".into()),
+            ..Default::default()
+        };
+        let out = filter_and_sort(&corpus(), &filter);
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|s| s.agent_type == "codex"));
+    }
+
+    #[test]
+    fn filters_by_name_substring_case_insensitive() {
+        let filter = SessionFilter {
+            query: Some("AMM".into()),
+            ..Default::default()
+        };
+        let out = filter_and_sort(&corpus(), &filter);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].session_name, "gamma");
+    }
+
+    #[test]
+    fn filters_by_date_range_inclusive_of_day() {
+        let filter = SessionFilter {
+            from: Some("2026-07-02".into()),
+            to: Some("2026-07-03".into()),
+            ..Default::default()
+        };
+        let out = filter_and_sort(&corpus(), &filter);
+        let names: Vec<_> = out.iter().map(|s| s.session_name.as_str()).collect();
+        // beta (07-03) is included thanks to the inclusive upper bound.
+        assert_eq!(names, vec!["beta", "gamma"]);
+    }
+
+    #[test]
+    fn blank_filters_are_no_constraint() {
+        let filter = SessionFilter {
+            user_id: Some("   ".into()),
+            query: Some("".into()),
+            ..Default::default()
+        };
+        assert_eq!(filter_and_sort(&corpus(), &filter).len(), 3);
+    }
+}

--- a/viewer-frontend/src/main.rs
+++ b/viewer-frontend/src/main.rs
@@ -1,0 +1,59 @@
+//! Standalone archive-viewer WASM app (#1288, PR 3a).
+//!
+//! Renders archived agent transcripts using the *real* portal renderers via
+//! [`frontend::viewer_api`]. Hash-routed so it can be served as static files
+//! from any path: `#/` is the session browser, `#/session/{user}/{session}` is
+//! the transcript view. The JSON API it fetches is provided by the
+//! `portal-archive serve` subcommand (PR 3b), which also embeds this `dist/`.
+
+mod api;
+mod browser;
+mod filters;
+mod media_rewrite;
+mod transcript;
+
+use browser::SessionBrowser;
+use transcript::TranscriptView;
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+#[derive(Clone, Routable, PartialEq)]
+pub enum Route {
+    #[at("/")]
+    Home,
+    #[at("/session/:user/:session")]
+    Session { user: String, session: String },
+    #[not_found]
+    #[at("/404")]
+    NotFound,
+}
+
+fn switch(route: Route) -> Html {
+    match route {
+        Route::Home => html! { <SessionBrowser /> },
+        Route::Session { user, session } => {
+            let key = format!("{user}/{session}");
+            html! { <TranscriptView {key} {user} {session} /> }
+        }
+        Route::NotFound => html! {
+            <div class="viewer-empty">
+                <h2>{ "Page not found" }</h2>
+                <a href="#/">{ "Back to sessions" }</a>
+            </div>
+        },
+    }
+}
+
+#[function_component(App)]
+fn app() -> Html {
+    html! {
+        <HashRouter>
+            <Switch<Route> render={switch} />
+        </HashRouter>
+    }
+}
+
+fn main() {
+    wasm_logger::init(wasm_logger::Config::default());
+    yew::Renderer::<App>::new().render();
+}

--- a/viewer-frontend/src/media_rewrite.rs
+++ b/viewer-frontend/src/media_rewrite.rs
@@ -1,0 +1,158 @@
+//! Rewrite archived media URLs to the viewer's own media endpoint.
+//!
+//! Archived transcript content carries the *original* portal served-media URLs
+//! — `/api/images/{uuid}` for images and `/api/media/{uuid}` for videos (see
+//! `backend/src/handlers/media_archive.rs` / `background.rs`). Those paths only
+//! resolve on the live portal's origin; on the viewer's origin they 404 and the
+//! renderer would show a broken image. The viewer instead serves each blob from
+//! its session-scoped endpoint `/api/media/{user}/{session}/{media_id}` (the
+//! pinned #1288 contract), where `{media_id}` is exactly the original `{uuid}`.
+//!
+//! This is a pure, string-level pass over the raw content JSON run *before*
+//! `RenderedMessage::new`, so the real renderers (`render_image_source` /
+//! `VideoViewer`) receive already-correct URLs and their existing
+//! expired-media placeholder still fires when the archive lacks the blob (the
+//! endpoint 404s → `<img onerror>` / `<video onerror>` → placeholder).
+
+/// Original portal image URL prefix (`/api/images/{uuid}`).
+const IMAGE_PREFIX: &str = "/api/images/";
+/// Original portal video URL prefix (`/api/media/{uuid}`).
+const VIDEO_PREFIX: &str = "/api/media/";
+/// Length of a canonical hyphenated UUID (`8-4-4-4-12`).
+const UUID_LEN: usize = 36;
+
+/// Rewrite every `/api/images/{uuid}` and `/api/media/{uuid}` occurrence in
+/// `content` to `/api/media/{user}/{session}/{uuid}`.
+///
+/// Operates on the raw JSON string so it catches the media id wherever it
+/// appears (a standalone `data` value or embedded in prose). Only a prefix
+/// immediately followed by a parseable UUID is rewritten; anything else is
+/// emitted verbatim, and already-rewritten output is never rescanned (so the
+/// `/api/media/` that the rewrite itself introduces is not re-matched).
+pub fn rewrite_media_urls(content: &str, user: &str, session: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    let mut rest = content;
+
+    loop {
+        // Earliest of the two prefixes in what remains.
+        let next = [IMAGE_PREFIX, VIDEO_PREFIX]
+            .iter()
+            .filter_map(|prefix| rest.find(prefix).map(|idx| (idx, *prefix)))
+            .min_by_key(|(idx, _)| *idx);
+
+        let Some((idx, prefix)) = next else {
+            out.push_str(rest);
+            break;
+        };
+
+        out.push_str(&rest[..idx]);
+        let after = &rest[idx + prefix.len()..];
+
+        // A rewrite requires exactly a canonical UUID right after the prefix.
+        // `get(..UUID_LEN)` is `None` at a non-char boundary or when short, so
+        // this never panics.
+        if let Some(candidate) = after.get(..UUID_LEN) {
+            if uuid::Uuid::parse_str(candidate).is_ok() {
+                out.push_str(VIDEO_PREFIX);
+                out.push_str(user);
+                out.push('/');
+                out.push_str(session);
+                out.push('/');
+                out.push_str(candidate);
+                rest = &after[UUID_LEN..];
+                continue;
+            }
+        }
+
+        // Not a media reference: emit the prefix literally, advance past it.
+        out.push_str(prefix);
+        rest = after;
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const USER: &str = "11111111-1111-1111-1111-111111111111";
+    const SESSION: &str = "22222222-2222-2222-2222-222222222222";
+    const MEDIA: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+    #[test]
+    fn rewrites_image_url_in_data_value() {
+        let content = format!(r#"{{"type":"image","data":"/api/images/{MEDIA}"}}"#);
+        let out = rewrite_media_urls(&content, USER, SESSION);
+        assert_eq!(
+            out,
+            format!(r#"{{"type":"image","data":"/api/media/{USER}/{SESSION}/{MEDIA}"}}"#)
+        );
+    }
+
+    #[test]
+    fn rewrites_video_url_in_data_value() {
+        let content = format!(r#"{{"data":"/api/media/{MEDIA}"}}"#);
+        let out = rewrite_media_urls(&content, USER, SESSION);
+        assert_eq!(
+            out,
+            format!(r#"{{"data":"/api/media/{USER}/{SESSION}/{MEDIA}"}}"#)
+        );
+    }
+
+    #[test]
+    fn rewrites_multiple_occurrences() {
+        let other = "12345678-1234-1234-1234-1234567890ab";
+        let content = format!("/api/images/{MEDIA} and /api/media/{other}");
+        let out = rewrite_media_urls(&content, USER, SESSION);
+        assert_eq!(
+            out,
+            format!("/api/media/{USER}/{SESSION}/{MEDIA} and /api/media/{USER}/{SESSION}/{other}")
+        );
+    }
+
+    #[test]
+    fn rewritten_url_is_not_double_rewritten() {
+        // The `/api/media/` the rewrite introduces must not be re-matched:
+        // its next segment is the user UUID, not a fresh media reference, and
+        // emitted output is never rescanned regardless.
+        let content = format!("/api/media/{MEDIA}");
+        let out = rewrite_media_urls(&content, USER, SESSION);
+        assert_eq!(out, format!("/api/media/{USER}/{SESSION}/{MEDIA}"));
+        // Idempotent-ish: running again over already-viewer-scoped URLs does
+        // rewrite the *first* uuid segment (the user), which is why we only
+        // ever run this once, at ingest.
+        assert_eq!(out.matches("/api/media/").count(), 1);
+    }
+
+    #[test]
+    fn leaves_non_uuid_paths_untouched() {
+        let content = r#"see /api/images/latest and /api/media/thumbnail.png"#;
+        let out = rewrite_media_urls(content, USER, SESSION);
+        assert_eq!(out, content);
+    }
+
+    #[test]
+    fn leaves_unrelated_content_untouched() {
+        let content = r#"{"type":"text","text":"no media here"}"#;
+        assert_eq!(rewrite_media_urls(content, USER, SESSION), content);
+    }
+
+    #[test]
+    fn handles_prefix_at_end_without_uuid() {
+        let content = "trailing /api/images/";
+        assert_eq!(rewrite_media_urls(content, USER, SESSION), content);
+    }
+
+    #[test]
+    fn preserves_surrounding_json_structure() {
+        let content = format!(
+            r#"{{"content":[{{"type":"image","media_type":"image/png","source_type":"url","data":"/api/images/{MEDIA}"}}]}}"#
+        );
+        let out = rewrite_media_urls(&content, USER, SESSION);
+        assert!(out.contains(&format!("/api/media/{USER}/{SESSION}/{MEDIA}")));
+        assert!(out.contains(r#""source_type":"url""#));
+        // Still valid JSON.
+        assert!(serde_json::from_str::<serde_json::Value>(&out).is_ok());
+    }
+}

--- a/viewer-frontend/src/transcript.rs
+++ b/viewer-frontend/src/transcript.rs
@@ -1,0 +1,187 @@
+//! Transcript view (`#/session/{user}/{session}`): manifest header card plus
+//! the archived messages rendered with the real portal renderers.
+
+use std::str::FromStr;
+
+use frontend::viewer_api::{group_messages, MessageGroupRenderer, RenderedMessage};
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+use crate::api::{self, FetchError, Manifest, MessageLine};
+use crate::media_rewrite::rewrite_media_urls;
+
+type Load<T> = Option<Result<T, FetchError>>;
+
+#[derive(Properties, PartialEq)]
+pub struct TranscriptProps {
+    pub user: String,
+    pub session: String,
+}
+
+#[function_component(TranscriptView)]
+pub fn transcript_view(props: &TranscriptProps) -> Html {
+    let manifest = use_state(|| None as Load<Manifest>);
+    let messages = use_state(|| None as Load<Vec<MessageLine>>);
+
+    {
+        let manifest = manifest.clone();
+        let messages = messages.clone();
+        let user = props.user.clone();
+        let session = props.session.clone();
+        use_effect_with((user.clone(), session.clone()), move |(user, session)| {
+            let path = format!("/api/sessions/{user}/{session}/manifest");
+            {
+                let manifest = manifest.clone();
+                spawn_local(async move {
+                    manifest.set(Some(api::fetch_json::<Manifest>(&path).await));
+                });
+            }
+            {
+                let (user, session) = (user.clone(), session.clone());
+                spawn_local(async move {
+                    messages.set(Some(api::fetch_messages(&user, &session).await));
+                });
+            }
+            || ()
+        });
+    }
+
+    // Agent type governs grouping; fall back to Claude if the manifest is not
+    // (yet) loaded or carries an unknown value.
+    let agent_type = match &*manifest {
+        Some(Ok(m)) => shared::AgentType::from_str(&m.agent_type).unwrap_or_default(),
+        _ => shared::AgentType::default(),
+    };
+    let session_id = Uuid::from_str(&props.session).unwrap_or(Uuid::nil());
+
+    html! {
+        <div class="viewer-root viewer-transcript">
+            <nav class="viewer-nav"><a href="#/">{ "← All sessions" }</a></nav>
+            { header_card(&manifest) }
+            { transcript_body(&messages, &props.user, &props.session, agent_type, session_id) }
+        </div>
+    }
+}
+
+fn header_card(manifest: &Load<Manifest>) -> Html {
+    match manifest {
+        None => html! { <div class="viewer-loading">{ "Loading manifest…" }</div> },
+        Some(Err(e)) => html! {
+            <div class="viewer-error">{ format!("Could not load manifest: {e}") }</div>
+        },
+        Some(Ok(m)) => {
+            let name = if m.session_name.is_empty() {
+                m.session_id.clone()
+            } else {
+                m.session_name.clone()
+            };
+            html! {
+                <div class="viewer-manifest-card">
+                    <h2>{ name }</h2>
+                    <div class="manifest-grid">
+                        { field("Agent", &m.agent_type) }
+                        { field("Status", &m.status) }
+                        { field("User", &owner(m)) }
+                        { field("Host", &m.hostname) }
+                        { field("Directory", &m.working_directory) }
+                        { opt_field("Branch", &m.git_branch) }
+                        { opt_field("Repo", &m.repo_url) }
+                        { opt_field("PR", &m.pr_url) }
+                        { field("Created", &m.created_at) }
+                        { field("Last activity", &m.last_activity) }
+                        { field("Archived", &m.archived_at) }
+                        { field("Tokens", &m.tokens.total().to_string()) }
+                        { field("Cost", &format!("${:.4}", m.total_cost_usd)) }
+                    </div>
+                    <div class="manifest-provenance">
+                        { provenance("launcher", &m.launcher_version) }
+                        { provenance("client", &m.client_version) }
+                        { provenance("archiver", &m.archived_by_version) }
+                    </div>
+                </div>
+            }
+        }
+    }
+}
+
+fn owner(m: &Manifest) -> String {
+    match &m.owner_name {
+        Some(n) if !n.is_empty() => format!("{n} <{}>", m.owner_email),
+        _ => m.owner_email.clone(),
+    }
+}
+
+fn field(label: &str, value: &str) -> Html {
+    if value.is_empty() {
+        return Html::default();
+    }
+    html! {
+        <div class="manifest-field">
+            <span class="manifest-key">{ label }</span>
+            <span class="manifest-val">{ value }</span>
+        </div>
+    }
+}
+
+fn opt_field(label: &str, value: &Option<String>) -> Html {
+    match value {
+        Some(v) if !v.is_empty() => field(label, v),
+        _ => Html::default(),
+    }
+}
+
+fn provenance(label: &str, version: &Option<String>) -> Html {
+    let v = version.clone().filter(|s| !s.is_empty());
+    html! {
+        <span class="provenance-chip">
+            { format!("{label}: {}", v.unwrap_or_else(|| "—".to_string())) }
+        </span>
+    }
+}
+
+fn transcript_body(
+    messages: &Load<Vec<MessageLine>>,
+    user: &str,
+    session: &str,
+    agent_type: shared::AgentType,
+    session_id: Uuid,
+) -> Html {
+    match messages {
+        None => html! { <div class="viewer-loading">{ "Loading transcript…" }</div> },
+        Some(Err(e)) => html! {
+            <div class="viewer-error">{ format!("Could not load transcript: {e}") }</div>
+        },
+        Some(Ok(lines)) if lines.is_empty() => html! {
+            <div class="viewer-empty">{ "This session has no archived messages." }</div>
+        },
+        Some(Ok(lines)) => {
+            let rendered: Vec<RenderedMessage> = lines
+                .iter()
+                .map(|line| to_rendered(line, user, session))
+                .collect();
+            let groups = group_messages(&rendered, agent_type, None);
+            html! {
+                <div class="messages-container">
+                    { for groups.into_iter().map(|group| html! {
+                        <MessageGroupRenderer {group} {session_id} {agent_type} />
+                    }) }
+                </div>
+            }
+        }
+    }
+}
+
+/// Build a `RenderedMessage` from one archived line: serialize the stored
+/// content back to its wire JSON string, rewrite archived media URLs to the
+/// viewer's session-scoped endpoint, and attach the row timestamp so the
+/// renderers show real times.
+fn to_rendered(line: &MessageLine, user: &str, session: &str) -> RenderedMessage {
+    let raw = serde_json::to_string(&line.content).unwrap_or_else(|_| "{}".to_string());
+    let content = rewrite_media_urls(&raw, user, session);
+    let meta = shared::PortalMeta {
+        created_at: (!line.created_at.is_empty()).then(|| line.created_at.clone()),
+        ..Default::default()
+    };
+    RenderedMessage::new(content, Some(meta))
+}

--- a/viewer-frontend/styles/viewer.css
+++ b/viewer-frontend/styles/viewer.css
@@ -1,0 +1,227 @@
+/* Archive-viewer chrome. Reuses the portal's Tokyo-Night theme variables from
+   base.css (--bg-dark, --accent, etc.) so the browser and transcript surfaces
+   match the live app; the transcript message bodies come entirely from the
+   portal's own messages.css / tool styles. */
+
+body {
+    margin: 0;
+    background: var(--bg-dark, #1a1b26);
+    color: var(--text, #c0caf5);
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.viewer-root {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1.5rem;
+}
+
+.viewer-header h1 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 1rem;
+    color: var(--text-bright, #c0caf5);
+}
+
+.viewer-nav {
+    margin-bottom: 1rem;
+}
+
+.viewer-nav a,
+.viewer-empty a {
+    color: var(--accent, #7aa2f7);
+    text-decoration: none;
+}
+
+.viewer-nav a:hover,
+.viewer-empty a:hover {
+    text-decoration: underline;
+}
+
+/* --- Rollup strip --- */
+.viewer-rollup {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+}
+
+.rollup-tile {
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-darker, #16161e);
+    border: 1px solid var(--border, #292e42);
+    border-radius: 8px;
+    padding: 0.6rem 0.9rem;
+    min-width: 6rem;
+}
+
+.rollup-value {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--text-bright, #c0caf5);
+}
+
+.rollup-label {
+    font-size: 0.75rem;
+    color: var(--text-dim, #7f849c);
+}
+
+.rollup-user .rollup-value {
+    color: var(--accent, #7aa2f7);
+}
+
+/* --- Filters --- */
+.viewer-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    align-items: flex-end;
+}
+
+.viewer-filters label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.75rem;
+    color: var(--text-dim, #7f849c);
+    gap: 0.25rem;
+}
+
+.viewer-filters select,
+.viewer-filters input {
+    background: var(--bg-darker, #16161e);
+    color: var(--text, #c0caf5);
+    border: 1px solid var(--border, #292e42);
+    border-radius: 6px;
+    padding: 0.35rem 0.5rem;
+    font-size: 0.85rem;
+}
+
+.viewer-filter-search input {
+    min-width: 12rem;
+}
+
+/* --- Session table --- */
+.viewer-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+
+.viewer-table th,
+.viewer-table td {
+    text-align: left;
+    padding: 0.5rem 0.6rem;
+    border-bottom: 1px solid var(--border, #292e42);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 22ch;
+}
+
+.viewer-table th {
+    color: var(--text-dim, #7f849c);
+    font-weight: 600;
+    position: sticky;
+    top: 0;
+    background: var(--bg-dark, #1a1b26);
+}
+
+.viewer-table th.num,
+.viewer-table td.num {
+    text-align: right;
+}
+
+.viewer-row {
+    cursor: pointer;
+}
+
+.viewer-row:hover {
+    background: var(--bg-highlight, #1f2335);
+}
+
+.cell-name a {
+    color: var(--accent, #7aa2f7);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.cell-date {
+    color: var(--text-dim, #7f849c);
+}
+
+.cell-models {
+    color: var(--text-dim, #7f849c);
+    font-size: 0.78rem;
+}
+
+/* --- Manifest header card --- */
+.viewer-manifest-card {
+    background: var(--bg-darker, #16161e);
+    border: 1px solid var(--border, #292e42);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.viewer-manifest-card h2 {
+    margin: 0 0 0.75rem;
+    font-size: 1.1rem;
+    color: var(--text-bright, #c0caf5);
+}
+
+.manifest-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.4rem 1.5rem;
+}
+
+.manifest-field {
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.82rem;
+}
+
+.manifest-key {
+    color: var(--text-dim, #7f849c);
+    min-width: 6rem;
+}
+
+.manifest-val {
+    color: var(--text, #c0caf5);
+    word-break: break-word;
+}
+
+.manifest-provenance {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.provenance-chip {
+    font-size: 0.72rem;
+    color: var(--text-dim, #7f849c);
+    background: var(--bg-dark, #1a1b26);
+    border: 1px solid var(--border, #292e42);
+    border-radius: 999px;
+    padding: 0.15rem 0.6rem;
+}
+
+/* --- Loading / error / empty states --- */
+.viewer-loading,
+.viewer-empty {
+    color: var(--text-dim, #7f849c);
+    padding: 1.5rem 0;
+    text-align: center;
+}
+
+.viewer-error {
+    color: var(--error, #f7768e);
+    background: rgba(247, 118, 142, 0.08);
+    border: 1px solid var(--error, #f7768e);
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    margin: 0.5rem 0;
+}


### PR DESCRIPTION
Standalone read-only viewer for archived agent sessions (#1288 series, the UI half). A second Yew/WASM app that renders archived transcripts with the **real** portal renderers via the `frontend::viewer_api` facade, rather than reimplementing two agent protocols. The `portal-archive serve` subcommand (a follow-up) will embed this crate's `dist/` and serve the JSON API it fetches.

## What's here

- **New crate `viewer-frontend`** — a Trunk app, hash-routed so it can be served from any path: `#/` is the session browser, `#/session/{user}/{session}` is the transcript view.
- **Session browser** — fetches `/api/users`, `/api/sessions`, and `/api/rollup?group_by=user`; a compact rollup strip on top; filter controls (user, agent, date range, name substring — client-side at v1 scale); a table sorted by last-activity descending (name, agent, user, host, dates, msgs, cost, models) with row-click navigation.
- **Transcript view** — fetches the manifest (header card: name, agent, user, host, dirs, tokens/cost, and launcher/client/archiver provenance) plus the NDJSON messages, and renders them through `RenderedMessage` → `group_messages` → `MessageGroupRenderer` exactly per the facade recipe.
- **Styling** — Trunk references the portal's own stylesheets from `../frontend/styles/` (single source of truth, not duplicated) so transcripts match the live app, on the same Tokyo-Night base.
- **Loading / error / empty states** on every fetch.

## Workspace membership

`viewer-frontend` is a regular workspace member, exactly like `frontend`. Both are Yew apps that also compile on the host target (web-sys/js-sys are no-op stubs natively), so `cargo build --workspace` and the CI `cargo clippy --workspace --all-targets` lane cover it, and `trunk build` produces the WASM bundle. No workspace-build gymnastics were needed. Verified: workspace build, native + wasm clippy (`-D warnings`), `trunk build`, and `cargo build -p backend` all pass; `viewer-frontend/dist/` is gitignored.

## Media URL rewrite

Archived content carries the *original* portal media URLs (`/api/images/{uuid}`, `/api/media/{uuid}`), which only resolve on the live portal's origin. A pure string pass (`media_rewrite::rewrite_media_urls`) runs over the raw content JSON before `RenderedMessage::new`, rewriting each prefix-followed-by-a-parseable-UUID to the viewer's session-scoped `/api/media/{user}/{session}/{media_id}` (the media id is the same UUID). Already-emitted output is never rescanned, so the `/api/media/` the rewrite introduces isn't re-matched. When the archive lacks a blob the endpoint 404s and the renderer's existing expired-media placeholder fires unchanged. Unit-tested (image/video, multiple occurrences, non-UUID paths left untouched, JSON structure preserved).

## Facade

No gaps found — `frontend::viewer_api` was sufficient as documented; no additions to the facade were needed.
