### PR TITLE
Respect rail orientation for wheel scrolling

### DIFF
--- a/archive-viewer/src/fixture_tests.rs
+++ b/archive-viewer/src/fixture_tests.rs
@@ -8,7 +8,7 @@ use archive_format::{
     ArchiveMessageLine, ArchiveStore, ArchivedMediaMeta, LocalArchiveStore, SessionArchiveBundle,
 };
 use chrono::{NaiveDate, NaiveDateTime};
-use serde_json::json;
+use serde::Serialize;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -50,6 +50,48 @@ fn msg(role: &str, day_of_month: u32, content: serde_json::Value) -> ArchiveMess
     }
 }
 
+fn text_value(text: &str) -> serde_json::Value {
+    serde_json::Value::String(text.to_string())
+}
+
+#[derive(Serialize)]
+struct AssistantFixture {
+    content: Vec<AssistantFixtureBlock>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AssistantFixtureBlock {
+    Thinking {
+        thinking: &'static str,
+    },
+    Text {
+        text: &'static str,
+    },
+    ToolUse {
+        name: &'static str,
+        input: std::collections::BTreeMap<&'static str, &'static str>,
+    },
+}
+
+fn assistant_fixture_value() -> serde_json::Value {
+    serde_json::to_value(AssistantFixture {
+        content: vec![
+            AssistantFixtureBlock::Thinking {
+                thinking: "hidden reasoning",
+            },
+            AssistantFixtureBlock::Text {
+                text: "starting the refactor",
+            },
+            AssistantFixtureBlock::ToolUse {
+                name: "Edit",
+                input: std::collections::BTreeMap::new(),
+            },
+        ],
+    })
+    .unwrap()
+}
+
 /// Build the fixture archive and return the tempdir (kept alive) + store.
 fn build_fixture() -> (TempDir, ArchiveStore) {
     let dir = tempfile::tempdir().unwrap();
@@ -83,17 +125,9 @@ fn build_fixture() -> (TempDir, ArchiveStore) {
         .put_session_archive(&SessionArchiveBundle {
             manifest: a1,
             transcript_ndjson: Some(ndjson(&[
-                msg("user", 14, json!("please refactor the rail")),
-                msg(
-                    "assistant",
-                    14,
-                    json!({"content": [
-                        {"type": "thinking", "thinking": "hidden reasoning"},
-                        {"type": "text", "text": "starting the refactor"},
-                        {"type": "tool_use", "name": "Edit", "input": {}},
-                    ]}),
-                ),
-                msg("user", 14, json!("thanks")),
+                msg("user", 14, text_value("please refactor the rail")),
+                msg("assistant", 14, assistant_fixture_value()),
+                msg("user", 14, text_value("thanks")),
             ])),
         })
         .unwrap();
@@ -129,7 +163,7 @@ fn build_fixture() -> (TempDir, ArchiveStore) {
     store
         .put_session_archive(&SessionArchiveBundle {
             manifest: a2,
-            transcript_ndjson: Some(ndjson(&[msg("user", 12, json!("update the docs"))])),
+            transcript_ndjson: Some(ndjson(&[msg("user", 12, text_value("update the docs"))])),
         })
         .unwrap();
 
@@ -150,7 +184,7 @@ fn build_fixture() -> (TempDir, ArchiveStore) {
     store
         .put_session_archive(&SessionArchiveBundle {
             manifest: b1,
-            transcript_ndjson: Some(ndjson(&[msg("user", 13, json!("spike a codex flow"))])),
+            transcript_ndjson: Some(ndjson(&[msg("user", 13, text_value("spike a codex flow"))])),
         })
         .unwrap();
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -281,18 +281,24 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     // immediate rather than fighting CSS scroll-behavior: smooth.
     let on_wheel = {
         let rail_ref = rail_ref.clone();
+        let horizontal_rail = matches!(
+            props.rail_position,
+            crate::pages::dashboard::RailPosition::Top
+                | crate::pages::dashboard::RailPosition::Bottom
+        );
         Callback::from(move |e: WheelEvent| {
+            if !horizontal_rail {
+                return;
+            }
             if let Some(rail) = rail_ref.cast::<HtmlElement>() {
                 // This handler maps the wheel onto the rail's HORIZONTAL scroll,
                 // so a plain vertical scroll-wheel drives the top/bottom rail.
-                // The left/right rail scrolls *vertically* (`overflow-y: auto`)
-                // and has no horizontal overflow — there we must NOT intercept,
-                // or `prevent_default` kills the native vertical scroll while we
-                // only nudge `scroll_left` (a no-op), leaving the pills unscroll-
-                // able. The component doesn't know its orientation, so gate on
-                // the axis that actually overflows.
+                // The left/right rail scrolls vertically (`overflow-y: auto`);
+                // never infer orientation from `scroll_width`, because pill
+                // padding, host headers, and fixed-position menu geometry can
+                // produce a few pixels of horizontal overflow in vertical mode.
                 if rail.scroll_width() <= rail.client_width() {
-                    return; // vertical rail (or nothing to scroll) — let native scroll run
+                    return; // nothing to scroll — let native scroll run
                 }
                 let dx = e.delta_x();
                 let dy = e.delta_y();

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -152,6 +152,7 @@
    label rendered inline among the pills. In the horizontal (top/bottom) rail
    it reads as a compact chip that precedes each host's pills; in the vertical
    (left/right) rail it spans the column as a full-width section heading. */
+
 /* A thin, small-text section header sitting in the sliver of space above each
    host's pills: muted uppercase hostname plus a plain "(n)" parenthetical —
    deliberately not a chip/badge, so it reads as a label, not a control. */


### PR DESCRIPTION
## Summary
- Stop inferring rail orientation from scroll width in the session rail wheel handler
- Only translate vertical wheel input into horizontal scroll for top/bottom rails
- Let left/right dock rails use native vertical scrolling even if their content has incidental horizontal overflow

## Tests
- `cargo test -p frontend pill_menu_position`
- `cargo fmt --check`
- `env -u NO_COLOR -u CLICOLOR -u CLICOLOR_FORCE trunk build`