### PR TITLE
Surface thinking and subagent tokens across dashboards

### DIFF
--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -93,6 +93,16 @@ struct DeletedCostStats {
     sum_cache_read_tokens: i64,
 }
 
+/// Thinking + sub-agent token sums, which live only on `turn_metrics` (they
+/// are not tracked on the session row — see `AdminStats` field docs).
+#[derive(QueryableByName)]
+struct TurnTokenStats {
+    #[diesel(sql_type = BigInt)]
+    sum_thinking_tokens: i64,
+    #[diesel(sql_type = BigInt)]
+    sum_subagent_tokens: i64,
+}
+
 pub async fn get_stats(
     State(app_state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -141,6 +151,18 @@ pub async fn get_stats(
     .get_result(&mut conn)
     .map_err(|e| admin_db_query("Failed to query deleted session stats", e))?;
 
+    // Query 4: thinking + sub-agent tokens — sourced from turn_metrics, the
+    // only place they are recorded (they are not on the session row). Covers
+    // retained turn-metrics rows only.
+    let turn_token_stats: TurnTokenStats = diesel::sql_query(
+        "SELECT \
+         COALESCE(SUM(thinking_tokens), 0)::bigint as sum_thinking_tokens, \
+         COALESCE(SUM(subagent_tokens), 0)::bigint as sum_subagent_tokens \
+         FROM turn_metrics",
+    )
+    .get_result(&mut conn)
+    .map_err(|e| admin_db_query("Failed to query turn-metrics token stats", e))?;
+
     // Get connected client counts from session manager (no DB query needed)
     let connected_proxy_clients = app_state.session_manager.sessions.len();
     let connected_web_clients: usize = app_state
@@ -165,6 +187,8 @@ pub async fn get_stats(
             + deleted_stats.sum_cache_creation_tokens,
         total_cache_read_tokens: session_stats.sum_cache_read_tokens
             + deleted_stats.sum_cache_read_tokens,
+        total_thinking_tokens: turn_token_stats.sum_thinking_tokens,
+        total_subagent_tokens: turn_token_stats.sum_subagent_tokens,
     }))
 }
 

--- a/frontend/src/pages/admin/overview_tab.rs
+++ b/frontend/src/pages/admin/overview_tab.rs
@@ -72,6 +72,30 @@ pub fn admin_overview_tab(props: &AdminOverviewTabProps) -> Html {
                         label="Output Tokens"
                         value={utils::format_token_count(s.total_output_tokens)}
                     />
+                    <StatCard
+                        label="Thinking Tokens"
+                        value={utils::format_token_count(s.total_thinking_tokens)}
+                        subvalue={Some("within output".to_string())}
+                    />
+                    <StatCard
+                        label="Sub-agent Tokens"
+                        value={utils::format_token_count(s.total_subagent_tokens)}
+                        subvalue={Some("within output".to_string())}
+                    />
+                    <StatCard
+                        label="Total Integrated Tokens"
+                        value={utils::format_token_count(
+                            s.total_input_tokens
+                                + s.total_output_tokens
+                                + s.total_cache_creation_tokens
+                                + s.total_cache_read_tokens,
+                        )}
+                        subvalue={Some(format!(
+                            "{} cache read, {} cache write",
+                            utils::format_token_count(s.total_cache_read_tokens),
+                            utils::format_token_count(s.total_cache_creation_tokens),
+                        ))}
+                    />
                 </div>
             </div>
         }

--- a/frontend/src/pages/history/transcript.rs
+++ b/frontend/src/pages/history/transcript.rs
@@ -103,6 +103,8 @@ fn header_card(manifest: &Load<HistoryManifest>) -> Html {
                         { field("Last activity", &m.last_activity) }
                         { field("Archived", &m.archived_at) }
                         { field("Tokens", &m.tokens.total().to_string()) }
+                        { field("Thinking", &m.tokens.thinking.to_string()) }
+                        { field("Sub-agent", &m.tokens.subagent.to_string()) }
                         { field("Cost", &format!("${:.4}", m.total_cost_usd)) }
                     </div>
                     <div class="manifest-provenance">

--- a/shared/src/api/users.rs
+++ b/shared/src/api/users.rs
@@ -159,6 +159,18 @@ pub struct AdminStats {
     /// Total cache read tokens across all sessions
     #[serde(default)]
     pub total_cache_read_tokens: i64,
+    /// Total thinking tokens, summed from `turn_metrics` (the only source —
+    /// thinking is not tracked on the session row). Thinking is billed *within*
+    /// output, so this is a breakdown of `total_output_tokens`, not additive to
+    /// it. Covers only retained turn-metrics rows.
+    #[serde(default)]
+    pub total_thinking_tokens: i64,
+    /// Total sub-agent (Task/sidechain) tokens, summed from `turn_metrics`.
+    /// Reported separately from the main turn; `0` for Claude today (its wire
+    /// protocol surfaces no sub-agent field). Covers only retained
+    /// turn-metrics rows.
+    #[serde(default)]
+    pub total_subagent_tokens: i64,
 }
 
 /// One row in the admin sessions table.


### PR DESCRIPTION
Adds thinking-token and sub-agent-token visibility to the token stats.

**Admin overview** gains three cards: Thinking Tokens, Sub-agent Tokens, and a Total Integrated Tokens card (input + output + cache read/write). The two new totals are summed from `turn_metrics` in `get_stats` — no schema migration.

**History transcript** header gains Thinking and Sub-agent rows (the manifest already carried these totals from a `turn_metrics` rollup).

**Why sourced from `turn_metrics`:** it's the only place these two kinds are recorded — thinking is never written to the session row (and Claude reports it as 0 on the result frame), and sub-agent tokens are folded into `sessions.output_tokens` rather than stored separately.

**Why breakdowns, not added to totals:** thinking is billed *within* output and sub-agent is already inside `sessions.output_tokens`, so adding them to an integrated total would double-count. They're labeled "within output" to make that explicit.