### PR TITLE
Make forward status track reality and fix stream-limit 502s

### DIFF
--- a/backend/src/handlers/forward_proxy.rs
+++ b/backend/src/handlers/forward_proxy.rs
@@ -431,8 +431,31 @@ fn filtered_cookie_header(headers: &HeaderMap) -> Option<String> {
     (!kept.is_empty()).then(|| kept.join("; "))
 }
 
-fn plain_status(status: StatusCode, msg: &'static str) -> Response {
-    (status, msg).into_response()
+fn plain_status(status: StatusCode, msg: impl Into<String>) -> Response {
+    (status, msg.into()).into_response()
+}
+
+/// Feed a real routing outcome into the port-health cache and nudge web
+/// clients if `listening` actually flipped. This is what keeps the forward
+/// chip in step with what requests truly experience between the proxy's 10s
+/// background probes — the chip and the reverse proxy now share one source of
+/// truth instead of drifting.
+fn note_reachability(
+    app_state: &AppState,
+    session_key: &str,
+    session_id: Uuid,
+    port: u16,
+    listening: bool,
+) {
+    if app_state
+        .session_manager
+        .note_forward_reachability(session_id, port, listening)
+    {
+        app_state.session_manager.broadcast_to_web_clients(
+            &session_key.to_string(),
+            shared::ServerToClient::ForwardsChanged { session_id },
+        );
+    }
 }
 
 /// Reverse-proxy one request through a fresh tunnel stream.
@@ -451,19 +474,33 @@ async fn proxy_request(
         .open_tunnel(session_key, port)
         .await
     {
-        Ok(stream) => stream,
+        Ok(stream) => {
+            note_reachability(app_state, session_key, session_id, port, true);
+            stream
+        }
         Err(TunnelError::NotConnected) => {
             return plain_status(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "the agent for this session is offline",
             )
         }
-        Err(TunnelError::Refused(e)) => {
-            warn!("Tunnel refused for {}:{}: {}", session_id, port, e);
-            return plain_status(
-                StatusCode::BAD_GATEWAY,
-                "nothing is listening on the forwarded port",
-            );
+        Err(TunnelError::Refused(reason)) => {
+            use shared::TunnelRefuseReason::*;
+            warn!("Tunnel refused for {}:{}: {}", session_id, port, reason);
+            // Only a genuine "nothing listening" reflects on port health; a
+            // stream-limit or revocation refusal says nothing about the local
+            // service, so it must not tint the chip red.
+            let status = match reason {
+                NoListener => {
+                    note_reachability(app_state, session_key, session_id, port, false);
+                    StatusCode::BAD_GATEWAY
+                }
+                // Momentary saturation, not an error — a retry usually works.
+                StreamLimit => StatusCode::SERVICE_UNAVAILABLE,
+                NotForwarded => StatusCode::NOT_FOUND,
+                Protocol => StatusCode::BAD_GATEWAY,
+            };
+            return plain_status(status, reason.to_string());
         }
         Err(TunnelError::OpenTimeout) | Err(TunnelError::ClosedEarly) => {
             return plain_status(StatusCode::GATEWAY_TIMEOUT, "forward open timed out")

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -498,7 +498,7 @@ fn handle_proxy_message(
             session_manager.tunnel_in(f.stream_id, super::TunnelIn::Opened);
         }
         ProxyToServer::TunnelRefused(f) => {
-            session_manager.tunnel_in(f.stream_id, super::TunnelIn::Refused(f.error));
+            session_manager.tunnel_in(f.stream_id, super::TunnelIn::Refused(f.reason));
         }
         ProxyToServer::TunnelData(f) => {
             session_manager.tunnel_data_in(&f);

--- a/backend/src/handlers/websocket/session_manager/correlation.rs
+++ b/backend/src/handlers/websocket/session_manager/correlation.rs
@@ -98,9 +98,10 @@ impl SessionManager {
     }
 
     /// Record a probe verdict for `(session, port)`. Returns `true` when the
-    /// stored health *changed* — the caller broadcasts `ForwardsChanged` so
-    /// chips refetch and re-tint. The process name is part of the verdict so
-    /// an app swap on the same port also nudges clients.
+    /// `listening` bit *changed* — the caller broadcasts `ForwardsChanged` so
+    /// chips refetch and re-tint. The process name is stored for the tooltip
+    /// but does NOT by itself count as a change: its best-effort resolution
+    /// flickers, and re-broadcasting on every flicker was needless churn.
     pub fn update_forward_health(
         &self,
         session_id: Uuid,
@@ -108,10 +109,33 @@ impl SessionManager {
         listening: bool,
         process: Option<String>,
     ) -> bool {
-        let verdict = ForwardHealth { listening, process };
-        self.forward_health
-            .insert((session_id, port), verdict.clone())
-            != Some(verdict)
+        let prev = self
+            .forward_health
+            .insert((session_id, port), ForwardHealth { listening, process });
+        prev.map(|p| p.listening) != Some(listening)
+    }
+
+    /// Record the *actual* reachability observed while routing a real request
+    /// (a tunnel stream opened, or was refused because nothing was listening).
+    /// This is the ground-truth signal that keeps the chip honest between
+    /// 10s background probes; it preserves any process name already resolved
+    /// by the probe. Returns `true` when `listening` changed.
+    pub fn note_forward_reachability(&self, session_id: Uuid, port: u16, listening: bool) -> bool {
+        use dashmap::mapref::entry::Entry;
+        match self.forward_health.entry((session_id, port)) {
+            Entry::Occupied(mut e) => {
+                let changed = e.get().listening != listening;
+                e.get_mut().listening = listening;
+                changed
+            }
+            Entry::Vacant(e) => {
+                e.insert(ForwardHealth {
+                    listening,
+                    process: None,
+                });
+                true
+            }
+        }
     }
 
     /// The last reported health for `(session, port)`, if the proxy has
@@ -198,10 +222,11 @@ mod tests {
         assert_eq!(mgr.forward_health(session, 9000), health(true, py()));
         assert_eq!(mgr.forward_health(session, 8000), health(false, None));
 
-        // Change-detection: same verdict again is not a change; a listening
-        // flip or an app swap on the same port is.
+        // Change-detection keys on `listening` only: the same listening bit is
+        // not a change even if the best-effort process name flickers
+        // (de-noised); a listening flip is.
         assert!(!mgr.update_forward_health(session, 9000, true, py()));
-        assert!(mgr.update_forward_health(session, 9000, true, Some("vite".to_string())));
+        assert!(!mgr.update_forward_health(session, 9000, true, Some("vite".to_string())));
         assert!(mgr.update_forward_health(session, 9000, false, None));
 
         // Forgetting drops only the named pair.
@@ -234,5 +259,45 @@ mod tests {
         );
         // Nothing left for `a` → nothing removed → caller skips the broadcast.
         assert_eq!(mgr.forget_forward_health_for_session(a), 0);
+    }
+
+    #[test]
+    fn routing_feedback_flips_listening_but_keeps_process_name() {
+        // Real request outcomes keep the chip honest between probes, without
+        // clobbering the process name the probe resolved.
+        let mgr = SessionManager::default();
+        let session = Uuid::new_v4();
+
+        // Probe resolved a listener + name.
+        assert!(mgr.update_forward_health(session, 3000, true, Some("vite".to_string())));
+        // A request confirms it's still up: no change, name preserved.
+        assert!(!mgr.note_forward_reachability(session, 3000, true));
+        assert_eq!(
+            mgr.forward_health(session, 3000),
+            Some(ForwardHealth {
+                listening: true,
+                process: Some("vite".to_string())
+            })
+        );
+        // A request finds it down: change reported, name preserved for the
+        // tooltip until the next probe refreshes it.
+        assert!(mgr.note_forward_reachability(session, 3000, false));
+        assert_eq!(
+            mgr.forward_health(session, 3000),
+            Some(ForwardHealth {
+                listening: false,
+                process: Some("vite".to_string())
+            })
+        );
+
+        // First observation for an unprobed port seeds a nameless verdict.
+        assert!(mgr.note_forward_reachability(session, 4000, true));
+        assert_eq!(
+            mgr.forward_health(session, 4000),
+            Some(ForwardHealth {
+                listening: true,
+                process: None
+            })
+        );
     }
 }

--- a/backend/src/handlers/websocket/session_manager/tunnel_client.rs
+++ b/backend/src/handlers/websocket/session_manager/tunnel_client.rs
@@ -6,7 +6,7 @@
 //! the tunnel frames. The reverse-proxy handler hands the other end to a
 //! hyper HTTP/1.1 client — hyper never knows it isn't a TCP socket.
 //!
-//! Flow control mirrors the proxy side (`session_lib::tunnel`): 256 KiB
+//! Flow control mirrors the proxy side (`session_lib::tunnel`): a 64 KiB
 //! credit per direction, ≤16 KiB `TunnelData` frames, window re-granted as
 //! bytes drain into the pipe. The outgoing path is the session's unbounded
 //! `ProxySender`, so per-stream credit is what bounds queued tunnel bytes:
@@ -19,7 +19,8 @@ use std::time::Duration;
 use base64::Engine;
 use dashmap::DashMap;
 use shared::{
-    ServerToProxy, TunnelCloseFields, TunnelDataFields, TunnelOpenFields, TunnelWindowFields,
+    ServerToProxy, TunnelCloseFields, TunnelDataFields, TunnelOpenFields, TunnelRefuseReason,
+    TunnelWindowFields,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, Mutex, Notify};
@@ -30,8 +31,10 @@ use super::{ProxySender, SessionManager};
 
 /// Max decoded bytes per `TunnelData` frame (spec).
 pub const MAX_CHUNK: usize = 16 * 1024;
-/// Initial per-stream, per-direction flow-control window (spec).
-pub const INITIAL_WINDOW: u32 = 256 * 1024;
+/// Initial per-stream, per-direction flow-control window. Must match the proxy
+/// side (`session_lib::tunnel::INITIAL_WINDOW`) — both ends seed their credit
+/// from it.
+pub const INITIAL_WINDOW: u32 = 64 * 1024;
 /// How long to wait for the proxy's `TunnelOpened`/`TunnelRefused`.
 const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// Duplex pipe capacity between the relay and hyper.
@@ -40,7 +43,7 @@ const PIPE_CAPACITY: usize = 64 * 1024;
 /// Frames routed from the proxy socket into a stream's relay task.
 pub enum TunnelIn {
     Opened,
-    Refused(String),
+    Refused(TunnelRefuseReason),
     Data(Vec<u8>),
     Window(u32),
     Close,
@@ -71,7 +74,7 @@ pub enum TunnelError {
     #[error("session proxy is not connected")]
     NotConnected,
     #[error("proxy refused the stream: {0}")]
-    Refused(String),
+    Refused(TunnelRefuseReason),
     #[error("timed out waiting for the proxy to open the stream")]
     OpenTimeout,
     #[error("stream closed while opening")]
@@ -193,9 +196,9 @@ impl SessionManager {
         let verdict = tokio::time::timeout(OPEN_TIMEOUT, relay_rx.recv()).await;
         match verdict {
             Ok(Some(TunnelIn::Opened)) => {}
-            Ok(Some(TunnelIn::Refused(error))) => {
+            Ok(Some(TunnelIn::Refused(reason))) => {
                 self.tunnel_streams.remove(&stream_id);
-                return Err(TunnelError::Refused(error));
+                return Err(TunnelError::Refused(reason));
             }
             Ok(_) => {
                 self.tunnel_streams.remove(&stream_id);

--- a/session-lib/src/tunnel.rs
+++ b/session-lib/src/tunnel.rs
@@ -28,7 +28,8 @@ use std::time::Duration;
 use base64::Engine;
 use shared::{
     ForwardStatusFields, ProxyToServer, ServerToProxy, TunnelCloseFields, TunnelDataFields,
-    TunnelOpenFields, TunnelRefusedFields, TunnelStreamFields, TunnelWindowFields,
+    TunnelOpenFields, TunnelRefuseReason, TunnelRefusedFields, TunnelStreamFields,
+    TunnelWindowFields,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -43,21 +44,31 @@ pub type TunnelWsWrite = Arc<Mutex<ws_bridge::WsSender<ProxyToServer>>>;
 
 /// Max decoded bytes per `TunnelData` frame.
 pub const MAX_CHUNK: usize = 16 * 1024;
-/// Initial per-stream, per-direction flow-control window.
-pub const INITIAL_WINDOW: u32 = 256 * 1024;
-/// Max concurrent streams per session connection.
-pub const MAX_STREAMS: usize = 64;
-/// How long a probe/stream dial to loopback may take before it is refused.
+/// Initial per-stream, per-direction flow-control window. Kept small so the
+/// worst-case buffered bytes (`MAX_STREAMS × INITIAL_WINDOW` per direction)
+/// stay bounded even with a high stream cap; loopback/WS latency is low enough
+/// that a 64 KiB window saturates a single stream easily.
+pub const INITIAL_WINDOW: u32 = 64 * 1024;
+/// Max concurrent streams per session connection. A browser loading a
+/// resource-heavy page over HTTP/2 multiplexes many requests at once, each of
+/// which becomes one stream, so this is generous; the per-stream window keeps
+/// the aggregate memory bound flat (256 × 64 KiB = 16 MiB per direction).
+pub const MAX_STREAMS: usize = 256;
+/// How long a single dial to loopback may take before it is treated as a
+/// timeout (service hung, not down).
 const DIAL_TIMEOUT: Duration = Duration::from_secs(2);
-/// How long a *browser-stream* dial keeps retrying loopback before giving up.
-/// A refused dial usually just means the local service is momentarily down —
-/// mid-restart, or finishing a build — so we back off and retry within this
-/// budget instead of instantly reporting the port dead (which surfaces as
-/// "nothing listening on the forwarded port"). A genuinely dead port still
-/// fails within the budget rather than hanging the browser indefinitely. The
-/// background health probe (`probe_tick`) does NOT retry — it must reflect the
-/// true, current liveness for the frontend's forward chip.
+/// How long a *browser-stream* dial keeps retrying a *refused* loopback before
+/// giving up. A refusal usually just means the local service is momentarily
+/// down — mid-restart, or finishing a build — so [`connect_loopback`] backs
+/// off and retries within this budget instead of instantly reporting the port
+/// dead. A dial that *times out* is never retried (repeating a multi-second
+/// hang would only stall the browser).
 const STREAM_DIAL_RETRY_BUDGET: Duration = Duration::from_secs(8);
+/// Retry budget for the background health probe and the registration probe.
+/// Short: a small grace absorbs a momentary refusal (so the chip doesn't flap
+/// red on a blip) without the probe lingering for seconds on a genuinely dead
+/// port. Real traffic outcomes correct the chip faster than a probe anyway.
+const PROBE_DIAL_BUDGET: Duration = Duration::from_millis(1500);
 /// Cadence of the background port-health probe. A loopback dial is
 /// microseconds of work, so this can be frequent — it drives the green/red
 /// liveness tint on the frontend's forward chip.
@@ -90,12 +101,13 @@ pub struct TunnelManager {
     ws: TunnelWsWrite,
     allowed: Mutex<HashSet<u16>>,
     streams: Mutex<HashMap<Uuid, StreamHandle>>,
-    /// Last probe verdict per allowlisted port (`(listening, process name)`);
-    /// the background prober reports a `ForwardStatus` only when a port's
-    /// verdict *changes* (the registration-time probe seeds it), so steady
-    /// state costs no frames. The process name is part of the verdict so an
-    /// app swap on the same port re-reports.
-    last_health: Mutex<HashMap<u16, (bool, Option<String>)>>,
+    /// Last reported `listening` verdict per allowlisted port; the background
+    /// prober reports a `ForwardStatus` only when this flips (the
+    /// registration-time probe seeds it), so steady state costs no frames.
+    /// Process name is display-only and rides the frame but does not trigger a
+    /// report on its own — that name flickering (best-effort resolution) was a
+    /// source of spurious churn.
+    last_health: Mutex<HashMap<u16, bool>>,
     prober: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
@@ -133,12 +145,10 @@ impl TunnelManager {
             .await
             .retain(|port, _| ports.contains(port));
         for port in ports {
-            let (listening, error) =
-                match tokio::time::timeout(DIAL_TIMEOUT, dial_loopback(port)).await {
-                    Ok(Ok(_)) => (true, None),
-                    Ok(Err(e)) => (false, Some(e.to_string())),
-                    Err(_) => (false, Some("probe dial timed out".to_string())),
-                };
+            let (listening, error) = match connect_loopback(port, PROBE_DIAL_BUDGET).await {
+                Ok(_) => (true, None),
+                Err(e) => (false, Some(e.to_string())),
+            };
             let process = if listening {
                 process_on_port(port).await
             } else {
@@ -151,10 +161,9 @@ impl TunnelManager {
                 self.last_health.lock().await.remove(&port);
                 continue;
             }
-            let verdict = (listening, process.clone());
             let changed = {
                 let mut health = self.last_health.lock().await;
-                health.insert(port, verdict.clone()) != Some(verdict)
+                health.insert(port, listening) != Some(listening)
             };
             if changed {
                 info!(
@@ -184,12 +193,10 @@ impl TunnelManager {
                 let mgr = self.clone();
                 let port = f.port;
                 tokio::spawn(async move {
-                    let (listening, error) =
-                        match tokio::time::timeout(DIAL_TIMEOUT, dial_loopback(port)).await {
-                            Ok(Ok(_)) => (true, None),
-                            Ok(Err(e)) => (false, Some(e.to_string())),
-                            Err(_) => (false, Some("probe dial timed out".to_string())),
-                        };
+                    let (listening, error) = match connect_loopback(port, PROBE_DIAL_BUDGET).await {
+                        Ok(_) => (true, None),
+                        Err(e) => (false, Some(e.to_string())),
+                    };
                     let process = if listening {
                         process_on_port(port).await
                     } else {
@@ -201,10 +208,7 @@ impl TunnelManager {
                         return;
                     }
                     // Seed the background prober so it only reports changes.
-                    mgr.last_health
-                        .lock()
-                        .await
-                        .insert(port, (listening, process.clone()));
+                    mgr.last_health.lock().await.insert(port, listening);
                     mgr.send(ProxyToServer::ForwardStatus(ForwardStatusFields {
                         port,
                         listening,
@@ -305,16 +309,15 @@ impl TunnelManager {
     }
 
     async fn open_stream(self: &Arc<Self>, open: &TunnelOpenFields) {
-        let refuse = |error: String| {
+        let refuse = |reason: TunnelRefuseReason| {
             ProxyToServer::TunnelRefused(TunnelRefusedFields {
                 stream_id: open.stream_id,
-                error,
+                reason,
             })
         };
 
         if !self.allowed.lock().await.contains(&open.port) {
-            self.send(refuse(format!("port {} is not forwarded", open.port)))
-                .await;
+            self.send(refuse(TunnelRefuseReason::NotForwarded)).await;
             return;
         }
         // Register the inbox before the dial so ordered frames can't miss it.
@@ -324,13 +327,16 @@ impl TunnelManager {
             let mut streams = self.streams.lock().await;
             if streams.len() >= MAX_STREAMS {
                 drop(streams);
-                self.send(refuse(format!("stream limit ({MAX_STREAMS}) reached")))
-                    .await;
+                warn!(
+                    "Tunnel stream limit ({}) reached; refusing stream {}",
+                    MAX_STREAMS, open.stream_id
+                );
+                self.send(refuse(TunnelRefuseReason::StreamLimit)).await;
                 return;
             }
             if streams.contains_key(&open.stream_id) {
                 drop(streams);
-                self.send(refuse("duplicate stream id".to_string())).await;
+                self.send(refuse(TunnelRefuseReason::Protocol)).await;
                 return;
             }
             streams.insert(
@@ -347,13 +353,14 @@ impl TunnelManager {
         let stream_id = open.stream_id;
         let port = open.port;
         tokio::spawn(async move {
-            let tcp = match dial_loopback_for_stream(port).await {
+            let tcp = match connect_loopback(port, STREAM_DIAL_RETRY_BUDGET).await {
                 Ok(tcp) => tcp,
                 Err(e) => {
                     mgr.remove_stream(stream_id).await;
+                    warn!("Tunnel dial to port {} refused: {}", port, e);
                     mgr.send(ProxyToServer::TunnelRefused(TunnelRefusedFields {
                         stream_id,
-                        error: e.to_string(),
+                        reason: TunnelRefuseReason::NoListener,
                     }))
                     .await;
                     return;
@@ -380,27 +387,20 @@ impl TunnelManager {
     }
 }
 
-/// The proxy only ever dials loopback — hard-coded, not configurable.
-async fn dial_loopback(port: u16) -> std::io::Result<TcpStream> {
-    TcpStream::connect(("127.0.0.1", port)).await
-}
-
-/// Dial loopback for a browser stream, retrying while the local service is
-/// momentarily unavailable so a forward self-heals across a quick backend
-/// restart instead of reporting the port dead. Each attempt is bounded by
-/// `DIAL_TIMEOUT`; a *refused* dial backs off briefly and retries until
-/// `STREAM_DIAL_RETRY_BUDGET` elapses. A dial that *times out* (the service is
-/// hung, not down) is not retried — repeating a multi-second hang would only
-/// stall the browser — so it fails immediately.
-async fn dial_loopback_for_stream(port: u16) -> std::io::Result<TcpStream> {
-    let deadline = Instant::now() + STREAM_DIAL_RETRY_BUDGET;
+/// Dial loopback (`127.0.0.1:{port}` — hard-coded, not configurable), the one
+/// dial used by *both* real browser streams and the health probe so the two
+/// can never disagree on what "up" means. Each attempt is bounded by
+/// `DIAL_TIMEOUT`; a *refused* dial backs off and retries until `budget`
+/// elapses (the local service is likely mid-restart), while a dial that *times
+/// out* (hung, not down) fails immediately without retry. A zero `budget`
+/// means a single attempt.
+async fn connect_loopback(port: u16, budget: Duration) -> std::io::Result<TcpStream> {
+    let deadline = Instant::now() + budget;
     let mut backoff = Duration::from_millis(100);
     loop {
-        match tokio::time::timeout(DIAL_TIMEOUT, dial_loopback(port)).await {
+        match tokio::time::timeout(DIAL_TIMEOUT, TcpStream::connect(("127.0.0.1", port))).await {
             Ok(Ok(tcp)) => return Ok(tcp),
             Ok(Err(e)) => {
-                // Refused (or similar) — the service is likely mid-restart.
-                // Back off and retry until the budget runs out.
                 if Instant::now() + backoff >= deadline {
                     return Err(e);
                 }
@@ -614,7 +614,7 @@ mod tests {
         let accept = tokio::spawn(async move {
             let _ = listener.accept().await;
         });
-        let stream = dial_loopback_for_stream(port).await;
+        let stream = connect_loopback(port, STREAM_DIAL_RETRY_BUDGET).await;
         assert!(stream.is_ok(), "expected immediate connect, got {stream:?}");
         let _ = accept.await;
     }
@@ -641,7 +641,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(50)).await;
         });
 
-        let stream = dial_loopback_for_stream(port).await;
+        let stream = connect_loopback(port, STREAM_DIAL_RETRY_BUDGET).await;
         assert!(
             stream.is_ok(),
             "expected the retry to connect once the listener came up, got {stream:?}"

--- a/shared/src/endpoints/types.rs
+++ b/shared/src/endpoints/types.rs
@@ -254,11 +254,41 @@ pub struct TunnelStreamFields {
     pub stream_id: Uuid,
 }
 
+/// Why the proxy could not open a tunnel stream. The backend maps this to the
+/// right HTTP status and decides whether it reflects on port health — only
+/// `NoListener` means the local service is actually down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TunnelRefuseReason {
+    /// The loopback dial to `127.0.0.1:{port}` failed (connection refused or
+    /// timed out) — nothing is serving there right now.
+    NoListener,
+    /// The proxy has hit its concurrent-stream cap for this connection; the
+    /// port is fine, the tunnel is momentarily saturated.
+    StreamLimit,
+    /// The port is not in the proxy's forward allowlist (revoked/re-pointed).
+    NotForwarded,
+    /// Protocol misuse (duplicate stream id, oversize frame) — should not
+    /// happen in normal operation.
+    Protocol,
+}
+
+impl std::fmt::Display for TunnelRefuseReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::NoListener => "nothing is listening on the forwarded port",
+            Self::StreamLimit => "the forward is at its concurrent-connection limit",
+            Self::NotForwarded => "this port is not forwarded",
+            Self::Protocol => "forward protocol error",
+        };
+        f.write_str(s)
+    }
+}
+
 /// The proxy could not (or refused to) dial a stream.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TunnelRefusedFields {
     pub stream_id: Uuid,
-    pub error: String,
+    pub reason: TunnelRefuseReason,
 }
 
 /// Add/remove a port in the proxy's forward allowlist.


### PR DESCRIPTION
Fixes two long-standing port-forwarding annoyances: the up/down chip disagreeing with what the forward actually serves, and intermittent 502s under load.

**Status matches reality.** The chip's liveness and the reverse proxy previously used two independent dials with different retry semantics and a 10s sampling lag, so they routinely disagreed. This collapses both onto a single `connect_loopback` dial and feeds real request outcomes back into port health, so the chip is corrected by actual traffic between background probes.

**Correct, honest failures.** `TunnelRefused` now carries a typed reason. A stream-limit refusal returns **503** and a revoked forward returns **404**, instead of both masquerading as a "nothing is listening" **502**. Only a genuine no-listener marks the port down.

**No more concurrency 502s.** Forward origins are HTTPS, so browsers multiplex 100+ concurrent requests over one HTTP/2 connection — each a tunnel stream — which overran the 64-stream cap. Raised `MAX_STREAMS` to 256 (per-stream window shrunk 256 KiB → 64 KiB to keep the memory bound flat).

**Less churn.** Health change-detection now keys on the `listening` bit only, so best-effort process-name flicker no longer triggers needless chip refetches.

Connection reuse/pooling (a separate optimization that does not affect the 502s) is deferred to #1468.