### PR TITLE
Update claude-codes and codex-codes to latest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ agent-portal is a web-based proxy system for Claude Code sessions built with:
 
 We maintain **[meawoppl/rust-code-agent-sdks](https://github.com/meawoppl/rust-claude-codes)** — a workspace containing two Rust crates for parsing code agent CLI output:
 
-- **`claude-codes`** (v2.1.47) — Types for Claude Code's JSON protocol (`ClaudeOutput`, `ResultMessage`, `UsageInfo`, `RateLimitEvent`, etc.). Used by the proxy to deserialize Claude's stdout.
-- **`codex-codes`** (v0.101.0) — Types for OpenAI Codex CLI's JSONL protocol (`ThreadEvent`, `ThreadItem`, `Usage`, etc.). Phase 1 integration complete (AgentType, DB schema); see [docs/CODEX_SUPPORT.md](docs/CODEX_SUPPORT.md) for the full plan.
+- **`claude-codes`** (v2.1.165) — Types for Claude Code's JSON protocol (`ClaudeOutput`, `ResultMessage`, `UsageInfo`, `RateLimitEvent`, etc.). Used by the proxy to deserialize Claude's stdout.
+- **`codex-codes`** (v0.143.6) — Types for OpenAI Codex CLI's JSONL protocol (`ThreadEvent`, `ThreadItem`, `Usage`, etc.). Phase 1 integration complete (AgentType, DB schema); see [docs/CODEX_SUPPORT.md](docs/CODEX_SUPPORT.md) for the full plan.
 
 ## Architecture Quick Reference
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "archive-format"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "chrono",
  "object_store",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "archive-viewer"
-version = "2.13.10"
+version = "2.13.11"
 dependencies = [
  "anyhow",
  "archive-format",
@@ -1019,9 +1019,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.161"
+version = "2.1.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43463847135e5131f36df274467ea944b610675ec2f40296af28b6a97cea6e62"
+checksum = "7e866fa8ee015637d94f5104866595a4915ceda210eab510135f2d2201dbe43b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.143.4"
+version = "0.143.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea31c99a29afc51c6f3261477b0efaa22f494ba6ed5b5bb7ed09dbceac80ecca"
+checksum = "4bdba0e2546f5c4a27b1e417596007e4148a0890188957275911f15a12812c61"
 dependencies = [
  "log",
  "serde",
@@ -1841,7 +1841,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2149,7 +2149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4426,7 +4426,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5870,7 +5870,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5951,7 +5951,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7191,7 +7191,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8379,7 +8379,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.161", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.165", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.143.4", default-features = false, features = ["types"] }
+codex-codes = { version = "0.143.6", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -292,6 +292,9 @@ fn log_claude_output(output: &ClaudeOutput) {
                 ControlRequestPayload::Initialize(_) => {
                     debug!("  initialize");
                 }
+                ControlRequestPayload::Interrupt => {
+                    debug!("  interrupt");
+                }
             }
         }
         ClaudeOutput::ControlResponse(resp) => {

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -479,6 +479,10 @@ mod tests {
             structured_output: None,
             deferred_tool_use: None,
             origin: None,
+            // 2.1.163/2.1.164 additions — also absent here.
+            request_sent_wall_ms: None,
+            user_message_uuid: None,
+            fast_mode_disabled_reason: None,
         }
     }
 

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -33,6 +33,16 @@ enum CodexApprovalResponseKind {
     ApplyPatchApprovedDenied,
 }
 
+/// The rejection message Codex 0.143.5+ requires on a `denied` approval
+/// response — the user's deny comment when they left one, else a neutral
+/// default so the wire frame is never empty.
+fn rejection_text(decision: &PermissionDecision) -> String {
+    decision
+        .reason
+        .clone()
+        .unwrap_or_else(|| "Denied by user".to_string())
+}
+
 /// Map a neutral [`PermissionDecision`] to Codex's approval response. Codex's
 /// v2 command/file-change requests use `accept` / `decline`; older v1
 /// exec/apply-patch requests use `approved` / `denied`.
@@ -50,14 +60,14 @@ fn codex_approval_result(
         CodexApprovalResponseKind::ExecApprovedDenied if decision.allow => {
             serde_json::to_value(ExecCommandApprovalResponse::approved())
         }
-        CodexApprovalResponseKind::ExecApprovedDenied => {
-            serde_json::to_value(ExecCommandApprovalResponse::denied())
-        }
+        CodexApprovalResponseKind::ExecApprovedDenied => serde_json::to_value(
+            ExecCommandApprovalResponse::denied(rejection_text(decision)),
+        ),
         CodexApprovalResponseKind::ApplyPatchApprovedDenied if decision.allow => {
             serde_json::to_value(ApplyPatchApprovalResponse::approved())
         }
         CodexApprovalResponseKind::ApplyPatchApprovedDenied => {
-            serde_json::to_value(ApplyPatchApprovalResponse::denied())
+            serde_json::to_value(ApplyPatchApprovalResponse::denied(rejection_text(decision)))
         }
     };
     result.unwrap_or(serde_json::Value::Null)
@@ -1135,9 +1145,15 @@ mod tests {
         let exec_approved =
             codex_approval_result(&approve, CodexApprovalResponseKind::ExecApprovedDenied);
         assert_eq!(exec_approved["decision"], serde_json::json!("approved"));
+        // Codex 0.143.5+ denies carry a rejection message:
+        // `{"decision":{"denied":{"rejection":...}}}`. With no user comment,
+        // `rejection_text` supplies the neutral default.
         let exec_denied =
             codex_approval_result(&deny, CodexApprovalResponseKind::ExecApprovedDenied);
-        assert_eq!(exec_denied["decision"], serde_json::json!("denied"));
+        assert_eq!(
+            exec_denied["decision"],
+            serde_json::json!({ "denied": { "rejection": "Denied by user" } })
+        );
 
         let patch_approved = codex_approval_result(
             &approve,
@@ -1146,7 +1162,25 @@ mod tests {
         assert_eq!(patch_approved["decision"], serde_json::json!("approved"));
         let patch_denied =
             codex_approval_result(&deny, CodexApprovalResponseKind::ApplyPatchApprovedDenied);
-        assert_eq!(patch_denied["decision"], serde_json::json!("denied"));
+        assert_eq!(
+            patch_denied["decision"],
+            serde_json::json!({ "denied": { "rejection": "Denied by user" } })
+        );
+
+        // A user's deny comment flows through as the rejection text.
+        let deny_with_reason = PermissionDecision {
+            allow: false,
+            reason: Some("looks unsafe".to_string()),
+            ..Default::default()
+        };
+        let exec_denied_reason = codex_approval_result(
+            &deny_with_reason,
+            CodexApprovalResponseKind::ExecApprovedDenied,
+        );
+        assert_eq!(
+            exec_denied_reason["decision"],
+            serde_json::json!({ "denied": { "rejection": "looks unsafe" } })
+        );
     }
 
     #[test]


### PR DESCRIPTION
Bumps the two agent SDKs to their latest published versions and adapts to the breaking changes in their changelogs.

- **claude-codes** 2.1.161 → 2.1.165
- **codex-codes** 0.143.4 → 0.143.6

### Breaking-change adaptations
- **codex `ReviewDecision::Denied`** is now a struct variant carrying a required `rejection` string (`{"decision":{"denied":{"rejection":...}}}`), and the `denied()` constructors take it as an argument. We thread the user's deny comment (`PermissionDecision.reason`) through, falling back to a neutral default when none was left.
- **claude `ControlRequestPayload::Interrupt`** is a new variant; handled in the control-request debug log.

### Housekeeping
- Add the new `ResultMessage` fields (`request_sent_wall_ms`, `user_message_uuid`, `fast_mode_disabled_reason`) to a test fixture.
- Refresh the stale SDK version references in `CLAUDE.md`.

### On the other changelog additions
Reviewed the rest against what the portal actually consumes: **Opus 5** already displays correctly (the model-id parser handles `claude-opus-5` generically), and **PR-association** is already covered by the portal's own git/gh watcher (`git_metadata.rs`), so the new `code_change_published` event would be redundant. Remaining additions (`aborted`, subagent-retry, mcp_server_errors, codex app/read·installed, etc.) are additive fields the portal doesn't currently use.