### PR TITLE
Fix session-pill sparkline ticks parsed as local time

### DIFF
--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -27,7 +27,7 @@ use yew::prelude::*;
 use super::forward_chips::ForwardChips;
 use super::helpers::{
     autoscroll_transition, classify_output_msg_type, clear_completed_tools,
-    enrich_codex_file_change_permission, format_tool_elapsed, is_claude_awaiting,
+    enrich_codex_file_change_permission, format_tool_elapsed, is_claude_awaiting, parse_iso_ms_utc,
     reconcile_pending_sends, running_tool_key, update_pending_send_delivery, upsert_tool_progress,
     ActiveToolProgress, ActivityTag,
 };
@@ -920,7 +920,7 @@ impl SessionView {
                     self.dispatch_tasks(TasksInbound::Replay(ev));
                 }
             }
-            let ts_ms = js_sys::Date::parse(&msg.created_at);
+            let ts_ms = parse_iso_ms_utc(&msg.created_at);
             if ts_ms.is_finite() {
                 ctx.props().on_activity.emit((session_id, tag, ts_ms));
             }
@@ -1023,7 +1023,7 @@ impl SessionView {
         crate::audio::play_sound(crate::audio::SoundEvent::Activity);
         let activity_ts = output
             .raw_iso()
-            .map(js_sys::Date::parse)
+            .map(parse_iso_ms_utc)
             .filter(|ts| ts.is_finite())
             .unwrap_or_else(js_sys::Date::now);
         ctx.props()

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -261,6 +261,36 @@ pub(super) fn is_claude_awaiting(
         .is_some_and(|t| t == ActivityTag::Result)
 }
 
+/// Parse a server ISO timestamp to epoch-ms, treating a timezone-less string
+/// as UTC.
+///
+/// The backend serializes message `created_at` as a *naive* datetime (e.g.
+/// `2026-05-17T12:34:56.789`, no offset — see `backend/handlers/messages.rs`).
+/// `js_sys::Date::parse` reads a date-time form without an offset as *local*
+/// time, so on a browser west of UTC the event lands hours in the future
+/// relative to `js_sys::Date::now()`. That pushed sparkline ticks far past the
+/// 100% right edge (`left: ~8000%`) — invisibly off the pill. Appending `Z`
+/// when the string carries no timezone pins it to UTC so it lines up with
+/// `Date::now()`. Returns `NaN` when unparseable (callers check `is_finite`).
+pub(super) fn parse_iso_ms_utc(iso: &str) -> f64 {
+    js_sys::Date::parse(&normalize_iso_utc(iso))
+}
+
+/// Append a `Z` when an ISO timestamp carries no timezone designator, so it is
+/// read as UTC rather than local time. A designator is a `Z` or a `+`/`-`
+/// offset in the time portion (after `T`); date hyphens don't count. Pure so
+/// the timezone decision is unit-testable without a browser `Date`.
+fn normalize_iso_utc(iso: &str) -> std::borrow::Cow<'_, str> {
+    let has_tz = iso
+        .split_once('T')
+        .is_some_and(|(_, time)| time.contains(['Z', '+', '-']));
+    if has_tz {
+        std::borrow::Cow::Borrowed(iso)
+    } else {
+        std::borrow::Cow::Owned(format!("{iso}Z"))
+    }
+}
+
 /// Derive the [`ActivityTag`] used by `on_activity` / `CheckAwaiting` from a
 /// raw wire JSON string. Centralizes the parse-and-classify dance previously
 /// duplicated between `LoadHistory` (REST replay) and `handle_received_output`
@@ -589,6 +619,37 @@ pub(crate) fn format_tool_elapsed(seconds: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_iso_utc_appends_z_only_when_no_timezone() {
+        // Naive (the backend's message created_at shape) → pinned to UTC.
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T12:34:56.789"),
+            "2026-05-17T12:34:56.789Z"
+        );
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T12:34:56"),
+            "2026-05-17T12:34:56Z"
+        );
+        // Already zoned → untouched (Z or explicit offset).
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T12:34:56Z"),
+            "2026-05-17T12:34:56Z"
+        );
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T12:34:56+00:00"),
+            "2026-05-17T12:34:56+00:00"
+        );
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T12:34:56-05:00"),
+            "2026-05-17T12:34:56-05:00"
+        );
+        // Date hyphens must not be mistaken for an offset.
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T00:00:00"),
+            "2026-05-17T00:00:00Z"
+        );
+    }
 
     fn pending(content: &str) -> RenderedMessage {
         RenderedMessage::new(format!(r#"{{"type":"user","content":"{content}"}}"#), None)


### PR DESCRIPTION
The activity ticks on session pills disappeared because their timestamps were parsed as local time.

Message `created_at` is serialized as a **naive** datetime (e.g. `2026-05-17T12:34:56.789`, no offset — `backend/handlers/messages.rs`). The sparkline feed passed that straight to `js_sys::Date::parse`, which reads a date-time without an offset as **local** time. On a browser west of UTC each event then lands hours *ahead* of `js_sys::Date::now()`, so the tick's computed `left` blew past 100% (observed `~8000%`) and rendered off the right edge of the pill — invisible.

Fix: normalize the timestamp to UTC (append `Z` when it has no timezone designator) before parsing, at both feed sites (`handle_load_history` REST replay and `handle_received_output` live wire). The timezone decision is a pure `normalize_iso_utc` with a unit test; the `js_sys::Date` call wraps it. No wire-format change, so the `before`/`after` pagination cursors are untouched.

Note: a separate, smaller regression (#1449 diverted `tool_progress` heartbeats to a non-persisted side-channel that no longer feeds the sparkline) means long tool runs won't tick every ~30s even after this. Happy to restore that feed in a follow-up if wanted.