### PR TITLE
Add a single forward-error taxonomy for legible failures

### DIFF
--- a/backend/src/handlers/forward_proxy.rs
+++ b/backend/src/handlers/forward_proxy.rs
@@ -30,6 +30,7 @@ use uuid::Uuid;
 
 use crate::errors::AppError;
 use crate::AppState;
+use shared::api::ForwardError;
 
 /// Handoff token TTL (portal origin → forward origin redirect).
 const HANDOFF_TTL_SECS: i64 = 60;
@@ -247,11 +248,11 @@ async fn dispatch(app_state: Arc<AppState>, label: String, req: Request) -> Resp
     let (session_id, port, session_key) = {
         let mut conn = match app_state.conn() {
             Ok(conn) => conn,
-            Err(_) => return plain_status(StatusCode::SERVICE_UNAVAILABLE, "database unavailable"),
+            Err(_) => return forward_error(ForwardError::Unavailable),
         };
         let session_id = match crate::handlers::forwards::session_for_label(&mut conn, &label) {
             Ok(id) => id,
-            Err(_) => return plain_status(StatusCode::NOT_FOUND, "no such forward"),
+            Err(_) => return forward_error(ForwardError::UnknownForward),
         };
 
         if req.uri().path() == "/__portal/auth" {
@@ -262,7 +263,7 @@ async fn dispatch(app_state: Arc<AppState>, label: String, req: Request) -> Resp
         // forward" (which would masquerade as revocation/auth weirdness).
         let forward = match crate::handlers::forwards::active_forward(&mut conn, session_id) {
             Ok(forward) => forward,
-            Err(_) => return plain_status(StatusCode::SERVICE_UNAVAILABLE, "database unavailable"),
+            Err(_) => return forward_error(ForwardError::Unavailable),
         };
 
         // A *public* forward serves with no auth. Otherwise (private or
@@ -281,9 +282,7 @@ async fn dispatch(app_state: Arc<AppState>, label: String, req: Request) -> Resp
             }
             match forward {
                 Some((port, _)) => port,
-                None => {
-                    return plain_status(StatusCode::NOT_FOUND, "this forward has been revoked")
-                }
+                None => return forward_error(ForwardError::Revoked),
             }
         };
 
@@ -294,7 +293,7 @@ async fn dispatch(app_state: Arc<AppState>, label: String, req: Request) -> Resp
             .first::<String>(&mut conn)
         {
             Ok(key) => key,
-            Err(_) => return plain_status(StatusCode::NOT_FOUND, "session not found"),
+            Err(_) => return forward_error(ForwardError::UnknownForward),
         };
         (session_id, port, session_key)
     };
@@ -325,7 +324,7 @@ fn handle_auth(app_state: &AppState, session_id: Uuid, req: &Request) -> Respons
         .map(|t| verify_token(app_state, t, AUD_HANDOFF, session_id))
         .unwrap_or(false);
     if !valid {
-        return plain_status(StatusCode::FORBIDDEN, "invalid or expired forward token");
+        return forward_error(ForwardError::AuthRequired);
     }
 
     let cookie_jwt = mint_token(app_state, AUD_COOKIE, session_id, COOKIE_TTL_SECS);
@@ -347,7 +346,7 @@ fn handle_auth(app_state: &AppState, session_id: Uuid, req: &Request) -> Respons
 /// XHR/WS so API calls fail loudly instead of redirecting into HTML.
 fn unauthenticated_response(app_state: &AppState, session_id: Uuid, req: &Request) -> Response {
     if !should_redirect_for_forward_auth(req.method(), req.headers()) {
-        return plain_status(StatusCode::UNAUTHORIZED, "forward session expired");
+        return forward_error(ForwardError::SessionExpired);
     }
     let next = req
         .uri()
@@ -431,8 +430,59 @@ fn filtered_cookie_header(headers: &HeaderMap) -> Option<String> {
     (!kept.is_empty()).then(|| kept.join("; "))
 }
 
-fn plain_status(status: StatusCode, msg: impl Into<String>) -> Response {
-    (status, msg.into()).into_response()
+/// Render a [`ForwardError`] as the forward-origin HTTP response — the one and
+/// only place a forward failure becomes user-visible. Every failure path
+/// funnels here, so none can escape as a bare, cause-free string. Emits the
+/// mapped status, the stable `code` in `x-portal-forward-error` (so a client or
+/// agent can branch without scraping prose), and a small self-contained page.
+fn forward_error(err: ForwardError) -> Response {
+    let status = StatusCode::from_u16(err.http_status()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let mut response =
+        (status, axum::response::Html(render_forward_error_html(err))).into_response();
+    if let Ok(code) = HeaderValue::from_str(err.code()) {
+        response
+            .headers_mut()
+            .insert("x-portal-forward-error", code);
+    }
+    response
+}
+
+/// Self-contained dark error page. All fields are static taxonomy strings (no
+/// user input), so no escaping is required.
+fn render_forward_error_html(err: ForwardError) -> String {
+    format!(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\
+<title>{title}</title><style>\
+html{{color-scheme:dark}}\
+body{{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;\
+background:#1a1b26;color:#c0caf5;font:16px/1.5 system-ui,-apple-system,Segoe UI,sans-serif}}\
+main{{max-width:32rem;padding:2rem;text-align:center}}\
+h1{{font-size:1.4rem;margin:0 0 .75rem;color:#f7768e}}\
+p{{margin:0 0 1rem;color:#a9b1d6}}\
+code{{font:13px ui-monospace,monospace;color:#565f89}}\
+</style></head><body><main>\
+<h1>{title}</h1><p>{detail}</p><code>error: {code}</code></main></body></html>",
+        title = err.title(),
+        detail = err.detail(),
+        code = err.code(),
+    )
+}
+
+/// Map a backend [`TunnelError`] to its forward-facing [`ForwardError`], so the
+/// data-plane failure vocabulary and the user-facing taxonomy stay in lockstep.
+fn tunnel_error_to_forward(e: &crate::handlers::websocket::TunnelError) -> ForwardError {
+    use crate::handlers::websocket::TunnelError as Te;
+    use shared::TunnelRefuseReason as R;
+    match e {
+        Te::NotConnected => ForwardError::AgentOffline,
+        Te::Refused(R::NoListener) => ForwardError::NoListener,
+        Te::Refused(R::StreamLimit) => ForwardError::AtCapacity,
+        Te::Refused(R::NotForwarded) => ForwardError::NotForwarded,
+        Te::Refused(R::Protocol) => ForwardError::ProtocolFault,
+        Te::OpenTimeout => ForwardError::AgentUnreachable,
+        Te::ClosedEarly => ForwardError::OpenInterrupted,
+    }
 }
 
 /// Feed a real routing outcome into the port-health cache and nudge web
@@ -467,8 +517,6 @@ async fn proxy_request(
     label: &str,
     req: Request,
 ) -> Response {
-    use crate::handlers::websocket::TunnelError;
-
     let stream = match app_state
         .session_manager
         .open_tunnel(session_key, port)
@@ -478,32 +526,22 @@ async fn proxy_request(
             note_reachability(app_state, session_key, session_id, port, true);
             stream
         }
-        Err(TunnelError::NotConnected) => {
-            return plain_status(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "the agent for this session is offline",
-            )
-        }
-        Err(TunnelError::Refused(reason)) => {
-            use shared::TunnelRefuseReason::*;
-            warn!("Tunnel refused for {}:{}: {}", session_id, port, reason);
+        Err(e) => {
+            let ferr = tunnel_error_to_forward(&e);
             // Only a genuine "nothing listening" reflects on port health; a
-            // stream-limit or revocation refusal says nothing about the local
-            // service, so it must not tint the chip red.
-            let status = match reason {
-                NoListener => {
-                    note_reachability(app_state, session_key, session_id, port, false);
-                    StatusCode::BAD_GATEWAY
-                }
-                // Momentary saturation, not an error — a retry usually works.
-                StreamLimit => StatusCode::SERVICE_UNAVAILABLE,
-                NotForwarded => StatusCode::NOT_FOUND,
-                Protocol => StatusCode::BAD_GATEWAY,
-            };
-            return plain_status(status, reason.to_string());
-        }
-        Err(TunnelError::OpenTimeout) | Err(TunnelError::ClosedEarly) => {
-            return plain_status(StatusCode::GATEWAY_TIMEOUT, "forward open timed out")
+            // stream-limit, revocation, or transport failure says nothing about
+            // the local service, so it must not tint the chip red.
+            if ferr == ForwardError::NoListener {
+                note_reachability(app_state, session_key, session_id, port, false);
+            }
+            warn!(
+                "Tunnel open failed for {}:{}: {} ({})",
+                session_id,
+                port,
+                e,
+                ferr.code()
+            );
+            return forward_error(ferr);
         }
     };
 
@@ -512,7 +550,7 @@ async fn proxy_request(
         Ok(pair) => pair,
         Err(e) => {
             warn!("Tunnel HTTP handshake failed: {}", e);
-            return plain_status(StatusCode::BAD_GATEWAY, "upstream handshake failed");
+            return forward_error(ForwardError::BadOrigin);
         }
     };
     // `with_upgrades` keeps the connection driver alive after a 101 so the
@@ -539,14 +577,17 @@ async fn proxy_request(
 
     let upstream_req = match build_upstream_request(req, port, is_upgrade) {
         Ok(r) => r,
-        Err(msg) => return plain_status(StatusCode::BAD_REQUEST, msg),
+        Err(msg) => {
+            warn!("Bad forward request: {}", msg);
+            return forward_error(ForwardError::BadRequest);
+        }
     };
 
     let mut upstream_resp = match sender.send_request(upstream_req).await {
         Ok(resp) => resp,
         Err(e) => {
             warn!("Tunnel upstream request failed: {}", e);
-            return plain_status(StatusCode::BAD_GATEWAY, "upstream request failed");
+            return forward_error(ForwardError::BadOrigin);
         }
     };
 
@@ -564,10 +605,7 @@ async fn proxy_request(
         // send a dangling protocol switch.
         (None, true) => {
             warn!("Upstream returned 101 to a non-upgrade request; refusing");
-            plain_status(
-                StatusCode::BAD_GATEWAY,
-                "unexpected upstream protocol switch",
-            )
+            forward_error(ForwardError::BadOrigin)
         }
         // Normal response (browser wanted an upgrade or not; upstream said no).
         (_, false) => {
@@ -694,7 +732,7 @@ fn build_downstream_response(
     let mut response = Response::builder().status(parts.status);
     let headers = match response.headers_mut() {
         Some(h) => h,
-        None => return plain_status(StatusCode::BAD_GATEWAY, "bad upstream response"),
+        None => return forward_error(ForwardError::BadOrigin),
     };
 
     // Prefer reconstructing the origin from the request's own Host so the
@@ -760,7 +798,7 @@ fn build_downstream_response(
 
     match response.body(Body::new(body)) {
         Ok(r) => r,
-        Err(_) => plain_status(StatusCode::BAD_GATEWAY, "bad upstream response"),
+        Err(_) => forward_error(ForwardError::BadOrigin),
     }
 }
 

--- a/shared/src/api/forwards.rs
+++ b/shared/src/api/forwards.rs
@@ -131,3 +131,217 @@ pub struct SessionForwardsResponse {
     #[serde(default)]
     pub forwards: Vec<ForwardInfo>,
 }
+
+/// The single taxonomy of forward failures (docs/PORT_FORWARDING.md).
+///
+/// **Legibility is the point.** Every failure on the forward control/data path
+/// maps to exactly one variant, so no failure can ever reach a user — or the
+/// agent that caused it — as a bare, cause-free string. One variant carries
+/// everything the three audiences need, rendered from a single source:
+///
+/// * the browser error page (`title` + `detail`),
+/// * the CLI / agent-facing note (`code` + `detail`),
+/// * the HTTP boundary (`http_status`, plus the `code` echoed in the
+///   `x-portal-forward-error` header so a client can branch without scraping
+///   prose).
+///
+/// The `code` is a stable kebab slug (also the serde wire form) — safe to
+/// alert on and match against; the prose may be reworded freely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ForwardError {
+    /// Forwarding isn't configured on this server (no forward domain set).
+    NotConfigured,
+    /// A backend dependency (database) was unavailable while routing.
+    Unavailable,
+    /// The subdomain doesn't resolve to any session.
+    UnknownForward,
+    /// The forward existed but was closed or replaced by a newer one.
+    Revoked,
+    /// The request needs a portal login / a valid handoff token.
+    AuthRequired,
+    /// The forward-origin session cookie is missing, invalid, or expired.
+    SessionExpired,
+    /// The agent's proxy isn't connected — there is no tunnel to route through.
+    AgentOffline,
+    /// The agent is registered but didn't answer the open in time — almost
+    /// always its connection dropped and hasn't been reaped, or it is
+    /// reconnecting.
+    AgentUnreachable,
+    /// The tunnel tore down mid-open before the stream was established.
+    OpenInterrupted,
+    /// Nothing is listening on the forwarded port on the agent's machine.
+    NoListener,
+    /// The forward is momentarily at its concurrent-connection limit.
+    AtCapacity,
+    /// The port is not in the agent's forward allowlist (revoked / re-pointed).
+    NotForwarded,
+    /// The local server spoke malformed HTTP, or the upstream handshake/response
+    /// could not be completed.
+    BadOrigin,
+    /// A transient tunnel/protocol fault (should not happen in normal use).
+    ProtocolFault,
+    /// The incoming request line or headers were malformed.
+    BadRequest,
+}
+
+impl ForwardError {
+    /// Stable kebab-case identifier. Matches the serde wire form; echoed in the
+    /// `x-portal-forward-error` response header. Safe to alert/branch on.
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::NotConfigured => "not-configured",
+            Self::Unavailable => "unavailable",
+            Self::UnknownForward => "unknown-forward",
+            Self::Revoked => "revoked",
+            Self::AuthRequired => "auth-required",
+            Self::SessionExpired => "session-expired",
+            Self::AgentOffline => "agent-offline",
+            Self::AgentUnreachable => "agent-unreachable",
+            Self::OpenInterrupted => "open-interrupted",
+            Self::NoListener => "no-listener",
+            Self::AtCapacity => "at-capacity",
+            Self::NotForwarded => "not-forwarded",
+            Self::BadOrigin => "bad-origin",
+            Self::ProtocolFault => "protocol-fault",
+            Self::BadRequest => "bad-request",
+        }
+    }
+
+    /// HTTP status to return at the forward-origin boundary (raw `u16` so this
+    /// stays WASM-safe — the backend maps it to a `StatusCode`).
+    pub fn http_status(self) -> u16 {
+        match self {
+            Self::BadRequest => 400,
+            Self::AuthRequired | Self::SessionExpired => 401,
+            Self::UnknownForward | Self::Revoked | Self::NotForwarded => 404,
+            Self::NotConfigured | Self::Unavailable | Self::AgentOffline | Self::AtCapacity => 503,
+            Self::AgentUnreachable => 504,
+            Self::OpenInterrupted | Self::NoListener | Self::BadOrigin | Self::ProtocolFault => 502,
+        }
+    }
+
+    /// Short heading for the browser error page.
+    pub fn title(self) -> &'static str {
+        match self {
+            Self::NotConfigured => "Forwarding not available",
+            Self::Unavailable => "Temporarily unavailable",
+            Self::UnknownForward => "No such forward",
+            Self::Revoked => "This forward was closed",
+            Self::AuthRequired => "Sign-in required",
+            Self::SessionExpired => "Session expired",
+            Self::AgentOffline => "Agent offline",
+            Self::AgentUnreachable => "Agent not responding",
+            Self::OpenInterrupted => "Connection interrupted",
+            Self::NoListener => "Nothing is listening",
+            Self::AtCapacity => "Too many connections",
+            Self::NotForwarded => "Port not forwarded",
+            Self::BadOrigin => "Local server error",
+            Self::ProtocolFault => "Forwarding error",
+            Self::BadRequest => "Bad request",
+        }
+    }
+
+    /// One or two sentences: what happened, and what to do about it. Written for
+    /// the human at the browser and the agent reading it back over the CLI.
+    pub fn detail(self) -> &'static str {
+        match self {
+            Self::NotConfigured => {
+                "Port forwarding is not configured on this server, so this URL cannot route anywhere."
+            }
+            Self::Unavailable => {
+                "The portal could not reach a dependency it needs to route this forward. Try again in a moment."
+            }
+            Self::UnknownForward => {
+                "This forwarding URL does not match any active session. It may have been closed, or the link may be mistyped."
+            }
+            Self::Revoked => {
+                "The forward that used this URL was closed or replaced by a newer one. Ask the agent for its current forward URL."
+            }
+            Self::AuthRequired => {
+                "This forward is private. Open it from the portal (or sign in) to get a forward-session cookie first."
+            }
+            Self::SessionExpired => {
+                "Your forward session has expired. Reopen the forward from the portal to refresh it."
+            }
+            Self::AgentOffline => {
+                "The agent that serves this forward is not connected, so there is nothing to tunnel to. It may be starting up, reconnecting, or stopped."
+            }
+            Self::AgentUnreachable => {
+                "The agent is registered but did not answer in time — its connection most likely dropped and has not been cleaned up yet, or it is reconnecting. Retry shortly."
+            }
+            Self::OpenInterrupted => {
+                "The tunnel closed while the connection was being opened, usually because the agent reconnected mid-request. Retry."
+            }
+            Self::NoListener => {
+                "Nothing is listening on the forwarded port on the agent's machine. Confirm the local server is running and bound to that port."
+            }
+            Self::AtCapacity => {
+                "This forward is momentarily at its concurrent-connection limit. Retry in a moment; a page reload usually succeeds."
+            }
+            Self::NotForwarded => {
+                "This port is not currently forwarded for the session. The forward may have moved to a different port."
+            }
+            Self::BadOrigin => {
+                "The local server returned a response the proxy could not understand (malformed HTTP, or the connection failed mid-response)."
+            }
+            Self::ProtocolFault => {
+                "The forwarding tunnel hit an internal protocol error. Retry; if it persists, report it."
+            }
+            Self::BadRequest => {
+                "The request could not be forwarded because its path or headers were malformed."
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod forward_error_tests {
+    use super::ForwardError;
+
+    const ALL: &[ForwardError] = &[
+        ForwardError::NotConfigured,
+        ForwardError::Unavailable,
+        ForwardError::UnknownForward,
+        ForwardError::Revoked,
+        ForwardError::AuthRequired,
+        ForwardError::SessionExpired,
+        ForwardError::AgentOffline,
+        ForwardError::AgentUnreachable,
+        ForwardError::OpenInterrupted,
+        ForwardError::NoListener,
+        ForwardError::AtCapacity,
+        ForwardError::NotForwarded,
+        ForwardError::BadOrigin,
+        ForwardError::ProtocolFault,
+        ForwardError::BadRequest,
+    ];
+
+    #[test]
+    fn codes_are_unique_and_match_serde_wire_form() {
+        let mut seen = std::collections::HashSet::new();
+        for e in ALL {
+            assert!(seen.insert(e.code()), "duplicate code {}", e.code());
+            // serde encodes to the kebab code, so the wire form and the stable
+            // identifier can never drift.
+            let wire = serde_json::to_value(e).unwrap();
+            assert_eq!(wire, serde_json::Value::String(e.code().to_string()));
+            assert_eq!(
+                serde_json::from_value::<ForwardError>(wire).unwrap(),
+                *e,
+                "round-trip failed for {}",
+                e.code()
+            );
+        }
+    }
+
+    #[test]
+    fn every_variant_has_a_sane_status_and_nonempty_prose() {
+        for e in ALL {
+            let s = e.http_status();
+            assert!((400..=599).contains(&s), "{} bad status {s}", e.code());
+            assert!(!e.title().is_empty(), "{} empty title", e.code());
+            assert!(!e.detail().is_empty(), "{} empty detail", e.code());
+        }
+    }
+}


### PR DESCRIPTION
First PR of the forwarding re-seam: **legibility by construction.**

Introduces `ForwardError` (`shared/api/forwards.rs`) — the single taxonomy every forward failure maps to. Each variant carries a stable kebab `code`, an HTTP `status`, a `title`, and an actionable `detail`, so one value serves all three audiences: the browser error page, the CLI/agent note, and the HTTP boundary.

The backend funnels **every** failure path in `forward_proxy.rs` through one `forward_error()` renderer:
- mapped status,
- the `code` echoed in an `x-portal-forward-error` header (branch without scraping prose),
- a small self-contained dark HTML page (`title` + `detail` + `code`).

**De-collapses the opaque cases** that sent an agent debugging blind:
- `"forward open timed out"` → `agent-offline` / `agent-unreachable` / `open-interrupted`
- tunnel refusals → `no-listener` / `at-capacity` / `not-forwarded` / `protocol-fault`
- upstream failures → `bad-origin` / `bad-request`

No behavioral change to the happy path; this is the foundation the rest of the re-seam (plane split, hyper-util transport, idempotent registration, agent-visible errors) hangs off. Taxonomy invariants (unique codes, serde wire == code, sane statuses, non-empty prose) are unit-tested.