### PR TITLE
Surface recent forward failures back to the agent

### DIFF
--- a/backend/src/handlers/forward_proxy.rs
+++ b/backend/src/handlers/forward_proxy.rs
@@ -534,6 +534,12 @@ async fn proxy_request(
             if ferr == ForwardError::NoListener {
                 note_reachability(app_state, session_key, session_id, port, false);
             }
+            // Surface it to the owning agent (visible on its next `forwards`
+            // poll) so a failure the browser hit isn't invisible to the agent
+            // that caused it (#1476).
+            app_state
+                .session_manager
+                .record_forward_failure(session_id, port, ferr);
             warn!(
                 "Tunnel open failed for {}:{}: {} ({})",
                 session_id,

--- a/backend/src/handlers/forwards.rs
+++ b/backend/src/handlers/forwards.rs
@@ -23,7 +23,8 @@ use tracing::info;
 use uuid::Uuid;
 
 use shared::api::{
-    CreateForwardRequest, CreateForwardResponse, ForwardInfo, SessionForwardsResponse,
+    CreateForwardRequest, CreateForwardResponse, ForwardFailure, ForwardInfo,
+    SessionForwardsResponse,
 };
 use shared::{ForwardPortFields, ServerToClient, ServerToProxy};
 
@@ -383,7 +384,10 @@ pub async fn list_forwards(
     member_session(&mut conn, session_id, user_id)?;
 
     if app_state.forward_domain.is_none() {
-        return Ok(Json(SessionForwardsResponse { forwards: vec![] }));
+        return Ok(Json(SessionForwardsResponse {
+            forwards: vec![],
+            recent_failures: vec![],
+        }));
     }
 
     use crate::schema::session_forwards;
@@ -396,7 +400,27 @@ pub async fn list_forwards(
         (Some(row), Some(label)) => vec![to_forward_info(&app_state, &row, &label)?],
         _ => vec![],
     };
-    Ok(Json(SessionForwardsResponse { forwards }))
+    Ok(Json(SessionForwardsResponse {
+        forwards,
+        recent_failures: recent_failures(&app_state, session_id),
+    }))
+}
+
+/// The session's recent forward failures as wire [`ForwardFailure`]s (newest
+/// first), for the agent-visible readout (#1476).
+fn recent_failures(app_state: &AppState, session_id: Uuid) -> Vec<ForwardFailure> {
+    app_state
+        .session_manager
+        .recent_forward_failures(session_id)
+        .into_iter()
+        .filter_map(|(epoch, err, port)| {
+            DateTime::<Utc>::from_timestamp(epoch, 0).map(|at| ForwardFailure {
+                code: err.code().to_string(),
+                port,
+                at: at.to_rfc3339(),
+            })
+        })
+        .collect()
 }
 
 /// DELETE …/sessions/{id}/forwards — revoke the session's forward (owner only).

--- a/backend/src/handlers/websocket/session_manager/correlation.rs
+++ b/backend/src/handlers/websocket/session_manager/correlation.rs
@@ -2,11 +2,44 @@
 //! oneshot for a request id, the launcher socket completes it when the
 //! matching response frame arrives.
 
+use shared::api::ForwardError;
 use shared::{FileDownloadResponseFields, ForwardStatusFields, LauncherToServer};
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
 use super::{ForwardHealth, SessionManager};
+
+/// How many recent forward failures to retain per session for the
+/// agent-visible readout (#1476). Small — the goal is "what just went wrong",
+/// not an audit log.
+const MAX_FORWARD_FAILURES: usize = 10;
+
+impl SessionManager {
+    /// Record a forward-routing failure for `session_id` so the owning agent
+    /// can see it on its next `GET …/forwards` poll (docs/PORT_FORWARDING.md,
+    /// #1476). Newest first, capped at [`MAX_FORWARD_FAILURES`].
+    pub fn record_forward_failure(&self, session_id: Uuid, port: u16, err: ForwardError) {
+        let now = super::liveness::epoch_secs() as i64;
+        let mut entry = self.forward_failures.entry(session_id).or_default();
+        entry.push_front((now, err, port));
+        entry.truncate(MAX_FORWARD_FAILURES);
+    }
+
+    /// The recent forward failures for `session_id`, newest first — `(epoch
+    /// secs, error, port)`. Empty when there have been none since startup.
+    pub fn recent_forward_failures(&self, session_id: Uuid) -> Vec<(i64, ForwardError, u16)> {
+        self.forward_failures
+            .get(&session_id)
+            .map(|e| e.value().iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// Drop the recorded failures for a session (e.g. on a fresh successful
+    /// registration) so a stale error doesn't linger in the agent readout.
+    pub fn clear_forward_failures(&self, session_id: Uuid) {
+        self.forward_failures.remove(&session_id);
+    }
+}
 
 impl SessionManager {
     pub fn register_dir_request(&self, request_id: Uuid) -> oneshot::Receiver<LauncherToServer> {

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -13,6 +13,7 @@
 //! block.
 
 use dashmap::{DashMap, DashSet};
+use shared::api::ForwardError;
 use shared::{
     FileDownloadResponseFields, ForwardStatusFields, LauncherToServer, ServerToClient,
     ServerToProxy,
@@ -155,6 +156,11 @@ pub struct SessionManager {
     /// In-memory only — unknown after a backend restart until the next
     /// probe report.
     forward_health: Arc<DashMap<(Uuid, u16), ForwardHealth>>,
+    /// Recent forward-routing failures per session (newest first, capped),
+    /// surfaced back to the owning agent via `GET …/forwards` so a failure the
+    /// browser hit is visible to the agent that caused it instead of debugging
+    /// blind (docs/PORT_FORWARDING.md, #1476). In-memory only.
+    forward_failures: Arc<DashMap<Uuid, std::collections::VecDeque<(i64, ForwardError, u16)>>>,
     /// Live backend tunnel streams (docs/PORT_FORWARDING.md), keyed by
     /// stream id; the reverse proxy opens them, proxy sockets feed them.
     tunnel_streams: TunnelStreamMap,
@@ -194,6 +200,7 @@ impl Default for SessionManager {
             pending_file_downloads: Arc::new(DashMap::new()),
             pending_forward_status: Arc::new(DashMap::new()),
             forward_health: Arc::new(DashMap::new()),
+            forward_failures: Arc::new(DashMap::new()),
             tunnel_streams: Arc::new(DashMap::new()),
             pending_launch_sessions: Arc::new(DashMap::new()),
             last_input_sender: Arc::new(DashMap::new()),

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -118,6 +118,10 @@ pub struct ProxyConnection {
     pub last_seen: std::sync::atomic::AtomicU64,
 }
 
+/// Recent forward-routing failures for one session: `(epoch secs, error,
+/// port)`, newest first, capped. Surfaced to the owning agent (#1476).
+type ForwardFailureLog = VecDeque<(i64, ForwardError, u16)>;
+
 /// Latest probe verdict for a forwarded port, as reported by the proxy's
 /// background health check (docs/PORT_FORWARDING.md).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -160,7 +164,7 @@ pub struct SessionManager {
     /// surfaced back to the owning agent via `GET …/forwards` so a failure the
     /// browser hit is visible to the agent that caused it instead of debugging
     /// blind (docs/PORT_FORWARDING.md, #1476). In-memory only.
-    forward_failures: Arc<DashMap<Uuid, std::collections::VecDeque<(i64, ForwardError, u16)>>>,
+    forward_failures: Arc<DashMap<Uuid, ForwardFailureLog>>,
     /// Live backend tunnel streams (docs/PORT_FORWARDING.md), keyed by
     /// stream id; the reverse proxy opens them, proxy sockets feed them.
     tunnel_streams: TunnelStreamMap,

--- a/launcher/src/forward.rs
+++ b/launcher/src/forward.rs
@@ -100,10 +100,18 @@ pub async fn list() -> Result<()> {
     let data: SessionForwardsResponse = resp.json().await.context("malformed response")?;
     if data.forwards.is_empty() {
         println!("No active forwards.");
-        return Ok(());
+    } else {
+        for f in &data.forwards {
+            println!(":{}  {}", f.port, f.url);
+        }
     }
-    for f in &data.forwards {
-        println!(":{}  {}", f.port, f.url);
+    // Recent failures go to stderr (diagnostic) so they don't pollute the URL
+    // list on stdout, but the agent still sees what the browser hit (#1476).
+    if !data.recent_failures.is_empty() {
+        eprintln!("\nrecent forward failures (newest first):");
+        for fail in &data.recent_failures {
+            eprintln!("  {}  :{}  {}", fail.at, fail.port, fail.code);
+        }
     }
     Ok(())
 }

--- a/shared/src/api/forwards.rs
+++ b/shared/src/api/forwards.rs
@@ -127,11 +127,29 @@ pub struct CreateForwardResponse {
     pub probe_error: Option<String>,
 }
 
+/// A recent forward failure, surfaced back to the owning agent so it can see
+/// what the browser saw instead of debugging blind (docs/PORT_FORWARDING.md,
+/// #1476). Newest first.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ForwardFailure {
+    /// Stable [`ForwardError`] code (e.g. `no-listener`, `agent-offline`).
+    pub code: String,
+    /// The port the failed request targeted.
+    pub port: u16,
+    /// When it happened, RFC 3339.
+    pub at: String,
+}
+
 /// Response for `GET …/forwards`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SessionForwardsResponse {
     #[serde(default)]
     pub forwards: Vec<ForwardInfo>,
+    /// Recent failures routing to this session's forward, newest first — the
+    /// agent-visible half of the error taxonomy (#1476). Empty when there have
+    /// been none since the backend last (re)started.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recent_failures: Vec<ForwardFailure>,
 }
 
 /// The single taxonomy of forward failures (docs/PORT_FORWARDING.md).


### PR DESCRIPTION
Part of the forwarding re-seam (legibility) — closes the agent-visibility gap in #1476.

Forward-routing failures used to reach only the user's browser. The agent that owns the session (and is usually the one debugging) never saw them, so it worked blind while the user relayed an opaque string.

Now the backend records recent per-session failures — the typed `ForwardError` code, the port, and the time — at the tunnel-open failure site (newest first, capped at 10, in-memory). `GET …/forwards` returns them in a new additive `recent_failures` field, and `agent-portal forward list` prints them (to stderr, so the URL list on stdout stays clean):

```
recent forward failures (newest first):
  2026-07-26T…Z  :8791  no-listener
```

Builds on the taxonomy PR (reuses the stable `ForwardError` codes). Additive wire field (serde default), so older clients are unaffected.