### PR TITLE
Document archive config; hide History when archiving is disabled

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,33 @@ PORT=3000
 BASE_URL=http://localhost:3000
 
 # -----------------------------------------------------------------------------
+# Session History Archive (Optional — powers the "History" viewer)
+# -----------------------------------------------------------------------------
+# The /history page reads sessions from a long-term archive. When
+# PORTAL_SESSION_ARCHIVE_BACKEND is UNSET, archiving is OFF: nothing is
+# archived and the History page returns 404 ("archived session missing").
+# Setting a backend is what makes History work — and it fails silently if
+# left unset, so if History "stopped working" after a deploy, this is the
+# first thing to check (backend logs also print
+# "Session archive disabled (PORTAL_SESSION_ARCHIVE_BACKEND unset)").
+#
+# Backend: "disabled" (default), "local", or "s3".
+# PORTAL_SESSION_ARCHIVE_BACKEND=local
+#
+# backend=local — filesystem root the archive is written to. It MUST persist
+# across restarts/redeploys (in Docker, mount a volume at this path):
+# PORTAL_SESSION_ARCHIVE_LOCAL_ROOT=/var/lib/agent-portal/archive
+#
+# backend=s3 — bucket (+ optional key prefix); region/credentials/endpoint via
+# the standard AWS_* environment variables:
+# PORTAL_SESSION_ARCHIVE_S3_BUCKET=my-portal-archive
+# PORTAL_SESSION_ARCHIVE_S3_PREFIX=prod
+#
+# Optional toggles (default true once the archive is enabled):
+# PORTAL_SESSION_ARCHIVE_TRANSCRIPTS=true  # archive transcript bodies (zstd)
+# PORTAL_SESSION_ARCHIVE_MEDIA=true        # keep `agent-portal show` media durable
+
+# -----------------------------------------------------------------------------
 # Development Mode (Optional)
 # -----------------------------------------------------------------------------
 # Set to true to bypass OAuth and use test user (testing@testing.local)

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -412,9 +412,10 @@ impl ServerConfig {
                     cfg.media
                 );
             }
-            None => {
-                tracing::info!("Session archive disabled (PORTAL_SESSION_ARCHIVE_BACKEND unset)")
-            }
+            None => tracing::info!(
+                "Session archive disabled (PORTAL_SESSION_ARCHIVE_BACKEND unset) — the History \
+                 viewer will be hidden and /api/history/* will 404 until it is set"
+            ),
         }
 
         // VAPID private key for Web Push (mobile-apps plan §8.3). Only the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,14 @@ services:
       # APP_TITLE: "Agent Portal"           # Header text shown in the dashboard
       # ALLOWED_EMAIL_DOMAIN: "company.com" # Restrict logins to one domain
       # ALLOWED_EMAILS: "a@b.com,c@d.com"  # Whitelist specific email addresses
+      # --- Session history archive (powers the /history viewer) ---
+      # Unset = OFF: History returns 404. "local" needs a persistent volume at
+      # the root below (see the `volumes:` mount example); "s3" needs a bucket
+      # plus AWS_* credentials. See .env.example for the full reference.
+      # PORTAL_SESSION_ARCHIVE_BACKEND: "local"
+      # PORTAL_SESSION_ARCHIVE_LOCAL_ROOT: "/data/archive"
+      # PORTAL_SESSION_ARCHIVE_S3_BUCKET: "my-portal-archive"
+      # PORTAL_SESSION_ARCHIVE_S3_PREFIX: "prod"
       HOST: "0.0.0.0"
       PORT: "3000"
       # RUST_LOG: "info"

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -706,9 +706,21 @@ pub fn dashboard_page() -> Html {
                             html! {}
                         }
                     }
-                    <button class="header-button" onclick={go_to_history.clone()}>
-                        { "History" }
-                    </button>
+                    // History reads from the long-term archive; when archiving
+                    // is disabled the page can only 404, so hide the entry
+                    // rather than lead the user to a confusing error. (Config's
+                    // `archive_enabled` comes from `/api/config`.)
+                    {
+                        if archive_enabled {
+                            html! {
+                                <button class="header-button" onclick={go_to_history.clone()}>
+                                    { "History" }
+                                </button>
+                            }
+                        } else {
+                            html! {}
+                        }
+                    }
                     <button class="header-button" onclick={go_to_settings.clone()}>
                         { "Settings" }
                     </button>


### PR DESCRIPTION
The History viewer silently breaks when the session-archive backend isn't configured: the list 404s as "archived session missing," and nothing in the operator-facing deployment surface even mentions the vars.

Root cause of the silent break: `PORTAL_SESSION_ARCHIVE_*` was documented only in `CLAUDE.md` and `archive-viewer/README.md` — **not** in `.env.example`, `docker-compose.yml`, or the `Dockerfile`. So a redeploy easily drops it; the backend boots fine with `archive = None`, and History returns 404.

This PR makes the disabled state legible instead of a trap:
- **`.env.example` + `docker-compose.yml`** now document `PORTAL_SESSION_ARCHIVE_BACKEND` / `LOCAL_ROOT` / `S3_BUCKET` (+ prefix, transcripts, media), and call out that unset = History off, fails silently, persistence matters for `local`.
- **Frontend** hides the History header button when `archive_enabled` (already on `/api/config`) is false — no button that leads only to a 404.
- **Startup log** disabled-line now spells out the consequence (History hidden, `/api/history/*` 404s until set).

Does not change default behavior (archive still off by default); it just stops the disabled state from being invisible.