### PR TITLE
Update claude-codes to 2.1.166 and codex-codes to 0.145.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ agent-portal is a web-based proxy system for Claude Code sessions built with:
 
 We maintain **[meawoppl/rust-code-agent-sdks](https://github.com/meawoppl/rust-claude-codes)** — a workspace containing two Rust crates for parsing code agent CLI output:
 
-- **`claude-codes`** (v2.1.165) — Types for Claude Code's JSON protocol (`ClaudeOutput`, `ResultMessage`, `UsageInfo`, `RateLimitEvent`, etc.). Used by the proxy to deserialize Claude's stdout.
-- **`codex-codes`** (v0.143.6) — Types for OpenAI Codex CLI's JSONL protocol (`ThreadEvent`, `ThreadItem`, `Usage`, etc.). Phase 1 integration complete (AgentType, DB schema); see [docs/CODEX_SUPPORT.md](docs/CODEX_SUPPORT.md) for the full plan.
+- **`claude-codes`** (v2.1.166) — Types for Claude Code's JSON protocol (`ClaudeOutput`, `ResultMessage`, `UsageInfo`, `RateLimitEvent`, etc.). Used by the proxy to deserialize Claude's stdout.
+- **`codex-codes`** (v0.145.0) — Types for OpenAI Codex CLI's JSONL protocol (`ThreadEvent`, `ThreadItem`, `Usage`, etc.). Phase 1 integration complete (AgentType, DB schema); see [docs/CODEX_SUPPORT.md](docs/CODEX_SUPPORT.md) for the full plan.
 
 ## Architecture Quick Reference
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,9 +1004,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.165"
+version = "2.1.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e866fa8ee015637d94f5104866595a4915ceda210eab510135f2d2201dbe43b"
+checksum = "cbe3b4c5af09f54977712ac9a6b1fb4f13a9d3649de116de88810bd2d8ba14bc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.143.6"
+version = "0.145.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bdba0e2546f5c4a27b1e417596007e4148a0890188957275911f15a12812c61"
+checksum = "9e47b54d772322cd4052021bf1d57f3554b7d5fb7a33b484fcf6b6963bfb8f89"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,10 +74,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.165", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.166", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.143.6", default-features = false, features = ["types"] }
+codex-codes = { version = "0.145.0", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
Routine SDK bump.

- **claude-codes 2.1.165 → 2.1.166** — maintenance only: tested-CLI version bump (2.1.220, no wire drift) and the SDK's own workspace-dependency reshuffle. **No new API surface.**
- **codex-codes 0.143.6 → 0.145.0** — adds *optional* builder APIs (`AppServerBuilder::env`/`envs`, `build_command`/`build_command_sync`, `AsyncClient::new`/`SyncClient::new`) for customizing app-server spawn. Additive; the portal doesn't need them yet. **No breaking changes** in this range (the `ReviewDecision::Denied` break was 0.143.5, already handled when we moved to 0.143.6).

**Integration:** nothing required — this delta introduces no new types/fields the portal must consume. The genuinely-new capabilities from the prior window (aborted turns, `code_change_published`, fast-mode reason, richer sub-agent status) are already tracked in #1472–#1475.

Builds clean, clippy `--all-targets` clean, touched-crate tests pass (claude-session-lib 49, codex-session-lib 34, shared 111).