### PR TITLE
Drop empty grouped message parts; fix thinking-block headroom

### DIFF
--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -103,15 +103,21 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
     }
 }
 
+/// Render one member of an identity group. `None` when the member produces no
+/// visible content, so the caller omits the `grouped-message-part` wrapper
+/// (and its flex gap) rather than emitting a spaced-but-empty row.
 pub(crate) fn render_identity_group_part(
     message: &RenderedMessage,
     agent_type: shared::AgentType,
     session_id: Uuid,
     continuation_statuses: &HashMap<Uuid, String>,
     on_schedule_continuation: Callback<Uuid>,
-) -> Html {
+) -> Option<Html> {
     if let Some(shared::MessageSource::Agent { .. }) = message.source() {
-        return renderers::render_agent_message_body(&message_text(message), session_id);
+        return Some(renderers::render_agent_message_body(
+            &message_text(message),
+            session_id,
+        ));
     }
 
     let json = message.content.as_str();
@@ -126,16 +132,18 @@ pub(crate) fn render_identity_group_part(
         AgentFrame::Claude(ClaudeMessage::Assistant(msg)) => {
             renderers::render_assistant_message_content(&msg, session_id)
         }
-        AgentFrame::Claude(ClaudeMessage::Portal(msg)) => renderers::render_portal_message_content(
-            &msg,
-            session_id,
-            continuation_statuses,
-            on_schedule_continuation,
-        ),
-        AgentFrame::Codex(event) => {
-            crate::components::codex_renderer::render_codex_frame_content(&event, session_id)
+        AgentFrame::Claude(ClaudeMessage::Portal(msg)) => {
+            Some(renderers::render_portal_message_content(
+                &msg,
+                session_id,
+                continuation_statuses,
+                on_schedule_continuation,
+            ))
         }
-        _ => html! {},
+        AgentFrame::Codex(event) => {
+            Some(crate::components::codex_renderer::render_codex_frame_content(&event, session_id))
+        }
+        _ => None,
     }
 }
 

--- a/frontend/src/components/message_renderer/group_renderer.rs
+++ b/frontend/src/components/message_renderer/group_renderer.rs
@@ -89,7 +89,34 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                 GroupCategory::Thinking => "assistant-message",
             };
             let visible = visible_group_indices(*category, messages);
-            let visible_count = visible.len();
+            // Render each member first, dropping the ones that produce nothing
+            // (empty assistant/user bodies, empty tool results, etc.) so we
+            // never emit an empty `grouped-message-part` — a zero-height flex
+            // item that the body's `gap` still spaces into a blank row.
+            let parts: Vec<Html> = visible
+                .iter()
+                .filter_map(|&i| {
+                    let message = &messages[i];
+                    let content = dispatch::render_identity_group_part(
+                        message,
+                        props.agent_type,
+                        props.session_id,
+                        &props.continuation_statuses,
+                        props.on_schedule_continuation.clone(),
+                    )?;
+                    let key = message
+                        .raw_iso()
+                        .map(|iso| format!("m-{}", iso))
+                        .unwrap_or_else(|| format!("m{}", i));
+                    Some(html! { <div {key} class="grouped-message-part">{ content }</div> })
+                })
+                .collect();
+            // Every member rendered empty → collapse the whole group card
+            // rather than show a header over an empty body.
+            if parts.is_empty() {
+                return html! {};
+            }
+            let visible_count = parts.len();
             html! {
                 <div class={classes!("claude-message", wrapper_class)}>
                     <div class="message-header" title={ts.unwrap_or_default()}>
@@ -101,13 +128,7 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                         }
                     </div>
                     <div class="message-body grouped-message-body">
-                        { for visible.iter().map(|&i| {
-                            let message = &messages[i];
-                            let key = message.raw_iso()
-                                .map(|iso| format!("m-{}", iso))
-                                .unwrap_or_else(|| format!("m{}", i));
-                            html! { <div {key} class="grouped-message-part">{ dispatch::render_identity_group_part(message, props.agent_type, props.session_id, &props.continuation_statuses, props.on_schedule_continuation.clone()) }</div> }
-                        })}
+                        { for parts.into_iter() }
                     </div>
                     if let Some(iso) = last_iso {
                         <div class="message-footer">

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -84,7 +84,7 @@ pub fn render_optimistic_user_message(
                 { render_delivery_progress(delivery) }
                 <CopyButton text={msg.content.clone()} title="Copy message" />
             </div>
-            <div class="message-body">{ render_optimistic_user_message_content(msg, session_id) }</div>
+            <div class="message-body">{ render_optimistic_user_message_content(msg, session_id).unwrap_or_default() }</div>
         </div>
     }
 }
@@ -108,7 +108,7 @@ pub fn render_user_message(
     if has_tool_results {
         html! {
             <div class="claude-message user-message tool-result-message">
-                <div class="message-body">{ render_user_message_content(msg, session_id) }</div>
+                <div class="message-body">{ render_user_message_content(msg, session_id).unwrap_or_default() }</div>
             </div>
         }
     } else if !text_content.is_empty() {
@@ -126,7 +126,7 @@ pub fn render_user_message(
                     { render_delivery_progress(delivery) }
                     <CopyButton text={text_content.clone()} title="Copy message" />
                 </div>
-                <div class="message-body">{ render_user_message_content(msg, session_id) }</div>
+                <div class="message-body">{ render_user_message_content(msg, session_id).unwrap_or_default() }</div>
             </div>
         }
     } else {
@@ -137,16 +137,21 @@ pub fn render_user_message(
 pub fn render_optimistic_user_message_content(
     msg: &OptimisticUserMessage,
     session_id: Uuid,
-) -> Html {
-    html! {
-        <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&msg.content), session_id) }</div>
-    }
+) -> Option<Html> {
+    (!msg.content.trim().is_empty()).then(|| {
+        html! {
+            <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&msg.content), session_id) }</div>
+        }
+    })
 }
 
-pub fn render_user_message_content(msg: &shared::UserMessage, session_id: Uuid) -> Html {
+/// Render a user message's body, returning `None` when it produces nothing
+/// (empty text, or a tool-result envelope whose results are all empty) so
+/// callers can drop the surrounding wrapper/card rather than emit a blank one.
+pub fn render_user_message_content(msg: &shared::UserMessage, session_id: Uuid) -> Option<Html> {
     if let Some(Ok(input)) = msg.tool_use_result_as::<shared::AskUserQuestionInput>() {
         if has_askuserquestion_answers(&input) {
-            return render_askuserquestion_result(&input);
+            return Some(render_askuserquestion_result(&input));
         }
     }
 
@@ -155,11 +160,11 @@ pub fn render_user_message_content(msg: &shared::UserMessage, session_id: Uuid) 
     if has_tool_results {
         render_content_blocks(&msg.message.content, session_id)
     } else if text_content.is_empty() {
-        html! {}
+        None
     } else {
-        html! {
+        Some(html! {
             <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&text_content), session_id) }</div>
-        }
+        })
     }
 }
 

--- a/frontend/src/components/message_renderer/renderers/assistant.rs
+++ b/frontend/src/components/message_renderer/renderers/assistant.rs
@@ -141,7 +141,7 @@ pub fn render_assistant_message(
                     }
                 }
             </div>
-            <div class="message-body">{ render_assistant_message_content(msg, session_id) }</div>
+            <div class="message-body">{ render_assistant_message_content(msg, session_id).unwrap_or_default() }</div>
             if let Some(iso) = raw_iso {
                 <div class="message-footer">
                     <TimeAgo iso={iso.to_string()} />
@@ -151,114 +151,112 @@ pub fn render_assistant_message(
     }
 }
 
-pub fn render_assistant_message_content(msg: &AssistantMessage, session_id: Uuid) -> Html {
-    let blocks = msg.message.content.clone();
-    render_content_blocks(&blocks, session_id)
+pub fn render_assistant_message_content(msg: &AssistantMessage, session_id: Uuid) -> Option<Html> {
+    render_content_blocks(&msg.message.content, session_id)
 }
 
-pub fn render_content_blocks(blocks: &[ContentBlock], session_id: Uuid) -> Html {
-    html! {
-        <>
-            {
-                blocks.iter().map(|block| {
-                    match block {
-                        ContentBlock::Text(t) => {
-                            html! {
-                                <div class="assistant-text">
-                                    { render_markdown_for_session(&t.text, session_id) }
-                                    { render_citations(&t.citations) }
-                                </div>
-                            }
-                        }
-                        ContentBlock::ToolUse(tu) => {
-                            render_tool_use(&tu.name, &tu.input)
-                        }
-                        ContentBlock::ToolResult(tr) => {
-                            let class = if tr.is_error.unwrap_or(false) { "tool-result error" } else { "tool-result" };
-                            match &tr.content {
-                                Some(ToolResultContent::Text(s)) => {
-                                    html! {
-                                        <div class={class}>
-                                            <ExpandableText full_text={s.clone()} max_len={500} class="tool-result-content" />
-                                        </div>
-                                    }
-                                }
-                                Some(ToolResultContent::Structured(blocks)) => {
-                                    html! {
-                                        <div class={class}>
-                                            { for blocks.iter().map(|v| {
-                                                match serde_json::from_value::<shared::ContentBlock>(v.clone()) {
-                                                    Ok(typed) => render_structured_block(&typed),
-                                                    Err(_) => {
-                                                        let json = serde_json::to_string_pretty(v).unwrap_or_default();
-                                                        html! { <pre class="tool-result-content">{ json }</pre> }
-                                                    }
-                                                }
-                                            }) }
-                                        </div>
-                                    }
-                                }
-                                None => html! { <div class={class}></div> },
-                            }
-                        }
-                        ContentBlock::Image(img) => {
-                            render_image_source(&img.source, None)
-                        }
-                        ContentBlock::Thinking(th) => {
-                            let sig_title = if th.signature.is_empty() {
-                                "No signature on this thinking block.".to_string()
-                            } else {
-                                format!("Encrypted thinking signature:\n{}", th.signature)
-                            };
-                            html! {
-                                <div class="thinking-block">
-                                    <span class="thinking-label" title={sig_title}>{ "thinking" }</span>
-                                    if th.thinking.trim().is_empty() {
-                                        <div class="thinking-content muted" title="Thinking text was omitted by the model; the encrypted signature is preserved in the raw message.">
-                                            { "thinking omitted" }
-                                        </div>
-                                    } else {
-                                        <div class="thinking-content">{ crate::components::markdown::linkify_urls(&th.thinking) }</div>
-                                    }
-                                </div>
-                            }
-                        }
-                        ContentBlock::ServerToolUse(stu) => {
-                            render_server_tool_use(&stu.name, &stu.input)
-                        }
-                        ContentBlock::WebSearchToolResult(r) => {
-                            render_web_search_result(&r.content)
-                        }
-                        ContentBlock::CodeExecutionToolResult(r) => {
-                            render_code_execution_result(&r.content)
-                        }
-                        ContentBlock::McpToolUse(mtu) => {
-                            render_mcp_tool_use(&mtu.name, mtu.server_name.as_deref(), &mtu.input)
-                        }
-                        ContentBlock::McpToolResult(r) => {
-                            render_mcp_tool_result(&r.content, r.is_error.unwrap_or(false))
-                        }
-                        ContentBlock::ContainerUpload(upload) => {
-                            render_container_upload(&upload.data)
-                        }
-                        ContentBlock::Fallback(fb) => {
-                            // Typed model-fallback notice: the response switched
-                            // models mid-stream (e.g. overload fallback). Render
-                            // the from → to transition rather than a raw blob.
-                            html! {
-                                <div class="assistant-text model-fallback-notice">
-                                    { format!("Model fallback: {} → {}", fb.from.model, fb.to.model) }
-                                </div>
-                            }
-                        }
-                        ContentBlock::Unknown(value) => {
-                            render_unknown_block(value)
-                        }
-                    }
-                }).collect::<Html>()
+/// Render a run of content blocks, returning `None` when *no* block produces
+/// visible output (so callers can omit the surrounding wrapper/card entirely
+/// rather than emit a spaced-but-empty element).
+pub fn render_content_blocks(blocks: &[ContentBlock], session_id: Uuid) -> Option<Html> {
+    let rendered: Vec<Html> = blocks
+        .iter()
+        .filter_map(|block| render_block(block, session_id))
+        .collect();
+    (!rendered.is_empty()).then(|| html! { <>{ for rendered.into_iter() }</> })
+}
+
+/// Render one content block. `None` means the block renders nothing (e.g. a
+/// tool result that returned no content) — the caller drops it rather than
+/// emitting an empty box.
+fn render_block(block: &ContentBlock, session_id: Uuid) -> Option<Html> {
+    let rendered = match block {
+        ContentBlock::Text(t) => {
+            html! {
+                <div class="assistant-text">
+                    { render_markdown_for_session(&t.text, session_id) }
+                    { render_citations(&t.citations) }
+                </div>
             }
-        </>
-    }
+        }
+        ContentBlock::ToolUse(tu) => render_tool_use(&tu.name, &tu.input),
+        ContentBlock::ToolResult(tr) => {
+            let class = if tr.is_error.unwrap_or(false) {
+                "tool-result error"
+            } else {
+                "tool-result"
+            };
+            match &tr.content {
+                Some(ToolResultContent::Text(s)) => {
+                    html! {
+                        <div class={class}>
+                            <ExpandableText full_text={s.clone()} max_len={500} class="tool-result-content" />
+                        </div>
+                    }
+                }
+                Some(ToolResultContent::Structured(blocks)) => {
+                    html! {
+                        <div class={class}>
+                            { for blocks.iter().map(|v| {
+                                match serde_json::from_value::<shared::ContentBlock>(v.clone()) {
+                                    Ok(typed) => render_structured_block(&typed),
+                                    Err(_) => {
+                                        let json = serde_json::to_string_pretty(v).unwrap_or_default();
+                                        html! { <pre class="tool-result-content">{ json }</pre> }
+                                    }
+                                }
+                            }) }
+                        </div>
+                    }
+                }
+                // A tool result with no content renders nothing —
+                // drop it instead of emitting an empty box.
+                None => return None,
+            }
+        }
+        ContentBlock::Image(img) => render_image_source(&img.source, None),
+        ContentBlock::Thinking(th) => {
+            let sig_title = if th.signature.is_empty() {
+                "No signature on this thinking block.".to_string()
+            } else {
+                format!("Encrypted thinking signature:\n{}", th.signature)
+            };
+            html! {
+                <div class="thinking-block">
+                    <span class="thinking-label" title={sig_title}>{ "thinking" }</span>
+                    if th.thinking.trim().is_empty() {
+                        <div class="thinking-content muted" title="Thinking text was omitted by the model; the encrypted signature is preserved in the raw message.">
+                            { "thinking omitted" }
+                        </div>
+                    } else {
+                        <div class="thinking-content">{ crate::components::markdown::linkify_urls(&th.thinking) }</div>
+                    }
+                </div>
+            }
+        }
+        ContentBlock::ServerToolUse(stu) => render_server_tool_use(&stu.name, &stu.input),
+        ContentBlock::WebSearchToolResult(r) => render_web_search_result(&r.content),
+        ContentBlock::CodeExecutionToolResult(r) => render_code_execution_result(&r.content),
+        ContentBlock::McpToolUse(mtu) => {
+            render_mcp_tool_use(&mtu.name, mtu.server_name.as_deref(), &mtu.input)
+        }
+        ContentBlock::McpToolResult(r) => {
+            render_mcp_tool_result(&r.content, r.is_error.unwrap_or(false))
+        }
+        ContentBlock::ContainerUpload(upload) => render_container_upload(&upload.data),
+        ContentBlock::Fallback(fb) => {
+            // Typed model-fallback notice: the response switched
+            // models mid-stream (e.g. overload fallback). Render
+            // the from → to transition rather than a raw blob.
+            html! {
+                <div class="assistant-text model-fallback-notice">
+                    { format!("Model fallback: {} → {}", fb.from.model, fb.to.model) }
+                </div>
+            }
+        }
+        ContentBlock::Unknown(value) => render_unknown_block(value),
+    };
+    Some(rendered)
 }
 
 fn render_citations(citations: &[Citation]) -> Html {

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -886,6 +886,14 @@
     opacity: 0.6;
 }
 
+/* When a thinking block leads its group part, the grouped body's flex `gap`
+   already separates it from the block above — its own top margin then
+   double-counts into unusual headroom above the "THINKING" label. Drop the
+   redundant top margin in that leading position only. */
+.grouped-message-part > .thinking-block:first-child {
+    margin-top: 0;
+}
+
 .thinking-label {
     font-size: 0.7rem;
     text-transform: uppercase;


### PR DESCRIPTION
Two message-spacing fixes.

**1. Blank rows in conversation groups.** The group renderer wrapped *every* member in `<div class="grouped-message-part">` before rendering its content, so a member that rendered nothing (empty assistant/user body, a tool result with `content: None`, or Portal-classified content that isn't a Portal frame) still emitted a zero-height flex item that `grouped-message-body { gap: 0.5rem }` spaced into a visible blank row. Whole groups of only-empty members became a header over an empty body.

Per the "omit the div, don't CSS-hide it" direction: `render_identity_group_part` now returns `Option<Html>` (threaded down through `render_content_blocks` / `render_*_message_content`; an empty tool result now returns `None` instead of an empty `<div>`). The group loop `filter_map`s so **no wrapper div is emitted for an empty part**, and a group whose members all render empty **collapses entirely**.

**2. "THINKING" headroom.** `.thinking-block` has `margin: 0.5rem 0`; when it leads a group part, the body's flex `gap` *plus* that top margin double-counted into extra headroom above the "THINKING" label. Zeroed the redundant top margin for a leading thinking block only.

Renderer tests pass (63), clippy clean, WASM builds. Fix #2 is the one CSS touch (a genuine margin/gap double-count, not the empty-div class) — if any residual THINKING headroom remains after this, I'll pinpoint it from a screenshot rather than guess-tune further.