### PR TITLE
Render grouped inter-agent messages as their own card

### DIFF
--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -181,6 +181,25 @@ fn user_is_plain_text(msg: &shared::UserMessage) -> bool {
             .all(|b| matches!(b, shared::ContentBlock::Text(_)))
 }
 
+/// True iff a plain-text user message is actually a claude-echoed inter-agent
+/// message (`[message from <agent> <uuid>]\n…`). Such messages must render as
+/// their own provenance card rather than fold into a plain-text "You" run, so
+/// `classify` keeps them out of the User group. Uses the same detector the
+/// single-card renderer uses, so the two decisions can't drift.
+fn user_message_is_inter_agent(msg: &shared::UserMessage) -> bool {
+    let text = msg
+        .message
+        .content
+        .iter()
+        .filter_map(|b| match b {
+            shared::ContentBlock::Text(t) => Some(t.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    super::renderers::agent_message_event_from_agent_facing_text(&text).is_some()
+}
+
 /// Classify a single wire message into the display identity it belongs to,
 /// or `None` if it shouldn't roll into any group (renders as `Single`).
 ///
@@ -242,6 +261,17 @@ pub(super) fn classify(
                 });
             }
             if user_is_plain_text(&msg) {
+                // A claude-echoed inter-agent message (`[message from …]`) that
+                // carries no provenance metadata (the codex→claude case) must
+                // render as its own "Message from …" card, not merge into the
+                // "You" group and show its raw `[message from …]` / system-
+                // reminder wrapper. Returning `None` renders it as a `Single`,
+                // where the single-card path detects and cards it. (Source-
+                // tagged agent messages already route through `source_identity`
+                // above.)
+                if source.is_none() && user_message_is_inter_agent(&msg) {
+                    return None;
+                }
                 return Some(source.map_or_else(
                     || MessageIdentity {
                         category: GroupCategory::User,

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -218,6 +218,39 @@ mod tests {
         .to_string()
     }
 
+    /// A plain-text user message (the Claude echo shape) carrying `text`.
+    fn user_text_message(text: &str) -> String {
+        serde_json::json!({
+            "type": "user",
+            "message": { "role": "user", "content": [{ "type": "text", "text": text }] },
+            "session_id": "01890000-0000-7000-8000-000000000001",
+        })
+        .to_string()
+    }
+
+    /// A claude-echoed inter-agent message (`[message from …]`, no provenance
+    /// metadata) must render as its own "Message from …" card, so `classify`
+    /// keeps it out of the User group (returns `None` → `Single`). Ordinary
+    /// prose still groups as User. Regression: grouped inter-agent messages
+    /// were rendering their raw `[message from …]` / system-reminder wrapper.
+    #[test]
+    fn inter_agent_user_text_is_not_grouped() {
+        let sid = "e2d342f5-68c6-4134-a5d8-63cb4afcee9e";
+        let interagent = user_text_message(&format!(
+            "[message from codex {sid}]\nExactly.\n\n<system-reminder> reply to that agent </system-reminder>"
+        ));
+        assert!(
+            classify(&rendered(&interagent), shared::AgentType::Claude, None).is_none(),
+            "inter-agent message must render as a Single card, not group"
+        );
+
+        let prose = user_text_message("just some ordinary prose");
+        assert_eq!(
+            classify(&rendered(&prose), shared::AgentType::Claude, None).map(|i| i.category),
+            Some(GroupCategory::User),
+        );
+    }
+
     /// A tool-result user message coming from a Claude session MUST classify
     /// into the assistant group — otherwise serial Read tool uses don't roll
     /// together with their preceding assistant turn.


### PR DESCRIPTION
Inter-agent messages from a **codex** agent arriving in a **claude** session rendered raw:

```
[message from codex e2d342f5-…]
…body…
<system-reminder> This message came from another agent… </system-reminder>
```

instead of the "Message from Codex" provenance card.

**Cause:** a claude-echoed inter-agent message arrives as plain user text with **no** `MessageSource::Agent` metadata. `classify` sent it down the plain-text User branch, so it merged into a "You" group and rendered via the grouped body renderer — which shows the raw text. The single-card path already detects `[message from …]` and cards it (#1452), but that detection was never in the grouped path.

**Fix:** `classify` now returns `None` for a source-less plain-text user message whose text is an inter-agent envelope, so it renders as a `Single` — and the existing single-card path produces the proper "Message from Codex (short-id)" card with the clean, wrapper-stripped body. Source-tagged agent messages are unaffected (they already route through `source_identity`). The grouping decision reuses the renderer's own detector so they can't drift; regression-tested.