### PR TITLE
Add ON DELETE CASCADE FK on proxy_auth_tokens.session_id

### DIFF
--- a/backend/migrations/2026-07-28-120000_add_fk_proxy_auth_tokens_session_id/down.sql
+++ b/backend/migrations/2026-07-28-120000_add_fk_proxy_auth_tokens_session_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE proxy_auth_tokens DROP CONSTRAINT proxy_auth_tokens_session_id_fkey;

--- a/backend/migrations/2026-07-28-120000_add_fk_proxy_auth_tokens_session_id/up.sql
+++ b/backend/migrations/2026-07-28-120000_add_fk_proxy_auth_tokens_session_id/up.sql
@@ -1,0 +1,20 @@
+-- #1489: tie a session-bound proxy auth token's lifetime to its session.
+--
+-- `proxy_auth_tokens.session_id` had no foreign key, so a token whose session
+-- was deleted still verified successfully (verification looks the row up by
+-- `token_hash` alone). The only thing preventing a live credential pointing at
+-- a deleted session was every deletion path remembering to call
+-- `revoke_tokens_for_session` — a convention, not a constraint.
+
+-- Clean up existing orphans first: the FK below rejects rows whose session no
+-- longer exists. NULL session_id (user-scoped / unbound launch tokens) is left
+-- untouched — those are legitimately session-less.
+DELETE FROM proxy_auth_tokens
+WHERE session_id IS NOT NULL
+  AND session_id NOT IN (SELECT id FROM sessions);
+
+-- ON DELETE CASCADE (not SET NULL): a session-scoped credential must die with
+-- its session, never silently widen into a user-scoped one.
+ALTER TABLE proxy_auth_tokens
+    ADD CONSTRAINT proxy_auth_tokens_session_id_fkey
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE;

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -288,6 +288,7 @@ diesel::joinable!(messages -> sessions (session_id));
 diesel::joinable!(messages -> users (user_id));
 diesel::joinable!(pending_inputs -> sessions (session_id));
 diesel::joinable!(pending_permission_requests -> sessions (session_id));
+diesel::joinable!(proxy_auth_tokens -> sessions (session_id));
 diesel::joinable!(proxy_auth_tokens -> users (user_id));
 diesel::joinable!(push_subscriptions -> users (user_id));
 diesel::joinable!(scheduled_tasks -> users (user_id));


### PR DESCRIPTION
Fixes #1489.

`proxy_auth_tokens.session_id` had **no foreign key** to `sessions`. Token verification looks the row up by `token_hash` alone, so a token whose session was deleted still verified successfully. The only thing tying a session-bound token's lifetime to its session was every deletion path remembering to call `revoke_tokens_for_session` — a convention, not a constraint (this is #932's lesson re-encoded as a convention). In production, 885 token rows already pointed at deleted sessions (0 unrevoked — the convention has held, but it's a latent hazard the next new deletion path or admin script re-opens).

**Migration:**
- Deletes existing orphans (rows with a non-NULL `session_id` that no longer references a live session). NULL `session_id` (user-scoped / unbound launch tokens) is left untouched.
- Adds `proxy_auth_tokens_session_id_fkey` → `sessions(id) ON DELETE CASCADE`.

`ON DELETE CASCADE`, not `SET NULL`: a session-scoped credential must die with its session, never silently widen into a user-scoped one. `revoke_tokens_for_session` stays — it's still used to revoke tokens on *live* sessions without deleting them.

`schema.rs` regenerated (adds the one `joinable!` line).