### PR TITLE
Probe forward origin locally and report the result

### DIFF
--- a/launcher/src/forward.rs
+++ b/launcher/src/forward.rs
@@ -34,6 +34,142 @@ fn session_id() -> Result<String> {
     })
 }
 
+/// Outcome of a best-effort local probe of the origin the forward points at.
+enum OriginProbe {
+    /// Nothing accepted a TCP connection on the port.
+    Refused,
+    /// Got an HTTP response back.
+    Responded {
+        status_line: String,
+        bytes: usize,
+        elapsed_ms: u128,
+        /// The origin closed the connection after responding (`true`) or held
+        /// it open past our short close-probe deadline (`false`).
+        closed: bool,
+    },
+    /// Connected, but couldn't get a usable HTTP response (timeout / error).
+    Inconclusive(String),
+}
+
+const PROBE_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1000);
+/// Generous wait for the first byte (slow first-byte servers).
+const PROBE_FIRST_BYTE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1500);
+/// Short wait, after the response is in hand, to see whether the origin closes.
+/// Bounds the penalty for the common keep-alive origin to this.
+const PROBE_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(300);
+
+/// Best-effort local HTTP probe of `127.0.0.1:<port>`. The forward CLI runs on
+/// the same host as the origin, so this sees exactly what the tunnel's dial
+/// sees — crucially the failure the tunnel *can't* tell apart from a broken
+/// origin: a server that keeps the connection open after a complete,
+/// Content-Length-delimited response (an EOF-reading consumer hangs; a browser
+/// honoring Content-Length would not). Never fails the command — it only
+/// reports what it found (#1476).
+async fn probe_origin(port: u16) -> OriginProbe {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    let start = std::time::Instant::now();
+    let mut stream = match tokio::time::timeout(
+        PROBE_CONNECT_TIMEOUT,
+        TcpStream::connect(("127.0.0.1", port)),
+    )
+    .await
+    {
+        Ok(Ok(s)) => s,
+        Ok(Err(_)) => return OriginProbe::Refused,
+        Err(_) => return OriginProbe::Inconclusive("connect timed out".to_string()),
+    };
+
+    let req = format!(
+        "GET / HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nUser-Agent: agent-portal-forward-probe\r\nAccept: */*\r\n\r\n"
+    );
+    if let Err(e) = stream.write_all(req.as_bytes()).await {
+        return OriginProbe::Inconclusive(format!("write failed: {e}"));
+    }
+
+    let mut buf = vec![0u8; 8192];
+    let mut total = 0usize;
+    let mut status_line = String::new();
+    let mut closed = false;
+    let mut first = true;
+    loop {
+        let deadline = if first {
+            PROBE_FIRST_BYTE_TIMEOUT
+        } else {
+            PROBE_CLOSE_TIMEOUT
+        };
+        match tokio::time::timeout(deadline, stream.read(&mut buf)).await {
+            Ok(Ok(0)) => {
+                closed = true;
+                break;
+            }
+            Ok(Ok(n)) => {
+                if status_line.is_empty() {
+                    status_line = String::from_utf8_lossy(&buf[..n])
+                        .lines()
+                        .next()
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                }
+                total += n;
+                first = false;
+                // Enough to know the shape; don't slurp a large body.
+                if total >= 64 * 1024 {
+                    break;
+                }
+            }
+            Ok(Err(e)) => return OriginProbe::Inconclusive(format!("read failed: {e}")),
+            // Deadline: if we already have bytes the origin is holding open;
+            // if not, it never answered.
+            Err(_) => break,
+        }
+    }
+
+    if total == 0 {
+        return OriginProbe::Inconclusive(
+            "connected but no HTTP response before timeout".to_string(),
+        );
+    }
+    OriginProbe::Responded {
+        status_line,
+        bytes: total,
+        elapsed_ms: start.elapsed().as_millis(),
+        closed,
+    }
+}
+
+/// Print the origin probe as a one-line diagnostic (to stderr, so stdout stays
+/// the single relayable URL). This is the line that collapses the "forward open
+/// timed out" investigation into an obvious cause.
+fn report_origin_probe(port: u16, probe: OriginProbe) {
+    match probe {
+        OriginProbe::Responded {
+            status_line,
+            bytes,
+            elapsed_ms,
+            closed,
+        } => {
+            let status = if status_line.is_empty() {
+                "(non-HTTP response)".to_string()
+            } else {
+                status_line
+            };
+            eprintln!("  origin: {status}, {bytes} B in {elapsed_ms} ms");
+            if !closed {
+                eprintln!(
+                    "  warning: origin held the connection open after responding; if the browser reports a timeout, set a short idle/socket timeout on your server"
+                );
+            }
+        }
+        OriginProbe::Refused => eprintln!(
+            "  origin: nothing is listening on 127.0.0.1:{port} — start your server, then re-run"
+        ),
+        OriginProbe::Inconclusive(why) => eprintln!("  origin: probe inconclusive ({why})"),
+    }
+}
+
 /// `agent-portal forward <port>` — register a forward and print its URL.
 pub async fn open(port: u16) -> Result<()> {
     if port == 0 {
@@ -42,6 +178,10 @@ pub async fn open(port: u16) -> Result<()> {
     let (base, token) = api_base()?;
     let session = session_id()?;
     let client = reqwest::Client::new();
+
+    // Probe the origin locally first (same host as the CLI) so we can report
+    // exactly what the tunnel will see, before the round-trip to register.
+    let probe = probe_origin(port).await;
 
     let resp = client
         .post(format!("{base}/api/agent/sessions/{session}/forwards"))
@@ -66,19 +206,10 @@ pub async fn open(port: u16) -> Result<()> {
             "note: replaced the existing forward on port {old}; only port {port} is forwarded now (front multiple services behind your own reverse proxy)"
         );
     }
-    match data.listening {
-        Some(false) => eprintln!(
-            "warning: nothing is listening on port {} yet{}",
-            port,
-            data.probe_error
-                .map(|e| format!(" ({e})"))
-                .unwrap_or_default()
-        ),
-        None => eprintln!(
-            "warning: could not confirm the port is live (agent proxy offline or too old)"
-        ),
-        Some(true) => {}
-    }
+    // The local probe supersedes the backend's boolean listening check: it runs
+    // on the origin host and reports status/bytes/elapsed and whether the origin
+    // closed the connection (#1476).
+    report_origin_probe(port, probe);
     Ok(())
 }
 


### PR DESCRIPTION
Addresses the remaining piece of #1476. (Idempotency — the core correctness bug where re-running `forward <port>` silently retired the old URL — already landed on main in #1479/#1480/#1481.)

When `agent-portal forward <port>` fails, the agent debugs blind: the browser's opaque "forward open timed out" only reaches the user, and it can't distinguish a dead origin from an origin that keeps the connection open after a complete response (an EOF-reading consumer hangs; a browser honoring Content-Length would not). The natural Python-stdlib remedies combine into exactly that shape.

The forward CLI runs on the same host as the origin, so it can see precisely what the tunnel's dial sees. This adds a best-effort local HTTP probe of `127.0.0.1:<port>` at registration and prints a one-line diagnostic:

```
https://23088dfc.portal.cosmicfrontier.org/
  origin: HTTP/1.1 200 OK, 7157 B in 2 ms
  warning: origin held the connection open after responding; if the browser reports a timeout, set a short idle/socket timeout on your server
```

- Detects **nothing listening** (connection refused) and says so, with the exact address.
- Detects the **connection-held-open** pathology via a short (300 ms) close-probe after the response is in hand — so the common keep-alive origin adds at most ~300 ms, and a server that closes cleanly is instant.
- Diagnostics go to **stderr**; stdout stays the single relayable URL line.
- Never fails the command — it only reports what it found, and supersedes the backend's boolean `listening` check with a richer, host-local signal.