### PR TITLE
Detect half-open launcher control socket via heartbeat ack

### DIFF
--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -630,6 +630,17 @@ fn handle_launcher_message(
             if let Some(mut launcher) = app_state.session_manager.launchers.get_mut(&launcher_id) {
                 launcher.running_sessions = running_sessions;
             }
+            // Echo the heartbeat so a launcher that supports it can detect a
+            // half-open control socket and reconnect (#1366). Gated on the
+            // capability so older launchers never receive an undecodable frame.
+            if app_state.session_manager.launcher_supports_capability(
+                launcher_id,
+                shared::LAUNCHER_CAPABILITY_HEARTBEAT_ACK,
+            ) {
+                app_state
+                    .session_manager
+                    .send_to_launcher(&launcher_id, ServerToLauncher::LauncherHeartbeatAck);
+            }
             reconcile_desired_sessions(app_state, launcher_id, user_id);
         }
         LauncherToServer::ProxyLog {

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -9,6 +9,12 @@ use uuid::Uuid;
 
 const HEARTBEAT_INTERVAL: Duration =
     Duration::from_secs(shared::protocol::LAUNCHER_HEARTBEAT_INTERVAL_SECS);
+/// If the backend echoes our heartbeats (it advertises support by sending the
+/// first ack) but then goes this long without one, the control socket is
+/// half-open — force a reconnect. Three missed intervals tolerates a slow tick
+/// or a dropped ack without flapping (#1366).
+const HEARTBEAT_ACK_TIMEOUT: Duration =
+    Duration::from_secs(shared::protocol::LAUNCHER_HEARTBEAT_INTERVAL_SECS * 3);
 const MAX_BACKOFF: Duration = Duration::from_secs(shared::protocol::MAX_RECONNECT_BACKOFF_SECS);
 /// Retry cadence while parked on a fatal rejection: start here, double to the
 /// cap. Deliberately much slower than the network-error backoff — a fatal
@@ -32,6 +38,16 @@ fn classify_fatal(reason: Option<LauncherRejectReason>, error_msg: &str) -> Laun
     } else {
         LauncherRejectReason::DuplicateLauncher
     }
+}
+
+/// Whether the control socket looks half-open and should be reconnected.
+///
+/// Only ever true once we've seen at least one heartbeat ack (`ack_seen`) —
+/// against an older backend that never echoes, this stays `false` forever, so
+/// the watchdog can't cause false reconnect loops on a healthy-but-old hub
+/// (#1366).
+fn control_socket_half_open(ack_seen: bool, since_last_ack: Duration) -> bool {
+    ack_seen && since_last_ack > HEARTBEAT_ACK_TIMEOUT
 }
 
 /// The one-line operator instruction for a parked launcher.
@@ -99,6 +115,7 @@ pub async fn run_launcher_loop(
                     capabilities: vec![
                         shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string(),
                         shared::LAUNCHER_CAPABILITY_RESTART.to_string(),
+                        shared::LAUNCHER_CAPABILITY_HEARTBEAT_ACK.to_string(),
                     ],
                 };
                 if ws_sender.send(register).await.is_err() {
@@ -180,6 +197,13 @@ pub async fn run_launcher_loop(
                 // Main loop
                 let mut heartbeat_timer = tokio::time::interval(HEARTBEAT_INTERVAL);
                 let start = Instant::now();
+                // Half-open control-socket detection (#1366). `ack_seen` stays
+                // false against an older backend that doesn't echo heartbeats,
+                // which keeps the watchdog disabled (no false reconnects); once
+                // an ack proves the backend supports it, a subsequent drought
+                // past `HEARTBEAT_ACK_TIMEOUT` forces a reconnect.
+                let mut last_ack = Instant::now();
+                let mut ack_seen = false;
 
                 loop {
                     let sched_dur = scheduler
@@ -202,12 +226,22 @@ pub async fn run_launcher_loop(
                         result = ws_receiver.recv() => {
                             match result {
                                 Some(Ok(msg)) => {
-                                    handle_message(
-                                        msg,
-                                        &mut ws_sender,
-                                        &mut process_manager,
-                                        &mut scheduler,
-                                    ).await;
+                                    // A heartbeat echo proves the control socket
+                                    // is live end-to-end; record it and arm the
+                                    // watchdog. Handled here (not in
+                                    // `handle_message`) so the liveness state
+                                    // stays local to the loop.
+                                    if matches!(msg, ServerToLauncher::LauncherHeartbeatAck) {
+                                        last_ack = Instant::now();
+                                        ack_seen = true;
+                                    } else {
+                                        handle_message(
+                                            msg,
+                                            &mut ws_sender,
+                                            &mut process_manager,
+                                            &mut scheduler,
+                                        ).await;
+                                    }
                                 }
                                 Some(Err(e)) => {
                                     warn!("Decode error: {}", e);
@@ -221,6 +255,19 @@ pub async fn run_launcher_loop(
                         }
 
                         _ = heartbeat_timer.tick() => {
+                            // Half-open detection: if the backend has been
+                            // echoing heartbeats but has now gone silent past
+                            // the timeout, our sends are buffering into a dead
+                            // TCP connection — reconnect rather than believe the
+                            // socket is fine while the hub marks our sessions
+                            // disconnected (#1366).
+                            if control_socket_half_open(ack_seen, last_ack.elapsed()) {
+                                warn!(
+                                    "No launcher heartbeat ack for {}s — control socket half-open; reconnecting to re-establish sessions",
+                                    last_ack.elapsed().as_secs()
+                                );
+                                break;
+                            }
                             let hb = LauncherToServer::LauncherHeartbeat {
                                 launcher_id,
                                 running_sessions: process_manager.running_session_ids(),
@@ -797,6 +844,28 @@ mod tests {
             assert!(!parked_instruction(reason).is_empty());
         }
         assert!(parked_instruction(LauncherRejectReason::AuthFailed).contains("agent-portal login"));
+    }
+
+    #[test]
+    fn half_open_watchdog_never_fires_without_an_ack() {
+        // An older backend never echoes heartbeats, so `ack_seen` stays false
+        // and the watchdog must stay disabled no matter how long it's been —
+        // otherwise a new launcher would reconnect-loop against a healthy hub.
+        assert!(!control_socket_half_open(
+            false,
+            HEARTBEAT_ACK_TIMEOUT * 100
+        ));
+    }
+
+    #[test]
+    fn half_open_watchdog_fires_only_after_ack_drought() {
+        // Seen an ack and within the window: healthy.
+        assert!(!control_socket_half_open(true, HEARTBEAT_ACK_TIMEOUT / 2));
+        // Seen an ack but silent past the timeout: half-open, reconnect.
+        assert!(control_socket_half_open(
+            true,
+            HEARTBEAT_ACK_TIMEOUT + Duration::from_secs(1)
+        ));
     }
 
     fn home_test_dir(name: &str) -> std::path::PathBuf {

--- a/shared/src/endpoints/launcher.rs
+++ b/shared/src/endpoints/launcher.rs
@@ -299,4 +299,14 @@ pub enum ServerToLauncher {
     /// token is written to `launcher.json`. Older launchers may log a decode
     /// error and ignore this unknown frame; the old token remains valid.
     TokenRefresh { auth_token: String },
+
+    /// Echo of a `LauncherToServer::LauncherHeartbeat`. Lets the launcher tell
+    /// a live control socket from a half-open one: it sends heartbeats every
+    /// `LAUNCHER_HEARTBEAT_INTERVAL_SECS` but, on a half-open socket, the sends
+    /// succeed into a dead TCP connection and no ack ever comes back — so the
+    /// launcher can force a reconnect (which re-mints tokens and re-establishes
+    /// its sessions) instead of silently drifting them to `disconnected`
+    /// (#1366). Gated behind `LAUNCHER_CAPABILITY_HEARTBEAT_ACK` so it's never
+    /// sent to a launcher too old to decode it.
+    LauncherHeartbeatAck,
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -21,6 +21,12 @@ pub const LAUNCHER_CAPABILITY_CREATE_WORKTREE: &str = "launch.create_worktree";
 /// `ServerToLauncher::Restart` (restart the process without updating the binary).
 pub const LAUNCHER_CAPABILITY_RESTART: &str = "launcher.restart";
 
+/// Launcher capability advertised by versions that understand
+/// `ServerToLauncher::LauncherHeartbeatAck`. The backend only echoes heartbeat
+/// acks to launchers that advertise this, so older launchers never see an
+/// undecodable frame (#1366).
+pub const LAUNCHER_CAPABILITY_HEARTBEAT_ACK: &str = "launcher.heartbeat_ack";
+
 /// Split [`VERSION`] into `(major, minor, patch)` numeric components.
 /// `None` on the (impossible-by-construction) malformed string.
 pub fn version_parts() -> Option<(u64, u64, u64)> {


### PR DESCRIPTION
Fixes #1366.

A long-running launcher silently drifted its proxied sessions to `disconnected` on the hub after its control socket went half-open (e.g. after a hub redeploy). It never reconnected, never re-minted tokens, and logged nothing — it kept sending 30s heartbeats that buffered into a dead TCP connection (the sends *succeed*) while believing the socket was fine.

Root cause: the launcher's control-plane heartbeat was **send-only** — no echo, no liveness check, and `ws_receiver.recv()` had no deadline. A half-open socket wedges silently, which starves the backend reconcile loop that is the *only* thing that re-mints session tokens and re-establishes the sessions the hub already marked disconnected. (The per-session data plane already has a heartbeat watchdog; only the control plane lacked one.)

Fix — echo + watchdog:
- New `ServerToLauncher::LauncherHeartbeatAck`; the backend echoes each `LauncherHeartbeat`, gated on a new `LAUNCHER_CAPABILITY_HEARTBEAT_ACK` so older launchers never receive an undecodable frame.
- The launcher records acks and, if it has seen acks but then gets none for 3× the heartbeat interval (~90s), logs a WARN and reconnects — which re-registers, re-mints tokens, and restores the sessions.
- **Compat-safe both directions:** the watchdog only arms *after* the first ack, so a new launcher against an older backend (which never echoes) never false-fires; and the capability gate keeps a new backend from spamming decode errors at old launchers. This self-configuring property is covered by unit tests (`control_socket_half_open`).

This restores the automatic reconnect/re-mint path; the silent drift no longer requires a manual `systemctl --user restart agent-portal`.