### PR TITLE
Context-window usage bar on session pills

### DIFF
--- a/backend/migrations/2026-07-29-120000_add_model_context_window_to_turn_metrics/down.sql
+++ b/backend/migrations/2026-07-29-120000_add_model_context_window_to_turn_metrics/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE turn_metrics DROP COLUMN model_context_window;

--- a/backend/migrations/2026-07-29-120000_add_model_context_window_to_turn_metrics/up.sql
+++ b/backend/migrations/2026-07-29-120000_add_model_context_window_to_turn_metrics/up.sql
@@ -1,0 +1,4 @@
+-- The model's context window in tokens, as reported by the agent (Codex sends
+-- it on the wire; Claude does not, so claude rows stay NULL and the window is
+-- derived from the model id at read time). Powers the context-usage gauge.
+ALTER TABLE turn_metrics ADD COLUMN model_context_window BIGINT;

--- a/backend/src/handlers/websocket/turn_metrics.rs
+++ b/backend/src/handlers/websocket/turn_metrics.rs
@@ -126,6 +126,7 @@ pub fn handle_turn_metrics_report(
         tool_call_count: metrics.tool_call_count,
         stream_restarts: metrics.stream_restarts,
         total_cost_usd: metrics.total_cost_usd,
+        model_context_window: metrics.model_context_window,
     };
 
     use crate::schema::turn_metrics;

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -587,6 +587,7 @@ pub struct TurnMetric {
     pub created_at: DateTime<Utc>,
     pub user_id: Uuid,
     pub subagent_tokens: i64,
+    pub model_context_window: Option<i64>,
 }
 
 impl TurnMetric {
@@ -624,6 +625,7 @@ impl TurnMetric {
             tool_call_count: self.tool_call_count,
             stream_restarts: self.stream_restarts,
             total_cost_usd: self.total_cost_usd,
+            model_context_window: self.model_context_window,
         }
     }
 }
@@ -655,6 +657,7 @@ pub struct NewTurnMetric {
     pub tool_call_count: i32,
     pub stream_restarts: i32,
     pub total_cost_usd: Option<f64>,
+    pub model_context_window: Option<i64>,
 }
 
 #[cfg(test)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -257,6 +257,7 @@ diesel::table! {
         created_at -> Timestamptz,
         user_id -> Uuid,
         subagent_tokens -> Int8,
+        model_context_window -> Nullable<Int8>,
     }
 }
 

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -605,6 +605,10 @@ pub(crate) async fn claude_io_task(
                                 stop_reason: r.stop_reason.clone(),
                                 is_error: r.is_error,
                                 total_cost_usd: Some(r.total_cost_usd),
+                                // Claude's stream-json carries no window size;
+                                // `TurnMetrics::context_window` derives it from
+                                // the model id instead.
+                                model_context_window: None,
                             };
                             if let Some(metrics) = turn_tracker.finalize(
                                 Instant::now(),

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -358,6 +358,9 @@ pub(crate) async fn codex_io_task(
     // Latest `ThreadTokenUsageUpdated` capture for the current turn so we
     // can plug it into the finalized `TurnMetrics`.
     let mut current_turn_usage: Option<codex_codes::TokenUsageBreakdown> = None;
+    // Latched alongside `current_turn_usage` so the finalized `TurnMetrics`
+    // carries the window for the context-usage gauge.
+    let mut current_turn_context_window: Option<i64> = None;
     let mut current_turn_model: Option<String> = None;
     let mut subagent_token_tracker = CodexSubagentTokenTracker::new(thread_id.clone());
 
@@ -424,6 +427,8 @@ pub(crate) async fn codex_io_task(
                                         // finalized `TurnMetrics` can carry
                                         // the main-thread token counts.
                                         current_turn_usage = Some(p.token_usage.last.clone());
+                                        current_turn_context_window =
+                                            p.token_usage.model_context_window;
                                     } else {
                                         subagent_token_tracker
                                             .observe_token_usage(
@@ -488,6 +493,7 @@ pub(crate) async fn codex_io_task(
                                     codex_codes::TurnStatus::Completed
                                 );
                                 let usage = current_turn_usage.take();
+                                let model_context_window = current_turn_context_window.take();
                                 let model = current_turn_model
                                     .clone()
                                     .or_else(|| thread_model.clone())
@@ -521,6 +527,7 @@ pub(crate) async fn codex_io_task(
                                     stop_reason: Some(status.to_string()),
                                     is_error,
                                     total_cost_usd: None,
+                                    model_context_window,
                                 };
                                 if let Some(metrics) = turn_tracker.finalize(
                                     Instant::now(),

--- a/frontend/src/components/message_renderer/turn_metrics_footer.rs
+++ b/frontend/src/components/message_renderer/turn_metrics_footer.rs
@@ -351,6 +351,7 @@ mod tests {
             tool_call_count: 0,
             stream_restarts: 0,
             total_cost_usd: Some(0.014),
+            model_context_window: None,
         }
     }
 
@@ -407,6 +408,7 @@ mod tests {
             tool_call_count: 0,
             stream_restarts: 0,
             total_cost_usd: None, // None → cost chip drops
+            model_context_window: None,
         };
         let chips = build_chip_list(&m);
         assert_eq!(

--- a/frontend/src/components/turn_metrics_pill.rs
+++ b/frontend/src/components/turn_metrics_pill.rs
@@ -290,6 +290,7 @@ mod tests {
             model: model.map(|s| s.to_string()),
             service_tier: tier.map(|s| s.to_string()),
             total_cost_usd: Some(0.012),
+            model_context_window: None,
         }
     }
 

--- a/frontend/src/hooks/client_websocket_events.rs
+++ b/frontend/src/hooks/client_websocket_events.rs
@@ -131,6 +131,7 @@ mod tests {
             tool_call_count: 0,
             stream_restarts: 0,
             total_cost_usd: None,
+            model_context_window: None,
         }
     }
 

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -122,6 +122,16 @@ pub fn dashboard_page() -> Html {
         .filter_map(|m| m.model.clone().map(|model| (m.session_id, model)))
         .collect();
 
+    // Per-session context-window fill, same source and "latest turn wins"
+    // ordering as `live_models` above. Feeds each pill's top context bar; a
+    // turn whose window is unknown (e.g. an unrecognized model) is skipped, so
+    // that session simply shows no bar.
+    let context_fractions: HashMap<Uuid, f64> = ws_hook
+        .recent_turn_metrics
+        .iter()
+        .filter_map(|m| m.context_fraction().map(|frac| (m.session_id, frac)))
+        .collect();
+
     let active_sessions: Vec<SessionInfo> = {
         let mut sorted: Vec<SessionInfo> = sessions.to_vec();
         // Overlay the live model onto the polled row so the watermark reflects
@@ -778,6 +788,7 @@ pub fn dashboard_page() -> Html {
                         connected_sessions={session_state.connected_sessions.clone()}
                         nav_mode={keyboard_nav.nav_mode}
                         activity_timestamps={(*activity_timestamps).clone()}
+                        context_fractions={context_fractions.clone()}
                         broadcasts={(*agent_message_broadcasts).clone()}
                         rail_position={ui_state.rail_position}
                         server_version={server_version.clone()}

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -189,6 +189,7 @@ fn render_pill_section(
                 nav_mode={props.nav_mode}
                 server_version={props.server_version.clone()}
                 activity_timestamps={props.activity_timestamps.clone()}
+                context_fraction={props.context_fractions.get(&session.id).copied()}
                 is_broadcast_sender={broadcast_senders.contains(&session.id)}
                 is_broadcast_receiver={broadcast_receivers.contains(&session.id)}
                 render_time={render_time}
@@ -216,6 +217,11 @@ pub struct SessionRailProps {
     pub nav_mode: bool,
     #[prop_or_default]
     pub activity_timestamps: ActivityRef,
+    /// Per-session context-window fill fraction (session id → 0.0..), derived
+    /// from recent turn metrics upstream. Sessions absent from the map render
+    /// no context bar.
+    #[prop_or_default]
+    pub context_fractions: std::collections::HashMap<Uuid, f64>,
     #[prop_or_default]
     pub broadcasts: BroadcastRef,
     pub rail_position: crate::pages::dashboard::RailPosition,

--- a/frontend/src/pages/dashboard/session_rail/pill.rs
+++ b/frontend/src/pages/dashboard/session_rail/pill.rs
@@ -7,6 +7,37 @@ use yew::prelude::*;
 use super::sorted_prs;
 use super::sparkline::{render_activity_sparkline, ActivityRef};
 
+/// How long after a compaction marker the context bar keeps flashing.
+const COMPACTION_FLASH_MS: f64 = 4_000.0;
+/// Context fill above this reads amber; above [`CTX_HIGH`], red + pulse.
+const CTX_MID: f64 = 0.6;
+const CTX_HIGH: f64 = 0.85;
+
+/// Render the top context-usage bar for a pill: a thin left→right fill sized to
+/// the context fraction, colored green→amber→red, that drains smoothly on
+/// compaction (CSS `width` transition) and flashes when one just landed.
+/// Renders nothing when the fraction is unknown.
+fn render_context_bar(fraction: Option<f64>, compacting: bool) -> Html {
+    let Some(fraction) = fraction else {
+        return html! {};
+    };
+    let pct = (fraction.clamp(0.0, 1.0)) * 100.0;
+    let band = if fraction >= CTX_HIGH {
+        "ctx-high"
+    } else if fraction >= CTX_MID {
+        "ctx-mid"
+    } else {
+        "ctx-low"
+    };
+    let bar_class = classes!("pill-context-bar", compacting.then_some("compacting"));
+    let fill_class = classes!("pill-context-fill", band);
+    html! {
+        <div class={bar_class} title={format!("Context {:.0}% full", fraction * 100.0)}>
+            <div class={fill_class} style={format!("width: {pct:.1}%")} />
+        </div>
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum VcsView {
     PullRequests(Vec<(i64, String)>),
@@ -45,6 +76,11 @@ pub(super) struct SessionPillProps {
     pub nav_mode: bool,
     pub server_version: String,
     pub activity_timestamps: ActivityRef,
+    /// Fraction (0.0..) of the model's context window occupied on this
+    /// session's most recent turn, or `None` when unknown (no recent metrics /
+    /// unknown window). Drives the top context-usage bar.
+    #[prop_or_default]
+    pub context_fraction: Option<f64>,
     pub is_broadcast_sender: bool,
     pub is_broadcast_receiver: bool,
     pub render_time: f64,
@@ -71,6 +107,17 @@ pub(super) fn session_pill(props: &SessionPillProps) -> Html {
 
     let sparkline =
         render_activity_sparkline(&props.activity_timestamps, session.id, props.render_time);
+
+    // Top context-usage bar: the counterpart to the bottom activity ticks, but
+    // filling left→right with how full the model's context window is. Flashes
+    // briefly when a compaction just landed (context drains) — reusing the same
+    // compaction markers the bottom sparkline plots.
+    let compacting = props.activity_timestamps.recent_compaction(
+        session.id,
+        props.render_time,
+        COMPACTION_FLASH_MS,
+    );
+    let context_bar = render_context_bar(props.context_fraction, compacting);
 
     html! {
         <div
@@ -140,6 +187,7 @@ pub(super) fn session_pill(props: &SessionPillProps) -> Html {
             <button type="button" class="pill-menu-toggle" onclick={on_toggle_menu}>
                 { "▼" }
             </button>
+            { context_bar }
             { sparkline }
         </div>
     }

--- a/frontend/src/pages/dashboard/session_rail/sparkline.rs
+++ b/frontend/src/pages/dashboard/session_rail/sparkline.rs
@@ -58,6 +58,18 @@ impl ActivityRef {
         events.push((timestamp, tag));
     }
 
+    /// True if a compaction event occurred within `window_ms` of `now` for
+    /// this session. Drives the context-usage bar's brief compaction flash —
+    /// reuses the same compaction markers the bottom sparkline already plots.
+    pub fn recent_compaction(&self, session_id: Uuid, now: f64, window_ms: f64) -> bool {
+        let map = self.0.borrow();
+        map.get(&session_id).is_some_and(|events| {
+            events.iter().any(|(t, tag)| {
+                now - *t <= window_ms && (tag.is_compaction_start() || tag.is_compaction_end())
+            })
+        })
+    }
+
     /// Compute the sparkline view for one session at the given wall-clock time.
     fn view_for(&self, session_id: Uuid, now: f64) -> SparklineView {
         let cutoff = now - SPARKLINE_WINDOW_MS;

--- a/frontend/src/pages/dashboard/session_view/state.rs
+++ b/frontend/src/pages/dashboard/session_view/state.rs
@@ -84,6 +84,7 @@ mod tests {
             tool_call_count: 0,
             stream_restarts: 0,
             total_cost_usd: None,
+            model_context_window: None,
         }
     }
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -949,6 +949,71 @@
     opacity: 0.2;
 }
 
+/* Top context-usage bar: the counterpart to the bottom activity ticks, but a
+   single fill sized to how full the model's context window is. Clipped to the
+   pill's rounded top by the pill's own `overflow: hidden`, like the sparkline
+   at the bottom. */
+.pill-context-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    pointer-events: none;
+    background: rgba(192, 202, 245, 0.06);
+    overflow: hidden;
+}
+
+.pill-context-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-radius: 1px;
+    transform: translateZ(0);
+    background: var(--success);
+    /* Grows as context fills; drains smoothly when a compaction shrinks it. */
+    transition: width 0.6s ease, background-color 0.6s ease;
+}
+
+.pill-context-fill.ctx-mid {
+    background: #e0af68;
+}
+
+.pill-context-fill.ctx-high {
+    background: var(--error);
+    /* Ambient warning pulse when close to the window limit. */
+    animation: ctx-near-full 1.8s ease-in-out infinite;
+}
+
+@keyframes ctx-near-full {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}
+
+/* Brief flash the moment a compaction lands (context drains). */
+.pill-context-bar.compacting {
+    animation: ctx-compact-flash 0.8s ease-out;
+}
+
+@keyframes ctx-compact-flash {
+    0% {
+        box-shadow: 0 0 6px 1px var(--accent);
+    }
+    100% {
+        box-shadow: none;
+    }
+}
+
+.session-pill.hidden .pill-context-fill {
+    opacity: 0.2;
+}
+
 .pill-status {
     font-size: 0.6rem;
     line-height: 1;

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -972,6 +972,7 @@
     border-radius: 1px;
     transform: translateZ(0);
     background: var(--success);
+
     /* Grows as context fills; drains smoothly when a compaction shrinks it. */
     transition: width 0.6s ease, background-color 0.6s ease;
 }
@@ -982,6 +983,7 @@
 
 .pill-context-fill.ctx-high {
     background: var(--error);
+
     /* Ambient warning pulse when close to the window limit. */
     animation: ctx-near-full 1.8s ease-in-out infinite;
 }

--- a/session-lib/src/turn_tracker.rs
+++ b/session-lib/src/turn_tracker.rs
@@ -204,6 +204,7 @@ impl TurnTracker {
             tool_call_count: turn.tool_call_count,
             stream_restarts: turn.stream_restarts,
             total_cost_usd: outcome.total_cost_usd,
+            model_context_window: outcome.model_context_window,
         };
 
         // Structured per-turn performance + token-accounting log. One line per
@@ -257,6 +258,10 @@ pub struct TurnOutcome {
     pub stop_reason: Option<String>,
     pub is_error: bool,
     pub total_cost_usd: Option<f64>,
+    /// Context window in tokens as reported by the agent (Codex sends this;
+    /// Claude leaves it `None` and the window is derived from the model id).
+    /// See [`shared::TurnMetrics::model_context_window`].
+    pub model_context_window: Option<i64>,
 }
 
 fn duration_to_ms_i64(d: Duration) -> i64 {
@@ -288,6 +293,7 @@ mod tests {
             stop_reason: Some("end_turn".to_string()),
             is_error: false,
             total_cost_usd: Some(0.005),
+            model_context_window: None,
         }
     }
 
@@ -404,6 +410,7 @@ mod tests {
             stop_reason: Some("completed".to_string()),
             is_error: false,
             total_cost_usd: None,
+            model_context_window: Some(272_000),
         };
         let m = tracker
             .finalize(t0 + Duration::from_millis(400), Utc::now(), outcome)
@@ -413,6 +420,8 @@ mod tests {
         assert!(m.model.is_none());
         assert_eq!(m.input_tokens, 42);
         assert_eq!(m.output_tokens, 7);
+        // The agent-reported window flows through to the metrics.
+        assert_eq!(m.model_context_window, Some(272_000));
         // Only one content frame seen → gap measurable as 0 (one frame, no
         // inter-frame interval), not None.
         assert_eq!(m.max_inter_token_gap_ms, Some(0));

--- a/shared/src/api/metrics.rs
+++ b/shared/src/api/metrics.rs
@@ -109,6 +109,14 @@ pub struct TurnMetrics {
     /// `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_cost_usd: Option<f64>,
+
+    /// The model's context window in tokens, when the agent reports it. Codex
+    /// sends `model_context_window` on its wire, so codex turns carry it here.
+    /// Claude does not report a window, so claude turns leave this `None` and
+    /// [`TurnMetrics::context_window`] derives a nominal size from the model id
+    /// instead. Powers the context-usage gauge.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_context_window: Option<i64>,
 }
 
 impl TurnMetrics {
@@ -121,6 +129,47 @@ impl TurnMetrics {
             let value = value.trim();
             !value.is_empty() && !value.eq_ignore_ascii_case("unknown")
         })
+    }
+
+    /// Tokens occupying the context window on this turn's most recent request —
+    /// the numerator of the context-usage gauge.
+    ///
+    /// The math is **agent-specific** because the two protocols count input
+    /// tokens differently:
+    /// - **Claude** reports the three input buckets *disjointly* (`input`,
+    ///   `cache_read`, `cache_creation`), so the full prompt is their sum.
+    /// - **Codex** reports `input_tokens` as the *whole* prompt, with the
+    ///   cached / cache-write counts as subsets already inside it — so summing
+    ///   them would double-count. Its occupancy is just `input_tokens`.
+    pub fn context_tokens(&self) -> i64 {
+        match self.agent_type {
+            AgentType::Codex => self.input_tokens,
+            // Claude (and the default) — disjoint buckets sum to the prompt.
+            AgentType::Claude => {
+                self.input_tokens + self.cache_read_tokens + self.cache_creation_tokens
+            }
+        }
+    }
+
+    /// Effective context window in tokens: the value the agent reported, else a
+    /// nominal size derived from the model id (Claude). `None` when neither is
+    /// available (e.g. a Codex turn from before the window was on the wire, or
+    /// an unrecognized model) — the caller hides the gauge rather than guess.
+    pub fn context_window(&self) -> Option<i64> {
+        self.model_context_window.filter(|w| *w > 0).or_else(|| {
+            self.model
+                .as_deref()
+                .and_then(crate::context_window_for)
+                .map(|w| w as i64)
+        })
+    }
+
+    /// Fraction of the context window occupied on this turn, `0.0..`. Can
+    /// briefly exceed `1.0` right before an auto-compaction; callers clamp for
+    /// display. `None` when the window is unknown.
+    pub fn context_fraction(&self) -> Option<f64> {
+        let window = self.context_window()?;
+        (window > 0).then(|| self.context_tokens() as f64 / window as f64)
     }
 }
 
@@ -193,4 +242,116 @@ pub struct MetricBucket {
 pub struct MetricBucketsResponse {
     #[serde(default)]
     pub buckets: Vec<MetricBucket>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal turn with the token fields that drive the gauge.
+    fn turn(
+        agent_type: AgentType,
+        model: Option<&str>,
+        model_context_window: Option<i64>,
+        input_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
+    ) -> TurnMetrics {
+        TurnMetrics {
+            id: None,
+            session_id: uuid::Uuid::nil(),
+            user_message_id: None,
+            agent_type,
+            model: model.map(str::to_string),
+            service_tier: None,
+            started_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
+            first_token_at: None,
+            completed_at: None,
+            ttft_ms: None,
+            total_duration_ms: None,
+            generation_duration_ms: None,
+            max_inter_token_gap_ms: None,
+            input_tokens,
+            output_tokens: 0,
+            cache_creation_tokens,
+            cache_read_tokens,
+            thinking_tokens: 0,
+            subagent_tokens: 0,
+            stop_reason: None,
+            is_error: false,
+            tool_call_count: 0,
+            stream_restarts: 0,
+            total_cost_usd: None,
+            model_context_window,
+        }
+    }
+
+    #[test]
+    fn claude_context_tokens_sum_disjoint_buckets() {
+        // Claude: input + cache_read + cache_creation = full prompt.
+        let t = turn(
+            AgentType::Claude,
+            Some("claude-opus-4-8"),
+            None,
+            1_000,
+            40_000,
+            2_000,
+        );
+        assert_eq!(t.context_tokens(), 43_000);
+        // Window derived from the model-name map (200k).
+        assert_eq!(t.context_window(), Some(200_000));
+        assert_eq!(t.context_fraction(), Some(43_000.0 / 200_000.0));
+    }
+
+    #[test]
+    fn codex_context_tokens_do_not_double_count_cache() {
+        // Codex: input_tokens already includes the cached subset — occupancy is
+        // input_tokens alone, and the window comes from the wire.
+        let t = turn(
+            AgentType::Codex,
+            Some("gpt-5-codex"),
+            Some(400_000),
+            120_000,
+            90_000,
+            5_000,
+        );
+        assert_eq!(t.context_tokens(), 120_000);
+        assert_eq!(t.context_window(), Some(400_000));
+        assert_eq!(t.context_fraction(), Some(120_000.0 / 400_000.0));
+    }
+
+    #[test]
+    fn reported_window_wins_over_model_map() {
+        // A Claude turn that somehow carries an explicit window uses it.
+        let t = turn(
+            AgentType::Claude,
+            Some("claude-sonnet-5"),
+            Some(1_000_000),
+            500_000,
+            0,
+            0,
+        );
+        assert_eq!(t.context_window(), Some(1_000_000));
+    }
+
+    #[test]
+    fn no_window_when_unknown() {
+        // Codex turn with no wire window and a non-Claude model → gauge hidden.
+        let t = turn(AgentType::Codex, Some("gpt-5-codex"), None, 100, 0, 0);
+        assert_eq!(t.context_window(), None);
+        assert_eq!(t.context_fraction(), None);
+    }
+
+    #[test]
+    fn fraction_may_exceed_one_before_compaction() {
+        let t = turn(
+            AgentType::Claude,
+            Some("claude-opus-4-8"),
+            None,
+            210_000,
+            0,
+            0,
+        );
+        assert!(t.context_fraction().unwrap() > 1.0);
+    }
 }

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -310,6 +310,7 @@ mod tests {
             tool_call_count: 3,
             stream_restarts: 0,
             total_cost_usd: Some(0.0145),
+            model_context_window: None,
         };
         let json = serde_json::to_value(&metrics).unwrap();
         assert_eq!(json["agent_type"], "claude");
@@ -349,6 +350,7 @@ mod tests {
             tool_call_count: 0,
             stream_restarts: 0,
             total_cost_usd: None,
+            model_context_window: None,
         };
         assert!(metrics.has_known_model());
 
@@ -467,6 +469,7 @@ mod tests {
             tool_call_count: 0,
             stream_restarts: 0,
             total_cost_usd: None,
+            model_context_window: None,
         };
         let json = serde_json::to_value(&metrics).unwrap();
         assert_eq!(json["agent_type"], "codex");

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -70,7 +70,7 @@ pub mod timezone;
 
 // Compact model-version extraction for the session-pill watermark
 pub mod model_version;
-pub use model_version::compact_model_version;
+pub use model_version::{compact_model_version, context_window_for};
 
 // API client types and trait
 pub mod api;

--- a/shared/src/model_version.rs
+++ b/shared/src/model_version.rs
@@ -97,9 +97,32 @@ pub fn compact_model_version(model_id: &str) -> Option<String> {
     }
 }
 
+/// Nominal context-window size (in tokens) for a Claude model id.
+///
+/// Claude's stream-json output reports consumed tokens but *not* the window
+/// size (unlike Codex, which sends `model_context_window` at runtime), so a
+/// context-usage gauge needs a model → window map for Claude turns. Every
+/// current Claude family (Opus / Sonnet / Haiku, incl. the 3.x/4.x/5 lines)
+/// ships a 200k-token window by default, so recognized Claude ids map to
+/// `200_000`; anything unrecognized returns `None` (caller hides the gauge
+/// rather than guess).
+///
+/// Caveat: a 1M-token context is a per-request beta opt-in that isn't
+/// distinguishable from the model id alone, so a session running it will read
+/// as "more full" than it is. The nominal default matches what the CLI shows
+/// by default. Codex never uses this — it carries its own window on the wire.
+pub fn context_window_for(model_id: &str) -> Option<u64> {
+    let id = model_id.to_ascii_lowercase();
+    let is_claude = ["opus", "sonnet", "haiku"]
+        .iter()
+        .any(|family| id.contains(family))
+        || id.starts_with("claude");
+    is_claude.then_some(200_000)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::compact_model_version;
+    use super::{compact_model_version, context_window_for};
 
     #[test]
     fn claude_dashed_major_minor() {
@@ -161,5 +184,24 @@ mod tests {
     #[test]
     fn three_component_version_joins_all() {
         assert_eq!(compact_model_version("foo-1-2-3").as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn context_window_recognizes_claude_families() {
+        for id in [
+            "claude-opus-4-8",
+            "claude-sonnet-5",
+            "claude-haiku-4-5-20251001",
+            "claude-fable-5",
+        ] {
+            assert_eq!(context_window_for(id), Some(200_000), "{id}");
+        }
+    }
+
+    #[test]
+    fn context_window_none_for_non_claude_or_unknown() {
+        assert_eq!(context_window_for("gpt-5-codex"), None);
+        assert_eq!(context_window_for(""), None);
+        assert_eq!(context_window_for("garbled-nonsense"), None);
     }
 }


### PR DESCRIPTION
Adds a per-session context-window usage gauge for both Claude and Codex, as a thin fill bar across the **top** of each session pill — the counterpart to the activity ticks along the bottom.

## Computing the percentage

`% = context_tokens ÷ context_window`, defined once on `shared::TurnMetrics`:
- **context_tokens** is agent-aware: Claude reports its three input buckets *disjointly* so they sum to the prompt (`input + cache_read + cache_creation`); Codex's `input_tokens` already includes its cached subset, so summing would double-count — its occupancy is `input_tokens` alone.
- **context_window** comes from the agent when it reports one (Codex sends `model_context_window` on the wire — now latched into `TurnMetrics` and persisted), else a nominal per-model size from a new `context_window_for(model)` map (Claude, which doesn't report a window). Unknown window → no bar.

Plumbed `model_context_window` through `TurnOutcome` → `TurnMetrics` → wire → DB (migration + `schema.rs` + models). The math is unit-tested (agent-specific occupancy, window fallback, fraction).

## The gauge

- A thin top bar mirroring the bottom activity sparkline's style, filling left→right, colored **green → amber → red** as it fills, with an ambient pulse near the limit.
- **Drains smoothly** (CSS `width` transition) when a compaction shrinks the context, and **flashes** the moment a compaction lands — reusing the same compaction markers the bottom sparkline already plots.
- Data is derived client-side from the dashboard's existing `recent_turn_metrics` buffer (seeded from `/api/metrics/recent` on load + live broadcasts), latest-turn-wins per session — the same source/pattern as the pill's live model watermark. No new endpoint.

Sessions with no recent metrics or an unknown window simply show no bar.