### PR TITLE
Card inter-agent optimistic-user echoes instead of raw text

### DIFF
--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -200,6 +200,15 @@ fn user_message_is_inter_agent(msg: &shared::UserMessage) -> bool {
     super::renderers::agent_message_event_from_agent_facing_text(&text).is_some()
 }
 
+/// True iff a synthetic optimistic-user echo (its content is a single string,
+/// e.g. Codex's `UserEchoEvent` or an older proxy's raw echo) is actually an
+/// inter-agent message. The optimistic shape carries no content blocks, so this
+/// runs the detector on the string field directly, but the decision must match
+/// [`user_message_is_inter_agent`] so both echo shapes card identically.
+fn optimistic_user_is_inter_agent(msg: &super::types::OptimisticUserMessage) -> bool {
+    super::renderers::agent_message_event_from_agent_facing_text(&msg.content).is_some()
+}
+
 /// Classify a single wire message into the display identity it belongs to,
 /// or `None` if it shouldn't roll into any group (renders as `Single`).
 ///
@@ -282,7 +291,17 @@ pub(super) fn classify(
                 ));
             }
         }
-        AgentFrame::Claude(ClaudeMessage::OptimisticUser(_)) => {
+        AgentFrame::Claude(ClaudeMessage::OptimisticUser(msg)) => {
+            // A synthetic user echo carrying an inter-agent `[message from …]`
+            // payload with no provenance metadata must render as its own
+            // provenance card, not fold into the "You" group and expose its raw
+            // wrapper — mirroring the `ClaudeMessage::User` arm above. This shape
+            // is how Codex's `UserEchoEvent` (top-level `content` string, no
+            // `session_id`) and older proxies' echoes parse, so the `User`-arm
+            // detection alone missed them.
+            if source.is_none() && optimistic_user_is_inter_agent(&msg) {
+                return None;
+            }
             return Some(source.map_or_else(
                 || MessageIdentity {
                     category: GroupCategory::User,

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -250,6 +250,48 @@ mod tests {
         );
     }
 
+    /// The synthetic-echo (optimistic-user) shape carrying an inter-agent
+    /// message must ALSO render as its own card, not fold into "You". Codex's
+    /// `UserEchoEvent` and older proxies' echoes parse as `OptimisticUser`
+    /// (top-level `content` string), which the `User`-arm detection missed —
+    /// this is the regression that surfaced the raw `[message from …]` /
+    /// system-reminder wrapper again.
+    #[test]
+    fn inter_agent_optimistic_user_is_not_grouped() {
+        let sid = "e2d342f5-68c6-4134-a5d8-63cb4afcee9e";
+        let body = format!(
+            "[message from codex {sid}]\nReview started.\n\n\
+             <system-reminder>\nReply to that agent, not the user.\n</system-reminder>"
+        );
+
+        // Pure optimistic shape (no `message` field) — parses as OptimisticUser.
+        let bare = serde_json::json!({ "type": "user", "content": body }).to_string();
+        assert!(
+            classify(&rendered(&bare), shared::AgentType::Codex, None).is_none(),
+            "optimistic inter-agent echo must render as a Single card, not group"
+        );
+
+        // The full Codex `UserEchoEvent` shape (blocks + top-level content).
+        let codex_echo = serde_json::json!({
+            "type": "user",
+            "message": { "role": "user", "content": [{ "type": "text", "text": body }] },
+            "content": body,
+        })
+        .to_string();
+        assert!(
+            classify(&rendered(&codex_echo), shared::AgentType::Codex, None).is_none(),
+            "codex UserEchoEvent inter-agent shape must render as a Single card"
+        );
+
+        // An ordinary optimistic echo still groups as User.
+        let prose =
+            serde_json::json!({ "type": "user", "content": "ordinary pending prose" }).to_string();
+        assert_eq!(
+            classify(&rendered(&prose), shared::AgentType::Codex, None).map(|i| i.category),
+            Some(GroupCategory::User),
+        );
+    }
+
     /// A tool-result user message coming from a Claude session MUST classify
     /// into the assistant group — otherwise serial Read tool uses don't roll
     /// together with their preceding assistant turn.

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -66,6 +66,14 @@ pub fn render_optimistic_user_message(
     timestamp: Option<&str>,
     session_id: Uuid,
 ) -> Html {
+    // A synthetic echo carrying an inter-agent `[message from …]` payload (e.g.
+    // Codex's `UserEchoEvent`, or an older proxy's raw echo) renders as its own
+    // provenance card rather than a raw "You" bubble — mirroring
+    // `render_user_message`.
+    if let Some(event) = agent_message_event_from_agent_facing_text(&msg.content) {
+        return render_agent_message_event(&event, timestamp, session_id);
+    }
+
     let label = human_label(meta, current_user_id);
     let delivery = meta.and_then(|m| m.delivery.as_ref());
     let pending_class = if delivery.is_some_and(shared::DeliveryMeta::pending) {


### PR DESCRIPTION
## What

Inter-agent messages sometimes still render as a raw "You" bubble showing the full `[message from …]` header and the `<system-reminder>` wrapper, instead of the intended provenance card.

## Why

The frontend already routes the `[message from …]` payload to a provenance card when it arrives as a `ClaudeMessage::User` echo. But a synthetic user echo — Codex's `UserEchoEvent` (which carries a top-level `content` string and no `session_id`) and echoes from older proxies that predate the typed `display_event` synthesis — parses as `OptimisticUser`, not `User`. The `OptimisticUser` path had no inter-agent detection: `classify` folded it into the "You" group and the renderer printed it verbatim.

## Fix

Mirror the `ClaudeMessage::User` handling on the `OptimisticUser` shape:

- `classify` keeps a no-provenance inter-agent optimistic echo out of the "You" group (renders as a single card).
- `render_optimistic_user_message` detects the `[message from …]` payload and emits the provenance card.

Both decisions reuse the same `agent_message_event_from_agent_facing_text` detector as the `User` path, so the two echo shapes can't drift. Adds a regression test covering both the bare optimistic shape and the full Codex `UserEchoEvent` shape.