### PR TITLE
Accept binary data-plane sockets for port forwarding

### DIFF
--- a/backend/src/handlers/websocket/mod.rs
+++ b/backend/src/handlers/websocket/mod.rs
@@ -6,16 +6,37 @@ mod proxy_socket;
 mod registration;
 mod replay;
 mod session_manager;
+mod tunnel_socket;
+mod tunnel_ticket;
 mod turn_metrics;
 mod uploads;
 mod web_client_socket;
 
 pub use session_manager::{
-    conn_channel, ConnSender, ForwardHealth, LauncherConnection, ProxySender, SessionId,
-    SessionManager, TunnelError, TunnelIn, WebClientSender, LAUNCHER_CHANNEL_CAPACITY,
+    conn_channel, ConnSender, DataPlaneConnection, DataPlaneSender, ForwardHealth,
+    LauncherConnection, ProxySender, SessionId, SessionManager, TunnelError, TunnelIn,
+    WebClientSender, DATA_PLANE_CHANNEL_CAPACITY, LAUNCHER_CHANNEL_CAPACITY,
     LAUNCHER_LIVENESS_DEADLINE_SECS, LIVENESS_SWEEP_INTERVAL_SECS, PROXY_CHANNEL_CAPACITY,
     PROXY_LIVENESS_DEADLINE_SECS, WEB_CLIENT_CHANNEL_CAPACITY,
 };
+
+/// Mint a port-forward data-plane ticket (#1506). Re-exported so the proxy
+/// socket's `Register` handler can hand one to a capable proxy without
+/// depending on the ticket module's internals.
+pub(crate) fn mint_tunnel_ticket(
+    jwt_secret: &str,
+    session_id: uuid::Uuid,
+    session_key: &str,
+    gen: u64,
+) -> Option<String> {
+    tunnel_ticket::mint(
+        jwt_secret,
+        session_id,
+        session_key,
+        gen,
+        chrono::Utc::now().timestamp(),
+    )
+}
 
 use axum::{
     extract::{ws::WebSocketUpgrade, State},
@@ -33,6 +54,19 @@ pub async fn handle_session_websocket(
     State(app_state): State<Arc<AppState>>,
 ) -> Response {
     ws.on_upgrade(|socket| proxy_socket::handle_session_socket(socket, app_state))
+}
+
+/// Upgrade for the dedicated binary port-forward data plane (#1506).
+///
+/// Deliberately unauthenticated at the HTTP layer, exactly like `/ws/session`:
+/// the credential is the `Hello` ticket carried in the first frame, which also
+/// binds the socket to one control-connection generation. Nothing is registered
+/// and no frames are routed until that ticket verifies.
+pub async fn handle_tunnel_data_websocket(
+    ws: WebSocketUpgrade,
+    State(app_state): State<Arc<AppState>>,
+) -> Response {
+    ws.on_upgrade(|socket| tunnel_socket::handle_tunnel_data_socket(socket, app_state))
 }
 
 pub async fn handle_launcher_websocket(

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -106,6 +106,13 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
     // staleness — these streams rode this connection's now-dead sender.
     if let (Some(key), Some(gen)) = (session_key.as_ref(), connection_gen) {
         session_manager.close_tunnels_for_connection(key, gen);
+        // The data plane exists only to serve THIS control connection, so it
+        // goes with it — otherwise a later `open_tunnel` could route bytes into
+        // a socket whose session is gone. Also gen-guarded, so a stale
+        // teardown can't close a reconnect's data plane. The reverse is not
+        // true: a data socket dropping on its own never touches the session,
+        // it just reverts tunneling to this control socket.
+        session_manager.close_data_plane_for_connection(key, gen);
     }
 
     if !is_stale {
@@ -199,6 +206,7 @@ fn handle_proxy_message(
             repo_url,
             scheduled_task_id,
             claude_args,
+            capabilities,
         }) => {
             let key = claude_session_id.to_string();
 
@@ -230,6 +238,12 @@ fn handle_proxy_message(
             };
             let result = register_or_update_session(app_state, &params);
 
+            // Data-plane ticket, minted only for proxies that advertise the
+            // capability. Bound to this connection's generation (known only
+            // after `register_session` below), so it cannot be replayed onto a
+            // later reconnect. `None` ⇒ tunnel bytes keep riding this socket.
+            let mut tunnel_data_ticket = None;
+
             if result.success {
                 // Only now do we expose the socket via SessionManager and
                 // bind cleanup state. The send_task in handle_session_socket
@@ -238,6 +252,17 @@ fn handle_proxy_message(
                 // registration, so the proxy still gets a response on
                 // failure even though we never registered the socket.
                 let gen = session_manager.register_session(key.clone(), tx.clone(), cancel.clone());
+                if capabilities
+                    .iter()
+                    .any(|c| c == shared::PROXY_CAPABILITY_TUNNEL_BINARY_V1)
+                {
+                    tunnel_data_ticket = crate::handlers::websocket::mint_tunnel_ticket(
+                        &app_state.jwt_secret,
+                        claude_session_id,
+                        &key,
+                        gen,
+                    );
+                }
                 *session_key = Some(key);
                 *connection_gen = Some(gen);
                 *db_session_id = result.session_id;
@@ -252,6 +277,7 @@ fn handle_proxy_message(
                 // and would wedge on a missing field, so we keep sending it.
                 max_image_mb: app_state.max_image_mb,
                 retryable: result.retryable,
+                tunnel_data_ticket,
             });
 
             info!(

--- a/backend/src/handlers/websocket/session_manager/data_plane.rs
+++ b/backend/src/handlers/websocket/session_manager/data_plane.rs
@@ -1,0 +1,295 @@
+//! Registry of dedicated port-forward data-plane sockets (#1506).
+//!
+//! Each entry is the binary `/ws/session/data` socket belonging to *one*
+//! control connection, keyed by session key and tagged with that connection's
+//! generation. Every mutation is generation-guarded for the same reason
+//! [`proxy_lifecycle`](super::proxy_lifecycle) is: a proxy reconnect races its
+//! own teardown, and a stale socket must never evict — or be used by — the
+//! connection that replaced it.
+//!
+//! The registry is deliberately *optional* state. `open_tunnel` consults it per
+//! call and silently uses the JSON-over-control-socket path when there is no
+//! live entry, so an older proxy, a proxy whose data socket dropped, or a
+//! data socket that hasn't finished connecting yet all degrade to the previous
+//! behavior instead of failing.
+
+use dashmap::DashMap;
+use shared::TunnelFrame;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
+
+use super::{ConnSender, SessionId, SessionManager};
+
+/// Bounded outbound channel for a data-plane socket.
+///
+/// Sized well above the control socket's budget: this carries bulk stream bytes
+/// (one frame per chunk per stream), which is exactly the traffic that used to
+/// contend with heartbeats on the control socket. Overflow is still treated as
+/// a dead connection — the tunnel's per-stream credit windows are what bound
+/// in-flight bytes, so a peer that cannot drain this much is wedged.
+pub const DATA_PLANE_CHANNEL_CAPACITY: usize = 2048;
+
+pub type DataPlaneSender = ConnSender<TunnelFrame>;
+
+/// One registered data-plane socket.
+pub struct DataPlaneConnection {
+    pub sender: DataPlaneSender,
+    /// Generation of the *control* connection this socket serves. Frames are
+    /// only routed here while this matches the live control connection.
+    pub gen: u64,
+    /// Fired to force this socket's task to close (mirrors `ProxyConnection`).
+    pub cancel: CancellationToken,
+    /// Epoch seconds of the last inbound frame, for diagnostics.
+    pub last_seen: AtomicU64,
+}
+
+impl SessionManager {
+    /// Register a data-plane socket for `(session_key, gen)`.
+    ///
+    /// Returns `false` — and registers nothing — when `gen` is not the live
+    /// control connection's generation. That rejects both a ticket replayed
+    /// from a superseded connection and a data socket that finished connecting
+    /// after its control socket had already been replaced.
+    pub fn register_data_plane(
+        &self,
+        session_key: SessionId,
+        gen: u64,
+        sender: DataPlaneSender,
+        cancel: CancellationToken,
+    ) -> bool {
+        // NOTE: deliberately *not* `is_current_connection` — that returns true
+        // for a session with no registered proxy at all (it answers "has this
+        // been superseded?", which teardown wants). As an authorization guard we
+        // need positive proof of a live control connection at this exact
+        // generation, or a ticket replayed after the proxy disconnected would
+        // attach a data plane to nothing.
+        if self.current_connection_gen(&session_key) != Some(gen) {
+            debug!(
+                "Rejecting data-plane socket for {} (gen={}): no live control connection at that generation",
+                session_key, gen
+            );
+            return false;
+        }
+        // Displace any existing entry for this session; its task observes the
+        // cancel and exits. Two data sockets for one connection is not a
+        // supported shape, and keeping the newer one matches how the control
+        // socket handles a re-register.
+        if let Some(prev) = self.data_planes.insert(
+            session_key.clone(),
+            DataPlaneConnection {
+                sender,
+                gen,
+                cancel,
+                last_seen: AtomicU64::new(super::liveness::epoch_secs()),
+            },
+        ) {
+            prev.cancel.cancel();
+        }
+        info!(
+            "Registered binary data plane for session {} (gen={})",
+            session_key, gen
+        );
+        true
+    }
+
+    /// Remove a data-plane socket, but only if it is still the registered one
+    /// for `gen` — so a stale socket's teardown cannot evict its successor.
+    pub fn unregister_data_plane(&self, session_key: &SessionId, gen: u64) {
+        if self
+            .data_planes
+            .remove_if(session_key, |_, conn| conn.gen == gen)
+            .is_some()
+        {
+            debug!(
+                "Unregistered data plane for session {} (gen={})",
+                session_key, gen
+            );
+        }
+    }
+
+    /// Drop the data-plane socket belonging to a control connection that is
+    /// going away, closing its transport. Called from the control socket's
+    /// teardown: the data plane exists only to serve that connection, so
+    /// leaving it registered would let a later `open_tunnel` route bytes into
+    /// a socket whose session is gone.
+    pub fn close_data_plane_for_connection(&self, session_key: &SessionId, gen: u64) {
+        if let Some((_, conn)) = self
+            .data_planes
+            .remove_if(session_key, |_, conn| conn.gen == gen)
+        {
+            conn.cancel.cancel();
+            debug!(
+                "Closed data plane for ended connection {} (gen={})",
+                session_key, gen
+            );
+        }
+    }
+
+    /// Sender for the live data plane of `(session_key, gen)`, if one is
+    /// registered. `None` means "use the control-socket JSON path".
+    pub fn data_plane_sender(&self, session_key: &str, gen: u64) -> Option<DataPlaneSender> {
+        let conn = self.data_planes.get(session_key)?;
+        (conn.gen == gen).then(|| conn.sender.clone())
+    }
+
+    /// Stamp liveness for a data-plane socket (diagnostics only — the control
+    /// socket's heartbeat remains the authority on session liveness, which is
+    /// the entire point of separating the planes).
+    pub fn touch_data_plane(&self, session_key: &str) {
+        if let Some(conn) = self.data_planes.get(session_key) {
+            conn.last_seen.store(
+                super::liveness::epoch_secs(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+        }
+    }
+
+    /// Whether a live data plane is registered for `(session_key, gen)`.
+    pub fn has_data_plane(&self, session_key: &str, gen: u64) -> bool {
+        self.data_planes
+            .get(session_key)
+            .is_some_and(|c| c.gen == gen)
+    }
+}
+
+/// Shared map type for the registry.
+pub(super) type DataPlaneMap = Arc<DashMap<SessionId, DataPlaneConnection>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handlers::websocket::{conn_channel, SessionManager};
+
+    fn register_control(mgr: &SessionManager, key: &str) -> u64 {
+        let (tx, rx) = conn_channel::<shared::ServerToProxy>(8);
+        // Keep the receiver alive for the test's duration.
+        std::mem::forget(rx);
+        mgr.register_session(key.to_string(), tx, CancellationToken::new())
+    }
+
+    fn data_sender() -> (DataPlaneSender, tokio::sync::mpsc::Receiver<TunnelFrame>) {
+        conn_channel::<TunnelFrame>(8)
+    }
+
+    #[test]
+    fn registers_only_for_the_live_control_generation() {
+        let mgr = SessionManager::new();
+        let gen = register_control(&mgr, "s1");
+
+        let (tx, _rx) = data_sender();
+        assert!(mgr.register_data_plane("s1".into(), gen, tx, CancellationToken::new()));
+        assert!(mgr.has_data_plane("s1", gen));
+
+        // A stale generation is refused outright.
+        let (tx, _rx) = data_sender();
+        assert!(!mgr.register_data_plane("s1".into(), gen - 1, tx, CancellationToken::new()));
+    }
+
+    #[test]
+    fn rejects_data_plane_for_unknown_session() {
+        let mgr = SessionManager::new();
+        let (tx, _rx) = data_sender();
+        assert!(!mgr.register_data_plane("nope".into(), 1, tx, CancellationToken::new()));
+        assert!(!mgr.has_data_plane("nope", 1));
+    }
+
+    /// A ticket minted on a superseded connection must not attach a data plane
+    /// to the connection that replaced it.
+    #[test]
+    fn a_replayed_ticket_from_a_previous_connection_is_refused() {
+        let mgr = SessionManager::new();
+        let old_gen = register_control(&mgr, "s1");
+        let new_gen = register_control(&mgr, "s1");
+        assert_ne!(old_gen, new_gen);
+
+        let (tx, _rx) = data_sender();
+        assert!(!mgr.register_data_plane("s1".into(), old_gen, tx, CancellationToken::new()));
+
+        let (tx, _rx) = data_sender();
+        assert!(mgr.register_data_plane("s1".into(), new_gen, tx, CancellationToken::new()));
+        assert!(mgr.has_data_plane("s1", new_gen));
+        assert!(!mgr.has_data_plane("s1", old_gen));
+    }
+
+    #[test]
+    fn stale_unregister_cannot_evict_the_successor() {
+        let mgr = SessionManager::new();
+        let gen = register_control(&mgr, "s1");
+        let (tx, _rx) = data_sender();
+        mgr.register_data_plane("s1".into(), gen, tx, CancellationToken::new());
+
+        // A late teardown from an older generation is a no-op.
+        mgr.unregister_data_plane(&"s1".to_string(), gen - 1);
+        assert!(mgr.has_data_plane("s1", gen));
+
+        mgr.unregister_data_plane(&"s1".to_string(), gen);
+        assert!(!mgr.has_data_plane("s1", gen));
+    }
+
+    #[test]
+    fn re_registering_displaces_and_cancels_the_previous_socket() {
+        let mgr = SessionManager::new();
+        let gen = register_control(&mgr, "s1");
+
+        let first_cancel = CancellationToken::new();
+        let (tx, _rx) = data_sender();
+        mgr.register_data_plane("s1".into(), gen, tx, first_cancel.clone());
+
+        let (tx, _rx) = data_sender();
+        mgr.register_data_plane("s1".into(), gen, tx, CancellationToken::new());
+
+        assert!(
+            first_cancel.is_cancelled(),
+            "the displaced socket must be told to close"
+        );
+        assert!(mgr.has_data_plane("s1", gen));
+    }
+
+    #[test]
+    fn sender_lookup_is_generation_scoped() {
+        let mgr = SessionManager::new();
+        let gen = register_control(&mgr, "s1");
+        let (tx, _rx) = data_sender();
+        mgr.register_data_plane("s1".into(), gen, tx, CancellationToken::new());
+
+        assert!(mgr.data_plane_sender("s1", gen).is_some());
+        // Falling back to the control path is the correct answer for any other
+        // generation, and for a session with no data plane at all.
+        assert!(mgr.data_plane_sender("s1", gen + 1).is_none());
+        assert!(mgr.data_plane_sender("other", gen).is_none());
+    }
+
+    #[test]
+    fn closing_a_connection_drops_and_cancels_its_data_plane() {
+        let mgr = SessionManager::new();
+        let gen = register_control(&mgr, "s1");
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = data_sender();
+        mgr.register_data_plane("s1".into(), gen, tx, cancel.clone());
+
+        mgr.close_data_plane_for_connection(&"s1".to_string(), gen);
+
+        assert!(!mgr.has_data_plane("s1", gen));
+        assert!(cancel.is_cancelled());
+    }
+
+    /// A control connection ending must not take down the data plane of a
+    /// *newer* connection for the same session.
+    #[test]
+    fn closing_a_stale_connection_spares_the_current_data_plane() {
+        let mgr = SessionManager::new();
+        let old_gen = register_control(&mgr, "s1");
+        let new_gen = register_control(&mgr, "s1");
+
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = data_sender();
+        mgr.register_data_plane("s1".into(), new_gen, tx, cancel.clone());
+
+        mgr.close_data_plane_for_connection(&"s1".to_string(), old_gen);
+
+        assert!(mgr.has_data_plane("s1", new_gen));
+        assert!(!cancel.is_cancelled());
+    }
+}

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -26,6 +26,7 @@ use uuid::Uuid;
 
 mod client_fanout;
 mod correlation;
+mod data_plane;
 mod input_dedup;
 mod input_queue;
 mod launcher_registry;
@@ -35,6 +36,8 @@ mod proxy_lifecycle;
 mod session_tracking;
 mod tunnel_client;
 
+use data_plane::DataPlaneMap;
+pub use data_plane::{DataPlaneConnection, DataPlaneSender, DATA_PLANE_CHANNEL_CAPACITY};
 pub(crate) use input_dedup::{DedupVerdict, InputDeliveryState};
 pub use launcher_registry::LauncherConnection;
 pub use liveness::{
@@ -168,6 +171,11 @@ pub struct SessionManager {
     /// Live backend tunnel streams (docs/PORT_FORWARDING.md), keyed by
     /// stream id; the reverse proxy opens them, proxy sockets feed them.
     tunnel_streams: TunnelStreamMap,
+    /// Dedicated binary data-plane sockets for port forwarding, keyed by
+    /// session key and tagged with the control connection's generation
+    /// (#1506, see `data_plane.rs`). Optional state: absence simply means
+    /// tunnel bytes take the JSON-over-control-socket path.
+    data_planes: DataPlaneMap,
     pending_launch_sessions: Arc<DashMap<Uuid, Uuid>>,
     /// Tracks who sent the last input for each session (session_id → (user_id, display_name))
     last_input_sender: Arc<DashMap<Uuid, (Uuid, String)>>,
@@ -206,6 +214,7 @@ impl Default for SessionManager {
             forward_health: Arc::new(DashMap::new()),
             forward_failures: Arc::new(DashMap::new()),
             tunnel_streams: Arc::new(DashMap::new()),
+            data_planes: Arc::new(DashMap::new()),
             pending_launch_sessions: Arc::new(DashMap::new()),
             last_input_sender: Arc::new(DashMap::new()),
             subagent_tokens: Arc::new(DashMap::new()),

--- a/backend/src/handlers/websocket/session_manager/tunnel_client.rs
+++ b/backend/src/handlers/websocket/session_manager/tunnel_client.rs
@@ -19,8 +19,8 @@ use std::time::Duration;
 use base64::Engine;
 use dashmap::DashMap;
 use shared::{
-    ServerToProxy, TunnelCloseFields, TunnelDataFields, TunnelOpenFields, TunnelRefuseReason,
-    TunnelWindowFields,
+    ServerToProxy, TunnelCloseFields, TunnelDataFields, TunnelFrame, TunnelOpenFields,
+    TunnelRefuseReason, TunnelWindowFields,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, Mutex, Notify};
@@ -78,6 +78,91 @@ pub(super) struct BackendStreamEntry {
 /// Registry of live backend tunnel streams, keyed by stream id.
 pub(super) type TunnelStreamMap = Arc<DashMap<Uuid, BackendStreamEntry>>;
 
+/// Where a stream's outbound frames go: the dedicated binary data plane when
+/// one is registered for this connection, otherwise the legacy JSON path over
+/// the session control socket (#1506).
+///
+/// Selected once per stream at open time and carried by the relay, so the copy
+/// loops stay transport-agnostic. Choosing per stream (rather than globally) is
+/// what makes the rollout safe: a proxy without the capability, or one whose
+/// data socket has dropped, transparently keeps the old path.
+#[derive(Clone)]
+pub(super) enum TunnelEgress {
+    /// JSON frames over the shared control socket — base64-encoded payloads.
+    Control(ProxySender),
+    /// Binary frames over the dedicated data plane — raw payloads.
+    Binary(super::DataPlaneSender),
+}
+
+impl TunnelEgress {
+    /// Human label for logs/metrics.
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Control(_) => "control",
+            Self::Binary(_) => "binary",
+        }
+    }
+
+    fn open(&self, stream_id: Uuid, port: u16) -> bool {
+        match self {
+            Self::Control(tx) => tx
+                .send(ServerToProxy::TunnelOpen(TunnelOpenFields {
+                    stream_id,
+                    port,
+                }))
+                .is_ok(),
+            Self::Binary(tx) => tx.send(TunnelFrame::Open { stream_id, port }).is_ok(),
+        }
+    }
+
+    fn data(&self, stream_id: Uuid, bytes: &[u8]) -> bool {
+        match self {
+            Self::Control(tx) => tx
+                .send(ServerToProxy::TunnelData(TunnelDataFields {
+                    stream_id,
+                    data_base64: base64::engine::general_purpose::STANDARD.encode(bytes),
+                }))
+                .is_ok(),
+            // The point of the binary plane: the payload goes on the wire as-is.
+            Self::Binary(tx) => tx
+                .send(TunnelFrame::Data {
+                    stream_id,
+                    bytes: bytes.to_vec(),
+                })
+                .is_ok(),
+        }
+    }
+
+    fn window(&self, stream_id: Uuid, add_bytes: u32) -> bool {
+        match self {
+            Self::Control(tx) => tx
+                .send(ServerToProxy::TunnelWindow(TunnelWindowFields {
+                    stream_id,
+                    add_bytes,
+                }))
+                .is_ok(),
+            Self::Binary(tx) => tx
+                .send(TunnelFrame::Window {
+                    stream_id,
+                    add_bytes,
+                })
+                .is_ok(),
+        }
+    }
+
+    fn close(&self, stream_id: Uuid, reason: Option<String>) -> bool {
+        match self {
+            Self::Control(tx) => tx
+                .send(ServerToProxy::TunnelClose(TunnelCloseFields {
+                    stream_id,
+                    reason,
+                }))
+                .is_ok(),
+            Self::Binary(tx) => tx.send(TunnelFrame::Close { stream_id, reason }).is_ok(),
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum TunnelError {
     #[error("session proxy is not connected")]
@@ -101,44 +186,58 @@ impl SessionManager {
         }
     }
 
-    /// Route a `TunnelData` frame: decode outside any map lock, reject
-    /// oversized frames, and enforce the granted receive window before the
-    /// bytes may enter the unbounded relay inbox.
+    /// Route a JSON-plane `TunnelData` frame: decode outside any map lock, then
+    /// hand the bytes to the shared ingest path.
+    ///
+    /// This is the legacy control-socket transport, kept for proxies that don't
+    /// advertise [`PROXY_CAPABILITY_TUNNEL_BINARY_V1`](shared::PROXY_CAPABILITY_TUNNEL_BINARY_V1).
+    /// The binary data plane calls [`Self::tunnel_bytes_in`] directly — same
+    /// size and credit enforcement, no base64 step.
     pub fn tunnel_data_in(&self, fields: &shared::TunnelDataFields) {
-        let entry = self
-            .tunnel_streams
-            .get(&fields.stream_id)
-            .map(|e| (e.value().inbox.clone(), e.value().recv_credit.clone()));
-        let Some((inbox, recv_credit)) = entry else {
-            debug!("TunnelData for unknown stream {} dropped", fields.stream_id);
-            return;
-        };
         match base64::engine::general_purpose::STANDARD.decode(&fields.data_base64) {
-            Ok(bytes) if bytes.len() > MAX_CHUNK => {
-                tracing::warn!(
-                    "Oversized TunnelData ({} bytes) for stream {}; closing",
-                    bytes.len(),
-                    fields.stream_id
-                );
-                let _ = inbox.send(TunnelIn::Close);
-            }
-            Ok(bytes) => {
-                let prev =
-                    recv_credit.fetch_sub(bytes.len() as i64, std::sync::atomic::Ordering::AcqRel);
-                if prev < bytes.len() as i64 {
-                    tracing::warn!(
-                        "TunnelData beyond granted window for stream {}; closing",
-                        fields.stream_id
-                    );
-                    let _ = inbox.send(TunnelIn::Close);
-                } else {
-                    let _ = inbox.send(TunnelIn::Data(bytes));
-                }
-            }
+            Ok(bytes) => self.tunnel_bytes_in(fields.stream_id, bytes),
             Err(_) => {
                 tracing::warn!("Undecodable TunnelData for stream {}", fields.stream_id);
-                let _ = inbox.send(TunnelIn::Close);
+                if let Some(entry) = self.tunnel_streams.get(&fields.stream_id) {
+                    let _ = entry.value().inbox.send(TunnelIn::Close);
+                }
             }
+        }
+    }
+
+    /// Shared ingest for stream payload bytes, whichever transport carried them:
+    /// reject oversized frames and enforce the granted receive window before the
+    /// bytes may enter the unbounded relay inbox.
+    ///
+    /// The credit book — not the channel — is what bounds buffered downlink
+    /// bytes, so this check is load-bearing against a buggy or hostile peer.
+    pub fn tunnel_bytes_in(&self, stream_id: Uuid, bytes: Vec<u8>) {
+        let entry = self
+            .tunnel_streams
+            .get(&stream_id)
+            .map(|e| (e.value().inbox.clone(), e.value().recv_credit.clone()));
+        let Some((inbox, recv_credit)) = entry else {
+            debug!("Tunnel payload for unknown stream {} dropped", stream_id);
+            return;
+        };
+        if bytes.len() > MAX_CHUNK {
+            tracing::warn!(
+                "Oversized tunnel payload ({} bytes) for stream {}; closing",
+                bytes.len(),
+                stream_id
+            );
+            let _ = inbox.send(TunnelIn::Close);
+            return;
+        }
+        let prev = recv_credit.fetch_sub(bytes.len() as i64, std::sync::atomic::Ordering::AcqRel);
+        if prev < bytes.len() as i64 {
+            tracing::warn!(
+                "Tunnel payload beyond granted window for stream {}; closing",
+                stream_id
+            );
+            let _ = inbox.send(TunnelIn::Close);
+        } else {
+            let _ = inbox.send(TunnelIn::Data(bytes));
         }
     }
 
@@ -196,6 +295,15 @@ impl SessionManager {
             None => return Err(TunnelError::NotConnected),
         };
 
+        // Prefer the dedicated binary data plane when this exact connection has
+        // one registered; otherwise fall back to JSON over the control socket.
+        // Resolved per stream, so a data socket that appears or drops mid-session
+        // is picked up (or degraded away from) without any coordination.
+        let egress = match self.data_plane_sender(session_key, gen) {
+            Some(tx) => TunnelEgress::Binary(tx),
+            None => TunnelEgress::Control(proxy_tx.clone()),
+        };
+
         let stream_id = Uuid::new_v4();
         let (relay_tx, mut relay_rx) = mpsc::unbounded_channel::<TunnelIn>();
         let recv_credit = Arc::new(std::sync::atomic::AtomicI64::new(INITIAL_WINDOW as i64));
@@ -209,13 +317,7 @@ impl SessionManager {
             },
         );
 
-        if proxy_tx
-            .send(ServerToProxy::TunnelOpen(TunnelOpenFields {
-                stream_id,
-                port,
-            }))
-            .is_err()
-        {
+        if !egress.open(stream_id, port) {
             self.tunnel_streams.remove(&stream_id);
             return Err(TunnelError::NotConnected);
         }
@@ -235,19 +337,21 @@ impl SessionManager {
             Err(_) => {
                 self.tunnel_streams.remove(&stream_id);
                 // Best effort: tell the proxy to forget the half-open stream.
-                let _ = proxy_tx.send(ServerToProxy::TunnelClose(TunnelCloseFields {
-                    stream_id,
-                    reason: Some("open timed out".to_string()),
-                }));
+                egress.close(stream_id, Some("open timed out".to_string()));
                 return Err(TunnelError::OpenTimeout);
             }
         }
 
+        debug!(
+            "Tunnel stream {} open over the {} plane",
+            stream_id,
+            egress.kind()
+        );
         let (client_io, relay_io) = tokio::io::duplex(PIPE_CAPACITY);
         let streams = self.tunnel_streams.clone();
         tokio::spawn(run_relay(
             stream_id,
-            proxy_tx,
+            egress,
             relay_io,
             relay_rx,
             streams,
@@ -303,7 +407,7 @@ impl CreditGate {
 /// Copy loop between the duplex pipe (hyper side) and tunnel frames.
 async fn run_relay(
     stream_id: Uuid,
-    proxy_tx: ProxySender,
+    egress: TunnelEgress,
     relay_io: tokio::io::DuplexStream,
     mut inbox: mpsc::UnboundedReceiver<TunnelIn>,
     streams: TunnelStreamMap,
@@ -312,9 +416,9 @@ async fn run_relay(
     let (mut pipe_rd, mut pipe_wr) = tokio::io::split(relay_io);
     let send_credit = Arc::new(CreditGate::new(INITIAL_WINDOW));
 
-    // Uplink: bytes hyper writes (requests) → TunnelData frames, credit-gated.
+    // Uplink: bytes hyper writes (requests) → payload frames, credit-gated.
     let uplink_credit = send_credit.clone();
-    let uplink_tx = proxy_tx.clone();
+    let uplink_egress = egress.clone();
     let uplink = tokio::spawn(async move {
         let mut buf = vec![0u8; MAX_CHUNK];
         loop {
@@ -326,11 +430,7 @@ async fn run_relay(
             if n < budget {
                 uplink_credit.grant((budget - n) as u32).await;
             }
-            let frame = ServerToProxy::TunnelData(TunnelDataFields {
-                stream_id,
-                data_base64: base64::engine::general_purpose::STANDARD.encode(&buf[..n]),
-            });
-            if uplink_tx.send(frame).is_err() {
+            if !uplink_egress.data(stream_id, &buf[..n]) {
                 break;
             }
         }
@@ -347,10 +447,7 @@ async fn run_relay(
                 // Grant-on-drain: refill the peer's window and our
                 // receive-credit enforcement book together.
                 recv_credit.fetch_add(bytes.len() as i64, std::sync::atomic::Ordering::AcqRel);
-                let _ = proxy_tx.send(ServerToProxy::TunnelWindow(TunnelWindowFields {
-                    stream_id,
-                    add_bytes: bytes.len() as u32,
-                }));
+                egress.window(stream_id, bytes.len() as u32);
             }
             Some(TunnelIn::Window(n)) => send_credit.grant(n).await,
             Some(TunnelIn::Opened) => {} // late duplicate; ignore
@@ -360,10 +457,7 @@ async fn run_relay(
 
     uplink.abort();
     streams.remove(&stream_id);
-    let _ = proxy_tx.send(ServerToProxy::TunnelClose(TunnelCloseFields {
-        stream_id,
-        reason: None,
-    }));
+    egress.close(stream_id, None);
     debug!("Backend tunnel stream {} closed", stream_id);
 }
 

--- a/backend/src/handlers/websocket/tunnel_socket.rs
+++ b/backend/src/handlers/websocket/tunnel_socket.rs
@@ -1,0 +1,182 @@
+//! Backend accept path for the dedicated port-forward data plane (#1506).
+//!
+//! This socket carries **only** binary tunnel frames. Keeping it separate from
+//! `/ws/session` is the whole point: forward bytes used to share the control
+//! socket with agent stdio and heartbeats, so a busy preview could delay
+//! heartbeats past the liveness deadline, get the connection evicted, and take
+//! the agent session down with it.
+//!
+//! Consequences of that separation, both deliberate:
+//!
+//! - **This socket is never authoritative for session liveness.** Inbound
+//!   frames stamp a diagnostic timestamp only; the control socket's heartbeat
+//!   remains the sole liveness signal. A saturated data plane must not be able
+//!   to *prove* a session alive any more than it can kill it.
+//! - **Losing it is not a session failure.** On teardown the registry entry is
+//!   dropped and `open_tunnel` silently reverts to the control-socket JSON
+//!   path. Nothing about the agent session changes.
+//!
+//! Auth is the `Hello` ticket (see [`tunnel_ticket`](super::tunnel_ticket)),
+//! which also binds the socket to one control-connection generation.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::ws::WebSocket;
+use shared::{TunnelDataEndpoint, TunnelFrame};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use super::session_manager::DATA_PLANE_CHANNEL_CAPACITY;
+use super::{conn_channel, tunnel_ticket};
+use crate::AppState;
+
+/// How long a freshly connected data socket may take to send its `Hello`.
+/// Short: the proxy sends it as the very first frame, immediately after
+/// connecting. An unauthenticated socket that lingers is dropped rather than
+/// held open.
+const HELLO_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub async fn handle_tunnel_data_socket(socket: WebSocket, app_state: Arc<AppState>) {
+    let conn = ws_bridge::server::into_connection::<TunnelDataEndpoint>(socket);
+    let (mut ws_sender, mut ws_receiver) = conn.split();
+
+    // First frame must be the ticket. Nothing is registered — and no frames are
+    // routed — until it verifies.
+    let hello = match tokio::time::timeout(HELLO_TIMEOUT, ws_receiver.recv()).await {
+        Ok(Some(Ok(TunnelFrame::Hello { ticket }))) => ticket,
+        Ok(Some(Ok(other))) => {
+            warn!(
+                "Data-plane socket sent {:?} before Hello; closing",
+                std::mem::discriminant(&other)
+            );
+            return;
+        }
+        Ok(Some(Err(e))) => {
+            debug!("Data-plane socket failed to decode its first frame: {}", e);
+            return;
+        }
+        Ok(None) => {
+            debug!("Data-plane socket closed before Hello");
+            return;
+        }
+        Err(_) => {
+            debug!("Data-plane socket did not send Hello within the timeout");
+            return;
+        }
+    };
+
+    let Some(ticket) = tunnel_ticket::verify(&app_state.jwt_secret, &hello) else {
+        warn!("Rejecting data-plane socket: invalid or expired ticket");
+        return;
+    };
+
+    let session_manager = &app_state.session_manager;
+    let (tx, mut rx) = conn_channel::<TunnelFrame>(DATA_PLANE_CHANNEL_CAPACITY);
+    let cancel = CancellationToken::new();
+
+    // Generation-guarded: refuses a ticket replayed from a connection that has
+    // since been superseded, and a socket that finished connecting only after
+    // its control connection was replaced.
+    if !session_manager.register_data_plane(
+        ticket.session_key.clone(),
+        ticket.gen,
+        tx,
+        cancel.clone(),
+    ) {
+        warn!(
+            "Rejecting data-plane socket for session {} (gen={}): control connection is gone or superseded",
+            ticket.session_key, ticket.gen
+        );
+        return;
+    }
+
+    // Outbound: drain the registry channel onto the socket.
+    let send_cancel = cancel.clone();
+    let send_task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = send_cancel.cancelled() => break,
+                frame = rx.recv() => match frame {
+                    Some(frame) => {
+                        if ws_sender.send(frame).await.is_err() {
+                            break;
+                        }
+                    }
+                    None => break,
+                },
+            }
+        }
+        let _ = ws_sender.close().await;
+    });
+
+    info!(
+        "Data plane connected for session {} (gen={})",
+        ticket.session_key, ticket.gen
+    );
+
+    // Inbound: route tunnel frames into their streams' relays.
+    loop {
+        let frame = tokio::select! {
+            _ = cancel.cancelled() => break,
+            frame = ws_receiver.recv() => frame,
+        };
+        match frame {
+            Some(Ok(frame)) => {
+                // Diagnostics only — see the module note on liveness.
+                session_manager.touch_data_plane(&ticket.session_key);
+                if !route_inbound(&app_state, frame) {
+                    break;
+                }
+            }
+            Some(Err(e)) => {
+                debug!(
+                    "Data-plane decode error for session {}: {}",
+                    ticket.session_key, e
+                );
+                break;
+            }
+            None => break,
+        }
+    }
+
+    // Teardown is generation-guarded so a stale socket cannot evict its
+    // successor. Dropping the entry reverts `open_tunnel` to the control-socket
+    // path; the session itself is unaffected.
+    session_manager.unregister_data_plane(&ticket.session_key, ticket.gen);
+    cancel.cancel();
+    let _ = send_task.await;
+    info!(
+        "Data plane disconnected for session {} (gen={})",
+        ticket.session_key, ticket.gen
+    );
+}
+
+/// Feed one inbound frame to its stream. Returns `false` to close the socket.
+fn route_inbound(app_state: &AppState, frame: TunnelFrame) -> bool {
+    use super::TunnelIn;
+    let manager = &app_state.session_manager;
+    match frame {
+        TunnelFrame::Opened { stream_id } => manager.tunnel_in(stream_id, TunnelIn::Opened),
+        TunnelFrame::Refused { stream_id, reason } => {
+            manager.tunnel_in(stream_id, TunnelIn::Refused(reason))
+        }
+        TunnelFrame::Data { stream_id, bytes } => manager.tunnel_bytes_in(stream_id, bytes),
+        TunnelFrame::Window {
+            stream_id,
+            add_bytes,
+        } => manager.tunnel_in(stream_id, TunnelIn::Window(add_bytes)),
+        TunnelFrame::Close { stream_id, .. } => manager.tunnel_in(stream_id, TunnelIn::Close),
+        // Server→proxy only; a proxy sending these is confused.
+        TunnelFrame::Open { .. } => {
+            warn!("Data plane received a server-only Open frame; closing");
+            return false;
+        }
+        // A second Hello is protocol misuse: the socket is already bound.
+        TunnelFrame::Hello { .. } => {
+            warn!("Data plane sent a duplicate Hello; closing");
+            return false;
+        }
+    }
+    true
+}

--- a/backend/src/handlers/websocket/tunnel_ticket.rs
+++ b/backend/src/handlers/websocket/tunnel_ticket.rs
@@ -1,0 +1,216 @@
+//! Credential binding a port-forward data-plane socket to one session *and one
+//! control-connection generation* (#1506).
+//!
+//! The `/ws/session/data` upgrade cannot be authenticated the way `/ws/session`
+//! is: the control socket authenticates via the proxy JWT inside its `Register`
+//! message body, but the data plane speaks binary frames and has no such
+//! message. It also needs something the control socket never did — proof of
+//! *which connection generation* it belongs to, so a data socket opened by a
+//! reconnecting proxy can never be wired to the session's previous connection
+//! (or vice versa).
+//!
+//! One short-lived JWT solves both. The backend mints it during a successful
+//! `Register` (where the generation is already known) and returns it in
+//! `RegisterAck`; the proxy echoes it back as the data plane's first frame
+//! (`TunnelFrame::Hello`). Because the generation is a *claim*, the binding is
+//! established by verification rather than by a racy after-the-fact lookup.
+//!
+//! It rides in the frame body rather than a query parameter so it never reaches
+//! access logs or `Referer` headers, and the TTL is short because the proxy
+//! dials immediately after registering — a leaked ticket is useless within
+//! seconds, and it authorizes only tunnel bytes for one already-forwarded
+//! session, never session input.
+
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Audience claim — distinct from every other portal token audience so a token
+/// minted elsewhere with the same secret cannot authenticate a data socket.
+const AUD_TUNNEL_DATA: &str = "portal-tunnel-data";
+
+/// Ticket lifetime. The proxy dials the data plane immediately on receiving its
+/// `RegisterAck`, so this only has to cover one connect.
+const TICKET_TTL_SECS: i64 = 120;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TicketClaims {
+    aud: String,
+    /// Session this data socket may carry tunnel bytes for.
+    session_id: Uuid,
+    /// Session key (the proxy's session UUID string) used as the registry key.
+    session_key: String,
+    /// Control-connection generation this data socket is bound to.
+    gen: u64,
+    exp: i64,
+    iat: i64,
+}
+
+/// What a verified ticket authorizes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TunnelTicket {
+    pub session_id: Uuid,
+    pub session_key: String,
+    pub gen: u64,
+}
+
+/// Mint a data-plane ticket for `(session_id, session_key, gen)`.
+pub fn mint(
+    jwt_secret: &str,
+    session_id: Uuid,
+    session_key: &str,
+    gen: u64,
+    now: i64,
+) -> Option<String> {
+    let claims = TicketClaims {
+        aud: AUD_TUNNEL_DATA.to_string(),
+        session_id,
+        session_key: session_key.to_string(),
+        gen,
+        exp: now + TICKET_TTL_SECS,
+        iat: now,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(jwt_secret.as_bytes()),
+    )
+    .ok()
+}
+
+/// Verify a data-plane ticket, returning what it authorizes.
+///
+/// Requires both `exp` and `aud`: `set_audience` alone only checks `aud` *when
+/// present*, so without `set_required_spec_claims` a token minted for some other
+/// purpose with the same secret but no audience would pass this boundary. Same
+/// hardening as the forward-origin cookie check in `forward_proxy.rs`.
+pub fn verify(jwt_secret: &str, token: &str) -> Option<TunnelTicket> {
+    let mut validation = Validation::default();
+    validation.set_audience(&[AUD_TUNNEL_DATA]);
+    validation.set_required_spec_claims(&["exp", "aud"]);
+    let data = decode::<TicketClaims>(
+        token,
+        &DecodingKey::from_secret(jwt_secret.as_bytes()),
+        &validation,
+    )
+    .ok()?;
+    Some(TunnelTicket {
+        session_id: data.claims.session_id,
+        session_key: data.claims.session_key,
+        gen: data.claims.gen,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "test-secret-value-at-least-32-bytes-long";
+
+    fn now() -> i64 {
+        chrono::Utc::now().timestamp()
+    }
+
+    #[test]
+    fn roundtrips_session_key_and_generation() {
+        let sid = Uuid::new_v4();
+        let token = mint(SECRET, sid, "session-key", 42, now()).expect("mint");
+        assert_eq!(
+            verify(SECRET, &token),
+            Some(TunnelTicket {
+                session_id: sid,
+                session_key: "session-key".to_string(),
+                gen: 42,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_secret() {
+        let token = mint(SECRET, Uuid::new_v4(), "k", 1, now()).expect("mint");
+        assert!(verify("a-different-secret-at-least-32-bytes!!", &token).is_none());
+    }
+
+    /// Well past expiry. `jsonwebtoken`'s default validation allows 60s of
+    /// clock-skew leeway, which we keep (proxy and backend clocks drift), so the
+    /// skew here is comfortably beyond it rather than borderline.
+    #[test]
+    fn rejects_expired_ticket() {
+        let stale = now() - TICKET_TTL_SECS - 3600;
+        let token = mint(SECRET, Uuid::new_v4(), "k", 1, stale).expect("mint");
+        assert!(verify(SECRET, &token).is_none());
+    }
+
+    #[test]
+    fn rejects_garbage_and_empty() {
+        assert!(verify(SECRET, "").is_none());
+        assert!(verify(SECRET, "not.a.jwt").is_none());
+    }
+
+    /// A token signed with the same secret for a *different* audience (or none)
+    /// must not open a data socket — this is the boundary `forward_proxy.rs`
+    /// learned to require explicitly.
+    #[test]
+    fn rejects_other_audience_and_missing_audience() {
+        #[derive(Serialize)]
+        struct Other {
+            aud: &'static str,
+            session_id: Uuid,
+            session_key: &'static str,
+            gen: u64,
+            exp: i64,
+            iat: i64,
+        }
+        #[derive(Serialize)]
+        struct NoAud {
+            session_id: Uuid,
+            session_key: &'static str,
+            gen: u64,
+            exp: i64,
+            iat: i64,
+        }
+        let key = EncodingKey::from_secret(SECRET.as_bytes());
+        let (exp, iat) = (now() + 60, now());
+
+        let wrong_aud = encode(
+            &Header::default(),
+            &Other {
+                aud: "portal-forward-session",
+                session_id: Uuid::nil(),
+                session_key: "k",
+                gen: 1,
+                exp,
+                iat,
+            },
+            &key,
+        )
+        .unwrap();
+        assert!(verify(SECRET, &wrong_aud).is_none());
+
+        let no_aud = encode(
+            &Header::default(),
+            &NoAud {
+                session_id: Uuid::nil(),
+                session_key: "k",
+                gen: 1,
+                exp,
+                iat,
+            },
+            &key,
+        )
+        .unwrap();
+        assert!(verify(SECRET, &no_aud).is_none());
+    }
+
+    /// The generation is what stops a ticket from a *previous* connection being
+    /// replayed onto a reconnect: two registrations mint distinguishable
+    /// tickets, and the caller compares `gen` against the live connection.
+    #[test]
+    fn generation_distinguishes_successive_connections() {
+        let sid = Uuid::new_v4();
+        let first = mint(SECRET, sid, "k", 7, now()).expect("mint");
+        let second = mint(SECRET, sid, "k", 8, now()).expect("mint");
+        assert_eq!(verify(SECRET, &first).unwrap().gen, 7);
+        assert_eq!(verify(SECRET, &second).unwrap().gen, 8);
+    }
+}

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -323,6 +323,10 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             get(handlers::websocket::handle_session_websocket),
         )
         .route(
+            shared::TunnelDataEndpoint::PATH,
+            get(handlers::websocket::handle_tunnel_data_websocket),
+        )
+        .route(
             shared::ClientEndpoint::PATH,
             get(handlers::websocket::handle_web_client_websocket),
         )

--- a/backend/tests/harness.rs
+++ b/backend/tests/harness.rs
@@ -91,6 +91,7 @@ fn test_register_fields() -> RegisterFields {
         repo_url: None,
         scheduled_task_id: None,
         claude_args: vec![],
+        capabilities: Vec::new(),
     }
 }
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -658,6 +658,10 @@ pub async fn register_session(
         repo_url: get_repo_url(&config.working_directory),
         scheduled_task_id: config.scheduled_task_id,
         claude_args: config.claude_args.clone(),
+        // The binary port-forward data plane is advertised in a follow-up
+        // change (#1506); until the proxy can dial it, claiming support would
+        // make the backend mint a ticket nothing uses.
+        capabilities: Vec::new(),
     });
 
     if conn.send(register_msg).await.is_err() {
@@ -678,6 +682,9 @@ pub async fn register_session(
                     // was replaced by `agent-portal show` (see output_forwarder).
                     max_image_mb: _,
                     retryable,
+                    // Data-plane ticket (#1506): ignored until this proxy
+                    // advertises the capability and dials the data socket.
+                    tunnel_data_ticket: _,
                 }) => {
                     return Some((success, error, retryable));
                 }

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -96,6 +96,8 @@ pub fn connect_websocket(
                     repo_url: None,
                     scheduled_task_id: None,
                     claude_args: Vec::new(),
+                    // Web clients do not carry proxy protocol capabilities (#1506).
+                    capabilities: Vec::new(),
                 });
 
                 if sender.send(register_msg).await.is_err() {

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -44,6 +44,41 @@ mod tests {
         assert_eq!(back, SessionExitReason::CrashedEarly);
     }
 
+    /// Wire compat for the capability/ticket plumbing (#1506): an older proxy
+    /// sends no `capabilities`, and an older backend sends no
+    /// `tunnel_data_ticket`. Both must parse as "feature absent" rather than
+    /// failing the frame and wedging registration.
+    #[test]
+    fn tunnel_data_plane_fields_default_for_older_peers() {
+        let legacy_register = r#"{"type":"Register","session_id":"00000000-0000-0000-0000-000000000000","session_name":"s","auth_token":null,"working_directory":"/tmp"}"#;
+        match serde_json::from_str::<ProxyToServer>(legacy_register).unwrap() {
+            ProxyToServer::Register(reg) => assert!(reg.capabilities.is_empty()),
+            _ => panic!("expected Register"),
+        }
+
+        let legacy_ack = r#"{"type":"RegisterAck","success":true,"session_id":"00000000-0000-0000-0000-000000000000","max_image_mb":10}"#;
+        match serde_json::from_str::<ServerToProxy>(legacy_ack).unwrap() {
+            ServerToProxy::RegisterAck {
+                tunnel_data_ticket, ..
+            } => assert!(tunnel_data_ticket.is_none()),
+            _ => panic!("expected RegisterAck"),
+        }
+
+        // And the ticket is omitted from the wire entirely when absent, so an
+        // older proxy sees a byte-identical ack to what it got before.
+        let ack = ServerToProxy::RegisterAck {
+            success: true,
+            session_id: Uuid::nil(),
+            error: None,
+            max_image_mb: 10,
+            retryable: false,
+            tunnel_data_ticket: None,
+        };
+        assert!(!serde_json::to_string(&ack)
+            .unwrap()
+            .contains("tunnel_data_ticket"));
+    }
+
     #[test]
     fn client_endpoint_path() {
         assert_eq!(ClientEndpoint::PATH, "/ws/client");
@@ -72,6 +107,7 @@ mod tests {
             repo_url: None,
             scheduled_task_id: None,
             claude_args: Vec::new(),
+            capabilities: Vec::new(),
         });
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"Register""#));

--- a/shared/src/endpoints/session.rs
+++ b/shared/src/endpoints/session.rs
@@ -210,6 +210,20 @@ pub enum ServerToProxy {
         /// backends keep today's fatal semantics. #1264.
         #[serde(default)]
         retryable: bool,
+        /// Short-TTL credential authorizing this proxy to open the binary
+        /// data-plane socket ([`TunnelDataEndpoint`](crate::TunnelDataEndpoint))
+        /// for port forwarding (#1506).
+        ///
+        /// Present only when the proxy advertised
+        /// [`PROXY_CAPABILITY_TUNNEL_BINARY_V1`](crate::PROXY_CAPABILITY_TUNNEL_BINARY_V1)
+        /// and registration succeeded. The ticket is bound to this session *and
+        /// this connection's generation*, so it cannot be replayed onto a later
+        /// reconnect — that binding is what keeps the two sockets from crossing
+        /// wires when a proxy reconnects. `None` (older backend, or capability
+        /// not advertised) simply means tunnel bytes keep riding the control
+        /// socket as before.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tunnel_data_ticket: Option<String>,
     },
 
     /// Keepalive heartbeat

--- a/shared/src/endpoints/types.rs
+++ b/shared/src/endpoints/types.rs
@@ -93,6 +93,16 @@ pub struct RegisterFields {
     pub scheduled_task_id: Option<Uuid>,
     #[serde(default)]
     pub claude_args: Vec<String>,
+    /// Optional protocol features this client supports, mirroring the launcher
+    /// capability model (`crate::PROXY_CAPABILITY_*`). Defaults to empty, so an
+    /// older proxy — which sends no capabilities — is simply treated as
+    /// supporting none and keeps the pre-existing behavior.
+    ///
+    /// Before this, the session socket had no capability mechanism at all: new
+    /// frames relied purely on `#[serde(default)]` tolerance, which cannot
+    /// express "this peer can receive a frame shape it never used to get".
+    #[serde(default)]
+    pub capabilities: Vec<String>,
 }
 
 /// Core scheduled-task fields shared by `ScheduledTaskConfig`,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -27,6 +27,15 @@ pub const LAUNCHER_CAPABILITY_RESTART: &str = "launcher.restart";
 /// undecodable frame (#1366).
 pub const LAUNCHER_CAPABILITY_HEARTBEAT_ACK: &str = "launcher.heartbeat_ack";
 
+/// Proxy capability advertised by versions that can open the dedicated binary
+/// data-plane socket for port forwarding (#1506).
+///
+/// The backend mints a `RegisterAck.tunnel_data_ticket` only for proxies that
+/// advertise this, and routes tunnel bytes over the data plane only while such
+/// a socket is registered — so a proxy that never advertises it (or whose data
+/// socket has dropped) transparently keeps the JSON-over-control-socket path.
+pub const PROXY_CAPABILITY_TUNNEL_BINARY_V1: &str = "session.tunnel_binary_v1";
+
 /// Split [`VERSION`] into `(major, minor, patch)` numeric components.
 /// `None` on the (impossible-by-construction) malformed string.
 pub fn version_parts() -> Option<(u64, u64, u64)> {


### PR DESCRIPTION
PR 2 of 4 for #1506. **Dormant** — no proxy advertises the capability yet, so nothing dials this and every forward still takes the existing path. PR 3 turns it on.

## What

The backend half: `/ws/session/data` accept path, a generation-guarded data-plane registry, ticket mint/verify, and per-stream transport selection in `open_tunnel`.

## Auth and generation binding

The data plane speaks binary frames, so it has no `Register` message to carry the proxy JWT — and it needs something the control socket never did: proof of *which control-connection generation* it belongs to, so a reconnecting proxy's data socket can't be wired to the session's previous connection.

One short-TTL JWT (`aud=portal-tunnel-data`, claims `session_id`/`session_key`/`gen`) solves both. Minted during a successful `Register` (where the generation is already known), returned in `RegisterAck`, echoed back as the socket's first frame (`TunnelFrame::Hello`). Because the generation is a *claim*, the binding is established by verification rather than a racy after-the-fact lookup. It rides in the frame body, not a query param, so it never reaches access logs or `Referer`.

## Safe rollout

- A ticket is minted **only** for proxies advertising `session.tunnel_binary_v1` — a new `capabilities: Vec<String>` on `RegisterFields` (defaults empty), mirroring the launcher capability model the session socket never had.
- `open_tunnel` selects transport **per stream**: binary if this exact connection has a live data plane, else the existing JSON-over-control path, untouched. So a proxy without the capability, one whose data socket dropped, and one mid-connect all degrade transparently with no coordination.
- Wire compat verified both directions: an older proxy's `Register` (no `capabilities`) and an older backend's `RegisterAck` (no ticket) both parse as "feature absent", and the ticket is omitted from the wire when `None` so old proxies see a byte-identical ack.

## Lifecycle

Every registry mutation is generation-guarded, same reason `proxy_lifecycle` is. Control-socket teardown reaps its data plane (otherwise a later `open_tunnel` could route into a socket whose session is gone). The reverse is deliberately asymmetric: a data socket dropping only reverts tunneling to the control path and never disturbs the session, and its inbound frames stamp a **diagnostic-only** timestamp — the control heartbeat stays the sole liveness authority, so a saturated data plane can neither kill a session nor falsely prove one alive.

## Two bugs the tests caught

1. **`is_current_connection` is the wrong guard.** It returns `true` for a session with *no* registered proxy — correct for its teardown-staleness question, wrong as authorization. Using it would have let a ticket replayed after the proxy fully disconnected register a data plane attached to nothing. Now uses `current_connection_gen(..) == Some(gen)` for positive proof, with a comment so it isn't "simplified" back.
2. **`jsonwebtoken` allows 60s of clock-skew leeway by default.** Worth keeping (proxy/backend clocks drift), but my first expiry test sat exactly on the boundary and passed. Test now uses a clearly-expired token.

## Notes

`tunnel_data_in` (base64) and the new `tunnel_bytes_in` (binary) share one ingest path, so the oversize and receive-window checks — which are what actually bound buffered bytes against a hostile peer — cannot drift between transports.

Full workspace builds, `cargo test --workspace` green, clippy clean, `shared` still builds for `wasm32-unknown-unknown`. 15 new unit tests across the registry (generation guards, replay refusal, displacement, teardown asymmetry) and the ticket (audience hardening, expiry, wrong secret, generation distinctness).