### PR TITLE
Negotiate a larger v2 tunnel sizing profile

### DIFF
--- a/backend/src/handlers/websocket/mod.rs
+++ b/backend/src/handlers/websocket/mod.rs
@@ -28,12 +28,14 @@ pub(crate) fn mint_tunnel_ticket(
     session_id: uuid::Uuid,
     session_key: &str,
     gen: u64,
+    sizing: shared::TunnelSizing,
 ) -> Option<String> {
     tunnel_ticket::mint(
         jwt_secret,
         session_id,
         session_key,
         gen,
+        sizing,
         chrono::Utc::now().timestamp(),
     )
 }

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -242,7 +242,11 @@ fn handle_proxy_message(
             // capability. Bound to this connection's generation (known only
             // after `register_session` below), so it cannot be replayed onto a
             // later reconnect. `None` ⇒ tunnel bytes keep riding this socket.
+            // The negotiated sizing rides with it: reported in the ack so the
+            // proxy configures its tunnel, and embedded in the ticket so the
+            // data-socket registration knows it too (#1511).
             let mut tunnel_data_ticket = None;
+            let mut tunnel_sizing = None;
 
             if result.success {
                 // Only now do we expose the socket via SessionManager and
@@ -256,12 +260,16 @@ fn handle_proxy_message(
                     .iter()
                     .any(|c| c == shared::PROXY_CAPABILITY_TUNNEL_BINARY_V1)
                 {
+                    let sizing = shared::TunnelSizing::negotiate(&capabilities);
                     tunnel_data_ticket = crate::handlers::websocket::mint_tunnel_ticket(
                         &app_state.jwt_secret,
                         claude_session_id,
                         &key,
                         gen,
+                        sizing,
                     );
+                    // Only report sizing alongside a ticket the proxy can act on.
+                    tunnel_sizing = tunnel_data_ticket.as_ref().map(|_| sizing);
                 }
                 *session_key = Some(key);
                 *connection_gen = Some(gen);
@@ -278,6 +286,7 @@ fn handle_proxy_message(
                 max_image_mb: app_state.max_image_mb,
                 retryable: result.retryable,
                 tunnel_data_ticket,
+                tunnel_sizing,
             });
 
             info!(

--- a/backend/src/handlers/websocket/session_manager/data_plane.rs
+++ b/backend/src/handlers/websocket/session_manager/data_plane.rs
@@ -39,6 +39,9 @@ pub struct DataPlaneConnection {
     /// Generation of the *control* connection this socket serves. Frames are
     /// only routed here while this matches the live control connection.
     pub gen: u64,
+    /// Tunnel sizing negotiated for this connection (#1511); streams opened over
+    /// this data plane are configured to it.
+    pub sizing: shared::TunnelSizing,
     /// Fired to force this socket's task to close (mirrors `ProxyConnection`).
     pub cancel: CancellationToken,
     /// Epoch seconds of the last inbound frame, for diagnostics.
@@ -56,6 +59,7 @@ impl SessionManager {
         &self,
         session_key: SessionId,
         gen: u64,
+        sizing: shared::TunnelSizing,
         sender: DataPlaneSender,
         cancel: CancellationToken,
     ) -> bool {
@@ -81,6 +85,7 @@ impl SessionManager {
             DataPlaneConnection {
                 sender,
                 gen,
+                sizing,
                 cancel,
                 last_seen: AtomicU64::new(super::liveness::epoch_secs()),
             },
@@ -127,11 +132,18 @@ impl SessionManager {
         }
     }
 
-    /// Sender for the live data plane of `(session_key, gen)`, if one is
-    /// registered. `None` means "use the control-socket JSON path".
-    pub fn data_plane_sender(&self, session_key: &str, gen: u64) -> Option<DataPlaneSender> {
+    /// Sender and negotiated sizing for the live data plane of
+    /// `(session_key, gen)`, if one is registered. `None` means "use the
+    /// control-socket JSON path". The sizing is returned alongside the sender so
+    /// `open_tunnel` configures the stream from the same lookup that chose the
+    /// transport, with no second map access to race.
+    pub fn data_plane_egress(
+        &self,
+        session_key: &str,
+        gen: u64,
+    ) -> Option<(DataPlaneSender, shared::TunnelSizing)> {
         let conn = self.data_planes.get(session_key)?;
-        (conn.gen == gen).then(|| conn.sender.clone())
+        (conn.gen == gen).then(|| (conn.sender.clone(), conn.sizing))
     }
 
     /// Stamp liveness for a data-plane socket (diagnostics only — the control
@@ -179,19 +191,37 @@ mod tests {
         let gen = register_control(&mgr, "s1");
 
         let (tx, _rx) = data_sender();
-        assert!(mgr.register_data_plane("s1".into(), gen, tx, CancellationToken::new()));
+        assert!(mgr.register_data_plane(
+            "s1".into(),
+            gen,
+            shared::TunnelSizing::V1,
+            tx,
+            CancellationToken::new()
+        ));
         assert!(mgr.has_data_plane("s1", gen));
 
         // A stale generation is refused outright.
         let (tx, _rx) = data_sender();
-        assert!(!mgr.register_data_plane("s1".into(), gen - 1, tx, CancellationToken::new()));
+        assert!(!mgr.register_data_plane(
+            "s1".into(),
+            gen - 1,
+            shared::TunnelSizing::V1,
+            tx,
+            CancellationToken::new()
+        ));
     }
 
     #[test]
     fn rejects_data_plane_for_unknown_session() {
         let mgr = SessionManager::new();
         let (tx, _rx) = data_sender();
-        assert!(!mgr.register_data_plane("nope".into(), 1, tx, CancellationToken::new()));
+        assert!(!mgr.register_data_plane(
+            "nope".into(),
+            1,
+            shared::TunnelSizing::V1,
+            tx,
+            CancellationToken::new()
+        ));
         assert!(!mgr.has_data_plane("nope", 1));
     }
 
@@ -205,10 +235,22 @@ mod tests {
         assert_ne!(old_gen, new_gen);
 
         let (tx, _rx) = data_sender();
-        assert!(!mgr.register_data_plane("s1".into(), old_gen, tx, CancellationToken::new()));
+        assert!(!mgr.register_data_plane(
+            "s1".into(),
+            old_gen,
+            shared::TunnelSizing::V1,
+            tx,
+            CancellationToken::new()
+        ));
 
         let (tx, _rx) = data_sender();
-        assert!(mgr.register_data_plane("s1".into(), new_gen, tx, CancellationToken::new()));
+        assert!(mgr.register_data_plane(
+            "s1".into(),
+            new_gen,
+            shared::TunnelSizing::V1,
+            tx,
+            CancellationToken::new()
+        ));
         assert!(mgr.has_data_plane("s1", new_gen));
         assert!(!mgr.has_data_plane("s1", old_gen));
     }
@@ -218,7 +260,13 @@ mod tests {
         let mgr = SessionManager::new();
         let gen = register_control(&mgr, "s1");
         let (tx, _rx) = data_sender();
-        mgr.register_data_plane("s1".into(), gen, tx, CancellationToken::new());
+        mgr.register_data_plane(
+            "s1".into(),
+            gen,
+            shared::TunnelSizing::V1,
+            tx,
+            CancellationToken::new(),
+        );
 
         // A late teardown from an older generation is a no-op.
         mgr.unregister_data_plane(&"s1".to_string(), gen - 1);
@@ -235,10 +283,22 @@ mod tests {
 
         let first_cancel = CancellationToken::new();
         let (tx, _rx) = data_sender();
-        mgr.register_data_plane("s1".into(), gen, tx, first_cancel.clone());
+        mgr.register_data_plane(
+            "s1".into(),
+            gen,
+            shared::TunnelSizing::V1,
+            tx,
+            first_cancel.clone(),
+        );
 
         let (tx, _rx) = data_sender();
-        mgr.register_data_plane("s1".into(), gen, tx, CancellationToken::new());
+        mgr.register_data_plane(
+            "s1".into(),
+            gen,
+            shared::TunnelSizing::V1,
+            tx,
+            CancellationToken::new(),
+        );
 
         assert!(
             first_cancel.is_cancelled(),
@@ -252,13 +312,19 @@ mod tests {
         let mgr = SessionManager::new();
         let gen = register_control(&mgr, "s1");
         let (tx, _rx) = data_sender();
-        mgr.register_data_plane("s1".into(), gen, tx, CancellationToken::new());
+        mgr.register_data_plane(
+            "s1".into(),
+            gen,
+            shared::TunnelSizing::V1,
+            tx,
+            CancellationToken::new(),
+        );
 
-        assert!(mgr.data_plane_sender("s1", gen).is_some());
+        assert!(mgr.data_plane_egress("s1", gen).is_some());
         // Falling back to the control path is the correct answer for any other
         // generation, and for a session with no data plane at all.
-        assert!(mgr.data_plane_sender("s1", gen + 1).is_none());
-        assert!(mgr.data_plane_sender("other", gen).is_none());
+        assert!(mgr.data_plane_egress("s1", gen + 1).is_none());
+        assert!(mgr.data_plane_egress("other", gen).is_none());
     }
 
     #[test]
@@ -267,7 +333,13 @@ mod tests {
         let gen = register_control(&mgr, "s1");
         let cancel = CancellationToken::new();
         let (tx, _rx) = data_sender();
-        mgr.register_data_plane("s1".into(), gen, tx, cancel.clone());
+        mgr.register_data_plane(
+            "s1".into(),
+            gen,
+            shared::TunnelSizing::V1,
+            tx,
+            cancel.clone(),
+        );
 
         mgr.close_data_plane_for_connection(&"s1".to_string(), gen);
 
@@ -285,7 +357,13 @@ mod tests {
 
         let cancel = CancellationToken::new();
         let (tx, _rx) = data_sender();
-        mgr.register_data_plane("s1".into(), new_gen, tx, cancel.clone());
+        mgr.register_data_plane(
+            "s1".into(),
+            new_gen,
+            shared::TunnelSizing::V1,
+            tx,
+            cancel.clone(),
+        );
 
         mgr.close_data_plane_for_connection(&"s1".to_string(), old_gen);
 

--- a/backend/src/handlers/websocket/session_manager/tunnel_client.rs
+++ b/backend/src/handlers/websocket/session_manager/tunnel_client.rs
@@ -6,12 +6,15 @@
 //! the tunnel frames. The reverse-proxy handler hands the other end to a
 //! hyper HTTP/1.1 client — hyper never knows it isn't a TCP socket.
 //!
-//! Flow control mirrors the proxy side (`session_lib::tunnel`): a 64 KiB
-//! credit per direction, ≤16 KiB `TunnelData` frames, window re-granted as
-//! bytes drain into the pipe. The outgoing path is the session's unbounded
-//! `ProxySender`, so per-stream credit is what bounds queued tunnel bytes:
-//! at most `MAX_STREAMS × INITIAL_WINDOW` per session in the pathological
-//! case, in practice one window per active stream.
+//! Flow control mirrors the proxy side (`session_lib::tunnel`): a per-stream
+//! credit per direction and a max frame size, window re-granted as bytes drain
+//! into the pipe. Both come from the connection's negotiated
+//! [`shared::TunnelSizing`] (#1511) rather than a fixed constant — the sender
+//! and receiver of a stream must agree, so the values are chosen once per
+//! connection and carried on the stream. The outgoing path is the session's
+//! unbounded `ProxySender`, so per-stream credit is what bounds queued tunnel
+//! bytes: at most `MAX_STREAMS × window` per session in the pathological case,
+//! in practice one window per active stream.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -29,18 +32,6 @@ use uuid::Uuid;
 
 use super::{ProxySender, SessionManager};
 
-/// Max decoded bytes per payload frame (spec).
-///
-/// **Both ends must agree.** The sender chunks to this and the receiver closes
-/// any stream that exceeds it, so raising it on one side alone makes a
-/// build-skewed peer tear down every stream mid-deploy. `session.tunnel_binary_v1`
-/// already means "16 KiB chunks", so a larger frame size needs a negotiated
-/// protocol bump, not an edit here.
-pub const MAX_CHUNK: usize = 16 * 1024;
-/// Initial per-stream, per-direction flow-control window. Must match the proxy
-/// side (`session_lib::tunnel::INITIAL_WINDOW`) — both ends seed their credit
-/// from it.
-pub const INITIAL_WINDOW: u32 = 64 * 1024;
 /// How long to wait for the proxy's `TunnelOpened`/`TunnelRefused`.
 const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// Duplex pipe capacity between the relay and hyper.
@@ -66,11 +57,15 @@ pub enum TunnelIn {
 
 /// One live backend stream: the relay inbox plus receive-credit enforcement
 /// (mirrors the proxy side — the inbox is unbounded, so the credit book, not
-/// the channel, bounds buffered downlink bytes to [`INITIAL_WINDOW`] even
+/// the channel, bounds buffered downlink bytes to the negotiated window even
 /// against a buggy peer).
 pub(super) struct BackendStreamEntry {
     inbox: mpsc::UnboundedSender<TunnelIn>,
     recv_credit: Arc<std::sync::atomic::AtomicI64>,
+    /// Negotiated max frame size for this stream (#1511). Stored per stream so
+    /// the receive-side oversize check uses the value this connection agreed on,
+    /// not a global constant, keeping it correct if profiles ever differ.
+    max_chunk: usize,
     /// The connection this stream was opened on. Its relay task holds a clone
     /// of that connection's `ProxySender`, so when the connection tears down
     /// we must close the stream (dropping the clone) — otherwise the session
@@ -218,15 +213,18 @@ impl SessionManager {
     /// The credit book — not the channel — is what bounds buffered downlink
     /// bytes, so this check is load-bearing against a buggy or hostile peer.
     pub fn tunnel_bytes_in(&self, stream_id: Uuid, bytes: Vec<u8>) {
-        let entry = self
-            .tunnel_streams
-            .get(&stream_id)
-            .map(|e| (e.value().inbox.clone(), e.value().recv_credit.clone()));
-        let Some((inbox, recv_credit)) = entry else {
+        let entry = self.tunnel_streams.get(&stream_id).map(|e| {
+            (
+                e.value().inbox.clone(),
+                e.value().recv_credit.clone(),
+                e.value().max_chunk,
+            )
+        });
+        let Some((inbox, recv_credit, max_chunk)) = entry else {
             debug!("Tunnel payload for unknown stream {} dropped", stream_id);
             return;
         };
-        if bytes.len() > MAX_CHUNK {
+        if bytes.len() > max_chunk {
             tracing::warn!(
                 "Oversized tunnel payload ({} bytes) for stream {}; closing",
                 bytes.len(),
@@ -304,20 +302,28 @@ impl SessionManager {
         // Prefer the dedicated binary data plane when this exact connection has
         // one registered; otherwise fall back to JSON over the control socket.
         // Resolved per stream, so a data socket that appears or drops mid-session
-        // is picked up (or degraded away from) without any coordination.
-        let egress = match self.data_plane_sender(session_key, gen) {
-            Some(tx) => TunnelEgress::Binary(tx),
-            None => TunnelEgress::Control(proxy_tx.clone()),
+        // is picked up (or degraded away from) without any coordination. The
+        // data plane carries its negotiated sizing; the control fallback is
+        // always V1, which is exactly what a pre-#1511 proxy on that path uses.
+        let (egress, sizing) = match self.data_plane_egress(session_key, gen) {
+            Some((tx, sizing)) => (TunnelEgress::Binary(tx), sizing),
+            None => (
+                TunnelEgress::Control(proxy_tx.clone()),
+                shared::TunnelSizing::V1,
+            ),
         };
 
         let stream_id = Uuid::new_v4();
         let (relay_tx, mut relay_rx) = mpsc::unbounded_channel::<TunnelIn>();
-        let recv_credit = Arc::new(std::sync::atomic::AtomicI64::new(INITIAL_WINDOW as i64));
+        let recv_credit = Arc::new(std::sync::atomic::AtomicI64::new(
+            sizing.initial_window as i64,
+        ));
         self.tunnel_streams.insert(
             stream_id,
             BackendStreamEntry {
                 inbox: relay_tx,
                 recv_credit: recv_credit.clone(),
+                max_chunk: sizing.max_chunk as usize,
                 session_key: session_key.to_string(),
                 gen,
             },
@@ -358,6 +364,7 @@ impl SessionManager {
         tokio::spawn(run_relay(
             stream_id,
             egress,
+            sizing,
             relay_io,
             relay_rx,
             streams,
@@ -414,21 +421,23 @@ impl CreditGate {
 async fn run_relay(
     stream_id: Uuid,
     egress: TunnelEgress,
+    sizing: shared::TunnelSizing,
     relay_io: tokio::io::DuplexStream,
     mut inbox: mpsc::UnboundedReceiver<TunnelIn>,
     streams: TunnelStreamMap,
     recv_credit: Arc<std::sync::atomic::AtomicI64>,
 ) {
     let (mut pipe_rd, mut pipe_wr) = tokio::io::split(relay_io);
-    let send_credit = Arc::new(CreditGate::new(INITIAL_WINDOW));
+    let send_credit = Arc::new(CreditGate::new(sizing.initial_window));
+    let max_chunk = sizing.max_chunk as usize;
 
     // Uplink: bytes hyper writes (requests) → payload frames, credit-gated.
     let uplink_credit = send_credit.clone();
     let uplink_egress = egress.clone();
     let uplink = tokio::spawn(async move {
-        let mut buf = vec![0u8; MAX_CHUNK];
+        let mut buf = vec![0u8; max_chunk];
         loop {
-            let budget = uplink_credit.take(MAX_CHUNK).await;
+            let budget = uplink_credit.take(max_chunk).await;
             let n = match pipe_rd.read(&mut buf[..budget]).await {
                 Ok(0) | Err(_) => break,
                 Ok(n) => n,
@@ -485,7 +494,10 @@ mod tests {
             id,
             BackendStreamEntry {
                 inbox: tx,
-                recv_credit: Arc::new(std::sync::atomic::AtomicI64::new(INITIAL_WINDOW as i64)),
+                recv_credit: Arc::new(std::sync::atomic::AtomicI64::new(
+                    shared::TunnelSizing::V1.initial_window as i64,
+                )),
+                max_chunk: shared::TunnelSizing::V1.max_chunk as usize,
                 session_key: key.to_string(),
                 gen,
             },

--- a/backend/src/handlers/websocket/tunnel_socket.rs
+++ b/backend/src/handlers/websocket/tunnel_socket.rs
@@ -81,6 +81,7 @@ pub async fn handle_tunnel_data_socket(socket: WebSocket, app_state: Arc<AppStat
     if !session_manager.register_data_plane(
         ticket.session_key.clone(),
         ticket.gen,
+        ticket.sizing,
         tx,
         cancel.clone(),
     ) {

--- a/backend/src/handlers/websocket/tunnel_ticket.rs
+++ b/backend/src/handlers/websocket/tunnel_ticket.rs
@@ -42,8 +42,23 @@ struct TicketClaims {
     session_key: String,
     /// Control-connection generation this data socket is bound to.
     gen: u64,
+    /// Negotiated frame size (#1511); defaulted so a ticket minted by an older
+    /// backend still decodes, as V1.
+    #[serde(default = "default_max_chunk")]
+    max_chunk: u32,
+    /// Negotiated flow-control window (#1511); defaulted as V1.
+    #[serde(default = "default_initial_window")]
+    initial_window: u32,
     exp: i64,
     iat: i64,
+}
+
+fn default_max_chunk() -> u32 {
+    shared::TunnelSizing::V1.max_chunk
+}
+
+fn default_initial_window() -> u32 {
+    shared::TunnelSizing::V1.initial_window
 }
 
 /// What a verified ticket authorizes.
@@ -52,6 +67,9 @@ pub struct TunnelTicket {
     pub session_id: Uuid,
     pub session_key: String,
     pub gen: u64,
+    /// Sizing the backend negotiated for this connection; the data socket's
+    /// streams are configured to it.
+    pub sizing: shared::TunnelSizing,
 }
 
 /// Mint a data-plane ticket for `(session_id, session_key, gen)`.
@@ -60,6 +78,7 @@ pub fn mint(
     session_id: Uuid,
     session_key: &str,
     gen: u64,
+    sizing: shared::TunnelSizing,
     now: i64,
 ) -> Option<String> {
     let claims = TicketClaims {
@@ -67,6 +86,8 @@ pub fn mint(
         session_id,
         session_key: session_key.to_string(),
         gen,
+        max_chunk: sizing.max_chunk,
+        initial_window: sizing.initial_window,
         exp: now + TICKET_TTL_SECS,
         iat: now,
     };
@@ -98,6 +119,10 @@ pub fn verify(jwt_secret: &str, token: &str) -> Option<TunnelTicket> {
         session_id: data.claims.session_id,
         session_key: data.claims.session_key,
         gen: data.claims.gen,
+        sizing: shared::TunnelSizing {
+            max_chunk: data.claims.max_chunk,
+            initial_window: data.claims.initial_window,
+        },
     })
 }
 
@@ -114,20 +139,37 @@ mod tests {
     #[test]
     fn roundtrips_session_key_and_generation() {
         let sid = Uuid::new_v4();
-        let token = mint(SECRET, sid, "session-key", 42, now()).expect("mint");
+        let token = mint(
+            SECRET,
+            sid,
+            "session-key",
+            42,
+            shared::TunnelSizing::V2,
+            now(),
+        )
+        .expect("mint");
         assert_eq!(
             verify(SECRET, &token),
             Some(TunnelTicket {
                 session_id: sid,
                 session_key: "session-key".to_string(),
                 gen: 42,
+                sizing: shared::TunnelSizing::V2,
             })
         );
     }
 
     #[test]
     fn rejects_wrong_secret() {
-        let token = mint(SECRET, Uuid::new_v4(), "k", 1, now()).expect("mint");
+        let token = mint(
+            SECRET,
+            Uuid::new_v4(),
+            "k",
+            1,
+            shared::TunnelSizing::V1,
+            now(),
+        )
+        .expect("mint");
         assert!(verify("a-different-secret-at-least-32-bytes!!", &token).is_none());
     }
 
@@ -137,7 +179,15 @@ mod tests {
     #[test]
     fn rejects_expired_ticket() {
         let stale = now() - TICKET_TTL_SECS - 3600;
-        let token = mint(SECRET, Uuid::new_v4(), "k", 1, stale).expect("mint");
+        let token = mint(
+            SECRET,
+            Uuid::new_v4(),
+            "k",
+            1,
+            shared::TunnelSizing::V1,
+            stale,
+        )
+        .expect("mint");
         assert!(verify(SECRET, &token).is_none());
     }
 
@@ -208,8 +258,8 @@ mod tests {
     #[test]
     fn generation_distinguishes_successive_connections() {
         let sid = Uuid::new_v4();
-        let first = mint(SECRET, sid, "k", 7, now()).expect("mint");
-        let second = mint(SECRET, sid, "k", 8, now()).expect("mint");
+        let first = mint(SECRET, sid, "k", 7, shared::TunnelSizing::V1, now()).expect("mint");
+        let second = mint(SECRET, sid, "k", 8, shared::TunnelSizing::V1, now()).expect("mint");
         assert_eq!(verify(SECRET, &first).unwrap().gen, 7);
         assert_eq!(verify(SECRET, &second).unwrap().gen, 8);
     }

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -461,8 +461,8 @@ async fn run_single_connection<A: Agent>(session: &mut SessionState<'_, A>) -> C
 
     // Register with backend and wait for acknowledgment. A ticket in the ack
     // means we may open the binary port-forward data plane (#1506).
-    let tunnel_data_ticket = match register_session(&mut conn, &config_with_branch).await {
-        Ok(ticket) => ticket,
+    let tunnel_data_grant = match register_session(&mut conn, &config_with_branch).await {
+        Ok(grant) => grant,
         Err(RegisterError::Transient(duration)) => return ConnectionResult::Disconnected(duration),
         Err(RegisterError::Rejected) => return ConnectionResult::RegistrationRejected,
     };
@@ -608,7 +608,7 @@ async fn run_single_connection<A: Agent>(session: &mut SessionState<'_, A>) -> C
     }
 
     // Run the message loop - split connection for concurrent read/write
-    run_message_loop(session, &config_with_branch, conn, tunnel_data_ticket).await
+    run_message_loop(session, &config_with_branch, conn, tunnel_data_grant).await
 }
 
 /// Connect to the backend WebSocket
@@ -636,14 +636,15 @@ pub async fn connect_to_backend(
 
 /// Register session with the backend and wait for acknowledgment.
 ///
-/// On success returns the backend's `tunnel_data_ticket` when it issued one
-/// (#1506) — the credential for dialing the binary port-forward data plane.
-/// `None` means no data plane for this connection: an older backend, or one that
-/// declined, in which case tunnel bytes keep riding the control socket.
+/// On success returns the backend's data-plane grant when it issued one (#1506):
+/// the `(ticket, sizing)` for dialing the binary port-forward data plane, where
+/// `sizing` is the negotiated [`shared::TunnelSizing`] (#1511). `None` means no
+/// data plane for this connection — an older backend, or one that declined — in
+/// which case tunnel bytes keep riding the control socket.
 pub async fn register_session(
     conn: &mut NativeConnection,
     config: &ProxySessionConfig,
-) -> Result<Option<String>, RegisterError> {
+) -> Result<Option<(String, shared::TunnelSizing)>, RegisterError> {
     info!("Registering session...");
 
     let hostname = hostname_or_unknown();
@@ -690,8 +691,9 @@ pub async fn register_session(
                     max_image_mb: _,
                     retryable,
                     tunnel_data_ticket,
+                    tunnel_sizing,
                 }) => {
-                    return Some((success, error, retryable, tunnel_data_ticket));
+                    return Some((success, error, retryable, tunnel_data_ticket, tunnel_sizing));
                 }
                 Ok(_) => continue,
                 Err(_) => return None,
@@ -702,14 +704,24 @@ pub async fn register_session(
     .await;
 
     match ack_timeout {
-        Ok(Some((true, _, _, tunnel_data_ticket))) => {
-            info!(
-                "Session registered (data plane offered: {})",
-                tunnel_data_ticket.is_some()
-            );
-            Ok(tunnel_data_ticket)
+        Ok(Some((true, _, _, tunnel_data_ticket, tunnel_sizing))) => {
+            // Pair the ticket with its negotiated sizing. An older backend sends
+            // no sizing, so default to V1 — the profile the data plane shipped
+            // with (#1511).
+            let grant =
+                tunnel_data_ticket.map(|ticket| (ticket, tunnel_sizing.unwrap_or_default()));
+            if let Some((_, sizing)) = &grant {
+                info!(
+                    "Session registered (data plane offered, {} KiB frames / {} KiB window)",
+                    sizing.max_chunk / 1024,
+                    sizing.initial_window / 1024,
+                );
+            } else {
+                info!("Session registered (no data plane)");
+            }
+            Ok(grant)
         }
-        Ok(Some((false, error, retryable, _))) => {
+        Ok(Some((false, error, retryable, _, _))) => {
             let err_msg = error.as_deref().unwrap_or("Unknown error");
             if retryable {
                 // Transient infrastructure failure (DB blip mid-deploy) —
@@ -746,7 +758,7 @@ async fn run_message_loop<A: Agent>(
     session: &mut SessionState<'_, A>,
     config: &ProxySessionConfig,
     conn: NativeConnection,
-    tunnel_data_ticket: Option<String>,
+    tunnel_data_grant: Option<(String, shared::TunnelSizing)>,
 ) -> ConnectionResult {
     let connection_start = Instant::now();
     let session_id = config.session_id;
@@ -794,11 +806,12 @@ async fn run_message_loop<A: Agent>(
     // Bring up the binary data plane, if the backend issued a ticket (#1506).
     // Detached: forward bytes must never gate session startup, and every
     // failure inside just leaves tunneling on the control socket.
-    if let Some(ticket) = tunnel_data_ticket {
+    if let Some((ticket, sizing)) = tunnel_data_grant {
         tokio::spawn(session_lib::tunnel::run_data_plane(
             tunnel.clone(),
             config.backend_url.clone(),
             ticket,
+            sizing,
         ));
     }
 

--- a/docs/PORT_FORWARDING.md
+++ b/docs/PORT_FORWARDING.md
@@ -231,17 +231,23 @@ Semantics:
   not configurable.
 - `TunnelData`: stream bytes. On the data plane these are raw binary; on the
   control-socket fallback they are base64 inside JSON text. Either way at most
-  `MAX_CHUNK` (**16 KiB**) decoded per frame.
-- Flow control: each direction starts with an `INITIAL_WINDOW` (**64 KiB**)
+  the negotiated `max_chunk` decoded per frame.
+- Flow control: each direction starts with the negotiated `initial_window`
   credit per stream. A sender must not exceed its window; the receiver grants
   more via `TunnelWindow` as it drains bytes to the underlying socket.
-- **`MAX_CHUNK` and `INITIAL_WINDOW` are a cross-version contract.** The sender
-  chunks to `MAX_CHUNK` and the receiver closes any stream exceeding it; the
-  sender's credit gate and the receiver's credit book are seeded from the same
-  `INITIAL_WINDOW`. Raising either on one side alone makes a build-skewed peer
-  tear down every stream mid-deploy, so larger frames/windows need a negotiated
-  protocol bump (`…_v2`), not a constant edit. `MAX_STREAMS` is the exception —
-  purely proxy-local, so it can be raised on its own.
+- **Frame size / window are negotiated, because they're a cross-version
+  contract** (`shared::TunnelSizing`, #1511). The sender chunks to `max_chunk`
+  and the receiver closes any stream exceeding it; the sender's credit gate and
+  the receiver's credit book are seeded from the same `initial_window`. So they
+  can't be a constant bump — a build-skewed peer would tear down every stream
+  mid-deploy. Instead the proxy advertises the profiles it supports
+  (`session.tunnel_binary_v1`, and `…_v2` if newer), the backend picks the
+  largest both know and reports it in `RegisterAck.tunnel_sizing` (and embeds it
+  in the data-plane ticket), and both ends configure to it. A v2 proxy still
+  advertises v1, so a v1 backend keeps issuing V1. Profiles: **V1** = 16 KiB
+  frames / 64 KiB window (what the data plane shipped with); **V2** = 64 KiB /
+  256 KiB. `MAX_STREAMS` is the exception — purely proxy-local, so it can be
+  raised on its own.
 - **Writer capacity, not just credit.** Tunnel senders are pull-based: they read
   from the TCP socket / HTTP body only while holding stream credit, never
   eagerly, so credit is what bounds in-flight bytes. Beyond that, the two ends
@@ -620,12 +626,13 @@ protocol addition in M1 is a minor bump).
   links** (ngrok-style). Both are auth-model expansions to design separately.
 - **Path-prefix fallback mode** — superseded by subdomains; not worth
   maintaining two schemes.
-- **Negotiated larger chunk/window sizes** on the data plane. Now that stream
-  bytes have their own socket, the small 16 KiB/64 KiB values (chosen because the
-  socket was *shared*) are the main throughput limiter — but both ends must
-  agree, so this needs a `…_v2` capability rather than a constant bump.
 - **Pooling upstream tunnel connections** (#1468). Every request still opens its
   own stream, which is what makes `MAX_STREAMS` reachable at all and adds a
-  round-trip before each request.
+  round-trip before each request. With the V2 sizing (#1511) landed, this is now
+  the main remaining throughput lever, and it may dominate the frame-size win —
+  worth benchmarking the two together.
+- **A larger sizing profile (`…_v3`)** if V2's 64 KiB/256 KiB proves too small
+  once pooling lands. The negotiation (`shared::TunnelSizing`) is in place; a new
+  profile is a capability const plus a `TunnelSizing` entry.
 - **Port auto-discovery** (sniffing `LISTEN` sockets) — explicit declaration
   keeps the allowlist meaningful and the reminder teaches agents to declare.

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -384,8 +384,8 @@ async fn run_shim_loop(
             ..config.clone()
         };
 
-        let tunnel_data_ticket = match register_session(&mut conn, &config_with_branch).await {
-            Ok(ticket) => ticket,
+        let tunnel_data_grant = match register_session(&mut conn, &config_with_branch).await {
+            Ok(grant) => grant,
             Err(_) => {
                 warn!(
                     "Registration failed, retrying in {}s",
@@ -431,7 +431,7 @@ async fn run_shim_loop(
             permissions.clone(),
             output_buffer.clone(),
             portal_text_tx.clone(),
-            tunnel_data_ticket,
+            tunnel_data_grant,
         )
         .await;
 
@@ -494,7 +494,7 @@ async fn run_shim_connection(
     permissions: Arc<Mutex<HashMap<String, PermissionState>>>,
     output_buffer: Arc<Mutex<PendingOutputBuffer>>,
     portal_text_tx: mpsc::UnboundedSender<String>,
-    tunnel_data_ticket: Option<String>,
+    tunnel_data_grant: Option<(String, shared::TunnelSizing)>,
 ) -> ShimConnectionResult {
     let (ws_write, ws_read) = conn.split();
     let ws_write: SharedWsWrite = Arc::new(Mutex::new(ws_write));
@@ -505,11 +505,12 @@ async fn run_shim_connection(
 
     // Bring up the binary data plane, if the backend issued a ticket (#1506).
     // Detached and non-fatal: any failure leaves tunneling on the control socket.
-    if let Some(ticket) = tunnel_data_ticket {
+    if let Some((ticket, sizing)) = tunnel_data_grant {
         tokio::spawn(session_lib::tunnel::run_data_plane(
             tunnel.clone(),
             config.backend_url.clone(),
             ticket,
+            sizing,
         ));
     }
 

--- a/session-lib/src/tunnel.rs
+++ b/session-lib/src/tunnel.rs
@@ -23,14 +23,14 @@
 //! for the cross-socket ordering race it absorbs.
 //!
 //! Backpressure has two layers, per the spec:
-//! - **Stream credit**: each direction starts with an [`INITIAL_WINDOW`] credit;
-//!   the receiver re-grants as it drains bytes into the underlying socket
-//!   (`TunnelWindow`). A sender never reads more from TCP than it holds
-//!   credit for.
+//! - **Stream credit**: each direction starts with the negotiated
+//!   [`shared::TunnelSizing::initial_window`] credit; the receiver re-grants as
+//!   it drains bytes into the underlying socket (`TunnelWindow`). A sender never
+//!   reads more from TCP than it holds credit for.
 //! - **Writer capacity**: outgoing frames go straight through a shared
-//!   `WsSender` mutex (FIFO), one ≤[`MAX_CHUNK`] frame per lock. There is no
-//!   queue to grow — buffered tunnel data is bounded by streams × `MAX_CHUNK` and
-//!   waiting streams are served round-robin by mutex order. On the control
+//!   `WsSender` mutex (FIFO), one `max_chunk`-bounded frame per lock. There is
+//!   no queue to grow — buffered tunnel data is bounded by streams × the window
+//!   and waiting streams are served round-robin by mutex order. On the control
 //!   socket that mutex is shared with session frames, so tunnel traffic can
 //!   delay them (the reason the data plane exists); on the data plane it is
 //!   private, so it cannot.
@@ -80,36 +80,26 @@ enum StreamEgress {
     Binary,
 }
 
-/// Max decoded bytes per `TunnelData` frame.
-pub const MAX_CHUNK: usize = 16 * 1024;
-/// Initial per-stream, per-direction flow-control window.
-///
-/// Kept small so the worst-case buffered bytes
-/// (`MAX_STREAMS × INITIAL_WINDOW` per direction) stay bounded even with a high
-/// stream cap; loopback/WS latency is low enough that this saturates a single
-/// stream easily.
-///
-/// **Both ends must agree** (`backend::…::tunnel_client::INITIAL_WINDOW`): the
-/// sender's credit gate and the receiver's credit book are seeded from this same
-/// value, so a mismatch makes the sender exceed the receiver's book and every
-/// stream closes as "beyond granted window". Raising it therefore needs a
-/// negotiated protocol bump rather than an edit here.
-pub const INITIAL_WINDOW: u32 = 64 * 1024;
+// The per-stream frame size and flow-control window are no longer constants:
+// they are the connection's negotiated [`shared::TunnelSizing`] (#1511),
+// defaulting to [`shared::TunnelSizing::V1`] on the control-socket fallback.
+// Both ends of a stream must agree, which is exactly why they are negotiated
+// rather than hard-coded here.
+
 /// Max concurrent streams per session connection.
 ///
 /// Purely proxy-local: the backend has no cap of its own, it just receives a
 /// [`TunnelRefuseReason::StreamLimit`] refusal. That makes this the one sizing
 /// knob that needs no cross-version agreement, so it is safe to raise on its own
-/// (unlike `MAX_CHUNK`/`INITIAL_WINDOW`, which both ends must match — see their
-/// docs).
+/// (unlike the negotiated frame size / window — see [`shared::TunnelSizing`]).
 ///
 /// Every request becomes its own stream because upstream connections are not yet
 /// pooled (#1468), so a resource-heavy page or a polling app can burst through
 /// hundreds at once; past the cap requests fail with `at-capacity`. 512 doubles
-/// the previous headroom while keeping the worst case bounded at
-/// `MAX_STREAMS × INITIAL_WINDOW` = 32 MiB per direction — and that is the
-/// pathological all-streams-saturated figure, not steady state. Pooling is the
-/// real fix for the cap; this buys room until it lands.
+/// the original headroom while keeping the worst case bounded at
+/// `MAX_STREAMS × window` per direction (32 MiB at the V1 window, 128 MiB at
+/// V2) — the pathological all-streams-saturated figure, not steady state.
+/// Pooling is the real fix for the cap; this buys room until it lands.
 pub const MAX_STREAMS: usize = 512;
 /// How long a single dial to loopback may take before it is treated as a
 /// timeout (service hung, not down).
@@ -146,9 +136,19 @@ struct StreamHandle {
     /// reader decrements on arrival; the stream task re-increments as bytes
     /// drain into the socket. Going negative is a protocol violation and
     /// closes the stream — the inbox is unbounded, so this (not the channel)
-    /// is what bounds per-stream buffered downlink data to [`INITIAL_WINDOW`]
-    /// even against a buggy or hostile peer.
+    /// is what bounds per-stream buffered downlink data to the negotiated
+    /// window even against a buggy or hostile peer.
     recv_credit: Arc<std::sync::atomic::AtomicI64>,
+    /// Negotiated max frame size for this stream (#1511). The inbound handlers
+    /// close any stream whose frame exceeds it; stored per stream so the check
+    /// uses the value this connection agreed on.
+    max_chunk: usize,
+}
+
+/// The attached binary data plane and the sizing negotiated for it (#1511).
+struct DataPlane {
+    write: TunnelDataWrite,
+    sizing: shared::TunnelSizing,
 }
 
 /// Per-connection tunnel state. Create one per established session WS,
@@ -161,8 +161,9 @@ pub struct TunnelManager {
     /// `None` means every stream uses the control socket, which is exactly the
     /// pre-existing behavior — so an unavailable or dropped data plane degrades
     /// instead of failing. Only *stream* frames move here; the forward allowlist
-    /// and health reports stay on the control socket.
-    data: Mutex<Option<TunnelDataWrite>>,
+    /// and health reports stay on the control socket. Carries the negotiated
+    /// sizing (#1511) so binary streams are configured to it.
+    data: Mutex<Option<DataPlane>>,
     allowed: Mutex<HashSet<u16>>,
     streams: Mutex<HashMap<Uuid, StreamHandle>>,
     /// Last reported `listening` verdict per allowlisted port; the background
@@ -305,12 +306,12 @@ impl TunnelManager {
                     let streams = self.streams.lock().await;
                     streams
                         .get(&data.stream_id)
-                        .map(|h| (h.inbox.clone(), h.recv_credit.clone()))
+                        .map(|h| (h.inbox.clone(), h.recv_credit.clone(), h.max_chunk))
                 };
                 // Unknown stream: a post-close race; drop silently.
-                if let Some((inbox, recv_credit)) = handle {
+                if let Some((inbox, recv_credit, max_chunk)) = handle {
                     match base64::engine::general_purpose::STANDARD.decode(&data.data_base64) {
-                        Ok(bytes) if bytes.len() > MAX_CHUNK => {
+                        Ok(bytes) if bytes.len() > max_chunk => {
                             warn!(
                                 "Oversized TunnelData ({} bytes) for stream {}; closing",
                                 bytes.len(),
@@ -397,9 +398,14 @@ impl TunnelManager {
                 open.port
             );
         }
+        // Sizing is fixed at open (#1511): the negotiated profile for a binary
+        // stream, V1 for the control fallback.
+        let sizing = self.sizing_for(egress).await;
         // Register the inbox before the dial so ordered frames can't miss it.
         let (inbox_tx, inbox_rx) = mpsc::unbounded_channel();
-        let recv_credit = Arc::new(std::sync::atomic::AtomicI64::new(INITIAL_WINDOW as i64));
+        let recv_credit = Arc::new(std::sync::atomic::AtomicI64::new(
+            sizing.initial_window as i64,
+        ));
         {
             let mut streams = self.streams.lock().await;
             if streams.len() >= MAX_STREAMS {
@@ -424,6 +430,7 @@ impl TunnelManager {
                     port: open.port,
                     inbox: inbox_tx,
                     recv_credit: recv_credit.clone(),
+                    max_chunk: sizing.max_chunk as usize,
                 },
             );
         }
@@ -444,7 +451,7 @@ impl TunnelManager {
             };
             mgr.send_stream_opened(egress, stream_id).await;
             debug!("Tunnel stream {} open to port {}", stream_id, port);
-            run_stream(mgr, stream_id, egress, tcp, inbox_rx, recv_credit).await;
+            run_stream(mgr, stream_id, egress, sizing, tcp, inbox_rx, recv_credit).await;
         });
     }
 
@@ -459,11 +466,16 @@ impl TunnelManager {
         }
     }
 
-    /// Adopt a connected data plane. Streams opened from here on ride it;
-    /// streams already running keep the transport they opened with.
-    pub async fn attach_data_plane(&self, data: TunnelDataWrite) {
-        *self.data.lock().await = Some(data);
-        info!("Port-forward data plane attached (binary transport active)");
+    /// Adopt a connected data plane with the sizing negotiated for it. Streams
+    /// opened from here on ride it (at that sizing); streams already running
+    /// keep the transport they opened with.
+    pub async fn attach_data_plane(&self, write: TunnelDataWrite, sizing: shared::TunnelSizing) {
+        *self.data.lock().await = Some(DataPlane { write, sizing });
+        info!(
+            "Port-forward data plane attached ({} KiB frames / {} KiB window)",
+            sizing.max_chunk / 1024,
+            sizing.initial_window / 1024,
+        );
     }
 
     /// Forget the data plane (its socket ended). New streams fall back to the
@@ -480,6 +492,13 @@ impl TunnelManager {
         self.data.lock().await.is_some()
     }
 
+    /// Sizing to configure a stream opened over `egress`. Reads the attached
+    /// data plane's sizing (if any) and defers to [`sizing_for`].
+    async fn sizing_for(&self, egress: StreamEgress) -> shared::TunnelSizing {
+        let attached = self.data.lock().await.as_ref().map(|d| d.sizing);
+        sizing_for(egress, attached)
+    }
+
     /// Send one binary frame on the data plane. Returns `false` if there is no
     /// data plane or the send failed.
     async fn send_binary(&self, frame: TunnelFrame) -> bool {
@@ -487,7 +506,7 @@ impl TunnelManager {
         let Some(data) = guard.as_mut() else {
             return false;
         };
-        let mut ws = data.lock().await;
+        let mut ws = data.write.lock().await;
         match ws.send(frame).await {
             Ok(()) => true,
             Err(e) => {
@@ -614,11 +633,11 @@ impl TunnelManager {
                     let streams = self.streams.lock().await;
                     streams
                         .get(&stream_id)
-                        .map(|h| (h.inbox.clone(), h.recv_credit.clone()))
+                        .map(|h| (h.inbox.clone(), h.recv_credit.clone(), h.max_chunk))
                 };
                 // Unknown stream: a post-close race; drop silently.
-                if let Some((inbox, recv_credit)) = handle {
-                    if bytes.len() > MAX_CHUNK {
+                if let Some((inbox, recv_credit, max_chunk)) = handle {
+                    if bytes.len() > max_chunk {
                         warn!(
                             "Oversized data-plane payload ({} bytes) for stream {}; closing",
                             bytes.len(),
@@ -680,7 +699,12 @@ impl TunnelManager {
 /// so a dial error, a rejected ticket, or a mid-session drop leaves the session
 /// untouched and tunneling on the control socket. Spawn it and forget it — do
 /// not gate session startup on it.
-pub async fn run_data_plane(mgr: Arc<TunnelManager>, backend_url: String, ticket: String) {
+pub async fn run_data_plane(
+    mgr: Arc<TunnelManager>,
+    backend_url: String,
+    ticket: String,
+    sizing: shared::TunnelSizing,
+) {
     let conn =
         match ws_bridge::native_client::connect::<shared::TunnelDataEndpoint>(&backend_url).await {
             Ok(conn) => conn,
@@ -701,7 +725,8 @@ pub async fn run_data_plane(mgr: Arc<TunnelManager>, backend_url: String, ticket
         return;
     }
 
-    mgr.attach_data_plane(Arc::new(Mutex::new(write))).await;
+    mgr.attach_data_plane(Arc::new(Mutex::new(write)), sizing)
+        .await;
 
     while let Some(result) = read.recv().await {
         match result {
@@ -718,6 +743,24 @@ pub async fn run_data_plane(mgr: Arc<TunnelManager>, backend_url: String, ticket
     }
 
     mgr.detach_data_plane().await;
+}
+
+/// The sizing a stream opened over `egress` should use, given the sizing of the
+/// currently-attached data plane (`None` if none is attached).
+///
+/// Binary streams take the negotiated sizing; the control fallback — and a
+/// binary stream whose data plane vanished between its open frame and here —
+/// use [`shared::TunnelSizing::V1`], which is exactly what a control-socket
+/// stream has always used. Pure so the per-stream sizing choice is testable
+/// without a live manager.
+fn sizing_for(
+    egress: StreamEgress,
+    attached: Option<shared::TunnelSizing>,
+) -> shared::TunnelSizing {
+    match egress {
+        StreamEgress::Binary => attached.unwrap_or_default(),
+        StreamEgress::Control => shared::TunnelSizing::V1,
+    }
 }
 
 /// Grace period for the forward-allowlist sync race (see [`await_allowlist`]).
@@ -850,19 +893,21 @@ async fn run_stream(
     mgr: Arc<TunnelManager>,
     stream_id: Uuid,
     egress: StreamEgress,
+    sizing: shared::TunnelSizing,
     tcp: TcpStream,
     mut inbox: mpsc::UnboundedReceiver<StreamMsg>,
     recv_credit: Arc<std::sync::atomic::AtomicI64>,
 ) {
     let (mut tcp_rd, mut tcp_wr) = tcp.into_split();
-    let send_credit = Arc::new(CreditGate::new(INITIAL_WINDOW));
+    let send_credit = Arc::new(CreditGate::new(sizing.initial_window));
+    let max_chunk = sizing.max_chunk as usize;
 
     let uplink_credit = send_credit.clone();
     let uplink_mgr = mgr.clone();
     let uplink = tokio::spawn(async move {
-        let mut buf = vec![0u8; MAX_CHUNK];
+        let mut buf = vec![0u8; max_chunk];
         loop {
-            let budget = uplink_credit.take(MAX_CHUNK).await;
+            let budget = uplink_credit.take(max_chunk).await;
             let n = match tcp_rd.read(&mut buf[..budget]).await {
                 Ok(0) => break None,
                 Ok(n) => n,
@@ -913,6 +958,32 @@ mod tests {
 
     fn allowlist(ports: &[u16]) -> Mutex<HashSet<u16>> {
         Mutex::new(ports.iter().copied().collect())
+    }
+
+    /// Binary streams use the negotiated profile; the control fallback and a
+    /// binary stream whose data plane vanished both use V1 (#1511).
+    #[test]
+    fn stream_sizing_selection() {
+        // Binary with a negotiated V2 data plane → V2.
+        assert_eq!(
+            sizing_for(StreamEgress::Binary, Some(shared::TunnelSizing::V2)),
+            shared::TunnelSizing::V2
+        );
+        // Binary with a V1 data plane → V1.
+        assert_eq!(
+            sizing_for(StreamEgress::Binary, Some(shared::TunnelSizing::V1)),
+            shared::TunnelSizing::V1
+        );
+        // Binary but the data plane vanished → V1 default, never a panic.
+        assert_eq!(
+            sizing_for(StreamEgress::Binary, None),
+            shared::TunnelSizing::V1
+        );
+        // Control fallback is always V1, regardless of any attached plane.
+        assert_eq!(
+            sizing_for(StreamEgress::Control, Some(shared::TunnelSizing::V2)),
+            shared::TunnelSizing::V1
+        );
     }
 
     /// An already-synced port returns immediately, so the common path pays

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -64,8 +64,9 @@ mod tests {
             _ => panic!("expected RegisterAck"),
         }
 
-        // And the ticket is omitted from the wire entirely when absent, so an
-        // older proxy sees a byte-identical ack to what it got before.
+        // And the ticket + sizing are omitted from the wire entirely when
+        // absent, so an older proxy sees a byte-identical ack to what it got
+        // before.
         let ack = ServerToProxy::RegisterAck {
             success: true,
             session_id: Uuid::nil(),
@@ -73,10 +74,72 @@ mod tests {
             max_image_mb: 10,
             retryable: false,
             tunnel_data_ticket: None,
+            tunnel_sizing: None,
         };
-        assert!(!serde_json::to_string(&ack)
-            .unwrap()
-            .contains("tunnel_data_ticket"));
+        let json = serde_json::to_string(&ack).unwrap();
+        assert!(!json.contains("tunnel_data_ticket"));
+        assert!(!json.contains("tunnel_sizing"));
+    }
+
+    /// The sizing negotiation (#1511): the backend picks the largest profile the
+    /// proxy advertised, and a v2-capable proxy still advertises v1 so a v1
+    /// backend (which never sees v2) keeps issuing V1.
+    #[test]
+    fn tunnel_sizing_negotiation() {
+        use crate::{
+            TunnelSizing, PROXY_CAPABILITY_TUNNEL_BINARY_V1, PROXY_CAPABILITY_TUNNEL_BINARY_V2,
+        };
+
+        // No capabilities (pre-#1506 proxy) → V1.
+        assert_eq!(TunnelSizing::negotiate(&[]), TunnelSizing::V1);
+        // v1 only → V1.
+        assert_eq!(
+            TunnelSizing::negotiate(&[PROXY_CAPABILITY_TUNNEL_BINARY_V1.to_string()]),
+            TunnelSizing::V1
+        );
+        // v1 + v2 (the shape a v2 proxy actually sends) → V2.
+        assert_eq!(
+            TunnelSizing::negotiate(&[
+                PROXY_CAPABILITY_TUNNEL_BINARY_V1.to_string(),
+                PROXY_CAPABILITY_TUNNEL_BINARY_V2.to_string(),
+            ]),
+            TunnelSizing::V2
+        );
+        // V2 is strictly larger, and both keep the 4×-window ratio. Bind to
+        // runtime locals so this isn't a compile-time-const assertion
+        // (clippy::assertions_on_constants).
+        let (v1, v2) = (TunnelSizing::V1, TunnelSizing::V2);
+        assert!(v2.max_chunk > v1.max_chunk);
+        assert_eq!(v1.initial_window / v1.max_chunk, 4);
+        assert_eq!(v2.initial_window / v2.max_chunk, 4);
+    }
+
+    /// A v2 sizing survives the RegisterAck round-trip; older backends omit it
+    /// and the proxy reads `None` (→ V1).
+    #[test]
+    fn register_ack_carries_tunnel_sizing() {
+        let ack = ServerToProxy::RegisterAck {
+            success: true,
+            session_id: Uuid::nil(),
+            error: None,
+            max_image_mb: 10,
+            retryable: false,
+            tunnel_data_ticket: Some("tok".to_string()),
+            tunnel_sizing: Some(crate::TunnelSizing::V2),
+        };
+        let json = serde_json::to_string(&ack).unwrap();
+        match serde_json::from_str::<ServerToProxy>(&json).unwrap() {
+            ServerToProxy::RegisterAck { tunnel_sizing, .. } => {
+                assert_eq!(tunnel_sizing, Some(crate::TunnelSizing::V2));
+            }
+            _ => panic!("expected RegisterAck"),
+        }
+
+        let legacy = r#"{"type":"RegisterAck","success":true,"session_id":"00000000-0000-0000-0000-000000000000","max_image_mb":10}"#;
+        match serde_json::from_str::<ServerToProxy>(legacy).unwrap() {
+            ServerToProxy::RegisterAck { tunnel_sizing, .. } => assert!(tunnel_sizing.is_none()),
+            _ => panic!("expected RegisterAck"),
+        }
     }
 
     #[test]

--- a/shared/src/endpoints/session.rs
+++ b/shared/src/endpoints/session.rs
@@ -224,6 +224,13 @@ pub enum ServerToProxy {
         /// socket as before.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         tunnel_data_ticket: Option<String>,
+        /// The tunnel sizing profile the backend negotiated from the proxy's
+        /// advertised capabilities (#1511). `None` (older backend) means the
+        /// proxy uses [`TunnelSizing::V1`](crate::TunnelSizing::V1), the sizing
+        /// that shipped with the data plane — so a v2-capable proxy talking to a
+        /// v1 backend transparently stays on v1 frames.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tunnel_sizing: Option<crate::TunnelSizing>,
     },
 
     /// Keepalive heartbeat

--- a/shared/src/endpoints/tunnel.rs
+++ b/shared/src/endpoints/tunnel.rs
@@ -41,10 +41,70 @@
 //! UTF-8). Chunk-size policy stays with the callers, which enforce it against
 //! their negotiated flow-control window.
 
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use ws_bridge::{DecodeError, EncodeError, WsCodec, WsEndpoint, WsMessage};
 
 use super::types::TunnelRefuseReason;
+
+/// Per-stream tunnel sizing, negotiated once per connection at registration and
+/// then fixed for that connection's life (#1511).
+///
+/// Both ends must use the same values: the sender chunks payloads to `max_chunk`
+/// and the receiver **closes any stream whose frame exceeds it**; the sender's
+/// credit gate and the receiver's credit book are both seeded from
+/// `initial_window`, so a mismatch makes the sender overrun the book and every
+/// stream dies as "beyond granted window". That is why raising these is a
+/// negotiation, not a constant bump — see [`crate::PROXY_CAPABILITY_TUNNEL_BINARY_V2`].
+///
+/// The backend computes the agreed profile from the proxy's advertised
+/// capabilities and reports it back in `RegisterAck.tunnel_sizing`; both ends
+/// then configure their tunnel to it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TunnelSizing {
+    /// Max decoded payload bytes per `Data` frame.
+    pub max_chunk: u32,
+    /// Initial per-stream, per-direction flow-control credit.
+    pub initial_window: u32,
+}
+
+impl TunnelSizing {
+    /// The original profile (`session.tunnel_binary_v1`): 16 KiB frames, 64 KiB
+    /// window. Also the default whenever nothing was negotiated — an older
+    /// backend that sends no `tunnel_sizing`, or the JSON-over-control-socket
+    /// fallback.
+    pub const V1: TunnelSizing = TunnelSizing {
+        max_chunk: 16 * 1024,
+        initial_window: 64 * 1024,
+    };
+
+    /// The larger profile (`session.tunnel_binary_v2`): 64 KiB frames, 256 KiB
+    /// window. The 4× window-to-chunk ratio matches V1, so a single stream can
+    /// keep four frames in flight before waiting on a grant.
+    pub const V2: TunnelSizing = TunnelSizing {
+        max_chunk: 64 * 1024,
+        initial_window: 256 * 1024,
+    };
+
+    /// The sizing to use given a proxy's advertised capabilities. The backend is
+    /// the negotiator: it supports every profile up to the newest it knows and
+    /// picks the highest the proxy also advertised. Unknown/empty capabilities
+    /// yield [`TunnelSizing::V1`], which is what a pre-#1511 proxy gets.
+    pub fn negotiate(proxy_capabilities: &[String]) -> TunnelSizing {
+        let advertises = |cap: &str| proxy_capabilities.iter().any(|c| c == cap);
+        if advertises(crate::PROXY_CAPABILITY_TUNNEL_BINARY_V2) {
+            TunnelSizing::V2
+        } else {
+            TunnelSizing::V1
+        }
+    }
+}
+
+impl Default for TunnelSizing {
+    fn default() -> Self {
+        TunnelSizing::V1
+    }
+}
 
 /// The dedicated data-plane endpoint. Symmetric: both directions speak
 /// [`TunnelFrame`].

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -34,7 +34,25 @@ pub const LAUNCHER_CAPABILITY_HEARTBEAT_ACK: &str = "launcher.heartbeat_ack";
 /// advertise this, and routes tunnel bytes over the data plane only while such
 /// a socket is registered — so a proxy that never advertises it (or whose data
 /// socket has dropped) transparently keeps the JSON-over-control-socket path.
+///
+/// Implies [`TunnelSizing::V1`] (16 KiB frames / 64 KiB window). A proxy that
+/// also supports larger frames advertises [`PROXY_CAPABILITY_TUNNEL_BINARY_V2`]
+/// *in addition*, never instead — so a v1 backend still recognizes it (#1511).
 pub const PROXY_CAPABILITY_TUNNEL_BINARY_V1: &str = "session.tunnel_binary_v1";
+
+/// Proxy capability advertised by versions that can use the larger
+/// [`TunnelSizing::V2`] profile on the binary data plane (#1511).
+///
+/// The 16 KiB/64 KiB v1 sizing was chosen when tunnel bytes shared the control
+/// socket; on the dedicated data plane it is the throughput limiter, but the
+/// frame size and credit window are a cross-version contract — the receiver
+/// closes any stream whose frame exceeds the agreed `max_chunk`, and both ends
+/// seed credit from the agreed `initial_window`. So the larger sizing can't be a
+/// constant bump: it is negotiated. The backend picks
+/// [`TunnelSizing::V2`] only when the proxy advertises this, and echoes the
+/// agreed profile in `RegisterAck.tunnel_sizing`. A v2 proxy still advertises
+/// [`PROXY_CAPABILITY_TUNNEL_BINARY_V1`] too, so a v1 backend keeps working.
+pub const PROXY_CAPABILITY_TUNNEL_BINARY_V2: &str = "session.tunnel_binary_v2";
 
 /// Split [`VERSION`] into `(major, minor, patch)` numeric components.
 /// `None` on the (impossible-by-construction) malformed string.


### PR DESCRIPTION
Closes #1511.

## What

Adds `session.tunnel_binary_v2`, letting the port-forward data plane use **64 KiB frames / 256 KiB window** instead of v1's 16 KiB / 64 KiB. Those small values were chosen when tunnel bytes shared the control socket; on the dedicated data plane (#1506) they were the throughput limiter, but #1510 deliberately left them alone because they're a cross-version contract. This does it the safe way — by negotiation.

## Why it has to be negotiated, not bumped

- The sender chunks payloads to `max_chunk` and the **receiver closes any stream whose frame exceeds it**.
- The sender's credit gate and the receiver's credit book are both seeded from `initial_window`; a mismatch makes the sender overrun the book and every stream dies as "beyond granted window".

`session.tunnel_binary_v1` already shipped *meaning* 16 KiB/64 KiB, so raising the constants under the same capability would tear down every stream during a rolling deploy.

## How the negotiation works

1. The proxy advertises the profiles it supports in `RegisterFields.capabilities` — `v1`, plus `v2` when it's new. A v2 proxy advertises **both**, so a v1 backend (which never looks for v2) still recognizes it and issues V1.
2. The backend picks the largest profile both know (`TunnelSizing::negotiate`), reports it in `RegisterAck.tunnel_sizing`, and embeds it in the data-plane ticket.
3. Both ends configure to it. The ticket carrying the sizing means the data socket's registration knows the profile without a second lookup.

Back-compat is symmetric and `#[serde(default)]`-covered: an older backend sends no `tunnel_sizing` and the proxy defaults to V1; an older proxy advertises no capabilities and gets V1. Both verified in tests, and the ack omits the field from the wire when `None` so an old proxy sees a byte-identical frame.

## Threading

Sizing is fixed **per connection** at registration and carried **per stream** — the receive-window seed, the send-credit gate, the uplink buffer size, and the receiver's oversize check all read the stream's negotiated values rather than a global constant. That keeps a stream's frames on one agreed profile and stays correct even if profiles ever differ. The old `MAX_CHUNK`/`INITIAL_WINDOW` module constants (backend and session-lib) are gone; `shared::TunnelSizing::V1` is now the single source of truth. `MAX_STREAMS` stays a plain proxy-local constant — it needs no agreement.

## Tests

- `TunnelSizing::negotiate` matrix (none / v1 / v1+v2), the 4× window ratio, and V2 > V1.
- `RegisterAck` round-trips the sizing and older-backend acks decode as `None`.
- Ticket mint/verify carries the sizing (and defaults V1 for a ticket from an older backend).
- Proxy-side `sizing_for` (pure): binary→negotiated, binary-with-vanished-plane→V1, control→V1.

`cargo test --workspace` green, clippy clean, `shared` builds for `wasm32-unknown-unknown`.

## Follow-ups (updated in the doc)

Pooling (#1468) is now the main remaining throughput lever and may dominate the frame-size win — worth benchmarking together. A `…_v3` profile, if ever needed, is just another capability const plus a `TunnelSizing` entry.