### PR TITLE
Fix launcher restart status line collapsing under the first column

### DIFF
--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -366,17 +366,21 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
     let status = match &props.phase {
         Some(UpdatePhase::Succeeded { new_version, .. }) => Some(html! {
             <tr class="launcher-update-status">
-                <td colspan="5" class="launcher-status launcher-status--success">
-                    { format!("Back online — v{new_version}") }
+                <td colspan="5">
+                    <div class="launcher-status launcher-status--success">
+                        { format!("Back online — v{new_version}") }
+                    </div>
                 </td>
             </tr>
         }),
         Some(UpdatePhase::SameVersion { version }) => Some(html! {
             <tr class="launcher-update-status">
-                <td colspan="5" class="launcher-status launcher-status--warning">
-                    { format!(
-                        "Came back on the same version (v{version}) — update may have failed."
-                    ) }
+                <td colspan="5">
+                    <div class="launcher-status launcher-status--warning">
+                        { format!(
+                            "Came back on the same version (v{version}) — update may have failed."
+                        ) }
+                    </div>
                 </td>
             </tr>
         }),
@@ -388,9 +392,11 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
             };
             Some(html! {
                 <tr class="launcher-update-status">
-                    <td colspan="5" class="launcher-status launcher-status--waiting">
-                        <span class="spinner-small"></span>
-                        { msg }
+                    <td colspan="5">
+                        <div class="launcher-status launcher-status--waiting">
+                            <span class="spinner-small"></span>
+                            { msg }
+                        </div>
                     </td>
                 </tr>
             })
@@ -497,8 +503,10 @@ fn phantom_launcher_row(props: &PhantomLauncherRowProps) -> Html {
                 <td class="token-actions">{ "—" }</td>
             </tr>
             <tr class="launcher-update-status">
-                <td colspan="5" class={classes!("launcher-status", status_class)}>
-                    { status_body }
+                <td colspan="5">
+                    <div class={classes!("launcher-status", status_class)}>
+                        { status_body }
+                    </div>
                 </td>
             </tr>
         </>

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -440,15 +440,22 @@
 }
 
 /* Per-launcher update lifecycle feedback (#710 follow-up) */
+
+/* The status line sits in a full-width cell beneath its row. Keep the cell a
+   real table cell so `colspan` spans every column (and its bottom border spans
+   with it) — the flex layout for the spinner + text lives on the inner div, NOT
+   the td. Putting `display: flex` on the td drops it out of table layout, which
+   makes it ignore `colspan` and collapse under the first column. */
 .launcher-update-status td {
     padding-top: 0;
 }
+
 .launcher-status {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     font-size: 0.85rem;
-    padding: 0.35rem 0 0.6rem;
+    padding-bottom: 0.25rem;
 }
 .launcher-status--waiting {
     color: var(--text-secondary);


### PR DESCRIPTION
## What you saw

When a launcher restart/update is requested, the status line ("Update requested — waiting for the launcher to restart…", "Restarting — waiting for launcher to come back… (24s)") rendered squashed under the **Name** column instead of spanning the row, with its divider only reaching partway across the table.

## Cause

The status row is `<tr><td colspan="5">`, but `.launcher-status` — which is `display: flex` (for the spinner + text) — was applied **directly to that `<td>`**. A `td` with `display: flex` leaves the table layout model, so it **ignores `colspan`**: the cell collapsed to its content width, hugged the left under the first column, and its bottom border only spanned that far. Both the live row and the phantom (dropped-off, mid-restart) row had it.

## Fix

Keep the `<td colspan="5">` a real table cell so `colspan` spans every column (and the divider spans with it), and move the flex layout onto an inner `<div class="launcher-status …">`. The `td` now supplies the normal cell padding, so the text also lines up with the other columns' left edge. Added a comment on the CSS rule explaining why `display: flex` must not go on the `td`, so it doesn't get "simplified" back.

Frontend builds, clippy clean, CSS lint clean.