### PR TITLE
Fix stale edit-mode keyboard hint (Esc → Ctrl/Cmd+K for nav mode)

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -863,7 +863,7 @@ pub fn dashboard_page() -> Html {
                                 } else {
                                     html! {
                                         <>
-                                            <span>{ "Esc = nav mode" }</span>
+                                            <span>{ "Ctrl/Cmd+K = nav mode" }</span>
                                             <span>{ "Shift+Tab = next active" }</span>
                                             <span>{ "Ctrl+M = voice" }</span>
                                             <span>{ "Enter = send" }</span>


### PR DESCRIPTION
The dashboard's bottom keyboard-hint bar advertised `Esc = nav mode` in edit mode, but since the #1377 nav-mode rework `Esc` is a no-op in edit mode — `Ctrl/Cmd+K` is the toggle (as the `?` help overlay and `use_keyboard_nav` already reflect). So the most prominent hint pointed at a dead key. Corrected to `Ctrl/Cmd+K = nav mode`; the remaining edit-mode hints were already accurate against the handlers.

Fixes #1397