### PR TITLE
Wrap voice interim transcription instead of truncating to one line

### DIFF
--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -303,15 +303,25 @@
     position: absolute;
     left: 48px;
     right: 100px;
-    top: 50%;
-    transform: translateY(-50%);
+
+    /* Top-aligned to the textarea's padding rather than vertically centered on
+       one line, so multi-sentence dictation reads as paragraphs from the top. */
+    top: 0.5rem;
     color: var(--text-muted);
     font-style: italic;
     font-size: 0.9rem;
+    line-height: 1.4;
     pointer-events: none;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+
+    /* Wrap long dictation into paragraphs instead of truncating to one line
+       with an ellipsis (#1408); very long tokens break rather than overflow. */
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+
+    /* Bound to the textarea's own max-height and scroll past it, so a long
+       preview stays inside the composer instead of overrunning the controls. */
+    max-height: 10em;
+    overflow-y: auto;
     z-index: 1;
 }
 


### PR DESCRIPTION
During voice dictation the interim transcript overlay was absolutely positioned on a single centered line (`white-space: nowrap` + `text-overflow: ellipsis`), so a long multi-sentence prompt was clipped and couldn't be reviewed before commit.

Top-align the overlay to the textarea's padding and let it wrap (`white-space: pre-wrap` + `overflow-wrap: anywhere`) into paragraphs, bounded to the textarea's `max-height` (10em) with vertical scroll so a long preview stays inside the composer instead of overrunning the controls.

Scope note: growing the composer's own height with the dictation (so it visibly expands) is a larger change — the interim text is a separate overlay, not the textarea value — and is intentionally left as a follow-up. This PR fixes the reported clipping/truncation and makes long input readable.

Fixes #1408