### PR TITLE
Show git hash + Pacific build time beside the version marker

### DIFF
--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -12,6 +12,8 @@ pub async fn get_config(State(app_state): State<Arc<AppState>>) -> Json<AppConfi
     Json(AppConfig {
         app_title: app_state.app_title.clone(),
         server_version: shared::VERSION.to_string(),
+        git_hash: shared::GIT_HASH.to_string(),
+        build_time: shared::BUILD_TIME.to_string(),
         splash_text: app_state.splash_text.clone(),
         archive_enabled: app_state.archive.is_some(),
     })

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -65,6 +65,8 @@ pub fn dashboard_page() -> Html {
     let current_user_id = bootstrap.current_user_id;
     let app_title = bootstrap.app_title;
     let server_version = bootstrap.server_version;
+    let git_hash = bootstrap.git_hash;
+    let build_time = bootstrap.build_time;
     let archive_enabled = bootstrap.archive_enabled;
 
     // Push-driven session refresh: the backend broadcasts
@@ -883,7 +885,25 @@ pub fn dashboard_page() -> Html {
                                 { "\u{1f41b}" }
                             </a>
                             if !server_version.is_empty() {
-                                <span class="server-version">{ format!("v{}", server_version) }</span>
+                                <span class="server-version">
+                                    { format!("v{}", server_version) }
+                                    // Short hash (links to the commit) + Pacific
+                                    // build time for deploy tracing (#1386);
+                                    // each shown only when the backend supplies
+                                    // it, so an older server degrades cleanly.
+                                    if !git_hash.is_empty() && git_hash != "unknown" {
+                                        { " · " }
+                                        <a
+                                            class="build-hash"
+                                            href={format!("https://github.com/meawoppl/agent-portal/commit/{git_hash}")}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >{ git_hash.clone() }</a>
+                                    }
+                                    if !build_time.is_empty() && build_time != "unknown" {
+                                        <span class="build-time">{ format!(" · {build_time}") }</span>
+                                    }
+                                </span>
                             }
                         </div>
                     </div>

--- a/frontend/src/pages/dashboard/page_bootstrap.rs
+++ b/frontend/src/pages/dashboard/page_bootstrap.rs
@@ -13,6 +13,10 @@ pub struct DashboardBootstrap {
     pub current_user_id: Option<Uuid>,
     pub app_title: String,
     pub server_version: String,
+    /// Short git hash + Pacific build time of the running server (#1386);
+    /// empty when an older backend omits them.
+    pub git_hash: String,
+    pub build_time: String,
     /// Whether the long-term session archive is enabled — drives the
     /// close-session copy (history preserved vs. permanently removed).
     pub archive_enabled: bool,
@@ -25,6 +29,8 @@ pub fn use_dashboard_bootstrap() -> DashboardBootstrap {
     let current_user_id = use_state(|| None::<Uuid>);
     let app_title = use_state(|| "Agent Portal".to_string());
     let server_version = use_state(String::new);
+    let git_hash = use_state(String::new);
+    let build_time = use_state(String::new);
     let archive_enabled = use_state(|| false);
 
     {
@@ -45,6 +51,8 @@ pub fn use_dashboard_bootstrap() -> DashboardBootstrap {
     {
         let app_title = app_title.clone();
         let server_version = server_version.clone();
+        let git_hash = git_hash.clone();
+        let build_time = build_time.clone();
         let archive_enabled = archive_enabled.clone();
         use_effect_with((), move |_| {
             spawn_local(async move {
@@ -53,6 +61,8 @@ pub fn use_dashboard_bootstrap() -> DashboardBootstrap {
                 {
                     app_title.set(config.app_title);
                     server_version.set(config.server_version);
+                    git_hash.set(config.git_hash);
+                    build_time.set(config.build_time);
                     archive_enabled.set(config.archive_enabled);
                 }
             });
@@ -65,6 +75,8 @@ pub fn use_dashboard_bootstrap() -> DashboardBootstrap {
         current_user_id: *current_user_id,
         app_title: (*app_title).clone(),
         server_version: (*server_version).clone(),
+        git_hash: (*git_hash).clone(),
+        build_time: (*build_time).clone(),
         archive_enabled: *archive_enabled,
     }
 }

--- a/frontend/styles/keyboard.css
+++ b/frontend/styles/keyboard.css
@@ -77,6 +77,18 @@
     white-space: nowrap;
 }
 
+/* Deploy-tracing hash/time beside the version (#1386): inherit the muted
+   version styling; the hash is a link but stays recessive until hovered. */
+.keyboard-hints .server-version .build-hash {
+    color: inherit;
+    text-decoration: none;
+    font-family: var(--font-mono, monospace);
+}
+
+.keyboard-hints .server-version .build-hash:hover {
+    text-decoration: underline;
+}
+
 /* ==========================================================================
    Delete Confirmation Modal
    ========================================================================== */

--- a/shared/build.rs
+++ b/shared/build.rs
@@ -38,9 +38,32 @@ fn main() {
     };
     println!("cargo:rustc-env=PORTAL_VERSION={major}.{minor}.{patch}");
 
-    // Recompute only when the commit count could have changed: HEAD moving
-    // (branch switch / detached commit) or the reflog appending (any
-    // commit/reset/checkout). Without git, fall through to Cargo's default.
+    // Short commit hash for deploy tracing (#1386). "unknown" in a build with
+    // no git (tarball / vendored) — same degradation as the patch above.
+    let git_hash = git(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=PORTAL_GIT_HASH={git_hash}");
+
+    // Build timestamp in Pacific, with the correct PST/PDT label from the
+    // system tz database rather than a hardcoded abbreviation. Shelled out to
+    // `date` so no timezone crate is pulled into the build. This is captured
+    // when build.rs runs, which — given the HEAD-based rerun triggers below —
+    // is each deploy (HEAD moves), so it reads as "last built/deployed".
+    let build_time = Command::new("date")
+        .args(["+%Y-%m-%d %H:%M %Z"])
+        .env("TZ", "America/Los_Angeles")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=PORTAL_BUILD_TIME={build_time}");
+
+    // Recompute only when the commit count / hash could have changed: HEAD
+    // moving (branch switch / detached commit) or the reflog appending (any
+    // commit/reset/checkout). This also refreshes the build time per deploy.
+    // Without git, fall through to Cargo's default.
     if let Some(git_dir) = git(&["rev-parse", "--absolute-git-dir"]) {
         println!("cargo:rerun-if-changed={git_dir}/HEAD");
         println!("cargo:rerun-if-changed={git_dir}/logs/HEAD");

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -13,6 +13,15 @@ use uuid::Uuid;
 /// placeholder.
 pub const VERSION: &str = env!("PORTAL_VERSION");
 
+/// Short git commit hash of this build, or `"unknown"` without git (#1386).
+/// Surfaced next to [`VERSION`] for deploy tracing.
+pub const GIT_HASH: &str = env!("PORTAL_GIT_HASH");
+
+/// Build timestamp in Pacific time with a `PST`/`PDT` label (or `"unknown"`),
+/// e.g. `2026-07-16 14:32 PDT` (#1386). Refreshes per deploy via `build.rs`'s
+/// HEAD-based rerun triggers, so it reads as "last built/deployed".
+pub const BUILD_TIME: &str = env!("PORTAL_BUILD_TIME");
+
 /// Launcher capability advertised by versions that honor
 /// `ServerToLauncher::LaunchSession.create_worktree`.
 pub const LAUNCHER_CAPABILITY_CREATE_WORKTREE: &str = "launch.create_worktree";
@@ -821,6 +830,13 @@ pub struct AppConfig {
     pub app_title: String,
     /// Backend server version string (e.g. "1.3.24")
     pub server_version: String,
+    /// Short git commit hash of the running server (#1386). `#[serde(default)]`
+    /// so an older backend that omits it degrades to empty (frontend hides it).
+    #[serde(default)]
+    pub git_hash: String,
+    /// Build/deploy timestamp of the running server, Pacific time (#1386).
+    #[serde(default)]
+    pub build_time: String,
     /// When set, replaces the marketing splash page with a minimal login page
     /// displaying this text as the heading. Set via SPLASH_TEXT env var.
     #[serde(default)]


### PR DESCRIPTION
The dashboard footer showed only `v{version}` — the commit count, which is monotonic but can't pin the exact commit or say when a host was built. Now it shows `v… · <short-hash> · <build-time>` so a glance at a deployed portal tells you precisely what's running and when it went up.

**Mechanism** (extends the existing version derivation):
- `shared/build.rs` also emits `PORTAL_GIT_HASH` (`git rev-parse --short HEAD`, `"unknown"` without git) and `PORTAL_BUILD_TIME` (shelled `date` with `TZ=America/Los_Angeles` → a correct `PST`/`PDT` label from the system tz db, no timezone crate). Exposed as `shared::GIT_HASH` / `shared::BUILD_TIME`.
- Both flow through `/api/config` next to `server_version`, so the values reflect the **running server**, not the separately-built WASM.
- The footer renders them beside the version, hash linking to `…/commit/<hash>`. Each piece is hidden when empty or `"unknown"`, and the `AppConfig` fields are `#[serde(default)]`, so an older backend degrades cleanly to just the version.

The existing HEAD-based `rerun-if-changed` in `build.rs` refreshes the hash and timestamp on each deploy (HEAD moves).

Fixes #1386