### PR TITLE
Surface fast-mode-disabled reason in the result and init chips

### DIFF
--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -35,6 +35,28 @@ fn preserve_user_newlines(text: &str) -> String {
     text.replace('\n', "  \n")
 }
 
+/// A human-readable phrase for why fast mode couldn't serve (#1475), shown in
+/// the "Fast off" tooltip. Shared by the result footer and the init bar so the
+/// two never drift. Unknown/novel reasons fall back to the raw code so nothing
+/// is silently swallowed.
+pub(super) fn fast_mode_disabled_label(reason: &shared::FastModeDisabledReason) -> String {
+    use shared::FastModeDisabledReason as R;
+    match reason {
+        R::Free => "requires a paid plan",
+        R::Preference => "turned off in preferences",
+        R::ExtraUsageDisabled => "extra usage disabled",
+        R::NetworkError => "network error",
+        R::NotFirstParty => "unavailable for this provider",
+        R::DisabledByEnv => "disabled by environment",
+        R::ModelNotAllowed => "model not allowed",
+        R::SdkOptInRequired => "SDK opt-in required",
+        R::Pending => "warming up",
+        R::UnknownReason => "unknown reason",
+        R::Unknown(s) => return format!("reason: {s}"),
+    }
+    .to_string()
+}
+
 /// Extract the joined text content and tool-result presence from a user
 /// message's content blocks. Shared by [`render_user_message`] and
 /// [`render_user_message_content`].
@@ -596,6 +618,17 @@ pub fn render_result_message(
                     html! {
                         <span class="stat-item fast-mode" title="Fast mode enabled">
                             { "Fast" }
+                        </span>
+                    }
+                } else if let Some(reason) = &msg.fast_mode_disabled_reason {
+                    // Fast mode was requested but couldn't serve — say why (#1475).
+                    let label = fast_mode_disabled_label(reason);
+                    html! {
+                        <span
+                            class="stat-item fast-mode-off"
+                            title={format!("Fast mode unavailable: {label}")}
+                        >
+                            { "Fast off" }
                         </span>
                     }
                 } else {

--- a/frontend/src/components/message_renderer/renderers/system.rs
+++ b/frontend/src/components/message_renderer/renderers/system.rs
@@ -76,6 +76,11 @@ fn render_init_bar(msg: &shared::SystemMessage, timestamp: Option<&str>) -> Html
         .as_ref()
         .and_then(|m| m.fast_mode_state.as_deref())
         .unwrap_or("off");
+    // Reason fast mode couldn't serve, when requested-but-disabled (#1475).
+    let fast_off_label = init
+        .as_ref()
+        .and_then(|m| m.fast_mode_disabled_reason.as_ref())
+        .map(super::fast_mode_disabled_label);
 
     html! {
         <div class="claude-message system-message compact" title={timestamp.unwrap_or_default().to_string()}>
@@ -88,6 +93,10 @@ fn render_init_bar(msg: &shared::SystemMessage, timestamp: Option<&str>) -> Html
             }
             if fast_mode == "on" {
                 <span class="init-badge fast">{ "Fast" }</span>
+            } else if let Some(label) = &fast_off_label {
+                <span class="init-badge fast-off" title={format!("Fast mode unavailable: {label}")}>
+                    { "Fast off" }
+                </span>
             }
             if mcp_count > 0 {
                 <span class="init-badge">{ format!("{} MCP", mcp_count) }</span>

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -478,6 +478,13 @@
     color: #e0af68;
 }
 
+/* Fast mode requested but unavailable (#1475): muted, not alarming — the
+   reason is in the tooltip. */
+.init-badge.fast-off {
+    color: var(--text-secondary);
+    opacity: 0.7;
+}
+
 /* System Message - Init */
 .system-message .message-subtype {
     color: var(--text-secondary);
@@ -974,6 +981,10 @@
 .result-message .stat-item.fast-mode {
     color: var(--accent);
     font-weight: 500;
+}
+
+.result-message .stat-item.fast-mode-off {
+    color: var(--text-secondary);
 }
 
 .result-message .stat-item.errors {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -132,6 +132,7 @@ pub use claude_codes::io::{
 };
 pub use claude_codes::CacheCreationDetails;
 pub use claude_codes::ClaudeOutput;
+pub use claude_codes::FastModeDisabledReason;
 
 // Re-export typed tool-input types so frontend renderers can match on enum
 // variants instead of poking at JSON field names.


### PR DESCRIPTION
`claude-codes` exposes `ResultMessage`/`InitMessage.fast_mode_disabled_reason` — an open enum explaining *why* fast mode can't serve. When a session requested fast mode but it isn't serving, we now show a muted **"Fast off"** chip whose tooltip gives the reason (`model not allowed`, `extra usage disabled`, `requires a paid plan`, …), instead of that session looking identical to one that never asked for fast mode.

- One shared helper maps the open `FastModeDisabledReason` (re-exported from `shared`) to a friendly phrase; unknown/novel variants fall back to the raw code so nothing is swallowed. Used by both the result footer (`render_result_message`) and the init bar (`render_init_bar`) so the two can't drift.
- The chip renders only when the reason is present (requested-but-disabled), so ordinary sessions are unaffected. Muted styling — it's informational, not an error.

Fixes #1475