### PR TITLE
Stand down nav-mode keys while a permission/choice dialog is open

### DIFF
--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -236,11 +236,17 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
             // dialog, full-page modals, and help overlay are included so their
             // own keys (Esc / backdrop) win and nav shortcuts don't fire
             // underneath them.
+            // `.permission-prompt` covers the permission dialog, the
+            // AskUserQuestion answer card, and the exit-plan-mode prompt (they
+            // share that root class). While one is open the user is answering
+            // it, so nav keys must stand down rather than double-handle the
+            // keystroke — driving navigation *and* leaking into the choice UI
+            // (#1413).
             if gloo::utils::document()
                 .query_selector(
                     ".sched-overlay, .share-dialog-overlay, .help-overlay, \
                      .launch-dialog-backdrop, .modal-overlay, .full-page-modal, \
-                     .health-timer-overlay",
+                     .health-timer-overlay, .permission-prompt",
                 )
                 .ok()
                 .flatten()


### PR DESCRIPTION
In Nav mode, with a permission prompt or an AskUserQuestion card open, a single keystroke was **double-handled** — it drove nav-mode navigation *and* leaked into the choice UI behind/within the dialog.

`use_keyboard_nav` already stands down for other overlays (launch dialog, modals, help overlay) via a `query_selector` guard, but the permission/choice dialogs weren't in that list. They share the `.permission-prompt` root class (the permission dialog, the AskUserQuestion answer card, and the exit-plan-mode prompt all use it), so adding that one selector makes nav suppress its hotkeys for the dialog's lifetime — the sanctioned "stand down" path from the issue — so keys go to exactly one place.

Fixes #1413