### PR TITLE
Wire nav-mode x to interrupt the focused session

### DIFF
--- a/frontend/src/components/help_overlay.rs
+++ b/frontend/src/components/help_overlay.rs
@@ -113,6 +113,10 @@ const GROUPS: &[ShortcutGroup] = &[
                 description: "Delete the focused session (with confirmation)",
             },
             Shortcut {
+                keys: &["x"],
+                description: "Interrupt the focused session's agent",
+            },
+            Shortcut {
                 keys: &["Enter"],
                 description: "Accept the current pane and return to edit mode",
             },

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -170,6 +170,9 @@ pub struct KeyboardNavConfig {
     /// Callback to jump the focused session's transcript to the newest message
     /// and resume live tailing (nav-mode `G`).
     pub on_jump_to_latest: Callback<()>,
+    /// Callback to interrupt the focused session's running agent (nav-mode
+    /// `x`). Same action as `Ctrl+C`, exposed as a single nav-mode key (#1330).
+    pub on_interrupt: Callback<()>,
 }
 
 /// Return value from the use_keyboard_nav hook.
@@ -231,6 +234,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let on_new_session = config.on_new_session.clone();
         let on_delete = config.on_delete.clone();
         let on_jump_to_latest = config.on_jump_to_latest.clone();
+        let on_interrupt = config.on_interrupt.clone();
         Callback::from(move |e: KeyboardEvent| {
             // Don't handle keyboard nav when a modal overlay is open. The launch
             // dialog, full-page modals, and help overlay are included so their
@@ -428,6 +432,15 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                         if let Some(session) = sessions.get(focused_index) {
                             on_delete.emit(session.id);
                         }
+                    }
+                    "x" => {
+                        // Interrupt the focused session's running agent — the
+                        // same action as Ctrl+C, as a single nav-mode key
+                        // (#1330). Non-destructive (the transcript/session stay);
+                        // `d` remains the destructive close-with-confirm. Stays
+                        // in nav mode like the other action keys.
+                        e.prevent_default();
+                        on_interrupt.emit(());
                     }
                     "G" => {
                         // Jump the focused session's transcript to the newest

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -243,6 +243,7 @@ pub fn dashboard_page() -> Html {
         on_new_session,
         on_delete: on_delete.clone(),
         on_jump_to_latest: focus.on_jump_to_latest.clone(),
+        on_interrupt: focus.on_interrupt.clone(),
     });
 
     // Ctrl+C interrupt: a window capture-phase listener so it fires in every
@@ -856,6 +857,7 @@ pub fn dashboard_page() -> Html {
                                             <span>{ "1-9 = select" }</span>
                                             <span>{ "w = next waiting" }</span>
                                             <span>{ "n = new" }</span>
+                                            <span>{ "x = interrupt" }</span>
                                             <span>{ "Enter or Ctrl/Cmd+K = edit mode" }</span>
                                             <span>{ "? = shortcuts" }</span>
                                         </>


### PR DESCRIPTION
Nav-mode `x` was a reserved no-op. Wire it to **interrupt** the focused session's running agent — the same action as `Ctrl+C`, as a single nav-mode key.

**Semantics decision** (the issue asked to confirm 'close' vs 'interrupt'): chose **interrupt**. `d` already deletes the session with a confirm modal, so binding `x` to another destructive close would be redundant; a non-destructive *stop* is otherwise only reachable via `Ctrl+C` (which is additionally overloaded with copy-on-selection). Interrupt is the distinct, useful meaning. Easy to redirect to close if you'd rather.

Reuses the dashboard's existing interrupt callback (`focus.on_interrupt`, the one `use_interrupt_hotkey` already drives), so there's no new interrupt plumbing — just a new `on_interrupt` field on `KeyboardNavConfig` and the `x` arm. Added to the on-screen nav hints and the `?` shortcuts overlay so it's discoverable and the two stay in sync.

Fixes #1330