### PR TITLE
Give forward opens headroom + visibility (fix agent-unreachable misclassification)

### DIFF
--- a/backend/src/handlers/websocket/session_manager/tunnel_client.rs
+++ b/backend/src/handlers/websocket/session_manager/tunnel_client.rs
@@ -32,8 +32,18 @@ use uuid::Uuid;
 
 use super::{ProxySender, SessionManager};
 
-/// How long to wait for the proxy's `TunnelOpened`/`TunnelRefused`.
-const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long to wait for the proxy's `TunnelOpened`/`TunnelRefused` before
+/// giving up and reporting `agent-unreachable`.
+///
+/// **Invariant (#1504):** this must exceed the proxy's worst-case time to
+/// *produce* a verdict, plus network RTT, or a truthful `no-listener` refusal
+/// arrives after the deadline — the stream is already reaped, so the verdict is
+/// dropped and the user sees the misleading `agent-unreachable` instead. The
+/// proxy retries a refused loopback dial for `STREAM_DIAL_RETRY_BUDGET` (8 s)
+/// with a `DIAL_TIMEOUT` (2 s) final attempt, so a mid-restart origin can emit
+/// its refusal as late as ~10 s. 15 s leaves ~3 s of RTT/queueing headroom;
+/// keep `STREAM_DIAL_RETRY_BUDGET + DIAL_TIMEOUT + RTT < OPEN_TIMEOUT`.
+const OPEN_TIMEOUT: Duration = Duration::from_secs(15);
 /// Duplex pipe capacity between the relay and hyper.
 const PIPE_CAPACITY: usize = 64 * 1024;
 
@@ -183,7 +193,25 @@ impl SessionManager {
         if let Some(entry) = self.tunnel_streams.get(&stream_id) {
             let _ = entry.value().inbox.send(msg);
         } else {
-            debug!("Tunnel frame for unknown stream {} dropped", stream_id);
+            // A verdict (`Opened`/`Refused`) for an unknown stream almost always
+            // means it arrived *after* `OPEN_TIMEOUT` reaped the stream — so the
+            // browser was already told `agent-unreachable` even though the proxy
+            // did answer. Log that at INFO so the misclassification is visible
+            // (#1504) rather than silently dropped; it also disambiguates a lost
+            // frame (no late verdict ever arrives) from a slow one. Data/Window/
+            // Close for an unknown stream are ordinary post-close races — quiet.
+            match msg {
+                TunnelIn::Opened => tracing::info!(
+                    "Late tunnel Opened for reaped stream {stream_id} \
+                     (arrived after OPEN_TIMEOUT; was reported agent-unreachable)"
+                ),
+                TunnelIn::Refused(reason) => tracing::info!(
+                    "Late tunnel Refused({reason:?}) for reaped stream {stream_id} \
+                     (arrived after OPEN_TIMEOUT; was reported agent-unreachable — \
+                     the truthful verdict was this refusal)"
+                ),
+                _ => debug!("Tunnel frame for unknown stream {} dropped", stream_id),
+            }
         }
     }
 
@@ -354,7 +382,10 @@ impl SessionManager {
             }
         }
 
-        debug!(
+        // INFO, not DEBUG: a deployment diagnosing a forward incident needs to
+        // see that opens are arriving and succeeding without turning on debug
+        // logging fleet-wide (#1504).
+        tracing::info!(
             "Tunnel stream {} open over the {} plane",
             stream_id,
             egress.kind()

--- a/session-lib/src/tunnel.rs
+++ b/session-lib/src/tunnel.rs
@@ -110,6 +110,12 @@ const DIAL_TIMEOUT: Duration = Duration::from_secs(2);
 /// off and retries within this budget instead of instantly reporting the port
 /// dead. A dial that *times out* is never retried (repeating a multi-second
 /// hang would only stall the browser).
+///
+/// **Invariant (#1504):** the backend gives up on the open verdict after its
+/// `OPEN_TIMEOUT`, so this budget plus the final [`DIAL_TIMEOUT`] plus RTT must
+/// stay under that, or a truthful `NoListener` refusal lands after the backend
+/// has already reported `agent-unreachable`. Backend `OPEN_TIMEOUT` is 15 s vs.
+/// `8 + 2` here, leaving ~5 s of margin; keep it that way if either moves.
 const STREAM_DIAL_RETRY_BUDGET: Duration = Duration::from_secs(8);
 /// Retry budget for the background health probe and the registration probe.
 /// Short: a small grace absorbs a momentary refusal (so the chip doesn't flap
@@ -450,7 +456,10 @@ impl TunnelManager {
                 }
             };
             mgr.send_stream_opened(egress, stream_id).await;
-            debug!("Tunnel stream {} open to port {}", stream_id, port);
+            // INFO so a deployment diagnosing a forward incident can see opens
+            // arriving on the agent side without fleet-wide debug logging
+            // (#1504 actionable 3).
+            info!("Tunnel stream {} open to port {}", stream_id, port);
             run_stream(mgr, stream_id, egress, sizing, tcp, inbox_rx, recv_credit).await;
         });
     }


### PR DESCRIPTION
A browser hitting an active forward whose origin was **mid-restart** got the `agent-unreachable` (504) page even though the launcher, session WebSocket, and backend registration were all healthy — the truthful verdict was `no-listener`.

## Cause (verified in the incident, #1504)

The proxy retries a refused loopback dial for `STREAM_DIAL_RETRY_BUDGET` (8 s) plus a 2 s final `DIAL_TIMEOUT`, so it can emit its `TunnelRefused` as late as ~10 s. The backend's `OPEN_TIMEOUT` was *also* 10 s — so during a restart window the refusal routinely lost the race: the stream was already reaped, the late verdict was dropped silently, and the browser saw `agent-unreachable` instead of the honest `no-listener`.

## Changes (actionables 1–3; 4 is ops)

1. **Headroom.** `OPEN_TIMEOUT` 10 s → **15 s**, with the invariant `retry_budget + dial_timeout + RTT < OPEN_TIMEOUT` documented on *both* constants (backend + proxy) so they can't silently drift back into contention. A mid-restart refusal now reaches the browser as the truthful `no-listener`.
2. **Classify late verdicts.** An `Opened`/`Refused` arriving for an already-reaped stream now logs at **INFO** (including the refusal reason) instead of dropping silently — making the race visible and distinguishing a *slow* verdict from a *lost* frame (candidate (a) vs (b) in the incident).
3. **Open visibility.** The tunnel-open log lines (backend `open over the {} plane`, proxy `open to port {}`) go from `debug!` to `info!`, so a deployment diagnosing a forward incident can see opens arriving without turning on fleet-wide debug logging.

Actionable 4 (surface launcher build age / `--no-update` hygiene on the hub) is operational and out of scope here.

Tunnel unit tests pass, clippy clean.

Fixes #1504