### PR TITLE
Honor the manifest transcript.compression flag on the read path

### DIFF
--- a/archive-format/src/lib.rs
+++ b/archive-format/src/lib.rs
@@ -70,6 +70,22 @@ pub fn zstd_decode(bytes: &[u8]) -> std::io::Result<Vec<u8>> {
     zstd::decode_all(bytes)
 }
 
+/// Decode a transcript body according to the codec its manifest declares in
+/// `transcript.compression`, so readers stay self-describing (#1466). An
+/// unknown codec fails loudly instead of feeding garbage to the zstd decoder.
+/// `zstd` is the only codec today (and the write-side default); the dispatch
+/// exists so a future schema version can add one without silently breaking old
+/// readers.
+pub fn decode_transcript(compression: &str, bytes: &[u8]) -> std::io::Result<Vec<u8>> {
+    match compression {
+        TRANSCRIPT_COMPRESSION => zstd_decode(bytes),
+        other => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("unsupported transcript compression `{other}`"),
+        )),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Manifest / bundle types
 // ---------------------------------------------------------------------------
@@ -473,6 +489,21 @@ mod tests {
         let encoded = zstd_encode(body).unwrap();
         assert_eq!(&encoded[..4], &[0x28, 0xb5, 0x2f, 0xfd], "zstd magic bytes");
         assert_eq!(zstd_decode(&encoded).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_transcript_dispatches_on_declared_codec() {
+        let body = b"{\"id\":1}\n";
+        let encoded = zstd_encode(body).unwrap();
+        // The manifest's default codec decodes.
+        assert_eq!(
+            decode_transcript(TRANSCRIPT_COMPRESSION, &encoded).unwrap(),
+            body
+        );
+        // An unknown codec fails loudly rather than handing garbage to zstd.
+        let err = decode_transcript("gzip", &encoded).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("gzip"), "{err}");
     }
 
     #[test]

--- a/archive-format/src/store.rs
+++ b/archive-format/src/store.rs
@@ -8,9 +8,9 @@ use object_store::ObjectStoreExt as _;
 use uuid::Uuid;
 
 use crate::{
-    manifest_key, media_key, media_meta_key, parse_transcript_ndjson, transcript_key, zstd_decode,
-    zstd_encode, ArchiveMessageLine, ArchivedMediaMeta, SessionArchiveBundle,
-    SessionArchiveManifest,
+    decode_transcript, manifest_key, media_key, media_meta_key, parse_transcript_ndjson,
+    transcript_key, zstd_encode, ArchiveMessageLine, ArchivedMediaMeta, SessionArchiveBundle,
+    SessionArchiveManifest, TRANSCRIPT_COMPRESSION,
 };
 
 // ---------------------------------------------------------------------------
@@ -194,7 +194,16 @@ impl ArchiveStore {
             Some(bytes) => bytes,
             None => return Ok(None),
         };
-        parse_transcript_ndjson(&zstd_decode(&raw)?).map(Some)
+        // Honor the manifest's declared codec rather than assuming zstd (#1466).
+        // The manifest is written last (its existence implies a complete
+        // transcript), so if it's absent we're reading mid-write — fall back to
+        // the write-side default, which is what that partial object is.
+        let compression = self
+            .get_session_manifest(user_id, session_id)?
+            .and_then(|m| m.transcript)
+            .map(|t| t.compression)
+            .unwrap_or_else(|| TRANSCRIPT_COMPRESSION.to_string());
+        parse_transcript_ndjson(&decode_transcript(&compression, &raw)?).map(Some)
     }
 
     /// Write a raw object at `key` (overwrites; deterministic keys make this
@@ -494,13 +503,23 @@ impl LocalArchiveStore {
 }
 
 /// Decompress + parse an archived transcript (test/inspection helper).
+///
+/// Honors the sibling manifest's `transcript.compression` (#1466), falling back
+/// to the write-side default if the manifest is absent/unreadable — matching
+/// [`ArchiveStore::read_transcript_lines`].
 pub fn read_transcript(
     root: &Path,
     user_id: Uuid,
     session_id: Uuid,
 ) -> std::io::Result<Vec<ArchiveMessageLine>> {
     let raw = std::fs::read(root.join(transcript_key(user_id, session_id)))?;
-    parse_transcript_ndjson(&zstd_decode(&raw)?)
+    let compression = std::fs::read(root.join(manifest_key(user_id, session_id)))
+        .ok()
+        .and_then(|m| serde_json::from_slice::<SessionArchiveManifest>(&m).ok())
+        .and_then(|m| m.transcript)
+        .map(|t| t.compression)
+        .unwrap_or_else(|| TRANSCRIPT_COMPRESSION.to_string());
+    parse_transcript_ndjson(&decode_transcript(&compression, &raw)?)
 }
 
 #[cfg(test)]

--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -39,12 +39,12 @@
 // ---------------------------------------------------------------------------
 
 pub use archive_format::{
-    archive_config_from_env, manifest_key, media_key, media_meta_key, merge_transcript_lines,
-    read_transcript, scan, transcript_key, zstd_decode, zstd_encode, ArchiveBackendConfig,
-    ArchiveConfig, ArchiveMemberEntry, ArchiveMessageLine, ArchiveStore, ArchiveTokenTotals,
-    ArchiveTranscriptInfo, ArchiveTurnStats, ArchivedMediaMeta, LocalArchiveStore, MediaEntry,
-    ObjectArchiveStore, SessionArchiveBundle, SessionArchiveManifest, ARCHIVE_SCHEMA_VERSION,
-    TRANSCRIPT_COMPRESSION,
+    archive_config_from_env, decode_transcript, manifest_key, media_key, media_meta_key,
+    merge_transcript_lines, read_transcript, scan, transcript_key, zstd_decode, zstd_encode,
+    ArchiveBackendConfig, ArchiveConfig, ArchiveMemberEntry, ArchiveMessageLine, ArchiveStore,
+    ArchiveTokenTotals, ArchiveTranscriptInfo, ArchiveTurnStats, ArchivedMediaMeta,
+    LocalArchiveStore, MediaEntry, ObjectArchiveStore, SessionArchiveBundle,
+    SessionArchiveManifest, ARCHIVE_SCHEMA_VERSION, TRANSCRIPT_COMPRESSION,
 };
 
 /// How often the archival sweep runs.

--- a/backend/src/handlers/history.rs
+++ b/backend/src/handlers/history.rs
@@ -38,7 +38,8 @@ use uuid::Uuid;
 use shared::api::{HistorySessionSummary, HistorySessionsResponse};
 
 use crate::archive::{
-    manifest_key, scan, transcript_key, zstd_decode, ArchiveRuntime, SessionArchiveManifest,
+    decode_transcript, manifest_key, scan, transcript_key, ArchiveRuntime, SessionArchiveManifest,
+    TRANSCRIPT_COMPRESSION,
 };
 use crate::auth::extract_user;
 use crate::errors::AppError;
@@ -262,7 +263,18 @@ pub async fn get_history_messages(
             .store
             .get_object(&transcript_key(owner_id, session_id))?
         {
-            Some(raw) => zstd_decode(&raw).map(Some),
+            // Decode per the manifest's declared codec, not a hardcoded zstd
+            // (#1466). Manifest-last write order means an absent manifest is a
+            // mid-write read; fall back to the write-side default.
+            Some(raw) => {
+                let compression = runtime
+                    .store
+                    .get_session_manifest(owner_id, session_id)?
+                    .and_then(|m| m.transcript)
+                    .map(|t| t.compression)
+                    .unwrap_or_else(|| TRANSCRIPT_COMPRESSION.to_string());
+                decode_transcript(&compression, &raw).map(Some)
+            }
             None => Ok(None),
         }
     })


### PR DESCRIPTION
The archive manifest records `transcript.compression` (fixed to `"zstd"` at write time) so archives are self-describing — but every reader unconditionally zstd-decoded the transcript object. The field was written and never read; an unknown codec would have fed garbage straight to the zstd decoder.

- New shared `decode_transcript(compression, bytes)` in `archive-format`: decodes per the declared codec, and returns a clear `unsupported transcript compression \`X\`` (`InvalidData`) error on anything else.
- All readers now route through it, sourcing the codec from the manifest: `ArchiveStore::read_transcript_lines`, the `read_transcript` inspection helper, and the `/api/history` transcript endpoint. (The standalone viewer CLI isn't in the main tree.)
- Manifest-last write order means an absent manifest is a mid-write read, so each site falls back to the write-side default (zstd) — additive within schema v1, since every existing manifest says `zstd`, so no current behavior changes.

zstd stays the write-side default (the point of the field is self-description, not a plaintext option). New unit test covers the decode/dispatch + unknown-codec error; archive-format and backend tests pass.

Fixes #1466