### PR TITLE
Render SVGs that declare no intrinsic size

### DIFF
--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -404,6 +404,26 @@ struct ImageViewerProps {
     pub filename: Option<String>,
 }
 
+/// Does this media type need a CSS width fallback to be visible?
+///
+/// Raster formats always carry intrinsic pixel dimensions, but an SVG may
+/// declare none — a bare `viewBox`, or percentage `width`/`height`, is common
+/// in hand-authored diagrams (matplotlib is fine; it emits `width`/`height` in
+/// points). Such an image has *only* an aspect ratio, so inside the
+/// shrink-to-fit `.tool-result-image` frame the frame's width depends on the
+/// image and the image's `max-width: 100%` depends on the frame. Nothing can
+/// resolve that cycle and browsers collapse it to **0×0** — the diagram
+/// silently vanishes, leaving just the frame's 1px border.
+///
+/// Tagging those elements with `svg` lets CSS supply a definite width basis.
+/// Don't drop this without re-testing a `viewBox`-only SVG: it fails silently
+/// (no `onerror`, no console warning), so it's easy to regress unnoticed.
+/// See `.tool-result-image.svg` / `.image-lightbox-content img.svg` in
+/// `frontend/styles/markdown.css`.
+fn needs_size_fallback(media_type: &str) -> bool {
+    media_type == "image/svg+xml"
+}
+
 #[function_component(ImageViewer)]
 fn image_viewer(props: &ImageViewerProps) -> Html {
     let expanded = use_state(|| false);
@@ -451,15 +471,17 @@ fn image_viewer(props: &ImageViewerProps) -> Html {
         .clone()
         .unwrap_or_else(|| format!("image.{ext}"));
 
+    let size_fallback = needs_size_fallback(&props.media_type).then_some("svg");
+
     html! {
         <>
-            <div class="tool-result-image" onclick={on_thumb_click}>
+            <div class={classes!("tool-result-image", size_fallback)} onclick={on_thumb_click}>
                 <img src={props.src.clone()} alt="Tool result image" onerror={on_error} />
             </div>
             if *expanded {
                 <div class="image-lightbox" onclick={on_close.clone()}>
                     <div class="image-lightbox-content" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                        <img src={props.src.clone()} alt="Full size image" />
+                        <img class={classes!(size_fallback)} src={props.src.clone()} alt="Full size image" />
                         <div class="image-lightbox-controls">
                             <a
                                 class="image-lightbox-download"
@@ -832,5 +854,31 @@ fn format_error_type(error_type: &str) -> String {
         "rate_limit_error" => "Rate Limited".to_string(),
         "request_too_large" => "Request Too Large".to_string(),
         other => other.replace('_', " ").to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn svg_gets_a_size_fallback_but_rasters_do_not() {
+        // SVG can lack intrinsic dimensions and collapse to 0x0 without it.
+        assert!(needs_size_fallback("image/svg+xml"));
+        // Raster formats always carry pixel dimensions; forcing a width on them
+        // would stretch small images instead of letting the frame hug them.
+        for raster in ["image/png", "image/jpeg", "image/gif", "image/webp"] {
+            assert!(!needs_size_fallback(raster), "{raster} needs no fallback");
+        }
+    }
+
+    #[test]
+    fn every_allowed_image_type_is_classified() {
+        // Guards against a new format being allowed without deciding whether it
+        // can render without intrinsic dimensions.
+        for media_type in ALLOWED_IMAGE_MEDIA_TYPES {
+            let expected = *media_type == "image/svg+xml";
+            assert_eq!(needs_size_fallback(media_type), expected, "{media_type}");
+        }
     }
 }

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -349,6 +349,20 @@
     display: block;
 }
 
+/* An SVG may declare no intrinsic pixel size (a bare `viewBox`, or percentage
+   `width`/`height`) — common in hand-authored diagrams. It then has only an
+   aspect ratio, so the shrink-to-fit frame above sizes to the image while the
+   image's `max-width: 100%` sizes to the frame. Browsers resolve that cycle at
+   zero and the diagram renders 0x0: invisible, with no `onerror` to trigger the
+   "media expired" fallback. `min-width` breaks the cycle with a definite basis
+   without capping SVGs that *do* carry a size (a matplotlib plot still renders
+   at its full natural width). `min(100%, ...)` keeps it from overflowing a
+   narrow phone column. Frame class is set by `needs_size_fallback` in
+   frontend/src/components/message_renderer/renderers.rs. */
+.tool-result-image.svg {
+    min-width: min(100%, 320px);
+}
+
 /* Video shown via `agent-portal show`. Sizing mirrors `.tool-result-image`
    so images and videos read as one family in the transcript. */
 .tool-result-video {
@@ -412,6 +426,14 @@
     max-height: 85vh;
     object-fit: contain;
     border-radius: 4px;
+}
+
+/* Same 0x0 collapse as `.tool-result-image.svg` (see the note there): this img
+   is the cross-axis item of a centered flex column, so it is shrink-to-fit too.
+   Here we set `width` rather than `min-width` — the lightbox is the "zoom" view,
+   and an SVG is vector, so scaling one up to fill the overlay stays crisp. */
+.image-lightbox-content img.svg {
+    width: min(95vw, 900px);
 }
 
 .image-lightbox-controls {


### PR DESCRIPTION
## Problem

`agent-portal show <file>.svg` rendered nothing for SVGs that declare no intrinsic pixel size — a bare `viewBox`, or percentage `width`/`height`. All you got was the 🖼️ filename header with a ~2px speck under it.

`.tool-result-image` is `width: fit-content`, so the frame sizes to the image, while `img { max-width: 100% }` sizes the image to the frame. An SVG with only an aspect ratio can't break that cycle, and browsers resolve it at **0×0**. The lightbox had the same defect — its `<img>` is the cross-axis item of a centered flex column, so it's shrink-to-fit too, meaning clicking such an SVG opened an empty overlay.

The failure was silent in a way that made it hard to spot: the bytes load fine (correct `Content-Type`, HTTP 200), so no `onerror` fires and the "media expired" fallback never renders. Nothing appears in the console either.

This hit the common case. Hand-authored diagrams are precisely the SVGs that omit `width`/`height` — `dropps-vs-allfreeclear-venn.svg` in this repo is one — and the portal's own reminder text tells agents to *prefer* SVG for diagrams. Raster images and matplotlib plots were always fine, since matplotlib emits `width`/`height` in points.

## Fix

Tag the frame and the lightbox image with an `svg` class when the media type is `image/svg+xml`, and give them a definite width basis:

- **Frame:** `min-width: min(100%, 320px)` — a floor, not a cap, so SVGs that *do* carry a size keep their natural width. An earlier attempt using `width: min(100%, 480px)` downscaled the matplotlib plot 576→480, regressing a working case. The `min(100%, …)` wrapper matters too: a bare `320px` overflows a 260px phone column.
- **Lightbox:** `width: min(95vw, 900px)` — this is the zoom view and SVG is vector, so scaling up stays crisp. Note this does upscale a small SVG to fill the overlay; that's deliberate.

Raster types are deliberately left alone — forcing a width on them would stretch small images instead of letting the frame hug them.

## Verification

Headless Chromium against the real stylesheet, with the markup `ImageViewer` now emits:

| SVG sizing | Before | After |
|---|---|---|
| `width`/`height` in px | 240×80 | 240×80 (unchanged) |
| `width`/`height` in pt (matplotlib) | 576×288 | 576×288 (unchanged) |
| `viewBox` only | **0×0** | 320×107 |
| `width="100%"` | **0×0** | 320×107 |
| raster PNG | fits column | unchanged |

Lightbox: `viewBox`-only SVG goes 0×0 → 855×285.

Two unit tests lock in which media types get the fallback; the second iterates `ALLOWED_IMAGE_MEDIA_TYPES` so adding a format forces a decision rather than silently inheriting raster behavior. `cargo clippy` clean, 523 frontend tests pass, `trunk build` succeeds with both rules present in the bundle.

## Follow-ups (not in this PR)

Two related issues surfaced while tracing, both out of scope here:

1. `archive-viewer/src/serve.rs:363` falls back to `application/octet-stream` when the sidecar has no content type. Browsers sniff raster formats but **never** sniff SVG, so that path silently breaks SVG while PNG/JPEG keep working — same asymmetry, different layer.
2. `GET /api/images/{id}` serves uploaded SVG with no sanitization and no `Content-Disposition`. Inert inside `<img>`, but the lightbox Download link and direct navigation render it as a same-origin document, so embedded script would execute. Worth a security look.