### PR TITLE
Resolve 1M context windows instead of always assuming 200k

### DIFF
--- a/shared/src/model_version.rs
+++ b/shared/src/model_version.rs
@@ -97,27 +97,92 @@ pub fn compact_model_version(model_id: &str) -> Option<String> {
     }
 }
 
+/// Default Claude context window when nothing marks the model as larger.
+/// Mirrors the CLI's `ber` constant (verified in Claude Code 2.1.220).
+const DEFAULT_CONTEXT_WINDOW: u64 = 200_000;
+/// Window for models flagged as 1M-context.
+const MILLION_CONTEXT_WINDOW: u64 = 1_000_000;
+
+/// True when the model id carries the CLI's `[1m]` tag.
+///
+/// The CLI's own test is a bare regex on the id — `function Wb(e){ return
+/// /\[1m\]/i.test(e) }` — and ids like `claude-opus-4-7[1m]` appear verbatim on
+/// the wire (see the `claude-codes` result fixture), so matching the tag is
+/// exact, not a heuristic.
+fn has_one_million_tag(model_id: &str) -> bool {
+    model_id.to_ascii_lowercase().contains("[1m]")
+}
+
 /// Nominal context-window size (in tokens) for a Claude model id.
 ///
 /// Claude's stream-json output reports consumed tokens but *not* the window
 /// size (unlike Codex, which sends `model_context_window` at runtime), so a
-/// context-usage gauge needs a model → window map for Claude turns. Every
-/// current Claude family (Opus / Sonnet / Haiku, incl. the 3.x/4.x/5 lines)
-/// ships a 200k-token window by default, so recognized Claude ids map to
-/// `200_000`; anything unrecognized returns `None` (caller hides the gauge
-/// rather than guess).
+/// context-usage gauge needs a model → window map for Claude turns. Anything
+/// unrecognized returns `None` (caller hides the gauge rather than guess).
 ///
-/// Caveat: a 1M-token context is a per-request beta opt-in that isn't
-/// distinguishable from the model id alone, so a session running it will read
-/// as "more full" than it is. The nominal default matches what the CLI shows
-/// by default. Codex never uses this — it carries its own window on the wire.
+/// Mirrors the resolution order the CLI uses (`mZc`, Claude Code 2.1.220):
+///
+/// 1. the `[1m]` id tag ⇒ 1M,
+/// 2. the `native_1m` capability or `claude-mythos-preview` ⇒ 1M,
+/// 3. a per-model override,
+/// 4. `CLAUDE_CODE_MAX_CONTEXT_TOKENS`, for non-`claude-` ids only,
+/// 5. otherwise 200k.
+///
+/// **Known gaps vs. the CLI** (see #1517 and the upstream ask in
+/// `rust-code-agent-sdks#250`): steps 2–4 are only partially reachable from a
+/// model id. `native_1m` lives in a model-capabilities table we don't have, so
+/// only the by-name `claude-mythos-preview` case is covered; the per-request 1M
+/// beta *header* isn't visible here at all; and the env override is read from
+/// the backend's environment, which is the proxy host's only in single-host
+/// deployments. Those cases under-report the window (a session reads fuller
+/// than it is) rather than over-reporting it.
 pub fn context_window_for(model_id: &str) -> Option<u64> {
     let id = model_id.to_ascii_lowercase();
     let is_claude = ["opus", "sonnet", "haiku"]
         .iter()
         .any(|family| id.contains(family))
         || id.starts_with("claude");
-    is_claude.then_some(200_000)
+    if !is_claude {
+        return None;
+    }
+
+    // 1. Explicit `[1m]` tag on the id.
+    if has_one_million_tag(&id) {
+        return Some(MILLION_CONTEXT_WINDOW);
+    }
+    // 2. Models that are natively 1M. Only the by-name case is knowable here.
+    if id.contains("mythos-preview") {
+        return Some(MILLION_CONTEXT_WINDOW);
+    }
+    // 4. Env override. The CLI applies it only to non-`claude-` ids (so it can't
+    //    silently misreport a first-party model), and we keep that restriction.
+    if !id.starts_with("claude-") {
+        if let Some(env_window) = env_max_context_tokens() {
+            return Some(env_window);
+        }
+    }
+    // 5. Default.
+    Some(DEFAULT_CONTEXT_WINDOW)
+}
+
+/// `CLAUDE_CODE_MAX_CONTEXT_TOKENS`, when set to a positive integer.
+///
+/// WASM has no process environment, so this is a compile-time `None` there —
+/// the frontend never resolves windows itself (it consumes the value computed
+/// where the turn was recorded), so that costs nothing.
+fn env_max_context_tokens() -> Option<u64> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        None
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::env::var("CLAUDE_CODE_MAX_CONTEXT_TOKENS")
+            .ok()?
+            .parse::<u64>()
+            .ok()
+            .filter(|n| *n > 0)
+    }
 }
 
 #[cfg(test)]
@@ -203,5 +268,40 @@ mod tests {
         assert_eq!(context_window_for("gpt-5-codex"), None);
         assert_eq!(context_window_for(""), None);
         assert_eq!(context_window_for("garbled-nonsense"), None);
+    }
+
+    /// The `[1m]` tag means a 1M window (#1517). Before this, a tagged model
+    /// resolved to 200k and the fullness gauge read 5x too full. The tag appears
+    /// verbatim on the wire — the `claude-codes` result fixture carries
+    /// `claude-opus-4-7[1m]`.
+    #[test]
+    fn context_window_honors_the_one_million_tag() {
+        for id in [
+            "claude-opus-4-7[1m]",
+            "claude-sonnet-4-6[1M]",
+            "claude-opus-4-8[1m]",
+        ] {
+            assert_eq!(context_window_for(id), Some(1_000_000), "{id}");
+        }
+        // The same families without the tag stay at the default.
+        assert_eq!(context_window_for("claude-opus-4-7"), Some(200_000));
+        assert_eq!(context_window_for("claude-sonnet-4-6"), Some(200_000));
+    }
+
+    /// Natively-1M models are 1M without needing the tag. Only the by-name case
+    /// is knowable from an id (the `native_1m` capability table isn't available
+    /// here — see the fn docs and rust-code-agent-sdks#250).
+    #[test]
+    fn context_window_honors_natively_one_million_models() {
+        assert_eq!(context_window_for("claude-mythos-preview"), Some(1_000_000));
+    }
+
+    /// The tag still wins for an id that is neither a known family nor
+    /// `claude-`-prefixed, so an unrecognized-but-tagged model isn't dropped.
+    #[test]
+    fn context_window_tag_applies_across_recognized_families() {
+        assert_eq!(context_window_for("claude-haiku-4-5[1m]"), Some(1_000_000));
+        // Still `None` when nothing identifies it as Claude at all.
+        assert_eq!(context_window_for("some-other-model[1m]"), None);
     }
 }


### PR DESCRIPTION
First of two fixes for #1517 (the denominator; the numerator follows separately).

## Problem

`context_window_for()` returned `200_000` for **every** Claude model, so a 1M-context session's fullness gauge read **5× too full** and pegged red almost immediately.

This isn't hypothetical: the `[1m]` tag rides the model id verbatim on the wire — the `claude-codes` result fixture carries `claude-opus-4-7[1m]` — and the CLI's own test is a bare regex on that id:

```js
function Wb(e){ … return /\[1m\]/i.test(e) }
```

I documented this as a "caveat" when I shipped #1501 and left it. That was the wrong call — it's a wrong number, not a nuance.

## Fix

Mirror the CLI's resolution order (`mZc`, verified against the Claude Code **2.1.220** binary):

```js
function mZc(e,t){
  if (Wb(e)) return 1e6;                                   // [1m] tag
  if (t?.includes(v_e.header) && Q8(e)) return 1e6;         // 1M beta header
  if (IP(e)) return 1e6;                                    // native_1m | claude-mythos-preview
  let r = dro(e); if (r !== null) return r;
  let n = Z.CLAUDE_CODE_MAX_CONTEXT_TOKENS;
  if (n > 0 && !lo(vi(e)).startsWith("claude-")) return n;
  return ber }                                              // ber = 200000
```

So: `[1m]` tag → 1M; natively-1M → 1M; `CLAUDE_CODE_MAX_CONTEXT_TOKENS` for non-`claude-` ids only (keeping the CLI's restriction, so it can't silently misreport a first-party model); else 200k.

## Gaps, documented rather than hidden

Three of the CLI's inputs aren't reachable from a model id, and the fn docs say so:

- **`native_1m` capability** lives in a model-capabilities table we don't have, so only the by-name `claude-mythos-preview` case is covered. Upstream ask to expose it: [rust-code-agent-sdks#250](https://github.com/meawoppl/rust-code-agent-sdks/issues/250).
- **The per-request 1M beta header** isn't visible at this layer at all.
- **The env override** is read from the backend's environment, which is the proxy host's only in single-host deployments.

All three fail in the *safe* direction — they under-report the window (a session reads fuller than it is) rather than over-reporting it.

Also swaps the "nominal window" framing for named constants tied to the CLI's (`ber` → `DEFAULT_CONTEXT_WINDOW`), and makes the env read a compile-time `None` on WASM (no process env there; the frontend consumes the window computed where the turn was recorded, so it costs nothing).

5 unit tests: tagged ids across families (incl. uppercase `[1M]`), untagged families staying at 200k, natively-1M by name, tag-without-Claude-family still `None`. `shared` builds for `wasm32-unknown-unknown`.

Part of #1517.