### PR TITLE
Sniff archived media's content type when the sidecar lacks one

### DIFF
--- a/backend/src/handlers/history.rs
+++ b/backend/src/handlers/history.rs
@@ -316,10 +316,16 @@ pub async fn get_history_media(
     .await?;
 
     let bytes = bytes.ok_or(AppError::NotFound("Media not found"))?;
-    // The sidecar carries the content type; fall back to octet-stream if a
-    // blob somehow lacks one.
+    // The sidecar carries the content type. When it's missing, sniff the bytes
+    // rather than serving `application/octet-stream`: browsers content-sniff
+    // raster formats and render them regardless, but they never sniff SVG, so a
+    // blanket octet-stream fallback breaks *only* SVG while PNG/JPEG keep
+    // working — a failure shaped to escape notice. Octet-stream remains the
+    // last resort for bytes we don't recognize.
     let content_type = meta
         .map(|m| m.content_type)
+        .filter(|ct| !ct.trim().is_empty())
+        .or_else(|| shared::media::sniff_content_type(&bytes).map(str::to_string))
         .unwrap_or_else(|| "application/octet-stream".to_string());
 
     Ok(bytes_response(&bytes, &content_type, &request_headers))

--- a/launcher/src/media.rs
+++ b/launcher/src/media.rs
@@ -13,7 +13,10 @@ use std::path::Path;
 use anyhow::{anyhow, Context, Result};
 
 use shared::api::ShowMediaResponse;
-use shared::media::{media_kind, MediaKind, SUPPORTED_FORMATS_HINT};
+use shared::media::{
+    has_gif_magic, has_jpeg_magic, has_mp4_magic, has_png_magic, has_webm_magic, has_webp_magic,
+    looks_like_svg, media_kind, MediaKind, SUPPORTED_FORMATS_HINT,
+};
 
 /// Detect a supported media content type from `path`'s extension, verified
 /// against `bytes`' magic. Returns the canonical content type (e.g.
@@ -48,43 +51,6 @@ pub(crate) fn detect_content_type(path: &Path, bytes: &[u8]) -> Result<&'static 
         ));
     }
     Ok(content_type)
-}
-
-fn has_png_magic(b: &[u8]) -> bool {
-    b.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
-}
-
-fn has_jpeg_magic(b: &[u8]) -> bool {
-    b.starts_with(&[0xFF, 0xD8, 0xFF])
-}
-
-fn has_gif_magic(b: &[u8]) -> bool {
-    b.starts_with(b"GIF87a") || b.starts_with(b"GIF89a")
-}
-
-fn has_webp_magic(b: &[u8]) -> bool {
-    b.len() >= 12 && &b[0..4] == b"RIFF" && &b[8..12] == b"WEBP"
-}
-
-fn has_mp4_magic(b: &[u8]) -> bool {
-    // ISO Base Media: an `ftyp` box at offset 4.
-    b.len() >= 12 && &b[4..8] == b"ftyp"
-}
-
-fn has_webm_magic(b: &[u8]) -> bool {
-    // EBML header (Matroska/WebM).
-    b.starts_with(&[0x1A, 0x45, 0xDF, 0xA3])
-}
-
-/// SVG is XML text, so there's no single magic number. Skip a UTF-8 BOM and
-/// leading whitespace, then look for an `<svg` (or `<?xml` prolog) near the
-/// start.
-fn looks_like_svg(b: &[u8]) -> bool {
-    let b = b.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(b);
-    let head = &b[..b.len().min(1024)];
-    let text = String::from_utf8_lossy(head).to_ascii_lowercase();
-    let trimmed = text.trim_start();
-    trimmed.starts_with("<svg") || trimmed.starts_with("<?xml") || text.contains("<svg")
 }
 
 /// Per-kind size cap (MB) from the environment, defaulting to the documented

--- a/shared/src/media.rs
+++ b/shared/src/media.rs
@@ -42,6 +42,82 @@ pub fn media_kind(content_type: &str) -> Option<MediaKind> {
 pub const SUPPORTED_FORMATS_HINT: &str =
     "png, jpg, jpeg, gif, webp, svg (images); mp4, webm (video)";
 
+// --- Format probes ---
+//
+// Shape checks for the supported formats, used two ways: the CLI verifies a
+// file's bytes against its extension before upload, and the archive read path
+// recovers a content type when a blob's sidecar is missing. Both live here so
+// the two can't drift (see the module docs).
+
+pub fn has_png_magic(b: &[u8]) -> bool {
+    b.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+}
+
+pub fn has_jpeg_magic(b: &[u8]) -> bool {
+    b.starts_with(&[0xFF, 0xD8, 0xFF])
+}
+
+pub fn has_gif_magic(b: &[u8]) -> bool {
+    b.starts_with(b"GIF87a") || b.starts_with(b"GIF89a")
+}
+
+pub fn has_webp_magic(b: &[u8]) -> bool {
+    b.len() >= 12 && &b[0..4] == b"RIFF" && &b[8..12] == b"WEBP"
+}
+
+pub fn has_mp4_magic(b: &[u8]) -> bool {
+    // ISO Base Media: an `ftyp` box at offset 4.
+    b.len() >= 12 && &b[4..8] == b"ftyp"
+}
+
+pub fn has_webm_magic(b: &[u8]) -> bool {
+    // EBML header (Matroska/WebM).
+    b.starts_with(&[0x1A, 0x45, 0xDF, 0xA3])
+}
+
+/// SVG is XML text, so there's no single magic number. Skip a UTF-8 BOM and
+/// leading whitespace, then look for an `<svg` (or `<?xml` prolog) near the
+/// start.
+pub fn looks_like_svg(b: &[u8]) -> bool {
+    let b = b.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(b);
+    let head = &b[..b.len().min(1024)];
+    let text = String::from_utf8_lossy(head).to_ascii_lowercase();
+    let trimmed = text.trim_start();
+    trimmed.starts_with("<svg") || trimmed.starts_with("<?xml") || text.contains("<svg")
+}
+
+/// Recover a supported content type from bytes alone, with no filename to go on.
+///
+/// For serving stored blobs whose declared type went missing. Guessing beats
+/// `application/octet-stream` there because of an asymmetry in how browsers
+/// treat it: they content-sniff raster formats and render them anyway, but they
+/// **never** sniff SVG. So an octet-stream fallback silently breaks only SVG
+/// while PNG/JPEG keep working — a bug shaped to hide from casual testing.
+///
+/// Binary magics are checked first since they're unambiguous; the SVG text
+/// heuristic goes last because it's the loosest. Returns `None` for anything
+/// outside the supported set, leaving the caller to pick a fallback — never
+/// invent a type for bytes we don't recognize.
+pub fn sniff_content_type(bytes: &[u8]) -> Option<&'static str> {
+    if has_png_magic(bytes) {
+        Some("image/png")
+    } else if has_jpeg_magic(bytes) {
+        Some("image/jpeg")
+    } else if has_gif_magic(bytes) {
+        Some("image/gif")
+    } else if has_webp_magic(bytes) {
+        Some("image/webp")
+    } else if has_mp4_magic(bytes) {
+        Some("video/mp4")
+    } else if has_webm_magic(bytes) {
+        Some("video/webm")
+    } else if looks_like_svg(bytes) {
+        Some("image/svg+xml")
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -60,5 +136,50 @@ mod tests {
         assert_eq!(media_kind("image/tiff"), None);
         assert_eq!(media_kind("video/quicktime"), None);
         assert_eq!(media_kind(""), None);
+    }
+
+    #[test]
+    fn sniffs_every_supported_format_from_bytes() {
+        let png = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0];
+        assert_eq!(sniff_content_type(&png), Some("image/png"));
+        assert_eq!(
+            sniff_content_type(&[0xFF, 0xD8, 0xFF, 0xE0]),
+            Some("image/jpeg")
+        );
+        assert_eq!(sniff_content_type(b"GIF89a...."), Some("image/gif"));
+        assert_eq!(sniff_content_type(b"RIFF____WEBPVP8 "), Some("image/webp"));
+        assert_eq!(sniff_content_type(b"\0\0\0\x18ftypisom"), Some("video/mp4"));
+        assert_eq!(
+            sniff_content_type(&[0x1A, 0x45, 0xDF, 0xA3, 0, 0, 0, 0]),
+            Some("video/webm")
+        );
+
+        // Every sniffed type must be one the rest of the pipeline accepts.
+        for bytes in [&png[..], &[0xFF, 0xD8, 0xFF, 0xE0][..]] {
+            let ct = sniff_content_type(bytes).expect("sniffed");
+            assert!(media_kind(ct).is_some(), "{ct} not in the supported set");
+        }
+    }
+
+    #[test]
+    fn sniffs_svg_in_its_common_shapes() {
+        // The case that regressed: SVG is never content-sniffed by browsers, so
+        // serving it as octet-stream renders nothing.
+        for svg in [
+            &b"<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>"[..],
+            &b"<?xml version=\"1.0\"?>\n<svg viewBox=\"0 0 1 1\"></svg>"[..],
+            &b"\n  <svg/>"[..],
+            &b"\xEF\xBB\xBF<svg/>"[..], // UTF-8 BOM
+        ] {
+            assert_eq!(sniff_content_type(svg), Some("image/svg+xml"));
+        }
+    }
+
+    #[test]
+    fn sniff_declines_unknown_bytes() {
+        // Must not invent a type; the caller falls back deliberately.
+        assert_eq!(sniff_content_type(b"%PDF-1.7"), None);
+        assert_eq!(sniff_content_type(b""), None);
+        assert_eq!(sniff_content_type(b"just some prose"), None);
     }
 }


### PR DESCRIPTION
Follow-up to #1525, same failure class one layer down.

## Problem

`GET /api/history/media/{user}/{session}/{media_id}` served archived blobs as `application/octet-stream` whenever the sidecar had no content type:

```rust
let content_type = meta
    .map(|m| m.content_type)
    .unwrap_or_else(|| "application/octet-stream".to_string());
```

That reads as a safe, type-agnostic default, but it isn't symmetric across formats. Browsers content-sniff raster images and render them regardless of the declared type — but they **never** sniff SVG. So this fallback broke *only* SVG while PNG/JPEG kept working: a bug shaped to hide from casual testing, since the obvious thing to test with is a screenshot.

## Fix

Sniff the bytes when the declared type is missing or blank, and keep `application/octet-stream` as the genuine last resort for formats we don't recognize — the sniffer returns `Option` and never invents a type.

The magic-byte probes move out of `launcher/src/media.rs` into `shared/src/media.rs`. That module already exists precisely so this policy can't drift between the CLI and the backend ("so the allow-list never drifts between the two sides"), and the archive read path is now a third consumer. The CLI's extension-vs-magic verification is unchanged and now shares one implementation with the read path.

Ordering is deliberate: unambiguous binary magics first, the SVG text heuristic last, since XML text has no magic number and the check is the loosest.

## Verification

- 4 new unit tests: every supported format sniffed from bytes; SVG in its four real-world shapes (plain, `<?xml>` prolog, leading whitespace, UTF-8 BOM); unknown bytes decline rather than guess; and a cross-check that anything sniffed is a type `media_kind` already accepts.
- The launcher's 8 existing `media::` tests pass untouched against the shared probes, confirming no behavior drift from the move.
- `cargo clippy` clean on shared/launcher/backend; `shared` still builds for `wasm32-unknown-unknown`.