### PR TITLE
Anchor Claude context usage on the last assistant usage, not the roll-up

### DIFF
--- a/backend/migrations/2026-07-31-120000_add_context_snapshot_tokens_to_turn_metrics/down.sql
+++ b/backend/migrations/2026-07-31-120000_add_context_snapshot_tokens_to_turn_metrics/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE turn_metrics DROP COLUMN context_snapshot_tokens;

--- a/backend/migrations/2026-07-31-120000_add_context_snapshot_tokens_to_turn_metrics/up.sql
+++ b/backend/migrations/2026-07-31-120000_add_context_snapshot_tokens_to_turn_metrics/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE turn_metrics ADD COLUMN context_snapshot_tokens BIGINT;

--- a/backend/src/handlers/websocket/turn_metrics.rs
+++ b/backend/src/handlers/websocket/turn_metrics.rs
@@ -127,6 +127,7 @@ pub fn handle_turn_metrics_report(
         stream_restarts: metrics.stream_restarts,
         total_cost_usd: metrics.total_cost_usd,
         model_context_window: metrics.model_context_window,
+        context_snapshot_tokens: metrics.context_snapshot_tokens,
     };
 
     use crate::schema::turn_metrics;

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -588,6 +588,7 @@ pub struct TurnMetric {
     pub user_id: Uuid,
     pub subagent_tokens: i64,
     pub model_context_window: Option<i64>,
+    pub context_snapshot_tokens: Option<i64>,
 }
 
 impl TurnMetric {
@@ -626,6 +627,7 @@ impl TurnMetric {
             stream_restarts: self.stream_restarts,
             total_cost_usd: self.total_cost_usd,
             model_context_window: self.model_context_window,
+            context_snapshot_tokens: self.context_snapshot_tokens,
         }
     }
 }
@@ -658,6 +660,7 @@ pub struct NewTurnMetric {
     pub stream_restarts: i32,
     pub total_cost_usd: Option<f64>,
     pub model_context_window: Option<i64>,
+    pub context_snapshot_tokens: Option<i64>,
 }
 
 #[cfg(test)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -258,6 +258,7 @@ diesel::table! {
         user_id -> Uuid,
         subagent_tokens -> Int8,
         model_context_window -> Nullable<Int8>,
+        context_snapshot_tokens -> Nullable<Int8>,
     }
 }
 

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -222,6 +222,64 @@ fn truncate_for_log(text: &str) -> String {
 // is_error=true. We retry that turn for the user with full-jitter exponential
 // backoff.
 const RATE_LIMIT_TEXT_PREFIX: &str = "API Error: Server is temporarily limiting requests";
+
+/// The model id the CLI stamps on messages it injects itself. Real usage never
+/// rides these, so they must not anchor context occupancy — the CLI's own
+/// predicate excludes them (`lIe`: `e.message.model !== jC`, where
+/// `jC = "<synthetic>"`; verified in Claude Code 2.1.220). #1517.
+const SYNTHETIC_MODEL: &str = "<synthetic>";
+
+/// Texts the CLI treats as injected/synthetic assistant content, excluded from
+/// the context anchor. These are the resolved members of the CLI's `_mt` set
+/// (`lIe`, Claude Code 2.1.220): interrupt notices and tool-rejection notices.
+/// Compared as prefixes because the longer two continue with instructions.
+const SYNTHETIC_ASSISTANT_TEXTS: &[&str] = &[
+    "[Request interrupted by user]",
+    "[Request interrupted by user for tool use]",
+    "No response requested.",
+    "The user doesn't want to take this action right now.",
+    "The user doesn't want to proceed with this tool use.",
+];
+
+/// Context tokens contributed by one assistant-message usage snapshot.
+///
+/// Matches the CLI's status-line form (`pro`, Claude Code 2.1.220):
+/// `input + cache_creation + cache_read`, **excluding** `output_tokens`. (The
+/// CLI's internal auto-compact accounting, `cIe`, does add output; the status
+/// line — what a user sees as "% context used" — does not, and that is the
+/// semantics this gauge reproduces.)
+fn context_snapshot_tokens(usage: &claude_codes::io::AssistantUsage) -> i64 {
+    usage.input_tokens as i64
+        + usage.cache_creation_input_tokens as i64
+        + usage.cache_read_input_tokens as i64
+}
+
+/// Whether an assistant frame may anchor context occupancy, mirroring the CLI's
+/// `lIe`: it must carry usage, not be CLI-injected content, and not be stamped
+/// with the synthetic model.
+fn can_anchor_context(msg: &claude_codes::io::AssistantMessage) -> bool {
+    if msg.message.model == SYNTHETIC_MODEL {
+        return false;
+    }
+    // The CLI only inspects the FIRST content block, so a real reply that merely
+    // quotes one of these strings later is unaffected.
+    let first_text = msg.message.content.iter().find_map(|b| match b {
+        ContentBlock::Text(t) => Some(t.text.as_str()),
+        _ => None,
+    });
+    let first_is_text = matches!(msg.message.content.first(), Some(ContentBlock::Text(_)));
+    if first_is_text {
+        if let Some(text) = first_text {
+            if SYNTHETIC_ASSISTANT_TEXTS
+                .iter()
+                .any(|synthetic| text.starts_with(synthetic))
+            {
+                return false;
+            }
+        }
+    }
+    true
+}
 const MAX_RATE_LIMIT_RETRIES: u32 = 30;
 const RATE_LIMIT_BACKOFF_CAP_SECS: u64 = 60;
 
@@ -426,6 +484,17 @@ pub(crate) async fn claude_io_task(
     // assistant message's `model` field (per-message); the tracker doesn't
     // know either on its own.
     let mut current_model: Option<String> = None;
+    // Context-occupancy anchor (#1517): tokens from the LAST real assistant
+    // usage, which is a per-API-call snapshot. Deliberately not the Result
+    // frame's usage — that is an accumulated roll-up across the turn's
+    // iterations (the CLI sums usage field-by-field in `vTo`), so its
+    // cache_read re-counts nearly the whole context once per tool call and a
+    // tool-heavy turn reads many times over the window.
+    let mut context_anchor_tokens: Option<i64> = None;
+    // Message id the anchor came from, so streamed chunks sharing an id don't
+    // re-anchor: the CLI takes the first chunk of a group (`e1d` de-dupes on
+    // `message.id`).
+    let mut context_anchor_msg_id: Option<String> = None;
     let mut current_service_tier: Option<String> = None;
     // Session-lifetime subagent (`Task`) usage rollup (claude-codes 2.1.160,
     // #1275). Unlike the hand-rolled per-turn sum it replaces, the rollup
@@ -529,6 +598,20 @@ pub(crate) async fn claude_io_task(
                                     if let Some(tier) = &usage.service_tier {
                                         current_service_tier = Some(tier.clone());
                                     }
+                                    // Re-anchor context occupancy on this frame
+                                    // unless it repeats the current message id
+                                    // (a streamed continuation) or is CLI-
+                                    // injected content. Later groups overwrite
+                                    // earlier ones, leaving the turn's last real
+                                    // usage as the anchor.
+                                    let id = asst.message.id.as_str();
+                                    let same_group =
+                                        context_anchor_msg_id.as_deref() == Some(id);
+                                    if !same_group && can_anchor_context(asst) {
+                                        context_anchor_msg_id = Some(id.to_string());
+                                        context_anchor_tokens =
+                                            Some(context_snapshot_tokens(usage));
+                                    }
                                 }
                                 // Count tool-use blocks for the turn.
                                 for block in &asst.message.content {
@@ -595,6 +678,9 @@ pub(crate) async fn claude_io_task(
                                     .map(|u| u.cache_read_input_tokens as i64)
                                     .unwrap_or(0),
                                 thinking_tokens: 0,
+                                // Per-request occupancy snapshot (#1517), not
+                                // the roll-up in the token fields above.
+                                context_snapshot_tokens: context_anchor_tokens,
                                 // Subagent (`Task`) tokens attributed to THIS
                                 // turn: the session-lifetime rollup's total
                                 // minus its value when the turn started —
@@ -1105,6 +1191,90 @@ mod tests {
         user_output_with_content(serde_json::json!([
             { "type": "text", "text": text }
         ]))
+    }
+
+    fn assistant_frame(model: &str, text: Option<&str>, usage: bool) -> serde_json::Value {
+        let content = match text {
+            Some(t) => serde_json::json!([{"type": "text", "text": t}]),
+            None => serde_json::json!([{"type": "tool_use", "id": "toolu_1",
+                                        "name": "Bash", "input": {}}]),
+        };
+        let mut message = serde_json::json!({
+            "id": "msg_1", "role": "assistant", "model": model, "content": content,
+        });
+        if usage {
+            message["usage"] = serde_json::json!({
+                "input_tokens": 10, "output_tokens": 1,
+                "cache_creation_input_tokens": 2, "cache_read_input_tokens": 3,
+            });
+        }
+        serde_json::json!({"type": "assistant", "message": message,
+                           "session_id": "01890000-0000-7000-8000-000000000001"})
+    }
+
+    fn parse_assistant(v: serde_json::Value) -> claude_codes::io::AssistantMessage {
+        match serde_json::from_value::<ClaudeOutput>(v).expect("parse") {
+            ClaudeOutput::Assistant(a) => a,
+            other => panic!("expected assistant, got {other:?}"),
+        }
+    }
+
+    /// The context anchor is the CLI's `pro` form: input + cache_creation +
+    /// cache_read, EXCLUDING output (#1517).
+    #[test]
+    fn context_snapshot_excludes_output_tokens() {
+        let asst = parse_assistant(assistant_frame("claude-opus-4-8", Some("hi"), true));
+        let usage = asst.message.usage.as_ref().expect("usage");
+        // 10 + 2 + 3 = 15; the output token is deliberately not counted.
+        assert_eq!(context_snapshot_tokens(usage), 15);
+    }
+
+    /// CLI-injected frames must never anchor context: the synthetic model, and
+    /// the interrupt / tool-rejection notices (the CLI's `_mt` set).
+    #[test]
+    fn synthetic_frames_cannot_anchor_context() {
+        // Real reply anchors.
+        assert!(can_anchor_context(&parse_assistant(assistant_frame(
+            "claude-opus-4-8",
+            Some("a real answer"),
+            true
+        ))));
+        // The `<synthetic>` model never anchors, whatever its text.
+        assert!(!can_anchor_context(&parse_assistant(assistant_frame(
+            SYNTHETIC_MODEL,
+            Some("a real answer"),
+            true
+        ))));
+        // Each known injected text is excluded.
+        for text in SYNTHETIC_ASSISTANT_TEXTS {
+            assert!(
+                !can_anchor_context(&parse_assistant(assistant_frame(
+                    "claude-opus-4-8",
+                    Some(text),
+                    true
+                ))),
+                "should not anchor: {text}"
+            );
+        }
+    }
+
+    /// The exclusion only inspects the FIRST content block, matching the CLI —
+    /// so a genuine reply that merely quotes one of those strings still anchors,
+    /// and a tool-use-first frame is unaffected.
+    #[test]
+    fn context_anchor_only_inspects_the_first_block() {
+        let quoting = format!("Here is what happened: {}", SYNTHETIC_ASSISTANT_TEXTS[0]);
+        assert!(can_anchor_context(&parse_assistant(assistant_frame(
+            "claude-opus-4-8",
+            Some(&quoting),
+            true
+        ))));
+        // Leading tool_use block (no text first) anchors normally.
+        assert!(can_anchor_context(&parse_assistant(assistant_frame(
+            "claude-opus-4-8",
+            None,
+            true
+        ))));
     }
 
     #[test]

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -524,6 +524,12 @@ pub(crate) async fn codex_io_task(
                                         .unwrap_or(0),
                                     subagent_tokens: subagent_token_tracker
                                         .take_current_turn_tokens(),
+                                    // Codex's `token_usage.last` is already the
+                                    // per-turn value, so there is no separate
+                                    // per-call snapshot to carry (#1517);
+                                    // `context_tokens()` falls back to
+                                    // `input_tokens`, which is that value.
+                                    context_snapshot_tokens: None,
                                     stop_reason: Some(status.to_string()),
                                     is_error,
                                     total_cost_usd: None,

--- a/frontend/src/components/message_renderer/turn_metrics_footer.rs
+++ b/frontend/src/components/message_renderer/turn_metrics_footer.rs
@@ -352,6 +352,7 @@ mod tests {
             stream_restarts: 0,
             total_cost_usd: Some(0.014),
             model_context_window: None,
+            context_snapshot_tokens: None,
         }
     }
 
@@ -409,6 +410,7 @@ mod tests {
             stream_restarts: 0,
             total_cost_usd: None, // None → cost chip drops
             model_context_window: None,
+            context_snapshot_tokens: None,
         };
         let chips = build_chip_list(&m);
         assert_eq!(

--- a/frontend/src/components/turn_metrics_pill.rs
+++ b/frontend/src/components/turn_metrics_pill.rs
@@ -291,6 +291,7 @@ mod tests {
             service_tier: tier.map(|s| s.to_string()),
             total_cost_usd: Some(0.012),
             model_context_window: None,
+            context_snapshot_tokens: None,
         }
     }
 

--- a/frontend/src/hooks/client_websocket_events.rs
+++ b/frontend/src/hooks/client_websocket_events.rs
@@ -126,6 +126,7 @@ mod tests {
             cache_read_tokens: 0,
             thinking_tokens: 0,
             subagent_tokens: 0,
+            context_snapshot_tokens: None,
             stop_reason: None,
             is_error: false,
             tool_call_count: 0,

--- a/frontend/src/pages/dashboard/session_view/state.rs
+++ b/frontend/src/pages/dashboard/session_view/state.rs
@@ -79,6 +79,7 @@ mod tests {
             cache_read_tokens: 0,
             thinking_tokens: 0,
             subagent_tokens: 0,
+            context_snapshot_tokens: None,
             stop_reason: None,
             is_error: false,
             tool_call_count: 0,

--- a/session-lib/src/turn_tracker.rs
+++ b/session-lib/src/turn_tracker.rs
@@ -197,6 +197,7 @@ impl TurnTracker {
             output_tokens: outcome.output_tokens,
             cache_creation_tokens: outcome.cache_creation_tokens,
             cache_read_tokens: outcome.cache_read_tokens,
+            context_snapshot_tokens: outcome.context_snapshot_tokens,
             thinking_tokens: outcome.thinking_tokens,
             subagent_tokens: outcome.subagent_tokens,
             stop_reason: outcome.stop_reason,
@@ -255,6 +256,16 @@ pub struct TurnOutcome {
     /// turn's tokens. `0` when no subagents ran or the agent protocol doesn't
     /// surface the rollup. See [`shared::TurnMetrics::subagent_tokens`].
     pub subagent_tokens: i64,
+    /// Context occupancy at the end of the turn, in tokens: the LAST real
+    /// assistant usage's `input + cache_creation + cache_read` (#1517).
+    ///
+    /// Deliberately separate from the token fields above, which are the turn's
+    /// accumulated roll-up — correct for cost and the per-turn footer, but wrong
+    /// as a context measure, because the roll-up re-counts `cache_read` once per
+    /// API call in a tool-use loop. `None` when the agent gives no per-call
+    /// snapshot (Codex, or a turn with no usable assistant usage), in which case
+    /// consumers fall back to the roll-up.
+    pub context_snapshot_tokens: Option<i64>,
     pub stop_reason: Option<String>,
     pub is_error: bool,
     pub total_cost_usd: Option<f64>,
@@ -290,6 +301,7 @@ mod tests {
             cache_read_tokens: 10,
             thinking_tokens: 3,
             subagent_tokens: 25,
+            context_snapshot_tokens: None,
             stop_reason: Some("end_turn".to_string()),
             is_error: false,
             total_cost_usd: Some(0.005),
@@ -407,6 +419,7 @@ mod tests {
             cache_read_tokens: 0,
             thinking_tokens: 0,
             subagent_tokens: 0,
+            context_snapshot_tokens: None,
             stop_reason: Some("completed".to_string()),
             is_error: false,
             total_cost_usd: None,

--- a/shared/src/api/metrics.rs
+++ b/shared/src/api/metrics.rs
@@ -117,6 +117,14 @@ pub struct TurnMetrics {
     /// instead. Powers the context-usage gauge.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_context_window: Option<i64>,
+    /// Context occupancy at the end of the turn, from the LAST real assistant
+    /// usage snapshot (#1517). The other token fields are the turn's accumulated
+    /// roll-up — right for cost, wrong for context, because the roll-up
+    /// re-counts `cache_read` once per API call in a tool-use loop. `None` from
+    /// agents/proxies that don't supply a snapshot, where
+    /// [`TurnMetrics::context_tokens`] falls back to the roll-up.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_snapshot_tokens: Option<i64>,
 }
 
 impl TurnMetrics {
@@ -142,9 +150,19 @@ impl TurnMetrics {
     ///   cached / cache-write counts as subsets already inside it — so summing
     ///   them would double-count. Its occupancy is just `input_tokens`.
     pub fn context_tokens(&self) -> i64 {
+        // Prefer the per-request snapshot when the proxy supplied one: for
+        // Claude the fields below are a roll-up across the turn's API calls, so
+        // a tool-heavy turn re-counts `cache_read` once per call and can read
+        // several times the window (#1517).
+        if let Some(snapshot) = self.context_snapshot_tokens.filter(|t| *t > 0) {
+            return snapshot;
+        }
         match self.agent_type {
             AgentType::Codex => self.input_tokens,
-            // Claude (and the default) — disjoint buckets sum to the prompt.
+            // Claude fallback (older proxy, or no usable assistant usage this
+            // turn): the disjoint buckets sum to the prompt. Correct for a
+            // single-call turn and an over-count for a multi-call one — the
+            // pre-#1517 behavior, kept so an old proxy still shows something.
             AgentType::Claude => {
                 self.input_tokens + self.cache_read_tokens + self.cache_creation_tokens
             }
@@ -277,6 +295,7 @@ mod tests {
             cache_read_tokens,
             thinking_tokens: 0,
             subagent_tokens: 0,
+            context_snapshot_tokens: None,
             stop_reason: None,
             is_error: false,
             tool_call_count: 0,
@@ -284,6 +303,52 @@ mod tests {
             total_cost_usd: None,
             model_context_window,
         }
+    }
+
+    /// The per-request snapshot wins over the roll-up when present (#1517).
+    /// This is the whole point of the field: on a tool-heavy Claude turn the
+    /// roll-up re-counts `cache_read` once per API call, so it can exceed the
+    /// window several times over while the true occupancy is far lower.
+    #[test]
+    fn snapshot_overrides_the_rolled_up_token_fields() {
+        // A 6-call turn whose roll-up sums to ~900k against a 200k window…
+        let mut t = turn(
+            AgentType::Claude,
+            Some("claude-opus-4-8"),
+            None,
+            60_000,
+            800_000,
+            40_000,
+        );
+        assert_eq!(t.context_tokens(), 900_000, "roll-up over-counts");
+        assert!(
+            t.context_fraction().unwrap() > 4.0,
+            "roll-up would peg the gauge"
+        );
+
+        // …but the last request actually held 150k of the 200k window.
+        t.context_snapshot_tokens = Some(150_000);
+        assert_eq!(t.context_tokens(), 150_000);
+        assert_eq!(t.context_fraction(), Some(150_000.0 / 200_000.0));
+    }
+
+    /// Absent or non-positive snapshots fall back to the pre-#1517 sum, so a
+    /// turn recorded by an older proxy still renders something.
+    #[test]
+    fn missing_snapshot_falls_back_to_the_sum() {
+        let mut t = turn(
+            AgentType::Claude,
+            Some("claude-opus-4-8"),
+            None,
+            30_000,
+            10_000,
+            3_000,
+        );
+        assert_eq!(t.context_snapshot_tokens, None);
+        assert_eq!(t.context_tokens(), 43_000);
+        // A zero snapshot is treated as "no data", not as an empty context.
+        t.context_snapshot_tokens = Some(0);
+        assert_eq!(t.context_tokens(), 43_000);
     }
 
     #[test]

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -311,6 +311,7 @@ mod tests {
             stream_restarts: 0,
             total_cost_usd: Some(0.0145),
             model_context_window: None,
+            context_snapshot_tokens: None,
         };
         let json = serde_json::to_value(&metrics).unwrap();
         assert_eq!(json["agent_type"], "claude");
@@ -351,6 +352,7 @@ mod tests {
             stream_restarts: 0,
             total_cost_usd: None,
             model_context_window: None,
+            context_snapshot_tokens: None,
         };
         assert!(metrics.has_known_model());
 
@@ -470,6 +472,7 @@ mod tests {
             stream_restarts: 0,
             total_cost_usd: None,
             model_context_window: None,
+            context_snapshot_tokens: None,
         };
         let json = serde_json::to_value(&metrics).unwrap();
         assert_eq!(json["agent_type"], "codex");


### PR DESCRIPTION
Second of two fixes for #1517 — the numerator. (#1526 is the denominator.)

## Problem

The gauge's Claude numerator came from `ResultMessage.usage`, which is an **accumulated roll-up across the turn's API calls**. Verified against the Claude Code **2.1.220** binary — the CLI sums usage field-by-field:

```js
function vTo(e,t){ return {
  input_tokens:                e.input_tokens                + t.input_tokens,
  cache_creation_input_tokens: e.cache_creation_input_tokens + t.cache_creation_input_tokens,
  cache_read_input_tokens:     e.cache_read_input_tokens     + t.cache_read_input_tokens,   // ← summed
  output_tokens:               e.output_tokens               + t.output_tokens, … }}
```

Every iteration re-reads nearly the whole prior context from cache, so on a turn with N tool calls `cache_read` is counted ~N times. A tool-heavy turn reported **several times the context window** and pegged the bar at 100% — a number that meant nothing. Context occupancy is a snapshot, not an accumulator.

Corroborating: the CLI's own reader deliberately avoids that roll-up, and its `iterations` breakdown carries **no cache fields** (`{input_tokens, output_tokens, type}`), which is why it can't be the source either:

```js
let o = n.iterations?.at(-1);
if (o) return o.input_tokens + o.output_tokens;
return n.input_tokens + n.output_tokens   // top level only as fallback
```

## Fix

Latch the **last real assistant usage** during the turn and carry it as a new `context_snapshot_tokens`, mirroring the CLI's anchor rule (`lIe`, `e1d`):

- skip frames stamped with the synthetic model — `jC = "<synthetic>"`, resolved from the binary;
- skip frames whose **first** content block is one of the CLI's injected notices (the `_mt` set: the two interrupt notices, `No response requested.`, and the two tool-rejection notices — all resolved from the binary). Only the first block is inspected, matching the CLI, so a real reply that merely quotes one still anchors;
- de-dupe streamed chunks sharing a `message.id`, so the first chunk of each group anchors and later groups overwrite it — leaving the turn's last real usage.

Value is `input + cache_creation + cache_read`, **excluding** output — the CLI's status-line form (`pro`), i.e. the "% context used" semantics a user actually sees. (Its internal auto-compact accounting, `cIe`, does add output; that's a different number and not what this gauge shows.)

## Why a new field, not a repurposed one

The existing `input_tokens`/`cache_read_tokens`/`cache_creation_tokens` stay the turn roll-up. That roll-up is **correct** for cost and the per-turn metrics footer — it's only wrong as a *context* measure. Overwriting them would have fixed the bar and broken the footer.

`context_tokens()` prefers the snapshot and falls back to the old sum when it's absent or non-positive, so turns recorded by older proxies still render (at the old, over-counting value — no worse than today). Codex passes `None`: its `token_usage.last` is already per-turn, so the fallback yields exactly that.

## Scope

New nullable column (`context_snapshot_tokens BIGINT`), plumbed proxy → `TurnOutcome` → `TurnMetrics` → wire → DB → gauge. Field is `#[serde(default, skip_serializing_if)]`, so mixed-version fleets are unaffected.

Tests: snapshot-overrides-roll-up (a 6-call turn whose roll-by would read >4× the window), fallback on absent/zero snapshot, output excluded from the snapshot sum, and the anchor predicate (synthetic model, each injected notice, first-block-only, tool-use-first). `cargo test --workspace` green, clippy clean, `shared` builds for wasm32.

## Known gaps

Two of the CLI's `_mt` members were resolved by prefix, and its set may grow between versions — a new injected notice would simply anchor where it shouldn't, slightly over-reporting one turn. Tracked with the other approximations in the follow-up issue; the upstream ask that would remove this class of guessing is [rust-code-agent-sdks#250](https://github.com/meawoppl/rust-code-agent-sdks/issues/250).

Fixes #1517