### PR TITLE
Stop uploaded SVGs from executing script on the portal origin

### DIFF
--- a/backend/src/handlers/history.rs
+++ b/backend/src/handlers/history.rs
@@ -329,7 +329,7 @@ pub async fn get_history_media(
 /// already in memory (`get_media_bytes`), so ranging is a slice.
 fn bytes_response(bytes: &[u8], content_type: &str, headers: &HeaderMap) -> Response {
     let total = bytes.len() as u64;
-    match parse_range(headers, total) {
+    let mut response = match parse_range(headers, total) {
         Some(Err(())) => Response::builder()
             .status(StatusCode::RANGE_NOT_SATISFIABLE)
             .header(header::ACCEPT_RANGES, "bytes")
@@ -358,7 +358,15 @@ fn bytes_response(bytes: &[u8], content_type: &str, headers: &HeaderMap) -> Resp
             .header(header::CONTENT_LENGTH, total)
             .body(Body::from(bytes.to_vec()))
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
-    }
+    };
+    // Archived media is the same attacker-influenced upload as the live copy, so
+    // it carries the same hardening (see `media_security`).
+    response
+        .headers_mut()
+        .extend(crate::handlers::media_security::media_security_headers(
+            content_type,
+        ));
+    response
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/images.rs
+++ b/backend/src/handlers/images.rs
@@ -11,7 +11,7 @@
 
 use axum::{
     extract::{Path, State},
-    http::header,
+    http::{header, HeaderValue},
     response::IntoResponse,
 };
 use base64::Engine;
@@ -227,16 +227,20 @@ pub async fn serve_image(
         }
     }
 
-    Ok((
-        [
-            (header::CONTENT_TYPE, image.content_type.clone()),
-            (
-                header::CACHE_CONTROL,
-                "private, max-age=86400, immutable".to_string(),
-            ),
-        ],
-        image.data.clone(),
-    ))
+    let mut headers = crate::handlers::media_security::media_security_headers(&image.content_type);
+    headers.insert(
+        header::CONTENT_TYPE,
+        image
+            .content_type
+            .parse()
+            .map_err(|_| AppError::Internal("stored image has an invalid content type".into()))?,
+    );
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("private, max-age=86400, immutable"),
+    );
+
+    Ok((headers, image.data.clone()))
 }
 
 /// Does `user_id` appear in `session_members` for `session_id`?

--- a/backend/src/handlers/media_security.rs
+++ b/backend/src/handlers/media_security.rs
@@ -1,0 +1,117 @@
+//! Hardening headers for responses that serve user-uploaded media.
+//!
+//! Media bytes arrive from an agent's `agent-portal show <file>`, so they are
+//! attacker-influenced input as far as the browser is concerned. Every path that
+//! serves them back ([`images`](super::images), [`media_store`](super::media_store),
+//! and the archived-media read in [`history`](super::history)) attaches these
+//! headers so the three can't drift apart.
+
+use axum::http::{header, HeaderMap, HeaderValue};
+
+/// CSP for served SVG.
+///
+/// `sandbox` — with no `allow-*` tokens — is the part that actually disables
+/// scripting; the rest stops an uploaded file from reaching the network.
+/// `img-src data:` and `style-src 'unsafe-inline'` are what ordinary SVGs need
+/// (an inline `<style>` block, embedded `data:` images); both matplotlib output
+/// and hand-authored diagrams render unchanged under this policy.
+const SVG_CSP: &str = "default-src 'none'; img-src data:; style-src 'unsafe-inline'; sandbox";
+
+/// Security headers for a served media blob of `content_type`.
+///
+/// `nosniff` goes on everything, so a browser can't disregard our declared type
+/// and re-interpret the bytes as something executable.
+///
+/// The CSP is **SVG-only**, because SVG is the one supported format that is a
+/// *document*: XML that can carry a `<script>` element. Inside `<img>` that
+/// script is inert, but the lightbox's Download link and any direct navigation
+/// to `/api/images/{id}` render the file as a top-level document on the portal's
+/// **own origin**, where its script would run with access to same-origin cookies
+/// and `localStorage`.
+///
+/// Deliberately not applied to rasters: they can't script, and a blanket
+/// `default-src 'none'` would also govern the image-document view a browser
+/// synthesizes when you open a PNG directly.
+pub fn media_security_headers(content_type: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    if is_svg(content_type) {
+        headers.insert(
+            header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static(SVG_CSP),
+        );
+    }
+    headers
+}
+
+/// Is this an SVG content type, ignoring any `; charset=...` parameters?
+fn is_svg(content_type: &str) -> bool {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .eq_ignore_ascii_case("image/svg+xml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn svg_gets_a_script_blocking_csp() {
+        let h = media_security_headers("image/svg+xml");
+        let csp = h
+            .get(header::CONTENT_SECURITY_POLICY)
+            .expect("svg must carry a CSP")
+            .to_str()
+            .unwrap();
+        // `sandbox` is the token that disables scripting; without it the rest of
+        // the policy would not stop an inline <script>.
+        assert!(csp.contains("sandbox"), "CSP must sandbox: {csp}");
+        assert!(csp.contains("default-src 'none'"), "{csp}");
+    }
+
+    #[test]
+    fn svg_csp_survives_a_charset_parameter() {
+        // Uploads may declare `image/svg+xml; charset=utf-8`; the protection must
+        // not fall off just because a parameter is present.
+        let h = media_security_headers("image/svg+xml; charset=utf-8");
+        assert!(h.contains_key(header::CONTENT_SECURITY_POLICY));
+    }
+
+    #[test]
+    fn rasters_and_video_get_nosniff_but_no_csp() {
+        for ct in ["image/png", "image/jpeg", "image/gif", "image/webp"] {
+            let h = media_security_headers(ct);
+            assert_eq!(h.get(header::X_CONTENT_TYPE_OPTIONS).unwrap(), "nosniff");
+            assert!(
+                !h.contains_key(header::CONTENT_SECURITY_POLICY),
+                "{ct} should not be CSP-restricted"
+            );
+        }
+        for ct in ["video/mp4", "video/webm"] {
+            let h = media_security_headers(ct);
+            assert_eq!(h.get(header::X_CONTENT_TYPE_OPTIONS).unwrap(), "nosniff");
+            assert!(!h.contains_key(header::CONTENT_SECURITY_POLICY), "{ct}");
+        }
+    }
+
+    #[test]
+    fn every_supported_image_type_is_covered() {
+        // A new image format must get nosniff automatically, and must be
+        // consciously classified as document-capable or not.
+        for ct in shared::media::SUPPORTED_IMAGE_TYPES {
+            let h = media_security_headers(ct);
+            assert!(h.contains_key(header::X_CONTENT_TYPE_OPTIONS), "{ct}");
+            assert_eq!(
+                h.contains_key(header::CONTENT_SECURITY_POLICY),
+                *ct == "image/svg+xml",
+                "{ct}"
+            );
+        }
+    }
+}

--- a/backend/src/handlers/media_store.rs
+++ b/backend/src/handlers/media_store.rs
@@ -327,7 +327,9 @@ pub async fn serve_media(
                 .await
                 .map_err(|e| AppError::Internal(format!("seek media: {e}")))?;
             let stream = ReaderStream::new(file.take(len));
-            Ok(Response::builder()
+            let security =
+                crate::handlers::media_security::media_security_headers(&meta.content_type);
+            let mut response = Response::builder()
                 .status(StatusCode::PARTIAL_CONTENT)
                 .header(header::CONTENT_TYPE, meta.content_type)
                 .header(header::ACCEPT_RANGES, "bytes")
@@ -338,21 +340,27 @@ pub async fn serve_media(
                 )
                 .header(header::CACHE_CONTROL, "private, max-age=86400, immutable")
                 .body(Body::from_stream(stream))
-                .map_err(|e| AppError::Internal(format!("build range response: {e}")))?)
+                .map_err(|e| AppError::Internal(format!("build range response: {e}")))?;
+            response.headers_mut().extend(security);
+            Ok(response)
         }
         None => {
             let file = tokio::fs::File::open(&meta.path)
                 .await
                 .map_err(|_| AppError::NotFound("Media not found"))?;
             let stream = ReaderStream::new(file);
-            Ok(Response::builder()
+            let security =
+                crate::handlers::media_security::media_security_headers(&meta.content_type);
+            let mut response = Response::builder()
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, meta.content_type)
                 .header(header::ACCEPT_RANGES, "bytes")
                 .header(header::CONTENT_LENGTH, total)
                 .header(header::CACHE_CONTROL, "private, max-age=86400, immutable")
                 .body(Body::from_stream(stream))
-                .map_err(|e| AppError::Internal(format!("build media response: {e}")))?)
+                .map_err(|e| AppError::Internal(format!("build media response: {e}")))?;
+            response.headers_mut().extend(security);
+            Ok(response)
         }
     }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod history;
 pub mod images;
 pub mod launchers;
 pub mod media_archive;
+pub mod media_security;
 pub mod media_store;
 pub mod messages;
 pub mod mobile_links;


### PR DESCRIPTION
Second follow-up to #1525. This one is a security fix.

## Problem

Media served back from `agent-portal show` carried no hardening headers. SVG is the one supported format that is a *document* — XML that can hold a `<script>` element.

Inside `<img>` that script is inert, which is why this never showed up in normal use. But two paths render the file as a **top-level document on the portal's own origin**:

- the lightbox's "Download" link (`href` points at the same-origin URL), and
- any direct navigation to `/api/images/{id}` (open-in-new-tab, or a pasted link).

There, a `<script>` inside an uploaded file runs with access to same-origin cookies and `localStorage`. Uploads come from an agent's `agent-portal show`, so the bytes aren't necessarily trustworthy.

Confirmed with headless Chromium — serving an SVG containing `<script>document.title = "PWNED"</script>` and navigating to it:

```
navigate, current behavior   title="PWNED"  scriptRan=true
navigate, hardened           title=""       scriptRan=false
<img>, current behavior      rendered 120x60
<img>, hardened              rendered 120x60   (unchanged)
```

## Fix

`X-Content-Type-Options: nosniff` on every served blob, so a browser can't disregard the declared type and reinterpret bytes as something executable. Plus a script-blocking CSP for SVG:

```
default-src 'none'; img-src data:; style-src 'unsafe-inline'; sandbox
```

`sandbox` (no `allow-*` tokens) is the part that actually disables scripting; the rest keeps an uploaded file from reaching the network. `img-src data:` and `style-src 'unsafe-inline'` are what ordinary SVGs genuinely need — verified that both a matplotlib plot and an SVG with an inline `<style>` block plus an embedded `data:` image still render under this policy, with zero CSP console errors.

The CSP is scoped to SVG on purpose. Rasters can't script, and a blanket `default-src 'none'` would also govern the image-document view a browser synthesizes when you open a PNG directly — a real risk of breaking legitimate viewing for no security gain.

One shared helper (`handlers/media_security.rs`) is applied by all three serving paths — the live image store, the on-disk video store, and the archived-media read in `history.rs` — so the policy can't drift between them.

## Verification

4 unit tests: SVG gets a sandboxing CSP; the protection survives a `; charset=utf-8` parameter; rasters and video get `nosniff` but no CSP; and a sweep over `SUPPORTED_IMAGE_TYPES` so a newly-allowed format has to be consciously classified as document-capable or not. Full backend lib suite: 273 passed. Clippy clean.