### PR TITLE
Bump claude-codes to 2.1.220 and drop the raw-JSON interrupt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,9 +1004,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.166"
+version = "2.1.220"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe3b4c5af09f54977712ac9a6b1fb4f13a9d3649de116de88810bd2d8ba14bc"
+checksum = "de1e407233d670143da2462d1a7ba7fdeea0164e38aef317362611e9f1a8f78f"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1826,7 +1826,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2134,7 +2134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4411,7 +4411,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5855,7 +5855,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5936,7 +5936,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7176,7 +7176,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8364,7 +8364,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.166", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.220", default-features = false, features = ["types"] }
 
 # Codex CLI integration
 codex-codes = { version = "0.145.0", default-features = false, features = ["types"] }

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -125,36 +125,16 @@ fn synthetic_user_echo_value(
     Some(claude_user_echo_value(text.to_string(), session_id))
 }
 
-/// Build the interrupt to write to claude's stdin as a wrapped `control_request`.
+/// Build the interrupt to write to claude's stdin.
 ///
-/// TODO(SDK meawoppl/rust-code-agent-sdks#218): `claude_codes::ClaudeInput::interrupt()`
-/// (claude-codes 2.1.161) serializes to a bare `{"subtype":"interrupt"}`, which the
-/// current claude CLI silently ignores (verified against claude 2.1.211 — the in-flight
-/// turn is never cancelled). The CLI's control protocol requires the interrupt wrapped as
-/// a `control_request` with a unique `request_id`, the same envelope as `can_use_tool` /
-/// `initialize`. There's no typed constructor for it today, so hand-build the JSON and
-/// send it as `ClaudeInput::Raw`; revert to `ClaudeInput::interrupt()` once #218 lands.
+/// The CLI's control protocol requires the interrupt wrapped as a
+/// `control_request` with a unique `request_id` — the same envelope as
+/// `can_use_tool` / `initialize`. A bare `{"subtype":"interrupt"}` is silently
+/// ignored. `claude-codes` 2.1.220 provides that envelope typed (SDK #218, which
+/// this used to hand-build as raw JSON), so the constructor is now the whole
+/// implementation.
 fn interrupt_input() -> ClaudeInput {
-    #[derive(serde::Serialize)]
-    struct Request {
-        #[serde(rename = "type")]
-        message_type: &'static str,
-        request_id: String,
-        request: Payload,
-    }
-    #[derive(serde::Serialize)]
-    struct Payload {
-        subtype: &'static str,
-    }
-    let value = serde_json::to_value(Request {
-        message_type: "control_request",
-        request_id: format!("interrupt-{}", uuid::Uuid::new_v4()),
-        request: Payload {
-            subtype: "interrupt",
-        },
-    })
-    .unwrap_or(serde_json::Value::Null);
-    ClaudeInput::Raw(value)
+    ClaudeInput::interrupt(format!("interrupt-{}", uuid::Uuid::new_v4()))
 }
 
 fn plain_input_text(input: &ClaudeInput) -> Option<String> {
@@ -1191,6 +1171,27 @@ mod tests {
         user_output_with_content(serde_json::json!([
             { "type": "text", "text": text }
         ]))
+    }
+
+    /// The typed `ClaudeInput::interrupt` (claude-codes 2.1.220, SDK #218) must
+    /// serialize to the exact envelope this code used to hand-build as raw JSON:
+    /// a `control_request` carrying a unique `request_id` and a
+    /// `{"subtype":"interrupt"}` payload. A bare `{"subtype":"interrupt"}` — what
+    /// the pre-#218 constructor emitted — is silently ignored by the CLI, so this
+    /// pins the shape rather than trusting the swap.
+    #[test]
+    fn interrupt_serializes_as_a_control_request() {
+        let value = serde_json::to_value(interrupt_input()).expect("serialize");
+        assert_eq!(value["type"], "control_request");
+        assert_eq!(value["request"]["subtype"], "interrupt");
+        let request_id = value["request_id"].as_str().expect("request_id present");
+        assert!(
+            request_id.starts_with("interrupt-"),
+            "unexpected request id: {request_id}"
+        );
+        // Unique per call, so a second interrupt can't be mistaken for a replay.
+        let other = serde_json::to_value(interrupt_input()).expect("serialize");
+        assert_ne!(value["request_id"], other["request_id"]);
     }
 
     fn assistant_frame(model: &str, text: Option<&str>, usage: bool) -> serde_json::Value {


### PR DESCRIPTION
`claude-codes` 2.1.166 → **2.1.220**. The version jump is upstream re-aligning the crate version with the tested Claude CLI; the actual changes are additive (`RawAsyncClient`, `user_message_without_session`, `ClaudeCliBuilder::working_directory`, Windows `CREATE_NO_WINDOW` launches).

## The real win: retires the `TODO(SDK #218)` workaround

`ClaudeInput::interrupt()` used to serialize a bare `{"subtype":"interrupt"}`, which the CLI **silently ignores** — the in-flight turn was never cancelled. So this crate hand-built the envelope as raw JSON via `ClaudeInput::Raw`, with a `TODO` to revert once upstream fixed it.

[SDK #218](https://github.com/meawoppl/rust-code-agent-sdks/issues/218) is closed and 2.1.220 has it:

```rust
pub fn interrupt(request_id: impl Into<String>) -> Self {
    ClaudeInput::ControlRequest(ControlRequest {
        request_id: request_id.into(),
        request: super::ControlRequestPayload::Interrupt,
    })
}
```

`ControlRequestPayload` is `#[serde(tag = "subtype", rename_all = "snake_case")]`, so the unit `Interrupt` variant emits `{"subtype":"interrupt"}` inside a `control_request` — byte-identical to what we were hand-assembling. ~25 lines of hand-rolled structs and JSON deleted; the constructor is now the whole implementation.

Because the failure mode here is **silent** (a wrong shape doesn't error, the interrupt just does nothing), I added a test pinning the serialized envelope — `type == "control_request"`, `request.subtype == "interrupt"`, a unique `interrupt-<uuid>` request id — rather than trusting the swap.

## What this does *not* include

[rust-code-agent-sdks#250](https://github.com/meawoppl/rust-code-agent-sdks/issues/250) — the asks from the context-gauge work (document that `ResultMessage.usage` is an accumulated roll-up, type `iterations`, expose model context-window capability) — is **still open**. So the local approximations tracked in #1529 stand; nothing in the gauge changes here.

`cargo test --workspace` green, clippy clean, `shared` builds for wasm32.