### PR TITLE
Bump codex-codes to 0.146.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.145.0"
+version = "0.146.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47b54d772322cd4052021bf1d57f3554b7d5fb7a33b484fcf6b6963bfb8f89"
+checksum = "da1486b578174fd694d3900979cfeca8e6f9f48b1d0c6fef3d0374c6361bd73f"
 dependencies = [
  "log",
  "serde",
@@ -1826,7 +1826,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2134,7 +2134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4411,7 +4411,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5855,7 +5855,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5936,7 +5936,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7176,7 +7176,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8364,7 +8364,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = { version = "2.1.166", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.145.0", default-features = false, features = ["types"] }
+codex-codes = { version = "0.146.0", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
`codex-codes` 0.145.0 → **0.146.0**, which pulls in the 0.145.1 release train:

- **`RawAsyncClient`** for newline-framed, undecoded app-server access, and Windows `CREATE_NO_WINDOW` process launches.
- **`threadSection/list` and `thread/section/move`** client requests, with generated `ThreadSection` / `…Params` / `…Response` types.
- **App-server schemas re-snapshotted** against `openai/codex@main` (upstream #241) — byte-identical to upstream at 172/172 schema coverage. This is the drift fix, so our generated types now match the CLI version we test against.
- Additive generated definitions and fields across `Thread`, `ThreadListParams`, `ThreadMetadataUpdateParams`, `PlanType`, and the plugin/import types; new `PluginDisabledReason`, `ThreadSearchSortKey`.

## Impact here

Purely additive — no call sites change, whole workspace builds, `cargo test --workspace` green, clippy clean.

One thing I checked rather than assumed: 0.146.0 adds an **`openai/form`** variant to `McpServerElicitationRequestParams`. Our classifier arm binds the payload as `_p` and ignores it, so the new variant is absorbed with no behavior change and no exhaustiveness break — but that's worth knowing, because it means a *meaningful* new variant would also pass silently there.

## Not unblocked

**#1050** (surface the MCP elicitation server name) stays blocked. I checked all three variants in 0.146.0 — `Form`, `OpenaiForm`, `Url` — and none carries a server identifier, so the permission text still reads ``MCP server `(unknown)` is asking …``.

Note 0.146.1 is in the upstream changelog (a further schema re-snapshot, upstream #248) but is **not published to crates.io** yet, so 0.146.0 is the newest installable.

Split from the `claude-codes` bump (#1531) so each crate's move is independently reviewable and revertable.