### PR TITLE
Key logins by provider identity instead of google_id

### DIFF
--- a/backend/migrations/2026-07-31-160000_add_user_identities/down.sql
+++ b/backend/migrations/2026-07-31-160000_add_user_identities/down.sql
@@ -1,0 +1,18 @@
+DROP INDEX IF EXISTS idx_users_email_lower;
+
+-- Restore the Google-only identity column from the identities table. Users
+-- whose only identity is non-Google cannot be represented, so they are dropped
+-- (they could not have existed before this migration).
+ALTER TABLE users ADD COLUMN google_id VARCHAR(255);
+
+UPDATE users u
+SET google_id = i.subject
+FROM user_identities i
+WHERE i.user_id = u.id AND i.provider = 'google';
+
+DELETE FROM users WHERE google_id IS NULL;
+
+ALTER TABLE users ALTER COLUMN google_id SET NOT NULL;
+ALTER TABLE users ADD CONSTRAINT users_google_id_key UNIQUE (google_id);
+
+DROP TABLE user_identities;

--- a/backend/migrations/2026-07-31-160000_add_user_identities/up.sql
+++ b/backend/migrations/2026-07-31-160000_add_user_identities/up.sql
@@ -1,0 +1,44 @@
+-- Multi-provider login identities (#1535).
+--
+-- Identity used to live on `users.google_id` (VARCHAR UNIQUE NOT NULL), which
+-- hard-coded exactly one provider: a GitHub-only user could not satisfy the NOT
+-- NULL, and two providers could in principle collide on a subject string. Move
+-- identity into its own table keyed by (provider, subject) so a user can hold
+-- several, and back-fill the existing Google identities before dropping the
+-- column.
+
+CREATE TABLE user_identities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- Stable provider key ("google", "github", ...). Not an enum: adding a
+    -- provider must not require a migration.
+    provider VARCHAR(32) NOT NULL,
+    -- The provider's immutable subject for this user (OIDC `sub`, GitHub's
+    -- numeric id as text). Never the email — emails change hands.
+    subject VARCHAR(255) NOT NULL,
+    -- Email as this provider asserted it, for auditing which identity supplied
+    -- the address on `users`. Nullable: not every provider returns one.
+    email VARCHAR(255),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    -- One account per (provider, subject); a subject may only ever map to one
+    -- user, so a second login through the same provider can never fork a user.
+    UNIQUE (provider, subject)
+);
+
+CREATE INDEX idx_user_identities_user_id ON user_identities(user_id);
+
+-- Back-fill every existing user's Google identity before the column goes away.
+INSERT INTO user_identities (user_id, provider, subject, email)
+SELECT id, 'google', google_id, email FROM users;
+
+ALTER TABLE users DROP COLUMN google_id;
+
+-- Emails now identify a human across providers (the account-linking rule keys
+-- on a verified email), so they must be unique. Case-insensitive because
+-- providers differ on casing and the allow-list check already lowercases.
+--
+-- Safe on existing data: logins were Google-only and keyed on a unique
+-- google_id, and two Google accounts cannot share a primary email — so
+-- duplicates are not reachable. If this index fails to build, the deploy has
+-- duplicate users that must be merged by hand rather than silently tolerated.
+CREATE UNIQUE INDEX idx_users_email_lower ON users (lower(email));

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -159,7 +159,6 @@ mod tests {
     fn user(disabled: bool) -> User {
         User {
             id: Uuid::new_v4(),
-            google_id: "google-id".to_string(),
             email: "user@example.com".to_string(),
             name: Some("User".to_string()),
             avatar_url: None,
@@ -191,7 +190,6 @@ mod tests {
         let id = Uuid::new_v4();
         let mut user: User = diesel::insert_into(users::table)
             .values(&NewUser {
-                google_id: format!("google-{id}"),
                 email: format!("auth-{id}@example.com"),
                 name: Some("Auth Test".to_string()),
                 avatar_url: None,

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -75,8 +75,9 @@ pub fn seed_dev_user(pool: &DbPool) -> Result<()> {
     let test_user = dev_user(&mut conn).optional()?;
 
     if test_user.is_none() {
+        // Dev login resolves by email (see `auth::dev_user`), so this user needs
+        // no `user_identities` row — it never goes through a provider.
         let new_user = NewUser {
-            google_id: "dev_mode_test_user".to_string(),
             email: DEV_USER_EMAIL.to_string(),
             name: Some("Test User".to_string()),
             avatar_url: None,

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -18,7 +18,7 @@ use crate::{
     handlers::proxy_tokens::{
         issue_proxy_token_with_type, verify_and_get_user_with_token, TokenPersist,
     },
-    models::{NewUser, User},
+    models::User,
     routes,
     schema::proxy_auth_tokens,
     AppState,
@@ -26,7 +26,10 @@ use crate::{
 
 use shared::protocol::SESSION_COOKIE_NAME;
 
+mod identity;
 mod oauth;
+
+pub use identity::{ProviderIdentity, PROVIDER_GITHUB, PROVIDER_GOOGLE};
 
 const MOBILE_TOKEN_TTL_DAYS: u32 = 30;
 const TOKEN_REFRESH_GRACE_MINUTES: i64 = 10;
@@ -122,6 +125,12 @@ pub struct AuthCallbackQuery {
 struct GoogleUserInfo {
     sub: String,
     email: String,
+    /// Google's own verification flag. Previously ignored; the account-linking
+    /// rule (#1535) requires it, and an unverified Google address must not be
+    /// able to claim an allow-listed domain. Defaults to `false` so a response
+    /// missing the field fails closed.
+    #[serde(default)]
+    email_verified: bool,
     name: Option<String>,
     picture: Option<String>,
 }
@@ -184,7 +193,12 @@ pub async fn callback(
             AppError::Internal(format!("Failed to exchange OAuth code: {e}"))
         })?;
 
-    // Fetch user info from Google
+    // Fetch user info from Google.
+    //
+    // Must stay on the OIDC (`v3`) endpoint: it spells the verification flag
+    // `email_verified`, whereas the legacy `v2` endpoint spells it
+    // `verified_email`. Since `GoogleUserInfo::email_verified` fails closed,
+    // switching endpoints without renaming the field would reject every login.
     let client = reqwest::Client::new();
     let user_info: GoogleUserInfo = client
         .get("https://www.googleapis.com/oauth2/v3/userinfo")
@@ -226,31 +240,35 @@ pub async fn callback(
         return Ok(redirect);
     }
 
-    // Save or update user in database
+    // Resolve the login to a user: existing identity, link on a verified email,
+    // or create. See `identity` for the rule and why linking is gated on
+    // verification (#1535).
     let mut conn = app_state.conn()?;
 
-    use crate::schema::users::dsl::*;
+    let resolved = identity::resolve_user(
+        &mut conn,
+        &ProviderIdentity {
+            provider: PROVIDER_GOOGLE,
+            subject: user_info.sub,
+            email: Some(user_info.email.clone()),
+            email_verified: user_info.email_verified,
+            name: user_info.name,
+            avatar_url: user_info.picture,
+        },
+    )
+    .map_err(|e| AppError::DbQuery(format!("Failed to resolve login identity: {e}")))?;
 
-    let user = users
-        .filter(google_id.eq(&user_info.sub))
-        .first::<User>(&mut conn)
-        .optional()
-        .map_err(|e| AppError::DbQuery(format!("Failed to look up user by google_id: {e}")))?;
-
-    let user = match user {
-        Some(user) => user,
-        None => {
-            let new_user = NewUser {
-                google_id: user_info.sub,
-                email: user_info.email,
-                name: user_info.name,
-                avatar_url: user_info.picture,
-            };
-
-            diesel::insert_into(users)
-                .values(&new_user)
-                .get_result::<User>(&mut conn)
-                .map_err(|e| AppError::DbQuery(format!("Failed to create user: {e}")))?
+    let user = match resolved {
+        Ok(user) => user,
+        Err(identity::IdentityError::UnverifiedEmail) => {
+            warn!(
+                target: "auth_audit",
+                event = "oauth_callback_denied",
+                flow = callback_kind,
+                reason = "unverified_email",
+                user_email = %user_info.email,
+            );
+            return Ok(unverified_email_redirect());
         }
     };
 
@@ -562,6 +580,20 @@ fn remove_session_cookie() -> Cookie<'static> {
     cookie
 }
 
+/// The provider gave us no verified email and we have never seen this identity,
+/// so we refuse rather than silently forking a second account for the same
+/// person (#1535). Reuses the access-denied page with an explanatory reason.
+fn unverified_email_redirect() -> Redirect {
+    Redirect::temporary(&format!(
+        "{}?reason={}",
+        routes::ACCESS_DENIED,
+        encode_query_value(
+            "Your identity provider did not supply a verified email address. \
+             Verify your email with that provider, then sign in again."
+        )
+    ))
+}
+
 fn banned_redirect(reason: &str) -> Redirect {
     Redirect::temporary(&format!(
         "{}?reason={}",
@@ -599,6 +631,32 @@ mod tests {
     use crate::models::{NewUser, ProxyAuthToken};
     use crate::schema::{proxy_auth_tokens, users};
     use axum::http::{header::AUTHORIZATION, HeaderValue};
+
+    /// Pins the field names of the OIDC (`v3`) userinfo response. The legacy
+    /// `v2` endpoint spells the flag `verified_email`, and because the field
+    /// fails closed, getting this wrong rejects every Google login rather than
+    /// failing loudly — so assert the happy-path payload parses as verified.
+    #[test]
+    fn google_userinfo_parses_the_oidc_verification_flag() {
+        let body = r#"{
+            "sub": "1234567890",
+            "email": "person@example.com",
+            "email_verified": true,
+            "name": "A Person",
+            "picture": "https://example.invalid/p.png"
+        }"#;
+        let info: GoogleUserInfo = serde_json::from_str(body).expect("parses v3 userinfo");
+        assert_eq!(info.sub, "1234567890");
+        assert!(info.email_verified);
+
+        // A response without the flag must fail closed, not default to trusted.
+        let missing = r#"{"sub": "1", "email": "p@example.com"}"#;
+        let info: GoogleUserInfo = serde_json::from_str(missing).expect("parses");
+        assert!(
+            !info.email_verified,
+            "a missing verification flag must not be treated as verified"
+        );
+    }
 
     #[test]
     fn auth_user_error_preserves_forbidden_and_database_errors() {
@@ -665,7 +723,6 @@ mod tests {
         let id = uuid::Uuid::new_v4();
         diesel::insert_into(users::table)
             .values(&NewUser {
-                google_id: format!("google-{id}"),
                 email: format!("mobile-{id}@example.com"),
                 name: Some("Mobile Test".to_string()),
                 avatar_url: None,

--- a/backend/src/handlers/auth/identity.rs
+++ b/backend/src/handlers/auth/identity.rs
@@ -1,0 +1,435 @@
+//! Resolving a login to a portal user across multiple identity providers
+//! (#1535).
+//!
+//! Identity is keyed by `(provider, subject)` in `user_identities`, never by
+//! email — a provider's subject is immutable, whereas an email address can be
+//! reassigned to a different human. Email is used for exactly one thing: the
+//! account-*linking* rule below.
+//!
+//! ## The linking rule, and why it is gated on verification
+//!
+//! Signing in through a *new* provider with the email of an existing account is
+//! the normal case for a real person adding a second login. Linking silently is
+//! convenient — and, if the new provider does not verify the address, it is an
+//! account-takeover primitive: set your unverified email to the victim's, sign
+//! in, inherit their sessions. Providers differ here (Google verifies; GitHub
+//! will happily report an unverified address), so this module refuses to link on
+//! an unverified email and makes the caller state verification explicitly.
+//!
+//! Consequently [`resolve_user`] has four outcomes, in order:
+//!
+//! 1. the `(provider, subject)` is known → that user, always;
+//! 2. else the email is **verified** and matches an existing user → link a new
+//!    identity to them;
+//! 3. else the email is **verified** and is new → create the user;
+//! 4. else (unverified or absent email, and no known identity) → refuse.
+//!
+//! Case 4 is a deliberate lockout rather than a silent second account: the
+//! alternative — creating a duplicate user holding the same address — was the
+//! pre-#1535 behavior and is worse, because the person appears logged in while
+//! seeing none of their own sessions.
+
+use diesel::prelude::*;
+use tracing::{info, warn};
+
+use crate::db::DbConnection;
+use crate::models::{NewUser, NewUserIdentity, User, UserIdentity};
+
+/// Provider key for Google logins, as stored in `user_identities.provider`.
+pub const PROVIDER_GOOGLE: &str = "google";
+/// Provider key for GitHub logins.
+pub const PROVIDER_GITHUB: &str = "github";
+
+/// A verified-or-not identity assertion from a provider's userinfo response.
+#[derive(Debug, Clone)]
+pub struct ProviderIdentity {
+    /// Provider key — one of the `PROVIDER_*` constants.
+    pub provider: &'static str,
+    /// The provider's immutable id for this person.
+    pub subject: String,
+    /// Email as asserted by the provider, if any.
+    pub email: Option<String>,
+    /// Whether the provider states it has *verified* that address. Only a
+    /// verified email may link to, or create, an account — see the module docs.
+    pub email_verified: bool,
+    pub name: Option<String>,
+    pub avatar_url: Option<String>,
+}
+
+/// Why a login could not be resolved to a user.
+#[derive(Debug, PartialEq, Eq)]
+pub enum IdentityError {
+    /// The provider supplied no email, or one it has not verified, and we have
+    /// never seen this `(provider, subject)` before.
+    UnverifiedEmail,
+}
+
+/// Look up the user for an identity, linking or creating as the rule allows.
+pub fn resolve_user(
+    conn: &mut DbConnection,
+    identity: &ProviderIdentity,
+) -> Result<Result<User, IdentityError>, diesel::result::Error> {
+    use crate::schema::{user_identities, users};
+
+    // 1. Known identity — the only path that does not consult email at all, so
+    //    an existing user keeps working even if their provider later stops
+    //    returning (or changes) their address.
+    let existing: Option<UserIdentity> = user_identities::table
+        .filter(user_identities::provider.eq(identity.provider))
+        .filter(user_identities::subject.eq(&identity.subject))
+        .select(UserIdentity::as_select())
+        .first(conn)
+        .optional()?;
+
+    if let Some(existing) = existing {
+        let user = users::table
+            .find(existing.user_id)
+            .select(User::as_select())
+            .first(conn)?;
+        return Ok(Ok(user));
+    }
+
+    // Everything below needs a trustworthy address.
+    let email = match (&identity.email, identity.email_verified) {
+        (Some(email), true) if !email.trim().is_empty() => email.trim().to_string(),
+        _ => {
+            warn!(
+                target: "auth_audit",
+                event = "identity_refused",
+                provider = identity.provider,
+                reason = "unverified_email",
+            );
+            return Ok(Err(IdentityError::UnverifiedEmail));
+        }
+    };
+    let email_lower = email.to_lowercase();
+
+    // 2. Verified email matches an existing account → link this provider to it.
+    let existing_user: Option<User> = users::table
+        .filter(
+            diesel::dsl::sql::<diesel::sql_types::Bool>("lower(email) = ")
+                .bind::<diesel::sql_types::Text, _>(&email_lower),
+        )
+        .select(User::as_select())
+        .first(conn)
+        .optional()?;
+
+    let user = match existing_user {
+        Some(user) => {
+            info!(
+                target: "auth_audit",
+                event = "identity_linked",
+                provider = identity.provider,
+                user_id = %user.id,
+                user_email = %user.email,
+            );
+            user
+        }
+        // 3. New person.
+        None => diesel::insert_into(users::table)
+            .values(&NewUser {
+                email,
+                name: identity.name.clone(),
+                avatar_url: identity.avatar_url.clone(),
+            })
+            .get_result::<User>(conn)?,
+    };
+
+    diesel::insert_into(user_identities::table)
+        .values(&NewUserIdentity {
+            user_id: user.id,
+            provider: identity.provider.to_string(),
+            subject: identity.subject.clone(),
+            email: identity.email.clone(),
+        })
+        .execute(conn)?;
+
+    Ok(Ok(user))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    /// Unique per run so tests never collide with dev data or each other; the
+    /// email-uniqueness rule makes fixed addresses unusable across runs.
+    fn nonce() -> String {
+        Uuid::new_v4().to_string()
+    }
+
+    /// Delete the users (and their cascading identities) a test created.
+    fn cleanup(conn: &mut DbConnection, ids: &[Uuid]) {
+        use crate::schema::users;
+        let _ = diesel::delete(users::table.filter(users::id.eq_any(ids))).execute(conn);
+    }
+
+    fn identity(
+        provider: &'static str,
+        subject: &str,
+        email: &str,
+        verified: bool,
+    ) -> ProviderIdentity {
+        ProviderIdentity {
+            provider,
+            subject: subject.to_string(),
+            email: Some(email.to_string()),
+            email_verified: verified,
+            name: Some("Test".to_string()),
+            avatar_url: None,
+        }
+    }
+
+    #[test]
+    fn creates_a_user_for_a_new_verified_identity() {
+        let Some(pool) = crate::test_support::shared_pool() else {
+            return;
+        };
+        let conn = &mut pool.get().expect("conn");
+        let n = nonce();
+        let id = identity(
+            PROVIDER_GOOGLE,
+            &format!("g-{n}"),
+            &format!("new-{n}@example.invalid"),
+            true,
+        );
+
+        let user = resolve_user(conn, &id).unwrap().unwrap();
+        // Signing in again returns the SAME user, not a second one.
+        let again = resolve_user(conn, &id).unwrap().unwrap();
+        let (uid, same) = (user.id, again.id);
+        cleanup(conn, &[uid]);
+
+        assert_eq!(same, uid);
+    }
+
+    /// The whole point of keying on subject: a provider changing the address it
+    /// reports must not fork the account.
+    #[test]
+    fn known_subject_wins_even_if_the_email_changed() {
+        let Some(pool) = crate::test_support::shared_pool() else {
+            return;
+        };
+        let conn = &mut pool.get().expect("conn");
+        let n = nonce();
+        let subject = format!("g-stable-{n}");
+
+        let user = resolve_user(
+            conn,
+            &identity(
+                PROVIDER_GOOGLE,
+                &subject,
+                &format!("before-{n}@example.invalid"),
+                true,
+            ),
+        )
+        .unwrap()
+        .unwrap();
+        let same = resolve_user(
+            conn,
+            &identity(
+                PROVIDER_GOOGLE,
+                &subject,
+                &format!("after-{n}@example.invalid"),
+                true,
+            ),
+        )
+        .unwrap()
+        .unwrap();
+        let (uid, same_id, email) = (user.id, same.id, same.email.clone());
+        cleanup(conn, &[uid]);
+
+        assert_eq!(same_id, uid);
+        // The user row keeps its original address; we do not chase renames.
+        assert_eq!(email, format!("before-{n}@example.invalid"));
+    }
+
+    /// A second provider with the same *verified* email is the same human.
+    #[test]
+    fn links_a_second_provider_on_a_verified_email() {
+        let Some(pool) = crate::test_support::shared_pool() else {
+            return;
+        };
+        let conn = &mut pool.get().expect("conn");
+        let n = nonce();
+        let email = format!("shared-{n}@example.invalid");
+
+        let user = resolve_user(
+            conn,
+            &identity(PROVIDER_GOOGLE, &format!("g-{n}"), &email, true),
+        )
+        .unwrap()
+        .unwrap();
+        let linked = resolve_user(
+            conn,
+            &identity(PROVIDER_GITHUB, &format!("gh-{n}"), &email, true),
+        )
+        .unwrap()
+        .unwrap();
+        let (uid, linked_id) = (user.id, linked.id);
+        cleanup(conn, &[uid]);
+
+        assert_eq!(linked_id, uid, "should link, not create a second user");
+    }
+
+    /// Case-insensitively, too — providers disagree on casing.
+    #[test]
+    fn linking_is_case_insensitive() {
+        let Some(pool) = crate::test_support::shared_pool() else {
+            return;
+        };
+        let conn = &mut pool.get().expect("conn");
+        let n = nonce();
+
+        let user = resolve_user(
+            conn,
+            &identity(
+                PROVIDER_GOOGLE,
+                &format!("g-{n}"),
+                &format!("Mixed-{n}@Example.invalid"),
+                true,
+            ),
+        )
+        .unwrap()
+        .unwrap();
+        let linked = resolve_user(
+            conn,
+            &identity(
+                PROVIDER_GITHUB,
+                &format!("gh-{n}"),
+                &format!("mixed-{n}@example.INVALID"),
+                true,
+            ),
+        )
+        .unwrap()
+        .unwrap();
+        let (uid, linked_id) = (user.id, linked.id);
+        cleanup(conn, &[uid]);
+
+        assert_eq!(linked_id, uid);
+    }
+
+    /// The takeover case: an unverified address must never reach an account.
+    #[test]
+    fn refuses_to_link_on_an_unverified_email() {
+        let Some(pool) = crate::test_support::shared_pool() else {
+            return;
+        };
+        let conn = &mut pool.get().expect("conn");
+        let n = nonce();
+        let email = format!("victim-{n}@example.invalid");
+
+        let victim = resolve_user(
+            conn,
+            &identity(PROVIDER_GOOGLE, &format!("g-{n}"), &email, true),
+        )
+        .unwrap()
+        .unwrap();
+        let attacker = resolve_user(
+            conn,
+            &identity(PROVIDER_GITHUB, &format!("gh-{n}"), &email, false),
+        )
+        .unwrap();
+
+        use crate::schema::user_identities;
+        let attached: i64 = user_identities::table
+            .filter(user_identities::user_id.eq(victim.id))
+            .count()
+            .get_result(conn)
+            .unwrap();
+        cleanup(conn, &[victim.id]);
+
+        assert!(
+            matches!(attacker, Err(IdentityError::UnverifiedEmail)),
+            "unverified email must not reach an existing account"
+        );
+        assert_eq!(
+            attached, 1,
+            "victim must still have only their own identity"
+        );
+    }
+
+    /// An unverified email must not create an account either — otherwise the
+    /// refusal above is trivially bypassed by signing up first.
+    #[test]
+    fn refuses_to_create_on_an_unverified_email() {
+        let Some(pool) = crate::test_support::shared_pool() else {
+            return;
+        };
+        let conn = &mut pool.get().expect("conn");
+        let n = nonce();
+        assert!(matches!(
+            resolve_user(
+                conn,
+                &identity(
+                    PROVIDER_GITHUB,
+                    &format!("gh-{n}"),
+                    &format!("nobody-{n}@example.invalid"),
+                    false
+                )
+            )
+            .unwrap(),
+            Err(IdentityError::UnverifiedEmail)
+        ));
+    }
+
+    /// A provider that returns no email at all is treated as unverified.
+    #[test]
+    fn refuses_when_the_provider_supplies_no_email() {
+        let Some(pool) = crate::test_support::shared_pool() else {
+            return;
+        };
+        let conn = &mut pool.get().expect("conn");
+        let n = nonce();
+        let mut no_email = identity(
+            PROVIDER_GITHUB,
+            &format!("gh-{n}"),
+            "x@example.invalid",
+            true,
+        );
+        no_email.email = None;
+        assert!(matches!(
+            resolve_user(conn, &no_email).unwrap(),
+            Err(IdentityError::UnverifiedEmail)
+        ));
+    }
+
+    /// Distinct providers may legitimately use the same subject string; they
+    /// must resolve to different accounts.
+    #[test]
+    fn same_subject_on_different_providers_is_two_accounts() {
+        let Some(pool) = crate::test_support::shared_pool() else {
+            return;
+        };
+        let conn = &mut pool.get().expect("conn");
+        let n = nonce();
+        let subject = format!("shared-subject-{n}");
+
+        let ua = resolve_user(
+            conn,
+            &identity(
+                PROVIDER_GOOGLE,
+                &subject,
+                &format!("a-{n}@example.invalid"),
+                true,
+            ),
+        )
+        .unwrap()
+        .unwrap();
+        let ub = resolve_user(
+            conn,
+            &identity(
+                PROVIDER_GITHUB,
+                &subject,
+                &format!("b-{n}@example.invalid"),
+                true,
+            ),
+        )
+        .unwrap()
+        .unwrap();
+        let (a, b) = (ua.id, ub.id);
+        cleanup(conn, &[a, b]);
+
+        assert_ne!(a, b);
+    }
+}

--- a/backend/src/handlers/media_archive.rs
+++ b/backend/src/handlers/media_archive.rs
@@ -317,7 +317,6 @@ mod tests {
         let nonce = Uuid::new_v4();
         let owner: Uuid = diesel::insert_into(users::table)
             .values(&NewUser {
-                google_id: format!("media_rt_{nonce}"),
                 email: format!("media_rt_{nonce}@example.invalid"),
                 name: Some("Media RT".into()),
                 avatar_url: None,

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -293,7 +293,6 @@ mod db_tests {
         use crate::schema::users;
         let nonce = uuid::Uuid::new_v4();
         let new_user = NewUser {
-            google_id: format!("test_messages_{}_{}", label, nonce),
             email: format!("test_messages_{}_{}@example.invalid", label, nonce),
             name: Some(format!("Test {}", label)),
             avatar_url: None,

--- a/backend/src/handlers/push.rs
+++ b/backend/src/handlers/push.rs
@@ -218,7 +218,6 @@ mod db_tests {
         use crate::schema::users;
         let nonce = Uuid::new_v4();
         let new_user = NewUser {
-            google_id: format!("test_push_prefs_{nonce}"),
             email: format!("test_push_prefs_{nonce}@example.invalid"),
             name: Some("Test Prefs".to_string()),
             avatar_url: None,

--- a/backend/src/handlers/session_access.rs
+++ b/backend/src/handlers/session_access.rs
@@ -198,7 +198,6 @@ mod db_tests {
         use crate::schema::users;
         let nonce = Uuid::new_v4();
         let new_user = NewUser {
-            google_id: format!("test_session_access_{}_{}", label, nonce),
             email: format!("test_session_access_{}_{}@example.invalid", label, nonce),
             name: Some(format!("Test {}", label)),
             avatar_url: None,

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -685,7 +685,6 @@ mod tests {
         use crate::schema::users;
         let nonce = Uuid::new_v4();
         let new_user = NewUser {
-            google_id: format!("test_overload_{nonce}"),
             email: format!("test_overload_{nonce}@example.invalid"),
             name: Some("Overload Test".to_string()),
             avatar_url: None,

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -545,7 +545,6 @@ mod tests {
         let nonce = Uuid::new_v4();
         let user = diesel::insert_into(users::table)
             .values(&NewUser {
-                google_id: format!("test_launcher_version_{nonce}"),
                 email: format!("test_launcher_version_{nonce}@example.invalid"),
                 name: Some("Launcher Version Test".to_string()),
                 avatar_url: None,

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -118,7 +118,6 @@ mod replay_tests {
         use crate::schema::users;
         let nonce = uuid::Uuid::new_v4();
         let new_user = NewUser {
-            google_id: format!("test_replay_{}_{}", label, nonce),
             email: format!("test_replay_{}_{}@example.invalid", label, nonce),
             name: Some(format!("Test {}", label)),
             avatar_url: None,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -8,7 +8,6 @@ use uuid::Uuid;
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct User {
     pub id: Uuid,
-    pub google_id: String,
     pub email: String,
     pub name: Option<String>,
     pub avatar_url: Option<String>,
@@ -24,10 +23,36 @@ pub struct User {
 #[derive(Debug, Insertable)]
 #[diesel(table_name = crate::schema::users)]
 pub struct NewUser {
-    pub google_id: String,
     pub email: String,
     pub name: Option<String>,
     pub avatar_url: Option<String>,
+}
+
+/// A login identity: one (provider, subject) pair belonging to a user (#1535).
+///
+/// Identity lives here rather than on `users` so one account can hold several
+/// providers. `subject` is the provider's immutable id for the person (OIDC
+/// `sub`, GitHub's numeric id as text) — deliberately never the email, which
+/// can change hands.
+#[derive(Debug, Queryable, Selectable, Clone)]
+#[diesel(table_name = crate::schema::user_identities)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct UserIdentity {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub provider: String,
+    pub subject: String,
+    pub email: Option<String>,
+    pub created_at: NaiveDateTime,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = crate::schema::user_identities)]
+pub struct NewUserIdentity {
+    pub user_id: Uuid,
+    pub provider: String,
+    pub subject: String,
+    pub email: Option<String>,
 }
 
 /// WIRE-SHAPE WARNING: this model is `#[serde(flatten)]`-ed onto the

--- a/backend/src/push/dispatcher.rs
+++ b/backend/src/push/dispatcher.rs
@@ -206,7 +206,6 @@ mod db_tests {
         use crate::schema::users;
         let nonce = Uuid::new_v4();
         let new_user = NewUser {
-            google_id: format!("test_push_{nonce}"),
             email: format!("test_push_{nonce}@example.invalid"),
             name: Some("Push Test".to_string()),
             avatar_url: None,

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -263,10 +263,22 @@ diesel::table! {
 }
 
 diesel::table! {
+    user_identities (id) {
+        id -> Uuid,
+        user_id -> Uuid,
+        #[max_length = 32]
+        provider -> Varchar,
+        #[max_length = 255]
+        subject -> Varchar,
+        #[max_length = 255]
+        email -> Nullable<Varchar>,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     users (id) {
         id -> Uuid,
-        #[max_length = 255]
-        google_id -> Varchar,
         #[max_length = 255]
         email -> Varchar,
         #[max_length = 255]
@@ -300,6 +312,7 @@ diesel::joinable!(session_forwards -> sessions (session_id));
 diesel::joinable!(session_members -> sessions (session_id));
 diesel::joinable!(session_members -> users (user_id));
 diesel::joinable!(sessions -> users (user_id));
+diesel::joinable!(user_identities -> users (user_id));
 diesel::joinable!(turn_metrics -> messages (user_message_id));
 diesel::joinable!(turn_metrics -> sessions (session_id));
 diesel::joinable!(turn_metrics -> users (user_id));
@@ -317,6 +330,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     session_continuations,
     session_forwards,
     session_members,
+    user_identities,
     sessions,
     turn_metrics,
     users,

--- a/backend/tests/history_api.rs
+++ b/backend/tests/history_api.rs
@@ -49,7 +49,6 @@ fn create_user(conn: &mut PgConnection, email: &str, is_admin: bool) -> User {
     use backend::schema::users;
     let user: User = diesel::insert_into(users::table)
         .values(backend::models::NewUser {
-            google_id: format!("hist-test-{}", Uuid::new_v4()),
             email: email.to_string(),
             name: Some(email.split('@').next().unwrap_or(email).to_string()),
             avatar_url: None,


### PR DESCRIPTION
Groundwork for signing in with providers other than Google. No new provider is wired up here — this is the data model and the linking policy, so that adding GitHub (and later GitLab/Microsoft/OIDC) is a small, self-contained change.

## What changes

`users.google_id` is replaced by a `user_identities` table keyed by `(provider, subject)`. A person may hold several identities pointing at one user row, and because `subject` is the provider's immutable id, a provider changing the email it reports no longer forks the account. `users.email` gains a case-insensitive unique index, since it becomes the linking key.

The migration backfills every existing user as a `google` identity before dropping the column, so current logins are unaffected. `down.sql` restores `google_id` from the table; both directions were exercised against a real database (96 users round-tripped, constraints verified).

## The linking decision — worth a look

The judgement call is what happens when a *new* provider presents the email of an existing account. Silent linking is what people expect, and it is an account-takeover primitive when the provider does not verify the address: set your unverified email to the victim's, sign in, inherit their sessions. Google verifies; GitHub will happily report an unverified address.

So linking is gated on verification, and `resolve_user` has four outcomes in order:

1. `(provider, subject)` known → that user, always (email never consulted)
2. else verified email matches an existing user → link a new identity to them
3. else verified email is new → create the user
4. else (unverified or absent email, no known identity) → refuse the login

Case 4 is a deliberate lockout rather than a silent second account: a duplicate user holding the same address is worse, because the person appears logged in while seeing none of their own sessions. They get the access-denied page with an explanation.

## Side effect on Google

Google's `email_verified` was being parsed away and ignored. It is now honored, and it fails closed if absent — which means an unverified Google address can no longer claim an allow-listed domain. The field name is endpoint-specific (`v3` says `email_verified`, the legacy `v2` says `verified_email`), so there is a test pinning the parse and a comment at the fetch site; getting it wrong would reject every login rather than fail loudly.

## Verification

Nine DB-backed tests cover the four outcomes plus case-insensitive linking, subject-stability across an email change, and the same subject on two providers staying two accounts. Full workspace suite green (26 binaries), clippy clean, WASM builds.

Refs #1535
