### PR TITLE
Add GitHub login and require a configured provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -552,9 +552,35 @@ There are **TWO COMPLETELY SEPARATE** authentication flows:
 **Critical**: The OAuth callback distinguishes flows by checking if `state` starts with `device:`. Regular CSRF tokens don't have this prefix.
 
 **Quick Reference**:
-- Web login → `/api/auth/google` → Google OAuth → `/dashboard`
+- Web login → `/api/auth/google` (or `/api/auth/github`) → provider OAuth → `/dashboard`
 - Device flow → CLI polls `/api/auth/device/poll` while user approves in browser
 - Dev mode bypasses OAuth, auto-logs in as `testing@testing.local`
+
+### Login providers and identity (#1535)
+
+A user is **not** a Google account. Identity lives in `user_identities`, keyed by
+`(provider, subject)`; `users` holds only the portal-side profile, and one person
+may hold several identities. `subject` is the provider's immutable id (GitHub's
+numeric `id`, not the renameable login handle), so a provider changing the email
+it reports never forks the account.
+
+**The linking rule — do not loosen it casually.** `handlers::auth::identity::resolve_user`
+links a new provider to an existing account *only* on a **verified** email, and
+refuses the login otherwise. Silent linking on an unverified address is an
+account-takeover primitive: set your unverified email to the victim's, sign in,
+inherit their sessions. This is why GitHub logins need `GET /user/emails` — the
+`/user` response has no verification flag and is null for private addresses.
+
+**Adding a provider** is meant to be small: add a `PROVIDER_*` const, an
+`oauth::Provider` entry (key, callback path, scopes), a `build_provider(...)`
+call plus a field in `OAuthProviders`, a `fetch_provider_identity` arm, routes,
+and a `provider_button`/`provider_icon` arm in the frontend splash. Everything
+else — CSRF, device flow, banning, allow-lists — is already provider-agnostic.
+
+**At least one provider must be configured** outside `--dev-mode`, or boot fails
+(`OAuthProviders::from_env`). Half-configuring one is also an error rather than a
+silent skip. The frontend renders a login button per entry in
+`AppConfig::auth_providers`, so an unconfigured provider is never offered.
 
 ## Troubleshooting Guide for AI Assistants
 
@@ -858,9 +884,12 @@ When making changes, verify:
 | Variable | Purpose | Required |
 |----------|---------|----------|
 | `DATABASE_URL` | PostgreSQL connection | Yes |
-| `GOOGLE_CLIENT_ID` | OAuth (prod) | Production only |
-| `GOOGLE_CLIENT_SECRET` | OAuth (prod) | Production only |
-| `GOOGLE_REDIRECT_URI` | OAuth callback | Production only |
+| `GOOGLE_CLIENT_ID` | Google login | With the other two `GOOGLE_*` vars, enables Google login |
+| `GOOGLE_CLIENT_SECRET` | Google login | Required if any `GOOGLE_*` var is set |
+| `GOOGLE_REDIRECT_URI` | Google OAuth callback | Required if any `GOOGLE_*` var is set |
+| `GITHUB_CLIENT_ID` | GitHub login | With the other two `GITHUB_*` vars, enables GitHub login |
+| `GITHUB_CLIENT_SECRET` | GitHub login | Required if any `GITHUB_*` var is set |
+| `GITHUB_REDIRECT_URI` | GitHub OAuth callback | Required if any `GITHUB_*` var is set |
 | `SESSION_SECRET` | Cookie signing + JWT secret | Production only |
 | `HOST` | Bind address | Optional (default: 0.0.0.0) |
 | `PORT` | Listen port | Optional (default: 3000) |

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -20,7 +20,7 @@ use tower_cookies::Key;
 
 use crate::handlers;
 
-pub type GoogleOAuthClient =
+pub type OAuthClient =
     BasicClient<EndpointSet, EndpointNotSet, EndpointNotSet, EndpointNotSet, EndpointSet>;
 
 /// Log the provenance of one resolved variable. Never logs the value — only the
@@ -90,51 +90,149 @@ fn string_or(name: &str, default: &str) -> String {
     }
 }
 
-/// Build the Google OAuth client from environment variables.
-/// Returns `None` in dev mode (OAuth is bypassed).
+/// The OAuth clients configured for this deploy, one per login provider.
 ///
-/// Reports **all** missing credentials at once (fail-fast) rather than
-/// panicking on the first one, so a misconfigured deploy is fixed in a single
-/// pass.
-pub fn build_google_oauth_client(dev_mode: bool) -> anyhow::Result<Option<GoogleOAuthClient>> {
-    if dev_mode {
+/// A provider is *enabled* when its credentials are present; every provider is
+/// individually optional, but outside dev mode [`OAuthProviders::from_env`]
+/// insists on at least one. Booting with none would serve a login page whose
+/// every button 404s — a failure that only shows up when a user tries to sign
+/// in, so it is worth catching at startup instead.
+#[derive(Clone, Default)]
+pub struct OAuthProviders {
+    pub google: Option<OAuthClient>,
+    pub github: Option<OAuthClient>,
+}
+
+impl OAuthProviders {
+    /// Build every provider whose credentials are configured.
+    ///
+    /// Returns an empty set in dev mode (OAuth is bypassed entirely). Partially
+    /// configured providers are an error rather than a silent skip: someone who
+    /// set two of a provider's three variables meant to enable it, and quietly
+    /// disabling it would be baffling.
+    pub fn from_env(dev_mode: bool) -> anyhow::Result<Self> {
+        if dev_mode {
+            return Ok(Self::default());
+        }
+
+        let google = build_provider(
+            "GOOGLE",
+            "https://accounts.google.com/o/oauth2/v2/auth",
+            "https://oauth2.googleapis.com/token",
+        )?;
+        let github = build_provider(
+            "GITHUB",
+            "https://github.com/login/oauth/authorize",
+            "https://github.com/login/oauth/access_token",
+        )?;
+
+        if google.is_none() && github.is_none() {
+            anyhow::bail!(
+                "No login provider is configured, so nobody could sign in. Set \
+                 GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET/GOOGLE_REDIRECT_URI or \
+                 GITHUB_CLIENT_ID/GITHUB_CLIENT_SECRET/GITHUB_REDIRECT_URI, or \
+                 pass --dev-mode to bypass OAuth."
+            );
+        }
+
+        Ok(Self { google, github })
+    }
+
+    /// The client for one provider key, or `None` when it is not configured.
+    pub fn client(&self, provider: &str) -> Option<&OAuthClient> {
+        match provider {
+            handlers::auth::PROVIDER_GOOGLE => self.google.as_ref(),
+            handlers::auth::PROVIDER_GITHUB => self.github.as_ref(),
+            _ => None,
+        }
+    }
+
+    /// Configured provider keys, in the order they are offered on the login
+    /// page. Empty in dev mode.
+    pub fn enabled(&self) -> Vec<&'static str> {
+        let mut keys = Vec::new();
+        if self.google.is_some() {
+            keys.push(handlers::auth::PROVIDER_GOOGLE);
+        }
+        if self.github.is_some() {
+            keys.push(handlers::auth::PROVIDER_GITHUB);
+        }
+        keys
+    }
+}
+
+/// Build one provider's client from `{PREFIX}_CLIENT_ID` / `_CLIENT_SECRET` /
+/// `_REDIRECT_URI`.
+///
+/// All three absent → `Ok(None)` (provider simply not enabled). Some present
+/// and some missing → an error naming every missing one at once, so a
+/// misconfigured deploy is fixed in a single pass.
+fn build_provider(
+    prefix: &str,
+    auth_url: &str,
+    token_url: &str,
+) -> anyhow::Result<Option<OAuthClient>> {
+    let names = [
+        format!("{prefix}_CLIENT_ID"),
+        format!("{prefix}_CLIENT_SECRET"),
+        format!("{prefix}_REDIRECT_URI"),
+    ];
+    let values: [Option<String>; 3] = [
+        env::var(&names[0]).ok(),
+        env::var(&names[1]).ok(),
+        env::var(&names[2]).ok(),
+    ];
+
+    let Some(credentials) = resolve_provider_vars(prefix, &names, values)? else {
+        return Ok(None);
+    };
+    for name in &names {
+        log_source(name, true);
+    }
+
+    let [client_id, client_secret, redirect_uri] = credentials;
+    Ok(Some(
+        BasicClient::new(ClientId::new(client_id))
+            .set_client_secret(ClientSecret::new(client_secret))
+            .set_auth_uri(AuthUrl::new(auth_url.to_string())?)
+            .set_token_uri(TokenUrl::new(token_url.to_string())?)
+            .set_redirect_uri(RedirectUrl::new(redirect_uri)?),
+    ))
+}
+
+/// Pure core of [`build_provider`]: classify a provider's three raw values as
+/// not-configured, fully configured, or a fail-fast error. No env read, no
+/// logging — kept separate so it is unit-testable without mutating process
+/// globals (same idiom as [`resolve_parse`]).
+fn resolve_provider_vars(
+    prefix: &str,
+    names: &[String; 3],
+    values: [Option<String>; 3],
+) -> Result<Option<[String; 3]>, anyhow::Error> {
+    if values.iter().all(|v| v.is_none()) {
         return Ok(None);
     }
 
-    let mut missing = Vec::new();
-    let mut required = |name: &str| match env::var(name) {
-        Ok(v) => {
-            log_source(name, true);
-            v
-        }
-        Err(_) => {
-            missing.push(name.to_string());
-            String::new()
-        }
-    };
-    let client_id = required("GOOGLE_CLIENT_ID");
-    let client_secret = required("GOOGLE_CLIENT_SECRET");
-    let redirect_uri_raw = required("GOOGLE_REDIRECT_URI");
-
+    let missing: Vec<&str> = names
+        .iter()
+        .zip(&values)
+        .filter(|(_, v)| v.is_none())
+        .map(|(n, _)| n.as_str())
+        .collect();
     if !missing.is_empty() {
         anyhow::bail!(
-            "Missing required OAuth environment variable(s): {}. \
-             Set them, or pass --dev-mode to bypass OAuth.",
+            "{prefix} login is partially configured — missing {}. Set the \
+             missing variable(s), or unset the others to disable {prefix} login.",
             missing.join(", ")
         );
     }
 
-    let auth_url = AuthUrl::new("https://accounts.google.com/o/oauth2/v2/auth".to_string())?;
-    let token_url = TokenUrl::new("https://oauth2.googleapis.com/token".to_string())?;
-    let redirect_uri = RedirectUrl::new(redirect_uri_raw)?;
-
-    Ok(Some(
-        BasicClient::new(ClientId::new(client_id))
-            .set_client_secret(ClientSecret::new(client_secret))
-            .set_auth_uri(auth_url)
-            .set_token_uri(token_url)
-            .set_redirect_uri(redirect_uri),
-    ))
+    let [id, secret, redirect] = values;
+    match (id, secret, redirect) {
+        (Some(id), Some(secret), Some(redirect)) => Ok(Some([id, secret, redirect])),
+        // Unreachable: `missing` is empty, so all three are `Some`.
+        _ => unreachable!("all three values present when nothing is missing"),
+    }
 }
 
 /// Server configuration parsed from environment variables.
@@ -621,6 +719,85 @@ fn native_push_config_from_env(errors: &mut Vec<String>) -> crate::push::NativeP
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn provider_names() -> [String; 3] {
+        [
+            "GITHUB_CLIENT_ID".to_string(),
+            "GITHUB_CLIENT_SECRET".to_string(),
+            "GITHUB_REDIRECT_URI".to_string(),
+        ]
+    }
+
+    #[test]
+    fn a_provider_with_no_variables_set_is_simply_disabled() {
+        let resolved = resolve_provider_vars("GITHUB", &provider_names(), [None, None, None])
+            .expect("absent is not an error");
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn a_fully_configured_provider_resolves_its_credentials() {
+        let resolved = resolve_provider_vars(
+            "GITHUB",
+            &provider_names(),
+            [
+                Some("id".to_string()),
+                Some("secret".to_string()),
+                Some("https://example.invalid/cb".to_string()),
+            ],
+        )
+        .expect("complete config is valid");
+        assert_eq!(
+            resolved,
+            Some([
+                "id".to_string(),
+                "secret".to_string(),
+                "https://example.invalid/cb".to_string()
+            ])
+        );
+    }
+
+    /// Half-configuring a provider is a typo, not a request to disable it —
+    /// silently skipping would leave the operator staring at a missing button.
+    #[test]
+    fn a_partially_configured_provider_names_every_missing_variable() {
+        let err = resolve_provider_vars(
+            "GITHUB",
+            &provider_names(),
+            [Some("id".to_string()), None, None],
+        )
+        .expect_err("partial config must fail");
+        let message = err.to_string();
+        assert!(message.contains("GITHUB_CLIENT_SECRET"), "{message}");
+        assert!(message.contains("GITHUB_REDIRECT_URI"), "{message}");
+        assert!(!message.contains("GITHUB_CLIENT_ID"), "{message}");
+    }
+
+    #[test]
+    fn dev_mode_enables_no_providers() {
+        let providers = OAuthProviders::from_env(true).expect("dev mode never fails");
+        assert!(providers.enabled().is_empty());
+        assert!(providers.client("google").is_none());
+    }
+
+    #[test]
+    fn enabled_lists_only_configured_providers_and_client_looks_them_up() {
+        let client = |redirect: &str| {
+            BasicClient::new(ClientId::new("id".to_string()))
+                .set_auth_uri(AuthUrl::new("https://example.invalid/a".to_string()).unwrap())
+                .set_token_uri(TokenUrl::new("https://example.invalid/t".to_string()).unwrap())
+                .set_redirect_uri(RedirectUrl::new(redirect.to_string()).unwrap())
+        };
+        let providers = OAuthProviders {
+            google: None,
+            github: Some(client("https://example.invalid/cb")),
+        };
+
+        assert_eq!(providers.enabled(), vec!["github"]);
+        assert!(providers.client("github").is_some());
+        assert!(providers.client("google").is_none());
+        assert!(providers.client("gitlab").is_none());
+    }
 
     #[test]
     fn unset_var_uses_default_marked_not_from_env() {

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -34,25 +34,46 @@ pub use identity::{ProviderIdentity, PROVIDER_GITHUB, PROVIDER_GOOGLE};
 const MOBILE_TOKEN_TTL_DAYS: u32 = 30;
 const TOKEN_REFRESH_GRACE_MINUTES: i64 = 10;
 
-/// Regular web login - redirects to Google OAuth
+/// Regular web login via Google.
 pub async fn login(State(app_state): State<Arc<AppState>>, cookies: Cookies) -> impl IntoResponse {
+    start_login(&oauth::GOOGLE, &app_state, &cookies)
+}
+
+/// Regular web login via GitHub.
+pub async fn github_login(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+) -> impl IntoResponse {
+    start_login(&oauth::GITHUB, &app_state, &cookies)
+}
+
+/// Begin the authorization-code flow for one provider.
+///
+/// With no client configured this falls through to dev login, which is only
+/// reachable in dev mode — outside it, boot fails unless a provider is
+/// configured, so the fallback cannot silently become the production path.
+fn start_login(
+    provider: &oauth::Provider,
+    app_state: &AppState,
+    cookies: &Cookies,
+) -> axum::response::Response {
+    let client = app_state.oauth.client(provider.key);
     info!(
         target: "auth_audit",
         event = "web_login_start",
-        oauth_configured = app_state.oauth_basic_client.is_some(),
+        provider = provider.key,
+        oauth_configured = client.is_some(),
     );
-    let client = match &app_state.oauth_basic_client {
-        Some(c) => c,
-        None => {
-            info!(
-                target: "auth_audit",
-                event = "web_login_dev_redirect",
-            );
-            return Redirect::temporary(routes::AUTH_DEV_LOGIN).into_response();
-        }
+    let Some(client) = client else {
+        info!(
+            target: "auth_audit",
+            event = "web_login_dev_redirect",
+            provider = provider.key,
+        );
+        return Redirect::temporary(routes::AUTH_DEV_LOGIN).into_response();
     };
 
-    oauth::regular_authorization_redirect(client, &cookies, &app_state).into_response()
+    oauth::regular_authorization_redirect(provider, client, cookies, app_state).into_response()
 }
 
 /// Device flow login - separate endpoint that stores device_user_code in state
@@ -60,6 +81,11 @@ pub async fn login(State(app_state): State<Arc<AppState>>, cookies: Cookies) -> 
 #[derive(Debug, Deserialize)]
 pub struct DeviceLoginQuery {
     pub device_user_code: String,
+    /// Which provider to authenticate with. Absent (the CLI never sends it)
+    /// means "whichever is configured first", so a deploy that enables only
+    /// GitHub still has a working device flow.
+    #[serde(default)]
+    pub provider: Option<String>,
 }
 
 pub async fn device_login(
@@ -71,10 +97,10 @@ pub async fn device_login(
         target: "auth_audit",
         event = "device_login_start",
         user_code = %query.device_user_code,
-        oauth_configured = app_state.oauth_basic_client.is_some(),
+        oauth_configured = !app_state.oauth.enabled().is_empty(),
     );
     // In dev mode, auto-login and redirect to device approval page
-    if app_state.oauth_basic_client.is_none() {
+    if app_state.oauth.enabled().is_empty() {
         let mut conn = app_state.conn()?;
 
         let user = crate::auth::dev_user(&mut conn).map_err(dev_user_lookup_error)?;
@@ -107,12 +133,26 @@ pub async fn device_login(
         return Ok(device_approval_redirect(&query.device_user_code).into_response());
     }
 
-    let client = app_state.oauth_basic_client.as_ref().unwrap();
+    let requested = query
+        .provider
+        .as_deref()
+        .or_else(|| app_state.oauth.enabled().first().copied())
+        .unwrap_or(PROVIDER_GOOGLE);
+    let provider =
+        oauth::by_key(requested).ok_or(AppError::ServiceUnavailable("Unknown login provider"))?;
+    let client = app_state
+        .oauth
+        .client(provider.key)
+        .ok_or(AppError::ServiceUnavailable("OAuth client not configured"))?;
 
-    Ok(
-        oauth::device_authorization_redirect(client, &cookies, &app_state, &query.device_user_code)
-            .into_response(),
+    Ok(oauth::device_authorization_redirect(
+        provider,
+        client,
+        &cookies,
+        &app_state,
+        &query.device_user_code,
     )
+    .into_response())
 }
 
 #[derive(Debug, Deserialize)]
@@ -135,11 +175,49 @@ struct GoogleUserInfo {
     picture: Option<String>,
 }
 
+/// GitHub's `/user` response. `id` is numeric and immutable — the login handle
+/// is renameable, so it must not be used as the subject.
+///
+/// `email` is deliberately ignored here even though the field exists: it is
+/// null when the user keeps their address private, and GitHub attaches no
+/// verification flag to it. The address comes from `/user/emails` instead.
+#[derive(Debug, Deserialize)]
+struct GitHubUserInfo {
+    id: u64,
+    name: Option<String>,
+    avatar_url: Option<String>,
+}
+
+/// One entry of GitHub's `/user/emails` response.
+#[derive(Debug, Deserialize)]
+struct GitHubEmail {
+    email: String,
+    primary: bool,
+    verified: bool,
+}
+
 pub async fn callback(
     State(app_state): State<Arc<AppState>>,
     cookies: Cookies,
     Query(query): Query<AuthCallbackQuery>,
 ) -> Result<impl IntoResponse, AppError> {
+    provider_callback(&oauth::GOOGLE, app_state, cookies, query).await
+}
+
+pub async fn github_callback(
+    State(app_state): State<Arc<AppState>>,
+    cookies: Cookies,
+    Query(query): Query<AuthCallbackQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    provider_callback(&oauth::GITHUB, app_state, cookies, query).await
+}
+
+async fn provider_callback(
+    provider: &oauth::Provider,
+    app_state: Arc<AppState>,
+    cookies: Cookies,
+    query: AuthCallbackQuery,
+) -> Result<axum::response::Response, AppError> {
     let callback_kind = if query
         .state
         .as_deref()
@@ -152,28 +230,31 @@ pub async fn callback(
     info!(
         target: "auth_audit",
         event = "oauth_callback_start",
+        provider = provider.key,
         flow = callback_kind,
         state_present = query.state.is_some(),
     );
 
     let client = app_state
-        .oauth_basic_client
-        .as_ref()
+        .oauth
+        .client(provider.key)
         .ok_or(AppError::ServiceUnavailable("OAuth client not configured"))?;
     let http_client = oauth2::reqwest::ClientBuilder::new()
         .redirect(oauth2::reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| AppError::Internal(format!("Failed to build OAuth HTTP client: {e}")))?;
 
-    let device_state = oauth::validate_callback_state(&cookies, &app_state, query.state.as_deref())
-        .inspect_err(|_| {
-            warn!(
-                target: "auth_audit",
-                event = "oauth_callback_denied",
-                flow = callback_kind,
-                reason = "invalid_state",
-            );
-        })?;
+    let device_state =
+        oauth::validate_callback_state(provider, &cookies, &app_state, query.state.as_deref())
+            .inspect_err(|_| {
+                warn!(
+                    target: "auth_audit",
+                    event = "oauth_callback_denied",
+                    provider = provider.key,
+                    flow = callback_kind,
+                    reason = "invalid_state",
+                );
+            })?;
 
     // Exchange code for token
     let token: oauth2::StandardTokenResponse<
@@ -193,70 +274,46 @@ pub async fn callback(
             AppError::Internal(format!("Failed to exchange OAuth code: {e}"))
         })?;
 
-    // Fetch user info from Google.
-    //
-    // Must stay on the OIDC (`v3`) endpoint: it spells the verification flag
-    // `email_verified`, whereas the legacy `v2` endpoint spells it
-    // `verified_email`. Since `GoogleUserInfo::email_verified` fails closed,
-    // switching endpoints without renaming the field would reject every login.
-    let client = reqwest::Client::new();
-    let user_info: GoogleUserInfo = client
-        .get("https://www.googleapis.com/oauth2/v3/userinfo")
-        .bearer_auth(token.access_token().secret())
-        .send()
+    let resolved_identity = fetch_provider_identity(provider, token.access_token().secret())
         .await
-        .map_err(|e| {
+        .inspect_err(|_| {
             warn!(
                 target: "auth_audit",
                 event = "oauth_callback_failed",
+                provider = provider.key,
                 flow = callback_kind,
-                stage = "userinfo_fetch",
+                stage = "userinfo",
             );
-            AppError::Internal(format!("Failed to fetch Google user info: {e}"))
-        })?
-        .json()
-        .await
-        .map_err(|e| {
-            warn!(
-                target: "auth_audit",
-                event = "oauth_callback_failed",
-                flow = callback_kind,
-                stage = "userinfo_parse",
-            );
-            AppError::Internal(format!("Failed to parse Google user info: {e}"))
         })?;
 
-    info!("User authenticated: {}", user_info.email);
-
-    // Check email access control
-    if let Err(redirect) = check_email_allowed(&app_state, &user_info.email) {
+    // An address the provider has not vouched for must not satisfy the
+    // allow-list — otherwise anyone could claim a permitted domain. Treat it as
+    // absent here and let `resolve_user` refuse below.
+    let allowlist_email = resolved_identity
+        .email
+        .as_deref()
+        .filter(|_| resolved_identity.email_verified)
+        .unwrap_or_default();
+    if let Err(redirect) = check_email_allowed(&app_state, allowlist_email) {
         warn!(
             target: "auth_audit",
             event = "oauth_callback_denied",
+            provider = provider.key,
             flow = callback_kind,
             reason = "email_not_allowed",
-            user_email = %user_info.email,
         );
-        return Ok(redirect);
+        return Ok(redirect.into_response());
     }
+
+    info!("User authenticated via {}", provider.key);
 
     // Resolve the login to a user: existing identity, link on a verified email,
     // or create. See `identity` for the rule and why linking is gated on
     // verification (#1535).
     let mut conn = app_state.conn()?;
 
-    let resolved = identity::resolve_user(
-        &mut conn,
-        &ProviderIdentity {
-            provider: PROVIDER_GOOGLE,
-            subject: user_info.sub,
-            email: Some(user_info.email.clone()),
-            email_verified: user_info.email_verified,
-            name: user_info.name,
-            avatar_url: user_info.picture,
-        },
-    )
-    .map_err(|e| AppError::DbQuery(format!("Failed to resolve login identity: {e}")))?;
+    let resolved = identity::resolve_user(&mut conn, &resolved_identity)
+        .map_err(|e| AppError::DbQuery(format!("Failed to resolve login identity: {e}")))?;
 
     let user = match resolved {
         Ok(user) => user,
@@ -264,11 +321,11 @@ pub async fn callback(
             warn!(
                 target: "auth_audit",
                 event = "oauth_callback_denied",
+                provider = provider.key,
                 flow = callback_kind,
                 reason = "unverified_email",
-                user_email = %user_info.email,
             );
-            return Ok(unverified_email_redirect());
+            return Ok(unverified_email_redirect().into_response());
         }
     };
 
@@ -284,7 +341,7 @@ pub async fn callback(
             user_id = %user.id,
             user_email = %user.email,
         );
-        return Ok(banned_redirect(reason));
+        return Ok(banned_redirect(reason).into_response());
     }
 
     if let Some(device_state) = device_state {
@@ -303,7 +360,7 @@ pub async fn callback(
             user_email = %user.email,
             user_code = %device_state.user_code,
         );
-        return Ok(device_approval_redirect(&device_state.user_code));
+        return Ok(device_approval_redirect(&device_state.user_code).into_response());
     }
 
     add_session_cookie(&cookies, &app_state, &user);
@@ -315,7 +372,106 @@ pub async fn callback(
         user_email = %user.email,
     );
 
-    Ok(Redirect::temporary(routes::DASHBOARD))
+    Ok(Redirect::temporary(routes::DASHBOARD).into_response())
+}
+
+/// GitHub rejects API requests without a `User-Agent`, so every call sends one.
+const GITHUB_USER_AGENT: &str = "agent-portal";
+
+/// Ask the provider who just authorized us, normalized to a [`ProviderIdentity`].
+async fn fetch_provider_identity(
+    provider: &oauth::Provider,
+    access_token: &str,
+) -> Result<ProviderIdentity, AppError> {
+    let http = reqwest::Client::new();
+    match provider.key {
+        PROVIDER_GOOGLE => google_identity(&http, access_token).await,
+        PROVIDER_GITHUB => github_identity(&http, access_token).await,
+        other => Err(AppError::Internal(format!("Unknown provider: {other}"))),
+    }
+}
+
+/// Must stay on the OIDC (`v3`) userinfo endpoint: it spells the verification
+/// flag `email_verified`, whereas the legacy `v2` endpoint spells it
+/// `verified_email`. Since the field fails closed, switching endpoints without
+/// renaming it would reject every login rather than fail loudly.
+async fn google_identity(
+    http: &reqwest::Client,
+    access_token: &str,
+) -> Result<ProviderIdentity, AppError> {
+    let info: GoogleUserInfo = http
+        .get("https://www.googleapis.com/oauth2/v3/userinfo")
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to fetch Google user info: {e}")))?
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to parse Google user info: {e}")))?;
+
+    Ok(ProviderIdentity {
+        provider: PROVIDER_GOOGLE,
+        subject: info.sub,
+        email: Some(info.email),
+        email_verified: info.email_verified,
+        name: info.name,
+        avatar_url: info.picture,
+    })
+}
+
+/// GitHub needs two calls: `/user` for the immutable numeric id and profile,
+/// and `/user/emails` for an address we can trust. `/user` alone is not enough —
+/// its `email` is null for users with a private address and carries no
+/// verification flag, and an unverified address must never link an account.
+async fn github_identity(
+    http: &reqwest::Client,
+    access_token: &str,
+) -> Result<ProviderIdentity, AppError> {
+    let info: GitHubUserInfo = http
+        .get("https://api.github.com/user")
+        .bearer_auth(access_token)
+        .header(header::USER_AGENT, GITHUB_USER_AGENT)
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to fetch GitHub user: {e}")))?
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to parse GitHub user: {e}")))?;
+
+    let emails: Vec<GitHubEmail> = http
+        .get("https://api.github.com/user/emails")
+        .bearer_auth(access_token)
+        .header(header::USER_AGENT, GITHUB_USER_AGENT)
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to fetch GitHub emails: {e}")))?
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to parse GitHub emails: {e}")))?;
+
+    let email = primary_verified_email(&emails);
+
+    Ok(ProviderIdentity {
+        provider: PROVIDER_GITHUB,
+        subject: info.id.to_string(),
+        email_verified: email.is_some(),
+        email,
+        name: info.name,
+        avatar_url: info.avatar_url,
+    })
+}
+
+/// Pick the address GitHub considers primary **and** verified.
+///
+/// Both conditions are required, and neither is inferable from the other: a
+/// user may have several verified addresses, and the primary one may be
+/// unverified. Returning `None` makes the caller refuse the login rather than
+/// trust an address the user has not proven they control.
+fn primary_verified_email(emails: &[GitHubEmail]) -> Option<String> {
+    emails
+        .iter()
+        .find(|e| e.primary && e.verified)
+        .map(|e| e.email.clone())
 }
 
 pub async fn me(
@@ -631,6 +787,60 @@ mod tests {
     use crate::models::{NewUser, ProxyAuthToken};
     use crate::schema::{proxy_auth_tokens, users};
     use axum::http::{header::AUTHORIZATION, HeaderValue};
+
+    fn gh_email(email: &str, primary: bool, verified: bool) -> GitHubEmail {
+        GitHubEmail {
+            email: email.to_string(),
+            primary,
+            verified,
+        }
+    }
+
+    #[test]
+    fn github_picks_the_primary_verified_address() {
+        let emails = vec![
+            gh_email("alt@example.invalid", false, true),
+            gh_email("main@example.invalid", true, true),
+        ];
+        assert_eq!(
+            primary_verified_email(&emails),
+            Some("main@example.invalid".to_string())
+        );
+    }
+
+    /// An unverified primary must not fall back to some other verified address:
+    /// the account the person is signing into is the primary one, and silently
+    /// substituting a different address would link the wrong portal account.
+    #[test]
+    fn github_refuses_when_the_primary_address_is_unverified() {
+        let emails = vec![
+            gh_email("main@example.invalid", true, false),
+            gh_email("alt@example.invalid", false, true),
+        ];
+        assert_eq!(primary_verified_email(&emails), None);
+    }
+
+    #[test]
+    fn github_refuses_when_no_address_is_verified() {
+        let emails = vec![gh_email("main@example.invalid", true, false)];
+        assert_eq!(primary_verified_email(&emails), None);
+        assert_eq!(primary_verified_email(&[]), None);
+    }
+
+    /// GitHub ids are numeric; the subject must be the id and not the
+    /// renameable login handle.
+    #[test]
+    fn github_user_info_parses_the_numeric_id() {
+        let body = r#"{
+            "id": 583231,
+            "login": "octocat",
+            "name": "The Octocat",
+            "avatar_url": "https://example.invalid/a.png"
+        }"#;
+        let info: GitHubUserInfo = serde_json::from_str(body).expect("parses /user");
+        assert_eq!(info.id.to_string(), "583231");
+        assert_eq!(info.name.as_deref(), Some("The Octocat"));
+    }
 
     /// Pins the field names of the OIDC (`v3`) userinfo response. The legacy
     /// `v2` endpoint spells the flag `verified_email`, and because the field

--- a/backend/src/handlers/auth/oauth.rs
+++ b/backend/src/handlers/auth/oauth.rs
@@ -3,23 +3,63 @@ use oauth2::{CsrfToken, Scope};
 use tower_cookies::{cookie::SameSite, Cookie, Cookies};
 use tracing::error;
 
-use crate::{errors::AppError, routes, AppState, GoogleOAuthClient};
+use super::identity::{PROVIDER_GITHUB, PROVIDER_GOOGLE};
+use crate::{errors::AppError, routes, AppState, OAuthClient};
 
 const OAUTH_CSRF_COOKIE: &str = "oauth_csrf";
 const OAUTH_DEVICE_CSRF_COOKIE: &str = "oauth_device_csrf";
 
+/// The per-provider knobs of an otherwise identical authorization-code flow.
+pub(super) struct Provider {
+    /// Value stored in `user_identities.provider`.
+    pub(super) key: &'static str,
+    /// Where this provider sends the authorization code back to. Doubles as the
+    /// CSRF cookies' `Path`: two providers use the same cookie *names*, and it
+    /// is the differing path that keeps concurrent logins from clobbering each
+    /// other — a cookie is identified by name **and** path, and each callback
+    /// only receives the one scoped to it.
+    pub(super) callback_path: &'static str,
+    pub(super) scopes: &'static [&'static str],
+}
+
+pub(super) const GOOGLE: Provider = Provider {
+    key: PROVIDER_GOOGLE,
+    callback_path: routes::AUTH_GOOGLE_CALLBACK,
+    scopes: &["openid", "email", "profile"],
+};
+
+/// `user:email` is required on top of `read:user`: GitHub's `/user` endpoint
+/// omits the address entirely when the user has it set to private, and carries
+/// no verification flag either way — see `github_user_info`.
+pub(super) const GITHUB: Provider = Provider {
+    key: PROVIDER_GITHUB,
+    callback_path: routes::AUTH_GITHUB_CALLBACK,
+    scopes: &["read:user", "user:email"],
+};
+
+/// Look up a provider by its `user_identities.provider` key.
+pub(super) fn by_key(key: &str) -> Option<&'static Provider> {
+    match key {
+        PROVIDER_GOOGLE => Some(&GOOGLE),
+        PROVIDER_GITHUB => Some(&GITHUB),
+        _ => None,
+    }
+}
+
 pub(super) fn regular_authorization_redirect(
-    client: &GoogleOAuthClient,
+    provider: &Provider,
+    client: &OAuthClient,
     cookies: &Cookies,
     app_state: &AppState,
 ) -> Redirect {
-    let auth_request = add_default_scopes(client.authorize_url(CsrfToken::new_random));
+    let auth_request = add_scopes(provider, client.authorize_url(CsrfToken::new_random));
     let (auth_url, csrf_token) = auth_request.url();
 
     // Store the CSRF token in a short-lived signed cookie so we can verify it on callback.
     cookies.signed(&app_state.cookie_key).add(oauth_csrf_cookie(
         OAUTH_CSRF_COOKIE,
         csrf_token.secret(),
+        provider.callback_path,
         !app_state.dev_mode,
     ));
 
@@ -27,7 +67,8 @@ pub(super) fn regular_authorization_redirect(
 }
 
 pub(super) fn device_authorization_redirect(
-    client: &GoogleOAuthClient,
+    provider: &Provider,
+    client: &OAuthClient,
     cookies: &Cookies,
     app_state: &AppState,
     device_user_code: &str,
@@ -38,16 +79,21 @@ pub(super) fn device_authorization_redirect(
     cookies.signed(&app_state.cookie_key).add(oauth_csrf_cookie(
         OAUTH_DEVICE_CSRF_COOKIE,
         device_csrf.secret(),
+        provider.callback_path,
         !app_state.dev_mode,
     ));
 
-    let auth_request = add_default_scopes(client.authorize_url(|| CsrfToken::new(state_value)));
+    let auth_request = add_scopes(
+        provider,
+        client.authorize_url(|| CsrfToken::new(state_value)),
+    );
     let (auth_url, _csrf_token) = auth_request.url();
 
     Redirect::temporary(auth_url.as_str())
 }
 
 pub(super) fn validate_callback_state(
+    provider: &Provider,
     cookies: &Cookies,
     app_state: &AppState,
     state: Option<&str>,
@@ -74,7 +120,10 @@ pub(super) fn validate_callback_state(
 
         cookies
             .signed(&app_state.cookie_key)
-            .add(remove_oauth_csrf_cookie(OAUTH_DEVICE_CSRF_COOKIE));
+            .add(remove_oauth_csrf_cookie(
+                OAUTH_DEVICE_CSRF_COOKIE,
+                provider.callback_path,
+            ));
     } else {
         let csrf_cookie = cookies
             .signed(&app_state.cookie_key)
@@ -92,24 +141,32 @@ pub(super) fn validate_callback_state(
 
         cookies
             .signed(&app_state.cookie_key)
-            .add(remove_oauth_csrf_cookie(OAUTH_CSRF_COOKIE));
+            .add(remove_oauth_csrf_cookie(
+                OAUTH_CSRF_COOKIE,
+                provider.callback_path,
+            ));
     }
 
     Ok(device_state)
 }
 
-fn add_default_scopes(
-    auth_request: oauth2::AuthorizationRequest<'_>,
-) -> oauth2::AuthorizationRequest<'_> {
-    auth_request
-        .add_scope(Scope::new("openid".to_string()))
-        .add_scope(Scope::new("email".to_string()))
-        .add_scope(Scope::new("profile".to_string()))
+fn add_scopes<'a>(
+    provider: &Provider,
+    auth_request: oauth2::AuthorizationRequest<'a>,
+) -> oauth2::AuthorizationRequest<'a> {
+    provider.scopes.iter().fold(auth_request, |req, scope| {
+        req.add_scope(Scope::new((*scope).to_string()))
+    })
 }
 
-fn oauth_csrf_cookie(name: &'static str, value: &str, secure: bool) -> Cookie<'static> {
+fn oauth_csrf_cookie(
+    name: &'static str,
+    value: &str,
+    path: &'static str,
+    secure: bool,
+) -> Cookie<'static> {
     let mut cookie = Cookie::new(name, value.to_owned());
-    cookie.set_path(routes::AUTH_GOOGLE_CALLBACK);
+    cookie.set_path(path);
     cookie.set_http_only(true);
     cookie.set_secure(secure);
     cookie.set_same_site(SameSite::Lax);
@@ -117,9 +174,9 @@ fn oauth_csrf_cookie(name: &'static str, value: &str, secure: bool) -> Cookie<'s
     cookie
 }
 
-fn remove_oauth_csrf_cookie(name: &'static str) -> Cookie<'static> {
+fn remove_oauth_csrf_cookie(name: &'static str, path: &'static str) -> Cookie<'static> {
     let mut cookie = Cookie::new(name, "");
-    cookie.set_path(routes::AUTH_GOOGLE_CALLBACK);
+    cookie.set_path(path);
     cookie.set_max_age(tower_cookies::cookie::time::Duration::ZERO);
     cookie
 }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -16,5 +16,11 @@ pub async fn get_config(State(app_state): State<Arc<AppState>>) -> Json<AppConfi
         build_time: shared::BUILD_TIME.to_string(),
         splash_text: app_state.splash_text.clone(),
         archive_enabled: app_state.archive.is_some(),
+        auth_providers: app_state
+            .oauth
+            .enabled()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
     })
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -40,7 +40,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use handlers::websocket::SessionManager;
 
-pub use crate::config::GoogleOAuthClient;
+pub use crate::config::{OAuthClient, OAuthProviders};
 
 #[derive(Parser, Debug, Clone)]
 #[command(name = "agent-portal-backend")]
@@ -60,7 +60,7 @@ pub struct AppState {
     pub dev_mode: bool,
     pub db_pool: DbPool,
     pub session_manager: SessionManager,
-    pub oauth_basic_client: Option<GoogleOAuthClient>,
+    pub oauth: OAuthProviders,
     pub device_flow_store: Option<DeviceFlowStore>,
     pub public_url: String,
     pub cookie_key: Key,
@@ -138,8 +138,9 @@ pub async fn run() -> anyhow::Result<()> {
     // Create device flow store
     let device_flow_store = handlers::device_flow::DeviceFlowStore::default();
 
-    // Create OAuth client (skip in dev mode)
-    let oauth_basic_client = config::build_google_oauth_client(args.dev_mode)?;
+    // Build every configured login provider (none in dev mode; outside dev
+    // mode at least one is required, enforced by `from_env`).
+    let oauth = config::OAuthProviders::from_env(args.dev_mode)?;
 
     // Create test user in dev mode
     if args.dev_mode {
@@ -173,7 +174,7 @@ pub async fn run() -> anyhow::Result<()> {
         dev_mode: args.dev_mode,
         db_pool: pool,
         session_manager,
-        oauth_basic_client,
+        oauth,
         device_flow_store: Some(device_flow_store),
         public_url: config.public_url,
         cookie_key: config.cookie_key,

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -22,6 +22,8 @@ pub const ACCESS_DENIED: &str = "/access-denied";
 
 pub const AUTH_GOOGLE: &str = "/api/auth/google";
 pub const AUTH_GOOGLE_CALLBACK: &str = "/api/auth/google/callback";
+pub const AUTH_GITHUB: &str = "/api/auth/github";
+pub const AUTH_GITHUB_CALLBACK: &str = "/api/auth/github/callback";
 pub const AUTH_ME: &str = "/api/auth/me";
 pub const AUTH_REFRESH: &str = "/api/auth/refresh";
 pub const AUTH_TOKEN_LOGIN: &str = "/api/auth/token-login";
@@ -84,6 +86,8 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
     let auth_login_routes = Router::new()
         .route(AUTH_GOOGLE, get(handlers::auth::login))
         .route(AUTH_GOOGLE_CALLBACK, get(handlers::auth::callback))
+        .route(AUTH_GITHUB, get(handlers::auth::github_login))
+        .route(AUTH_GITHUB_CALLBACK, get(handlers::auth::github_callback))
         .route(AUTH_DEV_LOGIN, get(handlers::auth::dev_login))
         .route(AUTH_DEVICE_LOGIN, get(handlers::auth::device_login))
         .layer(rate_limit(2, 20))

--- a/backend/src/test_support.rs
+++ b/backend/src/test_support.rs
@@ -47,7 +47,7 @@ pub fn test_app_state(pool: DbPool) -> AppState {
         dev_mode: false,
         db_pool: pool,
         session_manager: SessionManager::new(),
-        oauth_basic_client: None,
+        oauth: crate::config::OAuthProviders::default(),
         device_flow_store: None,
         public_url: "http://localhost:3000".to_string(),
         cookie_key: Key::generate(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,14 @@ services:
     environment:
       # --- Required ---
       DATABASE_URL: "postgresql://claude_portal:dev_password_change_in_production@db:5432/claude_portal"
-      # --- Auth (required in production) ---
+      # --- Auth: at least one provider is required in production ---
       GOOGLE_CLIENT_ID: "${GOOGLE_CLIENT_ID:-your_client_id}"
       GOOGLE_CLIENT_SECRET: "${GOOGLE_CLIENT_SECRET:-your_client_secret}"
-      GOOGLE_REDIRECT_URI: "http://localhost:3000/auth/google/callback"
+      GOOGLE_REDIRECT_URI: "http://localhost:3000/api/auth/google/callback"
+      # Uncomment to offer GitHub login too (all three or none):
+      # GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID}"
+      # GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET}"
+      # GITHUB_REDIRECT_URI: "http://localhost:3000/api/auth/github/callback"
       SESSION_SECRET: "${SESSION_SECRET:-dev_secret_change_in_production_please}"
       # --- Optional ---
       # APP_TITLE: "Agent Portal"           # Header text shown in the dashboard

--- a/frontend/src/pages/splash.rs
+++ b/frontend/src/pages/splash.rs
@@ -9,35 +9,114 @@ use yew::prelude::*;
 
 #[function_component(SplashPage)]
 pub fn splash_page() -> Html {
-    let splash_text = use_state(|| None::<String>);
+    let config = use_state(|| None::<AppConfig>);
 
     {
-        let splash_text = splash_text.clone();
+        let config = config.clone();
         use_effect_with((), move |_| {
             wasm_bindgen_futures::spawn_local(async move {
                 // Pre-login page: a 401 here must not bounce through logout.
-                if let Ok(config) =
+                if let Ok(loaded) =
                     utils::fetch_json::<AppConfig>("/api/config", On401::Ignore).await
                 {
-                    splash_text.set(config.splash_text);
+                    config.set(Some(loaded));
                 }
             });
             || ()
         });
     }
 
-    match (*splash_text).clone() {
-        Some(text) => minimal_splash(text),
-        None => marketing_splash(),
+    let buttons = login_buttons(config.as_ref());
+    match config.as_ref().and_then(|c| c.splash_text.clone()) {
+        Some(text) => minimal_splash(text, buttons),
+        None => marketing_splash(buttons),
     }
 }
 
-fn login_callback() -> Callback<MouseEvent> {
-    Callback::from(|_| {
-        console::log!("Redirecting to Google OAuth...");
+/// A provider key as it appears in [`AppConfig::auth_providers`], paired with
+/// the button copy and the route that starts its flow. Unknown keys render
+/// nothing, so a backend advertising a provider this build does not know about
+/// degrades to hiding it rather than showing a dead button.
+fn provider_button(provider: &str) -> Option<(&'static str, &'static str)> {
+    match provider {
+        "google" => Some(("Sign in with Google", "/api/auth/google")),
+        "github" => Some(("Sign in with GitHub", "/api/auth/github")),
+        _ => None,
+    }
+}
+
+/// The GitHub mark, inlined rather than shipped as an asset so it inherits the
+/// button's `currentColor` and needs no extra request.
+fn provider_icon(provider: &str) -> Html {
+    match provider {
+        "github" => html! {
+            <svg
+                class="provider-icon"
+                viewBox="0 0 24 24"
+                width="18"
+                height="18"
+                fill="currentColor"
+                aria-hidden="true"
+            >
+                <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 \
+                         0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 \
+                         17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 \
+                         1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 \
+                         0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 \
+                         1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 \
+                         3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 \
+                         5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 \
+                         22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+            </svg>
+        },
+        _ => html! { <span class="provider-icon google-icon">{ "G" }</span> },
+    }
+}
+
+/// Render one button per configured provider.
+///
+/// Nothing renders until the config arrives, so a provider the deploy has no
+/// credentials for is never offered — the alternative is a button that 404s on
+/// click. An empty provider list means dev mode, where login is bypassed: the
+/// Google route redirects to dev login, so a single generic button is right.
+fn login_buttons(config: Option<&AppConfig>) -> Html {
+    let Some(config) = config else {
+        return html! {};
+    };
+
+    if config.auth_providers.is_empty() {
+        return html! {
+            <button class="login-button" onclick={login_callback("/api/auth/google")}>
+                { "Sign in" }
+            </button>
+        };
+    }
+
+    html! {
+        <div class="login-buttons">
+            { for config.auth_providers.iter().filter_map(|provider| {
+                let (label, route) = provider_button(provider)?;
+                Some(html! {
+                    <button
+                        key={provider.clone()}
+                        class="login-button"
+                        onclick={login_callback(route)}
+                    >
+                        { provider_icon(provider) }
+                        { format!(" {label}") }
+                    </button>
+                })
+            }) }
+        </div>
+    }
+}
+
+fn login_callback(route: &'static str) -> Callback<MouseEvent> {
+    Callback::from(move |_| {
+        console::log!("Redirecting to OAuth:", route);
         let window = web_sys::window().expect("no global `window` exists");
         let location = window.location();
-        let auth_url = utils::api_url("/api/auth/google");
+        let auth_url = utils::api_url(route);
         let _ = location.set_href(&auth_url);
     })
 }
@@ -75,9 +154,7 @@ fn splash_footer(github_icon: bool) -> Html {
     }
 }
 
-fn minimal_splash(heading: String) -> Html {
-    let handle_login = login_callback();
-
+fn minimal_splash(heading: String, login_buttons: Html) -> Html {
     html! {
         <div class="splash-container">
             <div class="splash-content splash-minimal">
@@ -85,10 +162,7 @@ fn minimal_splash(heading: String) -> Html {
                     <h1>{ heading }</h1>
                 </div>
 
-                <button class="login-button" onclick={handle_login}>
-                    <span class="google-icon">{ "G" }</span>
-                    { " Sign in with Google" }
-                </button>
+                { login_buttons }
 
                 { splash_footer(false) }
             </div>
@@ -96,9 +170,7 @@ fn minimal_splash(heading: String) -> Html {
     }
 }
 
-fn marketing_splash() -> Html {
-    let handle_login = login_callback();
-
+fn marketing_splash(login_buttons: Html) -> Html {
     html! {
         <div class="splash-container">
             <div class="splash-content">
@@ -194,14 +266,11 @@ fn marketing_splash() -> Html {
                     </div>
                     <div class="feature">
                         <h3>{ "Secure" }</h3>
-                        <p>{ "Google OAuth authentication and encrypted connections" }</p>
+                        <p>{ "OAuth authentication and encrypted connections" }</p>
                     </div>
                 </div>
 
-                <button class="login-button" onclick={handle_login}>
-                    <span class="google-icon">{ "G" }</span>
-                    { " Sign in with Google" }
-                </button>
+                { login_buttons }
 
                 { splash_footer(true) }
             </div>

--- a/frontend/styles/splash.css
+++ b/frontend/styles/splash.css
@@ -164,6 +164,19 @@
     font-weight: bold;
 }
 
+/* Stacks the per-provider sign-in buttons; a single provider looks unchanged. */
+.login-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.provider-icon {
+    display: inline-flex;
+    align-items: center;
+}
+
 .splash-footer {
     margin-top: 2rem;
     display: flex;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -847,6 +847,14 @@ pub struct AppConfig {
     /// closing a session preserves archived history only when this is true.
     #[serde(default)]
     pub archive_enabled: bool,
+    /// Login providers this deploy has credentials for, in the order they
+    /// should be offered (`"google"`, `"github"`). The splash page renders one
+    /// button per entry, so a provider without credentials is never shown — a
+    /// button that always 404s is worse than no button.
+    ///
+    /// Empty in dev mode, where login is bypassed entirely.
+    #[serde(default)]
+    pub auth_providers: Vec<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Builds on the identity model from #1536: adds GitHub as a second login provider, makes the login page reflect what is actually configured, and refuses to boot a deploy nobody can sign into.

## Provider registry

The Google-only path becomes a small registry. A provider supplies its callback path, its scopes, and how to turn an access token into a `ProviderIdentity`; everything else — CSRF, the device flow, ban checks, email allow-lists, session cookies — was already provider-agnostic and is now shared outright.

The sharpest coupling was the CSRF cookie, which hard-coded the *Google* callback as its `Path`. It is now each provider's own callback path, which is also what keeps two concurrent logins from clobbering each other: same cookie name, different path, and each callback only receives its own.

Adding the next provider (GitLab, Microsoft, OIDC) is now: a `PROVIDER_*` const, an `oauth::Provider` entry, a `build_provider` call, a `fetch_provider_identity` arm, two routes, and a button arm.

## GitHub specifics

Two calls, not one. `/user` gives the immutable numeric `id` — used as the subject, because the login handle is renameable — plus name and avatar. The address comes from `/user/emails` and is accepted only when it is both **primary** and **verified**.

`/user` alone is not enough: its `email` is null for anyone with a private address, and it carries no verification flag at all. Under #1536's linking rule an unverified address must never reach an existing account, so an unverifiable login is refused rather than guessed at. A verified *non-primary* address is also not substituted for an unverified primary — that would link the wrong portal account.

## Startup requirement

Outside `--dev-mode`, boot fails unless at least one provider has credentials:

```
Error: No login provider is configured, so nobody could sign in. Set
GOOGLE_CLIENT_ID/... or GITHUB_CLIENT_ID/..., or pass --dev-mode to bypass OAuth.
```

Half-configuring a provider is also an error naming every missing variable, rather than a silent skip — setting two of three variables is a typo, not a request to disable it. Previously the three `GOOGLE_*` vars were unconditionally required; now each provider is independently optional, but the set cannot be empty.

## Login page

`/api/config` now advertises `auth_providers`, and the splash renders one button per entry, so a provider without credentials is never shown — a button that 404s on click is worse than no button. Unknown keys from a newer backend are skipped rather than rendered dead. The GitHub mark is inlined as SVG so it inherits `currentColor` and costs no extra request.

Also fixes `docker-compose.yml`, which advertised `/auth/google/callback` — the route is `/api/auth/google/callback`.

## Verification

Beyond unit tests (primary+verified selection and its two refusal cases, numeric-id parsing, partial/absent/complete provider config, provider lookup), I ran the server and checked the real surface:

- both gates fire with the exact messages above
- `/api/config` → `["google","github"]`
- `/api/auth/github` → GitHub authorize URL with `read:user user:email`, cookie `Path=/api/auth/github/callback`
- `/api/auth/google` unchanged, cookie `Path=/api/auth/google/callback`
- `device-login` defaults to Google and honors `?provider=github`, so a GitHub-only deploy keeps a working CLI flow

Workspace suite green (26 binaries), clippy clean, WASM and CSS lint pass.

Refs #1535
