### PR TITLE
Support all ten speech-to-text providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -901,9 +901,15 @@ When making changes, verify:
 | `MESSAGE_RETENTION_COUNT` | Max messages per session | Optional (default: 100) |
 | `MESSAGE_RETENTION_DAYS` | Days before message deletion | Optional (default: 30) |
 | `SESSION_MAX_AGE_DAYS` | Days before session deletion | Optional (default: 14) |
-| `PORTAL_STT_BACKEND` | Server-side speech-to-text provider: `disabled`, `openai`, or `deepgram`. Unset/`disabled` keeps voice on the browser's Web Speech API | Optional (default: disabled) |
-| `PORTAL_STT_API_KEY` | API key for the selected STT provider | Required when `PORTAL_STT_BACKEND` is not `disabled` |
-| `PORTAL_STT_MODEL` | Override the provider's default model (`gpt-4o-transcribe` / `nova-3`). Note: Deepgram keyterm biasing needs Nova-3 | Optional |
+| `PORTAL_STT_BACKEND` | Speech-to-text provider: `disabled` or one of `assemblyai`, `aws`, `azure`, `deepgram`, `google`, `ibm`, `openai`, `revai`, `simplismart`, `speechmatics`. Unset/`disabled` keeps voice on the browser's Web Speech API | Optional (default: disabled) |
+| `PORTAL_STT_API_KEY` | API key for the selected provider | Required by every provider except `google` (service account) and `aws` (`AWS_*` credentials) |
+| `PORTAL_STT_MODEL` | Override the provider's default model / operating point / custom deployment | Optional |
+| `PORTAL_STT_ENDPOINT` | Override the API host — self-hosted Deepgram, OpenAI-compatible gateways, a Simplismart deployment | Required for `ibm` (per-instance URL); optional elsewhere |
+| `PORTAL_STT_REGION` | Cloud region | Required for `azure` and `aws` (`aws` also accepts `AWS_REGION`) |
+| `PORTAL_STT_LANGUAGE` | Default BCP-47 language when the client does not send one | Optional |
+| `PORTAL_STT_BUCKET` | S3 bucket used to stage audio | Required for `aws` |
+| `PORTAL_STT_SERVICE_ACCOUNT_PATH` | Google service-account JSON | Required for `google` |
+| `PORTAL_STT_VOCABULARY_NAME` | Pre-created custom-vocabulary resource | Optional (`aws`) |
 | `PORTAL_MAX_AUDIO_MB` | Per-recording cap for `POST /api/stt/transcribe` | Optional (default: 25) |
 | `PORTAL_MAX_IMAGE_MB` | Max image size for proxies (also the per-file cap for image `agent-portal show`) | Optional (default: 10) |
 | `PORTAL_MAX_VIDEO_MB` | Per-file cap for videos shown via `agent-portal show` | Optional (default: 100) |
@@ -938,15 +944,30 @@ Voice defaults to the browser's Web Speech API and needs no credentials. Setting
 because the browser API has **no vocabulary hook**: `clippy`, `Diesel`, branch
 names and file paths come back mangled, and Firefox has no support at all.
 
-`backend/src/stt/` holds the providers as an **enum, not a trait object** — same
-reasoning as `ArchiveStore`, so adding one is a compile error until every arm is
-filled in. A new provider is: a variant, a `from_env` arm, a `key()` arm, and a
-module implementing `transcribe`.
+The **`portal-stt` crate** holds the providers as an **enum, not a trait object**
+— same reasoning as `ArchiveStore`, so adding one is a compile error until every
+arm is filled in. It has its own infrastructure because the vendors genuinely
+differ: `http.rs` normalizes error responses, `poll.rs` drives the ones that
+transcribe as an asynchronous job, `config.rs` maps one env var per *concept*
+onto per-provider requirements.
 
-The accuracy comes mostly from `stt::session_keyterms`, which turns the session's
-repo / branch / working directory / agent into bias terms. Keep that list short
-and specific — a long tail of common words measurably *hurts* accuracy, which is
-why `STOP_TERMS` and `MAX_KEYTERMS` exist.
+| Shape | Providers |
+|---|---|
+| Single request | OpenAI, Deepgram, Azure, Google, IBM, Simplismart |
+| Submit → poll → fetch | AssemblyAI, Rev AI, Speechmatics, AWS |
+
+**Not every provider can bias.** `SttProvider::supports_keyterms` is the single
+source of truth: AssemblyAI, Deepgram, Google, OpenAI, Rev AI and Speechmatics
+take a per-request vocabulary; Azure, IBM and Simplismart need a trained model,
+and AWS needs a pre-created named vocabulary. The backend skips building hints
+when the provider cannot use them, so don't add a caller that assumes they are
+always sent.
+
+**Verify a provider with the probe, not by reasoning about it.** Network code
+cannot be unit-tested, so `cargo run -p portal-stt --bin stt-probe` sends real
+audio (or a generated moment of silence) to the real API. With a deliberately
+wrong key, a `provider`-class error proves the URL, headers and body reached the
+vendor; a `transport` error or a 404 means the request is built wrong.
 
 **Do not make this mandatory.** Server STT was removed once already (2.6.x)
 because it required a GCP service account, a gRPC client, a `/ws/voice/{id}`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,9 +441,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-credential-types"
-version = "1.3.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.5.1"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+checksum = "9bfe75fad52793ce6dec0dc3d4b1f388f038b5eb866c8d4d7f3a8e21b5ea5051"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -487,20 +487,21 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "http 0.2.12",
  "http 1.5.0",
+ "once_cell",
  "percent-encoding",
- "sha2 0.11.0",
+ "sha2",
  "time",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.3.0"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+checksum = "127fcfad33b7dfc531141fda7e1c402ac65f88aca5511a4d31e2e3d2cd01ce9c"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -509,19 +510,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.64.0"
+version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
- "futures-util",
- "http 1.5.0",
- "http-body 1.0.1",
- "http-body-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
@@ -530,12 +530,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.14.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+checksum = "ec7204f9fd94749a7c53b26da1b961b4ac36bf070ef1e0b94bb09f79d4f6c193"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -547,30 +546,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-runtime-api-macros"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "aws-smithy-types"
-version = "1.6.1"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+checksum = "25f535879a207fce0db74b679cfc3e91a3159c8144d717d55f5832aea9eef46e"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.5.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
  "itoa",
  "num-integer",
  "pin-project-lite",
@@ -668,7 +653,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2 0.10.9",
+ "sha2",
  "shared",
  "tempfile",
  "thiserror 2.0.18",
@@ -1365,10 +1350,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "base64 0.22.1",
- "hmac 0.12.1",
+ "hmac",
  "percent-encoding",
  "rand 0.8.6",
- "sha2 0.10.9",
+ "sha2",
  "subtle",
  "time",
  "version_check",
@@ -1923,9 +1908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
  "crypto-common 0.2.2",
- "ctutils",
 ]
 
 [[package]]
@@ -1967,7 +1950,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2145,7 +2128,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 1.0.69",
 ]
 
@@ -2275,7 +2258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3440,7 +3423,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
 ]
 
 [[package]]
@@ -3450,15 +3433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
-dependencies = [
- "digest 0.11.3",
 ]
 
 [[package]]
@@ -4157,7 +4131,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.9",
+ "sha2",
  "signature 2.2.0",
 ]
 
@@ -4572,7 +4546,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4683,7 +4657,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 1.0.69",
  "url",
 ]
@@ -5038,7 +5012,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -5050,7 +5024,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -5419,7 +5393,7 @@ dependencies = [
  "hex",
  "reqwest 0.12.28",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "tracing",
 ]
 
@@ -5970,7 +5944,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -6008,7 +5982,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2 0.10.9",
+ "sha2",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -6050,7 +6024,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6131,7 +6105,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6585,17 +6559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
-
-[[package]]
 name = "sha256"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6604,7 +6567,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "hex",
- "sha2 0.10.9",
+ "sha2",
  "tokio",
 ]
 
@@ -7173,7 +7136,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -7382,7 +7345,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8576,7 +8539,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9220,7 +9183,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2 0.10.9",
+ "sha2",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "f279fc8b1f1a64138f0f4b9cda9be488ae35bc2f8556c7ffe60730f1c07d005a"
 dependencies = [
  "base64 0.21.7",
  "erased-serde 0.3.31",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-rustls 0.26.0",
@@ -440,6 +440,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-credential-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +475,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sigv4"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.5.0",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.5.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.5.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,8 +591,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -506,8 +624,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -550,7 +668,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2",
+ "sha2 0.10.9",
  "shared",
  "tempfile",
  "thiserror 2.0.18",
@@ -592,6 +710,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -775,6 +903,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -1227,10 +1365,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "base64 0.22.1",
- "hmac",
+ "hmac 0.12.1",
  "percent-encoding",
  "rand 0.8.6",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "version_check",
@@ -1785,7 +1923,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2005,7 +2145,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -2940,7 +3080,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils 0.2.0",
- "http 1.4.0",
+ "http 1.5.0",
  "js-sys",
  "pin-project",
  "serde",
@@ -3224,7 +3364,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -3300,7 +3440,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3310,6 +3450,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3370,12 +3519,23 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3385,7 +3545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -3396,8 +3556,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -3440,8 +3600,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -3458,7 +3618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http 1.4.0",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "rustls 0.22.4",
@@ -3475,7 +3635,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "rustls 0.23.40",
@@ -3525,8 +3685,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -3997,7 +4157,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature 2.2.0",
 ]
 
@@ -4517,13 +4677,13 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
- "http 1.4.0",
+ "http 1.5.0",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -4739,7 +4899,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body-util",
  "humantime",
  "hyper",
@@ -4864,6 +5024,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4872,7 +5038,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4884,7 +5050,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5075,6 +5241,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pinned"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5224,11 +5396,19 @@ name = "portal-stt"
 version = "2.13.11"
 dependencies = [
  "anyhow",
+ "aws-credential-types",
+ "aws-sigv4",
+ "base64 0.22.1",
  "bytes",
+ "chrono",
+ "http 1.5.0",
+ "jsonwebtoken",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -5239,7 +5419,7 @@ dependencies = [
  "hex",
  "reqwest 0.12.28",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -5708,8 +5888,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.0",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls 0.27.9",
@@ -5754,8 +5934,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.0",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls 0.27.9",
@@ -5790,7 +5970,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -5828,7 +6008,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -6405,6 +6585,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha256"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6413,7 +6604,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "hex",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
 ]
 
@@ -6909,7 +7100,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http 1.4.0",
+ "http 1.5.0",
  "jni 0.21.1",
  "libc",
  "log",
@@ -6982,7 +7173,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -7090,7 +7281,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http 1.4.0",
+ "http 1.5.0",
  "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
@@ -7113,7 +7304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
- "http 1.4.0",
+ "http 1.5.0",
  "jni 0.21.1",
  "log",
  "objc2",
@@ -7145,7 +7336,7 @@ dependencies = [
  "dom_query",
  "dunce",
  "glob",
- "http 1.4.0",
+ "http 1.5.0",
  "infer",
  "json-patch",
  "log",
@@ -7571,8 +7762,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.4.0",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -7617,7 +7808,7 @@ dependencies = [
  "axum-core",
  "cookie",
  "futures-util",
- "http 1.4.0",
+ "http 1.5.0",
  "parking_lot",
  "pin-project-lite",
  "tower-layer",
@@ -7633,8 +7824,8 @@ dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -7663,7 +7854,7 @@ dependencies = [
  "axum",
  "forwarded-header-value",
  "governor",
- "http 1.4.0",
+ "http 1.5.0",
  "pin-project",
  "thiserror 2.0.18",
  "tonic",
@@ -7788,7 +7979,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -7807,7 +7998,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -8003,6 +8194,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vswhom"
@@ -9009,7 +9206,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "gtk",
- "http 1.4.0",
+ "http 1.5.0",
  "javascriptcore-rs",
  "jni 0.21.1",
  "libc",
@@ -9023,7 +9220,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/backend/src/handlers/stt.rs
+++ b/backend/src/handlers/stt.rs
@@ -69,13 +69,17 @@ pub async fn transcribe(
         )));
     }
 
-    // Vocabulary hints, when the caller named a session they belong to. A
-    // session they are *not* a member of contributes nothing rather than
-    // erroring: the transcript is still useful, and this keeps the endpoint
-    // from doubling as a membership oracle.
+    // Vocabulary hints, when the caller named a session they belong to and the
+    // provider can actually use them — several vendors bias through a trained
+    // model instead, and there is no point paying for the query to build a list
+    // nobody reads. A session the user is *not* a member of contributes nothing
+    // rather than erroring: the transcript is still useful, and this keeps the
+    // endpoint from doubling as a membership oracle.
     let keyterms = match query.session_id {
-        Some(session_id) => keyterms_for_session(&app_state, user_id, session_id)?,
-        None => Vec::new(),
+        Some(session_id) if provider.supports_keyterms() => {
+            keyterms_for_session(&app_state, user_id, session_id)?
+        }
+        _ => Vec::new(),
     };
 
     let audio_len = body.len();

--- a/portal-stt/Cargo.toml
+++ b/portal-stt/Cargo.toml
@@ -6,8 +6,16 @@ description = "Speech-to-text providers for Agent Portal"
 
 [dependencies]
 anyhow = { workspace = true }
-aws-credential-types = "1.3.0"
-aws-sigv4 = "1.5.1"
+# SigV4 request signing, for Amazon Transcribe (the one provider with no
+# synchronous API, so it signs S3 + Transcribe calls itself).
+#
+# Pinned exactly: aws-sigv4 1.5 and the smithy crates it drags in raised their
+# MSRV to 1.94.1, and CI builds on 1.92.0 (.github/workflows/ci.yml). The
+# transitive smithy versions are held in Cargo.lock to match. If you bump these,
+# check `cargo +1.92.0 check -p portal-stt` still resolves, or raise the CI
+# toolchain first.
+aws-credential-types = "=1.2.1"
+aws-sigv4 = "=1.2.9"
 base64 = "0.22.1"
 bytes = "1"
 chrono.workspace = true

--- a/portal-stt/Cargo.toml
+++ b/portal-stt/Cargo.toml
@@ -6,11 +6,22 @@ description = "Speech-to-text providers for Agent Portal"
 
 [dependencies]
 anyhow = { workspace = true }
+aws-credential-types = "1.3.0"
+aws-sigv4 = "1.5.1"
+base64 = "0.22.1"
 bytes = "1"
+chrono.workspace = true
+http = "1.5.0"
+jsonwebtoken = "9.3"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio.workspace = true
 tracing = { workspace = true }
+uuid.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util", "macros", "rt"] }

--- a/portal-stt/src/bin/stt-probe.rs
+++ b/portal-stt/src/bin/stt-probe.rs
@@ -1,0 +1,149 @@
+//! Exercise one speech-to-text provider end to end, without the portal.
+//!
+//! Network code cannot be unit-tested, so this is how a provider gets verified:
+//! point it at the real API and see what comes back. Two useful modes —
+//!
+//! * with valid credentials and an audio file, it prints the transcript;
+//! * with deliberately invalid credentials, a provider-level auth error proves
+//!   the URL, headers and body shape reached the vendor and were understood.
+//!   A transport error or a 404 means we built the request wrong.
+//!
+//! ```text
+//! PORTAL_STT_BACKEND=deepgram PORTAL_STT_API_KEY=… \
+//!     cargo run -p portal-stt --bin stt-probe -- recording.webm
+//! ```
+//!
+//! With no file argument it sends a fraction of a second of silence, which is
+//! enough to get past request validation and reach authentication.
+
+use portal_stt::{SttEnv, SttProvider, TranscribeRequest, BACKENDS};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> std::process::ExitCode {
+    let mut args = std::env::args().skip(1);
+    let audio_path = args.next();
+
+    let backend = match std::env::var("PORTAL_STT_BACKEND") {
+        Ok(value) if !value.trim().is_empty() => value.trim().to_ascii_lowercase(),
+        _ => {
+            eprintln!(
+                "set PORTAL_STT_BACKEND to one of: {}\n\
+                 usage: stt-probe [audio-file]",
+                BACKENDS.join(", ")
+            );
+            return std::process::ExitCode::from(2);
+        }
+    };
+
+    let (audio, content_type) = match &audio_path {
+        Some(path) => match std::fs::read(path) {
+            Ok(bytes) => (bytes, content_type_for(path)),
+            Err(error) => {
+                eprintln!("could not read {path}: {error}");
+                return std::process::ExitCode::from(2);
+            }
+        },
+        None => (silent_wav(), "audio/wav"),
+    };
+
+    let provider = match SttProvider::build(&backend, &SttEnv::from_process()) {
+        Ok(provider) => provider,
+        Err(error) => {
+            eprintln!("configuration error: {error}");
+            return std::process::ExitCode::from(2);
+        }
+    };
+
+    let keyterms = portal_stt::session_keyterms(
+        "/home/dev/repos/agent-portal",
+        Some("meawoppl/stt-all-providers"),
+        Some("https://github.com/meawoppl/agent-portal.git"),
+        "claude",
+    );
+    println!(
+        "provider={} audio={} bytes ({content_type}) keyterms={}",
+        provider.key(),
+        audio.len(),
+        if provider.supports_keyterms() {
+            keyterms.len().to_string()
+        } else {
+            "unsupported".to_string()
+        },
+    );
+
+    let request = TranscribeRequest {
+        audio: audio.into(),
+        content_type,
+        language: None,
+        keyterms: if provider.supports_keyterms() {
+            &keyterms
+        } else {
+            &[]
+        },
+    };
+
+    match provider.transcribe(request).await {
+        Ok(text) => {
+            println!("OK: {text:?}");
+            std::process::ExitCode::SUCCESS
+        }
+        Err(error) => {
+            println!("ERR[{}]: {error}", error_kind(&error));
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+/// Which arm of `SttError` this is — the distinction that matters when reading
+/// a probe run, since only `provider` proves we reached the vendor.
+fn error_kind(error: &portal_stt::SttError) -> &'static str {
+    match error {
+        portal_stt::SttError::Provider(_) => "provider",
+        portal_stt::SttError::Transport(_) => "transport",
+        portal_stt::SttError::Decode(_) => "decode",
+    }
+}
+
+fn content_type_for(path: &str) -> &'static str {
+    match path
+        .rsplit('.')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "wav" => "audio/wav",
+        "mp3" => "audio/mpeg",
+        "m4a" | "mp4" => "audio/mp4",
+        "ogg" | "opus" => "audio/ogg",
+        "flac" => "audio/flac",
+        _ => "audio/webm",
+    }
+}
+
+/// A quarter-second of 16 kHz mono silence, as a complete RIFF/WAVE file.
+///
+/// Real audio would be better, but a well-formed file is all that is needed to
+/// get past a provider's format validation and reach the auth check — and it
+/// keeps the probe dependency-free and offline-safe.
+fn silent_wav() -> Vec<u8> {
+    const SAMPLE_RATE: u32 = 16_000;
+    const SAMPLES: u32 = SAMPLE_RATE / 4;
+    let data_len = SAMPLES * 2;
+
+    let mut wav = Vec::with_capacity(44 + data_len as usize);
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&(36 + data_len).to_le_bytes());
+    wav.extend_from_slice(b"WAVEfmt ");
+    wav.extend_from_slice(&16u32.to_le_bytes()); // PCM header size
+    wav.extend_from_slice(&1u16.to_le_bytes()); // format: PCM
+    wav.extend_from_slice(&1u16.to_le_bytes()); // channels: mono
+    wav.extend_from_slice(&SAMPLE_RATE.to_le_bytes());
+    wav.extend_from_slice(&(SAMPLE_RATE * 2).to_le_bytes()); // byte rate
+    wav.extend_from_slice(&2u16.to_le_bytes()); // block align
+    wav.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&data_len.to_le_bytes());
+    wav.resize(44 + data_len as usize, 0);
+    wav
+}

--- a/portal-stt/src/config.rs
+++ b/portal-stt/src/config.rs
@@ -1,0 +1,173 @@
+//! Environment configuration, shared across providers.
+//!
+//! Every provider needs a key; beyond that they diverge — Azure and AWS are
+//! regional, Google authenticates with a service-account file rather than a
+//! key, IBM issues a per-instance URL, AWS needs a bucket to stage audio in.
+//! Rather than invent a variable per provider per field, there is one variable
+//! per *concept* and each provider declares what it requires, so a missing
+//! value names the provider that wanted it.
+
+pub const BACKEND_VAR: &str = "PORTAL_STT_BACKEND";
+pub const API_KEY_VAR: &str = "PORTAL_STT_API_KEY";
+pub const MODEL_VAR: &str = "PORTAL_STT_MODEL";
+pub const ENDPOINT_VAR: &str = "PORTAL_STT_ENDPOINT";
+pub const REGION_VAR: &str = "PORTAL_STT_REGION";
+pub const LANGUAGE_VAR: &str = "PORTAL_STT_LANGUAGE";
+pub const BUCKET_VAR: &str = "PORTAL_STT_BUCKET";
+pub const SERVICE_ACCOUNT_VAR: &str = "PORTAL_STT_SERVICE_ACCOUNT_PATH";
+pub const VOCABULARY_VAR: &str = "PORTAL_STT_VOCABULARY_NAME";
+
+/// Every STT-related variable, read once at boot.
+#[derive(Debug, Default, Clone)]
+pub struct SttEnv {
+    pub api_key: Option<String>,
+    pub model: Option<String>,
+    pub endpoint: Option<String>,
+    pub region: Option<String>,
+    pub language: Option<String>,
+    pub bucket: Option<String>,
+    pub service_account_path: Option<String>,
+    pub vocabulary_name: Option<String>,
+}
+
+impl SttEnv {
+    pub fn from_process() -> Self {
+        let read = |name: &str| {
+            std::env::var(name)
+                .ok()
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+        };
+        Self {
+            api_key: read(API_KEY_VAR),
+            model: read(MODEL_VAR),
+            endpoint: read(ENDPOINT_VAR),
+            region: read(REGION_VAR),
+            language: read(LANGUAGE_VAR),
+            bucket: read(BUCKET_VAR),
+            service_account_path: read(SERVICE_ACCOUNT_VAR),
+            vocabulary_name: read(VOCABULARY_VAR),
+        }
+    }
+
+    /// A required value, or an error naming both the variable and the provider
+    /// that needs it — the two things an operator needs to fix it.
+    pub fn require(&self, field: Field, backend: &str) -> anyhow::Result<String> {
+        self.get(field).ok_or_else(|| {
+            anyhow::anyhow!(
+                "{BACKEND_VAR}={backend} requires {} to be set",
+                field.var_name()
+            )
+        })
+    }
+
+    pub fn get(&self, field: Field) -> Option<String> {
+        match field {
+            Field::ApiKey => self.api_key.clone(),
+            Field::Model => self.model.clone(),
+            Field::Endpoint => self.endpoint.clone(),
+            Field::Region => self.region.clone(),
+            Field::Language => self.language.clone(),
+            Field::Bucket => self.bucket.clone(),
+            Field::ServiceAccountPath => self.service_account_path.clone(),
+            Field::VocabularyName => self.vocabulary_name.clone(),
+        }
+    }
+
+    /// The configured model, or the provider's default.
+    pub fn model_or(&self, default: &str) -> String {
+        self.model.clone().unwrap_or_else(|| default.to_string())
+    }
+
+    /// The configured endpoint, or the provider's default.
+    pub fn endpoint_or(&self, default: &str) -> String {
+        self.endpoint
+            .clone()
+            .unwrap_or_else(|| default.to_string())
+            .trim_end_matches('/')
+            .to_string()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Field {
+    ApiKey,
+    Model,
+    Endpoint,
+    Region,
+    Language,
+    Bucket,
+    ServiceAccountPath,
+    VocabularyName,
+}
+
+impl Field {
+    pub fn var_name(self) -> &'static str {
+        match self {
+            Self::ApiKey => API_KEY_VAR,
+            Self::Model => MODEL_VAR,
+            Self::Endpoint => ENDPOINT_VAR,
+            Self::Region => REGION_VAR,
+            Self::Language => LANGUAGE_VAR,
+            Self::Bucket => BUCKET_VAR,
+            Self::ServiceAccountPath => SERVICE_ACCOUNT_VAR,
+            Self::VocabularyName => VOCABULARY_VAR,
+        }
+    }
+}
+
+/// The language a request should use: the caller's, else the deploy default,
+/// else the supplied fallback. Providers that *require* a language (Google,
+/// Azure) need the fallback; the rest pass `None` through as auto-detect.
+pub fn resolve_language(
+    request_language: Option<&str>,
+    configured: Option<&str>,
+    fallback: &str,
+) -> String {
+    request_language
+        .or(configured)
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_missing_requirement_names_the_variable_and_the_provider() {
+        let env = SttEnv::default();
+        let err = env.require(Field::Region, "azure").unwrap_err().to_string();
+        assert!(err.contains(REGION_VAR), "{err}");
+        assert!(err.contains("azure"), "{err}");
+    }
+
+    #[test]
+    fn model_and_endpoint_fall_back_to_provider_defaults() {
+        let env = SttEnv::default();
+        assert_eq!(env.model_or("nova-3"), "nova-3");
+        assert_eq!(env.endpoint_or("https://x.invalid"), "https://x.invalid");
+
+        let configured = SttEnv {
+            model: Some("whisper-1".into()),
+            endpoint: Some("https://y.invalid/".into()),
+            ..Default::default()
+        };
+        assert_eq!(configured.model_or("nova-3"), "whisper-1");
+        // Trailing slash stripped so providers can append paths freely.
+        assert_eq!(
+            configured.endpoint_or("https://x.invalid"),
+            "https://y.invalid"
+        );
+    }
+
+    #[test]
+    fn request_language_wins_over_deploy_default_which_wins_over_fallback() {
+        assert_eq!(
+            resolve_language(Some("fr-FR"), Some("de-DE"), "en-US"),
+            "fr-FR"
+        );
+        assert_eq!(resolve_language(None, Some("de-DE"), "en-US"), "de-DE");
+        assert_eq!(resolve_language(None, None, "en-US"), "en-US");
+    }
+}

--- a/portal-stt/src/http.rs
+++ b/portal-stt/src/http.rs
@@ -1,0 +1,68 @@
+//! HTTP plumbing shared by every provider.
+
+use crate::SttError;
+
+/// How much of an error body to keep. Enough to identify the fault, short
+/// enough that a provider returning an HTML error page doesn't flood the log.
+const MAX_ERROR_BODY: usize = 400;
+
+/// Turn a non-2xx response into [`SttError::Provider`], preserving the status
+/// and a bounded prefix of the body.
+///
+/// Every provider funnels through this so a misconfiguration reads the same
+/// regardless of vendor, and so no provider forgets to check the status and
+/// then fails confusingly at JSON decoding instead.
+pub(crate) async fn ensure_ok(response: reqwest::Response) -> Result<reqwest::Response, SttError> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response.text().await.unwrap_or_default();
+    Err(SttError::Provider(format!(
+        "HTTP {status}: {}",
+        truncate(&body, MAX_ERROR_BODY)
+    )))
+}
+
+pub(crate) fn transport(error: reqwest::Error) -> SttError {
+    SttError::Transport(error.to_string())
+}
+
+pub(crate) fn decode(error: impl std::fmt::Display) -> SttError {
+    SttError::Decode(error.to_string())
+}
+
+/// Char-safe truncation with an ellipsis marker, so a multi-byte body can't
+/// panic on a byte-index slice.
+pub(crate) fn truncate(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(max_chars).collect();
+    format!("{kept}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_text_is_untouched() {
+        assert_eq!(truncate("hello", 400), "hello");
+    }
+
+    #[test]
+    fn long_text_is_marked_as_cut() {
+        let cut = truncate(&"x".repeat(500), 400);
+        assert_eq!(cut.chars().count(), 401);
+        assert!(cut.ends_with('…'));
+    }
+
+    /// A byte-index slice here would panic; providers do return non-ASCII
+    /// error bodies.
+    #[test]
+    fn multibyte_bodies_do_not_panic() {
+        let text = "é".repeat(500);
+        assert_eq!(truncate(&text, 10).chars().count(), 11);
+    }
+}

--- a/portal-stt/src/lib.rs
+++ b/portal-stt/src/lib.rs
@@ -29,16 +29,14 @@
 
 pub use bytes::Bytes;
 
+mod config;
+mod http;
 mod keyterms;
+mod poll;
 mod providers;
 
+pub use config::{SttEnv, BACKEND_VAR};
 pub use keyterms::session_keyterms;
-
-/// Environment variable selecting the provider (`disabled`, `openai`,
-/// `deepgram`). Named to match `PORTAL_SESSION_ARCHIVE_BACKEND`.
-const BACKEND_VAR: &str = "PORTAL_STT_BACKEND";
-const API_KEY_VAR: &str = "PORTAL_STT_API_KEY";
-const MODEL_VAR: &str = "PORTAL_STT_MODEL";
 
 /// What the caller wants transcribed, plus the context to bias it with.
 pub struct TranscribeRequest<'a> {
@@ -73,12 +71,58 @@ impl std::fmt::Display for SttError {
     }
 }
 
-/// A configured speech-to-text provider.
-#[derive(Clone)]
-pub enum SttProvider {
-    OpenAi(providers::openai::OpenAiStt),
-    Deepgram(providers::deepgram::DeepgramStt),
+/// The message from a provider's `from_env` failure.
+///
+/// Providers deliberately do not derive `Debug` — they hold API keys, and a
+/// derived impl would print them — so tests cannot call `unwrap_err` directly.
+#[cfg(test)]
+pub(crate) fn config_error<T>(result: anyhow::Result<T>) -> String {
+    result
+        .map(|_| ())
+        .expect_err("expected a configuration error")
+        .to_string()
 }
+
+/// A configured speech-to-text provider.
+///
+/// Opaque on the outside — callers only need [`key`](Self::key),
+/// [`supports_keyterms`](Self::supports_keyterms) and
+/// [`transcribe`](Self::transcribe) — and a closed enum on the inside, so
+/// adding a vendor is a compile error in every arm that has to learn about it.
+#[derive(Clone)]
+pub struct SttProvider {
+    inner: Inner,
+}
+
+#[derive(Clone)]
+enum Inner {
+    AssemblyAi(providers::assemblyai::AssemblyAiStt),
+    Aws(providers::aws::AwsStt),
+    Azure(providers::azure::AzureStt),
+    Deepgram(providers::deepgram::DeepgramStt),
+    Google(providers::google::GoogleStt),
+    Ibm(providers::ibm::IbmStt),
+    OpenAi(providers::openai::OpenAiStt),
+    RevAi(providers::revai::RevAiStt),
+    Simplismart(providers::simplismart::SimplismartStt),
+    Speechmatics(providers::speechmatics::SpeechmaticsStt),
+}
+
+/// Every backend name accepted by `PORTAL_STT_BACKEND`, for error messages and
+/// for the probe tool. Kept adjacent to [`SttProvider::build`] so the two do not
+/// drift.
+pub const BACKENDS: &[&str] = &[
+    "assemblyai",
+    "aws",
+    "azure",
+    "deepgram",
+    "google",
+    "ibm",
+    "openai",
+    "revai",
+    "simplismart",
+    "speechmatics",
+];
 
 impl SttProvider {
     /// Build the configured provider, or `None` when STT is disabled.
@@ -92,43 +136,83 @@ impl SttProvider {
         if backend.is_empty() || backend == "disabled" {
             return Ok(None);
         }
+        Self::build(&backend, &SttEnv::from_process()).map(Some)
+    }
 
-        let api_key = std::env::var(API_KEY_VAR).map_err(|_| {
-            anyhow::anyhow!("{BACKEND_VAR}={backend} requires {API_KEY_VAR} to be set")
-        })?;
-        if api_key.trim().is_empty() {
-            anyhow::bail!("{API_KEY_VAR} is set but empty");
-        }
-        let model = std::env::var(MODEL_VAR)
-            .ok()
-            .map(|m| m.trim().to_string())
-            .filter(|m| !m.is_empty());
-
-        match backend.as_str() {
-            "openai" => Ok(Some(Self::OpenAi(providers::openai::OpenAiStt::new(
-                api_key, model,
-            )))),
-            "deepgram" => Ok(Some(Self::Deepgram(providers::deepgram::DeepgramStt::new(
-                api_key, model,
-            )))),
+    /// Construct one provider by name from an explicit environment. Separate
+    /// from [`Self::from_env`] so it is reachable without mutating process
+    /// globals.
+    pub fn build(backend: &str, env: &SttEnv) -> anyhow::Result<Self> {
+        let inner = match backend {
+            "assemblyai" => Inner::AssemblyAi(providers::assemblyai::AssemblyAiStt::from_env(env)?),
+            "aws" => Inner::Aws(providers::aws::AwsStt::from_env(env)?),
+            "azure" => Inner::Azure(providers::azure::AzureStt::from_env(env)?),
+            "deepgram" => Inner::Deepgram(providers::deepgram::DeepgramStt::from_env(env)?),
+            "google" => Inner::Google(providers::google::GoogleStt::from_env(env)?),
+            "ibm" => Inner::Ibm(providers::ibm::IbmStt::from_env(env)?),
+            "openai" => Inner::OpenAi(providers::openai::OpenAiStt::from_env(env)?),
+            "revai" => Inner::RevAi(providers::revai::RevAiStt::from_env(env)?),
+            "simplismart" => {
+                Inner::Simplismart(providers::simplismart::SimplismartStt::from_env(env)?)
+            }
+            "speechmatics" => {
+                Inner::Speechmatics(providers::speechmatics::SpeechmaticsStt::from_env(env)?)
+            }
             other => anyhow::bail!(
-                "unknown {BACKEND_VAR}={other:?}; expected one of: disabled, openai, deepgram"
+                "unknown {BACKEND_VAR}={other:?}; expected disabled or one of: {}",
+                BACKENDS.join(", ")
             ),
-        }
+        };
+        Ok(Self { inner })
     }
 
     /// Stable key for logs and `/api/config`.
     pub fn key(&self) -> &'static str {
-        match self {
-            Self::OpenAi(_) => "openai",
-            Self::Deepgram(_) => "deepgram",
+        match &self.inner {
+            Inner::AssemblyAi(_) => "assemblyai",
+            Inner::Aws(_) => "aws",
+            Inner::Azure(_) => "azure",
+            Inner::Deepgram(_) => "deepgram",
+            Inner::Google(_) => "google",
+            Inner::Ibm(_) => "ibm",
+            Inner::OpenAi(_) => "openai",
+            Inner::RevAi(_) => "revai",
+            Inner::Simplismart(_) => "simplismart",
+            Inner::Speechmatics(_) => "speechmatics",
+        }
+    }
+
+    /// Whether this provider can bias decoding with [`session_keyterms`].
+    ///
+    /// Not every vendor exposes a per-request vocabulary: Azure, IBM and
+    /// Simplismart need a trained model instead, and AWS needs a pre-created
+    /// named vocabulary. Callers use this to avoid computing hints nobody will
+    /// read, and it keeps the "which providers actually bias?" answer in one
+    /// place rather than scattered through the modules.
+    pub fn supports_keyterms(&self) -> bool {
+        match &self.inner {
+            Inner::AssemblyAi(_)
+            | Inner::Deepgram(_)
+            | Inner::Google(_)
+            | Inner::OpenAi(_)
+            | Inner::RevAi(_)
+            | Inner::Speechmatics(_) => true,
+            Inner::Aws(_) | Inner::Azure(_) | Inner::Ibm(_) | Inner::Simplismart(_) => false,
         }
     }
 
     pub async fn transcribe(&self, request: TranscribeRequest<'_>) -> Result<String, SttError> {
-        match self {
-            Self::OpenAi(provider) => provider.transcribe(request).await,
-            Self::Deepgram(provider) => provider.transcribe(request).await,
+        match &self.inner {
+            Inner::AssemblyAi(provider) => provider.transcribe(request).await,
+            Inner::Aws(provider) => provider.transcribe(request).await,
+            Inner::Azure(provider) => provider.transcribe(request).await,
+            Inner::Deepgram(provider) => provider.transcribe(request).await,
+            Inner::Google(provider) => provider.transcribe(request).await,
+            Inner::Ibm(provider) => provider.transcribe(request).await,
+            Inner::OpenAi(provider) => provider.transcribe(request).await,
+            Inner::RevAi(provider) => provider.transcribe(request).await,
+            Inner::Simplismart(provider) => provider.transcribe(request).await,
+            Inner::Speechmatics(provider) => provider.transcribe(request).await,
         }
     }
 }
@@ -150,6 +234,7 @@ pub(crate) fn extension_for(content_type: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{API_KEY_VAR, MODEL_VAR};
 
     /// `from_env` reads process globals, so these run serially under one lock
     /// and restore what they touched — matching the archive-config tests.

--- a/portal-stt/src/poll.rs
+++ b/portal-stt/src/poll.rs
@@ -1,0 +1,131 @@
+//! Driver for providers that transcribe as an asynchronous *job*.
+//!
+//! AssemblyAI, Rev AI, Speechmatics and Amazon Transcribe all answer a submit
+//! with an id and make you ask again until the work is done. That shape is
+//! identical across the four, so it lives here once: the provider supplies a
+//! closure that reports the job's state, and this decides how often to ask and
+//! when to give up.
+//!
+//! The wait is bounded because it happens inside an HTTP request the browser is
+//! blocking on. A voice utterance is seconds of audio and these providers
+//! typically finish in a few seconds; [`DEFAULT_TIMEOUT`] is the point past
+//! which something is wrong and a clear error beats a hung request.
+
+use std::time::Duration;
+
+use crate::SttError;
+
+/// First gap between polls. Short, because a short utterance is often ready
+/// almost immediately and the first poll frequently succeeds.
+const INITIAL_INTERVAL: Duration = Duration::from_millis(400);
+/// Ceiling for the backoff, so a slow job doesn't get polled ever-less-often
+/// into the timeout.
+const MAX_INTERVAL: Duration = Duration::from_secs(2);
+/// Total budget before giving up.
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// What one probe of a job found.
+pub(crate) enum JobState<T> {
+    /// Still working — ask again.
+    Pending,
+    Done(T),
+    /// The provider says this job will never finish.
+    Failed(String),
+}
+
+/// Poll `probe` until it reports done, fails, or the budget runs out.
+///
+/// `label` names the provider in the timeout message; without it a timeout is
+/// indistinguishable across providers in a log.
+pub(crate) async fn poll_job<T, F, Fut>(
+    label: &str,
+    timeout: Duration,
+    mut probe: F,
+) -> Result<T, SttError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<JobState<T>, SttError>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut interval = INITIAL_INTERVAL;
+
+    loop {
+        match probe().await? {
+            JobState::Done(value) => return Ok(value),
+            JobState::Failed(reason) => {
+                return Err(SttError::Provider(format!("{label} job failed: {reason}")))
+            }
+            JobState::Pending => {}
+        }
+
+        let now = tokio::time::Instant::now();
+        if now + interval >= deadline {
+            return Err(SttError::Provider(format!(
+                "{label} did not finish within {}s",
+                timeout.as_secs()
+            )));
+        }
+        tokio::time::sleep(interval).await;
+        interval = (interval * 2).min(MAX_INTERVAL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test(start_paused = true)]
+    async fn returns_the_value_once_the_job_completes() {
+        let calls = AtomicUsize::new(0);
+        let result = poll_job("test", DEFAULT_TIMEOUT, || async {
+            Ok(if calls.fetch_add(1, Ordering::SeqCst) < 2 {
+                JobState::Pending
+            } else {
+                JobState::Done("transcript".to_string())
+            })
+        })
+        .await
+        .expect("job completes");
+
+        assert_eq!(result, "transcript");
+        assert_eq!(calls.load(Ordering::SeqCst), 3, "should poll until done");
+    }
+
+    /// A provider-reported failure must surface immediately rather than being
+    /// retried until the timeout.
+    #[tokio::test(start_paused = true)]
+    async fn a_failed_job_stops_at_once() {
+        let calls = AtomicUsize::new(0);
+        let err = poll_job("test", DEFAULT_TIMEOUT, || async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok::<JobState<String>, SttError>(JobState::Failed("bad audio".to_string()))
+        })
+        .await
+        .expect_err("failure propagates");
+
+        assert!(err.to_string().contains("bad audio"), "{err}");
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "must not retry a failure");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_job_that_never_finishes_times_out() {
+        let err = poll_job("test", Duration::from_secs(5), || async {
+            Ok::<JobState<String>, SttError>(JobState::Pending)
+        })
+        .await
+        .expect_err("times out");
+        assert!(err.to_string().contains("did not finish"), "{err}");
+    }
+
+    /// A transport error inside the probe is the caller's, not a job failure.
+    #[tokio::test(start_paused = true)]
+    async fn probe_errors_propagate_unchanged() {
+        let err = poll_job("test", DEFAULT_TIMEOUT, || async {
+            Err::<JobState<String>, _>(SttError::Transport("connection reset".to_string()))
+        })
+        .await
+        .expect_err("probe error propagates");
+        assert!(matches!(err, SttError::Transport(_)), "{err}");
+    }
+}

--- a/portal-stt/src/providers/assemblyai.rs
+++ b/portal-stt/src/providers/assemblyai.rs
@@ -3,7 +3,7 @@
 //! Three calls: the audio is uploaded to get a URL, a transcript job is created
 //! against that URL, then the job is polled. Keyterms map onto `word_boost`.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{Field, SttEnv};
 use crate::http::{decode, ensure_ok, transport};
@@ -22,6 +22,20 @@ pub(crate) struct AssemblyAiStt {
     language: Option<String>,
     model: Option<String>,
     http: reqwest::Client,
+}
+
+#[derive(Serialize)]
+struct TranscriptRequest<'a> {
+    audio_url: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    word_boost: Option<&'a [String]>,
+    /// Only meaningful alongside `word_boost`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    boost_param: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    language_code: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    speech_model: Option<&'a str>,
 }
 
 #[derive(Deserialize)]
@@ -82,18 +96,14 @@ impl AssemblyAiStt {
     }
 
     async fn submit(&self, audio_url: &str, keyterms: &[String]) -> Result<String, SttError> {
-        let mut payload = serde_json::json!({ "audio_url": audio_url });
-        if !keyterms.is_empty() {
-            let boosted: Vec<&String> = keyterms.iter().take(MAX_WORD_BOOST).collect();
-            payload["word_boost"] = serde_json::json!(boosted);
-            payload["boost_param"] = serde_json::json!("high");
-        }
-        if let Some(language) = &self.language {
-            payload["language_code"] = serde_json::json!(language);
-        }
-        if let Some(model) = &self.model {
-            payload["speech_model"] = serde_json::json!(model);
-        }
+        let boosted = &keyterms[..keyterms.len().min(MAX_WORD_BOOST)];
+        let payload = TranscriptRequest {
+            audio_url,
+            word_boost: (!boosted.is_empty()).then_some(boosted),
+            boost_param: (!boosted.is_empty()).then_some("high"),
+            language_code: self.language.as_deref(),
+            speech_model: self.model.as_deref(),
+        };
 
         let response = self
             .http

--- a/portal-stt/src/providers/assemblyai.rs
+++ b/portal-stt/src/providers/assemblyai.rs
@@ -1,0 +1,200 @@
+//! AssemblyAI — upload, submit, poll.
+//!
+//! Three calls: the audio is uploaded to get a URL, a transcript job is created
+//! against that URL, then the job is polled. Keyterms map onto `word_boost`.
+
+use serde::Deserialize;
+
+use crate::config::{Field, SttEnv};
+use crate::http::{decode, ensure_ok, transport};
+use crate::poll::{poll_job, JobState, DEFAULT_TIMEOUT};
+use crate::{SttError, TranscribeRequest};
+
+const DEFAULT_ENDPOINT: &str = "https://api.assemblyai.com";
+/// AssemblyAI caps `word_boost` at 1000 entries; our keyterm list is far
+/// shorter, but the cap is documented here so a future change notices it.
+const MAX_WORD_BOOST: usize = 1000;
+
+#[derive(Clone)]
+pub(crate) struct AssemblyAiStt {
+    api_key: String,
+    endpoint: String,
+    language: Option<String>,
+    model: Option<String>,
+    http: reqwest::Client,
+}
+
+#[derive(Deserialize)]
+struct UploadBody {
+    upload_url: String,
+}
+
+#[derive(Deserialize)]
+struct TranscriptBody {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct TranscriptStatus {
+    status: String,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+impl AssemblyAiStt {
+    pub(crate) fn from_env(env: &SttEnv) -> anyhow::Result<Self> {
+        Ok(Self {
+            api_key: env.require(Field::ApiKey, "assemblyai")?,
+            endpoint: env.endpoint_or(DEFAULT_ENDPOINT),
+            language: env.language.clone(),
+            model: env.model.clone(),
+            http: reqwest::Client::new(),
+        })
+    }
+
+    pub(crate) async fn transcribe(
+        &self,
+        request: TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
+        let audio_url = self.upload(request.audio).await?;
+        let job_id = self.submit(&audio_url, request.keyterms).await?;
+
+        poll_job("assemblyai", DEFAULT_TIMEOUT, || async {
+            let status = self.job_status(&job_id).await?;
+            Ok(classify(&status))
+        })
+        .await
+    }
+
+    async fn upload(&self, audio: crate::Bytes) -> Result<String, SttError> {
+        let response = self
+            .http
+            .post(format!("{}/v2/upload", self.endpoint))
+            .header(reqwest::header::AUTHORIZATION, &self.api_key)
+            .body(audio)
+            .send()
+            .await
+            .map_err(transport)?;
+        let body: UploadBody = ensure_ok(response).await?.json().await.map_err(decode)?;
+        Ok(body.upload_url)
+    }
+
+    async fn submit(&self, audio_url: &str, keyterms: &[String]) -> Result<String, SttError> {
+        let mut payload = serde_json::json!({ "audio_url": audio_url });
+        if !keyterms.is_empty() {
+            let boosted: Vec<&String> = keyterms.iter().take(MAX_WORD_BOOST).collect();
+            payload["word_boost"] = serde_json::json!(boosted);
+            payload["boost_param"] = serde_json::json!("high");
+        }
+        if let Some(language) = &self.language {
+            payload["language_code"] = serde_json::json!(language);
+        }
+        if let Some(model) = &self.model {
+            payload["speech_model"] = serde_json::json!(model);
+        }
+
+        let response = self
+            .http
+            .post(format!("{}/v2/transcript", self.endpoint))
+            .header(reqwest::header::AUTHORIZATION, &self.api_key)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(transport)?;
+        let body: TranscriptBody = ensure_ok(response).await?.json().await.map_err(decode)?;
+        Ok(body.id)
+    }
+
+    async fn job_status(&self, job_id: &str) -> Result<TranscriptStatus, SttError> {
+        let response = self
+            .http
+            .get(format!("{}/v2/transcript/{job_id}", self.endpoint))
+            .header(reqwest::header::AUTHORIZATION, &self.api_key)
+            .send()
+            .await
+            .map_err(transport)?;
+        ensure_ok(response).await?.json().await.map_err(decode)
+    }
+}
+
+/// Map AssemblyAI's status string onto a poll decision.
+///
+/// An unrecognized status is treated as still-running rather than an error, so
+/// a newly introduced intermediate state degrades into waiting (and eventually
+/// the timeout) instead of failing a transcription that was going to succeed.
+fn classify(status: &TranscriptStatus) -> JobState<String> {
+    match status.status.as_str() {
+        "completed" => JobState::Done(status.text.clone().unwrap_or_default().trim().to_string()),
+        "error" => JobState::Failed(
+            status
+                .error
+                .clone()
+                .unwrap_or_else(|| "no reason given".to_string()),
+        ),
+        _ => JobState::Pending,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> TranscriptStatus {
+        serde_json::from_str(json).expect("valid AssemblyAI status")
+    }
+
+    fn done_text(state: JobState<String>) -> Option<String> {
+        match state {
+            JobState::Done(text) => Some(text),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn a_completed_job_yields_its_text() {
+        let state = classify(&parse(
+            r#"{"status":"completed","text":" run cargo clippy "}"#,
+        ));
+        assert_eq!(done_text(state).as_deref(), Some("run cargo clippy"));
+    }
+
+    #[test]
+    fn an_errored_job_carries_the_reason() {
+        let state = classify(&parse(r#"{"status":"error","error":"audio too short"}"#));
+        match state {
+            JobState::Failed(reason) => assert_eq!(reason, "audio too short"),
+            _ => panic!("expected failure"),
+        }
+    }
+
+    #[test]
+    fn queued_and_processing_keep_polling() {
+        assert!(matches!(
+            classify(&parse(r#"{"status":"queued"}"#)),
+            JobState::Pending
+        ));
+        assert!(matches!(
+            classify(&parse(r#"{"status":"processing"}"#)),
+            JobState::Pending
+        ));
+    }
+
+    /// A status this build has never heard of must not fail a job that is
+    /// simply still running.
+    #[test]
+    fn an_unknown_status_is_treated_as_still_running() {
+        assert!(matches!(
+            classify(&parse(r#"{"status":"reprocessing"}"#)),
+            JobState::Pending
+        ));
+    }
+
+    /// Silence completes with no `text` at all rather than an empty string.
+    #[test]
+    fn a_completed_job_without_text_is_empty_not_an_error() {
+        let state = classify(&parse(r#"{"status":"completed"}"#));
+        assert_eq!(done_text(state).as_deref(), Some(""));
+    }
+}

--- a/portal-stt/src/providers/aws.rs
+++ b/portal-stt/src/providers/aws.rs
@@ -1,0 +1,443 @@
+//! Amazon Transcribe.
+//!
+//! The awkward one. Transcribe has no synchronous "bytes in, text out" call:
+//! audio must be staged in S3, a job started against that object, the job
+//! polled, and the transcript fetched from a presigned URL. That is why this
+//! provider — alone among the ten — needs `PORTAL_STT_BUCKET`.
+//!
+//! Requests are SigV4-signed with the standard `AWS_ACCESS_KEY_ID` /
+//! `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` variables, the same ones the
+//! session archive's S3 backend uses, so a deploy already using S3 needs no new
+//! credentials. They are read per request so rotation is picked up without a
+//! restart.
+//!
+//! **Keyterms cannot be passed inline.** Transcribe's vocabulary is a
+//! pre-created named resource, not a per-request list; set
+//! `PORTAL_STT_VOCABULARY_NAME` to use one.
+
+use std::time::SystemTime;
+
+use aws_credential_types::Credentials;
+use aws_sigv4::http_request::{
+    sign, PayloadChecksumKind, SignableBody, SignableRequest, SigningSettings,
+};
+use aws_sigv4::sign::v4;
+use serde::Deserialize;
+
+use crate::config::{resolve_language, Field, SttEnv};
+use crate::http::{decode, ensure_ok, transport};
+use crate::poll::{poll_job, JobState, DEFAULT_TIMEOUT};
+use crate::{extension_for, SttError, TranscribeRequest};
+
+const DEFAULT_LANGUAGE: &str = "en-US";
+const JSON_1_1: &str = "application/x-amz-json-1.1";
+
+#[derive(Clone)]
+pub(crate) struct AwsStt {
+    region: String,
+    bucket: String,
+    language: Option<String>,
+    vocabulary_name: Option<String>,
+    http: reqwest::Client,
+}
+
+#[derive(Deserialize)]
+struct GetJobBody {
+    #[serde(rename = "TranscriptionJob")]
+    transcription_job: TranscriptionJob,
+}
+
+#[derive(Deserialize)]
+struct TranscriptionJob {
+    #[serde(rename = "TranscriptionJobStatus")]
+    status: String,
+    #[serde(default, rename = "Transcript")]
+    transcript: Option<Transcript>,
+    #[serde(default, rename = "FailureReason")]
+    failure_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Transcript {
+    #[serde(default, rename = "TranscriptFileUri")]
+    transcript_file_uri: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TranscriptDocument {
+    #[serde(default)]
+    results: TranscriptResults,
+}
+
+#[derive(Default, Deserialize)]
+struct TranscriptResults {
+    #[serde(default)]
+    transcripts: Vec<TranscriptText>,
+}
+
+#[derive(Deserialize)]
+struct TranscriptText {
+    #[serde(default)]
+    transcript: String,
+}
+
+impl AwsStt {
+    pub(crate) fn from_env(env: &SttEnv) -> anyhow::Result<Self> {
+        let region = env
+            .get(Field::Region)
+            .or_else(|| std::env::var("AWS_REGION").ok())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "{}=aws requires {} (or AWS_REGION) to be set",
+                    crate::config::BACKEND_VAR,
+                    Field::Region.var_name()
+                )
+            })?;
+        Ok(Self {
+            region,
+            bucket: env.require(Field::Bucket, "aws")?,
+            language: env.language.clone(),
+            vocabulary_name: env.get(Field::VocabularyName),
+            http: reqwest::Client::new(),
+        })
+    }
+
+    pub(crate) async fn transcribe(
+        &self,
+        request: TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
+        let job_name = format!("agent-portal-{}", uuid::Uuid::new_v4());
+        let key = format!(
+            "agent-portal-stt/{job_name}.{}",
+            extension_for(request.content_type)
+        );
+
+        self.put_object(&key, request.audio.clone(), request.content_type)
+            .await?;
+
+        // Whatever happens next, don't leave the staged audio behind.
+        let outcome = self.run_job(&job_name, &key, &request).await;
+        if let Err(error) = self.delete_object(&key).await {
+            tracing::warn!(
+                target: "stt",
+                event = "aws_stage_cleanup_failed",
+                key = %key,
+                error = %error,
+            );
+        }
+        outcome
+    }
+
+    async fn run_job(
+        &self,
+        job_name: &str,
+        key: &str,
+        request: &TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
+        self.start_job(job_name, key, request).await?;
+
+        let uri = poll_job("aws transcribe", DEFAULT_TIMEOUT, || async {
+            let body = self.get_job(job_name).await?;
+            Ok(classify(&body.transcription_job))
+        })
+        .await?;
+
+        // Presigned by AWS when no output bucket is configured, so this fetch
+        // is deliberately unsigned.
+        let response = self.http.get(&uri).send().await.map_err(transport)?;
+        let document: TranscriptDocument =
+            ensure_ok(response).await?.json().await.map_err(decode)?;
+        Ok(joined_transcript(&document))
+    }
+
+    async fn start_job(
+        &self,
+        job_name: &str,
+        key: &str,
+        request: &TranscribeRequest<'_>,
+    ) -> Result<(), SttError> {
+        let language =
+            resolve_language(request.language, self.language.as_deref(), DEFAULT_LANGUAGE);
+        let mut payload = serde_json::json!({
+            "TranscriptionJobName": job_name,
+            "LanguageCode": language,
+            "Media": { "MediaFileUri": format!("s3://{}/{key}", self.bucket) },
+        });
+        if let Some(format) = media_format_for(request.content_type) {
+            payload["MediaFormat"] = serde_json::json!(format);
+        }
+        if let Some(vocabulary) = &self.vocabulary_name {
+            payload["Settings"] = serde_json::json!({ "VocabularyName": vocabulary });
+        }
+
+        self.transcribe_call("StartTranscriptionJob", &payload)
+            .await
+            .map(|_| ())
+    }
+
+    async fn get_job(&self, job_name: &str) -> Result<GetJobBody, SttError> {
+        let payload = serde_json::json!({ "TranscriptionJobName": job_name });
+        let text = self
+            .transcribe_call("GetTranscriptionJob", &payload)
+            .await?;
+        serde_json::from_str(&text).map_err(decode)
+    }
+
+    /// One signed call to the Transcribe JSON-RPC endpoint.
+    async fn transcribe_call(
+        &self,
+        target: &str,
+        payload: &serde_json::Value,
+    ) -> Result<String, SttError> {
+        let url = format!("https://transcribe.{}.amazonaws.com/", self.region);
+        let body = serde_json::to_vec(payload).map_err(decode)?;
+        let headers = vec![
+            ("content-type".to_string(), JSON_1_1.to_string()),
+            ("x-amz-target".to_string(), format!("Transcribe.{target}")),
+        ];
+
+        let request = self.signed_request("POST", &url, headers, body, "transcribe")?;
+        let response = self.http.execute(request).await.map_err(transport)?;
+        ensure_ok(response).await?.text().await.map_err(decode)
+    }
+
+    async fn put_object(
+        &self,
+        key: &str,
+        audio: crate::Bytes,
+        content_type: &str,
+    ) -> Result<(), SttError> {
+        let url = self.object_url(key);
+        let headers = vec![("content-type".to_string(), content_type.to_string())];
+        let request = self.signed_request("PUT", &url, headers, audio.to_vec(), "s3")?;
+        let response = self.http.execute(request).await.map_err(transport)?;
+        ensure_ok(response).await.map(|_| ())
+    }
+
+    async fn delete_object(&self, key: &str) -> Result<(), SttError> {
+        let url = self.object_url(key);
+        let request = self.signed_request("DELETE", &url, Vec::new(), Vec::new(), "s3")?;
+        let response = self.http.execute(request).await.map_err(transport)?;
+        ensure_ok(response).await.map(|_| ())
+    }
+
+    fn object_url(&self, key: &str) -> String {
+        format!(
+            "https://{}.s3.{}.amazonaws.com/{key}",
+            self.bucket, self.region
+        )
+    }
+
+    /// Build a SigV4-signed request. Credentials are read here, per call, so a
+    /// rotation lands without a restart.
+    fn signed_request(
+        &self,
+        method: &str,
+        url: &str,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+        service: &str,
+    ) -> Result<reqwest::Request, SttError> {
+        let access_key = std::env::var("AWS_ACCESS_KEY_ID")
+            .map_err(|_| SttError::Provider("AWS_ACCESS_KEY_ID is not set".to_string()))?;
+        let secret_key = std::env::var("AWS_SECRET_ACCESS_KEY")
+            .map_err(|_| SttError::Provider("AWS_SECRET_ACCESS_KEY is not set".to_string()))?;
+        let session_token = std::env::var("AWS_SESSION_TOKEN").ok();
+
+        let identity =
+            Credentials::new(access_key, secret_key, session_token, None, "portal-stt").into();
+
+        let mut settings = SigningSettings::default();
+        // S3 rejects a signed request that omits the payload hash header.
+        settings.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+
+        let params = v4::SigningParams::builder()
+            .identity(&identity)
+            .region(&self.region)
+            .name(service)
+            .time(SystemTime::now())
+            .settings(settings)
+            .build()
+            .map_err(|e| SttError::Provider(format!("could not build signing params: {e}")))?;
+
+        let signable = SignableRequest::new(
+            method,
+            url,
+            headers.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+            SignableBody::Bytes(&body),
+        )
+        .map_err(|e| SttError::Provider(format!("could not prepare request for signing: {e}")))?;
+
+        let (instructions, _signature) = sign(signable, &params.into())
+            .map_err(|e| SttError::Provider(format!("could not sign request: {e}")))?
+            .into_parts();
+
+        let mut builder = http::Request::builder().method(method).uri(url);
+        for (name, value) in &headers {
+            builder = builder.header(name, value);
+        }
+        let mut http_request = builder
+            .body(body)
+            .map_err(|e| SttError::Provider(format!("could not build request: {e}")))?;
+        instructions.apply_to_request_http1x(&mut http_request);
+
+        reqwest::Request::try_from(http_request)
+            .map_err(|e| SttError::Provider(format!("could not convert signed request: {e}")))
+    }
+}
+
+/// Transcribe wants the container named. Unknown types are left unset so it can
+/// infer, rather than being told something wrong.
+fn media_format_for(content_type: &str) -> Option<&'static str> {
+    match content_type.split(';').next().unwrap_or("").trim() {
+        "audio/webm" => Some("webm"),
+        "audio/ogg" => Some("ogg"),
+        "audio/mpeg" => Some("mp3"),
+        "audio/mp4" | "audio/x-m4a" => Some("mp4"),
+        "audio/wav" | "audio/x-wav" => Some("wav"),
+        "audio/flac" => Some("flac"),
+        _ => None,
+    }
+}
+
+/// A completed job carries the URL of its transcript; anything else is either
+/// terminal failure or still running.
+fn classify(job: &TranscriptionJob) -> JobState<String> {
+    match job.status.as_str() {
+        "COMPLETED" => match job
+            .transcript
+            .as_ref()
+            .and_then(|t| t.transcript_file_uri.clone())
+        {
+            Some(uri) => JobState::Done(uri),
+            // Completed with nowhere to read the result from is a failure we
+            // cannot recover by waiting.
+            None => JobState::Failed("completed without a transcript URI".to_string()),
+        },
+        "FAILED" => JobState::Failed(
+            job.failure_reason
+                .clone()
+                .unwrap_or_else(|| "no reason given".to_string()),
+        ),
+        _ => JobState::Pending,
+    }
+}
+
+fn joined_transcript(document: &TranscriptDocument) -> String {
+    document
+        .results
+        .transcripts
+        .iter()
+        .map(|t| t.transcript.trim())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job(json: &str) -> TranscriptionJob {
+        serde_json::from_str::<GetJobBody>(json)
+            .expect("valid Transcribe body")
+            .transcription_job
+    }
+
+    #[test]
+    fn a_completed_job_yields_its_transcript_url() {
+        let state = classify(&job(
+            r#"{"TranscriptionJob":{"TranscriptionJobStatus":"COMPLETED",
+                "Transcript":{"TranscriptFileUri":"https://s3.invalid/t.json"}}}"#,
+        ));
+        match state {
+            JobState::Done(uri) => assert_eq!(uri, "https://s3.invalid/t.json"),
+            _ => panic!("expected completion"),
+        }
+    }
+
+    #[test]
+    fn in_progress_keeps_polling() {
+        assert!(matches!(
+            classify(&job(
+                r#"{"TranscriptionJob":{"TranscriptionJobStatus":"IN_PROGRESS"}}"#
+            )),
+            JobState::Pending
+        ));
+        assert!(matches!(
+            classify(&job(
+                r#"{"TranscriptionJob":{"TranscriptionJobStatus":"QUEUED"}}"#
+            )),
+            JobState::Pending
+        ));
+    }
+
+    #[test]
+    fn a_failed_job_carries_the_reason() {
+        let state = classify(&job(
+            r#"{"TranscriptionJob":{"TranscriptionJobStatus":"FAILED",
+                "FailureReason":"The audio format is not supported."}}"#,
+        ));
+        match state {
+            JobState::Failed(reason) => assert!(reason.contains("not supported"), "{reason}"),
+            _ => panic!("expected failure"),
+        }
+    }
+
+    /// Completing with no URI would otherwise poll to the timeout and report a
+    /// misleading "did not finish".
+    #[test]
+    fn completed_without_a_uri_fails_rather_than_hanging() {
+        let state = classify(&job(
+            r#"{"TranscriptionJob":{"TranscriptionJobStatus":"COMPLETED"}}"#,
+        ));
+        assert!(matches!(state, JobState::Failed(_)));
+    }
+
+    #[test]
+    fn reads_the_transcript_document() {
+        let document: TranscriptDocument = serde_json::from_str(
+            r#"{"jobName":"x","results":{"transcripts":[{"transcript":"run cargo clippy"}]}}"#,
+        )
+        .expect("valid transcript document");
+        assert_eq!(joined_transcript(&document), "run cargo clippy");
+    }
+
+    #[test]
+    fn silence_yields_an_empty_transcript() {
+        let document: TranscriptDocument =
+            serde_json::from_str(r#"{"results":{"transcripts":[]}}"#).expect("valid");
+        assert_eq!(joined_transcript(&document), "");
+    }
+
+    #[test]
+    fn browser_containers_map_to_transcribe_media_formats() {
+        assert_eq!(media_format_for("audio/webm;codecs=opus"), Some("webm"));
+        assert_eq!(media_format_for("audio/mp4"), Some("mp4"));
+        assert_eq!(media_format_for("application/octet-stream"), None);
+    }
+
+    #[test]
+    fn aws_requires_a_staging_bucket() {
+        let env = SttEnv {
+            region: Some("us-east-1".into()),
+            ..Default::default()
+        };
+        let err = crate::config_error(AwsStt::from_env(&env));
+        assert!(err.contains("PORTAL_STT_BUCKET"), "{err}");
+    }
+
+    #[test]
+    fn the_object_url_is_region_and_bucket_scoped() {
+        let provider = AwsStt::from_env(&SttEnv {
+            region: Some("eu-west-1".into()),
+            bucket: Some("my-bucket".into()),
+            ..Default::default()
+        })
+        .expect("configured");
+        assert_eq!(
+            provider.object_url("agent-portal-stt/x.webm"),
+            "https://my-bucket.s3.eu-west-1.amazonaws.com/agent-portal-stt/x.webm"
+        );
+    }
+}

--- a/portal-stt/src/providers/aws.rs
+++ b/portal-stt/src/providers/aws.rs
@@ -22,7 +22,7 @@ use aws_sigv4::http_request::{
     sign, PayloadChecksumKind, SignableBody, SignableRequest, SigningSettings,
 };
 use aws_sigv4::sign::v4;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{resolve_language, Field, SttEnv};
 use crate::http::{decode, ensure_ok, transport};
@@ -39,6 +39,38 @@ pub(crate) struct AwsStt {
     language: Option<String>,
     vocabulary_name: Option<String>,
     http: reqwest::Client,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct StartJobRequest<'a> {
+    transcription_job_name: &'a str,
+    language_code: &'a str,
+    media: Media,
+    /// Omitted when the container is not one Transcribe names — see
+    /// [`media_format_for`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    media_format: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    settings: Option<JobSettings<'a>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct Media {
+    media_file_uri: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct JobSettings<'a> {
+    vocabulary_name: &'a str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct GetJobRequest<'a> {
+    transcription_job_name: &'a str,
 }
 
 #[derive(Deserialize)]
@@ -158,17 +190,18 @@ impl AwsStt {
     ) -> Result<(), SttError> {
         let language =
             resolve_language(request.language, self.language.as_deref(), DEFAULT_LANGUAGE);
-        let mut payload = serde_json::json!({
-            "TranscriptionJobName": job_name,
-            "LanguageCode": language,
-            "Media": { "MediaFileUri": format!("s3://{}/{key}", self.bucket) },
-        });
-        if let Some(format) = media_format_for(request.content_type) {
-            payload["MediaFormat"] = serde_json::json!(format);
-        }
-        if let Some(vocabulary) = &self.vocabulary_name {
-            payload["Settings"] = serde_json::json!({ "VocabularyName": vocabulary });
-        }
+        let payload = StartJobRequest {
+            transcription_job_name: job_name,
+            language_code: &language,
+            media: Media {
+                media_file_uri: format!("s3://{}/{key}", self.bucket),
+            },
+            media_format: media_format_for(request.content_type),
+            settings: self
+                .vocabulary_name
+                .as_deref()
+                .map(|vocabulary_name| JobSettings { vocabulary_name }),
+        };
 
         self.transcribe_call("StartTranscriptionJob", &payload)
             .await
@@ -176,7 +209,9 @@ impl AwsStt {
     }
 
     async fn get_job(&self, job_name: &str) -> Result<GetJobBody, SttError> {
-        let payload = serde_json::json!({ "TranscriptionJobName": job_name });
+        let payload = GetJobRequest {
+            transcription_job_name: job_name,
+        };
         let text = self
             .transcribe_call("GetTranscriptionJob", &payload)
             .await?;
@@ -187,7 +222,7 @@ impl AwsStt {
     async fn transcribe_call(
         &self,
         target: &str,
-        payload: &serde_json::Value,
+        payload: &impl Serialize,
     ) -> Result<String, SttError> {
         let url = format!("https://transcribe.{}.amazonaws.com/", self.region);
         let body = serde_json::to_vec(payload).map_err(decode)?;

--- a/portal-stt/src/providers/azure.rs
+++ b/portal-stt/src/providers/azure.rs
@@ -1,0 +1,155 @@
+//! Microsoft Azure AI Speech — Fast Transcription.
+//!
+//! One multipart call: the audio as a file part, and a `definition` JSON part
+//! carrying the locale. Regional, so `PORTAL_STT_REGION` is required.
+//!
+//! **Keyterms are not used here.** Azure's biasing story is a trained Custom
+//! Speech model, not an inline phrase list, so there is nowhere to put them on
+//! this endpoint. Point `PORTAL_STT_MODEL` at a Custom Speech deployment to get
+//! domain vocabulary.
+
+use serde::Deserialize;
+
+use crate::config::{resolve_language, Field, SttEnv};
+use crate::http::{decode, ensure_ok, transport};
+use crate::{extension_for, SttError, TranscribeRequest};
+
+const API_VERSION: &str = "2024-11-15";
+const DEFAULT_LOCALE: &str = "en-US";
+
+#[derive(Clone)]
+pub(crate) struct AzureStt {
+    api_key: String,
+    endpoint: String,
+    language: Option<String>,
+    /// Custom Speech deployment id, when one is configured.
+    model: Option<String>,
+    http: reqwest::Client,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FastTranscriptionBody {
+    #[serde(default)]
+    combined_phrases: Vec<CombinedPhrase>,
+}
+
+#[derive(Deserialize)]
+struct CombinedPhrase {
+    #[serde(default)]
+    text: String,
+}
+
+impl AzureStt {
+    pub(crate) fn from_env(env: &SttEnv) -> anyhow::Result<Self> {
+        let api_key = env.require(Field::ApiKey, "azure")?;
+        let region = env.require(Field::Region, "azure")?;
+        Ok(Self {
+            api_key,
+            endpoint: env.endpoint_or(&format!("https://{region}.api.cognitive.microsoft.com")),
+            language: env.language.clone(),
+            model: env.model.clone(),
+            http: reqwest::Client::new(),
+        })
+    }
+
+    pub(crate) async fn transcribe(
+        &self,
+        request: TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
+        let locale = resolve_language(request.language, self.language.as_deref(), DEFAULT_LOCALE);
+        let mut definition = serde_json::json!({ "locales": [locale] });
+        if let Some(model) = &self.model {
+            definition["model"] = serde_json::json!({ "self": model });
+        }
+
+        let audio = reqwest::multipart::Part::bytes(request.audio.to_vec())
+            .file_name(format!("audio.{}", extension_for(request.content_type)))
+            .mime_str(request.content_type)
+            .map_err(|e| SttError::Provider(format!("unsupported audio content type: {e}")))?;
+        let form = reqwest::multipart::Form::new()
+            .part("audio", audio)
+            .text("definition", definition.to_string());
+
+        let response = self
+            .http
+            .post(format!(
+                "{}/speechtotext/transcriptions:transcribe?api-version={API_VERSION}",
+                self.endpoint
+            ))
+            .header("Ocp-Apim-Subscription-Key", &self.api_key)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(transport)?;
+
+        let body: FastTranscriptionBody =
+            ensure_ok(response).await?.json().await.map_err(decode)?;
+        Ok(combined_text(&body))
+    }
+}
+
+/// Azure returns the flat transcript as `combinedPhrases`, one entry per
+/// channel. Mono audio yields one; joining is the safe general case.
+fn combined_text(body: &FastTranscriptionBody) -> String {
+    body.combined_phrases
+        .iter()
+        .map(|p| p.text.trim())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> FastTranscriptionBody {
+        serde_json::from_str(json).expect("valid Azure body")
+    }
+
+    #[test]
+    fn reads_the_combined_transcript() {
+        let body = parse(
+            r#"{"durationMilliseconds":1200,
+                "combinedPhrases":[{"text":"run cargo clippy"}]}"#,
+        );
+        assert_eq!(combined_text(&body), "run cargo clippy");
+    }
+
+    #[test]
+    fn joins_multiple_channels() {
+        let body = parse(r#"{"combinedPhrases":[{"text":"one"},{"text":"two"}]}"#);
+        assert_eq!(combined_text(&body), "one two");
+    }
+
+    #[test]
+    fn silence_yields_an_empty_transcript() {
+        assert_eq!(combined_text(&parse(r#"{"combinedPhrases":[]}"#)), "");
+        assert_eq!(combined_text(&parse(r#"{}"#)), "");
+    }
+
+    #[test]
+    fn azure_requires_a_region() {
+        let env = SttEnv {
+            api_key: Some("k".into()),
+            ..Default::default()
+        };
+        let err = crate::config_error(AzureStt::from_env(&env));
+        assert!(err.contains("PORTAL_STT_REGION"), "{err}");
+    }
+
+    #[test]
+    fn the_endpoint_defaults_to_the_configured_region() {
+        let env = SttEnv {
+            api_key: Some("k".into()),
+            region: Some("westus2".into()),
+            ..Default::default()
+        };
+        let provider = AzureStt::from_env(&env).expect("configured");
+        assert_eq!(
+            provider.endpoint,
+            "https://westus2.api.cognitive.microsoft.com"
+        );
+    }
+}

--- a/portal-stt/src/providers/azure.rs
+++ b/portal-stt/src/providers/azure.rs
@@ -8,7 +8,7 @@
 //! this endpoint. Point `PORTAL_STT_MODEL` at a Custom Speech deployment to get
 //! domain vocabulary.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{resolve_language, Field, SttEnv};
 use crate::http::{decode, ensure_ok, transport};
@@ -25,6 +25,21 @@ pub(crate) struct AzureStt {
     /// Custom Speech deployment id, when one is configured.
     model: Option<String>,
     http: reqwest::Client,
+}
+
+/// The `definition` part of the multipart request.
+#[derive(Serialize)]
+struct Definition<'a> {
+    locales: [&'a str; 1],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<ModelRef<'a>>,
+}
+
+/// A Custom Speech deployment reference. The field really is named `self`.
+#[derive(Serialize)]
+struct ModelRef<'a> {
+    #[serde(rename = "self")]
+    self_uri: &'a str,
 }
 
 #[derive(Deserialize)]
@@ -58,10 +73,12 @@ impl AzureStt {
         request: TranscribeRequest<'_>,
     ) -> Result<String, SttError> {
         let locale = resolve_language(request.language, self.language.as_deref(), DEFAULT_LOCALE);
-        let mut definition = serde_json::json!({ "locales": [locale] });
-        if let Some(model) = &self.model {
-            definition["model"] = serde_json::json!({ "self": model });
-        }
+        let definition = Definition {
+            locales: [&locale],
+            model: self.model.as_deref().map(|self_uri| ModelRef { self_uri }),
+        };
+        let definition = serde_json::to_string(&definition)
+            .map_err(|e| SttError::Provider(format!("could not encode request: {e}")))?;
 
         let audio = reqwest::multipart::Part::bytes(request.audio.to_vec())
             .file_name(format!("audio.{}", extension_for(request.content_type)))
@@ -69,7 +86,7 @@ impl AzureStt {
             .map_err(|e| SttError::Provider(format!("unsupported audio content type: {e}")))?;
         let form = reqwest::multipart::Form::new()
             .part("audio", audio)
-            .text("definition", definition.to_string());
+            .text("definition", definition);
 
         let response = self
             .http

--- a/portal-stt/src/providers/deepgram.rs
+++ b/portal-stt/src/providers/deepgram.rs
@@ -12,15 +12,20 @@
 
 use serde::Deserialize;
 
+use crate::config::{Field, SttEnv};
+use crate::http::{decode, ensure_ok, transport};
 use crate::{SttError, TranscribeRequest};
 
-const ENDPOINT: &str = "https://api.deepgram.com/v1/listen";
+const DEFAULT_ENDPOINT: &str = "https://api.deepgram.com";
 const DEFAULT_MODEL: &str = "nova-3";
 
 #[derive(Clone)]
-pub struct DeepgramStt {
+pub(crate) struct DeepgramStt {
     api_key: String,
     model: String,
+    /// Overridable for Deepgram's self-hosted deployment.
+    endpoint: String,
+    language: Option<String>,
     /// Owned per provider, matching the push transports — a `Client` is a
     /// connection pool, so it must outlive individual requests.
     http: reqwest::Client,
@@ -47,22 +52,27 @@ struct ListenAlternative {
 }
 
 impl DeepgramStt {
-    pub fn new(api_key: String, model: Option<String>) -> Self {
-        Self {
-            api_key,
-            model: model.unwrap_or_else(|| DEFAULT_MODEL.to_string()),
+    pub(crate) fn from_env(env: &SttEnv) -> anyhow::Result<Self> {
+        Ok(Self {
+            api_key: env.require(Field::ApiKey, "deepgram")?,
+            model: env.model_or(DEFAULT_MODEL),
+            endpoint: env.endpoint_or(DEFAULT_ENDPOINT),
+            language: env.language.clone(),
             http: reqwest::Client::new(),
-        }
+        })
     }
 
-    pub async fn transcribe(&self, request: TranscribeRequest<'_>) -> Result<String, SttError> {
+    pub(crate) async fn transcribe(
+        &self,
+        request: TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
         // `smart_format` supplies punctuation and capitalization, which the
         // transcript needs to read as a prompt rather than a wall of words.
         let mut query: Vec<(&str, String)> = vec![
             ("model", self.model.clone()),
             ("smart_format", "true".to_string()),
         ];
-        if let Some(language) = request.language {
+        if let Some(language) = request.language.or(self.language.as_deref()) {
             query.push(("language", language.to_string()));
         }
         for term in request.keyterms {
@@ -71,7 +81,7 @@ impl DeepgramStt {
 
         let response = self
             .http
-            .post(ENDPOINT)
+            .post(format!("{}/v1/listen", self.endpoint))
             .query(&query)
             .header(
                 reqwest::header::AUTHORIZATION,
@@ -81,21 +91,9 @@ impl DeepgramStt {
             .body(request.audio)
             .send()
             .await
-            .map_err(|e| SttError::Transport(e.to_string()))?;
+            .map_err(transport)?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(SttError::Provider(format!(
-                "HTTP {status}: {}",
-                body.chars().take(400).collect::<String>()
-            )));
-        }
-
-        let body: ListenBody = response
-            .json()
-            .await
-            .map_err(|e| SttError::Decode(e.to_string()))?;
+        let body: ListenBody = ensure_ok(response).await?.json().await.map_err(decode)?;
         Ok(first_transcript(&body))
     }
 }
@@ -149,6 +147,19 @@ mod tests {
 
     #[test]
     fn the_default_model_is_used_when_none_is_configured() {
-        assert_eq!(DeepgramStt::new("k".to_string(), None).model, DEFAULT_MODEL);
+        let env = SttEnv {
+            api_key: Some("k".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            DeepgramStt::from_env(&env).expect("configured").model,
+            DEFAULT_MODEL
+        );
+    }
+
+    #[test]
+    fn deepgram_requires_a_key() {
+        let err = crate::config_error(DeepgramStt::from_env(&SttEnv::default()));
+        assert!(err.contains("PORTAL_STT_API_KEY"), "{err}");
     }
 }

--- a/portal-stt/src/providers/google.rs
+++ b/portal-stt/src/providers/google.rs
@@ -59,6 +59,37 @@ struct TokenResponse {
     expires_in: u64,
 }
 
+#[derive(Serialize)]
+struct RecognizeRequest<'a> {
+    config: RecognitionConfig<'a>,
+    audio: RecognitionAudio,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RecognitionConfig<'a> {
+    language_code: &'a str,
+    enable_automatic_punctuation: bool,
+    model: &'a str,
+    /// Omitted when the container describes itself — see [`encoding_for`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    encoding: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    speech_contexts: Option<[SpeechContext<'a>; 1]>,
+}
+
+#[derive(Serialize)]
+struct SpeechContext<'a> {
+    phrases: &'a [String],
+    boost: f32,
+}
+
+#[derive(Serialize)]
+struct RecognitionAudio {
+    /// Base64 of the recording.
+    content: String,
+}
+
 #[derive(Deserialize)]
 struct RecognizeBody {
     #[serde(default)]
@@ -117,25 +148,21 @@ impl GoogleStt {
         let language =
             resolve_language(request.language, self.language.as_deref(), DEFAULT_LANGUAGE);
 
-        let mut config = serde_json::json!({
-            "languageCode": language,
-            "enableAutomaticPunctuation": true,
-            "model": self.model,
-        });
-        if let Some(encoding) = encoding_for(request.content_type) {
-            config["encoding"] = serde_json::json!(encoding);
-        }
-        if !request.keyterms.is_empty() {
-            config["speechContexts"] = serde_json::json!([{
-                "phrases": request.keyterms,
-                "boost": PHRASE_BOOST,
-            }]);
-        }
-
-        let body = serde_json::json!({
-            "config": config,
-            "audio": { "content": base64::engine::general_purpose::STANDARD.encode(&request.audio) },
-        });
+        let body = RecognizeRequest {
+            config: RecognitionConfig {
+                language_code: &language,
+                enable_automatic_punctuation: true,
+                model: &self.model,
+                encoding: encoding_for(request.content_type),
+                speech_contexts: (!request.keyterms.is_empty()).then_some([SpeechContext {
+                    phrases: request.keyterms,
+                    boost: PHRASE_BOOST,
+                }]),
+            },
+            audio: RecognitionAudio {
+                content: base64::engine::general_purpose::STANDARD.encode(&request.audio),
+            },
+        };
 
         let response = self
             .http

--- a/portal-stt/src/providers/google.rs
+++ b/portal-stt/src/providers/google.rs
@@ -1,0 +1,297 @@
+//! Google Cloud Speech-to-Text v1 (`speech:recognize`).
+//!
+//! The synchronous endpoint, which takes the audio inline as base64 and is
+//! capped at roughly a minute — the same ceiling the voice UI already imposes
+//! on a single utterance.
+//!
+//! Biasing is real here: `speechContexts.phrases` is exactly a keyterm list.
+//!
+//! Auth is a service-account JWT exchanged for an access token, the same dance
+//! `push::fcm` does for FCM. Tokens are cached until shortly before expiry —
+//! minting one per utterance would add a round trip to every recording.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+
+use crate::config::{resolve_language, Field, SttEnv};
+use crate::http::{decode, ensure_ok, transport};
+use crate::{SttError, TranscribeRequest};
+
+const ENDPOINT: &str = "https://speech.googleapis.com/v1/speech:recognize";
+const SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+const DEFAULT_LANGUAGE: &str = "en-US";
+/// Short-form model, tuned for utterances rather than long recordings.
+const DEFAULT_MODEL: &str = "latest_short";
+/// How much boost to give keyterms. Google's scale runs 0-20; the docs warn
+/// that a high boost makes false positives more likely, so this sits mid-range.
+const PHRASE_BOOST: f32 = 12.0;
+/// Refresh this long before the token actually expires, so a request never
+/// races the boundary.
+const TOKEN_SKEW: Duration = Duration::from_secs(60);
+
+#[derive(Clone, Deserialize)]
+struct ServiceAccount {
+    client_email: String,
+    private_key: String,
+    #[serde(default = "default_token_uri")]
+    token_uri: String,
+}
+
+fn default_token_uri() -> String {
+    "https://oauth2.googleapis.com/token".to_string()
+}
+
+#[derive(Serialize)]
+struct JwtClaims<'a> {
+    iss: &'a str,
+    scope: &'a str,
+    aud: &'a str,
+    iat: u64,
+    exp: u64,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    expires_in: u64,
+}
+
+#[derive(Deserialize)]
+struct RecognizeBody {
+    #[serde(default)]
+    results: Vec<RecognizeResult>,
+}
+
+#[derive(Deserialize)]
+struct RecognizeResult {
+    #[serde(default)]
+    alternatives: Vec<RecognizeAlternative>,
+}
+
+#[derive(Deserialize)]
+struct RecognizeAlternative {
+    #[serde(default)]
+    transcript: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct GoogleStt {
+    service_account: ServiceAccount,
+    language: Option<String>,
+    model: String,
+    http: reqwest::Client,
+    cached_token: std::sync::Arc<tokio::sync::Mutex<Option<CachedToken>>>,
+}
+
+#[derive(Clone)]
+struct CachedToken {
+    value: String,
+    expires_at: SystemTime,
+}
+
+impl GoogleStt {
+    pub(crate) fn from_env(env: &SttEnv) -> anyhow::Result<Self> {
+        let path = env.require(Field::ServiceAccountPath, "google")?;
+        let raw = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("could not read {path}: {e}"))?;
+        let service_account: ServiceAccount = serde_json::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("{path} is not a service-account JSON file: {e}"))?;
+
+        Ok(Self {
+            service_account,
+            language: env.language.clone(),
+            model: env.model_or(DEFAULT_MODEL),
+            http: reqwest::Client::new(),
+            cached_token: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+        })
+    }
+
+    pub(crate) async fn transcribe(
+        &self,
+        request: TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
+        let token = self.access_token().await?;
+        let language =
+            resolve_language(request.language, self.language.as_deref(), DEFAULT_LANGUAGE);
+
+        let mut config = serde_json::json!({
+            "languageCode": language,
+            "enableAutomaticPunctuation": true,
+            "model": self.model,
+        });
+        if let Some(encoding) = encoding_for(request.content_type) {
+            config["encoding"] = serde_json::json!(encoding);
+        }
+        if !request.keyterms.is_empty() {
+            config["speechContexts"] = serde_json::json!([{
+                "phrases": request.keyterms,
+                "boost": PHRASE_BOOST,
+            }]);
+        }
+
+        let body = serde_json::json!({
+            "config": config,
+            "audio": { "content": base64::engine::general_purpose::STANDARD.encode(&request.audio) },
+        });
+
+        let response = self
+            .http
+            .post(ENDPOINT)
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(transport)?;
+
+        let body: RecognizeBody = ensure_ok(response).await?.json().await.map_err(decode)?;
+        Ok(joined_transcript(&body))
+    }
+
+    /// A cached access token, minting a new one when absent or near expiry.
+    async fn access_token(&self) -> Result<String, SttError> {
+        let mut cached = self.cached_token.lock().await;
+        if let Some(token) = cached.as_ref() {
+            if SystemTime::now() < token.expires_at {
+                return Ok(token.value.clone());
+            }
+        }
+
+        let assertion = self.signed_assertion()?;
+        let response = self
+            .http
+            .post(&self.service_account.token_uri)
+            .form(&[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+                ("assertion", &assertion),
+            ])
+            .send()
+            .await
+            .map_err(transport)?;
+        let token: TokenResponse = ensure_ok(response).await?.json().await.map_err(decode)?;
+
+        let lifetime = Duration::from_secs(token.expires_in.max(60));
+        *cached = Some(CachedToken {
+            value: token.access_token.clone(),
+            expires_at: SystemTime::now() + lifetime.saturating_sub(TOKEN_SKEW),
+        });
+        Ok(token.access_token)
+    }
+
+    fn signed_assertion(&self) -> Result<String, SttError> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| SttError::Provider(format!("system clock before epoch: {e}")))?
+            .as_secs();
+        let claims = JwtClaims {
+            iss: &self.service_account.client_email,
+            scope: SCOPE,
+            aud: &self.service_account.token_uri,
+            iat: now,
+            exp: now + 3600,
+        };
+        let key =
+            jsonwebtoken::EncodingKey::from_rsa_pem(self.service_account.private_key.as_bytes())
+                .map_err(|e| {
+                    SttError::Provider(format!("service-account private key is unusable: {e}"))
+                })?;
+        jsonwebtoken::encode(
+            &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
+            &claims,
+            &key,
+        )
+        .map_err(|e| SttError::Provider(format!("could not sign the auth assertion: {e}")))
+    }
+}
+
+/// Google wants the container named when it cannot infer one. Formats whose
+/// headers already describe the stream are left unset, which is what the API
+/// documents as the safe default.
+fn encoding_for(content_type: &str) -> Option<&'static str> {
+    match content_type.split(';').next().unwrap_or("").trim() {
+        "audio/webm" => Some("WEBM_OPUS"),
+        "audio/ogg" => Some("OGG_OPUS"),
+        "audio/mpeg" => Some("MP3"),
+        "audio/flac" => Some("FLAC"),
+        _ => None,
+    }
+}
+
+/// Google splits long audio into consecutive results; the transcript is their
+/// concatenation, each with its own best alternative.
+fn joined_transcript(body: &RecognizeBody) -> String {
+    body.results
+        .iter()
+        .filter_map(|r| r.alternatives.first())
+        .map(|a| a.transcript.trim())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> RecognizeBody {
+        serde_json::from_str(json).expect("valid Google body")
+    }
+
+    #[test]
+    fn concatenates_consecutive_results() {
+        let body = parse(
+            r#"{"results":[
+                {"alternatives":[{"transcript":"run cargo clippy"}]},
+                {"alternatives":[{"transcript":"across the workspace"}]}]}"#,
+        );
+        assert_eq!(
+            joined_transcript(&body),
+            "run cargo clippy across the workspace"
+        );
+    }
+
+    #[test]
+    fn takes_only_the_best_alternative_of_each_result() {
+        let body = parse(
+            r#"{"results":[{"alternatives":[
+                {"transcript":"clippy"},{"transcript":"clippie"}]}]}"#,
+        );
+        assert_eq!(joined_transcript(&body), "clippy");
+    }
+
+    #[test]
+    fn silence_yields_an_empty_transcript() {
+        assert_eq!(joined_transcript(&parse(r#"{"results":[]}"#)), "");
+        assert_eq!(joined_transcript(&parse(r#"{}"#)), "");
+    }
+
+    #[test]
+    fn browser_containers_are_named_explicitly() {
+        assert_eq!(encoding_for("audio/webm;codecs=opus"), Some("WEBM_OPUS"));
+        assert_eq!(encoding_for("audio/ogg"), Some("OGG_OPUS"));
+        // WAV carries its own header; Google infers it.
+        assert_eq!(encoding_for("audio/wav"), None);
+    }
+
+    #[test]
+    fn google_requires_a_service_account() {
+        let env = SttEnv {
+            api_key: Some("k".into()),
+            ..Default::default()
+        };
+        let err = crate::config_error(GoogleStt::from_env(&env));
+        assert!(err.contains("PORTAL_STT_SERVICE_ACCOUNT_PATH"), "{err}");
+    }
+
+    #[test]
+    fn a_missing_service_account_file_is_reported_with_its_path() {
+        let env = SttEnv {
+            service_account_path: Some("/nonexistent/sa.json".into()),
+            ..Default::default()
+        };
+        let err = crate::config_error(GoogleStt::from_env(&env));
+        assert!(err.contains("/nonexistent/sa.json"), "{err}");
+    }
+}

--- a/portal-stt/src/providers/ibm.rs
+++ b/portal-stt/src/providers/ibm.rs
@@ -1,0 +1,163 @@
+//! IBM Watson Speech to Text (`/v1/recognize`).
+//!
+//! Raw audio body, HTTP Basic auth with the literal username `apikey`. The
+//! service URL is per-instance, so `PORTAL_STT_ENDPOINT` is required — there is
+//! no global host to default to.
+//!
+//! **Keyterms are not sent.** Watson's `keywords` parameter is keyword
+//! *spotting* — it reports where listed words occur, it does not bias decoding
+//! — so passing keyterms there would cost request size and change nothing about
+//! the transcript. Watson's real biasing is a trained custom language model,
+//! selected through `PORTAL_STT_MODEL`.
+
+use base64::Engine;
+use serde::Deserialize;
+
+use crate::config::{resolve_language, Field, SttEnv};
+use crate::http::{decode, ensure_ok, transport};
+use crate::{SttError, TranscribeRequest};
+
+/// Watson names models `{language}_{variant}`, so the language selection is
+/// folded into the model rather than being a separate parameter.
+const DEFAULT_MODEL_SUFFIX: &str = "_Multimedia";
+const DEFAULT_LANGUAGE: &str = "en-US";
+
+#[derive(Clone)]
+pub(crate) struct IbmStt {
+    api_key: String,
+    endpoint: String,
+    model: Option<String>,
+    language: Option<String>,
+    http: reqwest::Client,
+}
+
+#[derive(Deserialize)]
+struct RecognizeBody {
+    #[serde(default)]
+    results: Vec<RecognizeResult>,
+}
+
+#[derive(Deserialize)]
+struct RecognizeResult {
+    #[serde(default)]
+    alternatives: Vec<RecognizeAlternative>,
+}
+
+#[derive(Deserialize)]
+struct RecognizeAlternative {
+    #[serde(default)]
+    transcript: String,
+}
+
+impl IbmStt {
+    pub(crate) fn from_env(env: &SttEnv) -> anyhow::Result<Self> {
+        Ok(Self {
+            api_key: env.require(Field::ApiKey, "ibm")?,
+            endpoint: env
+                .require(Field::Endpoint, "ibm")?
+                .trim_end_matches('/')
+                .to_string(),
+            model: env.model.clone(),
+            language: env.language.clone(),
+            http: reqwest::Client::new(),
+        })
+    }
+
+    pub(crate) async fn transcribe(
+        &self,
+        request: TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
+        let language =
+            resolve_language(request.language, self.language.as_deref(), DEFAULT_LANGUAGE);
+        let model = self
+            .model
+            .clone()
+            .unwrap_or_else(|| format!("{language}{DEFAULT_MODEL_SUFFIX}"));
+
+        let response = self
+            .http
+            .post(format!("{}/v1/recognize", self.endpoint))
+            .query(&[("model", model.as_str()), ("smart_formatting", "true")])
+            .header(reqwest::header::AUTHORIZATION, self.basic_auth())
+            .header(reqwest::header::CONTENT_TYPE, request.content_type)
+            .body(request.audio)
+            .send()
+            .await
+            .map_err(transport)?;
+
+        let body: RecognizeBody = ensure_ok(response).await?.json().await.map_err(decode)?;
+        Ok(joined_transcript(&body))
+    }
+
+    /// Watson uses Basic auth with a fixed username and the API key as the
+    /// password.
+    fn basic_auth(&self) -> String {
+        let raw = format!("apikey:{}", self.api_key);
+        format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD.encode(raw)
+        )
+    }
+}
+
+fn joined_transcript(body: &RecognizeBody) -> String {
+    body.results
+        .iter()
+        .filter_map(|r| r.alternatives.first())
+        .map(|a| a.transcript.trim())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> RecognizeBody {
+        serde_json::from_str(json).expect("valid Watson body")
+    }
+
+    #[test]
+    fn concatenates_result_alternatives() {
+        let body = parse(
+            r#"{"results":[
+                {"final":true,"alternatives":[{"transcript":"run cargo clippy "}]},
+                {"final":true,"alternatives":[{"transcript":"on the branch"}]}]}"#,
+        );
+        assert_eq!(joined_transcript(&body), "run cargo clippy on the branch");
+    }
+
+    #[test]
+    fn silence_yields_an_empty_transcript() {
+        assert_eq!(joined_transcript(&parse(r#"{"results":[]}"#)), "");
+    }
+
+    #[test]
+    fn ibm_requires_its_per_instance_url() {
+        let env = SttEnv {
+            api_key: Some("k".into()),
+            ..Default::default()
+        };
+        let err = crate::config_error(IbmStt::from_env(&env));
+        assert!(err.contains("PORTAL_STT_ENDPOINT"), "{err}");
+    }
+
+    #[test]
+    fn credentials_are_sent_as_basic_auth_under_the_apikey_user() {
+        let provider = IbmStt::from_env(&SttEnv {
+            api_key: Some("secret".into()),
+            endpoint: Some("https://api.example.invalid/instances/1/".into()),
+            ..Default::default()
+        })
+        .expect("configured");
+
+        assert_eq!(provider.endpoint, "https://api.example.invalid/instances/1");
+        let header = provider.basic_auth();
+        let encoded = header.strip_prefix("Basic ").expect("basic scheme");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .expect("valid base64");
+        assert_eq!(String::from_utf8(decoded).unwrap(), "apikey:secret");
+    }
+}

--- a/portal-stt/src/providers/mod.rs
+++ b/portal-stt/src/providers/mod.rs
@@ -1,8 +1,22 @@
 //! One module per speech-to-text vendor.
 //!
-//! Each provides a struct with `new(..)` and an inherent `transcribe`; the
+//! Each exposes a struct with `from_env(&SttEnv)` and an inherent `transcribe`;
 //! dispatch lives on [`crate::SttProvider`] so the set stays closed and
 //! exhaustively matched.
+//!
+//! The vendors do not share a request shape — single-shot multipart (OpenAI,
+//! Azure), raw body (Deepgram, IBM), base64-in-JSON (Google, Simplismart), and
+//! submit-then-poll jobs (AssemblyAI, Rev AI, Speechmatics, AWS) — which is why
+//! the common parts live in `crate::http` and `crate::poll` rather than in a
+//! shared base type.
 
+pub(crate) mod assemblyai;
+pub(crate) mod aws;
+pub(crate) mod azure;
 pub(crate) mod deepgram;
+pub(crate) mod google;
+pub(crate) mod ibm;
 pub(crate) mod openai;
+pub(crate) mod revai;
+pub(crate) mod simplismart;
+pub(crate) mod speechmatics;

--- a/portal-stt/src/providers/openai.rs
+++ b/portal-stt/src/providers/openai.rs
@@ -7,15 +7,20 @@
 
 use serde::Deserialize;
 
+use crate::config::{Field, SttEnv};
+use crate::http::{decode, ensure_ok, transport};
 use crate::{extension_for, SttError, TranscribeRequest};
 
-const ENDPOINT: &str = "https://api.openai.com/v1/audio/transcriptions";
+const DEFAULT_ENDPOINT: &str = "https://api.openai.com";
 const DEFAULT_MODEL: &str = "gpt-4o-transcribe";
 
 #[derive(Clone)]
-pub struct OpenAiStt {
+pub(crate) struct OpenAiStt {
     api_key: String,
     model: String,
+    /// Overridable for OpenAI-compatible gateways and self-hosted Whisper.
+    endpoint: String,
+    language: Option<String>,
     /// Owned per provider, matching the push transports — a `Client` is a
     /// connection pool, so it must outlive individual requests.
     http: reqwest::Client,
@@ -27,15 +32,20 @@ struct TranscriptionBody {
 }
 
 impl OpenAiStt {
-    pub fn new(api_key: String, model: Option<String>) -> Self {
-        Self {
-            api_key,
-            model: model.unwrap_or_else(|| DEFAULT_MODEL.to_string()),
+    pub(crate) fn from_env(env: &SttEnv) -> anyhow::Result<Self> {
+        Ok(Self {
+            api_key: env.require(Field::ApiKey, "openai")?,
+            model: env.model_or(DEFAULT_MODEL),
+            endpoint: env.endpoint_or(DEFAULT_ENDPOINT),
+            language: env.language.clone(),
             http: reqwest::Client::new(),
-        }
+        })
     }
 
-    pub async fn transcribe(&self, request: TranscribeRequest<'_>) -> Result<String, SttError> {
+    pub(crate) async fn transcribe(
+        &self,
+        request: TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
         let filename = format!("audio.{}", extension_for(request.content_type));
         let part = reqwest::multipart::Part::bytes(request.audio.to_vec())
             .file_name(filename)
@@ -46,7 +56,7 @@ impl OpenAiStt {
             .text("model", self.model.clone())
             .text("response_format", "json")
             .part("file", part);
-        if let Some(language) = request.language {
+        if let Some(language) = request.language.or(self.language.as_deref()) {
             form = form.text("language", language.to_string());
         }
         if let Some(prompt) = bias_prompt(request.keyterms) {
@@ -55,26 +65,14 @@ impl OpenAiStt {
 
         let response = self
             .http
-            .post(ENDPOINT)
+            .post(format!("{}/v1/audio/transcriptions", self.endpoint))
             .bearer_auth(&self.api_key)
             .multipart(form)
             .send()
             .await
-            .map_err(|e| SttError::Transport(e.to_string()))?;
+            .map_err(transport)?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(SttError::Provider(format!(
-                "HTTP {status}: {}",
-                body.chars().take(400).collect::<String>()
-            )));
-        }
-
-        let body: TranscriptionBody = response
-            .json()
-            .await
-            .map_err(|e| SttError::Decode(e.to_string()))?;
+        let body: TranscriptionBody = ensure_ok(response).await?.json().await.map_err(decode)?;
         Ok(body.text.trim().to_string())
     }
 }
@@ -113,9 +111,28 @@ mod tests {
 
     #[test]
     fn the_default_model_is_used_when_none_is_configured() {
-        let provider = OpenAiStt::new("k".to_string(), None);
-        assert_eq!(provider.model, DEFAULT_MODEL);
-        let overridden = OpenAiStt::new("k".to_string(), Some("whisper-1".to_string()));
-        assert_eq!(overridden.model, "whisper-1");
+        let env = SttEnv {
+            api_key: Some("k".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            OpenAiStt::from_env(&env).expect("configured").model,
+            DEFAULT_MODEL
+        );
+
+        let overridden = SttEnv {
+            model: Some("whisper-1".into()),
+            ..env.clone()
+        };
+        assert_eq!(
+            OpenAiStt::from_env(&overridden).expect("configured").model,
+            "whisper-1"
+        );
+    }
+
+    #[test]
+    fn openai_requires_a_key() {
+        let err = crate::config_error(OpenAiStt::from_env(&SttEnv::default()));
+        assert!(err.contains("PORTAL_STT_API_KEY"), "{err}");
     }
 }

--- a/portal-stt/src/providers/revai.rs
+++ b/portal-stt/src/providers/revai.rs
@@ -1,0 +1,191 @@
+//! Rev AI — submit a job, poll it, fetch the transcript.
+//!
+//! Unlike AssemblyAI the audio is posted directly with the job (multipart), and
+//! the finished transcript is a separate fetch rather than a field on the
+//! status. Keyterms map onto `custom_vocabularies`.
+
+use serde::Deserialize;
+
+use crate::config::{Field, SttEnv};
+use crate::http::{decode, ensure_ok, transport};
+use crate::poll::{poll_job, JobState, DEFAULT_TIMEOUT};
+use crate::{extension_for, SttError, TranscribeRequest};
+
+const DEFAULT_ENDPOINT: &str = "https://api.rev.ai";
+
+#[derive(Clone)]
+pub(crate) struct RevAiStt {
+    api_key: String,
+    endpoint: String,
+    language: Option<String>,
+    http: reqwest::Client,
+}
+
+#[derive(Deserialize)]
+struct JobBody {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct JobStatusBody {
+    status: String,
+    #[serde(default)]
+    failure_detail: Option<String>,
+    #[serde(default)]
+    failure: Option<String>,
+}
+
+impl RevAiStt {
+    pub(crate) fn from_env(env: &SttEnv) -> anyhow::Result<Self> {
+        Ok(Self {
+            api_key: env.require(Field::ApiKey, "revai")?,
+            endpoint: env.endpoint_or(DEFAULT_ENDPOINT),
+            language: env.language.clone(),
+            http: reqwest::Client::new(),
+        })
+    }
+
+    pub(crate) async fn transcribe(
+        &self,
+        request: TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
+        let job_id = self.submit(&request).await?;
+
+        poll_job("revai", DEFAULT_TIMEOUT, || async {
+            let status = self.job_status(&job_id).await?;
+            Ok(classify(&status))
+        })
+        .await?;
+
+        self.fetch_transcript(&job_id).await
+    }
+
+    async fn submit(&self, request: &TranscribeRequest<'_>) -> Result<String, SttError> {
+        let mut options = serde_json::json!({ "skip_diarization": true });
+        if !request.keyterms.is_empty() {
+            options["custom_vocabularies"] = serde_json::json!([{ "phrases": request.keyterms }]);
+        }
+        if let Some(language) = &self.language {
+            options["language"] = serde_json::json!(language);
+        }
+
+        let media = reqwest::multipart::Part::bytes(request.audio.to_vec())
+            .file_name(format!("audio.{}", extension_for(request.content_type)))
+            .mime_str(request.content_type)
+            .map_err(|e| SttError::Provider(format!("unsupported audio content type: {e}")))?;
+        let form = reqwest::multipart::Form::new()
+            .part("media", media)
+            .text("options", options.to_string());
+
+        let response = self
+            .http
+            .post(format!("{}/speechtotext/v1/jobs", self.endpoint))
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(transport)?;
+        let body: JobBody = ensure_ok(response).await?.json().await.map_err(decode)?;
+        Ok(body.id)
+    }
+
+    async fn job_status(&self, job_id: &str) -> Result<JobStatusBody, SttError> {
+        let response = self
+            .http
+            .get(format!("{}/speechtotext/v1/jobs/{job_id}", self.endpoint))
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .map_err(transport)?;
+        ensure_ok(response).await?.json().await.map_err(decode)
+    }
+
+    /// Rev AI serves the transcript as JSON by default; `text/plain` asks for
+    /// the flat text, which is all we want.
+    async fn fetch_transcript(&self, job_id: &str) -> Result<String, SttError> {
+        let response = self
+            .http
+            .get(format!(
+                "{}/speechtotext/v1/jobs/{job_id}/transcript",
+                self.endpoint
+            ))
+            .bearer_auth(&self.api_key)
+            .header(reqwest::header::ACCEPT, "text/plain")
+            .send()
+            .await
+            .map_err(transport)?;
+        let text = ensure_ok(response).await?.text().await.map_err(decode)?;
+        Ok(text.trim().to_string())
+    }
+}
+
+/// `transcribed` is Rev AI's success state; `failed` is terminal. Anything else
+/// (`in_progress`, or a state added later) means keep waiting.
+fn classify(status: &JobStatusBody) -> JobState<()> {
+    match status.status.as_str() {
+        "transcribed" => JobState::Done(()),
+        "failed" => JobState::Failed(
+            status
+                .failure_detail
+                .clone()
+                .or_else(|| status.failure.clone())
+                .unwrap_or_else(|| "no reason given".to_string()),
+        ),
+        _ => JobState::Pending,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> JobStatusBody {
+        serde_json::from_str(json).expect("valid Rev AI status")
+    }
+
+    #[test]
+    fn a_transcribed_job_is_done() {
+        assert!(matches!(
+            classify(&parse(r#"{"status":"transcribed"}"#)),
+            JobState::Done(())
+        ));
+    }
+
+    #[test]
+    fn in_progress_keeps_polling() {
+        assert!(matches!(
+            classify(&parse(r#"{"status":"in_progress"}"#)),
+            JobState::Pending
+        ));
+    }
+
+    /// Rev AI reports the reason in `failure_detail`, falling back to the
+    /// coarser `failure` code when the detail is absent.
+    #[test]
+    fn a_failed_job_prefers_the_detailed_reason() {
+        let state = classify(&parse(
+            r#"{"status":"failed","failure":"download_failure",
+                "failure_detail":"could not decode audio"}"#,
+        ));
+        match state {
+            JobState::Failed(reason) => assert_eq!(reason, "could not decode audio"),
+            _ => panic!("expected failure"),
+        }
+
+        let coarse = classify(&parse(
+            r#"{"status":"failed","failure":"internal_processing"}"#,
+        ));
+        match coarse {
+            JobState::Failed(reason) => assert_eq!(reason, "internal_processing"),
+            _ => panic!("expected failure"),
+        }
+    }
+
+    #[test]
+    fn a_failure_with_no_reason_still_reports_something() {
+        match classify(&parse(r#"{"status":"failed"}"#)) {
+            JobState::Failed(reason) => assert!(!reason.is_empty()),
+            _ => panic!("expected failure"),
+        }
+    }
+}

--- a/portal-stt/src/providers/revai.rs
+++ b/portal-stt/src/providers/revai.rs
@@ -4,7 +4,7 @@
 //! the finished transcript is a separate fetch rather than a field on the
 //! status. Keyterms map onto `custom_vocabularies`.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{Field, SttEnv};
 use crate::http::{decode, ensure_ok, transport};
@@ -19,6 +19,21 @@ pub(crate) struct RevAiStt {
     endpoint: String,
     language: Option<String>,
     http: reqwest::Client,
+}
+
+/// The `options` part of the multipart submit.
+#[derive(Serialize)]
+struct JobOptions<'a> {
+    skip_diarization: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    custom_vocabularies: Option<[CustomVocabulary<'a>; 1]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    language: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct CustomVocabulary<'a> {
+    phrases: &'a [String],
 }
 
 #[derive(Deserialize)]
@@ -61,13 +76,15 @@ impl RevAiStt {
     }
 
     async fn submit(&self, request: &TranscribeRequest<'_>) -> Result<String, SttError> {
-        let mut options = serde_json::json!({ "skip_diarization": true });
-        if !request.keyterms.is_empty() {
-            options["custom_vocabularies"] = serde_json::json!([{ "phrases": request.keyterms }]);
-        }
-        if let Some(language) = &self.language {
-            options["language"] = serde_json::json!(language);
-        }
+        let options = JobOptions {
+            skip_diarization: true,
+            custom_vocabularies: (!request.keyterms.is_empty()).then_some([CustomVocabulary {
+                phrases: request.keyterms,
+            }]),
+            language: self.language.as_deref(),
+        };
+        let options = serde_json::to_string(&options)
+            .map_err(|e| SttError::Provider(format!("could not encode request: {e}")))?;
 
         let media = reqwest::multipart::Part::bytes(request.audio.to_vec())
             .file_name(format!("audio.{}", extension_for(request.content_type)))
@@ -75,7 +92,7 @@ impl RevAiStt {
             .map_err(|e| SttError::Provider(format!("unsupported audio content type: {e}")))?;
         let form = reqwest::multipart::Form::new()
             .part("media", media)
-            .text("options", options.to_string());
+            .text("options", options);
 
         let response = self
             .http

--- a/portal-stt/src/providers/simplismart.rs
+++ b/portal-stt/src/providers/simplismart.rs
@@ -9,7 +9,7 @@
 //! initial-prompt parameter, so there is nowhere to put them.
 
 use base64::Engine;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{resolve_language, Field, SttEnv};
 use crate::http::{decode, ensure_ok, transport};
@@ -26,6 +26,14 @@ pub(crate) struct SimplismartStt {
     endpoint: String,
     language: Option<String>,
     http: reqwest::Client,
+}
+
+/// Request body: the audio travels base64-encoded inside the JSON.
+#[derive(Serialize)]
+struct InferRequest {
+    audio_data: String,
+    language: String,
+    task: &'static str,
 }
 
 #[derive(Deserialize)]
@@ -51,11 +59,11 @@ impl SimplismartStt {
     ) -> Result<String, SttError> {
         let language =
             resolve_language(request.language, self.language.as_deref(), DEFAULT_LANGUAGE);
-        let body = serde_json::json!({
-            "audio_data": base64::engine::general_purpose::STANDARD.encode(&request.audio),
-            "language": bare_language(&language),
-            "task": "transcribe",
-        });
+        let body = InferRequest {
+            audio_data: base64::engine::general_purpose::STANDARD.encode(&request.audio),
+            language: bare_language(&language),
+            task: "transcribe",
+        };
 
         let response = self
             .http

--- a/portal-stt/src/providers/simplismart.rs
+++ b/portal-stt/src/providers/simplismart.rs
@@ -1,0 +1,140 @@
+//! Simplismart / SimpliScribe — a finetuned Whisper behind a JSON endpoint.
+//!
+//! Audio goes up base64-encoded inside the JSON body rather than as bytes or a
+//! multipart part. The host is deployment-specific, so `PORTAL_STT_ENDPOINT`
+//! overrides the published default — self-hosted and dedicated deployments each
+//! get their own.
+//!
+//! **Keyterms are not sent**: the inference API exposes no vocabulary or
+//! initial-prompt parameter, so there is nowhere to put them.
+
+use base64::Engine;
+use serde::Deserialize;
+
+use crate::config::{resolve_language, Field, SttEnv};
+use crate::http::{decode, ensure_ok, transport};
+use crate::{SttError, TranscribeRequest};
+
+const DEFAULT_ENDPOINT: &str = "https://http.whisper.proxy.prod.s9t.link";
+const PATH: &str = "/model/infer/whisper";
+/// Whisper takes a bare language code, not a BCP-47 tag with a region.
+const DEFAULT_LANGUAGE: &str = "en";
+
+#[derive(Clone)]
+pub(crate) struct SimplismartStt {
+    api_key: String,
+    endpoint: String,
+    language: Option<String>,
+    http: reqwest::Client,
+}
+
+#[derive(Deserialize)]
+struct InferBody {
+    /// Segments of the transcript, in order.
+    #[serde(default)]
+    transcription: Vec<String>,
+}
+
+impl SimplismartStt {
+    pub(crate) fn from_env(env: &SttEnv) -> anyhow::Result<Self> {
+        Ok(Self {
+            api_key: env.require(Field::ApiKey, "simplismart")?,
+            endpoint: env.endpoint_or(DEFAULT_ENDPOINT),
+            language: env.language.clone(),
+            http: reqwest::Client::new(),
+        })
+    }
+
+    pub(crate) async fn transcribe(
+        &self,
+        request: TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
+        let language =
+            resolve_language(request.language, self.language.as_deref(), DEFAULT_LANGUAGE);
+        let body = serde_json::json!({
+            "audio_data": base64::engine::general_purpose::STANDARD.encode(&request.audio),
+            "language": bare_language(&language),
+            "task": "transcribe",
+        });
+
+        let response = self
+            .http
+            .post(format!("{}{PATH}", self.endpoint))
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(transport)?;
+
+        let body: InferBody = ensure_ok(response).await?.json().await.map_err(decode)?;
+        Ok(joined_transcription(&body))
+    }
+}
+
+/// `en-US` → `en`. Whisper rejects region-qualified tags.
+fn bare_language(language: &str) -> String {
+    language
+        .split(['-', '_'])
+        .next()
+        .unwrap_or(language)
+        .to_ascii_lowercase()
+}
+
+fn joined_transcription(body: &InferBody) -> String {
+    body.transcription
+        .iter()
+        .map(|segment| segment.trim())
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> InferBody {
+        serde_json::from_str(json).expect("valid Simplismart body")
+    }
+
+    #[test]
+    fn joins_transcription_segments() {
+        let body = parse(r#"{"transcription":["run cargo clippy","across the workspace"]}"#);
+        assert_eq!(
+            joined_transcription(&body),
+            "run cargo clippy across the workspace"
+        );
+    }
+
+    #[test]
+    fn silence_yields_an_empty_transcript() {
+        assert_eq!(joined_transcription(&parse(r#"{"transcription":[]}"#)), "");
+        assert_eq!(joined_transcription(&parse(r#"{"language":"en"}"#)), "");
+    }
+
+    /// The rest of the portal speaks BCP-47; Whisper does not.
+    #[test]
+    fn region_qualified_tags_are_reduced_to_the_language() {
+        assert_eq!(bare_language("en-US"), "en");
+        assert_eq!(bare_language("pt_BR"), "pt");
+        assert_eq!(bare_language("FR"), "fr");
+    }
+
+    #[test]
+    fn the_published_host_is_the_default_and_is_overridable() {
+        let default = SimplismartStt::from_env(&SttEnv {
+            api_key: Some("k".into()),
+            ..Default::default()
+        })
+        .expect("configured");
+        assert_eq!(default.endpoint, DEFAULT_ENDPOINT);
+
+        let custom = SimplismartStt::from_env(&SttEnv {
+            api_key: Some("k".into()),
+            endpoint: Some("https://my-deployment.invalid".into()),
+            ..Default::default()
+        })
+        .expect("configured");
+        assert_eq!(custom.endpoint, "https://my-deployment.invalid");
+    }
+}

--- a/portal-stt/src/providers/speechmatics.rs
+++ b/portal-stt/src/providers/speechmatics.rs
@@ -1,0 +1,235 @@
+//! Speechmatics — submit a job, poll it, fetch the transcript.
+//!
+//! Same three-step shape as Rev AI, with the job configuration supplied as a
+//! JSON part alongside the audio. Keyterms map onto `additional_vocab`.
+
+use serde::Deserialize;
+
+use crate::config::{resolve_language, Field, SttEnv};
+use crate::http::{decode, ensure_ok, transport};
+use crate::poll::{poll_job, JobState, DEFAULT_TIMEOUT};
+use crate::{extension_for, SttError, TranscribeRequest};
+
+const DEFAULT_ENDPOINT: &str = "https://asr.api.speechmatics.com";
+/// Speechmatics takes a bare language code.
+const DEFAULT_LANGUAGE: &str = "en";
+/// `additional_vocab` is capped at 1000 entries by the API.
+const MAX_ADDITIONAL_VOCAB: usize = 1000;
+
+#[derive(Clone)]
+pub(crate) struct SpeechmaticsStt {
+    api_key: String,
+    endpoint: String,
+    language: Option<String>,
+    /// Operating point (`standard` / `enhanced`), when configured.
+    model: Option<String>,
+    http: reqwest::Client,
+}
+
+#[derive(Deserialize)]
+struct CreateJobBody {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct JobDetailsBody {
+    job: JobDetails,
+}
+
+#[derive(Deserialize)]
+struct JobDetails {
+    status: String,
+    #[serde(default)]
+    errors: Vec<JobError>,
+}
+
+#[derive(Deserialize)]
+struct JobError {
+    #[serde(default)]
+    message: String,
+}
+
+impl SpeechmaticsStt {
+    pub(crate) fn from_env(env: &SttEnv) -> anyhow::Result<Self> {
+        Ok(Self {
+            api_key: env.require(Field::ApiKey, "speechmatics")?,
+            endpoint: env.endpoint_or(DEFAULT_ENDPOINT),
+            language: env.language.clone(),
+            model: env.model.clone(),
+            http: reqwest::Client::new(),
+        })
+    }
+
+    pub(crate) async fn transcribe(
+        &self,
+        request: TranscribeRequest<'_>,
+    ) -> Result<String, SttError> {
+        let job_id = self.submit(&request).await?;
+
+        poll_job("speechmatics", DEFAULT_TIMEOUT, || async {
+            let details = self.job_details(&job_id).await?;
+            Ok(classify(&details.job))
+        })
+        .await?;
+
+        self.fetch_transcript(&job_id).await
+    }
+
+    async fn submit(&self, request: &TranscribeRequest<'_>) -> Result<String, SttError> {
+        let language =
+            resolve_language(request.language, self.language.as_deref(), DEFAULT_LANGUAGE);
+        let mut transcription_config = serde_json::json!({
+            "language": bare_language(&language),
+        });
+        if let Some(model) = &self.model {
+            transcription_config["operating_point"] = serde_json::json!(model);
+        }
+        if !request.keyterms.is_empty() {
+            let vocab: Vec<serde_json::Value> = request
+                .keyterms
+                .iter()
+                .take(MAX_ADDITIONAL_VOCAB)
+                .map(|term| serde_json::json!({ "content": term }))
+                .collect();
+            transcription_config["additional_vocab"] = serde_json::json!(vocab);
+        }
+        let config = serde_json::json!({
+            "type": "transcription",
+            "transcription_config": transcription_config,
+        });
+
+        let data_file = reqwest::multipart::Part::bytes(request.audio.to_vec())
+            .file_name(format!("audio.{}", extension_for(request.content_type)))
+            .mime_str(request.content_type)
+            .map_err(|e| SttError::Provider(format!("unsupported audio content type: {e}")))?;
+        let form = reqwest::multipart::Form::new()
+            .part("data_file", data_file)
+            .text("config", config.to_string());
+
+        let response = self
+            .http
+            .post(format!("{}/v2/jobs", self.endpoint))
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(transport)?;
+        let body: CreateJobBody = ensure_ok(response).await?.json().await.map_err(decode)?;
+        Ok(body.id)
+    }
+
+    async fn job_details(&self, job_id: &str) -> Result<JobDetailsBody, SttError> {
+        let response = self
+            .http
+            .get(format!("{}/v2/jobs/{job_id}", self.endpoint))
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .map_err(transport)?;
+        ensure_ok(response).await?.json().await.map_err(decode)
+    }
+
+    async fn fetch_transcript(&self, job_id: &str) -> Result<String, SttError> {
+        let response = self
+            .http
+            .get(format!("{}/v2/jobs/{job_id}/transcript", self.endpoint))
+            .query(&[("format", "txt")])
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .map_err(transport)?;
+        let text = ensure_ok(response).await?.text().await.map_err(decode)?;
+        Ok(text.trim().to_string())
+    }
+}
+
+fn bare_language(language: &str) -> String {
+    language
+        .split(['-', '_'])
+        .next()
+        .unwrap_or(language)
+        .to_ascii_lowercase()
+}
+
+/// `done` is success; `rejected` and `expired` are terminal. `running` — and
+/// any state added later — means keep waiting.
+fn classify(job: &JobDetails) -> JobState<()> {
+    match job.status.as_str() {
+        "done" => JobState::Done(()),
+        "rejected" | "expired" => JobState::Failed(job_error(job)),
+        _ => JobState::Pending,
+    }
+}
+
+fn job_error(job: &JobDetails) -> String {
+    let joined = job
+        .errors
+        .iter()
+        .map(|e| e.message.trim())
+        .filter(|m| !m.is_empty())
+        .collect::<Vec<_>>()
+        .join("; ");
+    if joined.is_empty() {
+        format!("job {}", job.status)
+    } else {
+        joined
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> JobDetailsBody {
+        serde_json::from_str(json).expect("valid Speechmatics body")
+    }
+
+    #[test]
+    fn a_done_job_is_complete() {
+        assert!(matches!(
+            classify(&parse(r#"{"job":{"id":"x","status":"done"}}"#).job),
+            JobState::Done(())
+        ));
+    }
+
+    #[test]
+    fn running_keeps_polling() {
+        assert!(matches!(
+            classify(&parse(r#"{"job":{"id":"x","status":"running"}}"#).job),
+            JobState::Pending
+        ));
+    }
+
+    #[test]
+    fn a_rejected_job_reports_its_errors() {
+        let body = parse(
+            r#"{"job":{"id":"x","status":"rejected",
+                "errors":[{"message":"unsupported audio"}]}}"#,
+        );
+        match classify(&body.job) {
+            JobState::Failed(reason) => assert_eq!(reason, "unsupported audio"),
+            _ => panic!("expected failure"),
+        }
+    }
+
+    /// A rejection with no error list still has to say something actionable.
+    #[test]
+    fn a_rejection_without_errors_names_the_status() {
+        let body = parse(r#"{"job":{"id":"x","status":"rejected"}}"#);
+        match classify(&body.job) {
+            JobState::Failed(reason) => assert_eq!(reason, "job rejected"),
+            _ => panic!("expected failure"),
+        }
+    }
+
+    #[test]
+    fn expired_jobs_are_terminal_rather_than_polled_forever() {
+        let body = parse(r#"{"job":{"id":"x","status":"expired"}}"#);
+        assert!(matches!(classify(&body.job), JobState::Failed(_)));
+    }
+
+    #[test]
+    fn region_qualified_tags_are_reduced() {
+        assert_eq!(bare_language("en-US"), "en");
+    }
+}

--- a/portal-stt/src/providers/speechmatics.rs
+++ b/portal-stt/src/providers/speechmatics.rs
@@ -3,7 +3,7 @@
 //! Same three-step shape as Rev AI, with the job configuration supplied as a
 //! JSON part alongside the audio. Keyterms map onto `additional_vocab`.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{resolve_language, Field, SttEnv};
 use crate::http::{decode, ensure_ok, transport};
@@ -24,6 +24,28 @@ pub(crate) struct SpeechmaticsStt {
     /// Operating point (`standard` / `enhanced`), when configured.
     model: Option<String>,
     http: reqwest::Client,
+}
+
+/// The `config` part of the multipart submit.
+#[derive(Serialize)]
+struct JobConfig<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    transcription_config: TranscriptionConfig<'a>,
+}
+
+#[derive(Serialize)]
+struct TranscriptionConfig<'a> {
+    language: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    operating_point: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    additional_vocab: Option<Vec<AdditionalVocab<'a>>>,
+}
+
+#[derive(Serialize)]
+struct AdditionalVocab<'a> {
+    content: &'a str,
 }
 
 #[derive(Deserialize)]
@@ -78,25 +100,25 @@ impl SpeechmaticsStt {
     async fn submit(&self, request: &TranscribeRequest<'_>) -> Result<String, SttError> {
         let language =
             resolve_language(request.language, self.language.as_deref(), DEFAULT_LANGUAGE);
-        let mut transcription_config = serde_json::json!({
-            "language": bare_language(&language),
-        });
-        if let Some(model) = &self.model {
-            transcription_config["operating_point"] = serde_json::json!(model);
-        }
-        if !request.keyterms.is_empty() {
-            let vocab: Vec<serde_json::Value> = request
-                .keyterms
-                .iter()
-                .take(MAX_ADDITIONAL_VOCAB)
-                .map(|term| serde_json::json!({ "content": term }))
-                .collect();
-            transcription_config["additional_vocab"] = serde_json::json!(vocab);
-        }
-        let config = serde_json::json!({
-            "type": "transcription",
-            "transcription_config": transcription_config,
-        });
+        let config = JobConfig {
+            kind: "transcription",
+            transcription_config: TranscriptionConfig {
+                language: bare_language(&language),
+                operating_point: self.model.as_deref(),
+                additional_vocab: (!request.keyterms.is_empty()).then(|| {
+                    request
+                        .keyterms
+                        .iter()
+                        .take(MAX_ADDITIONAL_VOCAB)
+                        .map(|term| AdditionalVocab {
+                            content: term.as_str(),
+                        })
+                        .collect()
+                }),
+            },
+        };
+        let config = serde_json::to_string(&config)
+            .map_err(|e| SttError::Provider(format!("could not encode request: {e}")))?;
 
         let data_file = reqwest::multipart::Part::bytes(request.audio.to_vec())
             .file_name(format!("audio.{}", extension_for(request.content_type)))
@@ -104,7 +126,7 @@ impl SpeechmaticsStt {
             .map_err(|e| SttError::Provider(format!("unsupported audio content type: {e}")))?;
         let form = reqwest::multipart::Form::new()
             .part("data_file", data_file)
-            .text("config", config.to_string());
+            .text("config", config);
 
         let response = self
             .http


### PR DESCRIPTION
Adds the remaining eight providers from the requested list, on top of the crate extracted in #1542: **AssemblyAI, Amazon Transcribe, Azure, Google Cloud, IBM Watson, Rev AI, Simplismart/SimpliScribe and Speechmatics**, joining OpenAI and Deepgram.

## They are not the same shape

That's the whole reason this needed a crate rather than more files in the backend:

| Shape | Providers |
|---|---|
| Single request | OpenAI, Deepgram, Azure, Google, IBM, Simplismart |
| Submit → poll → fetch | AssemblyAI, Rev AI, Speechmatics, AWS |

Four transcribe as an asynchronous *job*, so `poll.rs` drives submit-then-poll once with a bounded budget (the wait happens inside a request the browser is blocking on). **Amazon Transcribe has no synchronous API at all** — it stages audio in S3, starts a job, polls, then fetches from a presigned URL, and signs every call with SigV4. It is the only provider needing extra storage config (`PORTAL_STT_BUCKET`), and it cleans up the staged object whatever the outcome.

Auth diverges too: bearer tokens, `Ocp-Apim-Subscription-Key`, HTTP Basic under a literal `apikey` user, a service-account JWT exchanged for an access token (cached, so it isn't re-minted per utterance), and SigV4.

Rather than a variable per provider per field, there is one variable per *concept* (`PORTAL_STT_REGION`, `PORTAL_STT_BUCKET`, …) and each provider declares what it requires, so a missing value names both the variable and the provider that wanted it.

## Only six can actually bias

The keyterm biasing that motivated this work isn't universal. AssemblyAI (`word_boost`), Deepgram (`keyterm`), Google (`speechContexts`), OpenAI (`prompt`), Rev AI (`custom_vocabularies`) and Speechmatics (`additional_vocab`) take a per-request vocabulary. Azure, IBM and Simplismart need a trained model instead, and AWS needs a pre-created named vocabulary.

`SttProvider::supports_keyterms` is the single source of truth, and the backend now skips the session query entirely when the provider can't use the result. Each module documents *why* it can't, so nobody re-adds a dead parameter later.

`SttProvider` also became an opaque handle over a private enum — callers only need `key`/`supports_keyterms`/`transcribe`, and the closed exhaustively-matched set stays an internal guarantee instead of leaking every provider type.

## Verification

74 unit tests cover the pure parts: response parsing for all ten, job-status classification (including that an *unknown* status keeps polling rather than failing a job that was going to succeed), the polling driver under a paused clock, config requirements, and language/MIME mapping.

Unit tests can't prove a request is well-formed, so `stt-probe` sends real audio to the real API. Run against every provider with a deliberately invalid key, a `provider`-class error proves URL, headers and body reached the vendor and were understood:

| Provider | Result |
|---|---|
| OpenAI | 401 `invalid_api_key` |
| Deepgram | 401 `INVALID_AUTH` |
| AssemblyAI | 401 `Invalid API key` |
| Rev AI | 401 `Authorization has been denied` |
| Azure | 401 `invalid subscription key` |
| IBM | 401 `Unauthorized` |
| Speechmatics | 401 `Authorization Required` |
| AWS | S3 parsed the SigV4 header and returned `InvalidAccessKeyId` — a signature error would have meant a bad canonical request |
| Google | RS256 assertion accepted structurally; `invalid_grant: account not found` |

**Simplismart is the exception and is unverified.** Its published host resolves but fails the TLS handshake from here, so I could only implement it to the documented contract (base64-in-JSON, `transcription` array). The endpoint is overridable, which it needs to be anyway since deployments are per-tenant. Worth a real key before trusting it.

Workspace suite green (29 binaries), clippy clean, WASM builds.
