### PR TITLE
Record and transcribe voice server-side when a provider is set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -963,6 +963,15 @@ and AWS needs a pre-created named vocabulary. The backend skips building hints
 when the provider cannot use them, so don't add a caller that assumes they are
 always sent.
 
+**The browser picks its capture path from `AppConfig::stt_enabled`.**
+`frontend/src/components/voice_input.rs` holds both strategies behind one
+button: `MediaRecorder` → `POST /api/stt/transcribe` when a provider is
+configured, and the Web Speech API otherwise. The iOS singleton/permission-race
+workarounds in that file apply to the **browser** path only — the recorder has
+neither problem, and it works in Firefox, which has no Web Speech API at all.
+The flag is threaded `use_dashboard_bootstrap` → `page.rs` → `SessionView` →
+`InputBar` → `VoiceInput`, the same way `archive_enabled` is.
+
 **Verify a provider with the probe, not by reasoning about it.** Network code
 cannot be unit-tested, so `cargo run -p portal-stt --bin stt-probe` sends real
 audio (or a generated moment of silence) to the real API. With a deliberately

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -55,6 +55,14 @@ web-sys = { workspace = true, features = [
     "File",
     "FileList",
     "Blob",
+    # Recording audio for server-side speech-to-text. MediaRecorder works in
+    # every browser we target, including Firefox, where the Web Speech API the
+    # browser-native path uses does not exist at all.
+    "MediaRecorder",
+    "MediaRecorderOptions",
+    "BlobEvent",
+    "MediaStream",
+    "MediaStreamTrack",
     # Audio APIs for ADSR synthesis (voice input uses Web Speech API directly via js-sys)
     "AudioContext",
     "AudioContextState",

--- a/frontend/src/components/voice_input.rs
+++ b/frontend/src/components/voice_input.rs
@@ -1,12 +1,23 @@
 //! Voice Input Component
 //!
-//! Browser-native voice input using the Web Speech API (`SpeechRecognition` /
-//! `webkitSpeechRecognition`). Recognition runs entirely in the user's browser;
-//! the backend is not involved.
+//! Two capture strategies behind one button, chosen by `server_stt` (which the
+//! dashboard sets from `AppConfig::stt_enabled`):
 //!
-//! When the API is not available (e.g. Firefox), the button is rendered in a
-//! greyed-out unsupported state. Hovering shows a native tooltip and clicking
-//! pops a short hint explaining the browser limitation.
+//! * **Server** — record the utterance with `MediaRecorder` and POST it to
+//!   `/api/stt/transcribe`. Works in every browser we target, and the server
+//!   biases the recognizer with the session's vocabulary, which is the whole
+//!   reason to prefer it.
+//! * **Browser** — the Web Speech API (`SpeechRecognition` /
+//!   `webkitSpeechRecognition`), used when no provider is configured. Needs no
+//!   credentials, but is unavailable in Firefox and cannot be told about
+//!   project-specific words.
+//!
+//! When neither is available the button renders greyed-out. Hovering shows a
+//! native tooltip and clicking pops a short hint explaining why.
+//!
+//! The iOS workarounds below apply to the **browser** path only — the
+//! recorder has no singleton constraint and no prompt race, which is a second
+//! reason to prefer the server path where it is available.
 //!
 //! iOS-specific behavior (see #840): iOS WebKit allows only one active
 //! `SpeechRecognition` per page, and races the permission prompt against
@@ -16,16 +27,28 @@
 //! session can't start until the previous one's `onend` has fired.
 
 use gloo::timers::callback::Timeout;
-use js_sys::{Array, Function, Object, Promise, Reflect};
+use js_sys::{Array, Function, Object, Promise, Reflect, Uint8Array};
+use shared::api::TranscriptionResponse;
+use uuid::Uuid;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::{spawn_local, JsFuture};
+use web_sys::{Blob, BlobEvent, MediaRecorder, MediaRecorderOptions, MediaStream};
 use yew::prelude::*;
+
+use crate::utils;
 
 const UNSUPPORTED_HINT: &str = "Voice input needs the Web Speech API. Try Chrome, Edge, or Safari.";
 const BUSY_HINT: &str = "Voice recognizer is busy — wait a moment and tap again.";
 const MIC_DENIED_HINT: &str =
     "Microphone permission was denied. Enable it in your browser settings and try again.";
+const RECORDING_UNSUPPORTED_HINT: &str =
+    "This browser cannot record audio, so voice input is unavailable.";
+
+/// Container preferences for the recording, best first. Chromium and Firefox
+/// take Opus in WebM; Safari records MP4/AAC. An empty tail lets the browser
+/// pick when it likes none of these.
+const PREFERRED_MIME_TYPES: &[&str] = &["audio/webm;codecs=opus", "audio/webm", "audio/mp4"];
 
 /// Return the `SpeechRecognition` (or `webkitSpeechRecognition`) constructor if
 /// available on the current `window`.
@@ -130,11 +153,29 @@ pub struct VoiceInputProps {
     /// Optional NodeRef to attach to the button for programmatic control
     #[prop_or_default]
     pub button_ref: Option<NodeRef>,
+    /// Record locally and transcribe on the server rather than using the
+    /// browser's recognizer. Set from `AppConfig::stt_enabled`.
+    #[prop_or(false)]
+    pub server_stt: bool,
+    /// Session the recording belongs to. Sent with the audio so the server can
+    /// bias the recognizer toward this session's vocabulary; without it the
+    /// transcript is still returned, just less accurate on project-specific
+    /// words.
+    #[prop_or_default]
+    pub session_id: Option<Uuid>,
 }
 
 pub enum VoiceInputMsg {
     ToggleRecording,
     SessionStarted(ActiveSession),
+    /// The recorder is live (server path).
+    RecordingStarted(ServerRecording),
+    /// The recorder flushed its final chunk: `(audio, content type)`.
+    AudioReady(Vec<u8>, String),
+    /// The server returned a transcript. Empty means silence, which is not an
+    /// error — the user simply said nothing.
+    Transcribed(String),
+    TranscribeFailed(String),
     StartFailed(StartFailure),
     Final(String),
     Interim(String),
@@ -163,12 +204,56 @@ const STOP_WATCHDOG_MS: u32 = 1500;
 /// holding the mic indicator on iOS.
 const MAX_SESSION_MS: u32 = 60_000;
 
+/// How long to wait after `MediaRecorder::stop()` for the final chunk before
+/// declaring the recording lost. Assembling a blob is fast; this only has to
+/// beat a wedged recorder, and it deliberately does not cover the upload,
+/// which can legitimately take seconds.
+const RECORDER_FLUSH_WATCHDOG_MS: u32 = 3000;
+
 /// Reasons the async start path can bail before a session is established.
 pub enum StartFailure {
     /// The user denied mic permission (or the browser blocked it).
     PermissionDenied,
     /// Anything else — surfaced to the parent via `on_error`.
     Other(String),
+}
+
+/// The in-flight capture. Only one strategy is ever active — which one is
+/// fixed by `server_stt` — so making them alternatives rather than two
+/// independent slots keeps "recording" a single question.
+enum Capture {
+    /// Browser-native recognition.
+    Browser(ActiveSession),
+    /// Local recording, transcribed by the server.
+    Server(ServerRecording),
+}
+
+/// Owns the `MediaRecorder`, the microphone stream and the event closures for
+/// one recording, plus the chunks delivered so far.
+///
+/// Dropping it stops the recorder and releases the microphone. Note the
+/// ordering constraint that follows: after `stop()` the browser still has to
+/// deliver `dataavailable` and `stop`, so this must stay alive until the audio
+/// has actually arrived — see `VoiceInputMsg::AudioReady`.
+pub struct ServerRecording {
+    recorder: MediaRecorder,
+    mic_stream: JsValue,
+    /// Container the browser actually chose, which is what the upload declares.
+    mime_type: String,
+    /// Chunks delivered by `dataavailable`, assembled on stop.
+    chunk_store: Array,
+    _on_data: Closure<dyn FnMut(BlobEvent)>,
+    _on_stop: Closure<dyn FnMut(JsValue)>,
+    _on_error: Closure<dyn FnMut(JsValue)>,
+}
+
+impl Drop for ServerRecording {
+    fn drop(&mut self) {
+        // `stop()` on an already-inactive recorder throws; ignore it, the point
+        // is only that it is not left running.
+        let _ = self.recorder.stop();
+        stop_media_stream(&self.mic_stream);
+    }
 }
 
 /// Owns the active `SpeechRecognition` instance, the primer `MediaStream`,
@@ -185,13 +270,24 @@ pub struct ActiveSession {
     _on_end: Closure<dyn FnMut(JsValue)>,
 }
 
-impl Drop for ActiveSession {
-    fn drop(&mut self) {
+impl ActiveSession {
+    /// Ask the recognizer to finish, which eventually fires `onend`.
+    ///
+    /// `Drop` does this too, as a safety net; calling it explicitly keeps the
+    /// two capture paths symmetric and makes the teardown visible where it
+    /// happens rather than implied by a scope ending.
+    fn request_stop(&self) {
         if let Ok(stop) = Reflect::get(&self.recognition, &JsValue::from_str("stop")) {
             if let Ok(stop_fn) = stop.dyn_into::<Function>() {
                 let _ = stop_fn.call0(&self.recognition);
             }
         }
+    }
+}
+
+impl Drop for ActiveSession {
+    fn drop(&mut self) {
+        self.request_stop();
         // Detach handlers so any late-firing event from the browser is a no-op.
         // The `onend` from this stop() will fire after Drop returns; the
         // component's `pending_stop` flag is what unblocks the next start.
@@ -217,7 +313,11 @@ pub struct VoiceInput {
     /// iOS WebKit will reject a second `start()` with
     /// `aborted/"Another request is started"`.
     pending_stop: bool,
-    session: Option<ActiveSession>,
+    /// `true` from the moment a recording stops until its transcript comes
+    /// back. The server path has no interim results, so this is what tells the
+    /// user something is still happening.
+    transcribing: bool,
+    capture: Option<Capture>,
     hint_message: Option<&'static str>,
     hint_timer: Option<Timeout>,
     /// Watchdog set when we call `stop()`; clears `pending_stop` if `onend`
@@ -232,13 +332,19 @@ impl Component for VoiceInput {
     type Message = VoiceInputMsg;
     type Properties = VoiceInputProps;
 
-    fn create(_ctx: &Context<Self>) -> Self {
+    fn create(ctx: &Context<Self>) -> Self {
         Self {
-            supported: is_speech_recognition_supported(),
+            supported: if ctx.props().server_stt {
+                MediaRecorder::is_type_supported("audio/webm")
+                    || MediaRecorder::is_type_supported("audio/mp4")
+            } else {
+                is_speech_recognition_supported()
+            },
             is_recording: false,
             is_starting: false,
             pending_stop: false,
-            session: None,
+            transcribing: false,
+            capture: None,
             hint_message: None,
             hint_timer: None,
             stop_watchdog: None,
@@ -253,24 +359,13 @@ impl Component for VoiceInput {
                     self.show_hint(ctx, UNSUPPORTED_HINT);
                     return true;
                 }
-                if self.pending_stop || self.is_starting {
+                if self.pending_stop || self.is_starting || self.transcribing {
                     self.show_hint(ctx, BUSY_HINT);
                     return true;
                 }
 
                 if self.is_recording {
-                    // User asked to stop. Drop the session; its onend will
-                    // fire VoiceInputMsg::Ended which clears pending_stop.
-                    self.session = None;
-                    self.is_recording = false;
-                    self.pending_stop = true;
-                    ctx.props().on_recording_change.emit(false);
-                    // Watchdog: iOS sometimes never fires onend after stop().
-                    // If Ended hasn't arrived in STOP_WATCHDOG_MS, force-clear.
-                    let link = ctx.link().clone();
-                    self.stop_watchdog = Some(Timeout::new(STOP_WATCHDOG_MS, move || {
-                        link.send_message(VoiceInputMsg::StopWatchdog);
-                    }));
+                    self.stop_capture(ctx);
                     return true;
                 }
 
@@ -281,16 +376,29 @@ impl Component for VoiceInput {
                 ctx.props().on_recording_change.emit(true);
 
                 let link = ctx.link().clone();
-                spawn_local(async move {
-                    match start_session_async(link.clone()).await {
-                        Ok(session) => {
-                            link.send_message(VoiceInputMsg::SessionStarted(session));
+                if ctx.props().server_stt {
+                    spawn_local(async move {
+                        match start_recording_async().await {
+                            Ok(recording) => {
+                                link.send_message(VoiceInputMsg::RecordingStarted(recording));
+                            }
+                            Err(failure) => {
+                                link.send_message(VoiceInputMsg::StartFailed(failure));
+                            }
                         }
-                        Err(failure) => {
-                            link.send_message(VoiceInputMsg::StartFailed(failure));
+                    });
+                } else {
+                    spawn_local(async move {
+                        match start_session_async(link.clone()).await {
+                            Ok(session) => {
+                                link.send_message(VoiceInputMsg::SessionStarted(session));
+                            }
+                            Err(failure) => {
+                                link.send_message(VoiceInputMsg::StartFailed(failure));
+                            }
                         }
-                    }
-                });
+                    });
+                }
                 true
             }
             VoiceInputMsg::SessionStarted(session) => {
@@ -302,12 +410,59 @@ impl Component for VoiceInput {
                     drop(session);
                     return true;
                 }
-                self.session = Some(session);
-                // Arm the max-duration safety stop.
+                self.capture = Some(Capture::Browser(session));
+                self.arm_max_duration(ctx);
+                true
+            }
+            VoiceInputMsg::RecordingStarted(recording) => {
+                self.is_starting = false;
+                if !self.is_recording {
+                    // Toggled off (or errored) while the permission primer was
+                    // still resolving; drop it so the mic is released.
+                    drop(recording);
+                    return true;
+                }
                 let link = ctx.link().clone();
-                self.max_duration_timer = Some(Timeout::new(MAX_SESSION_MS, move || {
-                    link.send_message(VoiceInputMsg::MaxDurationReached);
-                }));
+                recording.attach_stop_handler(link);
+                self.capture = Some(Capture::Server(recording));
+                self.arm_max_duration(ctx);
+                true
+            }
+            VoiceInputMsg::AudioReady(audio, content_type) => {
+                self.stop_watchdog = None;
+                // The recorder has delivered everything; release the mic now
+                // rather than holding it for the length of the upload.
+                self.capture = None;
+
+                if audio.is_empty() {
+                    self.transcribing = false;
+                    return true;
+                }
+
+                let link = ctx.link().clone();
+                let session_id = ctx.props().session_id;
+                spawn_local(async move {
+                    match transcribe(session_id, audio, content_type).await {
+                        Ok(text) => link.send_message(VoiceInputMsg::Transcribed(text)),
+                        Err(error) => link.send_message(VoiceInputMsg::TranscribeFailed(error)),
+                    }
+                });
+                true
+            }
+            VoiceInputMsg::Transcribed(text) => {
+                self.transcribing = false;
+                let trimmed = text.trim();
+                // Silence transcribes to nothing; that is not an error, and
+                // surfacing one for it would be noise.
+                if !trimmed.is_empty() {
+                    ctx.props().on_transcription.emit(trimmed.to_string());
+                }
+                true
+            }
+            VoiceInputMsg::TranscribeFailed(error) => {
+                self.transcribing = false;
+                log::warn!("Transcription failed: {}", error);
+                ctx.props().on_error.emit(error);
                 true
             }
             VoiceInputMsg::StartFailed(failure) => {
@@ -353,7 +508,7 @@ impl Component for VoiceInput {
 
                 // Any error tears down the session — fall through to the
                 // same cleanup as Ended.
-                self.session = None;
+                self.capture = None;
                 if self.is_recording {
                     self.is_recording = false;
                     self.pending_stop = true;
@@ -362,7 +517,7 @@ impl Component for VoiceInput {
                 true
             }
             VoiceInputMsg::Ended => {
-                self.session = None;
+                self.capture = None;
                 self.pending_stop = false;
                 self.stop_watchdog = None;
                 self.max_duration_timer = None;
@@ -374,6 +529,21 @@ impl Component for VoiceInput {
             }
             VoiceInputMsg::StopWatchdog => {
                 self.stop_watchdog = None;
+                // Server path: the recorder never delivered its final chunk,
+                // so there is nothing to upload and the mic is still held.
+                if matches!(self.capture, Some(Capture::Server(_))) {
+                    log::warn!(
+                        "MediaRecorder.stop() didn't deliver audio within {}ms",
+                        RECORDER_FLUSH_WATCHDOG_MS
+                    );
+                    self.capture = None;
+                    self.transcribing = false;
+                    self.max_duration_timer = None;
+                    ctx.props()
+                        .on_error
+                        .emit("Recording did not finish — please try again.".to_string());
+                    return true;
+                }
                 if self.pending_stop {
                     log::warn!(
                         "SpeechRecognition.stop() didn't deliver onend within \
@@ -381,7 +551,7 @@ impl Component for VoiceInput {
                         STOP_WATCHDOG_MS
                     );
                     self.pending_stop = false;
-                    self.session = None;
+                    self.capture = None;
                     self.max_duration_timer = None;
                     true
                 } else {
@@ -390,21 +560,12 @@ impl Component for VoiceInput {
             }
             VoiceInputMsg::MaxDurationReached => {
                 self.max_duration_timer = None;
-                if self.session.is_some() {
+                if self.capture.is_some() {
                     log::warn!(
                         "Voice session exceeded {}ms — auto-stopping",
                         MAX_SESSION_MS
                     );
-                    // Drop the session; its onend (if it fires) clears the
-                    // rest, but install a watchdog regardless.
-                    self.session = None;
-                    self.is_recording = false;
-                    self.pending_stop = true;
-                    ctx.props().on_recording_change.emit(false);
-                    let link = ctx.link().clone();
-                    self.stop_watchdog = Some(Timeout::new(STOP_WATCHDOG_MS, move || {
-                        link.send_message(VoiceInputMsg::StopWatchdog);
-                    }));
+                    self.stop_capture(ctx);
                     true
                 } else {
                     false
@@ -432,11 +593,18 @@ impl Component for VoiceInput {
         let button_class = classes!(
             "voice-button",
             self.is_recording.then_some("recording"),
+            self.transcribing.then_some("transcribing"),
             (!self.supported).then_some("unsupported"),
         );
 
         let title = if !self.supported {
-            UNSUPPORTED_HINT
+            if ctx.props().server_stt {
+                RECORDING_UNSUPPORTED_HINT
+            } else {
+                UNSUPPORTED_HINT
+            }
+        } else if self.transcribing {
+            "Transcribing…"
         } else if self.is_recording {
             "Stop recording (Ctrl+M)"
         } else {
@@ -458,6 +626,10 @@ impl Component for VoiceInput {
                 >
                     if self.is_recording {
                         <span class="voice-icon recording-icon">{ "\u{1F534}" }</span>
+                    } else if self.transcribing {
+                        // The server path has no interim text, so the button
+                        // itself has to show that work is still in flight.
+                        <span class="voice-icon transcribing-icon">{ "\u{22EF}" }</span>
                     } else if !self.supported {
                         <span class="voice-icon mic-icon unsupported">{ "\u{1F507}" }</span>
                     } else {
@@ -472,7 +644,7 @@ impl Component for VoiceInput {
     }
 
     fn destroy(&mut self, _ctx: &Context<Self>) {
-        self.session = None;
+        self.capture = None;
         self.hint_timer = None;
         self.stop_watchdog = None;
         self.max_duration_timer = None;
@@ -480,6 +652,46 @@ impl Component for VoiceInput {
 }
 
 impl VoiceInput {
+    /// End the in-flight capture, whichever strategy it is.
+    fn stop_capture(&mut self, ctx: &Context<Self>) {
+        let link = ctx.link().clone();
+        match self.capture.take() {
+            Some(Capture::Server(recording)) => {
+                // Ask for the final chunk and put the recording *back*: the
+                // browser still has to fire `stop`, and dropping now would
+                // detach the handler that hands us the audio.
+                recording.request_stop();
+                self.capture = Some(Capture::Server(recording));
+                self.transcribing = true;
+                self.stop_watchdog = Some(Timeout::new(RECORDER_FLUSH_WATCHDOG_MS, move || {
+                    link.send_message(VoiceInputMsg::StopWatchdog);
+                }));
+            }
+            // Browser path: the recognizer's `onend` clears `pending_stop`.
+            // iOS sometimes never fires it, hence the watchdog.
+            other => {
+                if let Some(Capture::Browser(session)) = &other {
+                    session.request_stop();
+                }
+                self.pending_stop = true;
+                self.stop_watchdog = Some(Timeout::new(STOP_WATCHDOG_MS, move || {
+                    link.send_message(VoiceInputMsg::StopWatchdog);
+                }));
+            }
+        }
+        self.is_recording = false;
+        self.max_duration_timer = None;
+        ctx.props().on_recording_change.emit(false);
+    }
+
+    /// Arm the safety stop that keeps a wedged capture from holding the mic.
+    fn arm_max_duration(&mut self, ctx: &Context<Self>) {
+        let link = ctx.link().clone();
+        self.max_duration_timer = Some(Timeout::new(MAX_SESSION_MS, move || {
+            link.send_message(VoiceInputMsg::MaxDurationReached);
+        }));
+    }
+
     fn show_hint(&mut self, ctx: &Context<Self>, message: &'static str) {
         self.hint_message = Some(message);
         let link = ctx.link().clone();
@@ -487,6 +699,218 @@ impl VoiceInput {
             link.send_message(VoiceInputMsg::HideHint);
         }));
     }
+}
+
+impl ServerRecording {
+    /// Ask the recorder for its final chunk. Safe to call once; a second call
+    /// on an inactive recorder throws and is ignored.
+    fn request_stop(&self) {
+        let _ = self.recorder.stop();
+    }
+
+    /// Wire up `onstop` now that the component can receive the result.
+    ///
+    /// Deliberately not done at construction: the handler needs the component
+    /// link, and attaching it here keeps `start_recording_async` free of any
+    /// dependency on the component being ready.
+    fn attach_stop_handler(&self, link: yew::html::Scope<VoiceInput>) {
+        let chunks = self.chunks();
+        let mime_type = self.mime_type.clone();
+        let on_stop = Closure::wrap(Box::new(move |_event: JsValue| {
+            let link = link.clone();
+            let mime_type = mime_type.clone();
+            let parts = chunks.clone();
+            spawn_local(async move {
+                let (audio, content_type) = collect_audio(&parts, &mime_type).await;
+                link.send_message(VoiceInputMsg::AudioReady(audio, content_type));
+            });
+        }) as Box<dyn FnMut(JsValue)>);
+        self.recorder
+            .set_onstop(Some(on_stop.as_ref().unchecked_ref()));
+        // Leak the closure: it must outlive this call, and the recorder is
+        // torn down immediately after `onstop` fires exactly once.
+        on_stop.forget();
+    }
+
+    fn chunks(&self) -> Array {
+        self.chunk_store.clone()
+    }
+}
+
+/// Assemble the recorded chunks into one buffer.
+///
+/// The blob's own type is preferred over the requested one: the browser is
+/// free to record something other than what was asked for, and the upload has
+/// to declare what was actually produced.
+async fn collect_audio(chunks: &Array, fallback_mime: &str) -> (Vec<u8>, String) {
+    let Ok(blob) = Blob::new_with_blob_sequence(chunks) else {
+        return (Vec::new(), fallback_mime.to_string());
+    };
+    let content_type = match blob.type_() {
+        t if t.is_empty() => fallback_mime.to_string(),
+        t => t,
+    };
+    let Ok(buffer) = JsFuture::from(blob.array_buffer()).await else {
+        return (Vec::new(), content_type);
+    };
+    (Uint8Array::new(&buffer).to_vec(), content_type)
+}
+
+/// The container to ask the recorder for: the first the browser admits to
+/// supporting, or `None` to let it choose.
+fn preferred_mime_type() -> Option<&'static str> {
+    PREFERRED_MIME_TYPES
+        .iter()
+        .copied()
+        .find(|candidate| MediaRecorder::is_type_supported(candidate))
+}
+
+/// Start recording: acquire the microphone, then build a recorder over it.
+///
+/// Unlike the browser path this has no permission race to work around — the
+/// recorder is constructed from a stream we already hold.
+async fn start_recording_async() -> Result<ServerRecording, StartFailure> {
+    let mic_stream = request_mic_stream().await.map_err(|name| {
+        log::warn!("getUserMedia rejected: {}", name);
+        if name == "NotAllowedError" || name == "PermissionDeniedError" {
+            StartFailure::PermissionDenied
+        } else {
+            StartFailure::Other(format!("Could not access microphone: {}", name))
+        }
+    })?;
+
+    let stream = mic_stream.clone().dyn_into::<MediaStream>().map_err(|_| {
+        stop_media_stream(&mic_stream);
+        StartFailure::Other("Microphone did not yield a media stream".into())
+    })?;
+
+    let requested_mime = preferred_mime_type();
+    let recorder = match requested_mime {
+        Some(mime) => {
+            let options = MediaRecorderOptions::new();
+            options.set_mime_type(mime);
+            MediaRecorder::new_with_media_stream_and_media_recorder_options(&stream, &options)
+        }
+        None => MediaRecorder::new_with_media_stream(&stream),
+    }
+    .map_err(|e| {
+        stop_media_stream(&mic_stream);
+        StartFailure::Other(format!("Could not start recording: {:?}", e))
+    })?;
+
+    let chunk_store = Array::new();
+    let sink = chunk_store.clone();
+    let on_data = Closure::wrap(Box::new(move |event: BlobEvent| {
+        if let Some(blob) = event.data() {
+            // Zero-length chunks show up on some browsers when a recording is
+            // stopped immediately; they contribute nothing to the blob.
+            if blob.size() > 0.0 {
+                sink.push(&blob);
+            }
+        }
+    }) as Box<dyn FnMut(BlobEvent)>);
+    recorder.set_ondataavailable(Some(on_data.as_ref().unchecked_ref()));
+
+    let on_error = Closure::wrap(Box::new(move |event: JsValue| {
+        log::warn!("MediaRecorder error: {:?}", event);
+    }) as Box<dyn FnMut(JsValue)>);
+    recorder.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+
+    // Placeholder until `attach_stop_handler` installs the real one.
+    let on_stop = Closure::wrap(Box::new(|_event: JsValue| {}) as Box<dyn FnMut(JsValue)>);
+
+    if let Err(e) = recorder.start() {
+        stop_media_stream(&mic_stream);
+        return Err(StartFailure::Other(format!(
+            "Could not start recording: {:?}",
+            e
+        )));
+    }
+
+    let mime_type = match recorder.mime_type() {
+        t if !t.is_empty() => t,
+        _ => requested_mime.unwrap_or("audio/webm").to_string(),
+    };
+
+    Ok(ServerRecording {
+        recorder,
+        mic_stream,
+        mime_type,
+        chunk_store,
+        _on_data: on_data,
+        _on_stop: on_stop,
+        _on_error: on_error,
+    })
+}
+
+/// POST one recording to the server and return the transcript.
+async fn transcribe(
+    session_id: Option<Uuid>,
+    audio: Vec<u8>,
+    content_type: String,
+) -> Result<String, String> {
+    let path = transcribe_path(session_id, document_language().as_deref());
+    let body = Uint8Array::from(audio.as_slice());
+    let response = gloo_net::http::Request::post(&utils::api_url(&path))
+        .header("Content-Type", &content_type)
+        .body(body)
+        .map_err(|e| format!("Could not build the upload: {e}"))?
+        .send()
+        .await
+        .map_err(|e| format!("Could not reach the server: {e}"))?;
+
+    if !response.ok() {
+        return Err(upload_error_message(response.status()));
+    }
+
+    response
+        .json::<TranscriptionResponse>()
+        .await
+        .map(|body| body.text)
+        .map_err(|e| format!("Could not read the transcript: {e}"))
+}
+
+/// Build the upload path, including whatever context we can supply.
+///
+/// Both parameters are optional: without a session the server just skips
+/// vocabulary biasing, and without a language it lets the provider decide.
+fn transcribe_path(session_id: Option<Uuid>, language: Option<&str>) -> String {
+    let mut params: Vec<String> = Vec::new();
+    if let Some(session_id) = session_id {
+        params.push(format!("session_id={session_id}"));
+    }
+    if let Some(language) = language.filter(|l| !l.is_empty()) {
+        params.push(format!("language={language}"));
+    }
+    if params.is_empty() {
+        "/api/stt/transcribe".to_string()
+    } else {
+        format!("/api/stt/transcribe?{}", params.join("&"))
+    }
+}
+
+/// Turn an upload failure into something the user can act on.
+///
+/// The two cases worth naming are a server with no provider configured and a
+/// recording over the size cap; everything else is a bare status, which is at
+/// least enough to match against the server log.
+fn upload_error_message(status: u16) -> String {
+    match status {
+        503 => "Speech-to-text is not configured on this server.".to_string(),
+        413 => "That recording is too long to transcribe.".to_string(),
+        401 => "Your session expired — reload and try again.".to_string(),
+        status => format!("Transcription failed (HTTP {status})."),
+    }
+}
+
+/// The document's declared language, used to tell the recognizer what to
+/// expect. Shared with the browser path, which reads the same attribute.
+fn document_language() -> Option<String> {
+    web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.document_element())
+        .and_then(|el| el.get_attribute("lang"))
+        .filter(|lang| !lang.is_empty())
 }
 
 /// Async start path: prime mic permission via `getUserMedia`, then construct
@@ -529,12 +953,7 @@ async fn start_session_async(
     set_bool("continuous", false);
     set_bool("interimResults", true);
 
-    let lang = web_sys::window()
-        .and_then(|w| w.document())
-        .and_then(|d| d.document_element())
-        .and_then(|el| el.get_attribute("lang"))
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "en-US".to_string());
+    let lang = document_language().unwrap_or_else(|| "en-US".to_string());
     let _ = Reflect::set(
         &recognition,
         &JsValue::from_str("lang"),
@@ -661,4 +1080,50 @@ async fn start_session_async(
         _on_error: on_error,
         _on_end: on_end,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_upload_path_carries_session_and_language() {
+        let id = Uuid::nil();
+        assert_eq!(
+            transcribe_path(Some(id), Some("en-US")),
+            format!("/api/stt/transcribe?session_id={id}&language=en-US")
+        );
+    }
+
+    /// Both are optional; the server degrades rather than rejecting.
+    #[test]
+    fn the_upload_path_omits_what_it_does_not_know() {
+        assert_eq!(transcribe_path(None, None), "/api/stt/transcribe");
+        assert_eq!(
+            transcribe_path(None, Some("fr-FR")),
+            "/api/stt/transcribe?language=fr-FR"
+        );
+        let id = Uuid::nil();
+        assert_eq!(
+            transcribe_path(Some(id), None),
+            format!("/api/stt/transcribe?session_id={id}")
+        );
+    }
+
+    /// An empty `lang` attribute is the same as none — sending `language=`
+    /// would have the server try to honor an empty tag.
+    #[test]
+    fn an_empty_language_is_dropped() {
+        assert_eq!(transcribe_path(None, Some("")), "/api/stt/transcribe");
+    }
+
+    #[test]
+    fn upload_failures_name_the_actionable_cases() {
+        assert!(upload_error_message(503).contains("not configured"));
+        assert!(upload_error_message(413).contains("too long"));
+        assert!(upload_error_message(401).contains("expired"));
+        // Anything else still carries the status so it can be correlated with
+        // the server log.
+        assert!(upload_error_message(500).contains("500"));
+    }
 }

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -68,6 +68,7 @@ pub fn dashboard_page() -> Html {
     let git_hash = bootstrap.git_hash;
     let build_time = bootstrap.build_time;
     let archive_enabled = bootstrap.archive_enabled;
+    let stt_enabled = bootstrap.stt_enabled;
 
     // Push-driven session refresh: the backend broadcasts
     // `ServerToClient::LaunchSessionResult` the moment the launcher's
@@ -829,6 +830,7 @@ pub fn dashboard_page() -> Html {
                                                 current_user_id={current_user_id.map(|id| id.to_string())}
                                                 interrupt_signal={focus.interrupt_signal}
                                                 jump_to_latest_signal={focus.jump_to_latest_signal}
+                                                stt_enabled={stt_enabled}
                                             />
                                         </div>
                                     }

--- a/frontend/src/pages/dashboard/page_bootstrap.rs
+++ b/frontend/src/pages/dashboard/page_bootstrap.rs
@@ -20,6 +20,10 @@ pub struct DashboardBootstrap {
     /// Whether the long-term session archive is enabled — drives the
     /// close-session copy (history preserved vs. permanently removed).
     pub archive_enabled: bool,
+    /// Whether the server can transcribe audio itself. Selects the voice
+    /// capture strategy: record-and-upload when true, the browser's Web Speech
+    /// API when false.
+    pub stt_enabled: bool,
 }
 
 /// Fetch current-user and app configuration data for the dashboard shell.
@@ -32,6 +36,7 @@ pub fn use_dashboard_bootstrap() -> DashboardBootstrap {
     let git_hash = use_state(String::new);
     let build_time = use_state(String::new);
     let archive_enabled = use_state(|| false);
+    let stt_enabled = use_state(|| false);
 
     {
         let is_admin = is_admin.clone();
@@ -54,6 +59,7 @@ pub fn use_dashboard_bootstrap() -> DashboardBootstrap {
         let git_hash = git_hash.clone();
         let build_time = build_time.clone();
         let archive_enabled = archive_enabled.clone();
+        let stt_enabled = stt_enabled.clone();
         use_effect_with((), move |_| {
             spawn_local(async move {
                 if let Ok(config) =
@@ -64,6 +70,7 @@ pub fn use_dashboard_bootstrap() -> DashboardBootstrap {
                     git_hash.set(config.git_hash);
                     build_time.set(config.build_time);
                     archive_enabled.set(config.archive_enabled);
+                    stt_enabled.set(config.stt_enabled);
                 }
             });
             || ()
@@ -78,5 +85,6 @@ pub fn use_dashboard_bootstrap() -> DashboardBootstrap {
         git_hash: (*git_hash).clone(),
         build_time: (*build_time).clone(),
         archive_enabled: *archive_enabled,
+        stt_enabled: *stt_enabled,
     }
 }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -73,6 +73,10 @@ pub struct SessionViewProps {
     /// jumps its transcript to the newest message and resumes live tailing.
     #[prop_or(0)]
     pub jump_to_latest_signal: u32,
+    /// Whether the server can transcribe audio (`AppConfig::stt_enabled`).
+    /// Forwarded to the voice button, which picks its capture strategy from it.
+    #[prop_or(false)]
+    pub stt_enabled: bool,
 }
 
 fn optimistic_user_message(
@@ -1153,6 +1157,7 @@ impl SessionView {
                 session_id={ctx.props().session.id}
                 focused={ctx.props().focused}
                 ws_connected={self.ws_connected}
+                stt_enabled={ctx.props().stt_enabled}
                 {on_register}
                 {on_send_text}
                 {on_send_frame}

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -41,6 +41,10 @@ pub struct InputBarProps {
     /// Whether the WebSocket is currently connected. Disables the textarea
     /// + send buttons when false.
     pub ws_connected: bool,
+    /// Whether the server can transcribe audio (`AppConfig::stt_enabled`).
+    /// Selects the voice button's capture strategy.
+    #[prop_or(false)]
+    pub stt_enabled: bool,
     /// Fired exactly once on `create`, handing the parent a callback it can
     /// invoke to push inbound events into the bar. Mirrors the
     /// dispatcher-registration pattern used by `PermissionHandler` and
@@ -836,6 +840,8 @@ impl InputBar {
                 {on_error}
                 disabled={!ctx.props().ws_connected}
                 button_ref={Some(button_ref)}
+                server_stt={ctx.props().stt_enabled}
+                session_id={Some(ctx.props().session_id)}
             />
         }
     }

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -252,6 +252,28 @@
     color: var(--error);
 }
 
+/* Server transcription is in flight. The recording has stopped, so this must
+   read as "working", not as "still listening" like .recording does. */
+.voice-button.transcribing {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.voice-button.transcribing .transcribing-icon {
+    animation: voice-transcribing-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes voice-transcribing-pulse {
+    0%,
+    100% {
+        opacity: 0.35;
+    }
+
+    50% {
+        opacity: 1;
+    }
+}
+
 .voice-button svg {
     width: 20px;
     height: 20px;


### PR DESCRIPTION
The user-visible half of the speech-to-text work. With a provider configured (#1543), the mic button now records locally and posts the utterance to `/api/stt/transcribe` instead of using the browser's recognizer. With no provider configured **nothing changes** — the Web Speech path stays exactly as it is.

## Why this is the piece that matters

The keyterm biasing built in #1543 had no way to reach a recognizer until now: the Web Speech API has no vocabulary hook at all. This is what connects the session's repo/branch/directory vocabulary to what the user actually says.

Two other things fall out of it:

- **Firefox gets voice for the first time.** It has no Web Speech API, so the button has always been greyed out there. `MediaRecorder` works everywhere we target.
- **The iOS workarounds stop applying.** The recorder has no singleton constraint and no permission-prompt race, so the `pending_stop` / watchdog / "another request is started" machinery is now explicitly scoped to the browser path rather than being the cost of voice in general.

## Shape

`VoiceInput` keeps its existing prop interface, so `InputBar` needed only the two new inputs — the capture strategy swapped underneath without touching how transcripts are delivered. The two strategies are alternatives in one `Capture` enum rather than two independent slots, so "is it recording" stays a single question.

Ownership is the fiddly part and is commented where it bites: after `MediaRecorder::stop()` the browser still has to deliver `dataavailable` and `stop`, so the recording is deliberately kept alive past the stop and released when the audio actually arrives — dropping early would detach the handler that hands us the bytes. A watchdog covers the recorder failing to flush, and deliberately does not cover the upload, which can legitimately take seconds.

The server path has no interim text, so the button gets a `transcribing` state between stopping and the transcript landing; without it the UI would look idle while work was in flight. Silence transcribes to an empty string, which is treated as "nothing said" rather than an error.

`stt_enabled` is threaded `use_dashboard_bootstrap` → `page.rs` → `SessionView` → `InputBar` → `VoiceInput`, matching how `archive_enabled` already flows.

## Verification

Unit tests cover the pure parts (upload path construction with/without session and language, empty-language dropping, and the error-message mapping).

The rest was checked against a running server, since the contract the client now depends on is the interesting risk — the exact request the frontend builds:

| Check | Result |
|---|---|
| `/api/config` advertises the flag | `stt_enabled: true` |
| `POST …?session_id=…&language=en-US`, `Content-Type: audio/webm;codecs=opus` | reaches the provider (502 on the deliberately bad key) |
| Same with no query params | also accepted — both are optional |
| Body over `PORTAL_MAX_AUDIO_MB` | 413, which the UI maps to "That recording is too long" |

Workspace suite green (29 binaries), clippy clean, stylelint clean, `trunk build` succeeds.

## Not done here

No live microphone test — that needs a real browser and a real provider key. The request/response contract is verified end to end; what remains unproven is the `MediaRecorder` capture itself in each browser.
