### PR TITLE
Refresh PR metadata on the CLI's code_change_published signal

### DIFF
--- a/claude-session-lib/src/proxy_session/git_metadata.rs
+++ b/claude-session-lib/src/proxy_session/git_metadata.rs
@@ -12,6 +12,24 @@ use uuid::Uuid;
 
 use super::SharedWsWrite;
 
+/// The CLI's own "this session now has a published PR/MR" signal
+/// (`system/code_change_published`, claude-codes 2.1.163+), if this is one.
+///
+/// This is more immediate and authoritative than the heuristic
+/// [`claude_output_has_git_signal`] scan of bash commands: it fires the moment
+/// the CLI publishes, so the caller can refresh PR metadata now instead of
+/// waiting for the next deferred git poll. We still route it through the shared
+/// `gh`-backed refresh rather than trusting the event's URL blindly, so branch /
+/// repo / open-PR fields stay consistent with everything else on the session.
+pub(super) fn claude_output_code_change_published(
+    output: &ClaudeOutput,
+) -> Option<claude_codes::CodeChangePublishedMessage> {
+    match output {
+        ClaudeOutput::System(sys) => sys.as_code_change_published(),
+        _ => None,
+    }
+}
+
 pub(super) fn claude_output_has_git_signal(output: &ClaudeOutput) -> bool {
     if let ClaudeOutput::User(user) = output {
         for block in &user.message.content {
@@ -233,5 +251,39 @@ mod tests {
             assert!(!trigger.should_check_before_message());
         }
         assert!(trigger.should_check_before_message());
+    }
+
+    #[test]
+    fn code_change_published_is_recognized_and_carries_the_url() {
+        let output: ClaudeOutput = serde_json::from_value(json!({
+            "type": "system",
+            "subtype": "code_change_published",
+            "provider": "github",
+            "url": "https://github.com/meawoppl/agent-portal/pull/1473",
+            "repo": "meawoppl/agent-portal",
+            "identifier": "1473",
+            "uuid": "u-1",
+            "session_id": "s-1",
+        }))
+        .expect("valid code_change_published frame");
+
+        let published =
+            claude_output_code_change_published(&output).expect("should detect the signal");
+        assert_eq!(
+            published.url,
+            "https://github.com/meawoppl/agent-portal/pull/1473"
+        );
+        assert_eq!(published.provider, "github");
+    }
+
+    #[test]
+    fn other_system_messages_are_not_code_change_published() {
+        let output: ClaudeOutput = serde_json::from_value(json!({
+            "type": "system",
+            "subtype": "init",
+            "session_id": "s-1",
+        }))
+        .expect("valid system frame");
+        assert!(claude_output_code_change_published(&output).is_none());
     }
 }

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -20,7 +20,8 @@ use uuid::Uuid;
 use session_lib::output_buffer::PendingOutputBuffer;
 
 use super::git_metadata::{
-    check_and_send_branch_update, claude_output_has_git_signal, GitMetadataState, GitRefreshTrigger,
+    check_and_send_branch_update, claude_output_code_change_published,
+    claude_output_has_git_signal, GitMetadataState, GitRefreshTrigger,
 };
 use super::{format_duration, truncate, SharedWsWrite};
 
@@ -62,6 +63,24 @@ pub fn spawn_output_forwarder(
 
             if let Some(ref output) = parsed {
                 log_claude_output(output);
+
+                // The CLI's own PR-published signal: refresh PR metadata NOW
+                // rather than deferring, since the PR already exists in `gh`
+                // by the time this fires (#1473). Reuses the shared refresh so
+                // branch / repo / open-PR fields stay consistent.
+                if let Some(published) = claude_output_code_change_published(output) {
+                    debug!(
+                        "← code_change_published: {} {} ({})",
+                        published.provider, published.url, published.repo
+                    );
+                    check_and_send_branch_update(
+                        &ws_write,
+                        session_id,
+                        &working_directory,
+                        &git_metadata,
+                    )
+                    .await;
+                }
 
                 // Is THIS message a git-related bash command (for next iteration)?
                 if claude_output_has_git_signal(output) {


### PR DESCRIPTION
Closes #1473.

The proxy learns a session's PR URL by polling `git`/`gh`, triggered by a heuristic scan of bash commands for git-ish text (`claude_output_has_git_signal`) and deferred to the next output frame. claude-codes 2.1.163 added the CLI's own `system/code_change_published` event — the authoritative signal that a PR/MR was just published — and 2.1.165 the typed `SystemMessage::as_code_change_published()` accessor. We're on 2.1.220, so it's available now.

This detects that event (`claude_output_code_change_published`, dispatching on the typed variant) and, when it lands, runs the existing combined `check_and_send_branch_update` **immediately** rather than deferring to the next frame. The PR already exists in `gh` by the time the CLI emits the event, so a same-frame refresh picks it up.

**Why reuse the poll rather than trust the event's URL directly:** the shared refresh reads branch / PR / repo / open-PRs from local git together and sends one `SessionUpdate`, keeping all four consistent and the change-detection guards in sync. Taking just the event's `url` would need a partial-update path and risk the fields drifting. The event's value here is *immediacy* — firing now instead of on the next deferred poll — which this delivers without a second update mechanism.

Verified: two new unit tests (a `code_change_published` frame is detected and carries its URL; other system subtypes return `None`), all 7 git_metadata tests green, clippy clean.