### PR TITLE
Add a user display nickname

### DIFF
--- a/backend/migrations/2026-08-04-154204_add_nickname_to_users/down.sql
+++ b/backend/migrations/2026-08-04-154204_add_nickname_to_users/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN nickname;

--- a/backend/migrations/2026-08-04-154204_add_nickname_to_users/up.sql
+++ b/backend/migrations/2026-08-04-154204_add_nickname_to_users/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN nickname VARCHAR(64);

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -169,6 +169,7 @@ mod tests {
             ban_reason: None,
             sound_config: None,
             notification_prefs: None,
+            nickname: None,
         }
     }
 

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -198,10 +198,15 @@ fn archive_one_session(
     use schema::{messages, session_members, turn_metrics, users};
     use std::collections::BTreeMap;
 
-    let (owner_email, owner_name): (String, Option<String>) = users::table
-        .find(session.user_id)
-        .select((users::email, users::name))
-        .first(conn)?;
+    let (owner_email, owner_nickname, owner_name): (String, Option<String>, Option<String>) =
+        users::table
+            .find(session.user_id)
+            .select((users::email, users::nickname, users::name))
+            .first(conn)?;
+    // Bake the display label (nickname preferred) into the manifest so the
+    // history browser attributes the owner the same way live views do (#1485).
+    let owner_name =
+        crate::handlers::helpers::preferred_name(owner_nickname.as_deref(), owner_name.as_deref());
 
     // Membership snapshot for the manifest: visibility ("shared with me")
     // must survive the eventual deletion of the hot DB rows, so the archive

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -614,6 +614,7 @@ fn me_response(user: User) -> MeResponse {
         id: user.id,
         email: user.email,
         name: user.name,
+        nickname: user.nickname,
         avatar_url: user.avatar_url,
         is_admin: user.is_admin,
     }

--- a/backend/src/handlers/helpers.rs
+++ b/backend/src/handlers/helpers.rs
@@ -26,12 +26,33 @@ pub fn parse_iso_cursor(s: &str) -> Option<NaiveDateTime> {
         .ok()
 }
 
-/// Look up display names for the senders of the user-role messages in
-/// `message_list`: collect the distinct `user_id`s, load `(id, name, email)`
-/// for each, and map to name-or-email. Shared by the REST `list_messages`
-/// handler and the WebSocket history replay so both enrich user messages
-/// identically. Lookup failures degrade to an empty map (no sender names)
-/// rather than erroring.
+/// The label to attribute a user by, preferring their chosen nickname (#1485).
+///
+/// `None` when the user set neither a nickname nor a name — the single source
+/// of the nickname-then-name precedence, so every attribution surface resolves
+/// it identically.
+pub fn preferred_name(nickname: Option<&str>, name: Option<&str>) -> Option<String> {
+    // The first *non-blank* of nickname-then-name. Filtering after `.or()`
+    // would let a blank nickname shadow a real name and skip to email.
+    [nickname, name]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// [`preferred_name`] falling back to the email when neither is set — used by
+/// attribution surfaces that render a single name string (message bubbles).
+pub fn display_name(nickname: Option<&str>, name: Option<&str>, email: &str) -> String {
+    preferred_name(nickname, name).unwrap_or_else(|| email.to_string())
+}
+
+/// Display names for the senders of the user-role messages in `message_list`:
+/// collect the distinct `user_id`s, load each user's identity columns, and map
+/// to their [`display_name`]. Shared by the REST `list_messages` handler and
+/// the WebSocket history replay so both enrich user messages identically.
+/// Lookup failures degrade to an empty map rather than erroring.
 pub fn sender_names(conn: &mut PgConnection, message_list: &[Message]) -> HashMap<Uuid, String> {
     let user_ids: Vec<Uuid> = message_list
         .iter()
@@ -45,11 +66,16 @@ pub fn sender_names(conn: &mut PgConnection, message_list: &[Message]) -> HashMa
     }
     users::table
         .filter(users::id.eq_any(&user_ids))
-        .select((users::id, users::name, users::email))
-        .load::<(Uuid, Option<String>, String)>(conn)
+        .select((users::id, users::nickname, users::name, users::email))
+        .load::<(Uuid, Option<String>, Option<String>, String)>(conn)
         .unwrap_or_default()
         .into_iter()
-        .map(|(id, name, email)| (id, name.unwrap_or(email)))
+        .map(|(id, nickname, name, email)| {
+            (
+                id,
+                display_name(nickname.as_deref(), name.as_deref(), &email),
+            )
+        })
         .collect()
 }
 
@@ -219,6 +245,39 @@ pub fn delete_user_sessions(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn nickname_is_preferred_then_name_then_email() {
+        assert_eq!(
+            display_name(Some("mopps"), Some("Matt"), "matt@example.com"),
+            "mopps"
+        );
+        assert_eq!(display_name(None, Some("Matt"), "matt@example.com"), "Matt");
+        assert_eq!(
+            display_name(None, None, "matt@example.com"),
+            "matt@example.com"
+        );
+    }
+
+    /// A blank/whitespace nickname or name must fall through, not render as an
+    /// invisible label.
+    #[test]
+    fn blank_values_fall_through() {
+        assert_eq!(display_name(Some("  "), Some("Matt"), "e@x.com"), "Matt");
+        assert_eq!(display_name(Some(""), None, "e@x.com"), "e@x.com");
+        assert_eq!(preferred_name(Some("   "), Some("  ")), None);
+        // Preferred label is trimmed, not just non-empty-checked.
+        assert_eq!(
+            preferred_name(Some("  mopps  "), None).as_deref(),
+            Some("mopps")
+        );
+    }
+
+    #[test]
+    fn preferred_name_is_none_only_when_both_absent() {
+        assert_eq!(preferred_name(None, None), None);
+        assert_eq!(preferred_name(None, Some("Matt")).as_deref(), Some("Matt"));
+    }
 
     #[test]
     fn parse_iso_cursor_accepts_fractional_seconds() {

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -18,6 +18,7 @@ pub mod media_store;
 pub mod messages;
 pub mod mobile_links;
 pub mod privacy;
+pub mod profile;
 pub mod proxy_tokens;
 pub mod push;
 pub mod responses;

--- a/backend/src/handlers/profile.rs
+++ b/backend/src/handlers/profile.rs
@@ -1,0 +1,49 @@
+//! User profile settings (#1485).
+//!
+//! Currently just the display nickname. Kept separate from the OAuth `auth`
+//! handlers because this is a self-service profile edit, not part of any login
+//! flow.
+
+use axum::{extract::State, Json};
+use diesel::prelude::*;
+use shared::api::UpdateProfileRequest;
+use std::sync::Arc;
+
+use crate::auth::CurrentUserId;
+use crate::errors::AppError;
+use crate::handlers::responses::EmptyResponse;
+use crate::AppState;
+
+/// Longest nickname we store. Matches the `VARCHAR(64)` column; enforced here
+/// too so an over-long value is a clean 400 rather than a database error.
+const MAX_NICKNAME_LEN: usize = 64;
+
+/// `PUT /api/settings/profile` — set or clear the caller's display nickname.
+pub async fn update_profile(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+    Json(body): Json<UpdateProfileRequest>,
+) -> Result<EmptyResponse, AppError> {
+    // Trim and treat blank as "clear" — a whitespace-only nickname would render
+    // as an invisible label, which is worse than falling back to the name.
+    let nickname = body
+        .nickname
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    if let Some(ref n) = nickname {
+        if n.chars().count() > MAX_NICKNAME_LEN {
+            return Err(AppError::BadRequest("Nickname is too long"));
+        }
+    }
+
+    let mut conn = app_state.conn()?;
+    use crate::schema::users;
+    diesel::update(users::table.find(user_id))
+        .set(users::nickname.eq(nickname))
+        .execute(&mut conn)?;
+
+    Ok(EmptyResponse::OK)
+}

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -404,6 +404,7 @@ struct UserBasicInfo {
     id: Uuid,
     email: String,
     name: Option<String>,
+    nickname: Option<String>,
 }
 
 /// Validate a member role supplied by the caller
@@ -464,7 +465,7 @@ pub async fn list_session_members(
         .filter(session_members::session_id.eq(session_id))
         .select((
             SessionMember::as_select(),
-            (users::id, users::email, users::name),
+            (users::id, users::email, users::name, users::nickname),
         ))
         .load(&mut conn)?;
 
@@ -472,8 +473,13 @@ pub async fn list_session_members(
         .into_iter()
         .map(|(member, user)| SessionMemberInfo {
             user_id: user.id,
+            // Prefer the member's chosen nickname for the label; email stays
+            // shown alongside so the row still maps to a person (#1485).
+            name: crate::handlers::helpers::preferred_name(
+                user.nickname.as_deref(),
+                user.name.as_deref(),
+            ),
             email: user.email,
-            name: user.name,
             role: member.role.parse().unwrap_or(SessionRole::Unknown),
             created_at: member.created_at,
         })

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -18,6 +18,10 @@ pub struct User {
     pub ban_reason: Option<String>,
     pub sound_config: Option<serde_json::Value>,
     pub notification_prefs: Option<serde_json::Value>,
+    /// Optional display label shown in message attribution instead of `name`
+    /// (#1485). A cosmetic preference — auth, membership and admin views keep
+    /// the real `name`/`email`.
+    pub nickname: Option<String>,
 }
 
 #[derive(Debug, Insertable)]

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,5 +1,5 @@
 use axum::{
-    routing::{get, post},
+    routing::{get, post, put},
     Json, Router,
 };
 use governor::clock::QuantaInstant;
@@ -323,6 +323,10 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             "/api/settings/sound",
             get(handlers::sound_settings::get_sound_settings)
                 .put(handlers::sound_settings::save_sound_settings),
+        )
+        .route(
+            "/api/settings/profile",
+            put(handlers::profile::update_profile),
         )
         .route(AUTH_ME, get(handlers::auth::me))
         .route(AUTH_REFRESH, post(handlers::auth::refresh_token))

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -291,6 +291,8 @@ diesel::table! {
         ban_reason -> Nullable<Text>,
         sound_config -> Nullable<Jsonb>,
         notification_prefs -> Nullable<Jsonb>,
+        #[max_length = 64]
+        nickname -> Nullable<Varchar>,
     }
 }
 
@@ -312,10 +314,10 @@ diesel::joinable!(session_forwards -> sessions (session_id));
 diesel::joinable!(session_members -> sessions (session_id));
 diesel::joinable!(session_members -> users (user_id));
 diesel::joinable!(sessions -> users (user_id));
-diesel::joinable!(user_identities -> users (user_id));
 diesel::joinable!(turn_metrics -> messages (user_message_id));
 diesel::joinable!(turn_metrics -> sessions (session_id));
 diesel::joinable!(turn_metrics -> users (user_id));
+diesel::joinable!(user_identities -> users (user_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     custom_subdomains,
@@ -330,8 +332,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     session_continuations,
     session_forwards,
     session_members,
-    user_identities,
     sessions,
     turn_metrics,
+    user_identities,
     users,
 );

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -4,6 +4,7 @@ mod health_timer_panel;
 mod launchers_panel;
 mod notifications_panel;
 mod performance_panel;
+mod profile_panel;
 mod sessions_panel;
 mod sounds_panel;
 mod tokens_panel;
@@ -15,6 +16,7 @@ use health_timer_panel::HealthTimerPanel;
 use launchers_panel::LaunchersPanel;
 use notifications_panel::NotificationsPanel;
 use performance_panel::PerformancePanel;
+use profile_panel::ProfilePanel;
 use sessions_panel::SessionsPanel;
 use shared::{ProxyTokenInfo, SessionInfo};
 use sounds_panel::SoundsPanel;
@@ -23,6 +25,7 @@ use yew::prelude::*;
 
 #[derive(Clone, Copy, PartialEq)]
 enum SettingsTab {
+    Profile,
     Sessions,
     Tokens,
     Launchers,
@@ -67,6 +70,7 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
         let active_tab = active_tab.clone();
         Callback::from(move |_: MouseEvent| active_tab.set(tab))
     };
+    let on_profile_tab = make_tab_handler(SettingsTab::Profile);
     let on_sessions_tab = make_tab_handler(SettingsTab::Sessions);
     let on_tokens_tab = make_tab_handler(SettingsTab::Tokens);
     let on_launchers_tab = make_tab_handler(SettingsTab::Launchers);
@@ -95,6 +99,12 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
             </header>
 
             <nav class="settings-tabs">
+                <button
+                    class={classes!("tab-button", (*active_tab == SettingsTab::Profile).then_some("active"))}
+                    onclick={on_profile_tab}
+                >
+                    { "Profile" }
+                </button>
                 <button
                     class={classes!("tab-button", (*active_tab == SettingsTab::Sessions).then_some("active"))}
                     onclick={on_sessions_tab}
@@ -173,6 +183,9 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                 }
                 if *active_tab == SettingsTab::HealthTimer {
                     <HealthTimerPanel />
+                }
+                if *active_tab == SettingsTab::Profile {
+                    <ProfilePanel />
                 }
                 if *active_tab == SettingsTab::Sessions {
                     <SessionsPanel on_sessions_loaded={on_sessions_loaded} />

--- a/frontend/src/pages/settings/profile_panel.rs
+++ b/frontend/src/pages/settings/profile_panel.rs
@@ -1,0 +1,133 @@
+//! Profile settings: the display nickname (#1485).
+//!
+//! A cosmetic label shown in message attribution instead of the account name;
+//! auth, membership and admin views keep the real name/email. Prefilled from
+//! `/api/auth/me` and saved via `PUT /api/settings/profile`.
+
+use crate::utils::{self, On401};
+use gloo_net::http::Request;
+use shared::api::{MeResponse, UpdateProfileRequest};
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+#[function_component(ProfilePanel)]
+pub fn profile_panel() -> Html {
+    // The edited draft; seeded from the server once `/api/auth/me` lands.
+    let nickname = use_state(String::new);
+    // The account's real name/email, shown so the user knows the fallback.
+    let name = use_state(|| None::<String>);
+    let email = use_state(String::new);
+    let loading = use_state(|| true);
+    let saving = use_state(|| false);
+    let feedback = use_state(|| None::<&'static str>);
+
+    {
+        let nickname = nickname.clone();
+        let name = name.clone();
+        let email = email.clone();
+        let loading = loading.clone();
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                if let Ok(me) = utils::fetch_json::<MeResponse>("/api/auth/me", On401::Ignore).await
+                {
+                    nickname.set(me.nickname.unwrap_or_default());
+                    name.set(me.name);
+                    email.set(me.email);
+                }
+                loading.set(false);
+            });
+        });
+    }
+
+    let on_input = {
+        let nickname = nickname.clone();
+        let feedback = feedback.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            nickname.set(input.value());
+            // A pending edit invalidates the last "Saved" note.
+            feedback.set(None);
+        })
+    };
+
+    let on_save = {
+        let nickname = nickname.clone();
+        let saving = saving.clone();
+        let feedback = feedback.clone();
+        Callback::from(move |_: MouseEvent| {
+            let trimmed = (*nickname).trim().to_string();
+            let body = UpdateProfileRequest {
+                // Blank clears the nickname; send `None` so the server stores NULL.
+                nickname: (!trimmed.is_empty()).then(|| trimmed.clone()),
+            };
+            let saving = saving.clone();
+            let feedback = feedback.clone();
+            let nickname = nickname.clone();
+            saving.set(true);
+            spawn_local(async move {
+                let ok = match Request::put(&utils::api_url("/api/settings/profile")).json(&body) {
+                    Ok(req) => req.send().await.map(|r| r.ok()).unwrap_or(false),
+                    Err(_) => false,
+                };
+                // Reflect the normalized value locally so the field matches
+                // what the server stored.
+                nickname.set(trimmed);
+                saving.set(false);
+                feedback.set(Some(if ok {
+                    "Saved"
+                } else {
+                    "Couldn't save — try again"
+                }));
+            });
+        })
+    };
+
+    let fallback = (*name)
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| (*email).clone());
+
+    html! {
+        <section class="profile-section">
+            <div class="section-header">
+                <h2>{ "Profile" }</h2>
+                <p class="section-description">
+                    { "How you appear in message attribution. Cosmetic only — \
+                       your account name and email are unchanged." }
+                </p>
+            </div>
+
+            if *loading {
+                <p class="setting-description">{ "Loading…" }</p>
+            } else {
+                <div class="profile-setting">
+                    <h3>{ "Display nickname" }</h3>
+                    <p class="setting-description">
+                        { format!("Leave blank to show \u{201c}{fallback}\u{201d}.") }
+                    </p>
+                    <input
+                        type="text"
+                        class="profile-nickname-input"
+                        maxlength="64"
+                        placeholder={fallback.clone()}
+                        value={(*nickname).clone()}
+                        oninput={on_input}
+                    />
+                    <div class="profile-save-row">
+                        <button
+                            class="create-button"
+                            onclick={on_save}
+                            disabled={*saving}
+                        >
+                            { if *saving { "Saving…" } else { "Save" } }
+                        </button>
+                        if let Some(msg) = *feedback {
+                            <span class="save-feedback">{ msg }</span>
+                        }
+                    </div>
+                </div>
+            }
+        </section>
+    }
+}

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -930,6 +930,43 @@
    Appearance panel
    ========================================================================== */
 
+.profile-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.profile-setting {
+    background: var(--bg-darker);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem;
+}
+
+.profile-setting h3 {
+    margin: 0 0 0.25rem 0;
+    font-size: 1rem;
+    color: var(--text-primary);
+}
+
+.profile-nickname-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.5rem 0.75rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+}
+
+.profile-save-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
 .appearance-section {
     display: flex;
     flex-direction: column;

--- a/shared/src/api/settings.rs
+++ b/shared/src/api/settings.rs
@@ -8,6 +8,14 @@ pub struct SoundSettingsResponse {
     pub sound_config: Option<serde_json::Value>,
 }
 
+/// Body for `PUT /api/settings/profile` (#1485). A `nickname` of `None` or an
+/// empty/whitespace string clears the nickname (falls back to name/email).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateProfileRequest {
+    #[serde(default)]
+    pub nickname: Option<String>,
+}
+
 /// Response for POST /api/stt/transcribe.
 ///
 /// Empty `text` is a success, not a failure: it means the recording contained

--- a/shared/src/api/users.rs
+++ b/shared/src/api/users.rs
@@ -68,6 +68,11 @@ pub struct MeResponse {
     pub email: String,
     #[serde(default)]
     pub name: Option<String>,
+    /// Optional self-chosen display label (#1485); shown in message
+    /// attribution instead of `name`. The profile settings panel reads this
+    /// to prefill its field.
+    #[serde(default)]
+    pub nickname: Option<String>,
     #[serde(default)]
     pub avatar_url: Option<String>,
     #[serde(default)]


### PR DESCRIPTION
Closes #1485.

Message attribution — bubbles, shared-session member labels, history owner — showed the account name (or email). This adds an optional **nickname**, shown instead wherever a user is labelled. It's a display preference: auth, membership and admin views keep the real name/email.

## Shape

- **`users.nickname`** nullable column (migration round-tripped up/down against a real DB).
- **One precedence helper**, the single source of the rule: `preferred_name(nickname, name)` returns the first *non-blank* of the two (so a blank nickname falls through to the name, not past it), and `display_name(nickname, name, email)` adds the email fallback for surfaces that render a lone string.
- Applied at the **read-time** attribution sites so a nickname change shows immediately: message `sender_names` (REST + WS replay), the share-dialog member list, and the archived-history owner (baked at archive time).
- **`MeResponse.nickname`** + **`PUT /api/settings/profile`** (typed `UpdateProfileRequest`), and a **Settings ▸ Profile** panel that prefills from `/api/auth/me`, edits, and saves. Blank clears it; length-capped at 64 (enforced in the handler and the column).

## Notes / scope

- Archived history owner is baked at archive time, so a later nickname change doesn't rewrite old manifests — consistent with the snapshot nature of the archive.
- The share-dialog member label now prefers the nickname but still shows the email alongside, so a row still maps to a person.
- Deferred (open questions in the issue): per-session nicknames and an admin `nickname (real name)` annotation.

Found and fixed a real bug via a unit test along the way: trimming *after* `nickname.or(name)` let a whitespace-only nickname shadow a real name and skip to email; the helper now picks the first non-blank.

## Verified

Helper precedence unit tests (nickname → name → email, blank fall-through, trim); backend + full frontend suite (530) green; wasm build, clippy, and stylelint clean; migration up/down verified against Postgres.