### PR TITLE
Consolidate the duplicated make_user test helper

### DIFF
--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -287,21 +287,8 @@ mod tests {
 #[cfg(test)]
 mod db_tests {
     use super::*;
-    use crate::models::{NewSessionWithId, NewUser, Session, User};
+    use crate::models::{NewSessionWithId, Session};
     use chrono::Utc;
-    fn make_user(conn: &mut diesel::pg::PgConnection, label: &str) -> User {
-        use crate::schema::users;
-        let nonce = uuid::Uuid::new_v4();
-        let new_user = NewUser {
-            email: format!("test_messages_{}_{}@example.invalid", label, nonce),
-            name: Some(format!("Test {}", label)),
-            avatar_url: None,
-        };
-        diesel::insert_into(users::table)
-            .values(&new_user)
-            .get_result::<User>(conn)
-            .expect("insert test user")
-    }
 
     fn make_session(conn: &mut diesel::pg::PgConnection, owner_id: uuid::Uuid) -> Session {
         use crate::schema::sessions;
@@ -403,7 +390,7 @@ mod db_tests {
         };
         let mut conn = pool.get().expect("conn");
 
-        let user = make_user(&mut conn, "default");
+        let user = crate::test_support::insert_user(&mut conn, "default");
         let session = make_session(&mut conn, user.id);
         let stamps = seed_messages(&mut conn, session.id, user.id, 250);
 
@@ -439,7 +426,7 @@ mod db_tests {
         };
         let mut conn = pool.get().expect("conn");
 
-        let user = make_user(&mut conn, "before");
+        let user = crate::test_support::insert_user(&mut conn, "before");
         let session = make_session(&mut conn, user.id);
         let stamps = seed_messages(&mut conn, session.id, user.id, 50);
 
@@ -476,7 +463,7 @@ mod db_tests {
         };
         let mut conn = pool.get().expect("conn");
 
-        let user = make_user(&mut conn, "after");
+        let user = crate::test_support::insert_user(&mut conn, "after");
         let session = make_session(&mut conn, user.id);
         let stamps = seed_messages(&mut conn, session.id, user.id, 50);
 

--- a/backend/src/handlers/push.rs
+++ b/backend/src/handlers/push.rs
@@ -213,20 +213,6 @@ pub async fn put_prefs(
 #[cfg(test)]
 mod db_tests {
     use super::*;
-    use crate::models::{NewUser, User};
-    fn make_user(conn: &mut diesel::pg::PgConnection) -> User {
-        use crate::schema::users;
-        let nonce = Uuid::new_v4();
-        let new_user = NewUser {
-            email: format!("test_push_prefs_{nonce}@example.invalid"),
-            name: Some("Test Prefs".to_string()),
-            avatar_url: None,
-        };
-        diesel::insert_into(users::table)
-            .values(&new_user)
-            .get_result::<User>(conn)
-            .expect("insert test user")
-    }
 
     /// Read `users.notification_prefs`, applying the same NULL/parse-failure ->
     /// default fallback as the `get_prefs` handler.
@@ -248,7 +234,7 @@ mod db_tests {
             return;
         };
         let mut conn = pool.get().expect("get conn");
-        let user = make_user(&mut conn);
+        let user = crate::test_support::insert_user(&mut conn, "push_prefs");
 
         // GET on a fresh user: column is NULL -> defaults.
         assert_eq!(read_prefs(&mut conn, user.id), NotificationPrefs::default());

--- a/backend/src/handlers/session_access.rs
+++ b/backend/src/handlers/session_access.rs
@@ -192,21 +192,7 @@ pub fn is_session_mutator(app_state: &AppState, session_id: Uuid, user_id: Uuid)
 #[cfg(test)]
 mod db_tests {
     use super::*;
-    use crate::models::{NewSessionMember, NewSessionWithId, NewUser, Session, User};
-    /// Insert a throwaway user with a random google_id/email and return its row.
-    fn make_user(conn: &mut diesel::pg::PgConnection, label: &str) -> User {
-        use crate::schema::users;
-        let nonce = Uuid::new_v4();
-        let new_user = NewUser {
-            email: format!("test_session_access_{}_{}@example.invalid", label, nonce),
-            name: Some(format!("Test {}", label)),
-            avatar_url: None,
-        };
-        diesel::insert_into(users::table)
-            .values(&new_user)
-            .get_result::<User>(conn)
-            .expect("insert test user")
-    }
+    use crate::models::{NewSessionMember, NewSessionWithId, Session};
 
     /// Insert a throwaway session owned by `owner_id`.
     fn make_session(conn: &mut diesel::pg::PgConnection, owner_id: Uuid) -> Session {
@@ -275,9 +261,9 @@ mod db_tests {
         };
         let mut conn = pool.get().expect("conn");
 
-        let owner = make_user(&mut conn, "owner");
-        let viewer = make_user(&mut conn, "viewer");
-        let editor = make_user(&mut conn, "editor");
+        let owner = crate::test_support::insert_user(&mut conn, "owner");
+        let viewer = crate::test_support::insert_user(&mut conn, "viewer");
+        let editor = crate::test_support::insert_user(&mut conn, "editor");
         let session = make_session(&mut conn, owner.id);
         // The session-creation code path adds an owner member row; here we
         // skip that and add only viewer + editor, then verify the
@@ -309,8 +295,8 @@ mod db_tests {
         };
         let mut conn = pool.get().expect("conn");
 
-        let owner = make_user(&mut conn, "owner_nm");
-        let stranger = make_user(&mut conn, "stranger");
+        let owner = crate::test_support::insert_user(&mut conn, "owner_nm");
+        let stranger = crate::test_support::insert_user(&mut conn, "stranger");
         let session = make_session(&mut conn, owner.id);
 
         let stranger_result = verify_session_mutator(&mut conn, session.id, stranger.id);
@@ -331,7 +317,7 @@ mod db_tests {
 
         // Verifies the canonical path that `registration.rs::create_new_session`
         // produces: owner has both sessions.user_id AND a `role = owner` row.
-        let owner = make_user(&mut conn, "owner_mr");
+        let owner = crate::test_support::insert_user(&mut conn, "owner_mr");
         let session = make_session(&mut conn, owner.id);
         add_member(&mut conn, session.id, owner.id, "owner");
 

--- a/backend/src/push/dispatcher.rs
+++ b/backend/src/push/dispatcher.rs
@@ -200,21 +200,7 @@ pub(crate) fn disable_subscription(conn: &mut DbConnection, sub_id: Uuid) -> Que
 #[cfg(test)]
 mod db_tests {
     use super::*;
-    use crate::models::{NewPushSubscription, NewUser, PushSubscription, User};
-
-    fn make_user(conn: &mut DbConnection) -> User {
-        use crate::schema::users;
-        let nonce = Uuid::new_v4();
-        let new_user = NewUser {
-            email: format!("test_push_{nonce}@example.invalid"),
-            name: Some("Push Test".to_string()),
-            avatar_url: None,
-        };
-        diesel::insert_into(users::table)
-            .values(&new_user)
-            .get_result::<User>(conn)
-            .expect("insert test user")
-    }
+    use crate::models::{NewPushSubscription, PushSubscription};
 
     fn make_sub(conn: &mut DbConnection, user_id: Uuid) -> PushSubscription {
         use crate::schema::push_subscriptions;
@@ -238,7 +224,7 @@ mod db_tests {
             return;
         };
         let mut conn = pool.get().expect("db conn");
-        let user = make_user(&mut conn);
+        let user = crate::test_support::insert_user(&mut conn, "push");
         let sub = make_sub(&mut conn, user.id);
         assert!(sub.disabled_at.is_none());
 
@@ -267,7 +253,7 @@ mod db_tests {
             return;
         };
         let mut conn = pool.get().expect("db conn");
-        let user = make_user(&mut conn);
+        let user = crate::test_support::insert_user(&mut conn, "push");
         let sub = make_sub(&mut conn, user.id);
         assert!(sub.last_success_at.is_none());
 
@@ -288,7 +274,7 @@ mod db_tests {
             return;
         };
         let mut conn = pool.get().expect("db conn");
-        let user = make_user(&mut conn);
+        let user = crate::test_support::insert_user(&mut conn, "push");
 
         use crate::models::NewSessionWithId;
         use crate::schema::sessions;

--- a/backend/src/test_support.rs
+++ b/backend/src/test_support.rs
@@ -15,8 +15,12 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use diesel::pg::PgConnection;
+use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool};
 use tower_cookies::Key;
+use uuid::Uuid;
+
+use crate::models::{NewUser, User};
 
 use crate::config::MobileAppLinksConfig;
 use crate::db::DbPool;
@@ -120,4 +124,26 @@ pub fn shared_pool() -> Option<DbPool> {
         pool
     });
     Some(pool.clone())
+}
+
+/// Insert a throwaway user and return the persisted row.
+///
+/// Consolidates the near-identical `make_user` helpers that several handler
+/// test modules each defined (#924). `label` only disambiguates the generated
+/// email/name in logs — a fresh UUID keeps the row unique regardless — so
+/// tests that don't care can pass any short tag.
+///
+/// Takes a bare `&mut PgConnection` so it works with both a pooled connection
+/// and a direct one; call sites pass `&mut pool.get().unwrap()`.
+pub fn insert_user(conn: &mut PgConnection, label: &str) -> User {
+    use crate::schema::users;
+    let nonce = Uuid::new_v4();
+    diesel::insert_into(users::table)
+        .values(&NewUser {
+            email: format!("test_{label}_{nonce}@example.invalid"),
+            name: Some(format!("Test {label}")),
+            avatar_url: None,
+        })
+        .get_result::<User>(conn)
+        .expect("insert test user")
 }


### PR DESCRIPTION
First builder from #924. Four test modules — `push/dispatcher`, `handlers/messages`, `handlers/session_access`, `handlers/push` — each defined a near-identical `make_user` that inserts a nonce'd `NewUser` and reselects the row. They differed only in the throwaway email/name string.

Replaced all four with one `test_support::insert_user(conn, label)` builder, next to the `test_app_state` fixture that already centralizes `AppState` construction for the same reason. `label` only tags the generated email/name; a fresh UUID keeps rows unique. Takes a bare `&mut PgConnection` so both pooled and direct connections work.

Test-only, coverage unchanged (the 34 tests across those modules pass). `#924` stays open for the remaining candidates (sessions/members, websocket messages, Codex permission payloads, metric buckets).