### PR TITLE
Make the connection-registry SessionId a real newtype

### DIFF
--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -58,8 +58,11 @@ pub fn spawn_stale_session_cleanup(
         );
         tokio::time::sleep(std::time::Duration::from_secs(RECONNECT_GRACE_SECS)).await;
 
-        let connected_keys: std::collections::HashSet<String> =
-            manager.registered_session_keys().into_iter().collect();
+        let connected_keys: std::collections::HashSet<String> = manager
+            .registered_session_keys()
+            .into_iter()
+            .map(|k| k.to_string())
+            .collect();
 
         let Ok(mut conn) = pool.get() else {
             tracing::error!("Failed to get DB connection for stale session cleanup");

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -378,7 +378,7 @@ pub async fn list_sessions(
             let is_connected = app_state
                 .session_manager
                 .sessions
-                .contains_key(&session.id.to_string());
+                .contains_key(session.id.to_string().as_str());
 
             AdminSessionInfo {
                 id: session.id,

--- a/backend/src/handlers/forward_proxy.rs
+++ b/backend/src/handlers/forward_proxy.rs
@@ -502,7 +502,7 @@ fn note_reachability(
         .note_forward_reachability(session_id, port, listening)
     {
         app_state.session_manager.broadcast_to_web_clients(
-            &session_key.to_string(),
+            session_key,
             shared::ServerToClient::ForwardsChanged { session_id },
         );
     }

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -1,4 +1,4 @@
-use super::{ProxySender, SessionManager};
+use super::{ProxySender, SessionId, SessionManager};
 use crate::db::DbPool;
 use diesel::prelude::*;
 use serde::Deserialize;
@@ -138,7 +138,7 @@ fn parse_send_mode(value: &str) -> Option<SendMode> {
 /// Stable dependencies for handling one proxy-originated output frame.
 pub struct ClaudeOutputContext<'a> {
     pub session_manager: &'a SessionManager,
-    pub session_key: &'a Option<String>,
+    pub session_key: &'a Option<SessionId>,
     pub db_session_id: Option<Uuid>,
     pub db_pool: &'a DbPool,
     pub notifications: &'a crate::push::NotificationSender,
@@ -400,7 +400,7 @@ pub fn handle_claude_output(ctx: ClaudeOutputContext<'_>, frame: ClaudeOutputFra
 /// skip, since the "human already responded" guard has no baseline).
 fn maybe_schedule_overloaded_retry(
     session_manager: &SessionManager,
-    session_key: &Option<String>,
+    session_key: &Option<SessionId>,
     session_id: Uuid,
     db_pool: &DbPool,
     content: &serde_json::Value,

--- a/backend/src/handlers/websocket/permissions.rs
+++ b/backend/src/handlers/websocket/permissions.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 #[allow(clippy::too_many_arguments)]
 pub fn handle_permission_request(
     session_manager: &SessionManager,
-    session_key: &Option<String>,
+    session_key: &Option<SessionId>,
     db_session_id: Option<Uuid>,
     db_pool: &DbPool,
     notifications: &crate::push::NotificationSender,

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -208,7 +208,7 @@ fn handle_proxy_message(
             claude_args,
             capabilities,
         }) => {
-            let key = claude_session_id.to_string();
+            let key = SessionId::new(claude_session_id.to_string());
 
             // SECURITY (#780): authenticate *before* registering the socket
             // with the SessionManager. Previously the socket was registered

--- a/backend/src/handlers/websocket/session_manager/client_fanout.rs
+++ b/backend/src/handlers/websocket/session_manager/client_fanout.rs
@@ -37,7 +37,7 @@ impl SessionManager {
             .push(sender);
     }
 
-    pub fn broadcast_to_web_clients(&self, session_key: &SessionId, msg: ServerToClient) {
+    pub fn broadcast_to_web_clients(&self, session_key: &str, msg: ServerToClient) {
         if let Some(mut clients) = self.web_clients.get_mut(session_key) {
             fanout_to_clients(clients.value_mut(), msg);
         }
@@ -53,7 +53,7 @@ impl SessionManager {
     /// would keep suppressing pushes until the next failed send lazily
     /// pruned it (see docs/MOBILE_APPS_PLAN.md §8.2). The lazy prune in
     /// `fanout_to_clients` stays as a backstop.
-    pub fn remove_web_client(&self, session_key: &SessionId, sender: &WebClientSender) {
+    pub fn remove_web_client(&self, session_key: &str, sender: &WebClientSender) {
         if let Some(mut clients) = self.web_clients.get_mut(session_key) {
             clients.retain(|c| !c.same_channel(sender));
             if clients.is_empty() {
@@ -160,7 +160,7 @@ mod tests {
         mgr.add_web_client("s1".into(), tx1);
         mgr.add_web_client("s1".into(), tx2);
 
-        mgr.broadcast_to_web_clients(&"s1".into(), make_client_msg());
+        mgr.broadcast_to_web_clients("s1", make_client_msg());
 
         assert!(matches!(
             rx1.try_recv().unwrap(),
@@ -183,7 +183,7 @@ mod tests {
 
         drop(rx1);
 
-        mgr.broadcast_to_web_clients(&"s1".into(), make_client_msg());
+        mgr.broadcast_to_web_clients("s1", make_client_msg());
 
         assert!(matches!(
             rx2.try_recv().unwrap(),
@@ -210,7 +210,7 @@ mod tests {
 
         drop(rx3);
 
-        mgr.broadcast_to_web_clients(&"s1".into(), make_client_msg());
+        mgr.broadcast_to_web_clients("s1", make_client_msg());
 
         assert!(matches!(
             rx1.try_recv().unwrap(),
@@ -280,12 +280,12 @@ mod tests {
         mgr.add_web_client("s1".into(), tx2.clone());
 
         // Removing one sender leaves the other and keeps the entry.
-        mgr.remove_web_client(&"s1".into(), &tx1);
+        mgr.remove_web_client("s1", &tx1);
         assert_eq!(mgr.web_clients.get("s1").unwrap().len(), 1);
 
         // Removing the last sender drops the map entry entirely, so presence
         // checks (map contains session) stay correct.
-        mgr.remove_web_client(&"s1".into(), &tx2);
+        mgr.remove_web_client("s1", &tx2);
         assert!(mgr.web_clients.get("s1").is_none());
     }
 

--- a/backend/src/handlers/websocket/session_manager/data_plane.rs
+++ b/backend/src/handlers/websocket/session_manager/data_plane.rs
@@ -101,7 +101,7 @@ impl SessionManager {
 
     /// Remove a data-plane socket, but only if it is still the registered one
     /// for `gen` — so a stale socket's teardown cannot evict its successor.
-    pub fn unregister_data_plane(&self, session_key: &SessionId, gen: u64) {
+    pub fn unregister_data_plane(&self, session_key: &str, gen: u64) {
         if self
             .data_planes
             .remove_if(session_key, |_, conn| conn.gen == gen)
@@ -119,7 +119,7 @@ impl SessionManager {
     /// teardown: the data plane exists only to serve that connection, so
     /// leaving it registered would let a later `open_tunnel` route bytes into
     /// a socket whose session is gone.
-    pub fn close_data_plane_for_connection(&self, session_key: &SessionId, gen: u64) {
+    pub fn close_data_plane_for_connection(&self, session_key: &str, gen: u64) {
         if let Some((_, conn)) = self
             .data_planes
             .remove_if(session_key, |_, conn| conn.gen == gen)
@@ -178,7 +178,11 @@ mod tests {
         let (tx, rx) = conn_channel::<shared::ServerToProxy>(8);
         // Keep the receiver alive for the test's duration.
         std::mem::forget(rx);
-        mgr.register_session(key.to_string(), tx, CancellationToken::new())
+        mgr.register_session(
+            SessionId::new(key.to_string()),
+            tx,
+            CancellationToken::new(),
+        )
     }
 
     fn data_sender() -> (DataPlaneSender, tokio::sync::mpsc::Receiver<TunnelFrame>) {
@@ -269,10 +273,10 @@ mod tests {
         );
 
         // A late teardown from an older generation is a no-op.
-        mgr.unregister_data_plane(&"s1".to_string(), gen - 1);
+        mgr.unregister_data_plane("s1", gen - 1);
         assert!(mgr.has_data_plane("s1", gen));
 
-        mgr.unregister_data_plane(&"s1".to_string(), gen);
+        mgr.unregister_data_plane("s1", gen);
         assert!(!mgr.has_data_plane("s1", gen));
     }
 
@@ -341,7 +345,7 @@ mod tests {
             cancel.clone(),
         );
 
-        mgr.close_data_plane_for_connection(&"s1".to_string(), gen);
+        mgr.close_data_plane_for_connection("s1", gen);
 
         assert!(!mgr.has_data_plane("s1", gen));
         assert!(cancel.is_cancelled());
@@ -365,7 +369,7 @@ mod tests {
             cancel.clone(),
         );
 
-        mgr.close_data_plane_for_connection(&"s1".to_string(), old_gen);
+        mgr.close_data_plane_for_connection("s1", old_gen);
 
         assert!(mgr.has_data_plane("s1", new_gen));
         assert!(!cancel.is_cancelled());

--- a/backend/src/handlers/websocket/session_manager/input_queue.rs
+++ b/backend/src/handlers/websocket/session_manager/input_queue.rs
@@ -23,7 +23,7 @@ use crate::markers::{INPUT_SEQ_BUMP_FAILED, PENDING_INPUT_PERSIST_FAILED};
 use crate::db::DbPool;
 use crate::models::NewPendingInput;
 
-use super::{SessionId, SessionManager};
+use super::SessionManager;
 
 /// Outcome of [`SessionManager::enqueue_input`].
 pub(crate) struct EnqueueOutcome {
@@ -42,7 +42,7 @@ impl SessionManager {
     pub(crate) fn enqueue_input(
         &self,
         db_pool: &DbPool,
-        session_key: &SessionId,
+        session_key: &str,
         session_id: Uuid,
         content: serde_json::Value,
         send_mode: Option<SendMode>,

--- a/backend/src/handlers/websocket/session_manager/liveness.rs
+++ b/backend/src/handlers/websocket/session_manager/liveness.rs
@@ -40,7 +40,7 @@ pub(super) fn epoch_secs() -> u64 {
 
 impl SessionManager {
     /// Record inbound activity from a proxy connection.
-    pub fn touch_session(&self, session_key: &SessionId) {
+    pub fn touch_session(&self, session_key: &str) {
         if let Some(conn) = self.sessions.get(session_key) {
             conn.last_seen.store(epoch_secs(), Ordering::Relaxed);
         }
@@ -220,7 +220,7 @@ mod tests {
             .store(epoch_secs() - 3600, Ordering::Relaxed);
 
         // An inbound frame arrives: the connection is alive after all.
-        mgr.touch_session(&"s1".into());
+        mgr.touch_session("s1");
 
         let (proxies, _) = mgr.sweep_stale_connections(
             PROXY_LIVENESS_DEADLINE_SECS,
@@ -228,6 +228,6 @@ mod tests {
         );
         assert_eq!(proxies, 0);
         assert!(mgr.sessions.contains_key("s1"));
-        assert!(mgr.send_to_session(&"s1".into(), make_heartbeat()));
+        assert!(mgr.send_to_session("s1", make_heartbeat()));
     }
 }

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -47,7 +47,66 @@ use pending_queue::PendingMessage;
 use tunnel_client::TunnelStreamMap;
 pub use tunnel_client::{TunnelError, TunnelIn};
 
-pub type SessionId = String;
+/// The key a connection registry entry is filed under (#921).
+///
+/// Formerly `type SessionId = String`, which is exactly the trap #921 targets:
+/// a bare alias documents intent but gives no safety — any `String` (a
+/// `user_id.to_string()`, a hostname, an unrelated id) could be handed to the
+/// registry as a session key and the compiler would say nothing, mis-routing a
+/// connection. As a newtype it is distinct from `String`, so constructing one
+/// is now an explicit, greppable act.
+///
+/// `Borrow<str>` keeps `DashMap` lookups (`get`/`remove`/`contains_key`)
+/// working with a `&str` and no allocation, so only the places that *create* a
+/// session key changed; call sites that merely look one up did not.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SessionId(String);
+
+impl SessionId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for SessionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for SessionId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for SessionId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl std::borrow::Borrow<str> for SessionId {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+// Deref to `str` so a `&SessionId` reads like the key it wraps — coercing to
+// `&str` at lookup call sites and giving `{}`/comparison for free — while
+// *construction* stays explicit (`SessionId::new`/`from`), which is where the
+// type safety lives.
+impl std::ops::Deref for SessionId {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
 pub type ProxySender = ConnSender<ServerToProxy>;
 pub type WebClientSender = ConnSender<ServerToClient>;
 

--- a/backend/src/handlers/websocket/session_manager/pending_queue.rs
+++ b/backend/src/handlers/websocket/session_manager/pending_queue.rs
@@ -22,7 +22,7 @@ pub(super) struct PendingMessage {
 }
 
 impl SessionManager {
-    pub fn send_to_session(&self, session_key: &SessionId, msg: ServerToProxy) -> bool {
+    pub fn send_to_session(&self, session_key: &str, msg: ServerToProxy) -> bool {
         let msg = match self.sessions.get(session_key) {
             Some(conn) => match conn.sender.send(msg) {
                 Ok(()) => return true,
@@ -43,7 +43,7 @@ impl SessionManager {
         self.queue_pending_message(session_key, msg)
     }
 
-    pub fn send_to_connected_session(&self, session_key: &SessionId, msg: ServerToProxy) -> bool {
+    pub fn send_to_connected_session(&self, session_key: &str, msg: ServerToProxy) -> bool {
         match self.sessions.get(session_key) {
             Some(conn) => match conn.sender.send(msg) {
                 Ok(()) => true,
@@ -61,11 +61,7 @@ impl SessionManager {
 
     /// Drain this session's pending queue into `sender`, dropping entries
     /// older than [`MAX_PENDING_MESSAGE_AGE`]. Called on proxy registration.
-    pub(super) fn replay_pending_messages(
-        &self,
-        session_key: &SessionId,
-        sender: &ProxySender,
-    ) -> usize {
+    pub(super) fn replay_pending_messages(&self, session_key: &str, sender: &ProxySender) -> usize {
         let mut replayed = 0;
         let now = Instant::now();
 
@@ -91,10 +87,10 @@ impl SessionManager {
         replayed
     }
 
-    fn queue_pending_message(&self, session_key: &SessionId, msg: ServerToProxy) -> bool {
+    fn queue_pending_message(&self, session_key: &str, msg: ServerToProxy) -> bool {
         let mut queue = self
             .pending_messages
-            .entry(session_key.clone())
+            .entry(SessionId::from(session_key))
             .or_default();
 
         while queue.len() >= MAX_PENDING_MESSAGES_PER_SESSION {
@@ -137,8 +133,8 @@ mod tests {
     fn send_to_unregistered_queues_pending() {
         let mgr = SessionManager::new();
 
-        assert!(mgr.send_to_session(&"s1".into(), make_output(1)));
-        assert!(mgr.send_to_session(&"s1".into(), make_output(2)));
+        assert!(mgr.send_to_session("s1", make_output(1)));
+        assert!(mgr.send_to_session("s1", make_output(2)));
 
         let (tx, mut rx) = crate::handlers::websocket::conn_channel(64);
         register(&mgr, "s1", tx);
@@ -156,7 +152,7 @@ mod tests {
         let mgr = SessionManager::new();
 
         for i in 0..(MAX_PENDING_MESSAGES_PER_SESSION + 10) as u32 {
-            mgr.send_to_session(&"s1".into(), make_output(i));
+            mgr.send_to_session("s1", make_output(i));
         }
 
         // Must exceed MAX_PENDING_MESSAGES_PER_SESSION: registration replays
@@ -188,7 +184,7 @@ mod tests {
         drop(rx);
 
         let queued = mgr.send_to_session(
-            &"s1".into(),
+            "s1",
             ServerToProxy::OutputAck {
                 session_id: Uuid::nil(),
                 ack_seq: 7,
@@ -213,10 +209,10 @@ mod tests {
         let (tx, _rx) = crate::handlers::websocket::conn_channel(64);
 
         let gen = register(&mgr, "s1", tx);
-        mgr.unregister_session(&"s1".into(), Some(gen));
+        mgr.unregister_session("s1", Some(gen));
 
-        mgr.send_to_session(&"s1".into(), make_output(1));
-        mgr.send_to_session(&"s1".into(), make_output(2));
+        mgr.send_to_session("s1", make_output(1));
+        mgr.send_to_session("s1", make_output(2));
 
         let (tx2, mut rx2) = crate::handlers::websocket::conn_channel(64);
         register(&mgr, "s1", tx2);

--- a/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
+++ b/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
@@ -49,7 +49,7 @@ impl SessionManager {
     /// entry when it matches the current generation — preventing a stale
     /// connection's cleanup from removing a newer connection's registration.
     /// Pass `None` to force removal (e.g. admin delete).
-    pub fn unregister_session(&self, session_key: &SessionId, gen: Option<u64>) {
+    pub fn unregister_session(&self, session_key: &str, gen: Option<u64>) {
         let removed = match gen {
             // Atomic compare-and-remove under one shard lock (the previous
             // separate check-then-remove had a small TOCTOU window).
@@ -80,7 +80,7 @@ impl SessionManager {
     /// cancelled either way).
     pub(super) fn evict_dead_connection(
         &self,
-        session_key: &SessionId,
+        session_key: &str,
         gen: u64,
         cancel: &CancellationToken,
     ) -> bool {
@@ -101,7 +101,7 @@ impl SessionManager {
     /// Check whether the given generation is still the current connection for
     /// this session. Used by cleanup code to avoid overwriting a newer
     /// connection's DB status.
-    pub fn is_current_connection(&self, session_key: &SessionId, gen: u64) -> bool {
+    pub fn is_current_connection(&self, session_key: &str, gen: u64) -> bool {
         self.sessions
             .get(session_key)
             .is_none_or(|conn| conn.gen == gen)
@@ -151,7 +151,7 @@ mod tests {
 
         register(&mgr, "s1", tx);
 
-        assert!(mgr.send_to_session(&"s1".into(), make_heartbeat()));
+        assert!(mgr.send_to_session("s1", make_heartbeat()));
 
         let msg = rx.try_recv().unwrap();
         assert!(matches!(msg, ServerToProxy::Heartbeat));
@@ -165,7 +165,7 @@ mod tests {
         let gen = register(&mgr, "s1", tx);
         assert!(mgr.sessions.contains_key("s1"));
 
-        mgr.unregister_session(&"s1".into(), Some(gen));
+        mgr.unregister_session("s1", Some(gen));
         assert!(!mgr.sessions.contains_key("s1"));
     }
 
@@ -177,7 +177,7 @@ mod tests {
         register(&mgr, "s1", tx);
         assert!(mgr.sessions.contains_key("s1"));
 
-        mgr.unregister_session(&"s1".into(), None);
+        mgr.unregister_session("s1", None);
         assert!(!mgr.sessions.contains_key("s1"));
     }
 
@@ -194,11 +194,11 @@ mod tests {
         let _new_gen = register(&mgr, "s1", tx2);
 
         // Old connection's cleanup tries to unregister with stale gen
-        mgr.unregister_session(&"s1".into(), Some(old_gen));
+        mgr.unregister_session("s1", Some(old_gen));
 
         // Session should still be registered with the new sender
         assert!(mgr.sessions.contains_key("s1"));
-        assert!(mgr.send_to_session(&"s1".into(), make_heartbeat()));
+        assert!(mgr.send_to_session("s1", make_heartbeat()));
         assert!(matches!(rx2.try_recv().unwrap(), ServerToProxy::Heartbeat));
     }
 
@@ -208,12 +208,12 @@ mod tests {
         let (tx1, _rx1) = crate::handlers::websocket::conn_channel(64);
 
         let gen1 = register(&mgr, "s1", tx1);
-        assert!(mgr.is_current_connection(&"s1".into(), gen1));
+        assert!(mgr.is_current_connection("s1", gen1));
 
         let (tx2, _rx2) = crate::handlers::websocket::conn_channel(64);
         let gen2 = register(&mgr, "s1", tx2);
-        assert!(!mgr.is_current_connection(&"s1".into(), gen1));
-        assert!(mgr.is_current_connection(&"s1".into(), gen2));
+        assert!(!mgr.is_current_connection("s1", gen1));
+        assert!(mgr.is_current_connection("s1", gen2));
     }
 
     /// #1256: a send to a registered connection whose channel has died must
@@ -232,7 +232,7 @@ mod tests {
         // The direct send fails internally; the message is queued for the
         // successor (hence `true`), the dead entry is evicted, and its
         // socket is told to close.
-        assert!(mgr.send_to_session(&"s1".into(), make_heartbeat()));
+        assert!(mgr.send_to_session("s1", make_heartbeat()));
         assert!(!mgr.sessions.contains_key("s1"));
         assert!(cancel.is_cancelled());
 
@@ -256,11 +256,11 @@ mod tests {
         register(&mgr, "s1", tx2);
 
         drop(rx1);
-        mgr.evict_dead_connection(&"s1".into(), gen1, &cancel1);
+        mgr.evict_dead_connection("s1", gen1, &cancel1);
 
         // Successor survives and still receives.
         assert!(mgr.sessions.contains_key("s1"));
-        assert!(mgr.send_to_session(&"s1".into(), make_heartbeat()));
+        assert!(mgr.send_to_session("s1", make_heartbeat()));
         assert!(matches!(rx2.try_recv().unwrap(), ServerToProxy::Heartbeat));
         // The dead connection's socket still gets closed.
         assert!(cancel1.is_cancelled());

--- a/backend/src/handlers/websocket/session_manager/tunnel_client.rs
+++ b/backend/src/handlers/websocket/session_manager/tunnel_client.rs
@@ -509,6 +509,7 @@ async fn run_relay(
 
 #[cfg(test)]
 mod tests {
+    use super::super::SessionId;
     use super::*;
     use crate::handlers::websocket::SessionManager;
 
@@ -579,7 +580,7 @@ mod tests {
         let mgr = SessionManager::new();
         let (tx, _rx) = conn_channel::<ServerToProxy>(64);
         mgr.register_session(
-            "k".to_string(),
+            SessionId::new("k"),
             tx,
             tokio_util::sync::CancellationToken::new(),
         );

--- a/backend/src/handlers/websocket/tunnel_socket.rs
+++ b/backend/src/handlers/websocket/tunnel_socket.rs
@@ -28,7 +28,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use super::session_manager::DATA_PLANE_CHANNEL_CAPACITY;
-use super::{conn_channel, tunnel_ticket};
+use super::{conn_channel, tunnel_ticket, SessionId};
 use crate::AppState;
 
 /// How long a freshly connected data socket may take to send its `Hello`.
@@ -79,7 +79,7 @@ pub async fn handle_tunnel_data_socket(socket: WebSocket, app_state: Arc<AppStat
     // since been superseded, and a socket that finished connecting only after
     // its control connection was replaced.
     if !session_manager.register_data_plane(
-        ticket.session_key.clone(),
+        SessionId::new(ticket.session_key.clone()),
         ticket.gen,
         ticket.sizing,
         tx,

--- a/backend/src/handlers/websocket/uploads.rs
+++ b/backend/src/handlers/websocket/uploads.rs
@@ -402,7 +402,7 @@ mod tests {
         // forwarded, and (c) `pending_uploads` is cleared once the unique
         // chunk count hits `total_chunks`.
         let session_manager = SessionManager::new();
-        let session_key: SessionId = "test-session".to_string();
+        let session_key = SessionId::new("test-session");
         let (proxy_tx, mut proxy_rx) = crate::handlers::websocket::conn_channel(64);
         let (client_tx, _client_rx) = crate::handlers::websocket::conn_channel(64);
         session_manager.register_session(
@@ -484,7 +484,7 @@ mod tests {
         // remove the pending entry, so subsequent chunks for the same
         // upload_id are silently dropped (the unknown-upload_id path).
         let session_manager = SessionManager::new();
-        let session_key: SessionId = "test-session-2".to_string();
+        let session_key = SessionId::new("test-session-2");
         let (proxy_tx, mut proxy_rx) = crate::handlers::websocket::conn_channel(64);
         let (client_tx, _client_rx) = crate::handlers::websocket::conn_channel(64);
         session_manager.register_session(

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -346,7 +346,7 @@ fn handle_web_register(
     });
     match access {
         Ok(_session) => {
-            let key = session_id.to_string();
+            let key = SessionId::new(session_id.to_string());
             *session_key = Some(key.clone());
             *verified_session_id = Some(session_id);
 


### PR DESCRIPTION
Follow-up on #921 (the second focused newtype, after the task-panel ids in #1547): the connection registry's `SessionId`.

## The trap

`session_manager` declared `pub type SessionId = String` — a bare alias. It documents intent but gives **zero** safety: a `SessionId` *is* a `String`, so any `String` — a `user_id.to_string()`, a hostname, some unrelated id — could be handed to the registry as a session key and the compiler would say nothing. In a `DashMap<SessionId, ProxyConnection>` that keys live proxy/web-client routing, a wrong key silently mis-routes a connection. This is exactly the "important identifiers passed as plain String" case #921 calls out, at the highest-stakes boundary.

## The change

Promote the alias to a newtype `pub struct SessionId(String)`. **Construction becomes explicit** (`SessionId::new` / `From`) — the one place a wrong key could enter is now greppable and type-checked. To keep the read side from churning:

- `impl Borrow<str>` — `DashMap` `get`/`remove`/`contains_key` take `&str` and work against the `SessionId` keys with no allocation.
- `impl Deref<Target = str>` — a `&SessionId` coerces to `&str` at lookup call sites, and `{}`/comparison come for free.

So the registry's **lookup** methods now take `&str` (idiomatic — you look a map up by its borrowed key), while **insert/register** methods keep owned `SessionId`. Net: only the sites that *create* a session key changed; the ones that merely look one up did not.

## Scope

Backend-internal by design. The wire type (`SessionInfo.session_key`) and the Diesel models stay `String` — no serde/`FromSql` impls, no migration — and convert to `SessionId` at the registry boundary (e.g. the proxy `Register` handler, the tunnel-ticket JWT claim). The JWT claim itself stays `String`, since it's a serialized field.

## Verification

Compiler-driven throughout — every conversion site was a hard error, nothing silent. The connection-lifecycle registry has behavior tests (register/unregister/broadcast, generation guards, pending-queue); **all backend tests pass unchanged**, which is the proof this is a pure type-level change. Clippy clean, fmt clean. No wire/DB/frontend surface touched.

Refs #921 — the alias-to-newtype promotion was its clearest remaining high-value target; the issue can stay open for the smaller candidates (model names, service tiers) or close.