### PR TITLE
Clear a session's red 'needs response' outline once you've viewed it

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -582,9 +582,18 @@ pub fn dashboard_page() -> Html {
         )
     };
 
-    // Computed values
-    let waiting_count = session_state
+    // Computed values.
+    // The rail's red "needs response" outline and this count show sessions still
+    // awaiting a reply that the user hasn't looked at yet — awaiting minus the
+    // ones whose current awaiting state has been seen (see DashboardSessionState
+    // `seen_awaiting`). Viewing a session clears it here without disturbing the
+    // underlying "agent is parked" flag.
+    let effective_awaiting: HashSet<Uuid> = session_state
         .awaiting_sessions
+        .difference(&session_state.seen_awaiting)
+        .copied()
+        .collect();
+    let waiting_count = effective_awaiting
         .iter()
         .filter(|id| !effective_hidden_sessions.contains(id))
         .count();
@@ -785,7 +794,7 @@ pub fn dashboard_page() -> Html {
                     <SessionRail
                         sessions={active_sessions.clone()}
                         focused_index={focus.focused_index}
-                        awaiting_sessions={session_state.awaiting_sessions.clone()}
+                        awaiting_sessions={effective_awaiting.clone()}
                         hidden_sessions={effective_hidden_sessions.clone()}
                         inactive_hidden={ui_state.inactive_hidden}
                         group_by_host={ui_state.group_by_host}

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -16,6 +16,14 @@ use super::types::RailPosition;
 pub(super) struct DashboardSessionState {
     pub focused_id: Option<Uuid>,
     pub awaiting_sessions: HashSet<Uuid>,
+    /// Sessions whose *current* "needs response" state the user has already
+    /// looked at. The rail's red outline (and the waiting count) show
+    /// `awaiting_sessions - seen_awaiting`, so once you view an awaiting session
+    /// it stops nagging even after focus moves elsewhere — until a fresh
+    /// awaiting cycle (the agent finishing another turn) re-lights it. Kept as a
+    /// separate set rather than mutating `awaiting_sessions` so the underlying
+    /// "agent is parked" truth stays intact for other consumers.
+    pub seen_awaiting: HashSet<Uuid>,
     pub hidden_sessions: HashSet<Uuid>,
     pub connected_sessions: HashSet<Uuid>,
     pub activated_sessions: HashSet<Uuid>,
@@ -28,6 +36,7 @@ impl DashboardSessionState {
         Self {
             focused_id: None,
             awaiting_sessions: HashSet::new(),
+            seen_awaiting: HashSet::new(),
             hidden_sessions,
             connected_sessions: HashSet::new(),
             activated_sessions: HashSet::new(),
@@ -82,6 +91,11 @@ impl Reducible for DashboardSessionState {
             DashboardSessionAction::FocusAndActivate(session_id) => {
                 state.focused_id = Some(session_id);
                 state.activated_sessions.insert(session_id);
+                // Viewing a session acknowledges its current awaiting state, so
+                // the rail stops flagging it red even after focus moves on.
+                if state.awaiting_sessions.contains(&session_id) {
+                    state.seen_awaiting.insert(session_id);
+                }
             }
             DashboardSessionAction::Activate(session_id) => {
                 state.activated_sessions.insert(session_id);
@@ -93,6 +107,20 @@ impl Reducible for DashboardSessionState {
                 let changed = set_membership(&mut state.awaiting_sessions, session_id, awaiting);
                 if !changed {
                     return self;
+                }
+                if awaiting {
+                    // Rising edge (a genuinely new awaiting cycle). If the user
+                    // is already looking at this session, treat it as seen;
+                    // otherwise leave it unseen so the rail lights it red.
+                    if state.focused_id == Some(session_id) {
+                        state.seen_awaiting.insert(session_id);
+                    } else {
+                        state.seen_awaiting.remove(&session_id);
+                    }
+                } else {
+                    // Falling edge: forget any acknowledgement so the next
+                    // awaiting cycle re-alerts.
+                    state.seen_awaiting.remove(&session_id);
                 }
             }
             DashboardSessionAction::SetConnected {
@@ -111,7 +139,9 @@ impl Reducible for DashboardSessionState {
                 }
             }
             DashboardSessionAction::MessageSent(session_id) => {
-                if !state.awaiting_sessions.remove(&session_id) {
+                let was_awaiting = state.awaiting_sessions.remove(&session_id);
+                let was_seen = state.seen_awaiting.remove(&session_id);
+                if !was_awaiting && !was_seen {
                     return self;
                 }
             }
@@ -357,6 +387,87 @@ mod tests {
 
         let state = state.reduce(DashboardSessionAction::MessageSent(id(1)));
         assert!(!state.awaiting_sessions.contains(&id(1)));
+    }
+
+    fn set_awaiting(
+        awaiting: bool,
+    ) -> impl Fn(Rc<DashboardSessionState>) -> Rc<DashboardSessionState> {
+        move |state: Rc<DashboardSessionState>| {
+            state.reduce(DashboardSessionAction::SetAwaiting {
+                session_id: id(1),
+                awaiting,
+            })
+        }
+    }
+
+    #[test]
+    fn viewing_an_awaiting_session_marks_it_seen_until_the_next_cycle() {
+        // Becomes awaiting while unfocused → unseen, so the rail lights it red.
+        let state = reduce(
+            DashboardSessionState::new(HashSet::new()),
+            DashboardSessionAction::SetAwaiting {
+                session_id: id(1),
+                awaiting: true,
+            },
+        );
+        assert!(state.awaiting_sessions.contains(&id(1)));
+        assert!(!state.seen_awaiting.contains(&id(1)));
+
+        // User views it → acknowledged; still awaiting underneath.
+        let state = state.reduce(DashboardSessionAction::FocusAndActivate(id(1)));
+        assert!(state.seen_awaiting.contains(&id(1)));
+        assert!(state.awaiting_sessions.contains(&id(1)));
+
+        // A redundant re-assert of the same awaiting level is a no-op and keeps
+        // the acknowledgement (the agent is still parked on the same turn).
+        let state = set_awaiting(true)(state);
+        assert!(state.seen_awaiting.contains(&id(1)));
+
+        // User switches focus to a different session; the acknowledgement on the
+        // first one survives, so it stays quiet in the background.
+        let state = state.reduce(DashboardSessionAction::FocusAndActivate(id(2)));
+        assert!(state.seen_awaiting.contains(&id(1)));
+
+        // The agent works (falling edge) then finishes again (rising edge) while
+        // that session is unfocused → it re-alerts.
+        let state = set_awaiting(false)(state);
+        assert!(!state.seen_awaiting.contains(&id(1)));
+        let state = set_awaiting(true)(state);
+        assert!(state.awaiting_sessions.contains(&id(1)));
+        assert!(!state.seen_awaiting.contains(&id(1)));
+    }
+
+    #[test]
+    fn awaiting_while_focused_is_acknowledged_immediately() {
+        // Focus a session that is not yet awaiting.
+        let state = reduce(
+            DashboardSessionState::new(HashSet::new()),
+            DashboardSessionAction::FocusAndActivate(id(1)),
+        );
+        assert!(!state.seen_awaiting.contains(&id(1)));
+
+        // It finishes its turn while the user is looking at it → seen at once,
+        // so it never flashes red when the user later switches away.
+        let state = set_awaiting(true)(state);
+        assert!(state.awaiting_sessions.contains(&id(1)));
+        assert!(state.seen_awaiting.contains(&id(1)));
+    }
+
+    #[test]
+    fn message_sent_clears_both_awaiting_and_seen() {
+        let state = reduce(
+            DashboardSessionState::new(HashSet::new()),
+            DashboardSessionAction::SetAwaiting {
+                session_id: id(1),
+                awaiting: true,
+            },
+        );
+        let state = state.reduce(DashboardSessionAction::FocusAndActivate(id(1)));
+        assert!(state.seen_awaiting.contains(&id(1)));
+
+        let state = state.reduce(DashboardSessionAction::MessageSent(id(1)));
+        assert!(!state.awaiting_sessions.contains(&id(1)));
+        assert!(!state.seen_awaiting.contains(&id(1)));
     }
 
     fn reduce_ui(state: DashboardUiState, action: DashboardUiAction) -> Rc<DashboardUiState> {


### PR DESCRIPTION
## What

Viewing a session now clears its red "needs response" rail outline and keeps it clear after you switch away — until the agent genuinely finishes a *new* turn.

## Why

The red `.awaiting` pill border means "agent finished its turn, waiting on you." It's a live flag recomputed from message flow, and the **focused** pill already renders a blue focus ring instead of red — so red only shows on **background** sessions. That's the annoyance: the moment you click away from a session you just read, its red border snaps back, because the agent is still parked waiting. Sessions you've already looked at keep nagging.

## How

Add a `seen_awaiting` set to the dashboard reducer. The rail outline and the "N waiting" count now show `awaiting_sessions − seen_awaiting`:

- **Viewing** a session (`FocusAndActivate` — the path both a pill click and keyboard-nav selection take) marks its current awaiting state seen → stays quiet after focus moves on.
- **Fresh awaiting cycle re-alerts**: when the agent works (awaiting falls) then finishes again (rising edge) while the session is unfocused, the seen mark is dropped and it lights red again.
- **Finishing while focused** is acknowledged immediately, so it never flashes red when you later switch away.
- **Sending a message** clears both, as before.

The underlying `awaiting_sessions` "agent is parked" truth is left intact (kept as a separate set), so nothing else that reads it is affected.

## Verification

- New unit tests in `page_state.rs` cover: view-then-switch-away stays quiet, a new cycle re-alerts, awaiting-while-focused is acknowledged, and message-sent clears both. `cargo test -p frontend --lib page_state` → 10 passed.
- `cargo check` / `cargo clippy -p frontend --target wasm32-unknown-unknown`: clean, no warnings.