### PR TITLE
Update codex-codes to 0.146.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ agent-portal is a web-based proxy system for Claude Code sessions built with:
 
 We maintain **[meawoppl/rust-code-agent-sdks](https://github.com/meawoppl/rust-claude-codes)** — a workspace containing two Rust crates for parsing code agent CLI output:
 
-- **`claude-codes`** (v2.1.166) — Types for Claude Code's JSON protocol (`ClaudeOutput`, `ResultMessage`, `UsageInfo`, `RateLimitEvent`, etc.). Used by the proxy to deserialize Claude's stdout.
-- **`codex-codes`** (v0.145.0) — Types for OpenAI Codex CLI's JSONL protocol (`ThreadEvent`, `ThreadItem`, `Usage`, etc.). Phase 1 integration complete (AgentType, DB schema); see [docs/CODEX_SUPPORT.md](docs/CODEX_SUPPORT.md) for the full plan.
+- **`claude-codes`** (v2.1.220) — Types for Claude Code's JSON protocol (`ClaudeOutput`, `ResultMessage`, `UsageInfo`, `RateLimitEvent`, etc.). Used by the proxy to deserialize Claude's stdout.
+- **`codex-codes`** (v0.146.2) — Types for OpenAI Codex CLI's JSONL protocol (`ThreadEvent`, `ThreadItem`, `Usage`, etc.). Phase 1 integration complete (AgentType, DB schema); see [docs/CODEX_SUPPORT.md](docs/CODEX_SUPPORT.md) for the full plan.
 
 ## Architecture Quick Reference
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.146.0"
+version = "0.146.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1486b578174fd694d3900979cfeca8e6f9f48b1d0c6fef3d0374c6361bd73f"
+checksum = "31d58e57190c588fcc2d1fe33a5b9a0ffba1cb1c5e59a7214be841966f18f422"
 dependencies = [
  "log",
  "serde",
@@ -1282,7 +1282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2275,7 +2275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5670,7 +5670,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6050,7 +6050,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6131,7 +6131,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7382,7 +7382,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8576,7 +8576,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = { version = "2.1.220", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.146.0", default-features = false, features = ["types"] }
+codex-codes = { version = "0.146.2", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
Routine SDK refresh.

- **codex-codes** `0.146.0 → 0.146.2` — a patch bump, already inside the declared caret range; bumped the manifest floor + lockfile.
- **claude-codes** — already at the latest published `2.1.220`, nothing to do.

Both are declared once in `[workspace.dependencies]`, so this is a single point of change consumed by shared / backend / frontend / proxy / the session-lib crates.

Also updated the stale versions in CLAUDE.md's Related Projects section (they read v2.1.166 / v0.145.0).

Verified: `cargo build --workspace` + wasm build clean, codex-session-lib / shared / frontend tests green (6 binaries), clippy clean. Non-breaking.