### PR TITLE
Add a nav-mode 'c' hotkey to collapse (hide) the focused session

### DIFF
--- a/frontend/src/components/help_overlay.rs
+++ b/frontend/src/components/help_overlay.rs
@@ -117,6 +117,10 @@ const GROUPS: &[ShortcutGroup] = &[
                 description: "Interrupt the focused session's agent",
             },
             Shortcut {
+                keys: &["c"],
+                description: "Collapse (hide) / expand the focused session",
+            },
+            Shortcut {
                 keys: &["Enter"],
                 description: "Accept the current pane and return to edit mode",
             },

--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -203,6 +203,11 @@ pub struct KeyboardNavConfig {
     /// Callback to interrupt the focused session's running agent (nav-mode
     /// `x`). Same action as `Ctrl+C`, exposed as a single nav-mode key (#1330).
     pub on_interrupt: Callback<()>,
+    /// Callback to collapse (hide) / expand (show) a session, given its id
+    /// (nav-mode `c` on the focused session). Reuses the rail's Hide toggle, so
+    /// a collapsed session drops into the rail's hidden group and out of
+    /// focus/keyboard rotation.
+    pub on_toggle_hidden: Callback<Uuid>,
 }
 
 /// Return value from the use_keyboard_nav hook.
@@ -233,6 +238,7 @@ pub struct UseKeyboardNav {
 /// - Numbers 1-9 select directly (stays in Nav mode)
 /// - n -> new session (launch dialog)
 /// - d -> delete the focused session (via the confirm modal)
+/// - c -> collapse (hide) / expand (show) the focused session
 /// - w -> next waiting session
 /// - Enter -> accept the current pane and return to Edit Mode
 /// - Ctrl/Cmd+K -> back to Edit Mode
@@ -272,6 +278,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
         let on_delete = config.on_delete.clone();
         let on_jump_to_latest = config.on_jump_to_latest.clone();
         let on_interrupt = config.on_interrupt.clone();
+        let on_toggle_hidden = config.on_toggle_hidden.clone();
         Callback::from(move |e: KeyboardEvent| {
             // Don't handle keyboard nav when a modal overlay is open. The launch
             // dialog, full-page modals, and help overlay are included so their
@@ -476,6 +483,30 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                         // in nav mode like the other action keys.
                         e.prevent_default();
                         on_interrupt.emit(());
+                    }
+                    "c" => {
+                        // Collapse (hide) / expand (show) the focused session,
+                        // reusing the rail's Hide toggle — a keyboard path to
+                        // tuck a session out of rotation without the kebab menu.
+                        // When collapsing the focused session, advance focus to
+                        // the next active session so you land on something you're
+                        // working with rather than the pane you just hid. Stays in
+                        // nav mode like the other action keys.
+                        e.prevent_default();
+                        if let Some(session) = sessions.get(focused_index) {
+                            let was_hidden = hidden_sessions.contains(&session.id);
+                            on_toggle_hidden.emit(session.id);
+                            if !was_hidden {
+                                if let Some(new_idx) = navigate_to_next_active(focused_index) {
+                                    if new_idx != focused_index {
+                                        if let Some(next) = sessions.get(new_idx) {
+                                            on_activate.emit(next.id);
+                                        }
+                                        on_select.emit(new_idx);
+                                    }
+                                }
+                            }
+                        }
                     }
                     "G" => {
                         // Jump the focused session's transcript to the newest

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -236,6 +236,23 @@ pub fn dashboard_page() -> Html {
     };
 
     // Use the keyboard navigation hook
+    // Toggle a session between hidden ("collapsed") and shown. Shared by the
+    // rail kebab menu and the nav-mode `c` shortcut; persists to localStorage.
+    let on_toggle_hidden = {
+        let session_state = session_state.clone();
+        Callback::from(move |session_id: Uuid| {
+            let hidden = !session_state.hidden_sessions.contains(&session_id);
+            let mut set = session_state.hidden_sessions.clone();
+            if hidden {
+                set.insert(session_id);
+            } else {
+                set.remove(&session_id);
+            }
+            save_hidden_sessions(&set);
+            session_state.dispatch(DashboardSessionAction::SetHidden { session_id, hidden });
+        })
+    };
+
     let keyboard_nav = use_keyboard_nav(KeyboardNavConfig {
         sessions: active_sessions.clone(),
         focused_index: focus.focused_index,
@@ -247,6 +264,7 @@ pub fn dashboard_page() -> Html {
         on_delete: on_delete.clone(),
         on_jump_to_latest: focus.on_jump_to_latest.clone(),
         on_interrupt: focus.on_interrupt.clone(),
+        on_toggle_hidden: on_toggle_hidden.clone(),
     });
 
     // Ctrl+C interrupt: a window capture-phase listener so it fires in every
@@ -490,21 +508,6 @@ pub fn dashboard_page() -> Html {
                     }
                 }
             });
-        })
-    };
-
-    let on_toggle_hidden = {
-        let session_state = session_state.clone();
-        Callback::from(move |session_id: Uuid| {
-            let hidden = !session_state.hidden_sessions.contains(&session_id);
-            let mut set = session_state.hidden_sessions.clone();
-            if hidden {
-                set.insert(session_id);
-            } else {
-                set.remove(&session_id);
-            }
-            save_hidden_sessions(&set);
-            session_state.dispatch(DashboardSessionAction::SetHidden { session_id, hidden });
         })
     };
 


### PR DESCRIPTION
## What

A nav-mode **`c`** hotkey that collapses (hides) — or expands (shows) — the focused session, so you can tuck sessions out of the way and keep your active ones front-and-center without reaching for the mouse.

## Why

The dashboard already has a solid "Hide Session" mechanism (drops the session into the rail's collapsible hidden group and out of focus/keyboard rotation/waiting-count), but it was **only reachable through the pill's kebab menu** — there was no hotkey. This fills that gap rather than inventing a parallel "collapse" concept. (`h`, the natural "hide" mnemonic, is taken by vim-left movement; `c` = collapse.)

## How

- New `KeyboardNavConfig::on_toggle_hidden`, wired to the **existing** `on_toggle_hidden` callback (now defined once and shared by the rail menu and the hotkey — single source of truth, same localStorage persistence).
- Nav-mode `c` toggles hide on the focused session. When **collapsing** the focused one, focus advances to the next active session (via the existing `navigate_to_next_active`) so you land on something you're working with, not the pane you just hid. Pressing `c` on an already-hidden focused session just expands it (no focus change).
- Added to the keyboard-shortcuts help overlay (`?`), next to `x`/`d`.

To bring a collapsed session back you can also expand it from the rail's hidden group / kebab menu, exactly as today.

## Verification

- `cargo check` / `cargo clippy -p frontend --target wasm32-unknown-unknown`: clean, no warnings.
- Reuses the already-tested `SetHidden` reducer path; no protocol/backend changes.

_(Was #1555, which GitHub auto-closed when its stacked base branch was deleted after #1554 merged; rebased onto `main` as a single commit and reopened here.)_