### PR TITLE
Fix nav-mode guard matching transcript permission spans (Cmd+K dead in real sessions)

### DIFF
--- a/frontend/src/hooks/use_keyboard_nav.rs
+++ b/frontend/src/hooks/use_keyboard_nav.rs
@@ -284,17 +284,25 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
             // dialog, full-page modals, and help overlay are included so their
             // own keys (Esc / backdrop) win and nav shortcuts don't fire
             // underneath them.
-            // `.permission-prompt` covers the permission dialog, the
-            // AskUserQuestion answer card, and the exit-plan-mode prompt (they
-            // share that root class). While one is open the user is answering
-            // it, so nav keys must stand down rather than double-handle the
-            // keystroke — driving navigation *and* leaking into the choice UI
-            // (#1413).
+            // `div.permission-prompt` covers the permission dialog, the
+            // AskUserQuestion answer card, and the exit-plan-mode prompt (their
+            // three dialog roots are `<div class="permission-prompt …">`). While
+            // one is open the user is answering it, so nav keys must stand down
+            // rather than double-handle the keystroke — driving navigation *and*
+            // leaking into the choice UI (#1413).
+            //
+            // The `div.` qualifier is load-bearing: transcript tool renderers
+            // also emit `<span class="permission-prompt">` for each requested-
+            // permission line (`tool_renderers/interactive.rs`). A bare
+            // `.permission-prompt` therefore matches historical transcript
+            // content, so any session that has shown a tool permission would
+            // leave the guard permanently tripped and silently kill Cmd+K / all
+            // nav keys. Scoping to the dialog `<div>` avoids that collision.
             if gloo::utils::document()
                 .query_selector(
                     ".sched-overlay, .share-dialog-overlay, .help-overlay, \
                      .launch-dialog-backdrop, .modal-overlay, .full-page-modal, \
-                     .health-timer-overlay, .permission-prompt",
+                     .health-timer-overlay, div.permission-prompt",
                 )
                 .ok()
                 .flatten()
@@ -596,7 +604,7 @@ pub fn use_keyboard_nav(config: KeyboardNavConfig) -> UseKeyboardNav {
                         .query_selector(
                             ".sched-overlay, .share-dialog-overlay, .help-overlay, \
                              .launch-dialog-backdrop, .modal-overlay, .full-page-modal, \
-                             .health-timer-overlay, .permission-prompt",
+                             .health-timer-overlay, div.permission-prompt",
                         )
                         .ok()
                         .flatten()


### PR DESCRIPTION
## What

Scope the nav-mode modal-guard's permission selector from `.permission-prompt` to `div.permission-prompt`, so it stops matching transcript content and only matches the actual permission/choice **dialog**.

## The bug ("Cmd+K totally broken")

The guard (`use_keyboard_nav.rs`, added in #1521, later copied into the Cmd+K capture listener in #1553) does:

```rust
document.querySelector(".sched-overlay, …, .permission-prompt")  // → stand nav keys down
```

meant to catch the permission/choice **dialog** while it's open. But transcript tool renderers emit `<span class="permission-prompt">` for every requested-permission line (`tool_renderers/interactive.rs:199`, there since #296). So **any session whose transcript has ever shown a tool permission** leaves a `.permission-prompt` node in the DOM permanently → the guard is tripped forever → **Cmd+K and every nav-mode key silently die.**

This bites real sessions (which have transcripts), which is why it read as "totally broken" while an empty dashboard seemed fine. It was latent since #1521; my #1553 faithfully copied the guard into the capture listener, so it wasn't newly introduced there.

## The fix

The three dialog roots (permission, AskUserQuestion, exit-plan-mode) are all `<div class="permission-prompt …">`; the transcript line is a `<span>`. Qualifying the selector to `div.permission-prompt` matches the dialogs and ignores transcript history. One-line change in both guard copies (bubble handler + capture listener), with an inline comment explaining why the `div.` is load-bearing.

## Verification

Reproduced and fixed **end-to-end in headless Firefox** against a live dev build (real Ctrl/Cmd+K key events via WebDriver):

| step | before fix | after fix |
|---|---|---|
| Ctrl+K, no `.permission-prompt` in DOM | toggles ✅ | toggles ✅ |
| inject `.permission-prompt`, Ctrl+K | **dead ❌** | toggles ✅ |

Also `cargo clippy -p frontend --target wasm32-unknown-unknown`: clean.