### PR TITLE
Add an agent install/login triage matrix to settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -1143,13 +1149,15 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.220"
+version = "2.1.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1e407233d670143da2462d1a7ba7fdeea0164e38aef317362611e9f1a8f78f"
+checksum = "0bbd0075d21d9437d0db9d4eb9c84c96cc1880ca8f2f1b8459e3605309c9934b"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "log",
+ "portable-pty",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1241,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.146.2"
+version = "0.146.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d58e57190c588fcc2d1fe33a5b9a0ffba1cb1c5e59a7214be841966f18f422"
+checksum = "3b163a2775c1a881cfffc6fe4ad81af8dd4666756d509f64e8db337c04312298"
 dependencies = [
  "log",
  "serde",
@@ -1860,7 +1868,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "diesel_derives",
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "itoa",
  "num-bigint",
  "num-integer",
@@ -2048,6 +2056,12 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
@@ -2197,7 +2211,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2341,6 +2355,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -4544,13 +4569,25 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -4905,7 +4942,7 @@ dependencies = [
  "hyper",
  "itertools",
  "md-5",
- "nix",
+ "nix 0.31.3",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.40.1",
@@ -5377,6 +5414,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs 1.2.1",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "portal-auth"
 version = "2.13.11"
 dependencies = [
@@ -5624,7 +5682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -5665,7 +5723,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -6509,6 +6567,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16809bc35793b19ce4e0c53924bc0dce3937f15487997cfdaed936004180730"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6640,6 +6709,22 @@ dependencies = [
  "uuid",
  "ws-bridge",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -9078,6 +9163,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.220", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.223", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-codex-codes = { version = "0.146.2", default-features = false, features = ["types"] }
+codex-codes = { version = "0.146.4", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and

--- a/claude-session-lib/Cargo.toml
+++ b/claude-session-lib/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 session-lib = { path = "../session-lib" }
 shared = { path = "../shared" }
-claude-codes = { workspace = true, features = ["async-client"] }
+claude-codes = { workspace = true, features = ["async-client", "auth"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/claude-session-lib/src/auth.rs
+++ b/claude-session-lib/src/auth.rs
@@ -1,0 +1,27 @@
+//! Claude sign-in status for the launcher's agent triage matrix.
+//!
+//! Wraps claude-codes' `auth_status()` (`claude auth status --json`) and maps
+//! it onto the agent-neutral [`shared::AgentLoginStatus`] the matrix renders,
+//! so the launcher composes install state (from `session_lib::probe`) with
+//! login state without either side knowing the other's shape.
+
+use shared::AgentLoginStatus;
+
+/// Read `claude`'s sign-in status from the CLI on `PATH`.
+///
+/// Any failure — binary absent, or output we can't parse — maps to `Unknown`,
+/// never `LoggedOut`: "we couldn't tell" must not render as an actionable
+/// logged-out cell (the install column already says whether the binary exists).
+pub fn probe_login() -> AgentLoginStatus {
+    match claude_codes::auth::auth_status() {
+        Ok(status) if status.logged_in => AgentLoginStatus::LoggedIn {
+            // Prefer the human email; fall back to the credential kind
+            // (`claude.ai` / `console`) when the account has no email.
+            label: status.email.or(status.auth_method),
+            plan: status.subscription_type,
+            via: None,
+        },
+        Ok(_) => AgentLoginStatus::LoggedOut,
+        Err(_) => AgentLoginStatus::Unknown,
+    }
+}

--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -12,6 +12,7 @@
 //! forwarding) and isn't getting split until a future PR.
 
 pub mod agent;
+pub mod auth;
 pub mod io_task;
 pub mod proxy_session;
 mod spawn;

--- a/codex-session-lib/src/auth.rs
+++ b/codex-session-lib/src/auth.rs
@@ -1,0 +1,46 @@
+//! Codex sign-in status for the launcher's agent triage matrix.
+//!
+//! Hybrid, by design (see the agent-login contract): the sanctioned
+//! `codex login status` subprocess answers the **liveness** question (exit 0 =
+//! signed in — stored credentials are not necessarily live), and
+//! codex-codes' `auth_status_local()` supplies the **display label** (email +
+//! plan) by reading the CLI's own stored creds. The label is display-only and
+//! degrades to absent on any read/parse failure; the crate owns the
+//! private-file risk (fixture + live test there), so agent-portal never decodes
+//! that file itself.
+
+use shared::AgentLoginStatus;
+
+/// Read `codex`'s sign-in status: `codex login status` for the live boolean,
+/// enriched with the stored account label when signed in.
+pub fn probe_login() -> AgentLoginStatus {
+    // Liveness. A missing binary or spawn failure => Unknown (not "signed out").
+    let live = match std::process::Command::new("codex")
+        .args(["login", "status"])
+        .output()
+    {
+        Ok(out) => out.status.success(),
+        Err(_) => return AgentLoginStatus::Unknown,
+    };
+    if !live {
+        return AgentLoginStatus::LoggedOut;
+    }
+
+    // Label: typed, crate-owned read of the stored creds. Any failure just
+    // leaves the cell as an unlabeled "signed in".
+    let (label, plan) = match codex_codes::auth_local::auth_status_local() {
+        Ok(status) => match status.auth_mode.as_deref() {
+            // API-key auth carries no account identity by design.
+            Some("apikey") => (Some("API key".to_string()), None),
+            // ChatGPT (or anything that recorded an email): show it + plan.
+            _ => (status.email, status.plan_type),
+        },
+        Err(_) => (None, None),
+    };
+
+    AgentLoginStatus::LoggedIn {
+        label,
+        plan,
+        via: None,
+    }
+}

--- a/codex-session-lib/src/lib.rs
+++ b/codex-session-lib/src/lib.rs
@@ -10,6 +10,7 @@
 //! backed session.
 
 pub mod agent;
+pub mod auth;
 mod classifier;
 mod events;
 mod handler;

--- a/frontend/src/pages/settings/agents_panel.rs
+++ b/frontend/src/pages/settings/agents_panel.rs
@@ -1,0 +1,235 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Agents triage matrix (Settings ▸ Agents).
+//!
+//! A new user's first question is "what do I still need to set up, and where?".
+//! This pane answers it as a **computer × agent** grid: one row per launcher
+//! (host), one column per agent (Claude / Codex), each cell showing whether the
+//! CLI is installed and whether it's signed in (+ the account label when the
+//! agent exposes one). Data comes from the existing per-launcher probe
+//! (`/api/launchers/{id}/probe-agents`), fanned across the user's launchers;
+//! offline launchers render as unreachable rather than blank.
+//!
+//! Read-only for now. The login buttons that act on a "signed out" cell land in
+//! a follow-up against the rust-code-agent-sdks login flows.
+
+use crate::utils::{self, On401};
+use shared::api::ProbeAgentsResponse;
+use shared::{AgentInstall, AgentLoginStatus, AgentType, LauncherInfo};
+use std::collections::HashMap;
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+/// Columns of the matrix, in display order. Mirrors `AgentType`.
+const AGENTS: [(AgentType, &str); 2] = [(AgentType::Claude, "Claude"), (AgentType::Codex, "Codex")];
+
+/// Per-launcher probe outcome. The whole map is set once, after every probe
+/// resolves, so a launcher is either absent from the map (still loading, whole
+/// pane shows "Loading…") or in one of these terminal states.
+#[derive(Clone, PartialEq)]
+enum ProbeState {
+    /// Launcher is offline (not connected) — can't be probed.
+    Unreachable,
+    /// Probe returned; agents keyed by type for O(1) cell lookup.
+    Loaded(HashMap<AgentType, AgentInstall>),
+}
+
+#[function_component(AgentsPanel)]
+pub fn agents_panel() -> Html {
+    let launchers = use_state(|| None::<Vec<LauncherInfo>>);
+    let probes = use_state(HashMap::<Uuid, ProbeState>::new);
+    // Bumped by the refresh button to re-run the whole fan-out.
+    let refresh = use_state(|| 0u32);
+
+    {
+        let launchers = launchers.clone();
+        let probes = probes.clone();
+        use_effect_with(*refresh, move |_| {
+            launchers.set(None);
+            probes.set(HashMap::new());
+            spawn_local(async move {
+                let list = utils::fetch_json::<Vec<LauncherInfo>>("/api/launchers", On401::Ignore)
+                    .await
+                    .unwrap_or_default();
+
+                // Probe sequentially — a settings pane has a handful of hosts,
+                // and this keeps the state update race-free (one set at the end)
+                // without pulling in a join_all.
+                let mut collected: HashMap<Uuid, ProbeState> = HashMap::new();
+                for l in &list {
+                    if !l.connected {
+                        collected.insert(l.launcher_id, ProbeState::Unreachable);
+                        continue;
+                    }
+                    let path = format!("/api/launchers/{}/probe-agents", l.launcher_id);
+                    let state = match utils::fetch_json::<ProbeAgentsResponse>(&path, On401::Ignore)
+                        .await
+                    {
+                        Ok(resp) => ProbeState::Loaded(
+                            resp.agents.into_iter().map(|a| (a.agent_type, a)).collect(),
+                        ),
+                        // A connected launcher that fails to answer (dropped
+                        // mid-probe, timeout) is unreachable for our purposes.
+                        Err(_) => ProbeState::Unreachable,
+                    };
+                    collected.insert(l.launcher_id, state);
+                }
+
+                launchers.set(Some(list));
+                probes.set(collected);
+            });
+            || ()
+        });
+    }
+
+    let on_refresh = {
+        let refresh = refresh.clone();
+        Callback::from(move |_: MouseEvent| refresh.set(*refresh + 1))
+    };
+
+    let body = match (*launchers).clone() {
+        None => html! { <p class="setting-description">{ "Loading…" }</p> },
+        Some(list) if list.is_empty() => html! {
+            <p class="setting-description">
+                { "No computers connected yet. Install the agent-portal launcher on a \
+                   machine and it'll appear here." }
+            </p>
+        },
+        Some(list) => html! {
+            <table class="agents-matrix">
+                <thead>
+                    <tr>
+                        <th>{ "Computer" }</th>
+                        { for AGENTS.iter().map(|(_, name)| html! { <th>{ *name }</th> }) }
+                    </tr>
+                </thead>
+                <tbody>
+                    { for list.iter().map(|l| render_row(l, &probes)) }
+                </tbody>
+            </table>
+        },
+    };
+
+    html! {
+        <section class="agents-section">
+            <div class="section-header">
+                <h2>{ "Agents" }</h2>
+                <p class="section-description">
+                    { "Install and sign-in state for each agent on every connected \
+                       computer. " }
+                    <button class="link-button" onclick={on_refresh}>{ "Refresh" }</button>
+                </p>
+            </div>
+            { body }
+        </section>
+    }
+}
+
+fn render_row(launcher: &LauncherInfo, probes: &HashMap<Uuid, ProbeState>) -> Html {
+    let state = probes.get(&launcher.launcher_id);
+    html! {
+        <tr>
+            <td class="agents-host">
+                <span class="agents-host-name">{ &launcher.hostname }</span>
+                if launcher.launcher_name != launcher.hostname {
+                    <span class="agents-host-alias">{ format!("({})", launcher.launcher_name) }</span>
+                }
+            </td>
+            { for AGENTS.iter().map(|(agent, _)| render_cell(state, *agent)) }
+        </tr>
+    }
+}
+
+fn render_cell(state: Option<&ProbeState>, agent: AgentType) -> Html {
+    match state {
+        None => html! { <td class="agents-cell loading">{ "…" }</td> },
+        Some(ProbeState::Unreachable) => {
+            html! { <td class="agents-cell unreachable">{ "offline" }</td> }
+        }
+        Some(ProbeState::Loaded(agents)) => match agents.get(&agent) {
+            Some(install) => render_install_cell(install),
+            // Probe ran but didn't report this agent at all — treat as unknown.
+            None => html! { <td class="agents-cell unknown">{ "—" }</td> },
+        },
+    }
+}
+
+fn render_install_cell(install: &AgentInstall) -> Html {
+    if !install.installed {
+        return html! {
+            <td class="agents-cell not-installed">
+                <span class="agents-badge missing">{ "not installed" }</span>
+            </td>
+        };
+    }
+    let (login_class, login_text) = login_summary(&install.login);
+    html! {
+        <td class="agents-cell installed">
+            <span class="agents-badge installed">{ "installed" }</span>
+            <span class={classes!("agents-login", login_class)}>{ login_text }</span>
+        </td>
+    }
+}
+
+/// Cell text + CSS modifier for a login state. Pure, so the label precedence is
+/// unit-tested without mounting the component.
+fn login_summary(login: &AgentLoginStatus) -> (&'static str, String) {
+    match login {
+        AgentLoginStatus::Unknown => ("unknown", "sign-in unknown".to_string()),
+        AgentLoginStatus::LoggedOut => ("logged-out", "signed out".to_string()),
+        AgentLoginStatus::LoggedIn { label, plan, via } => {
+            let mut text = match label {
+                Some(l) => format!("signed in — {l}"),
+                None => "signed in".to_string(),
+            };
+            if let Some(plan) = plan {
+                text.push_str(&format!(" ({plan})"));
+            }
+            if let Some(via) = via {
+                text.push_str(&format!(" [{via}]"));
+            }
+            ("logged-in", text)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logged_in_with_email_and_plan_reads_naturally() {
+        let (class, text) = login_summary(&AgentLoginStatus::LoggedIn {
+            label: Some("matt@exclosure.io".to_string()),
+            plan: Some("max".to_string()),
+            via: None,
+        });
+        assert_eq!(class, "logged-in");
+        assert_eq!(text, "signed in — matt@exclosure.io (max)");
+    }
+
+    #[test]
+    fn logged_in_without_a_label_still_says_signed_in() {
+        // muse's case: authenticated but no account identity.
+        let (class, text) = login_summary(&AgentLoginStatus::LoggedIn {
+            label: None,
+            plan: None,
+            via: Some("env".to_string()),
+        });
+        assert_eq!(class, "logged-in");
+        assert_eq!(text, "signed in [env]");
+    }
+
+    #[test]
+    fn unknown_is_distinct_from_signed_out() {
+        // "couldn't tell" must never read as the actionable "signed out".
+        assert_eq!(login_summary(&AgentLoginStatus::Unknown).0, "unknown");
+        assert_eq!(login_summary(&AgentLoginStatus::LoggedOut).0, "logged-out");
+        assert_ne!(
+            login_summary(&AgentLoginStatus::Unknown).1,
+            login_summary(&AgentLoginStatus::LoggedOut).1
+        );
+    }
+}

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -1,3 +1,4 @@
+mod agents_panel;
 mod appearance_panel;
 mod forwarding_panel;
 mod health_timer_panel;
@@ -10,6 +11,7 @@ mod sounds_panel;
 mod tokens_panel;
 
 use crate::utils;
+use agents_panel::AgentsPanel;
 use appearance_panel::AppearancePanel;
 use forwarding_panel::ForwardingPanel;
 use health_timer_panel::HealthTimerPanel;
@@ -26,6 +28,7 @@ use yew::prelude::*;
 #[derive(Clone, Copy, PartialEq)]
 enum SettingsTab {
     Profile,
+    Agents,
     Sessions,
     Tokens,
     Launchers,
@@ -71,6 +74,7 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
         Callback::from(move |_: MouseEvent| active_tab.set(tab))
     };
     let on_profile_tab = make_tab_handler(SettingsTab::Profile);
+    let on_agents_tab = make_tab_handler(SettingsTab::Agents);
     let on_sessions_tab = make_tab_handler(SettingsTab::Sessions);
     let on_tokens_tab = make_tab_handler(SettingsTab::Tokens);
     let on_launchers_tab = make_tab_handler(SettingsTab::Launchers);
@@ -104,6 +108,12 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                     onclick={on_profile_tab}
                 >
                     { "Profile" }
+                </button>
+                <button
+                    class={classes!("tab-button", (*active_tab == SettingsTab::Agents).then_some("active"))}
+                    onclick={on_agents_tab}
+                >
+                    { "Agents" }
                 </button>
                 <button
                     class={classes!("tab-button", (*active_tab == SettingsTab::Sessions).then_some("active"))}
@@ -186,6 +196,9 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                 }
                 if *active_tab == SettingsTab::Profile {
                     <ProfilePanel />
+                }
+                if *active_tab == SettingsTab::Agents {
+                    <AgentsPanel />
                 }
                 if *active_tab == SettingsTab::Sessions {
                     <SessionsPanel on_sessions_loaded={on_sessions_loaded} />

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -930,6 +930,98 @@
    Appearance panel
    ========================================================================== */
 
+.agents-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.link-button {
+    background: none;
+    border: none;
+    color: var(--accent);
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    text-decoration: underline;
+}
+
+.agents-matrix {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.agents-matrix th,
+.agents-matrix td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+}
+
+.agents-matrix th {
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.agents-host-name {
+    font-family: var(--font-mono, monospace);
+    color: var(--text-primary);
+}
+
+.agents-host-alias {
+    color: var(--text-secondary);
+    margin-left: 0.4rem;
+    font-size: 0.8rem;
+}
+
+.agents-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.agents-cell.unreachable,
+.agents-cell.unknown,
+.agents-cell.loading {
+    color: var(--text-secondary);
+}
+
+.agents-badge {
+    display: inline-block;
+    width: fit-content;
+    padding: 0.05rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+}
+
+.agents-badge.installed {
+    background: color-mix(in srgb, var(--success, #9ece6a) 20%, transparent);
+    color: var(--success, #9ece6a);
+}
+
+.agents-badge.missing {
+    background: color-mix(in srgb, var(--error, #f7768e) 18%, transparent);
+    color: var(--error, #f7768e);
+}
+
+.agents-login {
+    font-size: 0.8rem;
+}
+
+.agents-login.logged-in {
+    color: var(--success, #9ece6a);
+}
+
+.agents-login.logged-out {
+    color: var(--error, #f7768e);
+}
+
+.agents-login.unknown {
+    color: var(--text-secondary);
+}
+
 .profile-section {
     display: flex;
     flex-direction: column;

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -453,13 +453,28 @@ pub async fn run_launcher_loop(
 fn probe_agents_for_response() -> Vec<shared::AgentInstall> {
     session_lib::probe::probe_all_agents()
         .into_iter()
-        .map(|(agent_type, result)| shared::AgentInstall {
-            agent_type,
-            installed: result.installed,
-            resolved_path: result
-                .resolved_path
-                .map(|p| p.to_string_lossy().to_string()),
-            version: result.version,
+        .map(|(agent_type, result)| {
+            // Only read sign-in state for agents that are actually installed —
+            // spawning `claude auth status` / `codex login status` for a binary
+            // that isn't there just burns a failed exec to reach the same
+            // `Unknown` the field defaults to.
+            let login = if result.installed {
+                match agent_type {
+                    shared::AgentType::Claude => claude_session_lib::auth::probe_login(),
+                    shared::AgentType::Codex => codex_session_lib::auth::probe_login(),
+                }
+            } else {
+                shared::AgentLoginStatus::Unknown
+            };
+            shared::AgentInstall {
+                agent_type,
+                installed: result.installed,
+                resolved_path: result
+                    .resolved_path
+                    .map(|p| p.to_string_lossy().to_string()),
+                version: result.version,
+                login,
+            }
         })
         .collect()
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -366,9 +366,44 @@ pub struct DirectoryEntry {
     pub is_dir: bool,
 }
 
+/// Whether an agent CLI is signed in on a launcher host, gathered alongside
+/// the install probe so the settings triage matrix can show a new user exactly
+/// what still needs doing on each computer.
+///
+/// The account label is best-effort and agent-specific (an email, a mode name
+/// like `API key`/`Bedrock`, or a provider like `meta`): claude exposes an
+/// email + plan, codex an email + plan only in ChatGPT mode, and muse no
+/// identity at all by CLI design — so a `None` label under `LoggedIn` is normal,
+/// not an error.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum AgentLoginStatus {
+    /// Not determined — the agent isn't installed, or the probe couldn't read
+    /// its auth state. Rendered as a neutral "unknown" cell, never as "logged
+    /// out" (which would wrongly imply an actionable login).
+    #[default]
+    Unknown,
+    LoggedOut,
+    LoggedIn {
+        /// Human label for the cell — an email, or a mode/provider name.
+        /// Absent when the agent persists no identity (e.g. muse).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+        /// Secondary badge, when the agent reports one (plan / subscription,
+        /// e.g. `max`, `plus`, `pro`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        plan: Option<String>,
+        /// How the credential is supplied, when notable — e.g. `env` for a
+        /// key coming from an environment variable rather than a saved file.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        via: Option<String>,
+    },
+}
+
 /// Result of probing one agent CLI on a launcher host. Built at launcher
 /// startup (sent in `LauncherRegister`) and refreshed on demand via
-/// `ProbeAgents` when the user opens the launch dialog.
+/// `ProbeAgents` when the user opens the launch dialog or the agents settings
+/// matrix.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentInstall {
     pub agent_type: AgentType,
@@ -380,6 +415,11 @@ pub struct AgentInstall {
     /// `<bin> --version` stdout, trimmed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Sign-in state for this agent on the host. `#[serde(default)]` =
+    /// `Unknown`, so an older launcher that only reports install state
+    /// deserializes cleanly (the matrix shows its login cells as unknown).
+    #[serde(default)]
+    pub login: AgentLoginStatus,
 }
 
 /// Info about a connected launcher daemon


### PR DESCRIPTION
The read-only first half of the agent onboarding surface (matrix-first, per the plan): a **Settings ▸ Agents** pane that answers a new user's "what do I still need to set up, and where?" as a **computer × agent** grid.

## What it shows
One row per connected launcher (computer), one column per agent (Claude / Codex), each cell showing:
- **install** state (installed / not installed), and
- **sign-in** state with the account label where the agent exposes one — e.g. `signed in — matt@exclosure.io (max)`.

Offline launchers render `offline`; an agent whose sign-in we genuinely can't read renders `sign-in unknown` — deliberately distinct from `signed out`, so "couldn't tell" never shows as an actionable logout.

## How
- New agent-neutral `shared::AgentLoginStatus` (`Unknown` / `LoggedOut` / `LoggedIn { label, plan, via }`), added to the probe result as a `#[serde(default)]` field — so an older launcher that only reports install state deserializes cleanly (login cells show `unknown`).
- The existing per-launcher probe (`session_lib::probe`) is composed with per-agent sign-in reads in the launcher, gated on `installed` (no spawning a missing binary):
  - **claude** — `claude auth status --json` via `claude-codes::auth::auth_status()` -> email + plan.
  - **codex** — a hybrid: `codex login status` exit code for the *live* boolean (stored != live), enriched with `codex-codes::auth_local::auth_status_local()` for the email+plan label. agent-portal never decodes codex's private creds file itself — that risk lives crate-side (fixture + live test there), per our "push schema gaps upstream" rule.
- The matrix **fans the existing `/api/launchers/{id}/probe-agents` endpoint across the user's launchers client-side** — zero new backend endpoint, and the `login` field rides the existing `ProbeAgentsResponse.agents` for free.
- Bumps **claude-codes 2.1.223 / codex-codes 0.146.4** for the typed auth APIs (the sdks maintainer shipped `auth_status_local()` for this).

## Scope
Read-only. The **login buttons** that act on a "signed out" cell (driving the crates' login flows, per the 5-constraint contract) are the deliberate PR2. **Muse** isn't in the grid — it isn't a runnable `AgentType` yet; it joins when integrated.

## Verified
- Pure cell-label helper unit-tested (email+plan, no-label, and unknown != signed-out).
- Full workspace build + **wasm build clean** (the newly-enabled claude-codes `auth` feature does not leak native deps into the wasm target — resolver 2), 13 test binaries green, clippy clean, stylelint clean.
- Ran the real CLIs on a dev host: `claude auth status --json` -> `matt@exclosure.io / max`, `codex login status` -> exit 0 + `auth.json` present — the matrix renders true data, not just compiles.

Nothing here needs provider sign-in (that's PR2).
