### PR TITLE
Add interactive agent sign-in from the Agents matrix

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -17,6 +17,11 @@ pub enum AppError {
     Conflict(&'static str),
     NotFound(&'static str),
     BadGateway(&'static str),
+    /// Like [`AppError::BadGateway`] but carries a dynamic upstream message —
+    /// used to relay an agent CLI's own error text (login start failures) to
+    /// the browser verbatim, matching the login contract's "errors relay as
+    /// Display strings".
+    BadGatewayMessage(String),
     GatewayTimeout(&'static str),
     ServiceUnavailable(&'static str),
     Internal(String),
@@ -57,6 +62,7 @@ impl IntoResponse for AppError {
             AppError::Conflict(msg) => (StatusCode::CONFLICT, *msg),
             AppError::NotFound(what) => (StatusCode::NOT_FOUND, *what),
             AppError::BadGateway(msg) => (StatusCode::BAD_GATEWAY, *msg),
+            AppError::BadGatewayMessage(msg) => (StatusCode::BAD_GATEWAY, msg.as_str()),
             AppError::GatewayTimeout(msg) => (StatusCode::GATEWAY_TIMEOUT, *msg),
             AppError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, *msg),
             AppError::Internal(e) => {

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -4,8 +4,13 @@ use axum::{
 };
 use diesel::prelude::*;
 use serde::Deserialize;
-use shared::api::{DirectoryListingResponse, LaunchRequest, ProbeAgentsResponse};
-use shared::{LauncherInfo, LauncherToServer, ServerToLauncher, SessionRole, SessionStatus};
+use shared::api::{
+    DirectoryListingResponse, LaunchRequest, ProbeAgentsResponse, StartAgentLoginRequest,
+    StartAgentLoginResponse, SubmitAgentLoginCodeRequest,
+};
+use shared::{
+    AgentLoginOutcome, LauncherInfo, LauncherToServer, ServerToLauncher, SessionRole, SessionStatus,
+};
 use std::sync::Arc;
 use tracing::{error, info, warn};
 use uuid::Uuid;
@@ -474,6 +479,170 @@ pub async fn probe_agents(
             warn!("Probe agents timed out for launcher {}", launcher_id);
             Err(AppError::GatewayTimeout("Agent probe timed out"))
         }
+    }
+}
+
+/// Confirm the caller owns `launcher_id` (agent logins run credentials on that
+/// host, so only its owner may drive them). 404 on unknown so we don't leak
+/// launcher existence to non-owners.
+fn require_launcher_owner(
+    app_state: &AppState,
+    launcher_id: Uuid,
+    user_id: Uuid,
+) -> Result<(), AppError> {
+    let launcher = app_state
+        .session_manager
+        .launchers
+        .get(&launcher_id)
+        .ok_or(AppError::NotFound("Launcher not found"))?;
+    if launcher.user_id != user_id {
+        return Err(AppError::Forbidden);
+    }
+    Ok(())
+}
+
+/// Relay one request/response RPC to a launcher, reusing the probe correlation.
+async fn launcher_rpc(
+    app_state: &AppState,
+    launcher_id: Uuid,
+    request_id: Uuid,
+    message: ServerToLauncher,
+    timeout_secs: u64,
+) -> Result<LauncherToServer, AppError> {
+    let rx = app_state.session_manager.register_probe_request(request_id);
+    if !app_state
+        .session_manager
+        .send_to_launcher(&launcher_id, message)
+    {
+        app_state.session_manager.cancel_probe_request(request_id);
+        return Err(AppError::BadGateway("Launcher is not connected"));
+    }
+    match tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), rx).await {
+        Ok(Ok(reply)) => Ok(reply),
+        Ok(Err(_)) => Err(AppError::Internal(
+            "Launcher response channel closed".into(),
+        )),
+        Err(_) => {
+            app_state.session_manager.cancel_probe_request(request_id);
+            Err(AppError::GatewayTimeout("Launcher did not respond in time"))
+        }
+    }
+}
+
+/// POST /api/launchers/:id/agent-login/start — begin an interactive login for
+/// an agent on that host. Returns the URL/code for the user to act on.
+pub async fn start_agent_login(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+    Path(launcher_id): Path<Uuid>,
+    Json(req): Json<StartAgentLoginRequest>,
+) -> Result<Json<StartAgentLoginResponse>, AppError> {
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
+
+    let request_id = Uuid::new_v4();
+    let flow_id = Uuid::new_v4();
+    // Starting can wait on the CLI printing its URL (claude ~30s); allow slack.
+    let reply = launcher_rpc(
+        &app_state,
+        launcher_id,
+        request_id,
+        ServerToLauncher::StartAgentLogin {
+            request_id,
+            flow_id,
+            agent_type: req.agent_type,
+        },
+        45,
+    )
+    .await?;
+
+    match reply {
+        LauncherToServer::AgentLoginStartResult {
+            presentable: Some(presentable),
+            interaction: Some(interaction),
+            ..
+        } => Ok(Json(StartAgentLoginResponse {
+            flow_id,
+            presentable,
+            interaction,
+        })),
+        LauncherToServer::AgentLoginStartResult {
+            error: Some(error), ..
+        } => Err(AppError::BadGatewayMessage(error)),
+        _ => Err(AppError::Internal(
+            "Unexpected launcher login response".into(),
+        )),
+    }
+}
+
+/// POST /api/launchers/:id/agent-login/:flow_id/code — submit the pasted code
+/// (claude). Blocks until the flow settles.
+pub async fn submit_agent_login_code(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+    Path((launcher_id, flow_id)): Path<(Uuid, Uuid)>,
+    Json(req): Json<SubmitAgentLoginCodeRequest>,
+) -> Result<Json<AgentLoginOutcome>, AppError> {
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
+    let request_id = Uuid::new_v4();
+    // The CLI can take up to ~a minute to settle after the code is submitted.
+    let reply = launcher_rpc(
+        &app_state,
+        launcher_id,
+        request_id,
+        ServerToLauncher::SubmitAgentLoginCode {
+            request_id,
+            flow_id,
+            code: req.code,
+        },
+        90,
+    )
+    .await?;
+    login_outcome(reply)
+}
+
+/// GET /api/launchers/:id/agent-login/:flow_id — poll an in-browser login
+/// (codex) for completion. `outcome.done == false` = keep polling.
+pub async fn poll_agent_login(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+    Path((launcher_id, flow_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<AgentLoginOutcome>, AppError> {
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
+    let request_id = Uuid::new_v4();
+    let reply = launcher_rpc(
+        &app_state,
+        launcher_id,
+        request_id,
+        ServerToLauncher::PollAgentLogin {
+            request_id,
+            flow_id,
+        },
+        8,
+    )
+    .await?;
+    login_outcome(reply)
+}
+
+/// POST /api/launchers/:id/agent-login/:flow_id/cancel — abandon a flow
+/// (browser closed). Fire-and-forget; the launcher drops the flow.
+pub async fn cancel_agent_login(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+    Path((launcher_id, flow_id)): Path<(Uuid, Uuid)>,
+) -> Result<crate::handlers::responses::EmptyResponse, AppError> {
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
+    app_state
+        .session_manager
+        .send_to_launcher(&launcher_id, ServerToLauncher::CancelAgentLogin { flow_id });
+    Ok(crate::handlers::responses::EmptyResponse::OK)
+}
+
+fn login_outcome(reply: LauncherToServer) -> Result<Json<AgentLoginOutcome>, AppError> {
+    match reply {
+        LauncherToServer::AgentLoginOutcomeResult { outcome, .. } => Ok(Json(outcome)),
+        _ => Err(AppError::Internal(
+            "Unexpected launcher login response".into(),
+        )),
     }
 }
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -691,6 +691,13 @@ fn handle_launcher_message(
                 .session_manager
                 .complete_probe_request(request_id, msg);
         }
+        LauncherToServer::AgentLoginStartResult { request_id, .. }
+        | LauncherToServer::AgentLoginOutcomeResult { request_id, .. } => {
+            // Same request/response correlation as the probe path.
+            app_state
+                .session_manager
+                .complete_probe_request(request_id, msg);
+        }
         LauncherToServer::RequestLaunch {
             request_id,
             working_directory,

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -370,6 +370,22 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             "/api/launchers/{launcher_id}/probe-agents",
             get(handlers::launchers::probe_agents),
         )
+        .route(
+            "/api/launchers/{launcher_id}/agent-login/start",
+            post(handlers::launchers::start_agent_login),
+        )
+        .route(
+            "/api/launchers/{launcher_id}/agent-login/{flow_id}/code",
+            post(handlers::launchers::submit_agent_login_code),
+        )
+        .route(
+            "/api/launchers/{launcher_id}/agent-login/{flow_id}",
+            get(handlers::launchers::poll_agent_login),
+        )
+        .route(
+            "/api/launchers/{launcher_id}/agent-login/{flow_id}/cancel",
+            post(handlers::launchers::cancel_agent_login),
+        )
         // Admin dashboard routes (admin-only)
         .route("/api/admin/stats", get(handlers::admin::get_stats))
         .route("/api/admin/users", get(handlers::admin::list_users))

--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod agent;
 pub mod auth;
 pub mod io_task;
+pub mod login;
 pub mod proxy_session;
 mod spawn;
 pub mod transcript;

--- a/claude-session-lib/src/login.rs
+++ b/claude-session-lib/src/login.rs
@@ -1,0 +1,203 @@
+//! Interactive claude sign-in for the portal's launcher-driven login surface.
+//!
+//! Wraps claude-codes' PTY-backed [`LoginFlow`] as a *parkable* session: `start`
+//! drives `claude auth login --claudeai` (persisted subscription login) far
+//! enough to hand back the OAuth URL, then the flow waits — on its own thread —
+//! for the code the user pastes back from the browser, which [`submit_code`]
+//! feeds in.
+//!
+//! Two rules from the login contract are load-bearing here:
+//! - the flow's blocking PTY calls run on a dedicated `std::thread`, never on
+//!   the async runtime;
+//! - dropping the session disconnects the code channel, so the worker drops the
+//!   `LoginFlow`, whose `Drop` SIGTERMs the PTY child ("LoginFlow dropped while
+//!   unfinished" in the logs) — a closed browser tab reaps cleanly.
+//!
+//! A rejected code settles the flow as a failure (the caller restarts with a
+//! fresh session) rather than driving `retry_new_url` in place — "drop and
+//! restart" is the contract-sanctioned handling, and the error screen has no
+//! input field for a same-URL retry anyway.
+//!
+//! [`submit_code`]: ClaudeLoginSession::submit_code
+
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use claude_codes::auth::{LoginFlow, LoginMode};
+use shared::{AgentLoginOutcome, LoginInteraction, LoginPresentable};
+
+/// Wait for the CLI to emit its OAuth URL after start.
+const AUTH_URL_TIMEOUT: Duration = Duration::from_secs(30);
+/// How long the parked flow waits for the user to paste a code back.
+const CODE_WAIT: Duration = Duration::from_secs(300);
+/// Wait for the CLI to settle after a code submission.
+const SUBMIT_TIMEOUT: Duration = Duration::from_secs(60);
+/// Longest failure detail we relay — enough of the CLI transcript to diagnose,
+/// bounded so a runaway TUI dump doesn't flood the UI.
+const MESSAGE_TAIL: usize = 400;
+
+/// A parked claude login flow, driven on a worker thread.
+pub struct ClaudeLoginSession {
+    /// Send the pasted code once. Dropping this (session drop) disconnects the
+    /// worker's recv, which drops the `LoginFlow` and reaps its PTY child.
+    code_tx: Sender<String>,
+    /// The settled outcome, delivered once by the worker. Behind a `Mutex<Option<>>`
+    /// so `submit_code` can consume it exactly once.
+    outcome_rx: Mutex<Option<Receiver<AgentLoginOutcome>>>,
+}
+
+impl ClaudeLoginSession {
+    /// Start the flow and return the URL for the user to open. Blocks only
+    /// until the CLI prints its URL (bounded by [`AUTH_URL_TIMEOUT`]).
+    ///
+    /// Runs on the caller's thread up to that point; call it from a
+    /// `spawn_blocking` context on the launcher.
+    pub fn start() -> Result<(Self, LoginPresentable, LoginInteraction), String> {
+        let (code_tx, code_rx) = std::sync::mpsc::channel::<String>();
+        let (url_tx, url_rx) = std::sync::mpsc::channel::<Result<String, String>>();
+        let (outcome_tx, outcome_rx) = std::sync::mpsc::channel::<AgentLoginOutcome>();
+
+        std::thread::spawn(move || run_flow(code_rx, &url_tx, &outcome_tx));
+
+        match url_rx.recv_timeout(AUTH_URL_TIMEOUT + Duration::from_secs(5)) {
+            Ok(Ok(url)) => Ok((
+                Self {
+                    code_tx,
+                    outcome_rx: Mutex::new(Some(outcome_rx)),
+                },
+                LoginPresentable::AuthUrl { url },
+                LoginInteraction::SubmitCode,
+            )),
+            Ok(Err(e)) => Err(e),
+            // Worker died or hung before yielding a URL.
+            Err(_) => Err("claude did not produce a sign-in URL in time".to_string()),
+        }
+    }
+
+    /// Feed the pasted code and wait for the flow to settle.
+    ///
+    /// Blocks until the CLI confirms or rejects (bounded by [`SUBMIT_TIMEOUT`]);
+    /// call it from a `spawn_blocking` context.
+    pub fn submit_code(&self, code: String) -> AgentLoginOutcome {
+        if self.code_tx.send(code).is_err() {
+            return failed("the sign-in session ended before the code was submitted");
+        }
+        let rx = self.outcome_rx.lock().unwrap().take();
+        match rx {
+            Some(rx) => match rx.recv_timeout(SUBMIT_TIMEOUT + Duration::from_secs(5)) {
+                Ok(outcome) => outcome,
+                Err(_) => failed("timed out waiting for the sign-in to complete"),
+            },
+            // A second submit against an already-consumed session.
+            None => failed("the code was already submitted for this session"),
+        }
+    }
+
+    /// Claude has no in-browser completion — it settles only via
+    /// [`submit_code`](Self::submit_code) — so a poll before then is "pending".
+    pub fn poll(&self) -> AgentLoginOutcome {
+        AgentLoginOutcome {
+            done: false,
+            success: false,
+            message: None,
+        }
+    }
+}
+
+fn run_flow(
+    code_rx: Receiver<String>,
+    url_tx: &Sender<Result<String, String>>,
+    outcome_tx: &Sender<AgentLoginOutcome>,
+) {
+    let mut flow = match LoginFlow::start(LoginMode::ClaudeAi) {
+        Ok(flow) => flow,
+        Err(e) => {
+            let _ = url_tx.send(Err(e.to_string()));
+            return;
+        }
+    };
+    let url = match flow.auth_url(AUTH_URL_TIMEOUT) {
+        Ok(url) => url,
+        Err(e) => {
+            let _ = url_tx.send(Err(e.to_string()));
+            return;
+        }
+    };
+    // If the receiver is gone the session was dropped between spawn and now;
+    // return, dropping `flow` → PTY child reaped.
+    if url_tx.send(Ok(url)).is_err() {
+        return;
+    }
+
+    let outcome = match code_rx.recv_timeout(CODE_WAIT) {
+        Ok(code) => match flow.submit_code_and_wait(&code, SUBMIT_TIMEOUT) {
+            // `credentials_updated` is the authoritative success signal
+            // (the creds store was written), independent of screen scraping.
+            Ok(out) if out.credentials_updated => AgentLoginOutcome {
+                done: true,
+                success: true,
+                message: None,
+            },
+            Ok(out) => AgentLoginOutcome {
+                done: true,
+                success: false,
+                message: Some(transcript_tail(&out.transcript)),
+            },
+            // CodeRejected / LoginTimeout / LoginChildExited all Display as
+            // self-describing text — relay it verbatim (login contract).
+            Err(e) => failed(&e.to_string()),
+        },
+        // Disconnected = session dropped (cancel); Timeout = user wandered off.
+        // Either way `flow` drops on return → PTY child reaped. Nobody is
+        // listening on a cancel, so the send is best-effort.
+        Err(RecvTimeoutError::Disconnected) => return,
+        Err(RecvTimeoutError::Timeout) => failed("timed out waiting for the sign-in code"),
+    };
+    let _ = outcome_tx.send(outcome);
+}
+
+fn failed(message: &str) -> AgentLoginOutcome {
+    AgentLoginOutcome {
+        done: true,
+        success: false,
+        message: Some(message.to_string()),
+    }
+}
+
+/// Keep the tail of a CLI transcript for a failure message — the end carries
+/// the error, and it's char-safe against multi-byte output.
+fn transcript_tail(transcript: &str) -> String {
+    let trimmed = transcript.trim();
+    let chars: Vec<char> = trimmed.chars().collect();
+    if chars.len() <= MESSAGE_TAIL {
+        return trimmed.to_string();
+    }
+    format!(
+        "…{}",
+        chars[chars.len() - MESSAGE_TAIL..]
+            .iter()
+            .collect::<String>()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcript_tail_keeps_the_end_and_is_char_safe() {
+        assert_eq!(transcript_tail("  short  "), "short");
+        let long = "é".repeat(MESSAGE_TAIL + 50);
+        let tail = transcript_tail(&long);
+        assert!(tail.starts_with('…'));
+        assert_eq!(tail.chars().count(), MESSAGE_TAIL + 1);
+    }
+
+    #[test]
+    fn failed_outcome_is_settled_and_carries_the_message() {
+        let o = failed("nope");
+        assert!(o.done && !o.success);
+        assert_eq!(o.message.as_deref(), Some("nope"));
+    }
+}

--- a/codex-session-lib/src/lib.rs
+++ b/codex-session-lib/src/lib.rs
@@ -16,6 +16,7 @@ mod events;
 mod handler;
 mod helpers;
 mod io_task;
+pub mod login;
 
 pub use agent::CodexAgent;
 pub use classifier::CodexClassifier;

--- a/codex-session-lib/src/login.rs
+++ b/codex-session-lib/src/login.rs
@@ -1,0 +1,162 @@
+//! Interactive codex sign-in for the portal's launcher-driven login surface.
+//!
+//! Codex is protocol-native: `start` spins a short-lived `codex app-server`,
+//! calls `account/login/start` in **device-code** mode, and hands back the
+//! `{user_code, verification_url}` for the user to approve in a browser. Unlike
+//! claude there is no code to paste back — the flow completes in the browser
+//! and the app-server emits an `account/login/completed` notification, which a
+//! background task waits for. The caller polls [`poll`] for the outcome.
+//!
+//! Dropping the session (browser closed) fires the cancel signal: the watcher
+//! calls `account/login/cancel` and drops the client, tearing down the
+//! app-server child (login contract: cancel reaps).
+//!
+//! [`poll`]: CodexLoginSession::poll
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use codex_codes::{
+    AppServerBuilder, AsyncClient as CodexAsyncClient, CancelLoginAccountParams,
+    LoginAccountParams, LoginAccountResponse, Notification, ServerMessage,
+};
+use shared::{AgentLoginOutcome, LoginInteraction, LoginPresentable};
+use tokio::sync::Notify;
+
+/// How long to wait for the user to approve the device code before giving up.
+const DEVICE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// An in-flight codex device-code login, watched on a background task.
+pub struct CodexLoginSession {
+    outcome: Arc<Mutex<Option<AgentLoginOutcome>>>,
+    /// Fired on drop to cancel the login and reap the app-server.
+    cancel: Arc<Notify>,
+}
+
+impl CodexLoginSession {
+    /// Start the app-server, kick off device-code login, and return the code +
+    /// URL to present. The completion watcher runs in the background.
+    pub async fn start() -> Result<(Self, LoginPresentable, LoginInteraction), String> {
+        let mut client = CodexAsyncClient::start_with(AppServerBuilder::new())
+            .await
+            .map_err(|e| format!("could not start the codex app-server: {e}"))?;
+
+        let resp = client
+            .account_login_start(&LoginAccountParams::ChatgptDeviceCode)
+            .await
+            .map_err(|e| format!("codex sign-in could not start: {e}"))?;
+
+        let (user_code, verification_url, login_id) = match resp {
+            LoginAccountResponse::ChatgptDeviceCode {
+                user_code,
+                verification_url,
+                login_id,
+            } => (user_code, verification_url, login_id),
+            other => {
+                return Err(format!(
+                    "codex returned an unexpected sign-in mode: {other:?}"
+                ))
+            }
+        };
+
+        let outcome = Arc::new(Mutex::new(None));
+        let cancel = Arc::new(Notify::new());
+        tokio::spawn(watch(client, login_id, outcome.clone(), cancel.clone()));
+
+        Ok((
+            Self { outcome, cancel },
+            LoginPresentable::DeviceCode {
+                user_code,
+                verification_url,
+            },
+            LoginInteraction::AwaitCompletion,
+        ))
+    }
+
+    /// Current outcome; `done == false` until the browser approval lands.
+    pub fn poll(&self) -> AgentLoginOutcome {
+        self.outcome
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or(AgentLoginOutcome {
+                done: false,
+                success: false,
+                message: None,
+            })
+    }
+
+    /// Codex needs no pasted code — this only exists for a uniform registry
+    /// interface and reports that.
+    pub fn submit_code(&self, _code: String) -> AgentLoginOutcome {
+        AgentLoginOutcome {
+            done: true,
+            success: false,
+            message: Some("codex sign-in completes in the browser — no code to enter here".into()),
+        }
+    }
+}
+
+impl Drop for CodexLoginSession {
+    fn drop(&mut self) {
+        // Wake the watcher so it cancels the login and drops the client
+        // (app-server reaped). If the watcher already finished this is a no-op.
+        self.cancel.notify_waiters();
+    }
+}
+
+async fn watch(
+    mut client: CodexAsyncClient,
+    login_id: String,
+    outcome: Arc<Mutex<Option<AgentLoginOutcome>>>,
+    cancel: Arc<Notify>,
+) {
+    let set = |o: AgentLoginOutcome| *outcome.lock().unwrap() = Some(o);
+    let deadline = tokio::time::sleep(DEVICE_TIMEOUT);
+    tokio::pin!(deadline);
+
+    loop {
+        tokio::select! {
+            // Distinct borrows: `cancel`/`deadline` touch neither `client`, so
+            // this compiles despite `next_message` holding `&mut client`.
+            _ = cancel.notified() => {
+                let _ = client
+                    .account_login_cancel(&CancelLoginAccountParams { login_id: login_id.clone() })
+                    .await;
+                return;
+            }
+            _ = &mut deadline => {
+                let _ = client
+                    .account_login_cancel(&CancelLoginAccountParams { login_id: login_id.clone() })
+                    .await;
+                set(failed("codex sign-in timed out waiting for approval"));
+                return;
+            }
+            msg = client.next_message() => match msg {
+                Ok(Some(ServerMessage::Notification(Notification::AccountLoginCompleted(n)))) => {
+                    set(AgentLoginOutcome {
+                        done: true,
+                        success: n.success,
+                        // Relay the CLI's own error text on failure.
+                        message: n.error,
+                    });
+                    return;
+                }
+                // Any other server traffic during login is not ours to handle.
+                Ok(Some(_)) => continue,
+                Ok(None) | Err(_) => {
+                    set(failed("the codex app-server closed during sign-in"));
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn failed(message: &str) -> AgentLoginOutcome {
+    AgentLoginOutcome {
+        done: true,
+        success: false,
+        message: Some(message.to_string()),
+    }
+}

--- a/frontend/src/pages/settings/agent_login.rs
+++ b/frontend/src/pages/settings/agent_login.rs
@@ -1,0 +1,460 @@
+//! Interactive agent sign-in modal (Settings ▸ Agents).
+//!
+//! Drives one launcher-side login flow to completion over the four backend
+//! relay endpoints (`/api/launchers/{id}/agent-login/...`). The two agents take
+//! different shapes, expressed by [`LoginInteraction`]:
+//!
+//! - **claude** ([`LoginInteraction::SubmitCode`]): show the auth URL, let the
+//!   user paste the code the browser hands back, POST it, await the outcome.
+//! - **codex** ([`LoginInteraction::AwaitCompletion`]): show the device code +
+//!   verification URL, then poll until the browser approval lands.
+//!
+//! Closing the modal before the flow settles cancels it launcher-side
+//! (fire-and-forget), so a parked PTY / app-server never lingers. A successful
+//! sign-in fires `on_success` so the matrix can re-probe.
+
+use gloo_net::http::Request;
+use shared::api::{StartAgentLoginRequest, StartAgentLoginResponse, SubmitAgentLoginCodeRequest};
+use shared::{AgentLoginOutcome, AgentType, LoginInteraction, LoginPresentable};
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+use crate::utils;
+
+/// How often to poll a browser-completion (codex) flow, in milliseconds.
+const POLL_INTERVAL_MS: u32 = 2000;
+
+#[derive(Properties, PartialEq)]
+pub struct AgentLoginModalProps {
+    pub launcher_id: Uuid,
+    pub agent_type: AgentType,
+    /// Human label for the agent (e.g. "Claude"), for the modal title.
+    pub agent_name: String,
+    /// Fired when the modal should close (cancel, or after a settled flow).
+    pub on_close: Callback<()>,
+    /// Fired once when a sign-in succeeds, so the caller can re-probe.
+    pub on_success: Callback<()>,
+}
+
+/// Where the flow currently is. The component owns `flow_id` separately (it's
+/// needed for cancel-on-close regardless of stage).
+enum Stage {
+    /// `POST /start` in flight.
+    Starting,
+    /// Flow started; waiting on the user. For claude this is the paste-a-code
+    /// step; for codex it's the poll-until-approved wait.
+    Presenting {
+        presentable: LoginPresentable,
+        interaction: LoginInteraction,
+    },
+    /// Terminal: the flow settled (success or a reported failure).
+    Settled(AgentLoginOutcome),
+    /// Terminal: we couldn't run the flow at all (start failed, transport).
+    Failed(String),
+}
+
+pub enum Msg {
+    Started(Result<StartAgentLoginResponse, String>),
+    CodeInput(String),
+    SubmitCode,
+    Settled(AgentLoginOutcome),
+    /// Timer tick: poll the browser-completion flow once.
+    Poll,
+    Polled(Result<AgentLoginOutcome, String>),
+    Close,
+}
+
+pub struct AgentLoginModal {
+    stage: Stage,
+    flow_id: Option<Uuid>,
+    code_input: String,
+    /// True while a `POST /code` is in flight, to disable the submit button.
+    submitting: bool,
+    /// Set once `on_success` has fired, so we never fire it twice.
+    notified_success: bool,
+}
+
+impl Component for AgentLoginModal {
+    type Message = Msg;
+    type Properties = AgentLoginModalProps;
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let launcher_id = ctx.props().launcher_id;
+        let agent_type = ctx.props().agent_type;
+        ctx.link()
+            .send_future(async move { Msg::Started(start_login(launcher_id, agent_type).await) });
+        Self {
+            stage: Stage::Starting,
+            flow_id: None,
+            code_input: String::new(),
+            submitting: false,
+            notified_success: false,
+        }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Msg) -> bool {
+        match msg {
+            Msg::Started(Ok(resp)) => {
+                self.flow_id = Some(resp.flow_id);
+                // Codex completes in the browser — start polling immediately.
+                if resp.interaction == LoginInteraction::AwaitCompletion {
+                    self.schedule_poll(ctx);
+                }
+                self.stage = Stage::Presenting {
+                    presentable: resp.presentable,
+                    interaction: resp.interaction,
+                };
+                true
+            }
+            Msg::Started(Err(e)) => {
+                self.stage = Stage::Failed(e);
+                true
+            }
+            Msg::CodeInput(v) => {
+                self.code_input = v;
+                true
+            }
+            Msg::SubmitCode => {
+                let (Some(flow_id), false) = (self.flow_id, self.submitting) else {
+                    return false;
+                };
+                let code = self.code_input.trim().to_string();
+                if code.is_empty() {
+                    return false;
+                }
+                self.submitting = true;
+                let launcher_id = ctx.props().launcher_id;
+                ctx.link().send_future(async move {
+                    match submit_code(launcher_id, flow_id, code).await {
+                        Ok(outcome) => Msg::Settled(outcome),
+                        Err(e) => Msg::Settled(AgentLoginOutcome {
+                            done: true,
+                            success: false,
+                            message: Some(e),
+                        }),
+                    }
+                });
+                true
+            }
+            Msg::Poll => {
+                let Some(flow_id) = self.flow_id else {
+                    return false;
+                };
+                let launcher_id = ctx.props().launcher_id;
+                ctx.link().send_future(async move {
+                    Msg::Polled(poll_login(launcher_id, flow_id).await)
+                });
+                false
+            }
+            Msg::Polled(Ok(outcome)) => {
+                if outcome.done {
+                    self.settle(ctx, outcome);
+                    true
+                } else {
+                    // Still waiting on the browser — poll again.
+                    self.schedule_poll(ctx);
+                    false
+                }
+            }
+            // A transient poll failure (launcher blip) shouldn't kill the flow;
+            // keep polling until it settles or the user closes.
+            Msg::Polled(Err(_)) => {
+                self.schedule_poll(ctx);
+                false
+            }
+            Msg::Settled(outcome) => {
+                self.submitting = false;
+                self.settle(ctx, outcome);
+                true
+            }
+            Msg::Close => {
+                self.cancel_if_unsettled(ctx);
+                ctx.props().on_close.emit(());
+                false
+            }
+        }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let on_close = ctx.link().callback(|_| Msg::Close);
+        let on_overlay = ctx.link().callback(|_| Msg::Close);
+        let stop = Callback::from(|e: MouseEvent| e.stop_propagation());
+
+        html! {
+            <div class="agent-login-overlay" onclick={on_overlay}>
+                <div class="agent-login-modal" onclick={stop}>
+                    <div class="agent-login-header">
+                        <h2>{ format!("Sign in to {}", ctx.props().agent_name) }</h2>
+                        <button class="agent-login-close" onclick={on_close.clone()}>{ "×" }</button>
+                    </div>
+                    <div class="agent-login-body">
+                        { self.view_stage(ctx) }
+                    </div>
+                    <div class="agent-login-footer">
+                        <button class="link-button" onclick={on_close}>{ self.close_label() }</button>
+                    </div>
+                </div>
+            </div>
+        }
+    }
+}
+
+impl AgentLoginModal {
+    /// Schedule one poll tick `POLL_INTERVAL_MS` from now.
+    fn schedule_poll(&self, ctx: &Context<Self>) {
+        let link = ctx.link().clone();
+        spawn_local(async move {
+            gloo::timers::future::TimeoutFuture::new(POLL_INTERVAL_MS).await;
+            link.send_message(Msg::Poll);
+        });
+    }
+
+    /// Move to a settled outcome, firing `on_success` exactly once on success.
+    fn settle(&mut self, ctx: &Context<Self>, outcome: AgentLoginOutcome) {
+        if outcome.success && !self.notified_success {
+            self.notified_success = true;
+            ctx.props().on_success.emit(());
+        }
+        self.stage = Stage::Settled(outcome);
+    }
+
+    /// Cancel the launcher-side flow if it's still parked (browser closed
+    /// mid-flow). No-op once settled — the launcher already dropped it.
+    fn cancel_if_unsettled(&self, ctx: &Context<Self>) {
+        if matches!(self.stage, Stage::Settled(_) | Stage::Failed(_)) {
+            return;
+        }
+        if let Some(flow_id) = self.flow_id {
+            cancel_login(ctx.props().launcher_id, flow_id);
+        }
+    }
+
+    fn close_label(&self) -> &'static str {
+        match self.stage {
+            Stage::Settled(_) | Stage::Failed(_) => "Close",
+            _ => "Cancel",
+        }
+    }
+
+    fn view_stage(&self, ctx: &Context<Self>) -> Html {
+        match &self.stage {
+            Stage::Starting => html! { <p class="agent-login-status">{ "Starting sign-in…" }</p> },
+            Stage::Failed(msg) => html! {
+                <p class="agent-login-status error">{ msg }</p>
+            },
+            Stage::Settled(outcome) => {
+                let (class, text) = outcome_status(outcome);
+                html! { <p class={classes!("agent-login-status", class)}>{ text }</p> }
+            }
+            Stage::Presenting {
+                presentable,
+                interaction,
+            } => self.view_presenting(ctx, presentable, *interaction),
+        }
+    }
+
+    fn view_presenting(
+        &self,
+        ctx: &Context<Self>,
+        presentable: &LoginPresentable,
+        interaction: LoginInteraction,
+    ) -> Html {
+        match presentable {
+            LoginPresentable::AuthUrl { url } => {
+                let on_input = ctx.link().callback(|e: InputEvent| {
+                    let input: HtmlInputElement = e.target_unchecked_into();
+                    Msg::CodeInput(input.value())
+                });
+                let on_submit = ctx.link().callback(|_| Msg::SubmitCode);
+                let on_key = ctx.link().batch_callback(|e: KeyboardEvent| {
+                    (e.key() == "Enter").then_some(Msg::SubmitCode)
+                });
+                html! {
+                    <>
+                        <p class="agent-login-instr">
+                            { "Open this URL, approve the sign-in, then paste the code it gives you:" }
+                        </p>
+                        <a class="agent-login-url" href={url.clone()} target="_blank" rel="noopener">
+                            { url }
+                        </a>
+                        <div class="agent-login-code-row">
+                            <input
+                                type="text"
+                                class="agent-login-code-input"
+                                placeholder="Paste code here"
+                                value={self.code_input.clone()}
+                                oninput={on_input}
+                                onkeypress={on_key}
+                                disabled={self.submitting}
+                            />
+                            <button
+                                class="agent-login-submit"
+                                onclick={on_submit}
+                                disabled={self.submitting || self.code_input.trim().is_empty()}
+                            >
+                                { if self.submitting { "Signing in…" } else { "Submit" } }
+                            </button>
+                        </div>
+                        // interaction is always SubmitCode here, but keep the shape honest.
+                        if interaction != LoginInteraction::SubmitCode {
+                            <p class="agent-login-status error">
+                                { "Unexpected sign-in mode for this agent." }
+                            </p>
+                        }
+                    </>
+                }
+            }
+            LoginPresentable::DeviceCode {
+                user_code,
+                verification_url,
+            } => html! {
+                <>
+                    <p class="agent-login-instr">
+                        { "Open this URL and enter the code to approve the sign-in:" }
+                    </p>
+                    <a
+                        class="agent-login-url"
+                        href={verification_url.clone()}
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        { verification_url }
+                    </a>
+                    <div class="agent-login-device-code">{ user_code }</div>
+                    <p class="agent-login-status">{ "Waiting for approval in your browser…" }</p>
+                </>
+            },
+        }
+    }
+}
+
+/// Cell text + CSS modifier for a settled outcome. Pure, so the success/failure
+/// wording is unit-tested without mounting the component.
+fn outcome_status(outcome: &AgentLoginOutcome) -> (&'static str, String) {
+    if outcome.success {
+        ("success", "Signed in.".to_string())
+    } else {
+        let detail = outcome
+            .message
+            .as_deref()
+            .filter(|m| !m.trim().is_empty())
+            .unwrap_or("sign-in did not complete");
+        ("error", format!("Sign-in failed: {detail}"))
+    }
+}
+
+async fn start_login(
+    launcher_id: Uuid,
+    agent_type: AgentType,
+) -> Result<StartAgentLoginResponse, String> {
+    let url = utils::api_url(&format!("/api/launchers/{launcher_id}/agent-login/start"));
+    let body = StartAgentLoginRequest { agent_type };
+    let resp = Request::post(&url)
+        .json(&body)
+        .map_err(|e| e.to_string())?
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !resp.ok() {
+        return Err(error_body(resp).await);
+    }
+    resp.json::<StartAgentLoginResponse>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn submit_code(
+    launcher_id: Uuid,
+    flow_id: Uuid,
+    code: String,
+) -> Result<AgentLoginOutcome, String> {
+    let url = utils::api_url(&format!(
+        "/api/launchers/{launcher_id}/agent-login/{flow_id}/code"
+    ));
+    let body = SubmitAgentLoginCodeRequest { code };
+    let resp = Request::post(&url)
+        .json(&body)
+        .map_err(|e| e.to_string())?
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !resp.ok() {
+        return Err(error_body(resp).await);
+    }
+    resp.json::<AgentLoginOutcome>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn poll_login(launcher_id: Uuid, flow_id: Uuid) -> Result<AgentLoginOutcome, String> {
+    let url = utils::api_url(&format!(
+        "/api/launchers/{launcher_id}/agent-login/{flow_id}"
+    ));
+    let resp = Request::get(&url).send().await.map_err(|e| e.to_string())?;
+    if !resp.ok() {
+        return Err(error_body(resp).await);
+    }
+    resp.json::<AgentLoginOutcome>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Best-effort fire-and-forget cancel; a dropped launcher flow reaps on its own
+/// deadline, so we don't surface failures here.
+fn cancel_login(launcher_id: Uuid, flow_id: Uuid) {
+    spawn_local(async move {
+        let url = utils::api_url(&format!(
+            "/api/launchers/{launcher_id}/agent-login/{flow_id}/cancel"
+        ));
+        let _ = Request::post(&url).send().await;
+    });
+}
+
+/// Read a non-2xx response body as the error message, falling back to the
+/// status. The backend relays the agent CLI's own text on login-start failures.
+async fn error_body(resp: gloo_net::http::Response) -> String {
+    let status = resp.status();
+    match resp.text().await {
+        Ok(t) if !t.trim().is_empty() => t,
+        _ => format!("HTTP {status}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_reads_cleanly() {
+        let (class, text) = outcome_status(&AgentLoginOutcome {
+            done: true,
+            success: true,
+            message: None,
+        });
+        assert_eq!(class, "success");
+        assert_eq!(text, "Signed in.");
+    }
+
+    #[test]
+    fn failure_surfaces_the_cli_message() {
+        let (class, text) = outcome_status(&AgentLoginOutcome {
+            done: true,
+            success: false,
+            message: Some("invalid code".to_string()),
+        });
+        assert_eq!(class, "error");
+        assert_eq!(text, "Sign-in failed: invalid code");
+    }
+
+    #[test]
+    fn failure_without_a_message_has_a_fallback() {
+        let (_, text) = outcome_status(&AgentLoginOutcome {
+            done: true,
+            success: false,
+            message: Some("   ".to_string()),
+        });
+        assert_eq!(text, "Sign-in failed: sign-in did not complete");
+    }
+}

--- a/frontend/src/pages/settings/agents_panel.rs
+++ b/frontend/src/pages/settings/agents_panel.rs
@@ -11,9 +11,11 @@
 //! (`/api/launchers/{id}/probe-agents`), fanned across the user's launchers;
 //! offline launchers render as unreachable rather than blank.
 //!
-//! Read-only for now. The login buttons that act on a "signed out" cell land in
-//! a follow-up against the rust-code-agent-sdks login flows.
+//! A "signed out"/"unknown" cell for an installed agent gets a Sign-in button
+//! that opens [`AgentLoginModal`], which drives the launcher-side login flow; a
+//! successful sign-in re-probes the matrix.
 
+use crate::pages::settings::agent_login::AgentLoginModal;
 use crate::utils::{self, On401};
 use shared::api::ProbeAgentsResponse;
 use shared::{AgentInstall, AgentLoginStatus, AgentType, LauncherInfo};
@@ -21,6 +23,14 @@ use std::collections::HashMap;
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
+
+/// Which cell's sign-in modal is open: (launcher, agent, agent display name).
+#[derive(Clone, PartialEq)]
+struct LoginTarget {
+    launcher_id: Uuid,
+    agent_type: AgentType,
+    agent_name: String,
+}
 
 /// Columns of the matrix, in display order. Mirrors `AgentType`.
 const AGENTS: [(AgentType, &str); 2] = [(AgentType::Claude, "Claude"), (AgentType::Codex, "Codex")];
@@ -40,8 +50,10 @@ enum ProbeState {
 pub fn agents_panel() -> Html {
     let launchers = use_state(|| None::<Vec<LauncherInfo>>);
     let probes = use_state(HashMap::<Uuid, ProbeState>::new);
-    // Bumped by the refresh button to re-run the whole fan-out.
+    // Bumped by the refresh button (and a successful sign-in) to re-run the fan-out.
     let refresh = use_state(|| 0u32);
+    // The open sign-in modal, if any.
+    let login_target = use_state(|| None::<LoginTarget>);
 
     {
         let launchers = launchers.clone();
@@ -89,6 +101,11 @@ pub fn agents_panel() -> Html {
         Callback::from(move |_: MouseEvent| refresh.set(*refresh + 1))
     };
 
+    let on_sign_in = {
+        let login_target = login_target.clone();
+        Callback::from(move |target: LoginTarget| login_target.set(Some(target)))
+    };
+
     let body = match (*launchers).clone() {
         None => html! { <p class="setting-description">{ "Loading…" }</p> },
         Some(list) if list.is_empty() => html! {
@@ -106,11 +123,31 @@ pub fn agents_panel() -> Html {
                     </tr>
                 </thead>
                 <tbody>
-                    { for list.iter().map(|l| render_row(l, &probes)) }
+                    { for list.iter().map(|l| render_row(l, &probes, &on_sign_in)) }
                 </tbody>
             </table>
         },
     };
+
+    let modal = (*login_target).clone().map(|target| {
+        let on_close = {
+            let login_target = login_target.clone();
+            Callback::from(move |_| login_target.set(None))
+        };
+        let on_success = {
+            let refresh = refresh.clone();
+            Callback::from(move |_| refresh.set(*refresh + 1))
+        };
+        html! {
+            <AgentLoginModal
+                launcher_id={target.launcher_id}
+                agent_type={target.agent_type}
+                agent_name={target.agent_name}
+                {on_close}
+                {on_success}
+            />
+        }
+    });
 
     html! {
         <section class="agents-section">
@@ -123,11 +160,16 @@ pub fn agents_panel() -> Html {
                 </p>
             </div>
             { body }
+            { for modal }
         </section>
     }
 }
 
-fn render_row(launcher: &LauncherInfo, probes: &HashMap<Uuid, ProbeState>) -> Html {
+fn render_row(
+    launcher: &LauncherInfo,
+    probes: &HashMap<Uuid, ProbeState>,
+    on_sign_in: &Callback<LoginTarget>,
+) -> Html {
     let state = probes.get(&launcher.launcher_id);
     html! {
         <tr>
@@ -137,26 +179,42 @@ fn render_row(launcher: &LauncherInfo, probes: &HashMap<Uuid, ProbeState>) -> Ht
                     <span class="agents-host-alias">{ format!("({})", launcher.launcher_name) }</span>
                 }
             </td>
-            { for AGENTS.iter().map(|(agent, _)| render_cell(state, *agent)) }
+            { for AGENTS.iter().map(|(agent, name)| {
+                render_cell(state, *agent, name, launcher.launcher_id, on_sign_in)
+            }) }
         </tr>
     }
 }
 
-fn render_cell(state: Option<&ProbeState>, agent: AgentType) -> Html {
+fn render_cell(
+    state: Option<&ProbeState>,
+    agent: AgentType,
+    agent_name: &str,
+    launcher_id: Uuid,
+    on_sign_in: &Callback<LoginTarget>,
+) -> Html {
     match state {
         None => html! { <td class="agents-cell loading">{ "…" }</td> },
         Some(ProbeState::Unreachable) => {
             html! { <td class="agents-cell unreachable">{ "offline" }</td> }
         }
         Some(ProbeState::Loaded(agents)) => match agents.get(&agent) {
-            Some(install) => render_install_cell(install),
+            Some(install) => {
+                render_install_cell(install, agent, agent_name, launcher_id, on_sign_in)
+            }
             // Probe ran but didn't report this agent at all — treat as unknown.
             None => html! { <td class="agents-cell unknown">{ "—" }</td> },
         },
     }
 }
 
-fn render_install_cell(install: &AgentInstall) -> Html {
+fn render_install_cell(
+    install: &AgentInstall,
+    agent: AgentType,
+    agent_name: &str,
+    launcher_id: Uuid,
+    on_sign_in: &Callback<LoginTarget>,
+) -> Html {
     if !install.installed {
         return html! {
             <td class="agents-cell not-installed">
@@ -169,8 +227,34 @@ fn render_install_cell(install: &AgentInstall) -> Html {
         <td class="agents-cell installed">
             <span class="agents-badge installed">{ "installed" }</span>
             <span class={classes!("agents-login", login_class)}>{ login_text }</span>
+            { for sign_in_button(&install.login, agent, agent_name, launcher_id, on_sign_in) }
         </td>
     }
+}
+
+/// A Sign-in button, shown only when the agent is installed but not signed in
+/// (or its state is unknown — offering the action can't hurt). `None` when
+/// already signed in, so the option collapses out of the cell.
+fn sign_in_button(
+    login: &AgentLoginStatus,
+    agent: AgentType,
+    agent_name: &str,
+    launcher_id: Uuid,
+    on_sign_in: &Callback<LoginTarget>,
+) -> Option<Html> {
+    if matches!(login, AgentLoginStatus::LoggedIn { .. }) {
+        return None;
+    }
+    let target = LoginTarget {
+        launcher_id,
+        agent_type: agent,
+        agent_name: agent_name.to_string(),
+    };
+    let on_sign_in = on_sign_in.clone();
+    let onclick = Callback::from(move |_: MouseEvent| on_sign_in.emit(target.clone()));
+    Some(html! {
+        <button class="agents-signin" {onclick}>{ "Sign in" }</button>
+    })
 }
 
 /// Cell text + CSS modifier for a login state. Pure, so the label precedence is

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -1,3 +1,4 @@
+mod agent_login;
 mod agents_panel;
 mod appearance_panel;
 mod forwarding_panel;

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -1022,6 +1022,140 @@
     color: var(--text-secondary);
 }
 
+.agents-signin {
+    width: fit-content;
+    margin-top: 0.15rem;
+    padding: 0.1rem 0.5rem;
+    font-size: 0.75rem;
+    border: 1px solid var(--accent, #7aa2f7);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--accent, #7aa2f7);
+    cursor: pointer;
+}
+
+.agents-signin:hover {
+    background: color-mix(in srgb, var(--accent, #7aa2f7) 15%, transparent);
+}
+
+/* Interactive sign-in modal (Settings ▸ Agents). */
+.agent-login-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.agent-login-modal {
+    background: var(--bg-secondary, #1f2335);
+    border: 1px solid var(--border, #2a2e42);
+    border-radius: 8px;
+    width: min(480px, 92vw);
+    max-height: 90vh;
+    overflow-y: auto;
+    padding: 1rem 1.25rem 1.25rem;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+}
+
+.agent-login-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
+}
+
+.agent-login-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.agent-login-close {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.agent-login-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.agent-login-instr {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.agent-login-url {
+    word-break: break-all;
+    font-size: 0.85rem;
+    color: var(--accent, #7aa2f7);
+}
+
+.agent-login-device-code {
+    font-family: var(--font-mono, monospace);
+    font-size: 1.4rem;
+    letter-spacing: 0.15rem;
+    text-align: center;
+    padding: 0.5rem;
+    border: 1px dashed var(--border, #2a2e42);
+    border-radius: 6px;
+}
+
+.agent-login-code-row {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.agent-login-code-input {
+    flex: 1;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid var(--border, #2a2e42);
+    border-radius: 4px;
+    background: var(--bg-primary, #1a1b26);
+    color: var(--text-primary, #c0caf5);
+}
+
+.agent-login-submit {
+    padding: 0.35rem 0.75rem;
+    border: 1px solid var(--accent, #7aa2f7);
+    border-radius: 4px;
+    background: var(--accent, #7aa2f7);
+    color: var(--bg-primary, #1a1b26);
+    cursor: pointer;
+}
+
+.agent-login-submit:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.agent-login-status {
+    margin: 0;
+    font-size: 0.9rem;
+}
+
+.agent-login-status.success {
+    color: var(--success, #9ece6a);
+}
+
+.agent-login-status.error {
+    color: var(--error, #f7768e);
+}
+
+.agent-login-footer {
+    margin-top: 1rem;
+    display: flex;
+    justify-content: flex-end;
+}
+
 .profile-section {
     display: flex;
     flex-direction: column;

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -84,6 +84,7 @@ pub async fn run_launcher_loop(
     // guidance, not just "Still parked".
     let mut last_parked_reason: Option<LauncherRejectReason> = None;
     let mut scheduler = Scheduler::new();
+    let mut login_registry = crate::login_registry::LoginRegistry::new();
 
     loop {
         // Re-resolve the token every attempt (CLI flag still wins): a parked
@@ -240,6 +241,7 @@ pub async fn run_launcher_loop(
                                             &mut ws_sender,
                                             &mut process_manager,
                                             &mut scheduler,
+                                            &mut login_registry,
                                         ).await;
                                     }
                                 }
@@ -613,6 +615,7 @@ async fn handle_message(
     ws_sender: &mut ws_bridge::WsSender<LauncherToServer>,
     process_manager: &mut ProcessManager,
     scheduler: &mut Scheduler,
+    login_registry: &mut crate::login_registry::LoginRegistry,
 ) {
     match msg {
         ServerToLauncher::LaunchSession {
@@ -735,6 +738,67 @@ async fn handle_message(
             if ws_sender.send(response).await.is_err() {
                 warn!("Failed to send list directories result");
             }
+        }
+        ServerToLauncher::StartAgentLogin {
+            request_id,
+            flow_id,
+            agent_type,
+        } => {
+            let response = match login_registry.start(flow_id, agent_type).await {
+                Ok((presentable, interaction)) => LauncherToServer::AgentLoginStartResult {
+                    request_id,
+                    flow_id,
+                    presentable: Some(presentable),
+                    interaction: Some(interaction),
+                    error: None,
+                },
+                Err(error) => LauncherToServer::AgentLoginStartResult {
+                    request_id,
+                    flow_id,
+                    presentable: None,
+                    interaction: None,
+                    error: Some(error),
+                },
+            };
+            if ws_sender.send(response).await.is_err() {
+                warn!("Failed to send agent login start result");
+            }
+        }
+        ServerToLauncher::SubmitAgentLoginCode {
+            request_id,
+            flow_id,
+            code,
+        } => {
+            let outcome = login_registry.submit_code(flow_id, code).await;
+            if outcome.done {
+                login_registry.remove(flow_id);
+            }
+            let response = LauncherToServer::AgentLoginOutcomeResult {
+                request_id,
+                outcome,
+            };
+            if ws_sender.send(response).await.is_err() {
+                warn!("Failed to send agent login outcome");
+            }
+        }
+        ServerToLauncher::PollAgentLogin {
+            request_id,
+            flow_id,
+        } => {
+            let outcome = login_registry.poll(flow_id);
+            if outcome.done {
+                login_registry.remove(flow_id);
+            }
+            let response = LauncherToServer::AgentLoginOutcomeResult {
+                request_id,
+                outcome,
+            };
+            if ws_sender.send(response).await.is_err() {
+                warn!("Failed to send agent login poll result");
+            }
+        }
+        ServerToLauncher::CancelAgentLogin { flow_id } => {
+            login_registry.remove(flow_id);
         }
         ServerToLauncher::ProbeAgents { request_id } => {
             // Synchronous probe in a blocking task so two `--version` spawns

--- a/launcher/src/login_registry.rs
+++ b/launcher/src/login_registry.rs
@@ -1,0 +1,117 @@
+//! Launcher-side registry of in-flight interactive agent logins.
+//!
+//! A login spans several backend RPCs — start (present a URL/code), then either
+//! a code submission (claude) or polling for browser completion (codex) — so
+//! the flow must live *between* messages, keyed by a `flow_id` the backend
+//! mints. This holds those parked sessions and adapts each agent's mechanics to
+//! one interface:
+//! - claude's calls are blocking (PTY), so they run on `spawn_blocking`;
+//! - codex's are async (app-server connection).
+//!
+//! Dropping a session (cancel, or the whole registry on disconnect) tears down
+//! its child — see each driver's `Drop`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use shared::{AgentLoginOutcome, AgentType, LoginInteraction, LoginPresentable};
+use uuid::Uuid;
+
+use claude_session_lib::login::ClaudeLoginSession;
+use codex_session_lib::login::CodexLoginSession;
+
+/// One parked login flow, per agent.
+enum LoginSession {
+    Claude(ClaudeLoginSession),
+    Codex(CodexLoginSession),
+}
+
+impl LoginSession {
+    fn submit_code(&self, code: String) -> AgentLoginOutcome {
+        match self {
+            Self::Claude(s) => s.submit_code(code),
+            Self::Codex(s) => s.submit_code(code),
+        }
+    }
+
+    fn poll(&self) -> AgentLoginOutcome {
+        match self {
+            Self::Claude(s) => s.poll(),
+            Self::Codex(s) => s.poll(),
+        }
+    }
+}
+
+/// Parked login flows, keyed by the backend-minted `flow_id`.
+#[derive(Default)]
+pub struct LoginRegistry {
+    flows: HashMap<Uuid, Arc<LoginSession>>,
+}
+
+impl LoginRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start a login for `agent_type`, park it under `flow_id`, and return what
+    /// the user must act on. `Err` if the flow couldn't even begin.
+    pub async fn start(
+        &mut self,
+        flow_id: Uuid,
+        agent_type: AgentType,
+    ) -> Result<(LoginPresentable, LoginInteraction), String> {
+        let (session, presentable, interaction) = match agent_type {
+            AgentType::Claude => {
+                // `start` blocks until the CLI prints its URL — off-runtime.
+                let started = tokio::task::spawn_blocking(ClaudeLoginSession::start)
+                    .await
+                    .map_err(|e| format!("claude login task failed to run: {e}"))??;
+                (LoginSession::Claude(started.0), started.1, started.2)
+            }
+            AgentType::Codex => {
+                let (s, p, i) = CodexLoginSession::start().await?;
+                (LoginSession::Codex(s), p, i)
+            }
+        };
+        self.flows.insert(flow_id, Arc::new(session));
+        Ok((presentable, interaction))
+    }
+
+    /// Feed a pasted code to a parked flow and wait for it to settle.
+    pub async fn submit_code(&self, flow_id: Uuid, code: String) -> AgentLoginOutcome {
+        let Some(session) = self.flows.get(&flow_id).cloned() else {
+            return gone();
+        };
+        // claude's submit blocks; codex's is a trivial message. Run both under
+        // spawn_blocking for uniformity (codex's is instant).
+        tokio::task::spawn_blocking(move || session.submit_code(code))
+            .await
+            .unwrap_or_else(|e| AgentLoginOutcome {
+                done: true,
+                success: false,
+                message: Some(format!("login task failed: {e}")),
+            })
+    }
+
+    /// Current state of a parked flow (for the poll path).
+    pub fn poll(&self, flow_id: Uuid) -> AgentLoginOutcome {
+        match self.flows.get(&flow_id) {
+            Some(session) => session.poll(),
+            None => gone(),
+        }
+    }
+
+    /// Drop a flow, tearing down its child. Called on cancel and after a
+    /// settled outcome so parked PTYs / app-servers don't linger.
+    pub fn remove(&mut self, flow_id: Uuid) {
+        self.flows.remove(&flow_id);
+    }
+}
+
+fn gone() -> AgentLoginOutcome {
+    AgentLoginOutcome {
+        done: true,
+        success: false,
+        message: Some("that sign-in session is no longer active — start again".into()),
+    }
+}

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -5,6 +5,7 @@
 mod config;
 mod connection;
 mod forward;
+mod login_registry;
 mod media;
 mod message;
 mod pastebin;

--- a/shared/src/api/launch.rs
+++ b/shared/src/api/launch.rs
@@ -47,3 +47,25 @@ pub struct ProbeAgentsResponse {
     #[serde(default)]
     pub agents: Vec<crate::AgentInstall>,
 }
+
+/// Body of POST /api/launchers/:id/agent-login/start — which agent to sign in.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StartAgentLoginRequest {
+    pub agent_type: crate::AgentType,
+}
+
+/// Response from the start endpoint: the flow id to reference in follow-up
+/// calls, plus what the user must act on and how the flow finishes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StartAgentLoginResponse {
+    pub flow_id: uuid::Uuid,
+    pub presentable: crate::LoginPresentable,
+    pub interaction: crate::LoginInteraction,
+}
+
+/// Body of POST /api/launchers/:id/agent-login/:flow/code — the pasted code
+/// (claude's `SubmitCode` interaction).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubmitAgentLoginCodeRequest {
+    pub code: String,
+}

--- a/shared/src/endpoints/launcher.rs
+++ b/shared/src/endpoints/launcher.rs
@@ -3,7 +3,9 @@ use uuid::Uuid;
 use ws_bridge::WsEndpoint;
 
 use super::types::{ContinuationConfig, ScheduledTaskConfig};
-use crate::{AgentInstall, AgentType, DirectoryEntry};
+use crate::{
+    AgentInstall, AgentLoginOutcome, AgentType, DirectoryEntry, LoginInteraction, LoginPresentable,
+};
 
 pub struct LauncherEndpoint;
 
@@ -103,6 +105,27 @@ pub enum LauncherToServer {
         error: Option<String>,
         #[serde(default)]
         resolved_path: Option<String>,
+    },
+
+    /// Reply to `StartAgentLogin`: either what the user must act on
+    /// (`presentable` + `interaction`) or why the flow couldn't start
+    /// (`error`). Exactly one of `{presentable, error}` is set.
+    AgentLoginStartResult {
+        request_id: Uuid,
+        flow_id: Uuid,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        presentable: Option<LoginPresentable>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        interaction: Option<LoginInteraction>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+
+    /// Reply to `SubmitAgentLoginCode` / `PollAgentLogin`: the flow's outcome,
+    /// possibly still pending (`outcome.done == false`).
+    AgentLoginOutcomeResult {
+        request_id: Uuid,
+        outcome: AgentLoginOutcome,
     },
 
     /// On-demand agent install probe result. The launcher re-runs the
@@ -268,6 +291,35 @@ pub enum ServerToLauncher {
     /// Ask the launcher to (re-)probe its agent CLIs. The launcher replies
     /// with `LauncherToServer::ProbeAgentsResult` carrying the fresh state.
     ProbeAgents { request_id: Uuid },
+
+    /// Begin an interactive login for `agent_type` on this host. The launcher
+    /// starts the agent's login flow, parks it under `flow_id`, and replies
+    /// with `AgentLoginStartResult` carrying what the user must act on. The
+    /// backend mints `flow_id`; subsequent `SubmitAgentLoginCode` /
+    /// `PollAgentLogin` / `CancelAgentLogin` reference it (#agent-login).
+    StartAgentLogin {
+        request_id: Uuid,
+        flow_id: Uuid,
+        agent_type: AgentType,
+    },
+
+    /// Feed the code the provider showed back into a parked
+    /// `LoginInteraction::SubmitCode` flow (claude). The launcher submits it and
+    /// replies `AgentLoginOutcomeResult`.
+    SubmitAgentLoginCode {
+        request_id: Uuid,
+        flow_id: Uuid,
+        code: String,
+    },
+
+    /// Ask a parked `LoginInteraction::AwaitCompletion` flow (codex) for its
+    /// current state. Replies `AgentLoginOutcomeResult` with `done=false` while
+    /// still awaiting the user.
+    PollAgentLogin { request_id: Uuid, flow_id: Uuid },
+
+    /// Abandon a parked login flow (browser closed / navigated away). The
+    /// launcher drops the flow, reaping any child process. Fire-and-forget.
+    CancelAgentLogin { flow_id: Uuid },
 
     /// Server is shutting down
     ServerShutdown {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -400,6 +400,51 @@ pub enum AgentLoginStatus {
     },
 }
 
+/// What the user must act on to complete an interactive agent login, relayed
+/// from the launcher to the browser (#agent-login).
+///
+/// Agent-neutral: claude and codex-ChatGPT hand back a URL to open; codex's
+/// device-code mode hands back a short code to enter at a verification URL.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum LoginPresentable {
+    /// Open this URL in a browser and complete sign-in there.
+    AuthUrl { url: String },
+    /// Enter `user_code` at `verification_url`.
+    DeviceCode {
+        user_code: String,
+        verification_url: String,
+    },
+}
+
+/// How the browser finishes the flow after showing the [`LoginPresentable`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LoginInteraction {
+    /// The provider shows the user a code to paste back into the portal
+    /// (claude has no device-code mode): present a code field, then submit.
+    SubmitCode,
+    /// Sign-in completes entirely in the provider's browser/device page
+    /// (codex): the portal polls for the async completion.
+    AwaitCompletion,
+}
+
+/// Terminal (or still-pending) result of an interactive login, relayed to the
+/// browser. `done == false` means "keep polling"; on `done` the matrix
+/// re-probes to pick up the new signed-in state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentLoginOutcome {
+    /// Whether the flow has settled (`false` = still awaiting the user).
+    pub done: bool,
+    /// On a settled flow, whether sign-in succeeded.
+    #[serde(default)]
+    pub success: bool,
+    /// Human-readable detail — the CLI's own error text on failure, when we
+    /// have it. Shown verbatim so a failure is diagnosable, not mysterious.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
 /// Result of probing one agent CLI on a launcher host. Built at launcher
 /// startup (sent in `LauncherRegister`) and refreshed on demand via
 /// `ProbeAgents` when the user opens the launch dialog or the agents settings
@@ -906,6 +951,54 @@ pub struct AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn agent_login_status_defaults_to_unknown_and_round_trips() {
+        // Older launcher omits `login` → must deserialize as Unknown, not a
+        // false "signed out".
+        let legacy = r#"{"agent_type":"claude","installed":true}"#;
+        let probe: AgentInstall = serde_json::from_str(legacy).expect("legacy probe");
+        assert_eq!(probe.login, AgentLoginStatus::Unknown);
+
+        let signed_in = AgentLoginStatus::LoggedIn {
+            label: Some("matt@exclosure.io".into()),
+            plan: Some("max".into()),
+            via: None,
+        };
+        let round: AgentLoginStatus =
+            serde_json::from_str(&serde_json::to_string(&signed_in).unwrap()).unwrap();
+        assert_eq!(round, signed_in);
+    }
+
+    #[test]
+    fn login_presentable_round_trips_both_shapes() {
+        for p in [
+            LoginPresentable::AuthUrl {
+                url: "https://claude.ai/oauth?x=1".into(),
+            },
+            LoginPresentable::DeviceCode {
+                user_code: "ABCD-1234".into(),
+                verification_url: "https://auth.openai.com/device".into(),
+            },
+        ] {
+            let round: LoginPresentable =
+                serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
+            assert_eq!(round, p);
+        }
+    }
+
+    #[test]
+    fn login_outcome_pending_omits_nothing_load_bearing() {
+        let pending = AgentLoginOutcome {
+            done: false,
+            success: false,
+            message: None,
+        };
+        let round: AgentLoginOutcome =
+            serde_json::from_str(&serde_json::to_string(&pending).unwrap()).unwrap();
+        assert_eq!(round, pending);
+        assert!(!round.done);
+    }
 
     #[test]
     fn session_mode_serde_and_default() {


### PR DESCRIPTION
Signed-out (or unknown-state) installed cells in **Settings ▸ Agents** now
carry a **Sign in** button that drives a launcher-side login flow to
completion, entirely from the browser. Builds on the read-only triage matrix.

## What it does

- **claude**: shows the auth URL, you approve in a browser and paste the code
  back; the launcher submits it and reports the outcome.
- **codex**: shows the device code + verification URL, then polls until the
  browser approval lands.
- On success the matrix re-probes, so the cell flips to "signed in" without a
  manual refresh. Closing the modal mid-flow cancels the launcher-side flow so
  no PTY / app-server lingers.

## Shape

- `shared`: agent-neutral `LoginPresentable` / `LoginInteraction` /
  `AgentLoginOutcome`; four `Start`/`Submit`/`Poll`/`Cancel` launcher protocol
  messages; REST request/response types.
- `claude-session-lib` / `codex-session-lib`: login drivers that park each
  agent's flow (claude's blocking PTY on a thread; codex's device-code watched
  on an async task) and reap it on drop.
- `launcher`: a `flow_id`-keyed `LoginRegistry` and four correlated RPC arms,
  reusing the existing probe request/response correlation.
- `backend`: four **owner-gated** relay endpoints; a dynamic-message 502
  (`AppError::BadGatewayMessage`) so a CLI's own error text reaches the browser.
- `frontend`: `AgentLoginModal` state machine + the matrix buttons.

## Verification

Unit-tested: shared serde round-trips (143), the frontend outcome-status
helper (3), backend error mapping. Full native + WASM builds and clippy are
clean.

⚠️ **The interactive OAuth handshake itself is NOT end-to-end verified** — it
needs a real signed-out agent account + a browser, which this environment
can't drive. Please manually confirm before relying on it:

- [ ] **claude**: a signed-out claude cell → Sign in → URL renders → approve →
      paste code → cell flips to "signed in".
- [ ] **codex**: a signed-out codex cell → Sign in → device code + URL render →
      approve in browser → modal reports success within a couple of polls.
- [ ] Closing the modal mid-flow leaves no orphaned `claude` / `codex app-server`
      process on the launcher host.
- [ ] A start failure (e.g. agent binary missing/broken) surfaces the CLI's own
      error text in the modal, not a generic 500.
- [ ] Only the launcher's owner can drive a login (non-owner → 403/404).
