### PR TITLE
Add install helpers to the Agents matrix

### DIFF
--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -5,11 +5,12 @@ use axum::{
 use diesel::prelude::*;
 use serde::Deserialize;
 use shared::api::{
-    DirectoryListingResponse, LaunchRequest, ProbeAgentsResponse, StartAgentLoginRequest,
-    StartAgentLoginResponse, SubmitAgentLoginCodeRequest,
+    DirectoryListingResponse, InstallAgentResponse, LaunchRequest, ProbeAgentsResponse,
+    StartAgentLoginRequest, StartAgentLoginResponse, SubmitAgentLoginCodeRequest,
 };
 use shared::{
-    AgentLoginOutcome, LauncherInfo, LauncherToServer, ServerToLauncher, SessionRole, SessionStatus,
+    AgentLoginOutcome, AgentType, LauncherInfo, LauncherToServer, ServerToLauncher, SessionRole,
+    SessionStatus,
 };
 use std::sync::Arc;
 use tracing::{error, info, warn};
@@ -642,6 +643,38 @@ fn login_outcome(reply: LauncherToServer) -> Result<Json<AgentLoginOutcome>, App
         LauncherToServer::AgentLoginOutcomeResult { outcome, .. } => Ok(Json(outcome)),
         _ => Err(AppError::Internal(
             "Unexpected launcher login response".into(),
+        )),
+    }
+}
+
+/// POST /api/launchers/:id/agents/:agent_type/install — run the agent's install
+/// command on that host and report the outcome. Owner-gated: installing on a
+/// host is a privileged action, so only the launcher's owner may trigger it.
+pub async fn install_agent(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+    Path((launcher_id, agent_type)): Path<(Uuid, AgentType)>,
+) -> Result<Json<InstallAgentResponse>, AppError> {
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
+    let request_id = Uuid::new_v4();
+    // A global npm install can run for tens of seconds — allow generous slack.
+    let reply = launcher_rpc(
+        &app_state,
+        launcher_id,
+        request_id,
+        ServerToLauncher::InstallAgent {
+            request_id,
+            agent_type,
+        },
+        180,
+    )
+    .await?;
+    match reply {
+        LauncherToServer::InstallAgentResult {
+            success, message, ..
+        } => Ok(Json(InstallAgentResponse { success, message })),
+        _ => Err(AppError::Internal(
+            "Unexpected launcher install response".into(),
         )),
     }
 }

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -692,7 +692,8 @@ fn handle_launcher_message(
                 .complete_probe_request(request_id, msg);
         }
         LauncherToServer::AgentLoginStartResult { request_id, .. }
-        | LauncherToServer::AgentLoginOutcomeResult { request_id, .. } => {
+        | LauncherToServer::AgentLoginOutcomeResult { request_id, .. }
+        | LauncherToServer::InstallAgentResult { request_id, .. } => {
             // Same request/response correlation as the probe path.
             app_state
                 .session_manager

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -386,6 +386,10 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             "/api/launchers/{launcher_id}/agent-login/{flow_id}/cancel",
             post(handlers::launchers::cancel_agent_login),
         )
+        .route(
+            "/api/launchers/{launcher_id}/agents/{agent_type}/install",
+            post(handlers::launchers::install_agent),
+        )
         // Admin dashboard routes (admin-only)
         .route("/api/admin/stats", get(handlers::admin::get_stats))
         .route("/api/admin/users", get(handlers::admin::list_users))

--- a/frontend/src/pages/settings/agent_install.rs
+++ b/frontend/src/pages/settings/agent_install.rs
@@ -1,0 +1,214 @@
+//! Agent install-helper modal (Settings ▸ Agents).
+//!
+//! A not-installed cell offers an Install button that opens this modal. It
+//! shows the exact command that will run on the launcher host (from
+//! [`AgentType::install_command`], so the user can see it's a global npm
+//! install — or, for agents whose only installer is a piped script, exactly
+//! that), waits for confirmation, then POSTs to the install endpoint. On
+//! success it fires `on_success` so the matrix re-probes.
+
+use gloo_net::http::Request;
+use shared::api::InstallAgentResponse;
+use shared::{AgentType, LauncherInfo};
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+use crate::utils;
+
+#[derive(Properties, PartialEq)]
+pub struct AgentInstallModalProps {
+    pub launcher_id: Uuid,
+    pub agent_type: AgentType,
+    /// Human label for the agent (e.g. "Codex"), for the modal title.
+    pub agent_name: String,
+    /// Host label, so the user knows *where* the install runs.
+    pub host: String,
+    pub on_close: Callback<()>,
+    /// Fired once when the install succeeds, so the caller can re-probe.
+    pub on_success: Callback<()>,
+}
+
+#[derive(Clone, PartialEq)]
+enum Stage {
+    /// Showing the command, waiting for the user to confirm.
+    Confirm,
+    /// `POST /install` in flight.
+    Running,
+    /// Terminal outcome (success or a reported failure).
+    Done(InstallAgentResponse),
+}
+
+#[function_component(AgentInstallModal)]
+pub fn agent_install_modal(props: &AgentInstallModalProps) -> Html {
+    let stage = use_state(|| Stage::Confirm);
+    let command = props.agent_type.install_command().display();
+
+    let on_install = {
+        let stage = stage.clone();
+        let launcher_id = props.launcher_id;
+        let agent_type = props.agent_type;
+        let on_success = props.on_success.clone();
+        Callback::from(move |_: MouseEvent| {
+            stage.set(Stage::Running);
+            let stage = stage.clone();
+            let on_success = on_success.clone();
+            spawn_local(async move {
+                let outcome = install_agent(launcher_id, agent_type).await;
+                let resp = match outcome {
+                    Ok(resp) => resp,
+                    Err(message) => InstallAgentResponse {
+                        success: false,
+                        message: Some(message),
+                    },
+                };
+                if resp.success {
+                    on_success.emit(());
+                }
+                stage.set(Stage::Done(resp));
+            });
+        })
+    };
+
+    let on_close = {
+        let on_close = props.on_close.clone();
+        Callback::from(move |_| on_close.emit(()))
+    };
+    let stop = Callback::from(|e: MouseEvent| e.stop_propagation());
+
+    let body = match &*stage {
+        Stage::Confirm => html! {
+            <>
+                <p class="agent-login-instr">
+                    { format!("This runs the following on {}:", props.host) }
+                </p>
+                <code class="agent-install-command">{ &command }</code>
+                <button class="agent-login-submit" onclick={on_install}>{ "Install" }</button>
+            </>
+        },
+        Stage::Running => html! {
+            <p class="agent-login-status">{ format!("Installing {}…", props.agent_name) }</p>
+        },
+        Stage::Done(resp) => {
+            let (class, text) = install_status(resp);
+            html! { <p class={classes!("agent-login-status", class)}>{ text }</p> }
+        }
+    };
+
+    let close_label = if matches!(&*stage, Stage::Done(_)) {
+        "Close"
+    } else {
+        "Cancel"
+    };
+
+    html! {
+        <div class="agent-login-overlay" onclick={on_close.clone()}>
+            <div class="agent-login-modal" onclick={stop}>
+                <div class="agent-login-header">
+                    <h2>{ format!("Install {}", props.agent_name) }</h2>
+                    <button class="agent-login-close" onclick={on_close.clone()}>{ "×" }</button>
+                </div>
+                <div class="agent-login-body">{ body }</div>
+                <div class="agent-login-footer">
+                    <button class="link-button" onclick={on_close}>{ close_label }</button>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+/// Host label for the modal: hostname, or the launcher alias when it differs.
+pub fn host_label(launcher: &LauncherInfo) -> String {
+    if launcher.launcher_name != launcher.hostname {
+        format!("{} ({})", launcher.hostname, launcher.launcher_name)
+    } else {
+        launcher.hostname.clone()
+    }
+}
+
+/// CSS modifier + text for a settled install. Pure, so the wording is
+/// unit-tested without mounting the component.
+fn install_status(resp: &InstallAgentResponse) -> (&'static str, String) {
+    if resp.success {
+        ("success", "Installed. Refreshing…".to_string())
+    } else {
+        let detail = resp
+            .message
+            .as_deref()
+            .filter(|m| !m.trim().is_empty())
+            .unwrap_or("the install command failed");
+        ("error", format!("Install failed: {detail}"))
+    }
+}
+
+async fn install_agent(
+    launcher_id: Uuid,
+    agent_type: AgentType,
+) -> Result<InstallAgentResponse, String> {
+    let url = utils::api_url(&format!(
+        "/api/launchers/{launcher_id}/agents/{}/install",
+        agent_type.as_str()
+    ));
+    let resp = Request::post(&url)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !resp.ok() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(if body.trim().is_empty() {
+            format!("HTTP {status}")
+        } else {
+            body
+        });
+    }
+    resp.json::<InstallAgentResponse>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_reads_cleanly() {
+        let (class, text) = install_status(&InstallAgentResponse {
+            success: true,
+            message: None,
+        });
+        assert_eq!(class, "success");
+        assert_eq!(text, "Installed. Refreshing…");
+    }
+
+    #[test]
+    fn failure_surfaces_the_command_output() {
+        let (class, text) = install_status(&InstallAgentResponse {
+            success: false,
+            message: Some("npm ERR! code EACCES".to_string()),
+        });
+        assert_eq!(class, "error");
+        assert_eq!(text, "Install failed: npm ERR! code EACCES");
+    }
+
+    #[test]
+    fn failure_without_a_message_has_a_fallback() {
+        let (_, text) = install_status(&InstallAgentResponse {
+            success: false,
+            message: None,
+        });
+        assert_eq!(text, "Install failed: the install command failed");
+    }
+
+    #[test]
+    fn command_line_is_the_documented_installer() {
+        assert_eq!(
+            AgentType::Codex.install_command().display(),
+            "npm install -g @openai/codex"
+        );
+        assert_eq!(
+            AgentType::Claude.install_command().display(),
+            "npm install -g @anthropic-ai/claude-code"
+        );
+    }
+}

--- a/frontend/src/pages/settings/agents_panel.rs
+++ b/frontend/src/pages/settings/agents_panel.rs
@@ -15,6 +15,7 @@
 //! that opens [`AgentLoginModal`], which drives the launcher-side login flow; a
 //! successful sign-in re-probes the matrix.
 
+use crate::pages::settings::agent_install::{host_label, AgentInstallModal};
 use crate::pages::settings::agent_login::AgentLoginModal;
 use crate::utils::{self, On401};
 use shared::api::ProbeAgentsResponse;
@@ -30,6 +31,16 @@ struct LoginTarget {
     launcher_id: Uuid,
     agent_type: AgentType,
     agent_name: String,
+}
+
+/// Which cell's install modal is open, plus the host label so the modal can
+/// say *where* the install runs.
+#[derive(Clone, PartialEq)]
+struct InstallTarget {
+    launcher_id: Uuid,
+    agent_type: AgentType,
+    agent_name: String,
+    host: String,
 }
 
 /// Columns of the matrix, in display order. Mirrors `AgentType`.
@@ -54,6 +65,8 @@ pub fn agents_panel() -> Html {
     let refresh = use_state(|| 0u32);
     // The open sign-in modal, if any.
     let login_target = use_state(|| None::<LoginTarget>);
+    // The open install modal, if any.
+    let install_target = use_state(|| None::<InstallTarget>);
 
     {
         let launchers = launchers.clone();
@@ -106,6 +119,11 @@ pub fn agents_panel() -> Html {
         Callback::from(move |target: LoginTarget| login_target.set(Some(target)))
     };
 
+    let on_install = {
+        let install_target = install_target.clone();
+        Callback::from(move |target: InstallTarget| install_target.set(Some(target)))
+    };
+
     let body = match (*launchers).clone() {
         None => html! { <p class="setting-description">{ "Loading…" }</p> },
         Some(list) if list.is_empty() => html! {
@@ -123,13 +141,13 @@ pub fn agents_panel() -> Html {
                     </tr>
                 </thead>
                 <tbody>
-                    { for list.iter().map(|l| render_row(l, &probes, &on_sign_in)) }
+                    { for list.iter().map(|l| render_row(l, &probes, &on_sign_in, &on_install)) }
                 </tbody>
             </table>
         },
     };
 
-    let modal = (*login_target).clone().map(|target| {
+    let login_modal = (*login_target).clone().map(|target| {
         let on_close = {
             let login_target = login_target.clone();
             Callback::from(move |_| login_target.set(None))
@@ -149,6 +167,27 @@ pub fn agents_panel() -> Html {
         }
     });
 
+    let install_modal = (*install_target).clone().map(|target| {
+        let on_close = {
+            let install_target = install_target.clone();
+            Callback::from(move |_| install_target.set(None))
+        };
+        let on_success = {
+            let refresh = refresh.clone();
+            Callback::from(move |_| refresh.set(*refresh + 1))
+        };
+        html! {
+            <AgentInstallModal
+                launcher_id={target.launcher_id}
+                agent_type={target.agent_type}
+                agent_name={target.agent_name}
+                host={target.host}
+                {on_close}
+                {on_success}
+            />
+        }
+    });
+
     html! {
         <section class="agents-section">
             <div class="section-header">
@@ -160,7 +199,8 @@ pub fn agents_panel() -> Html {
                 </p>
             </div>
             { body }
-            { for modal }
+            { for login_modal }
+            { for install_modal }
         </section>
     }
 }
@@ -169,6 +209,7 @@ fn render_row(
     launcher: &LauncherInfo,
     probes: &HashMap<Uuid, ProbeState>,
     on_sign_in: &Callback<LoginTarget>,
+    on_install: &Callback<InstallTarget>,
 ) -> Html {
     let state = probes.get(&launcher.launcher_id);
     html! {
@@ -180,7 +221,7 @@ fn render_row(
                 }
             </td>
             { for AGENTS.iter().map(|(agent, name)| {
-                render_cell(state, *agent, name, launcher.launcher_id, on_sign_in)
+                render_cell(state, *agent, name, launcher, on_sign_in, on_install)
             }) }
         </tr>
     }
@@ -190,8 +231,9 @@ fn render_cell(
     state: Option<&ProbeState>,
     agent: AgentType,
     agent_name: &str,
-    launcher_id: Uuid,
+    launcher: &LauncherInfo,
     on_sign_in: &Callback<LoginTarget>,
+    on_install: &Callback<InstallTarget>,
 ) -> Html {
     match state {
         None => html! { <td class="agents-cell loading">{ "…" }</td> },
@@ -200,7 +242,7 @@ fn render_cell(
         }
         Some(ProbeState::Loaded(agents)) => match agents.get(&agent) {
             Some(install) => {
-                render_install_cell(install, agent, agent_name, launcher_id, on_sign_in)
+                render_install_cell(install, agent, agent_name, launcher, on_sign_in, on_install)
             }
             // Probe ran but didn't report this agent at all — treat as unknown.
             None => html! { <td class="agents-cell unknown">{ "—" }</td> },
@@ -212,13 +254,23 @@ fn render_install_cell(
     install: &AgentInstall,
     agent: AgentType,
     agent_name: &str,
-    launcher_id: Uuid,
+    launcher: &LauncherInfo,
     on_sign_in: &Callback<LoginTarget>,
+    on_install: &Callback<InstallTarget>,
 ) -> Html {
     if !install.installed {
+        let target = InstallTarget {
+            launcher_id: launcher.launcher_id,
+            agent_type: agent,
+            agent_name: agent_name.to_string(),
+            host: host_label(launcher),
+        };
+        let on_install = on_install.clone();
+        let onclick = Callback::from(move |_: MouseEvent| on_install.emit(target.clone()));
         return html! {
             <td class="agents-cell not-installed">
                 <span class="agents-badge missing">{ "not installed" }</span>
+                <button class="agents-signin" {onclick}>{ "Install" }</button>
             </td>
         };
     }
@@ -227,7 +279,7 @@ fn render_install_cell(
         <td class="agents-cell installed">
             <span class="agents-badge installed">{ "installed" }</span>
             <span class={classes!("agents-login", login_class)}>{ login_text }</span>
-            { for sign_in_button(&install.login, agent, agent_name, launcher_id, on_sign_in) }
+            { for sign_in_button(&install.login, agent, agent_name, launcher.launcher_id, on_sign_in) }
         </td>
     }
 }

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -1,3 +1,4 @@
+mod agent_install;
 mod agent_login;
 mod agents_panel;
 mod appearance_panel;

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -1156,6 +1156,17 @@
     justify-content: flex-end;
 }
 
+.agent-install-command {
+    display: block;
+    font-family: var(--font-mono, monospace);
+    font-size: 0.85rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid var(--border, #2a2e42);
+    border-radius: 6px;
+    background: var(--bg-primary, #1a1b26);
+    word-break: break-all;
+}
+
 .profile-section {
     display: flex;
     flex-direction: column;

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -811,6 +811,30 @@ async fn handle_message(
                 warn!("Failed to send probe agents result");
             }
         }
+        ServerToLauncher::InstallAgent {
+            request_id,
+            agent_type,
+        } => {
+            info!("Installing agent {agent_type} on request");
+            // The install command (npm) can run for tens of seconds — off the
+            // message loop, like the probe.
+            let result = tokio::task::spawn_blocking(move || {
+                session_lib::install::install_agent(agent_type)
+            })
+            .await;
+            let (success, message) = match result {
+                Ok(r) => (r.success, r.message),
+                Err(e) => (false, Some(format!("install task failed to run: {e}"))),
+            };
+            let response = shared::LauncherToServer::InstallAgentResult {
+                request_id,
+                success,
+                message,
+            };
+            if ws_sender.send(response).await.is_err() {
+                warn!("Failed to send install agent result");
+            }
+        }
         ServerToLauncher::ScheduleSync { tasks } => {
             info!("Received ScheduleSync with {} task(s)", tasks.len());
             scheduler.update_tasks(tasks);

--- a/session-lib/src/install.rs
+++ b/session-lib/src/install.rs
@@ -1,0 +1,100 @@
+//! Best-effort install of an agent CLI on the launcher host.
+//!
+//! Runs the agent's `AgentType::install_command` (a global npm install)
+//! synchronously and reports whether it exited cleanly, surfacing the command's
+//! own output tail on failure so the user sees why — an npm error, `npm` not on
+//! PATH, a permissions problem. The launcher invokes this under
+//! `spawn_blocking`, exactly like [`crate::probe`].
+
+use shared::AgentType;
+use std::process::Command;
+
+/// Outcome of an install attempt.
+#[derive(Debug, Clone)]
+pub struct InstallResult {
+    pub success: bool,
+    /// The CLI's own output tail on failure (or a "could not run" reason).
+    /// `None` on success.
+    pub message: Option<String>,
+}
+
+/// Longest error tail to relay to the browser, so a noisy npm failure doesn't
+/// balloon a WS message.
+const MESSAGE_TAIL: usize = 2000;
+
+/// Run `agent`'s install command and report the outcome. The program/args come
+/// from [`AgentType::install_command`] and are spawned directly (never a
+/// shell), so there is nothing to escape.
+pub fn install_agent(agent: AgentType) -> InstallResult {
+    let cmd = agent.install_command();
+    match Command::new(cmd.program).args(&cmd.args).output() {
+        Ok(output) if output.status.success() => InstallResult {
+            success: true,
+            message: None,
+        },
+        Ok(output) => InstallResult {
+            success: false,
+            message: Some(failure_detail(&output)),
+        },
+        Err(e) => InstallResult {
+            success: false,
+            message: Some(format!(
+                "could not run `{}`: {e} — is it installed and on PATH?",
+                cmd.program
+            )),
+        },
+    }
+}
+
+/// Build a human error from a non-zero exit: prefer stderr, fall back to
+/// stdout, tail-truncated.
+fn failure_detail(output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let body = if stderr.trim().is_empty() {
+        String::from_utf8_lossy(&output.stdout)
+    } else {
+        stderr
+    };
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return format!("install command exited with {}", output.status);
+    }
+    tail(trimmed, MESSAGE_TAIL)
+}
+
+/// Last `max` chars of `s`, on a char boundary, prefixed with an ellipsis when
+/// truncated.
+fn tail(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let start = s.chars().count() - max;
+    let tail: String = s.chars().skip(start).collect();
+    format!("…{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tail_keeps_short_strings_whole() {
+        assert_eq!(tail("hello", 2000), "hello");
+    }
+
+    #[test]
+    fn tail_truncates_with_an_ellipsis() {
+        let long = "x".repeat(2100);
+        let out = tail(&long, 2000);
+        assert!(out.starts_with('…'));
+        assert_eq!(out.chars().count(), 2001); // ellipsis + 2000
+    }
+
+    #[test]
+    fn tail_respects_char_boundaries() {
+        let s = "é".repeat(2100);
+        let out = tail(&s, 2000);
+        // No panic, and the multibyte chars survive intact.
+        assert_eq!(out.chars().filter(|c| *c == 'é').count(), 2000);
+    }
+}

--- a/session-lib/src/lib.rs
+++ b/session-lib/src/lib.rs
@@ -26,6 +26,7 @@ pub mod buffer;
 pub mod error;
 pub mod git_metadata;
 pub mod heartbeat;
+pub mod install;
 pub mod io;
 pub mod output_buffer;
 pub mod probe;

--- a/shared/src/api/launch.rs
+++ b/shared/src/api/launch.rs
@@ -69,3 +69,12 @@ pub struct StartAgentLoginResponse {
 pub struct SubmitAgentLoginCodeRequest {
     pub code: String,
 }
+
+/// Response from POST /api/launchers/:id/agents/:agent/install — whether the
+/// install command succeeded, plus the CLI's own output tail on failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstallAgentResponse {
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}

--- a/shared/src/endpoints/launcher.rs
+++ b/shared/src/endpoints/launcher.rs
@@ -136,6 +136,15 @@ pub enum LauncherToServer {
         agents: Vec<AgentInstall>,
     },
 
+    /// Reply to `InstallAgent`: whether the install command exited cleanly, plus
+    /// the CLI's own output tail on failure. The frontend re-probes on success.
+    InstallAgentResult {
+        request_id: Uuid,
+        success: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+
     /// Request the backend to mint a token and launch a session
     RequestLaunch {
         request_id: Uuid,
@@ -291,6 +300,14 @@ pub enum ServerToLauncher {
     /// Ask the launcher to (re-)probe its agent CLIs. The launcher replies
     /// with `LauncherToServer::ProbeAgentsResult` carrying the fresh state.
     ProbeAgents { request_id: Uuid },
+
+    /// Ask the launcher to install `agent_type`'s CLI (its
+    /// `AgentType::install_command`). The launcher runs it and replies
+    /// `InstallAgentResult`; the frontend re-probes on success.
+    InstallAgent {
+        request_id: Uuid,
+        agent_type: AgentType,
+    },
 
     /// Begin an interactive login for `agent_type` on this host. The launcher
     /// starts the agent's login flow, parks it under `flow_id`, and replies

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -183,6 +183,44 @@ impl AgentType {
             AgentType::Codex => "codex",
         }
     }
+
+    /// The command that installs this agent's CLI, as structured data so the
+    /// launcher (which runs it) and the frontend (which displays it for the
+    /// user to confirm) agree on exactly one thing. Both ship as global npm
+    /// packages, the most portable option that avoids piping a remote script
+    /// into a shell on the user's host.
+    pub fn install_command(self) -> AgentInstallCommand {
+        let package = match self {
+            AgentType::Claude => "@anthropic-ai/claude-code",
+            AgentType::Codex => "@openai/codex",
+        };
+        AgentInstallCommand {
+            program: "npm",
+            args: vec!["install", "-g", package],
+        }
+    }
+}
+
+/// A resolved install command: a program and its arguments, ready to spawn or
+/// to render as `program args…` for a confirmation prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentInstallCommand {
+    pub program: &'static str,
+    pub args: Vec<&'static str>,
+}
+
+impl AgentInstallCommand {
+    /// The command as a single shell-style line, e.g.
+    /// `npm install -g @openai/codex`. Display only — the launcher spawns
+    /// `program`/`args` directly, never a shell.
+    pub fn display(&self) -> String {
+        let mut line = String::from(self.program);
+        for arg in &self.args {
+            line.push(' ');
+            line.push_str(arg);
+        }
+        line
+    }
 }
 
 impl std::fmt::Display for AgentType {


### PR DESCRIPTION
A **not-installed** cell in **Settings ▸ Agents** now carries an **Install**
button. It opens a modal showing the exact command that will run on the
launcher host, waits for confirmation, runs it, and re-probes the matrix on
success. Follow-up to the sign-in-buttons PR (#1562).

## Shape

- `shared`: `AgentType::install_command()` returns structured `program` +
  `args` (a global npm install) — one source of truth used both by the
  launcher (spawned directly, **never** through a shell) and by the frontend
  (rendered verbatim in the confirm dialog). Plus an `InstallAgent` /
  `InstallAgentResult` launcher protocol pair and an `InstallAgentResponse`
  REST type.
- `session-lib`: `install::install_agent()` runs the command and relays its
  output tail on failure (npm error, `npm` not on PATH, permissions).
- `launcher`: an `InstallAgent` arm running the install under `spawn_blocking`.
- `backend`: an **owner-gated** relay endpoint reusing the probe correlation,
  180s timeout for a slow install.
- `frontend`: `AgentInstallModal` (confirm → run → outcome), re-probing on
  success.

## Verification

Unit-tested: shared serde, `session-lib` output-tail truncation (incl.
multibyte safety), frontend install-status wording, and that the rendered
command line is the documented installer. Native + WASM builds, clippy, fmt
clean.

⚠️ **The actual install execution is NOT end-to-end verified** — needs a host
missing an agent CLI:

- [ ] not-installed cell → Install → modal shows `npm install -g <pkg>` for the
      right host → Install → success flips the cell to "installed".
- [ ] a failure (no `npm`, permissions) surfaces the command's own error text.
- [ ] only the launcher's owner can trigger an install (non-owner → 403/404).

claude + codex only, matching the current `AgentType`. Muse's install arm
lands with the Muse integration once `AgentType::Muse` exists.
