### PR TITLE
Add AgentType::Muse: probe, sandbox state, install and login seams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4521,6 +4521,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "muse-codes"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfb4a1bb9bf1e65774124e6937fec450a5d11610a4410a7c5e68220d38d13c0"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "which",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6619,6 +6633,7 @@ dependencies = [
  "directories",
  "libc",
  "listeners",
+ "muse-codes",
  "serde",
  "serde_json",
  "shared",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = { version = "2.1.223", default-features = false, features = ["types"] }
 
 # Codex CLI integration
+muse-codes = { version = "0.1.3", default-features = false, features = ["async-client"] }
 codex-codes = { version = "0.146.4", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -807,6 +807,12 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     // Launch mode: agent selector, directory browser, args, actions
                     <div class="launch-field">
                         <label>{ "Agent" }</label>
+                        // Muse is intentionally NOT offered here: it is
+                        // probeable/installable/loginable (it appears in the
+                        // agents matrix) but has no session implementation
+                        // yet, so launching it would fail at spawn and trip
+                        // the launch crashloop auto-pause. Add the option
+                        // when muse-session-lib lands.
                         <select class="launcher-select" onchange={on_agent_type_change}>
                             <option value="claude" selected={*agent_type == AgentType::Claude}>
                                 { &claude_label }

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -119,6 +119,7 @@ fn args_placeholder(agent_type: shared::AgentType) -> &'static str {
     match agent_type {
         shared::AgentType::Claude => "ex: --model sonnet --allowedTools \"Bash Edit\"",
         shared::AgentType::Codex => "ex: -c model=gpt-5.5 -c model_reasoning_effort=high",
+        shared::AgentType::Muse => "ex: --reasoning-effort high --preset native-basic",
     }
 }
 
@@ -705,6 +706,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     let selected_agent_label = match *agent_type {
         AgentType::Claude => "Claude",
         AgentType::Codex => "Codex",
+        AgentType::Muse => "Muse",
     };
 
     // Pre-compute directory listing HTML

--- a/frontend/src/components/model_select.rs
+++ b/frontend/src/components/model_select.rs
@@ -23,6 +23,9 @@ pub fn model_cli_args(agent_type: AgentType, model_value: &str) -> Vec<String> {
     match agent_type {
         AgentType::Claude => vec!["--model".to_string(), model_value.to_string()],
         AgentType::Codex => vec!["-c".to_string(), format!("model={model_value}")],
+        // `muse exec --model <id>`; the catalog is empty until sessions land
+        // (see model_catalog), so this only fires for hand-typed values.
+        AgentType::Muse => vec!["--model".to_string(), model_value.to_string()],
     }
 }
 
@@ -35,6 +38,10 @@ fn model_catalog(agent_type: AgentType) -> Vec<(&'static str, &'static str, bool
             .iter()
             .map(|m| (m.cli_arg(), m.display_name(), m.is_alias()))
             .collect(),
+        // Muse has no published model catalog yet (0.1.0 resolves the model
+        // server-side and reports it in-band via run.model.configured), so
+        // the picker offers nothing and users pass --model by hand.
+        AgentType::Muse => Vec::new(),
         AgentType::Codex => CodexModel::known()
             .iter()
             .filter(|m| !matches!(m, CodexModel::CodexAutoReview))
@@ -87,6 +94,10 @@ pub fn extract_model_arg(args: &[String], agent_type: AgentType) -> (Option<Stri
                     None
                 }
             }
+            // No catalog to validate against yet, so a hand-typed
+            // `--model` stays in the raw args rather than being lifted
+            // into the (empty) picker.
+            AgentType::Muse => None,
         };
 
         if let Some(value) = matched {
@@ -139,6 +150,9 @@ pub fn model_select(props: &ModelSelectProps) -> Html {
 
     let catalog = model_catalog(props.agent_type);
     let options: Html = match props.agent_type {
+        // Empty catalog: the picker renders no options and users pass
+        // `--model` in the raw-args field.
+        AgentType::Muse => html! {},
         AgentType::Claude => html! {
             <>
                 <optgroup label="Aliases — track the newest model">

--- a/frontend/src/components/skip_permissions.rs
+++ b/frontend/src/components/skip_permissions.rs
@@ -21,6 +21,9 @@ pub fn skip_permissions_args(agent_type: AgentType) -> &'static [&'static str] {
     match agent_type {
         AgentType::Claude => CLAUDE_SKIP_PERMISSIONS_ARGS,
         AgentType::Codex => CODEX_SKIP_PERMISSIONS_ARGS,
+        // Muse decides tool policy itself in headless runs and exposes no
+        // skip-permissions flag; the checkbox is hidden for it.
+        AgentType::Muse => &[],
     }
 }
 
@@ -29,6 +32,7 @@ pub fn skip_permissions_label(agent_type: AgentType) -> &'static str {
     match agent_type {
         AgentType::Claude => "--dangerously-skip-permissions",
         AgentType::Codex => "-c approval_policy=never -c sandbox_mode=danger-full-access",
+        AgentType::Muse => "(not applicable — Muse manages tool policy itself)",
     }
 }
 

--- a/frontend/src/pages/dashboard/session_rail/broadcast.rs
+++ b/frontend/src/pages/dashboard/session_rail/broadcast.rs
@@ -211,6 +211,7 @@ pub(super) fn render_broadcasts(
                 let orb_class = match view.agent_type {
                     AgentType::Claude => "claude",
                     AgentType::Codex => "codex",
+                    AgentType::Muse => "muse",
                 };
                 let (s1, s2, s3) = plasma_seeds(&view);
                 let style =

--- a/frontend/src/pages/dashboard/session_rail/pill.rs
+++ b/frontend/src/pages/dashboard/session_rail/pill.rs
@@ -263,6 +263,7 @@ impl PillViewModel {
             watermark_class: match session.agent_type {
                 shared::AgentType::Claude => "pill-watermark claude",
                 shared::AgentType::Codex => "pill-watermark codex",
+                shared::AgentType::Muse => "pill-watermark muse",
             },
             model_watermark: session
                 .last_model

--- a/frontend/src/pages/demo.rs
+++ b/frontend/src/pages/demo.rs
@@ -755,6 +755,7 @@ fn radio_messages(
     let peer_label = match peer_agent_type {
         AgentType::Claude => "Claude",
         AgentType::Codex => "Codex",
+        AgentType::Muse => "Muse",
     };
     let mut messages = vec![
         user(
@@ -777,7 +778,10 @@ fn radio_messages(
     ];
 
     match own_agent_type {
-        AgentType::Claude => {
+        // The demo transcript is hand-authored per agent; Muse has no
+        // scripted cards yet, so it reuses the Claude script (the demo is
+        // illustrative, not a protocol fixture).
+        AgentType::Claude | AgentType::Muse => {
             messages.push(assistant_text(
                 "2026-07-20T04:01:15.000000Z",
                 "Claude Sonnet 4.5",

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -464,6 +464,9 @@ fn probe_agents_for_response() -> Vec<shared::AgentInstall> {
                 match agent_type {
                     shared::AgentType::Claude => claude_session_lib::auth::probe_login(),
                     shared::AgentType::Codex => codex_session_lib::auth::probe_login(),
+                    // Muse persists no account identity (no whoami at 0.1.0),
+                    // so the cell is presence-only.
+                    shared::AgentType::Muse => session_lib::probe::probe_muse_login(),
                 }
             } else {
                 shared::AgentLoginStatus::Unknown
@@ -475,6 +478,7 @@ fn probe_agents_for_response() -> Vec<shared::AgentInstall> {
                     .resolved_path
                     .map(|p| p.to_string_lossy().to_string()),
                 version: result.version,
+                sandbox_ok: result.sandbox_ok,
                 login,
             }
         })

--- a/launcher/src/login_registry.rs
+++ b/launcher/src/login_registry.rs
@@ -72,6 +72,15 @@ impl LoginRegistry {
                 let (s, p, i) = CodexLoginSession::start().await?;
                 (LoginSession::Codex(s), p, i)
             }
+            // Muse's device-code flow maps onto `LoginPresentable::DeviceCode`
+            // + `AwaitCompletion` exactly (muse_codes::auth::DeviceLoginFlow
+            // yields {verification_url, code}, then wait_approved/cancel), but
+            // the driver is deliberately left to the follow-up that adds the
+            // muse arms to the matrix/login/install surfaces. Until then this
+            // reports honestly rather than parking a flow that can't settle.
+            AgentType::Muse => {
+                return Err("muse sign-in is not wired up yet".to_string());
+            }
         };
         self.flows.insert(flow_id, Arc::new(session));
         Ok((presentable, interaction))

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -302,6 +302,10 @@ impl AnySession {
                 Ok(Self::Claude(Session::<ClaudeAgent>::new(config).await?))
             }
             shared::AgentType::Codex => Ok(Self::Codex(Session::<CodexAgent>::new(config).await?)),
+            // Muse is probeable/installable/loginable ahead of its session
+            // implementation (muse-session-lib). Fail loudly rather than
+            // spawning a agent we can't stream.
+            shared::AgentType::Muse => Err(session_lib::SessionError::AgentNotSupported("Muse")),
         }
     }
 

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -305,7 +305,7 @@ impl AnySession {
             // Muse is probeable/installable/loginable ahead of its session
             // implementation (muse-session-lib). Fail loudly rather than
             // spawning a agent we can't stream.
-            shared::AgentType::Muse => Err(session_lib::SessionError::AgentNotSupported("Muse")),
+            shared::AgentType::Muse => Err(session_lib::SessionError::AgentNotSupported("muse")),
         }
     }
 

--- a/session-lib/Cargo.toml
+++ b/session-lib/Cargo.toml
@@ -12,6 +12,8 @@ shared = { path = "../shared" }
 # Pulled in as types-only — no native async / tokio bits — so this stays
 # agent-agnostic at the runtime level.
 claude-codes = { workspace = true, features = ["async-client"] }
+# Muse auth probe (credentials_present / AuthFile) for the agent matrix.
+muse-codes = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/session-lib/src/error.rs
+++ b/session-lib/src/error.rs
@@ -27,6 +27,13 @@ pub enum SessionError {
     /// have to depend on every agent SDK in its error surface.
     #[error("Agent error: {0}")]
     Agent(String),
+
+    /// The agent type is known to the portal (probes, matrix, install) but
+    /// has no session implementation yet. Muse is in this state until
+    /// `muse-session-lib` lands; the launch UI blocks it rather than
+    /// spawning something that can't stream.
+    #[error("{0} sessions are not supported by this launcher yet")]
+    AgentNotSupported(&'static str),
 }
 
 #[cfg(test)]

--- a/session-lib/src/error.rs
+++ b/session-lib/src/error.rs
@@ -32,7 +32,7 @@ pub enum SessionError {
     /// has no session implementation yet. Muse is in this state until
     /// `muse-session-lib` lands; the launch UI blocks it rather than
     /// spawning something that can't stream.
-    #[error("{0} sessions are not supported by this launcher yet")]
+    #[error("{0} launches are not supported yet")]
     AgentNotSupported(&'static str),
 }
 

--- a/session-lib/src/probe.rs
+++ b/session-lib/src/probe.rs
@@ -104,6 +104,15 @@ pub fn probe_muse_sandbox() -> Option<bool> {
         let status = text
             .lines()
             .find_map(|l| l.trim().strip_prefix("status="))?;
+        // The healthy string is a GUESS: `status=setup_required` was observed
+        // on an unconfigured host, but no ready value has been seen. Log the
+        // raw line so the first Windows user can confirm or correct this
+        // match instead of silently getting a wrong cell.
+        tracing::info!(
+            status = %status,
+            "muse sandbox windows check status (healthy-value match is unverified; report this \
+             line if the sandbox is configured but the matrix shows degraded)"
+        );
         Some(status == "ready" || status == "ok")
     }
     #[cfg(not(any(target_os = "linux", target_os = "windows")))]

--- a/session-lib/src/probe.rs
+++ b/session-lib/src/probe.rs
@@ -65,27 +65,51 @@ pub fn probe_agent(agent: AgentType) -> ProbeResult {
         resolved_path,
         version,
         sandbox_ok: if installed && agent == AgentType::Muse {
-            Some(probe_muse_sandbox())
+            probe_muse_sandbox()
         } else {
             None
         },
     }
 }
 
-/// Muse executes tools inside an OS sandbox (bubblewrap on Linux). Without
-/// it, runs still complete but every tool call comes back as a failed
-/// `tool.result` — an installed-but-degraded state the matrix must show
-/// distinctly from "not installed".
+/// Muse executes tools inside an OS sandbox. Without it, runs still
+/// complete but every tool call comes back as a failed `tool.result` — an
+/// installed-but-degraded state the matrix must show distinctly from "not
+/// installed".
 ///
-/// Probed by resolving the sandbox helper rather than executing anything:
-/// `muse sandbox` only exposes a Windows check subcommand at 0.1.0, so a
-/// PATH lookup of `bwrap` is the cheap, side-effect-free signal on Linux.
-/// Non-Linux hosts report ready (the sandbox ships differently there).
-pub fn probe_muse_sandbox() -> bool {
-    if cfg!(not(target_os = "linux")) {
-        return true;
+/// Returns `None` where this crate cannot honestly attest to sandbox state
+/// (rather than claiming ready), so the matrix shows no sandbox indicator
+/// instead of a green badge it can't back up.
+///
+/// - **Linux**: bubblewrap. Probed by resolving `bwrap` on PATH — cheap and
+///   side-effect-free (`muse sandbox` exposes no Linux check at 0.1.0).
+/// - **Windows**: `muse sandbox windows check` reports a real backend and
+///   status (`status=setup_required` is exactly the degraded state), so it
+///   is parsed. Written from the observed key=value output format; not yet
+///   exercised on a Windows host.
+/// - **macOS**: no probe — Muse supports macOS but exposes no sandbox
+///   check, and this crate will not assert readiness it cannot verify.
+pub fn probe_muse_sandbox() -> Option<bool> {
+    #[cfg(target_os = "linux")]
+    {
+        Some(which::which("bwrap").is_ok())
     }
-    which::which("bwrap").is_ok()
+    #[cfg(target_os = "windows")]
+    {
+        let out = Command::new("muse")
+            .args(["sandbox", "windows", "check"])
+            .output()
+            .ok()?;
+        let text = String::from_utf8_lossy(&out.stdout);
+        let status = text
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("status="))?;
+        Some(status == "ready" || status == "ok")
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        None
+    }
 }
 
 /// Presence-only login probe for Muse: the CLI persists no account

--- a/session-lib/src/probe.rs
+++ b/session-lib/src/probe.rs
@@ -13,12 +13,15 @@ pub struct ProbeResult {
     pub installed: bool,
     pub resolved_path: Option<PathBuf>,
     pub version: Option<String>,
+    /// Sandbox readiness for agents whose tool execution depends on host
+    /// packages. `None` for agents with no sandbox concept.
+    pub sandbox_ok: Option<bool>,
 }
 
 /// Probe both supported agent CLIs. Cheap — each binary returns from
 /// `--version` in tens of milliseconds.
 pub fn probe_all_agents() -> Vec<(AgentType, ProbeResult)> {
-    [AgentType::Claude, AgentType::Codex]
+    [AgentType::Claude, AgentType::Codex, AgentType::Muse]
         .into_iter()
         .map(|agent| (agent, probe_agent(agent)))
         .collect()
@@ -35,6 +38,7 @@ pub fn probe_agent(agent: AgentType) -> ProbeResult {
             installed: false,
             resolved_path: None,
             version: None,
+            sandbox_ok: None,
         };
     }
 
@@ -55,10 +59,58 @@ pub fn probe_agent(agent: AgentType) -> ProbeResult {
         Ok(_) | Err(_) => None,
     };
 
+    let installed = version.is_some();
     ProbeResult {
-        installed: version.is_some(),
+        installed,
         resolved_path,
         version,
+        sandbox_ok: if installed && agent == AgentType::Muse {
+            Some(probe_muse_sandbox())
+        } else {
+            None
+        },
+    }
+}
+
+/// Muse executes tools inside an OS sandbox (bubblewrap on Linux). Without
+/// it, runs still complete but every tool call comes back as a failed
+/// `tool.result` — an installed-but-degraded state the matrix must show
+/// distinctly from "not installed".
+///
+/// Probed by resolving the sandbox helper rather than executing anything:
+/// `muse sandbox` only exposes a Windows check subcommand at 0.1.0, so a
+/// PATH lookup of `bwrap` is the cheap, side-effect-free signal on Linux.
+/// Non-Linux hosts report ready (the sandbox ships differently there).
+pub fn probe_muse_sandbox() -> bool {
+    if cfg!(not(target_os = "linux")) {
+        return true;
+    }
+    which::which("bwrap").is_ok()
+}
+
+/// Presence-only login probe for Muse: the CLI persists no account
+/// identity (no `whoami` at 0.1.0), so a logged-in cell carries a provider
+/// label instead of a name, annotated when the credential comes from the
+/// environment rather than the saved file.
+pub fn probe_muse_login() -> shared::AgentLoginStatus {
+    let via_env = std::env::var("META_API_KEY")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false);
+    if via_env {
+        return shared::AgentLoginStatus::LoggedIn {
+            label: Some("meta".to_string()),
+            plan: None,
+            via: Some("env".to_string()),
+        };
+    }
+    if muse_codes::auth::credentials_present() {
+        shared::AgentLoginStatus::LoggedIn {
+            label: Some("meta".to_string()),
+            plan: None,
+            via: None,
+        }
+    } else {
+        shared::AgentLoginStatus::LoggedOut
     }
 }
 
@@ -66,3 +118,58 @@ pub fn probe_agent(agent: AgentType) -> ProbeResult {
 /// here so callers don't have to guess at the timeout for the request/response
 /// round-trip when probing via WS.
 pub const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(test)]
+mod muse_probe_tests {
+    use super::*;
+
+    /// Muse joins the probe set — the matrix needs a column for it even on
+    /// hosts where the binary is absent.
+    #[test]
+    fn probe_covers_all_three_agents() {
+        let probed: Vec<AgentType> = probe_all_agents().into_iter().map(|(a, _)| a).collect();
+        assert!(probed.contains(&AgentType::Muse));
+        assert_eq!(probed.len(), 3);
+    }
+
+    /// sandbox_ok is muse-only: claude/codex have no sandbox concept and
+    /// must serialize exactly as before (None => field omitted).
+    #[test]
+    fn sandbox_ok_is_none_for_non_muse_agents() {
+        for (agent, result) in probe_all_agents() {
+            if agent != AgentType::Muse {
+                assert_eq!(
+                    result.sandbox_ok, None,
+                    "{agent:?} should have no sandbox state"
+                );
+            }
+        }
+    }
+
+    /// An absent binary reports not-installed with no sandbox claim —
+    /// never `Some(false)`, which would read as "installed but degraded".
+    #[test]
+    fn missing_binary_makes_no_sandbox_claim() {
+        let r = probe_agent(AgentType::Muse);
+        if !r.installed {
+            assert_eq!(r.sandbox_ok, None);
+        }
+    }
+
+    /// Presence-only login shape: muse carries a provider label, never a
+    /// plan, and marks env-supplied credentials.
+    #[test]
+    fn muse_login_probe_shape() {
+        match probe_muse_login() {
+            shared::AgentLoginStatus::LoggedIn { label, plan, via } => {
+                assert_eq!(label.as_deref(), Some("meta"));
+                assert_eq!(plan, None, "muse exposes no plan/subscription");
+                assert!(via.is_none() || via.as_deref() == Some("env"));
+            }
+            shared::AgentLoginStatus::LoggedOut => {}
+            shared::AgentLoginStatus::Unknown => {
+                panic!("probe should decide presence, not return Unknown")
+            }
+        }
+    }
+}

--- a/shared/src/api/metrics.rs
+++ b/shared/src/api/metrics.rs
@@ -158,7 +158,10 @@ impl TurnMetrics {
             return snapshot;
         }
         match self.agent_type {
-            AgentType::Codex => self.input_tokens,
+            // Muse: no token-usage events exist in the observed 0.1.0 stream;
+            // whatever the proxy reports (typically 0 until usage lands on
+            // the wire) passes through flat, Codex-style.
+            AgentType::Codex | AgentType::Muse => self.input_tokens,
             // Claude fallback (older proxy, or no usable assistant usage this
             // turn): the disjoint buckets sum to the prompt. Correct for a
             // single-call turn and an over-count for a multi-call one — the

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -174,6 +174,8 @@ pub enum AgentType {
     #[default]
     Claude,
     Codex,
+    /// Meta Muse Code (`muse` CLI) — journal-stream agent, spawn-per-turn.
+    Muse,
 }
 
 impl AgentType {
@@ -181,6 +183,7 @@ impl AgentType {
         match self {
             AgentType::Claude => "claude",
             AgentType::Codex => "codex",
+            AgentType::Muse => "muse",
         }
     }
 
@@ -235,6 +238,7 @@ impl std::str::FromStr for AgentType {
         match s.trim().to_ascii_lowercase().as_str() {
             "claude" => Ok(AgentType::Claude),
             "codex" => Ok(AgentType::Codex),
+            "muse" => Ok(AgentType::Muse),
             other => Err(format!("unknown agent type: {}", other)),
         }
     }
@@ -498,6 +502,14 @@ pub struct AgentInstall {
     /// `<bin> --version` stdout, trimmed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Sandbox readiness for agents whose TOOL execution depends on host
+    /// packages (muse: bubblewrap on Linux). `None` = no sandbox concept
+    /// for this agent (claude/codex — serialization unchanged);
+    /// `Some(false)` = installed-but-degraded: runs complete but every
+    /// tool call fails; `Some(true)` = ready. Degraded is NEVER modeled
+    /// as `installed: false`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_ok: Option<bool>,
     /// Sign-in state for this agent on the host. `#[serde(default)]` =
     /// `Unknown`, so an older launcher that only reports install state
     /// deserializes cleanly (the matrix shows its login cells as unknown).

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -999,6 +999,56 @@ pub struct AppConfig {
 }
 
 #[cfg(test)]
+mod agent_install_serde_tests {
+    use super::*;
+
+    fn install(agent_type: AgentType, sandbox_ok: Option<bool>) -> AgentInstall {
+        AgentInstall {
+            agent_type,
+            installed: true,
+            resolved_path: Some("/usr/bin/x".to_string()),
+            version: Some("1.0".to_string()),
+            sandbox_ok,
+            login: AgentLoginStatus::Unknown,
+        }
+    }
+
+    /// Agents with no sandbox concept must serialize EXACTLY as before the
+    /// field existed — absent, not `null`. Otherwise every existing
+    /// AgentInstall consumer sees a new key.
+    #[test]
+    fn sandbox_ok_absent_from_claude_and_codex_json() {
+        for agent in [AgentType::Claude, AgentType::Codex] {
+            let json = serde_json::to_value(install(agent, None)).unwrap();
+            assert!(
+                json.get("sandbox_ok").is_none(),
+                "{agent:?} JSON must not carry a sandbox_ok key: {json}"
+            );
+        }
+    }
+
+    /// Muse carries the field when it has something to say.
+    #[test]
+    fn sandbox_ok_present_for_muse_when_known() {
+        let json = serde_json::to_value(install(AgentType::Muse, Some(false))).unwrap();
+        assert_eq!(json["sandbox_ok"], serde_json::json!(false));
+    }
+
+    /// Payloads written by an older launcher (no such key) still parse.
+    #[test]
+    fn old_payload_without_sandbox_ok_deserializes() {
+        let old = serde_json::json!({
+            "agent_type": "claude",
+            "installed": true,
+            "version": "1.0",
+            "login": {"state": "unknown"}
+        });
+        let parsed: AgentInstall = serde_json::from_value(old).unwrap();
+        assert_eq!(parsed.sandbox_ok, None);
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -189,17 +189,32 @@ impl AgentType {
 
     /// The command that installs this agent's CLI, as structured data so the
     /// launcher (which runs it) and the frontend (which displays it for the
-    /// user to confirm) agree on exactly one thing. Both ship as global npm
-    /// packages, the most portable option that avoids piping a remote script
-    /// into a shell on the user's host.
+    /// user to confirm) agree on exactly one thing. Claude and Codex ship as
+    /// global npm packages, the most portable option that avoids piping a
+    /// remote script into a shell on the user's host.
+    ///
+    /// Muse is the exception: at 0.1.0 Meta ships **only** an installer
+    /// script (no npm/Homebrew package, and no self-update subcommand), so
+    /// its command is that pipeline wrapped in `bash -c`. The arguments are
+    /// static — there is no interpolation and so no injection surface — and
+    /// the confirmation modal renders the whole line via
+    /// [`AgentInstallCommand::display`], so the user sees they are piping a
+    /// remote script to a shell before they approve it. Switch this to a
+    /// package manager the moment Meta publishes one.
     pub fn install_command(self) -> AgentInstallCommand {
-        let package = match self {
-            AgentType::Claude => "@anthropic-ai/claude-code",
-            AgentType::Codex => "@openai/codex",
-        };
-        AgentInstallCommand {
-            program: "npm",
-            args: vec!["install", "-g", package],
+        match self {
+            AgentType::Claude => AgentInstallCommand {
+                program: "npm",
+                args: vec!["install", "-g", "@anthropic-ai/claude-code"],
+            },
+            AgentType::Codex => AgentInstallCommand {
+                program: "npm",
+                args: vec!["install", "-g", "@openai/codex"],
+            },
+            AgentType::Muse => AgentInstallCommand {
+                program: "bash",
+                args: vec!["-c", "curl -fsSL https://dev.meta.ai/install.sh | bash"],
+            },
         }
     }
 }
@@ -1345,5 +1360,41 @@ mod tests {
         );
         assert_eq!(compact.leaf_message_count, Some(7));
         assert_eq!(compact.duration_ms, Some(1234));
+    }
+}
+
+#[cfg(test)]
+mod muse_install_command_tests {
+    use super::*;
+
+    /// Muse ships only an installer script at 0.1.0 — no npm/Homebrew
+    /// package — so its install command is a `bash -c` pipeline. The args
+    /// are static (no interpolation, no injection surface) and the whole
+    /// line is rendered for the user to confirm before it runs.
+    #[test]
+    fn muse_install_is_the_vendor_script_and_displays_verbatim() {
+        let cmd = AgentType::Muse.install_command();
+        assert_eq!(cmd.program, "bash");
+        assert_eq!(
+            cmd.display(),
+            "bash -c curl -fsSL https://dev.meta.ai/install.sh | bash"
+        );
+        assert!(
+            cmd.display().contains("dev.meta.ai/install.sh"),
+            "the confirm modal must show the remote script being piped"
+        );
+    }
+
+    /// The npm agents are untouched by muse's exception.
+    #[test]
+    fn npm_agents_unchanged() {
+        assert_eq!(
+            AgentType::Claude.install_command().display(),
+            "npm install -g @anthropic-ai/claude-code"
+        );
+        assert_eq!(
+            AgentType::Codex.install_command().display(),
+            "npm install -g @openai/codex"
+        );
     }
 }


### PR DESCRIPTION
Plan-PR-1 of the six-PR sequence in #1563. Makes Muse a **known** agent — probeable, installable, loginable-in-principle, visible in the agents matrix — **without** a session implementation yet (that's `muse-session-lib`, plan-PR-2). Pins `muse-codes 0.1.3`. Rebased onto main after #1562 / #1565.

## What lands

- **`shared`**: `AgentType::Muse` (as_str / FromStr / serde); additive `AgentInstall.sandbox_ok: Option<bool>` — `None` = agent has no sandbox concept (claude/codex serialize **unchanged**), `Some(false)` = installed-but-degraded, `Some(true)` = ready; and the muse arm of `install_command()`.
- **`session-lib::probe`**: muse joins `probe_all_agents`; `probe_muse_login` is presence-only (the CLI persists no account identity — no whoami at 0.1.0), using the existing `AgentLoginStatus::LoggedIn { label, plan, via }` with `via: "env"` when `META_API_KEY` wins.
- **`launcher`**: `SessionError::AgentNotSupported` for muse launches instead of spawning something that can't stream; `login_registry` returns a clear error for muse rather than parking a flow it can't settle.
- **`frontend`**: match arms for launch dialog, model picker (empty catalog — muse resolves the model server-side and reports it in-band via `run.model.configured`), skip-permissions (n/a — muse manages tool policy itself), rail/pill styling, demo.

## Install command: the one exception to "no curl | bash"

Claude and Codex install as global npm packages specifically to avoid piping a remote script into a shell. Muse has no npm or Homebrew package at 0.1.0 (and no self-update subcommand), so its command is `bash -c 'curl -fsSL https://dev.meta.ai/install.sh | bash'`.

The arguments are **static** — nothing is interpolated, so there is no injection surface — and `AgentInstallCommand::display()` renders the whole pipeline in the confirm modal, so the user sees they are piping a remote script to a shell **before** approving. A test locks that rendering. Switch to a package manager the moment Meta publishes one.

## Why sandbox state exists

Muse executes tools in an OS sandbox. Without it, **runs still complete but every tool call returns a failed `tool.result`** — an installed-but-degraded state that would otherwise look healthy in the matrix.

## ⚠️ Reviewer caveat: the Windows sandbox arm is untested on a real Windows host

`probe_muse_sandbox()` is deliberately per-platform and returns `Option<bool>`:

| Platform | Probe | Confidence |
|---|---|---|
| Linux | resolves `bwrap` on PATH (no Linux check subcommand exists at 0.1.0) | verified on this host |
| Windows | parses `muse sandbox windows check` — `status=setup_required` is a real degraded state (observed: `backend=windows_elevated status=setup_required`) | **written from observed key=value output; NOT exercised on Windows** |
| macOS | returns `None` | deliberate — Muse supports macOS but exposes no sandbox check, and this crate will not assert readiness it cannot verify |

Please treat the Windows cell as unproven until someone runs it on a Windows launcher.

## Verification

- Workspace `cargo check`, `clippy --all-targets`, `fmt` clean (repo builds with `-Dwarnings`)
- 4 probe tests, 3 `AgentInstall` serde tests — including one asserting claude/codex JSON carries **no** `sandbox_ok` key (wire-contract lock) and one proving old payloads without the key still deserialize — and 2 install-command tests

## Deliberately not included (owned by the follow-up)

- The **muse login driver**. `muse_codes::auth::DeviceLoginFlow` maps onto the existing `LoginPresentable::DeviceCode` + `AwaitCompletion` shape exactly, so it is a small addition — left to the follow-up that adds muse arms to the matrix/login/install surfaces.
- The launch dialog does not offer Muse as launchable (the picker is a hardcoded option list; the *why* is commented at the markup). Launching it would fail at spawn and trip the launch crashloop auto-pause. It becomes offerable when `muse-session-lib` lands.