### PR TITLE
Keep the dashboard header out from under the Dynamic Island

### DIFF
--- a/frontend/styles/dashboard.css
+++ b/frontend/styles/dashboard.css
@@ -1,16 +1,4 @@
 /* Dashboard */
-.dashboard-container {
-    min-height: 100vh;
-    padding: 2rem;
-}
-
-.dashboard-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 2rem;
-}
-
 .header-actions {
     display: flex;
     align-items: center;

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -2,9 +2,19 @@
    Mobile Responsiveness
    ========================================================================== */
 
-/* --- Safe area insets for notched devices (iPhone X+, etc.) -------------- */
+/* --- Safe area insets for notched devices (iPhone X+, etc.) --------------
+   `index.html` sets `viewport-fit=cover`, which deliberately extends the page
+   under the status bar / Dynamic Island / home indicator. That is only correct
+   if every top-level container adds the inset back — otherwise its first row
+   renders *behind* the clock. Miss the top inset and it is invisible in a
+   desktop browser and in the mobile Safari tab (whose chrome hides it), but
+   obvious in the native shell, which is edge-to-edge.
+
+   Keep `max(<base>, env(...))` rather than a bare `env(...)`: the inset is 0 on
+   non-notched devices, and a bare env() would collapse the normal padding. */
 @supports (padding: env(safe-area-inset-bottom)) {
     .focus-flow-header {
+        padding-top: max(0.75rem, env(safe-area-inset-top));
         padding-left: max(0.75rem, env(safe-area-inset-left));
         padding-right: max(0.75rem, env(safe-area-inset-right));
     }
@@ -23,8 +33,12 @@
     }
 
     /* ---- Header ---- */
+
+    /* Restates the insets from the @supports block above, which this rule would
+       otherwise reset — putting the first row back under the Dynamic Island. */
     .focus-flow-header {
-        padding: 0.5rem 0.75rem;
+        padding: max(0.5rem, env(safe-area-inset-top)) max(0.75rem, env(safe-area-inset-right)) 0.5rem
+            max(0.75rem, env(safe-area-inset-left));
         flex-wrap: wrap;
         gap: 0.5rem;
     }
@@ -199,16 +213,6 @@
     }
 
     /* ---- Dashboard page ---- */
-    .dashboard-container {
-        padding: 1rem;
-    }
-
-    .dashboard-header {
-        margin-bottom: 1rem;
-        flex-wrap: wrap;
-        gap: 0.75rem;
-    }
-
     .header-button {
         padding: 0.4rem 0.75rem;
         font-size: 0.8rem;
@@ -572,15 +576,6 @@
 
     .session-view-input .input-prompt {
         display: none;
-    }
-
-    /* Dashboard even tighter */
-    .dashboard-container {
-        padding: 0.75rem;
-    }
-
-    .dashboard-header {
-        margin-bottom: 0.75rem;
     }
 
     .header-actions {


### PR DESCRIPTION
On the native iOS shell the dashboard header renders *behind* the status bar: the title is clipped by the Dynamic Island, the clock sits on top of "+ Launch Session", and Admin is half-covered.

## Cause

`frontend/index.html:5` sets `viewport-fit=cover`, which intentionally extends the page under the status bar / Dynamic Island / home indicator. That's only correct if top-level containers add the inset back — and `safe-area-inset-top` appeared **nowhere** in the stylesheets. The single existing safe-area block covered `.focus-flow-header` for left/right only.

It survived this long because it's invisible everywhere it normally gets looked at: insets resolve to `0` in a desktop browser, and in a mobile Safari tab the browser chrome covers the region. Only the edge-to-edge native shell exposes it — a class of bug this repo will keep producing now that a native shell exists.

## Fix

Top inset on `.focus-flow-header`, **restated inside the `≤768px` rule**. That rule sets shorthand `padding: 0.5rem 0.75rem`, which was silently resetting the inset straight back under the notch — the shadowing is the actual subtlety here, not the inset itself.

`max(<base>, env(…))` rather than a bare `env(…)`, since the inset is `0` on non-notched devices and a bare `env()` would collapse the normal padding.

## Dead CSS removed

`.dashboard-container` and `.dashboard-header` are deleted. They read as the dashboard's styling but have **zero** markup references — the live chain is `.focus-flow-container > .focus-flow-header` (`pages/dashboard/page.rs:623`, `:662`).

This is not incidental tidying: my first cut of this fix patched exactly those dead rules. It would have shipped a no-op whose diff looked correct and whose verification looked performed. Removing them stops the next person making the same mistake.

## Verification

CSS lint clean. Not yet seen rendering on-device — the shell loads the deployed frontend, so this needs a deploy to observe. The reasoning is verified against the live markup rather than against the stylesheet, which is what caught the dead-rule error.