### PR TITLE
Paginate history session retrieval

### DIFF
--- a/archive-format/src/scan.rs
+++ b/archive-format/src/scan.rs
@@ -99,7 +99,10 @@ pub fn collect_rows(
 }
 
 /// Row filters. All are optional; an unset filter matches everything.
-#[derive(Default)]
+///
+/// `Clone` so a caller can derive a variant with one field relaxed — the
+/// history list builds an owner rollup from the same filters minus `user`.
+#[derive(Default, Clone)]
 pub struct Filters {
     /// Substring match against `owner_email`, or a session/user UUID prefix.
     pub user: Option<String>,

--- a/backend/src/handlers/history.rs
+++ b/backend/src/handlers/history.rs
@@ -20,7 +20,7 @@
 //! List requests share the [`ArchiveRuntime::scan_rows`] cache; per-session
 //! reads always hit the store for the freshest bytes.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -35,7 +35,10 @@ use tokio_util::io::ReaderStream;
 use tower_cookies::Cookies;
 use uuid::Uuid;
 
-use shared::api::{HistorySessionSummary, HistorySessionsResponse};
+use shared::api::{
+    HistoryOwnerRollup, HistorySessionSummary, HistorySessionsResponse, HistoryTotals,
+    DEFAULT_HISTORY_PAGE_SIZE, MAX_HISTORY_PAGE_SIZE,
+};
 
 use crate::archive::{
     decode_transcript, manifest_key, scan, transcript_key, ArchiveRuntime, SessionArchiveManifest,
@@ -142,6 +145,11 @@ pub struct HistoryListQuery {
     pub to: Option<String>,
     /// Session-name substring (case-insensitive).
     pub q: Option<String>,
+    /// Page size. Defaults to [`DEFAULT_HISTORY_PAGE_SIZE`], clamped to
+    /// [`MAX_HISTORY_PAGE_SIZE`] so a caller can't request the whole archive.
+    pub limit: Option<usize>,
+    /// Row offset into the filtered, sorted result set.
+    pub offset: Option<usize>,
 }
 
 /// GET /api/history/sessions — archived sessions visible to the caller,
@@ -167,16 +175,107 @@ pub async fn list_history_sessions(
     let rows = on_blocking(move || scan_runtime.scan_rows()).await?;
     let live_member_ids = live_member_session_ids(&app_state, user.id)?;
 
-    let mut kept: Vec<&scan::FlatRow> = rows
+    // Visibility first: everything below operates on rows this caller may see.
+    let visible: Vec<&scan::FlatRow> = rows
         .iter()
-        .filter(|r| row_visible(r, &user, &live_member_ids) && filters.matches(r))
+        .filter(|r| row_visible(r, &user, &live_member_ids))
         .collect();
-    kept.sort_by_key(|r| std::cmp::Reverse(r.manifest.last_activity));
+
+    // Owner rollup deliberately ignores the `user` filter — see the field doc on
+    // `HistorySessionsResponse::owners`. Admin-only, since it drives an
+    // admin-only control and would otherwise be dead weight in the payload.
+    let owners = if user.is_admin {
+        let without_user = scan::Filters {
+            user: None,
+            ..filters.clone()
+        };
+        owner_rollups(visible.iter().copied().filter(|r| without_user.matches(r)))
+    } else {
+        Vec::new()
+    };
+
+    let mut kept: Vec<&scan::FlatRow> =
+        visible.into_iter().filter(|r| filters.matches(r)).collect();
+    // Tie-break on name so equal timestamps don't reorder between page fetches —
+    // an unstable sort here would let a row repeat on one page and vanish from
+    // the next.
+    kept.sort_by(|a, b| {
+        b.manifest
+            .last_activity
+            .cmp(&a.manifest.last_activity)
+            .then_with(|| a.manifest.session_name.cmp(&b.manifest.session_name))
+    });
+
+    let totals = HistoryTotals {
+        session_count: kept.len() as i64,
+        message_count: kept.iter().map(|r| r.message_count()).sum(),
+        // `+ 0.0` normalises negative zero: Rust's `Sum for f64` folds from
+        // `-0.0`, so an empty (or all-zero) result set otherwise serialises as
+        // `-0.0` and renders as "$-0.00".
+        total_cost_usd: kept.iter().map(|r| r.manifest.total_cost_usd).sum::<f64>() + 0.0,
+    };
+    let total = kept.len() as i64;
+
+    let limit = q
+        .limit
+        .unwrap_or(DEFAULT_HISTORY_PAGE_SIZE)
+        .clamp(1, MAX_HISTORY_PAGE_SIZE);
+    let offset = q.offset.unwrap_or(0).min(kept.len());
 
     Ok(Json(HistorySessionsResponse {
-        sessions: kept.into_iter().map(session_summary).collect(),
+        sessions: kept
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .map(session_summary)
+            .collect(),
         is_admin: user.is_admin,
+        total,
+        totals,
+        owners,
     }))
+}
+
+/// Per-owner session count and spend, ordered by spend descending so the admin
+/// tiles lead with the biggest consumers.
+fn owner_rollups<'a>(rows: impl Iterator<Item = &'a scan::FlatRow>) -> Vec<HistoryOwnerRollup> {
+    let mut by_user: BTreeMap<String, HistoryOwnerRollup> = BTreeMap::new();
+    for row in rows {
+        let m = &row.manifest;
+        let entry = by_user
+            .entry(m.user_id.to_string())
+            .or_insert_with(|| HistoryOwnerRollup {
+                user_id: m.user_id.to_string(),
+                label: owner_label(m),
+                session_count: 0,
+                total_cost_usd: 0.0,
+            });
+        entry.session_count += 1;
+        entry.total_cost_usd += m.total_cost_usd;
+    }
+    let mut out: Vec<HistoryOwnerRollup> = by_user.into_values().collect();
+    out.sort_by(|a, b| {
+        b.total_cost_usd
+            .partial_cmp(&a.total_cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.label.cmp(&b.label))
+    });
+    out
+}
+
+/// Display name → email → raw id, matching what the browser used to derive
+/// client-side from a summary row.
+fn owner_label(m: &archive_format::SessionArchiveManifest) -> String {
+    m.owner_name
+        .clone()
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| {
+            if m.owner_email.is_empty() {
+                m.user_id.to_string()
+            } else {
+                m.owner_email.clone()
+            }
+        })
 }
 
 fn parse_date_param(

--- a/frontend/src/pages/history/browser.rs
+++ b/frontend/src/pages/history/browser.rs
@@ -1,34 +1,68 @@
 //! History browser (`/history`): stats strip, filter controls, session table.
 
-use std::collections::BTreeMap;
-
+use gloo::timers::callback::Timeout;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{HtmlInputElement, HtmlSelectElement};
 use yew::prelude::*;
 use yew_router::prelude::*;
 
-use shared::api::{HistorySessionSummary, HistorySessionsResponse};
+use shared::api::{HistorySessionSummary, HistorySessionsResponse, DEFAULT_HISTORY_PAGE_SIZE};
 
 use super::fetch::{fetch_json, Load};
-use super::filters::{filter_and_sort, SessionFilter};
+use super::filters::SessionFilter;
 use crate::Route;
+
+/// Rows requested per page. Must not exceed `MAX_HISTORY_PAGE_SIZE`, which the
+/// backend clamps to.
+const PAGE_SIZE: usize = DEFAULT_HISTORY_PAGE_SIZE;
+
+/// Delay before a filter/page change actually hits the network. Typing in the
+/// name box mutates the filter on every keystroke, and each request re-filters
+/// the whole archive server-side; without this, a ten-character search is ten
+/// requests. Short enough to feel immediate on a page-turn click.
+const FETCH_DEBOUNCE_MS: u32 = 250;
 
 #[function_component(HistoryBrowserPage)]
 pub fn history_browser_page() -> Html {
     let response = use_state(|| None as Load<HistorySessionsResponse>);
     let filter = use_state(SessionFilter::default);
+    let page = use_state(|| 0usize);
 
+    // One effect, keyed on both inputs, is the whole data path. Filter changes
+    // reset the page inside the control callbacks rather than in a second
+    // effect — an effect would observe the new filter with the old page, fetch,
+    // then reset the page and fetch again, doubling every request.
     {
         let response = response.clone();
-        use_effect_with((), move |_| {
-            spawn_local(async move {
-                response.set(Some(
-                    fetch_json::<HistorySessionsResponse>("/api/history/sessions").await,
-                ));
+        use_effect_with(((*filter).clone(), *page), move |(filter, page)| {
+            let query = filter.to_query(page * PAGE_SIZE, PAGE_SIZE);
+            let timeout = Timeout::new(FETCH_DEBOUNCE_MS, move || {
+                spawn_local(async move {
+                    let url = format!("/api/history/sessions?{query}");
+                    // Deliberately not cleared to `None` first: a refetch keeps
+                    // the current page on screen instead of flashing the loading
+                    // state on every keystroke.
+                    response.set(Some(fetch_json::<HistorySessionsResponse>(&url).await));
+                });
             });
-            || ()
+            // Dropping the timeout cancels it, so a superseded keystroke never
+            // reaches the network.
+            move || drop(timeout)
         });
     }
+
+    // Filter edits reset to page 0 together with the filter itself. Without it,
+    // narrowing while on a late page requests an offset past the end of the new
+    // result set and the table comes back empty — reading as "no matches" for a
+    // filter that in fact matched.
+    let on_filter = {
+        let filter = filter.clone();
+        let page = page.clone();
+        Callback::from(move |next: SessionFilter| {
+            filter.set(next);
+            page.set(0);
+        })
+    };
 
     let body = match &*response {
         None => html! { <div class="history-loading">{ "Loading history…" }</div> },
@@ -36,12 +70,16 @@ pub fn history_browser_page() -> Html {
             <div class="history-error">{ format!("Could not load history: {e}") }</div>
         },
         Some(Ok(resp)) => {
-            let rows = filter_and_sort(&resp.sessions, &filter);
+            let window = PageWindow::resolve(resp.total as usize, *page, PAGE_SIZE);
             html! {
                 <>
-                    { stats_strip(&rows, resp.is_admin) }
-                    { filter_controls(&resp.sessions, resp.is_admin, &filter) }
-                    { session_table(&rows, resp.is_admin) }
+                    // Totals and the owner list describe the whole filtered set,
+                    // computed server-side — deriving them from `resp.sessions`
+                    // would silently describe this page instead.
+                    { stats_strip(resp, &filter) }
+                    { filter_controls(resp, &filter, &on_filter) }
+                    { session_table(&resp.sessions, resp.is_admin) }
+                    { pagination_controls(&window, resp.sessions.len(), &page) }
                 </>
             }
         }
@@ -60,33 +98,28 @@ pub fn history_browser_page() -> Html {
     }
 }
 
-/// Totals over the *filtered* rows, so the tiles always agree with the table.
-/// Admins additionally get a per-user cost breakdown.
-fn stats_strip(rows: &[HistorySessionSummary], is_admin: bool) -> Html {
-    if rows.is_empty() {
+/// Totals across the whole filtered set (not this page), as computed by the
+/// backend. Admins additionally get a per-user cost breakdown.
+fn stats_strip(resp: &HistorySessionsResponse, filter: &UseStateHandle<SessionFilter>) -> Html {
+    if resp.total == 0 {
         return Html::default();
     }
-    let total_cost: f64 = rows.iter().map(|s| s.total_cost_usd).sum();
-    let total_messages: i64 = rows.iter().map(|s| s.message_count).sum();
 
-    let user_tiles = if is_admin {
-        let mut by_user: BTreeMap<String, (String, i64, f64)> = BTreeMap::new();
-        for s in rows {
-            let entry = by_user
-                .entry(s.user_id.clone())
-                .or_insert_with(|| (owner_label(s), 0, 0.0));
-            entry.1 += 1;
-            entry.2 += s.total_cost_usd;
-        }
-        let mut users: Vec<_> = by_user.into_values().collect();
-        users.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
-        users
-            .into_iter()
-            .map(|(label, sessions, cost)| {
+    // `owners` covers every filter *except* `user`, so when a user is selected
+    // narrow it here — that keeps the tiles agreeing with the table while the
+    // dropdown above still lists everyone.
+    let selected = filter.user_id.as_deref().filter(|s| !s.trim().is_empty());
+    let user_tiles = if resp.is_admin {
+        resp.owners
+            .iter()
+            .filter(|o| selected.is_none_or(|want| o.user_id == want))
+            .map(|o| {
                 html! {
                     <div class="rollup-tile rollup-user">
-                        <span class="rollup-value">{ format!("${cost:.2}") }</span>
-                        <span class="rollup-label">{ format!("{label} ({sessions} sess)") }</span>
+                        <span class="rollup-value">{ format!("${:.2}", o.total_cost_usd) }</span>
+                        <span class="rollup-label">
+                            { format!("{} ({} sess)", o.label, o.session_count) }
+                        </span>
                     </div>
                 }
             })
@@ -98,15 +131,17 @@ fn stats_strip(rows: &[HistorySessionSummary], is_admin: bool) -> Html {
     html! {
         <div class="history-rollup">
             <div class="rollup-tile">
-                <span class="rollup-value">{ rows.len() }</span>
+                <span class="rollup-value">{ resp.totals.session_count }</span>
                 <span class="rollup-label">{ "sessions" }</span>
             </div>
             <div class="rollup-tile">
-                <span class="rollup-value">{ total_messages }</span>
+                <span class="rollup-value">{ resp.totals.message_count }</span>
                 <span class="rollup-label">{ "messages" }</span>
             </div>
             <div class="rollup-tile">
-                <span class="rollup-value">{ format!("${total_cost:.2}") }</span>
+                <span class="rollup-value">
+                    { format!("${:.2}", resp.totals.total_cost_usd) }
+                </span>
                 <span class="rollup-label">{ "total spend" }</span>
             </div>
             { user_tiles }
@@ -114,84 +149,44 @@ fn stats_strip(rows: &[HistorySessionSummary], is_admin: bool) -> Html {
     }
 }
 
-fn owner_label(s: &HistorySessionSummary) -> String {
-    s.owner_name
-        .clone()
-        .filter(|n| !n.is_empty())
-        .unwrap_or_else(|| {
-            if s.owner_email.is_empty() {
-                s.user_id.clone()
-            } else {
-                s.owner_email.clone()
-            }
-        })
-}
-
+/// `on_change` carries the whole next filter rather than a per-field callback so
+/// the parent can reset the page in the same update — see `on_filter`.
 fn filter_controls(
-    all_sessions: &[HistorySessionSummary],
-    is_admin: bool,
+    resp: &HistorySessionsResponse,
     filter: &UseStateHandle<SessionFilter>,
+    on_change: &Callback<SessionFilter>,
 ) -> Html {
-    let on_user = {
-        let filter = filter.clone();
-        Callback::from(move |e: Event| {
-            let value = e.target_unchecked_into::<HtmlSelectElement>().value();
-            let mut next = (*filter).clone();
-            next.user_id = (!value.is_empty()).then_some(value);
-            filter.set(next);
-        })
-    };
-    let on_agent = {
-        let filter = filter.clone();
-        Callback::from(move |e: Event| {
-            let value = e.target_unchecked_into::<HtmlSelectElement>().value();
-            let mut next = (*filter).clone();
-            next.agent_type = (!value.is_empty()).then_some(value);
-            filter.set(next);
-        })
-    };
-    let on_from = {
-        let filter = filter.clone();
-        Callback::from(move |e: InputEvent| {
-            let value = e.target_unchecked_into::<HtmlInputElement>().value();
-            let mut next = (*filter).clone();
-            next.from = (!value.is_empty()).then_some(value);
-            filter.set(next);
-        })
-    };
-    let on_to = {
-        let filter = filter.clone();
-        Callback::from(move |e: InputEvent| {
-            let value = e.target_unchecked_into::<HtmlInputElement>().value();
-            let mut next = (*filter).clone();
-            next.to = (!value.is_empty()).then_some(value);
-            filter.set(next);
-        })
-    };
+    /// Build a handler that edits one field of the current filter and emits it.
+    macro_rules! field_handler {
+        ($event:ty, $target:ty, $field:ident) => {{
+            let filter = filter.clone();
+            let on_change = on_change.clone();
+            Callback::from(move |e: $event| {
+                let value = e.target_unchecked_into::<$target>().value();
+                let mut next = (*filter).clone();
+                next.$field = (!value.is_empty()).then_some(value);
+                on_change.emit(next);
+            })
+        }};
+    }
+
+    let on_user = field_handler!(Event, HtmlSelectElement, user_id);
+    let on_agent = field_handler!(Event, HtmlSelectElement, agent_type);
+    let on_from = field_handler!(InputEvent, HtmlInputElement, from);
+    let on_to = field_handler!(InputEvent, HtmlInputElement, to);
     // Uncontrolled (no `value` binding) so the node is never recreated on the
     // parent re-render each keystroke triggers — focus and caret stay put.
-    let on_query = {
-        let filter = filter.clone();
-        Callback::from(move |e: InputEvent| {
-            let value = e.target_unchecked_into::<HtmlInputElement>().value();
-            let mut next = (*filter).clone();
-            next.query = (!value.is_empty()).then_some(value);
-            filter.set(next);
-        })
-    };
+    let on_query = field_handler!(InputEvent, HtmlInputElement, query);
 
-    // Admin-only user dropdown, derived from the unfiltered visible rows so
-    // selecting a user doesn't shrink the option list.
-    let user_filter = if is_admin {
-        let mut owners: BTreeMap<String, String> = BTreeMap::new();
-        for s in all_sessions {
-            owners
-                .entry(s.user_id.clone())
-                .or_insert_with(|| owner_label(s));
-        }
-        let options = owners
-            .into_iter()
-            .map(|(id, label)| html! { <option value={id}>{ label }</option> })
+    // Admin-only user dropdown. `owners` is computed server-side over every
+    // filter except `user`, so selecting a user doesn't shrink the option list.
+    let user_filter = if resp.is_admin {
+        let options = resp
+            .owners
+            .iter()
+            .map(|o| {
+                html! { <option value={o.user_id.clone()}>{ o.label.clone() }</option> }
+            })
             .collect::<Html>();
         html! {
             <label>
@@ -230,6 +225,100 @@ fn filter_controls(
                 <input type="text" placeholder="substring…" oninput={on_query} />
             </label>
         </div>
+    }
+}
+
+/// A resolved page: which page is actually being shown and the row range it
+/// covers, always a valid slice of `total` rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PageWindow {
+    page: usize,
+    page_count: usize,
+    start: usize,
+    end: usize,
+}
+
+impl PageWindow {
+    /// Clamp `requested` against the current row count.
+    ///
+    /// Clamping is not belt-and-braces over the reset effect — it is required.
+    /// The effect that returns to page 0 on a filter change runs *after* the
+    /// render that observes the new filter, so for one frame a stale page index
+    /// is live against a shorter row set. Without clamping that frame panics on
+    /// an out-of-range slice.
+    fn resolve(total: usize, requested: usize, page_size: usize) -> Self {
+        debug_assert!(page_size > 0, "page size must be non-zero");
+        let page_count = total.div_ceil(page_size).max(1);
+        let page = requested.min(page_count - 1);
+        let start = (page * page_size).min(total);
+        let end = (start + page_size).min(total);
+        Self {
+            page,
+            page_count,
+            start,
+            end,
+        }
+    }
+
+    fn shown(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+/// Prev/next controls plus a "showing X–Y of N" summary.
+///
+/// This paginates the *rendered table* only: `/api/history/sessions` returns
+/// every visible session in a single response and the whole set is filtered and
+/// totalled client-side. That keeps the stats strip and the admin user dropdown
+/// honest — both need the full result set — at the cost of the response staying
+/// O(all sessions). Making the fetch itself paged means moving filtering to the
+/// server (the endpoint already accepts `user`/`agent`/`q`/`from`/`to`) *and*
+/// returning aggregates alongside the page, or the totals would silently start
+/// describing one page instead of the whole filter.
+///
+/// Hidden entirely for a single page, so the common case gains no chrome.
+fn pagination_controls(window: &PageWindow, total: usize, page: &UseStateHandle<usize>) -> Html {
+    if window.page_count <= 1 {
+        return Html::default();
+    }
+    let current = window.page;
+    let on_prev = {
+        let page = page.clone();
+        Callback::from(move |_: MouseEvent| page.set(current.saturating_sub(1)))
+    };
+    let on_next = {
+        let page = page.clone();
+        let last = window.page_count - 1;
+        Callback::from(move |_: MouseEvent| page.set((current + 1).min(last)))
+    };
+    html! {
+        <nav class="history-pagination" aria-label="History pages">
+            <button
+                class="history-page-button"
+                onclick={on_prev}
+                disabled={current == 0}
+                aria-label="Previous page"
+            >
+                { "← Prev" }
+            </button>
+            <span class="history-page-status">
+                { format!(
+                    "{}–{} of {total}  ·  page {} of {}",
+                    window.start + 1,
+                    window.start + window.shown(),
+                    current + 1,
+                    window.page_count,
+                ) }
+            </span>
+            <button
+                class="history-page-button"
+                onclick={on_next}
+                disabled={current + 1 >= window.page_count}
+                aria-label="Next page"
+            >
+                { "Next →" }
+            </button>
+        </nav>
     }
 }
 
@@ -317,11 +406,79 @@ fn session_row(props: &SessionRowProps) -> Html {
     }
 }
 
+/// Display name → email → raw id, for the admin User column. The rollup tiles
+/// use the label the backend resolved; this is the same rule applied to a row.
+fn owner_label(s: &HistorySessionSummary) -> String {
+    s.owner_name
+        .clone()
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| {
+            if s.owner_email.is_empty() {
+                s.user_id.clone()
+            } else {
+                s.owner_email.clone()
+            }
+        })
+}
+
 /// Trim an ISO timestamp to `YYYY-MM-DD HH:MM` for compact table display.
 fn short_date(iso: &str) -> String {
     let trimmed = iso.replace('T', " ");
     match trimmed.char_indices().nth(16) {
         Some((idx, _)) => trimmed[..idx].to_string(),
         None => trimmed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_page_of_an_exact_multiple() {
+        let w = PageWindow::resolve(100, 0, 50);
+        assert_eq!((w.page, w.page_count, w.start, w.end), (0, 2, 0, 50));
+    }
+
+    #[test]
+    fn last_page_is_short_when_rows_do_not_divide_evenly() {
+        let w = PageWindow::resolve(120, 2, 50);
+        assert_eq!((w.page, w.page_count, w.start, w.end), (2, 3, 100, 120));
+        assert_eq!(w.shown(), 20);
+    }
+
+    #[test]
+    fn a_stale_page_index_clamps_instead_of_slicing_out_of_range() {
+        // The frame after a filter narrows 500 rows to 3, before the reset
+        // effect runs: page 9 is still live and must not produce 450..460.
+        let w = PageWindow::resolve(3, 9, 50);
+        assert_eq!((w.page, w.page_count, w.start, w.end), (0, 1, 0, 3));
+    }
+
+    #[test]
+    fn no_rows_still_yields_one_empty_page() {
+        // page_count is floored at 1 so `page_count - 1` never underflows.
+        let w = PageWindow::resolve(0, 0, 50);
+        assert_eq!((w.page, w.page_count, w.start, w.end), (0, 1, 0, 0));
+        assert_eq!(w.shown(), 0);
+    }
+
+    #[test]
+    fn a_single_short_page_reports_one_page_so_controls_stay_hidden() {
+        let w = PageWindow::resolve(7, 0, 50);
+        assert_eq!(w.page_count, 1);
+        assert_eq!(w.shown(), 7);
+    }
+
+    #[test]
+    fn every_window_is_a_valid_slice_across_a_range_of_sizes() {
+        for total in 0..200usize {
+            for requested in [0usize, 1, 3, 17, 999] {
+                let w = PageWindow::resolve(total, requested, 50);
+                assert!(w.start <= w.end, "start past end at total={total}");
+                assert!(w.end <= total, "end past total at total={total}");
+                assert!(w.page < w.page_count, "page out of range at total={total}");
+            }
+        }
     }
 }

--- a/frontend/src/pages/history/filters.rs
+++ b/frontend/src/pages/history/filters.rs
@@ -1,81 +1,70 @@
-//! Client-side filtering and sorting for the history browser.
+//! Filter state for the history browser, and its translation to query params.
 //!
-//! The whole visible session list is fetched once (the backend has already
-//! scoped it to the caller) and filtered in the browser, keeping the controls
-//! responsive while typing.
-
-use shared::api::HistorySessionSummary;
+//! Filtering, sorting and paging all happen server-side: `/api/history/sessions`
+//! returns one page of already-filtered rows plus the whole-set totals. This
+//! module therefore only models the control state and how to ask for it — it
+//! deliberately does **not** filter rows in the browser, because the client only
+//! ever holds a single page and filtering that would silently narrow one page
+//! instead of the archive.
 
 /// Active filter selections from the browser controls. Empty/`None` fields
 /// are "no constraint".
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct SessionFilter {
-    /// Exact `user_id` match (admin-only control).
+    /// Exact `user_id` match (admin-only control). Sent as `user`, which the
+    /// backend matches as an email substring *or* a UUID prefix — a full UUID
+    /// is a prefix of itself, so an exact id works.
     pub user_id: Option<String>,
     /// Exact `agent_type` match (e.g. "claude", "codex").
     pub agent_type: Option<String>,
-    /// Inclusive lower bound on `last_activity` (ISO date/datetime prefix).
+    /// Inclusive lower bound on `last_activity` (`YYYY-MM-DD` or RFC3339).
     pub from: Option<String>,
-    /// Inclusive upper bound on `last_activity` (ISO date prefix; compared as
-    /// `< to~` — `~` sorts above any ISO time char — so a bare `YYYY-MM-DD`
-    /// includes that whole day).
+    /// Inclusive upper bound on `last_activity`; the backend widens a bare
+    /// `YYYY-MM-DD` to the end of that day.
     pub to: Option<String>,
     /// Case-insensitive substring match on `session_name`.
     pub query: Option<String>,
 }
 
 impl SessionFilter {
-    fn matches(&self, s: &HistorySessionSummary) -> bool {
-        if let Some(user) = non_empty(&self.user_id) {
-            if s.user_id != *user {
-                return false;
+    /// Build the `/api/history/sessions` query string for this filter and page.
+    ///
+    /// Values are percent-encoded; blank/whitespace-only fields are omitted
+    /// rather than sent empty, so a cleared control is a removed constraint
+    /// instead of a match-nothing one.
+    pub fn to_query(&self, offset: usize, limit: usize) -> String {
+        let mut parts = vec![format!("limit={limit}"), format!("offset={offset}")];
+        for (key, value) in [
+            ("user", &self.user_id),
+            ("agent", &self.agent_type),
+            ("from", &self.from),
+            ("to", &self.to),
+            ("q", &self.query),
+        ] {
+            if let Some(v) = non_empty(value) {
+                parts.push(format!("{key}={}", encode_component(v)));
             }
         }
-        if let Some(agent) = non_empty(&self.agent_type) {
-            if s.agent_type != *agent {
-                return false;
-            }
-        }
-        if let Some(from) = non_empty(&self.from) {
-            if s.last_activity.as_str() < from.as_str() {
-                return false;
-            }
-        }
-        if let Some(to) = non_empty(&self.to) {
-            let upper = format!("{to}~");
-            if s.last_activity.as_str() >= upper.as_str() {
-                return false;
-            }
-        }
-        if let Some(q) = non_empty(&self.query) {
-            if !s.session_name.to_lowercase().contains(&q.to_lowercase()) {
-                return false;
-            }
-        }
-        true
+        parts.join("&")
     }
 }
 
-fn non_empty(opt: &Option<String>) -> Option<&String> {
-    opt.as_ref().filter(|s| !s.trim().is_empty())
+fn non_empty(opt: &Option<String>) -> Option<&str> {
+    opt.as_deref().map(str::trim).filter(|s| !s.is_empty())
 }
 
-/// Filter then sort by `last_activity` descending (newest first). Ties break
-/// on `session_name` for a stable, human-predictable order.
-pub fn filter_and_sort(
-    sessions: &[HistorySessionSummary],
-    filter: &SessionFilter,
-) -> Vec<HistorySessionSummary> {
-    let mut out: Vec<HistorySessionSummary> = sessions
-        .iter()
-        .filter(|s| filter.matches(s))
-        .cloned()
-        .collect();
-    out.sort_by(|a, b| {
-        b.last_activity
-            .cmp(&a.last_activity)
-            .then_with(|| a.session_name.cmp(&b.session_name))
-    });
+/// Percent-encode everything outside the unreserved set. Hand-rolled to keep
+/// `shared`/frontend free of a URL-encoding dependency for five short values.
+fn encode_component(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*byte as char)
+            }
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
     out
 }
 
@@ -83,71 +72,48 @@ pub fn filter_and_sort(
 mod tests {
     use super::*;
 
-    fn session(name: &str, user: &str, agent: &str, last: &str) -> HistorySessionSummary {
-        HistorySessionSummary {
-            session_id: format!("sess-{name}"),
-            user_id: user.into(),
-            owner_email: format!("{user}@x.io"),
-            owner_name: None,
-            session_name: name.into(),
-            agent_type: agent.into(),
-            status: "archived".into(),
-            hostname: "host".into(),
-            created_at: last.into(),
-            last_activity: last.into(),
-            total_cost_usd: 0.0,
-            message_count: 0,
-            media_count: 0,
-            models: vec![],
-        }
-    }
-
-    fn corpus() -> Vec<HistorySessionSummary> {
-        vec![
-            session("alpha", "u1", "claude", "2026-07-01T10:00:00"),
-            session("beta", "u2", "codex", "2026-07-03T10:00:00"),
-            session("gamma", "u1", "codex", "2026-07-02T10:00:00"),
-        ]
+    #[test]
+    fn empty_filter_sends_only_paging() {
+        assert_eq!(
+            SessionFilter::default().to_query(0, 50),
+            "limit=50&offset=0"
+        );
     }
 
     #[test]
-    fn sorts_by_last_activity_desc() {
-        let out = filter_and_sort(&corpus(), &SessionFilter::default());
-        let names: Vec<_> = out.iter().map(|s| s.session_name.as_str()).collect();
-        assert_eq!(names, vec!["beta", "gamma", "alpha"]);
-    }
-
-    #[test]
-    fn filters_by_user_and_agent() {
-        let filter = SessionFilter {
+    fn set_fields_are_appended_in_a_stable_order() {
+        let f = SessionFilter {
             user_id: Some("u1".into()),
             agent_type: Some("codex".into()),
-            ..Default::default()
+            from: Some("2026-07-01".into()),
+            to: Some("2026-07-31".into()),
+            query: Some("refactor".into()),
         };
-        let out = filter_and_sort(&corpus(), &filter);
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].session_name, "gamma");
+        assert_eq!(
+            f.to_query(100, 50),
+            "limit=50&offset=100&user=u1&agent=codex&from=2026-07-01&to=2026-07-31&q=refactor"
+        );
     }
 
     #[test]
-    fn filters_by_date_range_inclusive_of_day() {
-        let filter = SessionFilter {
-            from: Some("2026-07-02".into()),
-            to: Some("2026-07-03".into()),
-            ..Default::default()
-        };
-        let out = filter_and_sort(&corpus(), &filter);
-        let names: Vec<_> = out.iter().map(|s| s.session_name.as_str()).collect();
-        assert_eq!(names, vec!["beta", "gamma"]);
-    }
-
-    #[test]
-    fn blank_filters_are_no_constraint() {
-        let filter = SessionFilter {
+    fn blank_and_whitespace_fields_are_omitted_not_sent_empty() {
+        let f = SessionFilter {
             user_id: Some("   ".into()),
-            query: Some("".into()),
+            query: Some(String::new()),
             ..Default::default()
         };
-        assert_eq!(filter_and_sort(&corpus(), &filter).len(), 3);
+        assert_eq!(f.to_query(0, 50), "limit=50&offset=0");
+    }
+
+    #[test]
+    fn special_characters_are_percent_encoded() {
+        let f = SessionFilter {
+            query: Some("fix & ship/now?".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            f.to_query(0, 50),
+            "limit=50&offset=0&q=fix%20%26%20ship%2Fnow%3F"
+        );
     }
 }

--- a/frontend/styles/history.css
+++ b/frontend/styles/history.css
@@ -225,3 +225,43 @@
     padding: 0.75rem 1rem;
     margin: 0.5rem 0;
 }
+
+/* --- Pagination --- */
+
+/* Bounds the rendered table only; the endpoint still returns every visible
+   session so the stats strip can total the whole filter. Hidden by the
+   component when there is a single page. */
+.history-root .history-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.history-root .history-page-button {
+    background: var(--bg-darker, #16161e);
+    color: var(--text, #c0caf5);
+    border: 1px solid var(--border, #292e42);
+    border-radius: 6px;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.history-root .history-page-button:hover:not(:disabled) {
+    border-color: var(--accent, #7aa2f7);
+    color: var(--accent, #7aa2f7);
+}
+
+.history-root .history-page-button:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.history-root .history-page-status {
+    font-size: 0.8rem;
+    color: var(--text-dim, #7f849c);
+    font-variant-numeric: tabular-nums;
+}

--- a/shared/src/api/history.rs
+++ b/shared/src/api/history.rs
@@ -10,13 +10,64 @@
 
 use serde::{Deserialize, Serialize};
 
-/// `GET /api/history/sessions` response.
+/// Rows per page when the caller doesn't say.
+pub const DEFAULT_HISTORY_PAGE_SIZE: usize = 50;
+/// Upper bound on `limit`, so a caller can't ask for the whole archive again.
+pub const MAX_HISTORY_PAGE_SIZE: usize = 200;
+
+/// `GET /api/history/sessions` response — **one page** of rows plus the
+/// whole-result-set facts the UI needs alongside it.
+///
+/// The page alone isn't enough to render the browser: the stats strip totals the
+/// entire filtered set, and the admin user dropdown lists every owner. Deriving
+/// either from `sessions` would silently start describing one page, so both are
+/// computed server-side over all matching rows and returned here.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HistorySessionsResponse {
-    /// Visible archived sessions, most recently active first.
+    /// This page of archived sessions, most recently active first.
     pub sessions: Vec<HistorySessionSummary>,
     /// Whether the caller is an admin (drives the all-users filter UI).
     pub is_admin: bool,
+    /// Rows matching the filter *before* paging — drives the page count.
+    #[serde(default)]
+    pub total: i64,
+    /// Aggregates over every matching row, not just this page.
+    #[serde(default)]
+    pub totals: HistoryTotals,
+    /// Per-owner rollup, admin-only, computed over rows matching every filter
+    /// **except** `user`.
+    ///
+    /// That one exclusion lets a single list serve both consumers: the dropdown
+    /// shows every owner (so picking one doesn't shrink the options), and the
+    /// per-user tiles stay correct because selecting a user just narrows this
+    /// list to that entry.
+    #[serde(default)]
+    pub owners: Vec<HistoryOwnerRollup>,
+}
+
+/// Totals across every row matching the active filter.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+pub struct HistoryTotals {
+    #[serde(default)]
+    pub session_count: i64,
+    #[serde(default)]
+    pub message_count: i64,
+    #[serde(default)]
+    pub total_cost_usd: f64,
+}
+
+/// One owner's slice of the filtered set (admin stats tiles + user dropdown).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HistoryOwnerRollup {
+    pub user_id: String,
+    /// Display name, falling back to email then id — resolved server-side so
+    /// the label is stable even when the owner has no session on this page.
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub session_count: i64,
+    #[serde(default)]
+    pub total_cost_usd: f64,
 }
 
 /// One archived session the caller may view.


### PR DESCRIPTION
`GET /api/history/sessions` returned **every** visible archived session in one response, and the browser filtered, sorted and rendered the whole set. Payload and table both grew without bound.

## API

`limit` (default 50, clamped `1..=200`) and `offset`. Filtering and sorting move to the server, which already accepted `user`/`agent`/`q`/`from`/`to` but was never asked for them.

A page alone can't render the browser — the stats strip totals the entire filtered set and the admin dropdown lists every owner. Deriving either from the page would silently make them describe 50 rows instead of the archive, so the response carries the whole-set facts alongside:

```jsonc
{
  "sessions": [ /* this page */ ],
  "total": 137,
  "totals": { "session_count": 137, "message_count": 676, "total_cost_usd": 93.16 },
  "owners": [ { "user_id": "…", "label": "Alice", "session_count": 69, "total_cost_usd": 47.2 } ],
  "is_admin": true
}
```

**`owners` applies every filter except `user`.** That one exclusion lets a single list serve both consumers: the dropdown keeps listing everyone (so picking a user doesn't shrink the options), while the per-user tiles stay correct because selecting a user just narrows the list to that entry.

## Details that matter

- **Sorting now tie-breaks on `session_name`.** Equal `last_activity` values under an unstable sort would let a row repeat on one page and vanish from the next.
- **Filter edits reset the page in the same update**, via a whole-filter callback. A separate reset effect would observe the new filter with the old page, fetch, then reset and fetch again — doubling every request.
- **250 ms debounce**, cancelled on supersede. Typing mutates the filter per keystroke and each request re-filters the archive.
- **Negative zero normalised.** Rust's `Sum for f64` folds from `-0.0`, so an empty result set serialised `total_cost_usd: -0.0` and would render `$-0.00`.
- **Client-side `filter_and_sort` deleted.** The client only ever holds one page, so filtering it would narrow a page rather than the archive. `SessionFilter` now builds query params instead.

`scan_rows()` is already TTL-cached, so page turns hit a warm cache rather than rescanning the archive.

## Verification

Against a local archive of 137 generated sessions across two owners:

| Check | Result |
|---|---|
| Pages 1/2/3 | 50 + 50 + 37 = 137, contiguous, descending |
| Totals across pages | identical on every page |
| `offset` past end | 0 rows, `total` still 137 |
| `limit=0` / `limit=9999` | clamps to 1 / 200 |
| `agent=codex` | 46 rows, all codex |
| `q=session-01` | 10 rows |
| Date window | `to` inclusive of that whole day |
| `user=<alice>` | `total` → 69, **`owners` still lists both** |

Plus unit tests for the page-window math (exact multiples, short tail, stale index, zero rows, and a loop asserting every window is a valid slice) and for query-param construction (omission of blanks, percent-encoding).