### PR TITLE
Stop gap and margin double-counting the space between blocks

### DIFF
--- a/frontend/src/pages/admin/subdomains_tab.rs
+++ b/frontend/src/pages/admin/subdomains_tab.rs
@@ -142,7 +142,7 @@ pub fn admin_subdomains_tab() -> Html {
         .unwrap_or_default();
 
     html! {
-        <section class="admin-subdomains">
+        <section class="section-stack admin-subdomains">
             <div class="section-header">
                 <h2>{ "Custom Subdomains" }</h2>
                 <p class="section-description">

--- a/frontend/src/pages/settings/appearance_panel.rs
+++ b/frontend/src/pages/settings/appearance_panel.rs
@@ -38,7 +38,7 @@ pub fn appearance_panel() -> Html {
     };
 
     html! {
-        <section class="appearance-section">
+        <section class="section-stack">
             <div class="section-header">
                 <h2>{ "Appearance" }</h2>
                 <p class="section-description">

--- a/frontend/src/pages/settings/forwarding_panel.rs
+++ b/frontend/src/pages/settings/forwarding_panel.rs
@@ -58,7 +58,7 @@ pub fn forwarding_panel() -> Html {
     };
 
     html! {
-        <section class="forwarding-section">
+        <section class="section-stack forwarding-section">
             <div class="section-header">
                 <h2>{ "Port Forwarding" }</h2>
                 <p class="section-description">

--- a/frontend/src/pages/settings/health_timer_panel.rs
+++ b/frontend/src/pages/settings/health_timer_panel.rs
@@ -49,7 +49,7 @@ pub fn health_timer_panel() -> Html {
     };
 
     html! {
-        <section class="health-settings-section">
+        <section class="section-stack health-settings-section">
             <div class="section-header">
                 <h2>{ "Health timer" }</h2>
                 <p class="section-description">

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -693,7 +693,7 @@ pub fn launchers_panel() -> Html {
     let has_rows = !launchers.is_empty() || !phantom.is_empty();
 
     html! {
-        <section class="tokens-section">
+        <section class="section-stack tokens-section">
             <div class="section-header">
                 <h2>{ "Launchers" }</h2>
                 <p class="section-description">

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -1,26 +1,20 @@
-mod agent_install;
-mod agent_login;
-mod agents_panel;
 mod appearance_panel;
 mod forwarding_panel;
 mod health_timer_panel;
 mod launchers_panel;
 mod notifications_panel;
 mod performance_panel;
-mod profile_panel;
 mod sessions_panel;
 mod sounds_panel;
 mod tokens_panel;
 
 use crate::utils;
-use agents_panel::AgentsPanel;
 use appearance_panel::AppearancePanel;
 use forwarding_panel::ForwardingPanel;
 use health_timer_panel::HealthTimerPanel;
 use launchers_panel::LaunchersPanel;
 use notifications_panel::NotificationsPanel;
 use performance_panel::PerformancePanel;
-use profile_panel::ProfilePanel;
 use sessions_panel::SessionsPanel;
 use shared::{ProxyTokenInfo, SessionInfo};
 use sounds_panel::SoundsPanel;
@@ -29,8 +23,6 @@ use yew::prelude::*;
 
 #[derive(Clone, Copy, PartialEq)]
 enum SettingsTab {
-    Profile,
-    Agents,
     Sessions,
     Tokens,
     Launchers,
@@ -75,8 +67,6 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
         let active_tab = active_tab.clone();
         Callback::from(move |_: MouseEvent| active_tab.set(tab))
     };
-    let on_profile_tab = make_tab_handler(SettingsTab::Profile);
-    let on_agents_tab = make_tab_handler(SettingsTab::Agents);
     let on_sessions_tab = make_tab_handler(SettingsTab::Sessions);
     let on_tokens_tab = make_tab_handler(SettingsTab::Tokens);
     let on_launchers_tab = make_tab_handler(SettingsTab::Launchers);
@@ -105,18 +95,6 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
             </header>
 
             <nav class="settings-tabs">
-                <button
-                    class={classes!("tab-button", (*active_tab == SettingsTab::Profile).then_some("active"))}
-                    onclick={on_profile_tab}
-                >
-                    { "Profile" }
-                </button>
-                <button
-                    class={classes!("tab-button", (*active_tab == SettingsTab::Agents).then_some("active"))}
-                    onclick={on_agents_tab}
-                >
-                    { "Agents" }
-                </button>
                 <button
                     class={classes!("tab-button", (*active_tab == SettingsTab::Sessions).then_some("active"))}
                     onclick={on_sessions_tab}
@@ -195,12 +173,6 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                 }
                 if *active_tab == SettingsTab::HealthTimer {
                     <HealthTimerPanel />
-                }
-                if *active_tab == SettingsTab::Profile {
-                    <ProfilePanel />
-                }
-                if *active_tab == SettingsTab::Agents {
-                    <AgentsPanel />
                 }
                 if *active_tab == SettingsTab::Sessions {
                     <SessionsPanel on_sessions_loaded={on_sessions_loaded} />

--- a/frontend/src/pages/settings/notifications_panel.rs
+++ b/frontend/src/pages/settings/notifications_panel.rs
@@ -164,7 +164,7 @@ pub fn notifications_panel() -> Html {
     };
 
     html! {
-        <section class="notifications-section">
+        <section class="section-stack notifications-section">
             <div class="section-header">
                 <h2>{ "Push Notifications" }</h2>
                 <p class="section-description">

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -59,7 +59,7 @@ pub fn performance_panel() -> Html {
     };
 
     html! {
-        <section class="performance-panel">
+        <section class="section-stack">
             <div class="section-header">
                 <h2>{ "Performance" }</h2>
                 <p class="section-description">

--- a/frontend/src/pages/settings/sessions_panel.rs
+++ b/frontend/src/pages/settings/sessions_panel.rs
@@ -181,7 +181,7 @@ pub fn sessions_panel(props: &SessionsPanelProps) -> Html {
 
     html! {
         <>
-            <section class="sessions-section">
+            <section class="section-stack sessions-section">
                 <div class="section-header">
                     <h2>{ "Session History" }</h2>
                     <p class="section-description">

--- a/frontend/src/pages/settings/sounds_panel.rs
+++ b/frontend/src/pages/settings/sounds_panel.rs
@@ -111,7 +111,7 @@ pub fn sounds_panel() -> Html {
 
     if *loading {
         return html! {
-            <section class="sounds-section">
+            <section class="section-stack sounds-section">
                 <div class="loading">
                     <div class="spinner"></div>
                     <p>{ "Loading sound settings..." }</p>
@@ -121,7 +121,7 @@ pub fn sounds_panel() -> Html {
     }
 
     html! {
-        <section class="sounds-section">
+        <section class="section-stack sounds-section">
             <div class="section-header">
                 <h2>{ "Sound Notifications" }</h2>
                 <p class="section-description">

--- a/frontend/src/pages/settings/tokens_panel.rs
+++ b/frontend/src/pages/settings/tokens_panel.rs
@@ -389,7 +389,7 @@ pub fn tokens_panel(props: &TokensPanelProps) -> Html {
 
     html! {
         <>
-            <section class="tokens-section">
+            <section class="section-stack tokens-section">
                 <div class="section-header">
                     <h2>{ "Proxy Credentials" }</h2>
                     <p class="section-description">

--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -402,9 +402,10 @@
 }
 
 /* Admin ▸ Subdomains */
-.admin-subdomains .section-header {
-    margin-bottom: 1rem;
-}
+
+/* No `.section-header` margin override here: `.section-stack` owns the spacing
+   below the header now. A descendant override would also out-specify the
+   shell's `> *` margin reset (0-2-0 vs 0-1-0) and silently re-add to the gap. */
 
 .subdomain-create {
     display: flex;

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -509,8 +509,10 @@
     font-size: 0.75rem;
 }
 
+/* No `margin-top`: the only parent is `.tool-use`, which is a flex column with
+   `gap: 0.25rem`. Flex margins add to `gap` rather than collapsing into it, so a
+   margin here rendered the gap below the tool header at 0.75rem — 3x intended. */
 .write-preview {
-    margin-top: 0.5rem;
     border-radius: 4px;
     overflow: hidden;
     background: rgba(0, 0, 0, 0.2);

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -876,12 +876,30 @@
     opacity: 0.6;
 }
 
-/* When a thinking block leads its group part, the grouped body's flex `gap`
-   already separates it from the block above — its own top margin then
-   double-counts into unusual headroom above the "THINKING" label. Drop the
-   redundant top margin in that leading position only. */
-.grouped-message-part > .thinking-block:first-child {
-    margin-top: 0;
+/* Inside a grouped body the flex `gap` is the single source of inter-part
+   spacing. Flex item margins do NOT collapse into `gap` — they add to it — so
+   any part whose outermost element carries its own vertical margin
+   double-counts every boundary. `.thinking-block` and `.tool-use` both ship
+   `margin: 0.5rem 0`, making an intended 8px gap render as 16px.
+   Neutralise once at the boundary rather than per part type: these are the
+   outermost elements of each part, so their vertical margin is purely
+   inter-part spacing that `gap` now owns. Descendants are untouched (direct
+   child selector), and the standalone `.thinking-block` / `.tool-use` margins
+   still apply in a plain `.message-body` — e.g. the codex reasoning card —
+   which has no `gap` to inherit from.
+   This replaces a narrower fix that zeroed only `margin-top`, and only for
+   `:first-child`: it cured the headroom above a leading "THINKING" label but
+   left `margin-bottom` double-counting at every boundary below it.
+ *
+ * `> [class]` rather than `> *` is deliberate, and load-bearing. `> *` scores
+ * 0-1-0, exactly tying every single-class rule it needs to override, so the
+ * winner would be decided by stylesheet source order — and `markdown.css`
+ * (`.tool-use`) loads *after* this file in index.html, so the tie went the wrong
+ * way and the reset silently did nothing for tool cards. The attribute selector
+ * makes it 0-2-0, which wins regardless of file order. Every part's outermost
+ * element carries a class, so coverage is unchanged. */
+.grouped-message-part > [class] {
+    margin-block: 0;
 }
 
 .thinking-label {

--- a/frontend/styles/performance.css
+++ b/frontend/styles/performance.css
@@ -3,11 +3,9 @@
    Hand-rolled SVG plots over /api/metrics/turns. Tokyo-Night palette.
    ============================================================================= */
 
-.performance-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-}
+/* The stack (column + gap) comes from `.section-stack` in settings.css, shared
+   with every other settings/admin panel. This panel's old 1.25rem gap is now the
+   common 1.5rem — a 4px change, taken deliberately in favour of one mechanism. */
 
 .performance-controls {
     display: flex;

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -91,13 +91,49 @@
     overflow-y: auto;
 }
 
+/* Section shell — the vertical stack every settings/admin panel is built from.
+   Its `gap` is the single source of spacing between the blocks inside it
+   (header, cards, lists, loading/empty states).
+ *
+ * Spacing lives on the shell rather than on the blocks because flex/grid item
+ * margins do NOT collapse into `gap` — they add to it. So any child carrying its
+ * own vertical margin double-counts every boundary. `.section-header` used to
+ * own the spacing below itself with `margin-bottom: 1.5rem`, which rendered at
+ * 3rem inside `.appearance-section` and 2.75rem inside `.performance-panel`
+ * (both already had a `gap`) while being correct in the shells that didn't.
+ * One mechanism in one place removes the whole class of bug, and the reset below
+ * keeps it from returning as children acquire margins.
+ *
+ * Sections keep their own class for what is genuinely theirs (`max-width`,
+ * colours); they should not redeclare the stack. */
+.section-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+/* Direct children only: a block's outermost vertical margin is inter-block
+   spacing, which the shell owns. Anything nested deeper keeps its margins.
+ *
+ * `> [class]` rather than `> *`: `> *` scores 0-1-0, which merely *ties* the
+ * single-class rules it must override (`.notification-prefs`, `.sound-toggle`,
+ * `.subdomain-create`), leaving stylesheet source order to decide — and all
+ * three are declared after this rule, so the reset would lose and do nothing.
+ * The attribute selector makes it 0-2-0, which wins regardless of order,
+ * including across files. Every child here carries a class.
+ *
+ * Those children keep their own margin declarations on purpose: they are correct
+ * outside a shell, so this scopes the removal to where `gap` actually applies. */
+.section-stack > [class] {
+    margin-block: 0;
+}
+
 .section-header {
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
-    margin-bottom: 1.5rem;
 }
 
 .section-header h2 {
@@ -930,285 +966,8 @@
    Appearance panel
    ========================================================================== */
 
-.agents-section {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-.link-button {
-    background: none;
-    border: none;
-    color: var(--accent);
-    cursor: pointer;
-    padding: 0;
-    font: inherit;
-    text-decoration: underline;
-}
-
-.agents-matrix {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.9rem;
-}
-
-.agents-matrix th,
-.agents-matrix td {
-    text-align: left;
-    padding: 0.6rem 0.75rem;
-    border-bottom: 1px solid var(--border);
-    vertical-align: top;
-}
-
-.agents-matrix th {
-    color: var(--text-secondary);
-    font-weight: 600;
-}
-
-.agents-host-name {
-    font-family: var(--font-mono, monospace);
-    color: var(--text-primary);
-}
-
-.agents-host-alias {
-    color: var(--text-secondary);
-    margin-left: 0.4rem;
-    font-size: 0.8rem;
-}
-
-.agents-cell {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-}
-
-.agents-cell.unreachable,
-.agents-cell.unknown,
-.agents-cell.loading {
-    color: var(--text-secondary);
-}
-
-.agents-badge {
-    display: inline-block;
-    width: fit-content;
-    padding: 0.05rem 0.4rem;
-    border-radius: 4px;
-    font-size: 0.75rem;
-}
-
-.agents-badge.installed {
-    background: color-mix(in srgb, var(--success, #9ece6a) 20%, transparent);
-    color: var(--success, #9ece6a);
-}
-
-.agents-badge.missing {
-    background: color-mix(in srgb, var(--error, #f7768e) 18%, transparent);
-    color: var(--error, #f7768e);
-}
-
-.agents-login {
-    font-size: 0.8rem;
-}
-
-.agents-login.logged-in {
-    color: var(--success, #9ece6a);
-}
-
-.agents-login.logged-out {
-    color: var(--error, #f7768e);
-}
-
-.agents-login.unknown {
-    color: var(--text-secondary);
-}
-
-.agents-signin {
-    width: fit-content;
-    margin-top: 0.15rem;
-    padding: 0.1rem 0.5rem;
-    font-size: 0.75rem;
-    border: 1px solid var(--accent, #7aa2f7);
-    border-radius: 4px;
-    background: transparent;
-    color: var(--accent, #7aa2f7);
-    cursor: pointer;
-}
-
-.agents-signin:hover {
-    background: color-mix(in srgb, var(--accent, #7aa2f7) 15%, transparent);
-}
-
-/* Interactive sign-in modal (Settings ▸ Agents). */
-.agent-login-overlay {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.55);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-}
-
-.agent-login-modal {
-    background: var(--bg-secondary, #1f2335);
-    border: 1px solid var(--border, #2a2e42);
-    border-radius: 8px;
-    width: min(480px, 92vw);
-    max-height: 90vh;
-    overflow-y: auto;
-    padding: 1rem 1.25rem 1.25rem;
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
-}
-
-.agent-login-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 0.75rem;
-}
-
-.agent-login-header h2 {
-    margin: 0;
-    font-size: 1.1rem;
-}
-
-.agent-login-close {
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    font-size: 1.4rem;
-    line-height: 1;
-    cursor: pointer;
-}
-
-.agent-login-body {
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-}
-
-.agent-login-instr {
-    margin: 0;
-    color: var(--text-secondary);
-    font-size: 0.85rem;
-}
-
-.agent-login-url {
-    word-break: break-all;
-    font-size: 0.85rem;
-    color: var(--accent, #7aa2f7);
-}
-
-.agent-login-device-code {
-    font-family: var(--font-mono, monospace);
-    font-size: 1.4rem;
-    letter-spacing: 0.15rem;
-    text-align: center;
-    padding: 0.5rem;
-    border: 1px dashed var(--border, #2a2e42);
-    border-radius: 6px;
-}
-
-.agent-login-code-row {
-    display: flex;
-    gap: 0.5rem;
-}
-
-.agent-login-code-input {
-    flex: 1;
-    padding: 0.35rem 0.5rem;
-    border: 1px solid var(--border, #2a2e42);
-    border-radius: 4px;
-    background: var(--bg-primary, #1a1b26);
-    color: var(--text-primary, #c0caf5);
-}
-
-.agent-login-submit {
-    padding: 0.35rem 0.75rem;
-    border: 1px solid var(--accent, #7aa2f7);
-    border-radius: 4px;
-    background: var(--accent, #7aa2f7);
-    color: var(--bg-primary, #1a1b26);
-    cursor: pointer;
-}
-
-.agent-login-submit:disabled {
-    opacity: 0.5;
-    cursor: default;
-}
-
-.agent-login-status {
-    margin: 0;
-    font-size: 0.9rem;
-}
-
-.agent-login-status.success {
-    color: var(--success, #9ece6a);
-}
-
-.agent-login-status.error {
-    color: var(--error, #f7768e);
-}
-
-.agent-login-footer {
-    margin-top: 1rem;
-    display: flex;
-    justify-content: flex-end;
-}
-
-.agent-install-command {
-    display: block;
-    font-family: var(--font-mono, monospace);
-    font-size: 0.85rem;
-    padding: 0.5rem 0.6rem;
-    border: 1px solid var(--border, #2a2e42);
-    border-radius: 6px;
-    background: var(--bg-primary, #1a1b26);
-    word-break: break-all;
-}
-
-.profile-section {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-}
-
-.profile-setting {
-    background: var(--bg-darker);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 1.25rem;
-}
-
-.profile-setting h3 {
-    margin: 0 0 0.25rem 0;
-    font-size: 1rem;
-    color: var(--text-primary);
-}
-
-.profile-nickname-input {
-    width: 100%;
-    box-sizing: border-box;
-    padding: 0.5rem 0.75rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    color: var(--text-primary);
-    font-size: 0.95rem;
-}
-
-.profile-save-row {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-top: 1rem;
-}
-
-.appearance-section {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-}
+/* Stack behaviour comes from `.section-stack`; nothing else is specific to this
+   panel, so the rule is gone rather than left as a duplicate. */
 
 .appearance-setting {
     background: var(--bg-darker);


### PR DESCRIPTION
Reported as "a lot of vertical space between messages", found via DevTools on `.grouped-message-body`. The root cause turned out to be systemic, so this fixes the class of bug rather than the one instance.

## The rule being broken

**Flex/grid item margins do not collapse into `gap` — they add to it.** Several containers set both, so boundaries rendered at 2–3× their intended spacing.

## Message groups

`.grouped-message-body` is a flex column with `gap: 0.5rem`, but `.thinking-block` and `.tool-use` each also carry `margin: 0.5rem 0` → an intended 8px gap renders as 16px.

There was already a partial fix with a comment diagnosing exactly this — but it zeroed only `margin-top`, and only for `:first-child`. That cured the headroom above a leading `THINKING` label and left `margin-bottom` double-counting at every boundary below it. Now neutralised once at the boundary instead of per part type.

Same fault one level down: `.tool-use` has `gap: 0.25rem` and `.write-preview` added `margin-top: 0.5rem` — **3× intended**, on every Write tool card.

## Settings and admin panels

An audit of all 157 `gap` containers against 140 margin-bearing classes turned up `.section-header`, which is *both* a gap container *and* carries `margin-bottom: 1.5rem`:

| Parent | Parent gap | Rendered | Intended |
|---|---|---|---|
| `.appearance-section` | 1.5rem | **3rem** | 1.5rem |
| `.performance-panel` | 1.25rem | **2.75rem** | 1.25rem |

Overriding per parent is brittle — a fourth gap parent silently reintroduces it. Instead there's now one shared **`.section-stack`** shell (flex column, `gap: 1.5rem`) used by all 11 section sites, owning the spacing. `.appearance-section` and `.performance-panel` had nothing left but the stack declarations afterwards, so those rules and their now-unused markup classes are gone.

## The `> [class]` selector is load-bearing

The resets use `> [class]`, not `> *`. `> *` scores **0-1-0**, which merely *ties* every single-class rule it must override, leaving stylesheet source order to break it — and `markdown.css` loads after `messages.css` (`index.html:78-79`), so `.tool-use` won the tie and my first version of the reset silently did nothing. The attribute selector makes it 0-2-0 and wins regardless of file order. Every child here carries a class, so coverage is unchanged.

Also removes `.admin-subdomains .section-header { margin-bottom: 1rem }`, which at 0-2-0 would have out-specified even the fixed reset and re-added to the gap.

Children keep their own margin declarations on purpose — they're correct outside a shell, so the reset scopes the removal to where `gap` actually applies.

## Expected visible changes

| Where | Before | After |
|---|---|---|
| Message group boundaries | 16px | 8px |
| Write tool card preview | 0.75rem | 0.25rem |
| Settings ▸ Appearance header | 3rem | 1.5rem |
| Settings ▸ Performance header | 2.75rem | 1.5rem |
| Performance inter-block | 1.25rem | 1.5rem |
| Admin ▸ Subdomains, below create row | 0.5rem | 1.5rem |
| Notifications, Sounds | 1.5rem | unchanged (margins were already collapsing to 1.5rem) |

Ruled out as false positives during the audit: `.feature`, `.divider-line`, `.option-content` children, `.launch-checkbox` children, `.toggle-label > .section-description`, `.appearance-setting` — in each case the margin is on a descendant or the elements are siblings.

## Verification

CSS lint and clippy clean. Not observed rendering — the spacing arithmetic is stated per row above so it can be checked against the deploy.