### PR TITLE
Muse backend: verify agent-agnostic persistence, surface impossible serialize branch

### DIFF
--- a/muse-session-lib/src/classifier.rs
+++ b/muse-session-lib/src/classifier.rs
@@ -130,12 +130,34 @@ struct MuseDecodeError<'a> {
     record_id: &'a str,
 }
 
-/// Serialization of these local structs cannot fail (no maps with
-/// non-string keys, no failing custom impls), so a failure here would be a
-/// bug in this module rather than a runtime condition — surface it as a
-/// null payload instead of panicking in a session's hot path.
+/// Serialization of these local structs cannot fail today (no maps with
+/// non-string keys, no failing custom impls), so a failure would be a bug
+/// in this module rather than a runtime condition.
+///
+/// Panicking in a session's I/O hot path over a provably-impossible branch
+/// would be worse than the impossible thing. But a silent `Value::Null`
+/// would be the one place in this file that can go quiet later: if a future
+/// refactor adds a non-string-keyed field, the failure would vanish into
+/// the stream looking like nothing happened. So the impossible branch
+/// surfaces as a visible, persisted error instead — same no-silent-gap rule
+/// the rest of this module follows.
 fn to_value<T: Serialize>(value: &T) -> serde_json::Value {
-    serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
+    match serde_json::to_value(value) {
+        Ok(v) => v,
+        Err(e) => serde_json::to_value(SerializeFailure {
+            kind: "muse_wire_serialize_error",
+            error: e.to_string(),
+        })
+        .unwrap_or(serde_json::Value::Null),
+    }
+}
+
+/// Emitted only if serializing a wire event ever fails — see [`to_value`].
+#[derive(Debug, Serialize)]
+struct SerializeFailure {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    error: String,
 }
 
 #[cfg(test)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1398,3 +1398,24 @@ mod muse_install_command_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod agent_type_parse_roundtrip {
+    use super::*;
+
+    /// The backend stores `agent_type` as a string and parses it back with
+    /// `.parse().unwrap_or(Claude)` in nine places. If `"muse"` failed to
+    /// parse, every muse session would silently be treated as Claude —
+    /// a data-integrity bug with no error anywhere. This pins the round
+    /// trip for every variant so adding one can't reintroduce that.
+    #[test]
+    fn every_agent_type_round_trips_through_its_string_form() {
+        for agent in [AgentType::Claude, AgentType::Codex, AgentType::Muse] {
+            let s = agent.as_str();
+            let parsed: AgentType = s.parse().unwrap_or_else(|_| {
+                panic!("{s} must parse back; the backend's unwrap_or(Claude) would mask it")
+            });
+            assert_eq!(parsed, agent, "{s} round trip");
+        }
+    }
+}


### PR DESCRIPTION
Plan-PR-3 of #1563 — and it is **much smaller than the plan predicted**, because investigation showed the backend is already agent-agnostic.

## The finding: no backend changes were needed

The plan called for routing muse sessions through the supervisor and adding persistence handling. Auditing the backend found only **nine** `AgentType` references, every one a `.parse().unwrap_or(Claude)` fallback over a string column — no enum constraint, no per-agent branch in the insert path, no migration required. Since `"muse"` parses (added in #1567), muse sessions persist correctly as-is.

Rather than manufacture changes, this PR pins the property that makes that true and closes a review item.

## What is here

1. **`AgentType` round-trip test.** The backend parses `agent_type` back from its stored string in nine places via `.parse().unwrap_or(Claude)`. A variant that failed to parse would silently run as **Claude** — wrong agent, wrong behavior, no error anywhere. The test asserts the round trip for every variant so adding one cannot reintroduce that.

2. **The deferred classifier refinement** from #1568 review: the impossible serialization branch now emits a visible `muse_wire_serialize_error` instead of a silent `Value::Null`. Still non-fatal — panicking a session I/O hot path over a provably-impossible branch would be worse than the impossible thing — but if a future refactor ever makes it possible, it surfaces persisted and visible rather than vanishing into the stream.

## Also verified, not changed

Muse records persist with `role = Unknown` (their `type` is `muse_record`). That matches existing **codex** behavior — codex emits `thread.started` / `turn.completed`, which map to `Unknown` too — so it is the established pattern for non-Claude agents, not a muse regression. Flagging rather than unilaterally changing a shared enum.

## Scope

Deliberately untouched: `ProxyToServer`/`ServerToClient`, `proxy_socket.rs`, and `session_view/*` — the Ephemeral transport is in flight on `meawoppl/ephemeral-side-channel` and is not mine.