### PR TITLE
Add a neutral ephemeral live-status side-channel

### DIFF
--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -475,6 +475,18 @@ fn handle_proxy_message(
                 );
             }
         }
+        ProxyToServer::Ephemeral {
+            session_id: _,
+            payload,
+        } => {
+            // Neutral ephemeral live-status (muse deltas / task status): fan out
+            // to web clients only — NO DB write, same contract as ToolProgress.
+            // Evaporates if no client is connected.
+            if let Some(key) = session_key {
+                session_manager
+                    .broadcast_to_web_clients(key, shared::ServerToClient::Ephemeral { payload });
+            }
+        }
         ProxyToServer::SessionLimitReached(fields) => {
             handle_session_limit_reached(
                 app_state,

--- a/claude-session-lib/src/proxy_session/session_event.rs
+++ b/claude-session-lib/src/proxy_session/session_event.rs
@@ -124,6 +124,26 @@ pub(super) async fn handle_next_event<A: Agent>(
         return None;
     }
 
+    // Neutral ephemeral live-status (muse's streamed deltas / task status):
+    // forward as a typed side-channel exactly like `ToolProgress` above.
+    // Deliberately bypasses the output buffer — live-status only, never
+    // persisted or replayed. The backend fans it out to web clients (never to
+    // the DB); if nobody is listening it evaporates.
+    if let Some(SessionEvent::Ephemeral(payload)) = event {
+        let msg = ProxyToServer::Ephemeral {
+            session_id: state.session_id,
+            payload,
+        };
+        let mut ws = state.ws_write.lock().await;
+        if ws.send(msg).await.is_err() {
+            error!("Failed to send ephemeral live-status frame");
+            return Some(ConnectionResult::Disconnected(
+                state.connection_start.elapsed(),
+            ));
+        }
+        return None;
+    }
+
     // Codex app-server thread id: hand it to the persistence sink (the proxy's
     // ProxyConfig writer) so the next resume of this session can call
     // `thread/resume` with it. Emitted once per spawn by codex-session-lib.

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -342,16 +342,11 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
             );
         }
         Some(SessionEvent::Ephemeral(_)) => {
-            // Live-status output (muse's streamed deltas / task status).
-            // Deliberately DROPPED here rather than forwarded as RawOutput:
-            // RawOutput persists, and persisting live-status is a mistake
-            // that takes a migration to unwind. The typed side-channel that
-            // carries these to web clients (`ProxyToServer::Ephemeral`,
-            // mirroring `ToolProgress`) lands with the backend fan-out; until
-            // then muse streams are simply not shown mid-turn — the durable
-            // `run.terminal.*` record still carries the full final text.
-            tracing::trace!("dropping ephemeral session event (no side-channel carrier yet)");
-            None
+            // Handled in session_event.rs (forwarded as ProxyToServer::Ephemeral)
+            // before calling this function — same as ToolProgress below.
+            unreachable!(
+                "Ephemeral should be handled before calling handle_session_event_with_wiggum"
+            );
         }
         Some(SessionEvent::ToolProgress { .. }) => {
             // Handled in run_main_loop (session_event::handle_next_event) before

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -27,9 +27,9 @@ use yew::prelude::*;
 use super::forward_chips::ForwardChips;
 use super::helpers::{
     autoscroll_transition, classify_output_msg_type, clear_completed_tools,
-    enrich_codex_file_change_permission, format_tool_elapsed, is_claude_awaiting, parse_iso_ms_utc,
-    reconcile_pending_sends, running_tool_key, update_pending_send_delivery, upsert_tool_progress,
-    ActiveToolProgress, ActivityTag,
+    enrich_codex_file_change_permission, ephemeral_summary, format_tool_elapsed,
+    is_claude_awaiting, parse_iso_ms_utc, reconcile_pending_sends, running_tool_key,
+    update_pending_send_delivery, upsert_tool_progress, ActiveToolProgress, ActivityTag,
 };
 use super::input_bar::{InputBar, InputBarInbound};
 use super::outbox::Outbox;
@@ -265,6 +265,12 @@ pub struct SessionView {
     /// ends. Kept out of the memoized message-render props on purpose (see the
     /// `helpers` tool-progress section).
     active_tools: Vec<ActiveToolProgress>,
+    /// Latest neutral ephemeral live-status line (`WsEvent::Ephemeral`), shown
+    /// as a transient strip at the transcript tail while a turn runs and
+    /// cleared when a durable message arrives. Never persisted. Muse's streamed
+    /// deltas / task status flow here; the rich per-agent view is layered on
+    /// top of this same stream separately.
+    ephemeral_status: Option<String>,
     /// Monotonic tick bumped on every `ForwardsChanged` frame; passed to the
     /// forward-chip strip as a prop so it refetches (docs/PORT_FORWARDING.md).
     forwards_refresh: u32,
@@ -344,6 +350,7 @@ impl Component for SessionView {
             turn_metrics: Vec::new(),
             continuation_statuses: HashMap::new(),
             active_tools: Vec::new(),
+            ephemeral_status: None,
             forwards_refresh: 0,
         }
     }
@@ -676,6 +683,7 @@ impl Component for SessionView {
                             html! { <MessageRenderer key={format!("p{}", i)} message={message.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
                         })}
                         { self.render_active_tools() }
+                        { self.render_ephemeral_status() }
                     </div>
                     if !is_tailing {
                         <button
@@ -807,6 +815,18 @@ impl SessionView {
                 let key = running_tool_key(&tool_use_id, parent_tool_use_id.as_deref());
                 upsert_tool_progress(&mut self.active_tools, key, tool_name, elapsed_time_seconds);
                 true
+            }
+            WsEvent::Ephemeral(payload) => {
+                // Transient live status: replace the strip line. Never touches
+                // `messages` (no persistence, no replay watermark). A frame we
+                // can't summarize is ignored rather than clearing a good line.
+                match ephemeral_summary(&payload) {
+                    Some(summary) => {
+                        self.ephemeral_status = Some(summary);
+                        true
+                    }
+                    None => false,
+                }
             }
         }
     }
@@ -1039,6 +1059,8 @@ impl SessionView {
         // tool_result for the running tool, or a turn `result` that ends the
         // turn entirely. (The live heartbeat side-channel only adds entries.)
         clear_completed_tools(&mut self.active_tools, &output.content);
+        // A durable message supersedes the transient live-status line.
+        self.ephemeral_status = None;
 
         push_message_with_limit(&mut self.messages, output, MAX_MESSAGES_PER_SESSION);
         true
@@ -1067,6 +1089,23 @@ impl SessionView {
                         </div>
                     }
                 }) }
+            </div>
+        }
+    }
+
+    /// Transient live-status strip fed by the neutral `WsEvent::Ephemeral`
+    /// channel (muse's streamed deltas / task status). One line, replaced per
+    /// frame, cleared when a durable message arrives. Renders nothing when
+    /// idle. Deliberately minimal — a placeholder the per-agent live view
+    /// (muse's task tree) replaces, not a base to extend.
+    fn render_ephemeral_status(&self) -> Html {
+        let Some(status) = self.ephemeral_status.as_deref() else {
+            return html! {};
+        };
+        html! {
+            <div class="ephemeral-status-strip">
+                <span class="ephemeral-status-spinner" />
+                <span class="ephemeral-status-text">{ status }</span>
             </div>
         }
     }

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -616,9 +616,85 @@ pub(crate) fn format_tool_elapsed(seconds: f64) -> String {
     }
 }
 
+/// Derive a one-line human summary from a neutral ephemeral live-status frame
+/// (`WsEvent::Ephemeral`) for the transient status strip.
+///
+/// The payload is opaque wire JSON by design — the frontend can't depend on
+/// the native `muse-codes` types — so this reads it defensively: streaming
+/// text (`payload.text`) or a status message (`payload.event.message`) when
+/// present, else the dotted `payload_type` as a fallback label so an unmodeled
+/// frame still names itself instead of showing nothing. Returns `None` only
+/// when the frame carries no usable signal at all.
+///
+/// This is an interim, agent-neutral render; the rich per-agent view (muse's
+/// task tree) is built on top of this same live stream in a follow-up.
+pub(crate) fn ephemeral_summary(payload: &serde_json::Value) -> Option<String> {
+    let inner = payload.get("payload");
+    // Streaming output text (muse `run.output.delta`).
+    if let Some(text) = inner
+        .and_then(|p| p.get("text"))
+        .and_then(|t| t.as_str())
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+    {
+        return Some(text.to_string());
+    }
+    // Status message (muse `task.lifecycle.status`).
+    if let Some(msg) = inner
+        .and_then(|p| p.get("event"))
+        .and_then(|e| e.get("message"))
+        .and_then(|m| m.as_str())
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+    {
+        return Some(msg.to_string());
+    }
+    // Fallback: name the frame by its type rather than showing nothing.
+    payload
+        .get("payload_type")
+        .and_then(|t| t.as_str())
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_string)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ephemeral_summary_prefers_streaming_text() {
+        let frame = json!({
+            "payload_type": "run.output.delta",
+            "payload": {"text": "  hello world  "}
+        });
+        assert_eq!(ephemeral_summary(&frame).as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn ephemeral_summary_falls_back_to_status_message() {
+        let frame = json!({
+            "payload_type": "task.lifecycle.status",
+            "payload": {"event": {"message": "opening stream"}}
+        });
+        assert_eq!(ephemeral_summary(&frame).as_deref(), Some("opening stream"));
+    }
+
+    #[test]
+    fn ephemeral_summary_labels_unmodeled_frames_by_type() {
+        // No text/message — an unmodeled ephemeral still names itself.
+        let frame = json!({"payload_type": "subagent.progress.heartbeat", "payload": {}});
+        assert_eq!(
+            ephemeral_summary(&frame).as_deref(),
+            Some("subagent.progress.heartbeat")
+        );
+    }
+
+    #[test]
+    fn ephemeral_summary_none_when_no_signal() {
+        assert_eq!(ephemeral_summary(&json!({"payload": {}})), None);
+    }
 
     #[test]
     fn normalize_iso_utc_appends_z_only_when_no_timezone() {

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -64,6 +64,10 @@ pub enum WsEvent {
         tool_name: String,
         elapsed_time_seconds: f64,
     },
+    /// Neutral ephemeral live-status frame (`ServerToClient::Ephemeral`).
+    /// Drives a transient per-session live-status line (muse's streamed
+    /// deltas / task status); never persisted, not part of `Output`.
+    Ephemeral(serde_json::Value),
 }
 
 /// Connect to WebSocket and start receiving messages.
@@ -253,6 +257,9 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
                 tool_name,
                 elapsed_time_seconds,
             });
+        }
+        ServerToClient::Ephemeral { payload } => {
+            on_event.emit(WsEvent::Ephemeral(payload));
         }
         unhandled => {
             // Variants we haven't wired a UI route for yet (e.g. new
@@ -619,6 +626,7 @@ mod tests {
             WsEvent::ForwardsChanged => "ForwardsChanged",
             WsEvent::UploadResult(_) => "UploadResult",
             WsEvent::ToolProgress { .. } => "ToolProgress",
+            WsEvent::Ephemeral(_) => "Ephemeral",
         }
     }
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1533,3 +1533,32 @@
 .active-tool-status {
     color: var(--text-muted);
 }
+
+/* Transient live-status line (neutral ephemeral channel; muse deltas/status). */
+.ephemeral-status-strip {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.1rem 0.1rem;
+    font-size: 0.75rem;
+    font-family: var(--font-mono);
+    color: var(--text-secondary);
+}
+
+.ephemeral-status-spinner {
+    width: 0.7rem;
+    height: 0.7rem;
+    border: 2px solid rgba(122, 162, 247, 0.35);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    flex-shrink: 0;
+}
+
+.ephemeral-status-text {
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+}

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -342,4 +342,13 @@ pub enum ServerToClient {
         tool_name: String,
         elapsed_time_seconds: f64,
     },
+
+    /// Neutral ephemeral live-status, fanned out from
+    /// [`ProxyToServer::Ephemeral`]. Same live-only contract as
+    /// [`ServerToClient::ToolProgress`]: never persisted, never part of
+    /// `HistoryBatch`, no `created_at` / `PortalMeta`. Carries the opaque
+    /// per-frame `payload` (e.g. a muse journal record) for the frontend to
+    /// render as transient live status and drop at turn end. A client offline
+    /// during the frame loses nothing.
+    Ephemeral { payload: serde_json::Value },
 }

--- a/shared/src/endpoints/session.rs
+++ b/shared/src/endpoints/session.rs
@@ -149,6 +149,19 @@ pub enum ProxyToServer {
         elapsed_time_seconds: f64,
     },
 
+    /// A neutral ephemeral live-status frame — the agent-agnostic generalization
+    /// of [`ProxyToServer::ToolProgress`]. Same contract: never buffered, never
+    /// persisted, never replayed; the backend fans it out to the session's web
+    /// clients as [`ServerToClient::Ephemeral`] and it evaporates if nobody is
+    /// listening. Unlike `ToolProgress` it carries an opaque `payload` instead
+    /// of Claude's tool-heartbeat fields, so backends whose live-status is not a
+    /// tool heartbeat (muse's `run.output.delta` / `task.lifecycle.status`) can
+    /// use it. Produced from `session_lib::SessionEvent::Ephemeral`.
+    Ephemeral {
+        session_id: Uuid,
+        payload: serde_json::Value,
+    },
+
     /// Claude reported a hard session limit with a reset time. The backend
     /// persists a one-shot continuation candidate and asks the user whether
     /// to schedule it.


### PR DESCRIPTION
Makes muse (and any future agent) stream live status to the UI without
persisting it. Completes the transport half of the ephemeral path whose
producer side landed in muse-session-lib (#1568).

## The problem

Muse marks ~⅓ of its journal records **ephemeral** (`run.output.delta`
streaming text, `task.lifecycle.status`) — live status that should stream to
the browser but must **never** become transcript rows. The session-lib
classifier already routes these to `SessionEvent::Ephemeral`, but the proxy
was *dropping* them (correctly refusing to persist, but leaving muse turns
showing nothing until the final text landed). This carries them the rest of
the way.

## Shape — mirrors the existing `ToolProgress` side-channel end-to-end

- **shared**: `ProxyToServer::Ephemeral { session_id, payload }` +
  `ServerToClient::Ephemeral { payload }` — the agent-neutral generalization of
  `ToolProgress`, carrying an opaque per-frame payload instead of Claude's
  tool-heartbeat fields.
- **proxy** (`claude-session-lib`): forward `SessionEvent::Ephemeral` as a
  typed side-channel (wiggum's interim drop arm becomes `unreachable!`, handled
  in `session_event.rs` like `ToolProgress`).
- **backend**: fan out to the session's web clients — **no DB write**, same
  contract as `ToolProgress`.
- **frontend**: a transient one-line live-status strip fed by
  `WsEvent::Ephemeral`, cleared when a durable message arrives. Uses a
  tolerant `ephemeral_summary` helper (streaming text → status message →
  `payload_type` label). **Deliberately minimal** — a placeholder the
  per-agent live view (muse's task tree, separate PR) replaces, not a base to
  extend.

Ephemerals are never buffered, persisted, or replayed — a client offline
during a frame loses nothing, exactly like tool-progress heartbeats.

## Verification

Unit-tested: `ephemeral_summary` (streaming-text / status-message / unmodeled
fallback / no-signal). Native (backend, proxy, launcher) + WASM builds, clippy,
and fmt are clean; the compiler's exhaustive `ProxyToServer` / `ServerToClient`
/ `WsEvent` matches confirm every hop is covered.

The end-to-end live render (real muse deltas hitting the browser strip) is best
confirmed against a live muse session, but every deterministic layer is tested
and the path is a line-for-line mirror of the proven `ToolProgress` channel.
