### PR TITLE
Pre-fill the unrecognized-frame report link with the frame

### DIFF
--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -162,6 +162,10 @@ fn render_raw_json(json: &str) -> Html {
         .and_then(|v| serde_json::to_string_pretty(&v).ok())
         .unwrap_or_else(|| json.to_string());
 
+    // Deep-link to a NEW issue prefilled with the frame, not the issues list —
+    // the reporter clicks once and the raw JSON the SDK needs is already there.
+    let report_href = report_issue_url(&display);
+
     html! {
         <div class="claude-message raw-message">
             <div class="message-header">
@@ -172,12 +176,124 @@ fn render_raw_json(json: &str) -> Html {
                 <pre class="raw-json">{ display }</pre>
                 <p class="raw-message-hint">
                     { "This message type is not yet supported by the portal. " }
-                    <a href="https://github.com/meawoppl/rust-code-agent-sdks/issues"
+                    <a href={report_href}
                        target="_blank" rel="noopener noreferrer">
                         { "Report this issue" }
                     </a>
+                    { " (opens a pre-filled issue with this frame)." }
                 </p>
             </div>
         </div>
+    }
+}
+
+/// Base repo for unrecognized-frame reports: the SDK repo, since an unrendered
+/// frame is a typed-model gap there, not a portal bug.
+const REPORT_REPO: &str = "https://github.com/meawoppl/rust-code-agent-sdks";
+
+/// Largest raw-JSON snippet to inline in the issue body. GitHub 414s on
+/// over-long URLs and percent-encoding a JSON blob roughly triples its size, so
+/// we cap the pre-fill well short of the ~8k URL limit; the card's Copy button
+/// carries the full frame for anything larger.
+const MAX_REPORT_JSON: usize = 2000;
+
+/// Build a `issues/new?title=…&body=…` URL pre-filled with an unrecognized
+/// frame: its `payload_type`/`type` in the title, the raw JSON (fenced) in the
+/// body. Pure + host-testable (hand-rolled encoder, no `js_sys`).
+fn report_issue_url(pretty_json: &str) -> String {
+    let frame_type = serde_json::from_str::<Value>(pretty_json)
+        .ok()
+        .and_then(|v| {
+            v.get("payload_type")
+                .or_else(|| v.get("type"))
+                .and_then(|t| t.as_str())
+                .map(str::to_string)
+        });
+    let title = match &frame_type {
+        Some(t) => format!("Unrecognized frame: {t}"),
+        None => "Unrecognized frame".to_string(),
+    };
+
+    let (snippet, truncated) = if pretty_json.chars().count() > MAX_REPORT_JSON {
+        (
+            pretty_json
+                .chars()
+                .take(MAX_REPORT_JSON)
+                .collect::<String>(),
+            true,
+        )
+    } else {
+        (pretty_json.to_string(), false)
+    };
+
+    let mut body =
+        String::from("The portal received an agent frame it doesn't render yet.\n\n```json\n");
+    body.push_str(&snippet);
+    body.push_str("\n```\n");
+    if truncated {
+        body.push_str("\n_(truncated — use the card's Copy button for the full frame)_\n");
+    }
+    body.push_str(&format!("\n---\nagent-portal {}\n", crate::VERSION));
+
+    format!(
+        "{REPORT_REPO}/issues/new?title={}&body={}",
+        percent_encode(&title),
+        percent_encode(&body),
+    )
+}
+
+/// Percent-encode a query-parameter value (RFC 3986 unreserved set kept raw,
+/// everything else `%XX`). Mirrors the encoder in `markdown::sanitizer` — kept
+/// local and pure so `report_issue_url` is testable without a JS runtime.
+fn percent_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for &byte in input.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_url_titles_from_payload_type() {
+        let url = report_issue_url(r#"{"type":"muse_record","payload_type":"task.lifecycle.foo"}"#);
+        // payload_type wins over type, and spaces/colons are encoded.
+        assert!(url.contains("title=Unrecognized%20frame%3A%20task.lifecycle.foo"));
+        assert!(url.starts_with(REPORT_REPO));
+        assert!(url.contains("/issues/new?"));
+    }
+
+    #[test]
+    fn report_url_falls_back_to_type_then_generic() {
+        assert!(report_issue_url(r#"{"type":"weird_frame"}"#)
+            .contains("title=Unrecognized%20frame%3A%20weird_frame"));
+        // Non-JSON → generic title, no panic.
+        assert!(report_issue_url("not json").contains("title=Unrecognized%20frame&"));
+    }
+
+    #[test]
+    fn report_url_body_carries_fenced_json() {
+        let url = report_issue_url(r#"{"type":"x"}"#);
+        // The ```json fence is percent-encoded (backtick = %60, newline = %0A).
+        assert!(url.contains("body="));
+        assert!(url.contains("%60%60%60json"));
+    }
+
+    #[test]
+    fn report_url_truncates_oversized_frames() {
+        let big = format!("{{\"blob\":\"{}\"}}", "x".repeat(MAX_REPORT_JSON + 500));
+        let url = report_issue_url(&big);
+        // Truncation note present (percent-encoded "truncated").
+        assert!(url.contains("truncated"));
+        // And the URL stays bounded despite a huge input.
+        assert!(url.len() < MAX_REPORT_JSON * 4);
     }
 }


### PR DESCRIPTION
The **Unrecognized Message** card's "Report this issue" link pointed at the SDK
repo's issues *list*, so a reporter had to hand-copy the frame into a new issue.
This deep-links to `issues/new` with the frame already filled in:

- **Title** = `Unrecognized frame: <payload_type or type>` (falls back to a
  generic title for non-JSON).
- **Body** = the raw JSON, fenced, so the SDK maintainer sees the exact wire
  shape that didn't render.

Capped at 2 KB of JSON — GitHub 414s on over-long URLs and percent-encoding a
JSON blob roughly triples its size, so the pre-fill stays well under the ~8 KB
URL limit; the card's **Copy** button still carries the full frame, and the body
notes when it truncated.

The URL builder is pure and host-tested (4 tests: title from `payload_type` >
`type` > generic, fenced-JSON body, truncation). No `js_sys` — a small
hand-rolled percent-encoder mirroring the one in `markdown::sanitizer`, so it's
testable without a JS runtime. WASM build, clippy, fmt clean.
