### PR TITLE
Render muse journal records as grouped task-tree cards

### DIFF
--- a/frontend/src/components/agent_frame.rs
+++ b/frontend/src/components/agent_frame.rs
@@ -19,6 +19,10 @@ use super::message_renderer::types::ClaudeMessage;
 pub enum AgentFrame {
     Claude(ClaudeMessage),
     Codex(CodexEvent),
+    /// One muse journal record (`type: "muse_record"`), kept as parsed JSON:
+    /// the task-tree reducer consumes `serde_json::Value` directly, so a
+    /// typed intermediate here would be parsed only to be re-serialized.
+    Muse(serde_json::Value),
     RawJson,
 }
 
@@ -47,6 +51,7 @@ pub enum AgentFrameKind {
     CodexReasoningSummaryPartAdded,
     CodexReasoningTextDelta,
     CodexThreadCompacted,
+    MuseRecord,
     RawJson,
 }
 
@@ -54,6 +59,7 @@ pub enum AgentFrameKind {
 pub enum FrameRenderer {
     Claude,
     Codex,
+    Muse,
     RawJson,
 }
 
@@ -85,6 +91,14 @@ impl AgentFrame {
             }
         }
 
+        if agent_type == shared::AgentType::Muse {
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(json) {
+                if value.get("type").and_then(|t| t.as_str()) == Some("muse_record") {
+                    return Self::Muse(value);
+                }
+            }
+        }
+
         Self::RawJson
     }
 
@@ -92,6 +106,7 @@ impl AgentFrame {
         match self {
             Self::Claude(message) => message.kind(),
             Self::Codex(event) => event.kind(),
+            Self::Muse(_) => AgentFrameKind::MuseRecord,
             Self::RawJson => AgentFrameKind::RawJson,
         }
     }
@@ -123,6 +138,7 @@ impl FrameRenderer {
             | AgentFrameKind::CodexReasoningSummaryPartAdded
             | AgentFrameKind::CodexReasoningTextDelta
             | AgentFrameKind::CodexThreadCompacted => Self::Codex,
+            AgentFrameKind::MuseRecord => Self::Muse,
             AgentFrameKind::RawJson => Self::RawJson,
         }
     }

--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -83,6 +83,7 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
             }
             AgentFrame::Claude(ClaudeMessage::Unknown)
             | AgentFrame::Codex(_)
+            | AgentFrame::Muse(_)
             | AgentFrame::RawJson => render_raw_json(json),
         },
         FrameRenderer::Codex => match frame {
@@ -91,6 +92,26 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
                 ctx.session_id,
                 ctx.turn_metrics,
             ),
+            _ => html! {},
+        },
+        // A muse record reaching here rendered alone (grouping folds runs of
+        // them into one task-tree card): draw a one-record tree rather than
+        // the raw-JSON "Unrecognized Message" bubble — the type IS recognized.
+        FrameRenderer::Muse => match frame {
+            AgentFrame::Muse(value) => {
+                let mut tree = crate::components::muse_renderer::TaskTree::default();
+                tree.apply(&value);
+                html! {
+                    <div class="claude-message assistant-message muse-task-card">
+                        <div class="message-header">
+                            <span class="message-type-badge assistant">{ "Muse" }</span>
+                        </div>
+                        <div class="message-body">
+                            { crate::components::muse_renderer::render_task_tree(&tree) }
+                        </div>
+                    </div>
+                }
+            }
             _ => html! {},
         },
         FrameRenderer::RawJson => render_raw_json(json),

--- a/frontend/src/components/message_renderer/group_renderer.rs
+++ b/frontend/src/components/message_renderer/group_renderer.rs
@@ -77,12 +77,42 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                 };
             }
 
+            // A run of muse journal records renders as ONE task-tree card:
+            // the group's records replay through the reducer and the tree
+            // draws once, instead of ~100 raw-JSON bubbles per turn. This is
+            // also what makes reload work — grouping runs over persisted
+            // history, so the tree rebuilds from the transcript itself.
+            if *category == GroupCategory::Muse {
+                let mut tree = crate::components::muse_renderer::TaskTree::default();
+                for message in messages {
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&message.content) {
+                        tree.apply(&value);
+                    }
+                }
+                // Nothing structural and nothing to footnote — a group of
+                // records the reducer consumed without visible effect (e.g.
+                // pure identity bookkeeping) renders no card at all.
+                if tree.is_empty() && tree.other_records().next().is_none() {
+                    return html! {};
+                }
+                return html! {
+                    <div class="claude-message assistant-message muse-task-card" title={ts.unwrap_or_default()}>
+                        <div class="message-header">
+                            <span class="message-type-badge assistant">{ "Muse" }</span>
+                        </div>
+                        <div class="message-body">
+                            { crate::components::muse_renderer::render_task_tree(&tree) }
+                        </div>
+                    </div>
+                };
+            }
+
             let wrapper_class = match category {
                 GroupCategory::User => "user-message",
                 GroupCategory::Portal => "portal-message",
                 GroupCategory::Assistant | GroupCategory::Codex => "assistant-message",
                 // Handled above with an early return; arm kept for exhaustiveness.
-                GroupCategory::Thinking => "assistant-message",
+                GroupCategory::Thinking | GroupCategory::Muse => "assistant-message",
             };
             let visible = visible_group_indices(*category, messages);
             // Render each member first, dropping the ones that produce nothing

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -19,6 +19,10 @@ pub enum GroupCategory {
     User,
     /// Consecutive Codex protocol events (any non-Unknown `CodexEvent`).
     Codex,
+    /// Consecutive muse journal records. A live turn journals ~100 of them;
+    /// the group renders as ONE task-tree card (see `MessageGroupRenderer`)
+    /// instead of one raw-JSON bubble each.
+    Muse,
     /// Consecutive `system`/`thinking_tokens` markers emitted by the Claude CLI.
     /// These carry no renderable body — the portal collapses a run of them into
     /// a single compact `thinking × N` chip instead of one empty badge each.
@@ -37,6 +41,7 @@ impl GroupCategory {
             GroupCategory::User => "u",
             GroupCategory::Codex => "x",
             GroupCategory::Thinking => "t",
+            GroupCategory::Muse => "m",
         }
     }
 }
@@ -332,6 +337,13 @@ pub(super) fn classify(
             return Some(MessageIdentity {
                 category: GroupCategory::Codex,
                 label: "Codex".to_string(),
+                badge_class: "assistant".to_string(),
+            });
+        }
+        AgentFrame::Muse(_) => {
+            return Some(MessageIdentity {
+                category: GroupCategory::Muse,
+                label: "Muse".to_string(),
                 badge_class: "assistant".to_string(),
             });
         }

--- a/frontend/src/components/message_renderer/mod.rs
+++ b/frontend/src/components/message_renderer/mod.rs
@@ -811,6 +811,86 @@ mod tests {
         }
     }
 
+    use crate::components::agent_frame::{AgentFrame, AgentFrameRegistry};
+
+    /// A durable muse journal record exactly as the classifier persists it —
+    /// the shape that live testing showed raining into the transcript as
+    /// "Unrecognized Message" bubbles (one per record, ~100 per turn).
+    fn muse_lifecycle_message(kind: &str, task_id: &str) -> String {
+        serde_json::json!({
+            "type": "muse_record",
+            "payload_type": format!("task.lifecycle.{kind}"),
+            "stream_id": "9e369f06-72b8-423e-8c43-8051424922d9",
+            "record_id": "018f0000-0000-7000-8000-00000000c3c7",
+            "causation_id": "d9f89d76-d145-4155-a672-0c074ea940ac",
+            "sequence": 62,
+            "durability": "durable",
+            "record_type": "event",
+            "recorded_at": 1780531400000119u64,
+            "payload": {
+                "kind": "task_lifecycle",
+                "task_id": task_id,
+                "event": {"kind": kind, "task_id": task_id},
+            },
+        })
+        .to_string()
+    }
+
+    fn group_for_muse_tests(messages: &[String]) -> Vec<MessageGroup> {
+        group_messages(&rendered_vec(messages), shared::AgentType::Muse, None)
+    }
+
+    /// The regression behind the live bug report: on a Muse session a journal
+    /// record must classify as a Muse frame, never fall through to RawJson
+    /// (which renders the "Unrecognized Message" bubble).
+    #[test]
+    fn muse_record_is_a_recognized_frame_on_muse_sessions() {
+        let json = muse_lifecycle_message("proposed", "t1");
+        let frame = AgentFrameRegistry::parse(&json, shared::AgentType::Muse);
+        assert!(
+            matches!(frame, AgentFrame::Muse(_)),
+            "muse_record fell through to {frame:?} — it will render as raw JSON"
+        );
+        // On non-muse sessions the shape stays raw: another agent's transcript
+        // must not grow muse cards from a stray look-alike payload.
+        let frame = AgentFrameRegistry::parse(&json, shared::AgentType::Claude);
+        assert!(matches!(frame, AgentFrame::RawJson));
+    }
+
+    /// A turn's worth of journal records collapses into ONE muse group — the
+    /// group renderer draws it as a single task-tree card.
+    #[test]
+    fn serial_muse_records_collapse_into_one_group() {
+        let messages = vec![
+            muse_lifecycle_message("proposed", "t1"),
+            muse_lifecycle_message("started", "t1"),
+            muse_lifecycle_message("completed", "t1"),
+        ];
+        let groups = group_for_muse_tests(&messages);
+        assert_eq!(groups.len(), 1);
+        match &groups[0] {
+            MessageGroup::IdentityGroup {
+                category: GroupCategory::Muse,
+                messages,
+                ..
+            } => assert_eq!(messages.len(), 3),
+            other => panic!("expected one Muse identity run, got {other:?}"),
+        }
+    }
+
+    /// A user message between turns splits the run, so each turn renders its
+    /// own task-tree card rather than merging across the conversation.
+    #[test]
+    fn muse_run_breaks_on_intervening_portal_message() {
+        let messages = vec![
+            muse_lifecycle_message("proposed", "t1"),
+            portal_text_message("reconnected"),
+            muse_lifecycle_message("proposed", "t2"),
+        ];
+        let groups = group_for_muse_tests(&messages);
+        assert_eq!(groups.len(), 3);
+    }
+
     #[test]
     fn codex_event_classifies_into_codex_group() {
         let msg = codex_item_started_agent_message("hi");

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -3,10 +3,80 @@
 //! Muse's journal is a third protocol shape (see `docs/MUSE_SUPPORT.md`),
 //! and its distinguishing feature for the view is that work arrives as a
 //! **task tree** rather than tool-use blocks. [`task_tree`] holds the pure
-//! reducer that turns classified records into that tree; the records reach
-//! it from two channels (persisted output for structure, the ephemeral
-//! side-channel for live status) which the session view interleaves.
+//! reducer that turns classified records into that tree; [`render_task_tree`]
+//! draws it. The transcript groups a run of consecutive muse records into one
+//! card (see `MessageGroupRenderer`), builds a tree from the group, and
+//! renders it here — so a live turn's ~100 journal records read as one
+//! structural view instead of a hundred raw-JSON bubbles.
+
+use yew::prelude::*;
 
 pub mod task_tree;
 
 pub use task_tree::{TaskNode, TaskTree};
+
+/// Draw a task tree: one collapsible node per task showing lifecycle state,
+/// tool outcomes, streamed output, and the policy decision muse applied to
+/// any side effect (muse decides tool policy itself and never prompts, so
+/// those render as an audit trail rather than an approval). Records the tree
+/// holds no structure for are named in a muted footer — nothing on the wire
+/// disappears silently.
+pub fn render_task_tree(tree: &TaskTree) -> Html {
+    let footer: Vec<String> = tree
+        .other_records()
+        .map(|(payload_type, count)| {
+            if count > 1 {
+                format!("{payload_type} ×{count}")
+            } else {
+                payload_type.to_string()
+            }
+        })
+        .collect();
+    html! {
+        <div class="muse-task-tree">
+            { for tree.nodes().map(render_task_node) }
+            if !footer.is_empty() {
+                <div class="muse-journal-footer">{ footer.join(" · ") }</div>
+            }
+        </div>
+    }
+}
+
+fn render_task_node(node: &TaskNode) -> Html {
+    let state = node.state;
+    let kind = node.task_kind.as_deref().unwrap_or("task");
+    html! {
+        <details class="muse-task" open={!state.is_terminal()}>
+            <summary class="muse-task-summary">
+                <span class={classes!("muse-task-badge", format!("muse-task-{}", state.label()))}>
+                    { state.label() }
+                </span>
+                <span class="muse-task-kind">{ kind }</span>
+                if let Some(status) = node.status.as_deref() {
+                    <span class="muse-task-status">{ status }</span>
+                }
+            </summary>
+            if let Some(reason) = node.reason.as_deref() {
+                <div class="muse-task-reason">{ reason }</div>
+            }
+            if let Some((op, decision)) = node.side_effect.as_ref() {
+                <div class="muse-task-side-effect">
+                    { format!("{op} — policy: {decision}") }
+                </div>
+            }
+            { for node.tool_results.iter().map(|r| {
+                let outcome = r.outcome.as_deref().unwrap_or("unknown");
+                let tool = r.tool_name.as_deref().unwrap_or("tool");
+                html! {
+                    <div class={classes!("muse-tool-result", format!("muse-tool-{outcome}"))}>
+                        <span class="muse-tool-name">{ tool }</span>
+                        <span class="muse-tool-text">{ &r.text }</span>
+                    </div>
+                }
+            }) }
+            { for node.output.iter().map(|chunk| html! {
+                <div class="muse-task-output">{ chunk }</div>
+            }) }
+        </details>
+    }
+}

--- a/frontend/src/components/muse_renderer/task_tree.rs
+++ b/frontend/src/components/muse_renderer/task_tree.rs
@@ -125,6 +125,11 @@ pub struct TaskTree {
     order: Vec<String>,
     /// Turn this tree belongs to (`causation_id`), set by the first record.
     pub causation_id: Option<String>,
+    /// Count per `payload_type` of records the tree does not render
+    /// structurally (`run.model.configured`, `command.received`, terminal
+    /// records, future vocabulary). Surfaced as a muted footer so nothing
+    /// on the wire silently disappears from the transcript.
+    other_records: BTreeMap<String, usize>,
 }
 
 impl TaskTree {
@@ -176,8 +181,16 @@ impl TaskTree {
             }
             t if t.starts_with("task.lifecycle.") => self.apply_lifecycle(payload),
             "tool.result" => self.apply_tool_result(payload),
-            _ => {}
+            other => {
+                *self.other_records.entry(other.to_string()).or_default() += 1;
+            }
         }
+    }
+
+    /// `payload_type → count` of records not rendered as tree structure, in
+    /// stable order, for the card footer.
+    pub fn other_records(&self) -> impl Iterator<Item = (&str, usize)> {
+        self.other_records.iter().map(|(k, v)| (k.as_str(), *v))
     }
 
     fn apply_lifecycle(&mut self, payload: &serde_json::Value) {

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -28,9 +28,8 @@ use super::forward_chips::ForwardChips;
 use super::helpers::{
     autoscroll_transition, classify_output_msg_type, clear_completed_tools,
     enrich_codex_file_change_permission, ephemeral_summary, format_tool_elapsed,
-    is_claude_awaiting, is_muse_record, parse_iso_ms_utc, reconcile_pending_sends,
-    running_tool_key, update_pending_send_delivery, upsert_tool_progress, ActiveToolProgress,
-    ActivityTag,
+    is_claude_awaiting, parse_iso_ms_utc, reconcile_pending_sends, running_tool_key,
+    update_pending_send_delivery, upsert_tool_progress, ActiveToolProgress, ActivityTag,
 };
 use super::input_bar::{InputBar, InputBarInbound};
 use super::outbox::Outbox;
@@ -266,12 +265,6 @@ pub struct SessionView {
     /// ends. Kept out of the memoized message-render props on purpose (see the
     /// `helpers` tool-progress section).
     active_tools: Vec<ActiveToolProgress>,
-    /// Live task tree for Muse turns, fed from BOTH channels: durable
-    /// structure from the persisted output stream and live status from
-    /// `WsEvent::Ephemeral`. The reducer is channel-agnostic — see
-    /// [`crate::components::muse_renderer::TaskTree`] — so both feed one
-    /// `apply()`. Empty for non-Muse agents, which never emit these records.
-    muse_tasks: crate::components::muse_renderer::TaskTree,
     /// Latest neutral ephemeral live-status line (`WsEvent::Ephemeral`), shown
     /// as a transient strip at the transcript tail while a turn runs and
     /// cleared when a durable message arrives. Never persisted. Muse's streamed
@@ -357,7 +350,6 @@ impl Component for SessionView {
             turn_metrics: Vec::new(),
             continuation_statuses: HashMap::new(),
             active_tools: Vec::new(),
-            muse_tasks: Default::default(),
             ephemeral_status: None,
             forwards_refresh: 0,
         }
@@ -691,7 +683,6 @@ impl Component for SessionView {
                             html! { <MessageRenderer key={format!("p{}", i)} message={message.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
                         })}
                         { self.render_active_tools() }
-                        { self.render_muse_tasks() }
                         { self.render_ephemeral_status() }
                     </div>
                     if !is_tailing {
@@ -826,22 +817,18 @@ impl SessionView {
                 true
             }
             WsEvent::Ephemeral(payload) => {
-                // Live status. Never touches `messages` (no persistence, no
-                // replay watermark). Muse records feed the task tree, which
-                // renders them structurally; anything else falls back to the
-                // one-line strip so a new agent's live status is visible
-                // rather than silently dropped.
-                if is_muse_record(&payload) {
-                    self.muse_tasks.apply(&payload);
-                    true
-                } else {
-                    match ephemeral_summary(&payload) {
-                        Some(summary) => {
-                            self.ephemeral_status = Some(summary);
-                            true
-                        }
-                        None => false,
+                // Transient live status: replace the strip line. Never touches
+                // `messages` (no persistence, no replay watermark). A frame we
+                // can't summarize is ignored rather than clearing a good line.
+                // Durable muse structure renders as the transcript's task-tree
+                // card (`GroupCategory::Muse`); this strip carries only the
+                // between-records heartbeat.
+                match ephemeral_summary(&payload) {
+                    Some(summary) => {
+                        self.ephemeral_status = Some(summary);
+                        true
                     }
+                    None => false,
                 }
             }
         }
@@ -1077,16 +1064,6 @@ impl SessionView {
         clear_completed_tools(&mut self.active_tools, &output.content);
         // A durable message supersedes the transient live-status line.
         self.ephemeral_status = None;
-        // Durable muse records carry the task tree's STRUCTURE (stream
-        // links, lifecycle transitions, tool results); the ephemeral channel
-        // carries its live status. Same reducer, both channels. Persisted
-        // content arrives as a JSON string, so parse before routing; a
-        // non-JSON or non-muse message simply isn't tree material.
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&output.content) {
-            if is_muse_record(&value) {
-                self.muse_tasks.apply(&value);
-            }
-        }
 
         push_message_with_limit(&mut self.messages, output, MAX_MESSAGES_PER_SESSION);
         true
@@ -1116,61 +1093,6 @@ impl SessionView {
                     }
                 }) }
             </div>
-        }
-    }
-
-    /// The Muse task tree: one collapsible node per task, showing its
-    /// lifecycle state, the live status line for a running task, tool
-    /// outcomes, and the policy decision muse applied to any side effect
-    /// (it decides tool policy itself and never prompts, so these are an
-    /// audit trail rather than an approval).
-    fn render_muse_tasks(&self) -> Html {
-        if self.muse_tasks.is_empty() {
-            return html! {};
-        }
-        html! {
-            <div class="muse-task-tree">
-                { for self.muse_tasks.nodes().map(Self::render_muse_task) }
-            </div>
-        }
-    }
-
-    fn render_muse_task(node: &crate::components::muse_renderer::TaskNode) -> Html {
-        let state = node.state;
-        let kind = node.task_kind.as_deref().unwrap_or("task");
-        html! {
-            <details class="muse-task" open={!state.is_terminal()}>
-                <summary class="muse-task-summary">
-                    <span class={classes!("muse-task-badge", format!("muse-task-{}", state.label()))}>
-                        { state.label() }
-                    </span>
-                    <span class="muse-task-kind">{ kind }</span>
-                    if let Some(status) = node.status.as_deref() {
-                        <span class="muse-task-status">{ status }</span>
-                    }
-                </summary>
-                if let Some(reason) = node.reason.as_deref() {
-                    <div class="muse-task-reason">{ reason }</div>
-                }
-                if let Some((op, decision)) = node.side_effect.as_ref() {
-                    <div class="muse-task-side-effect">
-                        { format!("{op} — policy: {decision}") }
-                    </div>
-                }
-                { for node.tool_results.iter().map(|r| {
-                    let outcome = r.outcome.as_deref().unwrap_or("unknown");
-                    let tool = r.tool_name.as_deref().unwrap_or("tool");
-                    html! {
-                        <div class={classes!("muse-tool-result", format!("muse-tool-{outcome}"))}>
-                            <span class="muse-tool-name">{ tool }</span>
-                            <span class="muse-tool-text">{ &r.text }</span>
-                        </div>
-                    }
-                }) }
-                { for node.output.iter().map(|chunk| html! {
-                    <div class="muse-task-output">{ chunk }</div>
-                }) }
-            </details>
         }
     }
 

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -1341,30 +1341,3 @@ mod tests {
         assert_eq!(format_tool_elapsed(-5.0), "0s");
     }
 }
-
-/// True when a payload is one of muse's journal records (the classifier
-/// stamps `type: "muse_record"`), so the session view can route it to the
-/// task tree instead of the generic live-status strip.
-pub fn is_muse_record(payload: &serde_json::Value) -> bool {
-    payload.get("type").and_then(|t| t.as_str()) == Some("muse_record")
-}
-
-#[cfg(test)]
-mod muse_record_tests {
-    use super::*;
-    use serde_json::json;
-
-    /// Only muse's own records route to the task tree; another agent's
-    /// ephemerals must keep falling back to the generic status strip
-    /// rather than silently disappearing into a tree that can't render
-    /// them.
-    #[test]
-    fn only_muse_records_are_routed_to_the_task_tree() {
-        assert!(is_muse_record(
-            &json!({"type": "muse_record", "payload_type": "x"})
-        ));
-        assert!(!is_muse_record(&json!({"type": "thread.started"})));
-        assert!(!is_muse_record(&json!({"no_type": true})));
-        assert!(!is_muse_record(&json!("a bare string")));
-    }
-}

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1673,3 +1673,14 @@
     white-space: pre-wrap;
     overflow-wrap: anywhere;
 }
+
+.muse-task-card .message-body {
+    padding-top: 0.15rem;
+}
+
+.muse-journal-footer {
+    margin-top: 0.3rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--text-tertiary, #666);
+}


### PR DESCRIPTION
Fixes the live-testing report (https://gist.github.com/meawoppl/9fb3b8c97476f865048f236f2133cb5b): every durable muse record rendered as its own raw-JSON **"Unrecognized Message"** bubble — ~100 per turn.

## Diagnosis

The wire was healthy: every `payload_type` in the dump is known vocabulary (`task.stream.linked`, `task.lifecycle.*`, `tool.result`, `run.terminal.completed`), correctly persisted by the classifier. The bug was render-side: `AgentFrame` had no muse branch, so `type: "muse_record"` fell through to `RawJson` → one raw bubble per record.

It also exposed a second, quieter bug in #1576: the bottom-of-view task tree was fed only by the live socket, so on **reload** it came back empty while the transcript showed the hundred bubbles.

## Fix — the transcript owns the tree

- `AgentFrame::Muse` recognized on muse sessions (gated on agent type, exactly the Codex pattern; the shape stays raw on other agents so a look-alike payload can't grow muse cards elsewhere)
- Grouping collapses a consecutive run of muse records into one `GroupCategory::Muse` identity group, rendered as **a single task-tree card** through the existing reducer
- Reload works by construction: grouping runs over persisted history, so the tree rebuilds from the transcript itself — no separate hydration path
- The bottom-of-view tree and its `is_muse_record` routing are removed; the neutral ephemeral strip (#1575) returns to carrying live status for all agents, muse included
- Records the tree holds no structure for are named in a muted card footer (`run.model.configured · run.terminal.completed`) — recognized-but-unrendered types stay visible instead of silently disappearing

## Tests

557 frontend tests green, including three new regressions pinned to the report: muse records must never classify as `RawJson` on a muse session, a turn's records collapse to one group, and an intervening message splits the run. Reducer tests against real captures unchanged (plus footer counting).

Same caveat as before: logic verified against captures; visual behavior needs a live look — same gist workflow.
