### PR TITLE
Render muse's answer text as prose, not a footer count

### DIFF
--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -33,12 +33,25 @@ pub fn render_task_tree(tree: &TaskTree) -> Html {
         })
         .collect();
     html! {
-        <div class="muse-task-tree">
-            { for tree.nodes().map(render_task_node) }
-            if !footer.is_empty() {
-                <div class="muse-journal-footer">{ footer.join(" · ") }</div>
+        <>
+            // The agent's actual reply, rendered as markdown prose like a
+            // Claude/Codex assistant message — the task tree below is the
+            // supporting work log, the same way tool-use cards sit under
+            // assistant text.
+            if let Some(answer) = tree.answer() {
+                <div class="muse-answer">
+                    { crate::components::markdown::render_markdown(answer) }
+                </div>
             }
-        </div>
+            if tree.nodes().next().is_some() || !footer.is_empty() {
+                <div class="muse-task-tree">
+                    { for tree.nodes().map(render_task_node) }
+                    if !footer.is_empty() {
+                        <div class="muse-journal-footer">{ footer.join(" · ") }</div>
+                    }
+                </div>
+            }
+        </>
     }
 }
 

--- a/frontend/src/components/muse_renderer/task_tree.rs
+++ b/frontend/src/components/muse_renderer/task_tree.rs
@@ -191,12 +191,20 @@ impl TaskTree {
             }
             t if t.starts_with("task.lifecycle.") => self.apply_lifecycle(payload),
             "tool.result" => self.apply_tool_result(payload),
-            // The run's final answer text — the agent's actual reply. Render it
-            // as prose, not a footer count. Later terminal records (retries)
-            // overwrite, so the last answer wins.
-            "run.terminal.completed" => {
-                if let Some(text) = str_field(payload, "text").filter(|t| !t.trim().is_empty()) {
-                    self.answer = Some(text);
+            // The run's final answer — the agent's actual reply. Match the whole
+            // `run.terminal.*` family, not just `.completed`: the terminal state
+            // is encoded in the suffix (completed / failed / cancelled / future
+            // suffixes), and a failed run's reply must render as text — not a
+            // footer count — on exactly the turns the user most needs to read
+            // it. Prefer `text`; fall back to `reason` when a failed run carries
+            // only that. Last terminal wins, and a blank retry keeps the prior
+            // answer (better a stale reply than a blank card) — deliberate.
+            t if t.starts_with("run.terminal.") => {
+                let answer = str_field(payload, "text")
+                    .filter(|t| !t.trim().is_empty())
+                    .or_else(|| str_field(payload, "reason").filter(|r| !r.trim().is_empty()));
+                if answer.is_some() {
+                    self.answer = answer;
                 }
             }
             other => {
@@ -466,6 +474,24 @@ mod tests {
             "payload": {"terminal": "completed", "text": "   "},
         }));
         assert_eq!(tree.answer(), None);
+    }
+
+    /// A FAILED terminal (a different `run.terminal.*` suffix) still renders as
+    /// text: its `reason` becomes the answer when it carries no `text`. This is
+    /// the turn the user most needs to read, and matching only `.completed`
+    /// would drop it to the footer.
+    #[test]
+    fn failed_terminal_falls_back_to_reason() {
+        let mut tree = TaskTree::new();
+        tree.apply(&json!({
+            "payload_type": "run.terminal.failed",
+            "payload": {"terminal": "failed", "reason": "model hit its context limit"},
+        }));
+        assert_eq!(tree.answer(), Some("model hit its context limit"));
+        assert!(
+            tree.other_records().next().is_none(),
+            "a failed terminal must render, not footer-count"
+        );
     }
 
     /// A frame the model cannot interpret must not break the tree built by

--- a/frontend/src/components/muse_renderer/task_tree.rs
+++ b/frontend/src/components/muse_renderer/task_tree.rs
@@ -125,10 +125,15 @@ pub struct TaskTree {
     order: Vec<String>,
     /// Turn this tree belongs to (`causation_id`), set by the first record.
     pub causation_id: Option<String>,
+    /// The run's final answer text (`run.terminal.completed` → `payload.text`),
+    /// in markdown. This is the agent's actual reply — rendered as prose above
+    /// the task tree, the same way a Claude/Codex assistant message renders —
+    /// rather than being dropped into the footer as a bare count.
+    answer: Option<String>,
     /// Count per `payload_type` of records the tree does not render
-    /// structurally (`run.model.configured`, `command.received`, terminal
-    /// records, future vocabulary). Surfaced as a muted footer so nothing
-    /// on the wire silently disappears from the transcript.
+    /// structurally (`run.model.configured`, `command.received`, future
+    /// vocabulary). Surfaced as a muted footer so nothing on the wire silently
+    /// disappears from the transcript.
     other_records: BTreeMap<String, usize>,
 }
 
@@ -146,7 +151,12 @@ impl TaskTree {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.order.is_empty()
+        self.order.is_empty() && self.answer.is_none()
+    }
+
+    /// The run's final answer text, if a terminal record carried one.
+    pub fn answer(&self) -> Option<&str> {
+        self.answer.as_deref()
     }
 
     /// Look up one node. Used by tests asserting state transitions; the
@@ -181,6 +191,14 @@ impl TaskTree {
             }
             t if t.starts_with("task.lifecycle.") => self.apply_lifecycle(payload),
             "tool.result" => self.apply_tool_result(payload),
+            // The run's final answer text — the agent's actual reply. Render it
+            // as prose, not a footer count. Later terminal records (retries)
+            // overwrite, so the last answer wins.
+            "run.terminal.completed" => {
+                if let Some(text) = str_field(payload, "text").filter(|t| !t.trim().is_empty()) {
+                    self.answer = Some(text);
+                }
+            }
             other => {
                 *self.other_records.entry(other.to_string()).or_default() += 1;
             }
@@ -414,6 +432,40 @@ mod tests {
             "live status must clear at terminal state"
         );
         assert!(node.reason.is_some(), "the failure reason must be kept");
+    }
+
+    /// The run's final answer text is captured as prose, not dumped into the
+    /// footer — this is the whole point of the muse card carrying the reply.
+    #[test]
+    fn terminal_text_becomes_the_answer_not_a_footer_count() {
+        let mut tree = TaskTree::new();
+        tree.apply(&json!({
+            "payload_type": "run.terminal.completed",
+            "payload": {"terminal": "completed", "reason": null,
+                        "text": "Created `hello.txt` — contents:\n\n```\nhello\n```"},
+        }));
+        assert_eq!(
+            tree.answer(),
+            Some("Created `hello.txt` — contents:\n\n```\nhello\n```")
+        );
+        // It must NOT also show as an "unrendered" footer count.
+        assert!(
+            tree.other_records().next().is_none(),
+            "the answer is rendered, so it must not appear in the footer too"
+        );
+        // An answer-only turn (no tasks) is still a card worth rendering.
+        assert!(!tree.is_empty(), "a tree with an answer is not empty");
+    }
+
+    /// A blank terminal text leaves no answer (and no empty prose block).
+    #[test]
+    fn blank_terminal_text_sets_no_answer() {
+        let mut tree = TaskTree::new();
+        tree.apply(&json!({
+            "payload_type": "run.terminal.completed",
+            "payload": {"terminal": "completed", "text": "   "},
+        }));
+        assert_eq!(tree.answer(), None);
     }
 
     /// A frame the model cannot interpret must not break the tree built by

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1586,6 +1586,16 @@
    their live status line (fed by the ephemeral channel); terminal ones
    collapse and drop the status, since a finished task's last progress
    message is stale by definition. */
+/* The agent's actual reply, rendered as markdown prose — the primary content
+   of a muse turn, sitting above the task-tree work log. */
+.muse-answer {
+    margin-bottom: 0.5rem;
+}
+
+.muse-answer:last-child {
+    margin-bottom: 0;
+}
+
 .muse-task-tree {
     display: flex;
     flex-direction: column;

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1586,6 +1586,7 @@
    their live status line (fed by the ephemeral channel); terminal ones
    collapse and drop the status, since a finished task's last progress
    message is stale by definition. */
+
 /* The agent's actual reply, rendered as markdown prose — the primary content
    of a muse turn, sitting above the task-tree work log. */
 .muse-answer {


### PR DESCRIPTION
**Muse's actual reply wasn't rendering as text.** A muse turn's final answer
lives in the `run.terminal.completed` record's `payload.text` (markdown, e.g.
`"Created [hello.txt](…) and read it back — contents:\n\n\`\`\`\nhello\n\`\`\`"`),
which is durable and persisted. But the task-tree reducer only handled
`task.stream.linked` / `task.lifecycle.*` / `tool.result` — **every `run.*`
record fell into the "unrendered" footer as a bare count**, so the reply showed
up as `run.terminal.completed` in a muted footer line instead of as the agent's
message.

## Fix

- **Reducer** (`task_tree.rs`): capture `run.terminal.completed` → `payload.text`
  as the tree's `answer` (last terminal wins on retries; blank text ignored).
  It no longer counts toward the footer.
- **Renderer** (`muse_renderer.rs`): render the answer as **markdown**, via the
  same `render_markdown` the Claude/Codex assistant renderers use, **above** the
  task tree — so muse reads like a normal assistant reply with the task tree as
  its supporting work log (the analogue of assistant text + tool-use cards).
- **`is_empty()`** now counts an answer, so an answer-only turn (a prose reply
  with no sub-tasks) still draws a card instead of being skipped by the
  empty-group guard.

Grounded in the committed real captures (`meta_tool_use.jsonl` /
`meta_subagents.jsonl`), which carry `run.output.delta` ×4/57 + one
`run.terminal.completed` per turn — exactly the records that were being dropped.

## Verification

Two new reducer tests (terminal text → `answer`, not a footer count; blank text
→ no answer). 9 `task_tree` tests green; WASM build, clippy, fmt clean.

Scope: the functional text-rendering fix only. Muse still borrows the green
`assistant` badge rather than a distinct agent hue — a cosmetic follow-up, left
out here deliberately.
