### PR TITLE
Unify muse display: blue identity + codex-style task stacking

### DIFF
--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -102,9 +102,9 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
                 let mut tree = crate::components::muse_renderer::TaskTree::default();
                 tree.apply(&value);
                 html! {
-                    <div class="claude-message assistant-message muse-task-card">
+                    <div class="claude-message muse-message muse-task-card">
                         <div class="message-header">
-                            <span class="message-type-badge assistant">{ "Muse" }</span>
+                            <span class="message-type-badge muse">{ "Muse" }</span>
                         </div>
                         <div class="message-body">
                             { crate::components::muse_renderer::render_task_tree(&tree) }

--- a/frontend/src/components/message_renderer/group_renderer.rs
+++ b/frontend/src/components/message_renderer/group_renderer.rs
@@ -96,9 +96,9 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                     return html! {};
                 }
                 return html! {
-                    <div class="claude-message assistant-message muse-task-card" title={ts.unwrap_or_default()}>
+                    <div class="claude-message muse-message muse-task-card" title={ts.unwrap_or_default()}>
                         <div class="message-header">
-                            <span class="message-type-badge assistant">{ "Muse" }</span>
+                            <span class="message-type-badge muse">{ "Muse" }</span>
                         </div>
                         <div class="message-body">
                             { crate::components::muse_renderer::render_task_tree(&tree) }

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -13,7 +13,7 @@ use yew::prelude::*;
 
 pub mod task_tree;
 
-pub use task_tree::{TaskNode, TaskTree};
+pub use task_tree::{TaskNode, TaskState, TaskTree};
 
 /// Draw a task tree: one collapsible node per task showing lifecycle state,
 /// tool outcomes, streamed output, and the policy decision muse applied to
@@ -58,9 +58,18 @@ pub fn render_task_tree(tree: &TaskTree) -> Html {
 fn render_task_node(node: &TaskNode) -> Html {
     let state = node.state;
     let kind = node.task_kind.as_deref().unwrap_or("task");
+    // Codex-style stacked item: one card per task, no accordion. A running
+    // task (Started, not yet terminal) carries the same in-progress cue as a
+    // `.codex-item-in-progress` card — a pulsing dot + dimmed text.
+    let running = state == TaskState::Started;
+    let item_class = classes!(
+        "muse-task",
+        format!("muse-task-{}", state.label()),
+        running.then_some("muse-task-in-progress"),
+    );
     html! {
-        <details class="muse-task" open={!state.is_terminal()}>
-            <summary class="muse-task-summary">
+        <div class={item_class}>
+            <div class="muse-task-header">
                 <span class={classes!("muse-task-badge", format!("muse-task-{}", state.label()))}>
                     { state.label() }
                 </span>
@@ -68,7 +77,7 @@ fn render_task_node(node: &TaskNode) -> Html {
                 if let Some(status) = node.status.as_deref() {
                     <span class="muse-task-status">{ status }</span>
                 }
-            </summary>
+            </div>
             if let Some(reason) = node.reason.as_deref() {
                 <div class="muse-task-reason">{ reason }</div>
             }
@@ -90,6 +99,6 @@ fn render_task_node(node: &TaskNode) -> Html {
             { for node.output.iter().map(|chunk| html! {
                 <div class="muse-task-output">{ chunk }</div>
             }) }
-        </details>
+        </div>
     }
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -107,6 +107,14 @@
     color: #7dcfff;
 }
 
+/* Muse's agent identity: blue, its own hue rather than Claude's green
+   `assistant` badge — the same way Codex owns purple and Portal owns teal. */
+.message-type-badge.muse {
+    background: rgba(122, 162, 247, 0.2);
+    color: var(--accent);
+    text-transform: none;
+}
+
 /* Inter-agent message (`agent-portal message send`): the "external" link hue
    so it reads as coming from another agent, distinct from the user's own. */
 .message-type-badge.other-agent {
@@ -144,6 +152,12 @@
 
 .portal-message {
     border-left: 3px solid #7dcfff;
+}
+
+/* Muse turn card: blue agent stripe, mirroring the codex/portal/user
+   left-accent treatment so muse reads as its own agent, not an assistant. */
+.muse-message {
+    border-left: 3px solid var(--accent);
 }
 
 .continuation-card {
@@ -285,7 +299,7 @@
  * `item.completed` one), the styling disappears.
  * ----------------------------------------------------------------------- */
 
-@keyframes codex-item-pulse {
+@keyframes agent-inflight-pulse {
     0%, 100% { opacity: 0.45; }
     50% { opacity: 1.0; }
 }
@@ -300,7 +314,7 @@
     content: "\25CF"; /* filled bullet */
     color: var(--warning); /* tokyo-night orange — portal "in-flight" cue */
     margin-right: 0.5rem;
-    animation: codex-item-pulse 1.5s ease-in-out infinite;
+    animation: agent-inflight-pulse 1.5s ease-in-out infinite;
     font-size: 0.7em;
     vertical-align: middle;
 }
@@ -1605,17 +1619,40 @@
     font-size: 0.8rem;
 }
 
+/* One task per stacked card (no accordion) — the Codex `.codex-item` pattern:
+   a run of tasks reads as a vertical stack, and a running one carries the
+   same pulsing-dot in-flight cue. */
 .muse-task {
-    border-left: 2px solid var(--border-subtle, #333);
-    padding-left: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.35rem 0.5rem;
+    background: rgba(0, 0, 0, 0.12);
 }
 
-.muse-task-summary {
+.muse-task-header {
     display: flex;
     align-items: baseline;
     gap: 0.45rem;
-    cursor: pointer;
-    list-style: none;
+}
+
+/* In-flight cue, shared with `.codex-item-in-progress`: a pulsing dot before
+   the header and slightly dimmed body while the task runs. */
+.muse-task-in-progress .muse-task-header {
+    position: relative;
+}
+
+.muse-task-in-progress .muse-task-header::before {
+    content: "\25CF"; /* filled bullet */
+    color: var(--warning);
+    margin-right: 0.35rem;
+    animation: agent-inflight-pulse 1.5s ease-in-out infinite;
+    font-size: 0.7em;
+    vertical-align: middle;
+}
+
+.muse-task-in-progress .muse-task-output,
+.muse-task-in-progress .muse-task-status {
+    opacity: 0.82;
 }
 
 .muse-task-badge {
@@ -1625,22 +1662,25 @@
     letter-spacing: 0.03em;
     padding: 0.05rem 0.35rem;
     border-radius: 0.2rem;
-    background: var(--bg-subtle, #222);
+    background: var(--bg-dark);
     color: var(--text-secondary);
 }
 
 .muse-task-running {
-    color: var(--accent, #7aa2f7);
+    color: var(--accent);
 }
+
 .muse-task-completed {
-    color: var(--success, #9ece6a);
+    color: var(--success);
 }
+
 .muse-task-failed,
 .muse-task-rejected {
-    color: var(--error, #f7768e);
+    color: var(--error);
 }
+
 .muse-task-cancelled {
-    color: var(--text-tertiary, #666);
+    color: var(--text-muted);
 }
 
 .muse-task-kind {
@@ -1649,7 +1689,7 @@
 }
 
 .muse-task-status {
-    color: var(--text-tertiary, #888);
+    color: var(--text-muted);
     font-style: italic;
 }
 
@@ -1680,7 +1720,7 @@
 }
 
 .muse-tool-text {
-    color: var(--text-tertiary, #888);
+    color: var(--text-muted);
     white-space: pre-wrap;
     overflow-wrap: anywhere;
 }
@@ -1693,5 +1733,5 @@
     margin-top: 0.3rem;
     font-family: var(--font-mono);
     font-size: 0.7rem;
-    color: var(--text-tertiary, #666);
+    color: var(--text-muted);
 }


### PR DESCRIPTION
Follow-up to the answer-text fix (#1579), addressing the two display asks:
give muse a coherent identity and stack its task progress like Codex.

## Before

Muse rendered with Claude's green `assistant` badge (so it read as Claude),
and its task list used three **nonexistent** CSS vars (`--border-subtle` /
`--bg-subtle` / `--text-tertiary`) that fell back to off-palette grays
(`#333`/`#222`/`#666`), inside a bespoke `<details>` accordion unlike anything
else in the transcript.

## Changes (view-only — the TaskTree reducer is untouched)

- **Agent identity**: a `.muse` badge + `.muse-message` card left-stripe in
  blue (`--accent`) — muse's own hue, the way Codex owns purple and Portal owns
  teal — replacing the borrowed green `assistant` badge, in both the grouped
  and single-record render paths.
- **Task progress stacks like Codex**: each task is now a flat card in a
  vertical stack (no accordion), and a **running** task (`state == Started`)
  carries the same pulsing in-flight dot as `.codex-item-in-progress`. The
  pulse keyframe is renamed `codex-item-pulse` → `agent-inflight-pulse` and
  shared by both agents.
- **Palette fix**: the task-tree's nonexistent vars → real Tokyo-Night tokens
  (`--border` / `--bg-dark` / `--text-muted`), so it stops rendering in
  mismatched grays.

## Verification

`task_tree` reducer tests (10) still green — the model is unchanged, only its
draw functions and CSS. WASM build, clippy, `cargo fmt`, and **stylelint** all
clean.

Visual behavior is best confirmed against a live muse session (the logic/markup
is straightforward, but I can't click through it here).
