### PR TITLE
Raise message cap so muse turns don't evict user messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -898,7 +898,7 @@ When making changes, verify:
 | `SPLASH_TEXT` | Custom splash text on login page | Optional |
 | `ALLOWED_EMAIL_DOMAIN` | Restrict to email domain | Optional |
 | `ALLOWED_EMAILS` | Comma-separated allowed emails | Optional |
-| `MESSAGE_RETENTION_COUNT` | Max messages per session | Optional (default: 100) |
+| `MESSAGE_RETENTION_COUNT` | Max messages (wire records) per session | Optional (default: 1000) |
 | `MESSAGE_RETENTION_DAYS` | Days before message deletion | Optional (default: 30) |
 | `SESSION_MAX_AGE_DAYS` | Days before session deletion | Optional (default: 14) |
 | `PORTAL_STT_BACKEND` | Speech-to-text provider: `disabled` or one of `assemblyai`, `aws`, `azure`, `deepgram`, `google`, `ibm`, `openai`, `revai`, `simplismart`, `speechmatics`. Unset/`disabled` keeps voice on the browser's Web Speech API | Optional (default: disabled) |

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -393,8 +393,14 @@ impl ServerConfig {
             );
         }
 
-        // Message retention settings
-        let message_retention_count: i64 = parse_or(&mut errors, "MESSAGE_RETENTION_COUNT", 100);
+        // Message retention settings. The default counts wire records, not
+        // turns: muse journals ~60–90 durable records per turn, so a default of
+        // 100 kept barely one muse turn and the per-session trim evicted the
+        // user's own earlier messages (and split older muse turns) on reload.
+        // 1000 holds ~10+ muse turns and is a no-op for Claude/Codex sessions,
+        // which rarely reach even the old cap. Kept in sync with the frontend
+        // live-buffer cap (`MAX_MESSAGES_PER_SESSION`).
+        let message_retention_count: i64 = parse_or(&mut errors, "MESSAGE_RETENTION_COUNT", 1000);
         let message_retention_days: u32 = parse_or(&mut errors, "MESSAGE_RETENTION_DAYS", 30);
 
         let session_max_age_days: u32 = parse_or(&mut errors, "SESSION_MAX_AGE_DAYS", 14);

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -38,7 +38,7 @@ SESSION_SECRET=generate-a-random-32-char-secret-here
 # ALLOWED_EMAILS=user1@gmail.com,user2@example.com
 
 # Optional - Message retention (data cleanup)
-# MESSAGE_RETENTION_COUNT=100    # Max messages per session (default: 100)
+# MESSAGE_RETENTION_COUNT=1000   # Max messages per session (default: 1000)
 # MESSAGE_RETENTION_DAYS=30      # Delete messages older than N days (default: 30, 0=disabled)
 
 # Optional - Session cleanup
@@ -181,7 +181,7 @@ Admins can access the admin dashboard at `/admin` which provides:
 - **HTTPS**: Use HTTPS in production (handled by reverse proxy)
 - **Environment Secrets**: Never commit `.env` to version control
 - **Database**: Use SSL/TLS for database connections in production
-- **Data Retention**: Message data is automatically deleted based on `MESSAGE_RETENTION_DAYS` (default 30) and per-session limits (`MESSAGE_RETENTION_COUNT`, default 100). Adjust these values based on your compliance requirements.
+- **Data Retention**: Message data is automatically deleted based on `MESSAGE_RETENTION_DAYS` (default 30) and per-session limits (`MESSAGE_RETENTION_COUNT`, default 1000). Adjust these values based on your compliance requirements.
 
 ## Platform Support
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -57,7 +57,7 @@ SESSION_SECRET=generate-a-random-32-char-secret-here
 # ALLOWED_EMAILS=user1@gmail.com,user2@example.com
 
 # Optional - Message retention (data cleanup)
-# MESSAGE_RETENTION_COUNT=100    # Max messages per session (default: 100)
+# MESSAGE_RETENTION_COUNT=1000   # Max messages per session (default: 1000)
 # MESSAGE_RETENTION_DAYS=30      # Delete messages older than N days (default: 30, 0=disabled)
 ```
 
@@ -190,7 +190,7 @@ docker buildx build \
 | `PROXY_BINARY_PATH` | Auto-detected | Path to `claude-portal` binary for downloads |
 | `ALLOWED_EMAIL_DOMAIN` | *(none)* | Restrict sign-in to emails from this domain |
 | `ALLOWED_EMAILS` | *(none)* | Comma-separated list of allowed email addresses |
-| `MESSAGE_RETENTION_COUNT` | `100` | Maximum messages to keep per session |
+| `MESSAGE_RETENTION_COUNT` | `1000` | Maximum messages to keep per session |
 | `MESSAGE_RETENTION_DAYS` | `30` | Delete messages older than N days (0 = disabled) |
 | `SESSION_MAX_AGE_DAYS` | `14` | Delete sessions older than N days (0 = disabled) |
 | `PORTAL_MAX_IMAGE_MB` | `10` | Max image size in MB for proxy inlining |

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -31,8 +31,18 @@ pub const SESSION_RAIL_GROUP_BY_HOST_STORAGE_KEY: &str = "claude-portal-session-
 /// Storage key for the opt-in vim editing mode in localStorage
 pub const VIM_MODE_STORAGE_KEY: &str = "claude-portal-vim-mode";
 
-/// Maximum number of messages to keep in frontend memory (matches backend limit)
-pub const MAX_MESSAGES_PER_SESSION: usize = 100;
+/// Maximum number of messages to keep in the frontend live buffer.
+///
+/// This counts individual wire records, not conversational turns. Claude/Codex
+/// emit a handful of records per turn, but **muse journals ~60–90 durable
+/// records per turn** (each task lifecycle transition, tool result, etc. is its
+/// own record, later grouped into one task-tree card). At the old cap of 100 a
+/// single muse turn nearly filled the buffer and the next turn's flood evicted
+/// the oldest entries — the user's own prior messages — and left partial muse
+/// turns whose task-tree card rebuilt from a truncated record set. Sized to
+/// hold ~10+ muse turns so a turn's records never push the user's messages (or
+/// a neighbouring turn's records) out of view.
+pub const MAX_MESSAGES_PER_SESSION: usize = 1000;
 
 /// Type alias for WebSocket sender.
 ///


### PR DESCRIPTION
**Bug:** on a muse session, messages the user sends stop appearing after muse
responds.

**Root cause:** the per-session message cap counts individual *wire records*,
and was `100` on both sides (frontend live buffer `MAX_MESSAGES_PER_SESSION`
and backend retention default `MESSAGE_RETENTION_COUNT`). Claude/Codex emit a
handful of records per turn, but **muse journals ~60–90 *durable* records per
turn** — one per task-lifecycle transition, tool result, etc., later grouped
into a single task-tree card. Measured in the committed captures: **59**
(`meta_subagents`) and **86** (`meta_tool_use`) durable records for one turn.

So a single muse turn nearly filled the 100-slot buffer, and the next turn's
flood evicted the oldest entries — which are the user's own earlier messages —
and also left older muse turns whose grouped task-tree card then rebuilt from a
*truncated* record set (a corrupted card).

**Fix:** raise both caps to `1000` (they're documented to stay in sync). That
holds ~10+ muse turns, and it's a no-op for Claude/Codex sessions, which rarely
reach even the old cap of 100. Frontend fixes the live symptom; backend keeps
reload/history consistent. Env-var docs updated to the new default.

## Note on the number

`1000` is right-sizing, not a true fix for the impedance mismatch (a bounded
*record* buffer holding an agent whose turn is ~80 records). A very long muse
session (>~11 turns) would still eventually trim oldest turns — acceptable, and
it trims at the newest-N boundary so the current turn is always intact. A
turn-aware cap would be the deeper fix; out of scope here.

## Verification

Backend builds; 13 config tests pass (none asserted the old default). Frontend
WASM build, clippy, `cargo fmt` clean.
