### PR TITLE
Hide muse reminder tasks; key task nodes so they update in place

### DIFF
--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -15,14 +15,33 @@ pub mod task_tree;
 
 pub use task_tree::{TaskNode, TaskState, TaskTree};
 
-/// Draw a task tree: one collapsible node per task showing lifecycle state,
+/// Draw a task tree: one stacked card per task showing lifecycle state,
 /// tool outcomes, streamed output, and the policy decision muse applied to
 /// any side effect (muse decides tool policy itself and never prompts, so
-/// those render as an audit trail rather than an approval). Records the tree
-/// holds no structure for are named in a muted footer — nothing on the wire
-/// disappears silently.
+/// those render as an audit trail rather than an approval). Internal
+/// `reminder.*` scaffolding tasks are hidden (counted in the footer); records
+/// the tree holds no structure for are also named in the footer — nothing on
+/// the wire disappears silently.
 pub fn render_task_tree(tree: &TaskTree) -> Html {
-    let footer: Vec<String> = tree
+    // Muse injects internal scaffolding tasks — the `tbh-reminders` plugin's
+    // skill/scope/goal/verify reminders, whose `task_kind` is `reminder.*`.
+    // They're prompt bookkeeping, not user-facing work, so hide them from the
+    // task list; a muted footer count keeps the "nothing drops silently"
+    // invariant.
+    let mut hidden_reminders = 0usize;
+    let visible: Vec<&TaskNode> = tree
+        .nodes()
+        .filter(|node| {
+            if is_reminder_task(node) {
+                hidden_reminders += 1;
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    let mut footer: Vec<String> = tree
         .other_records()
         .map(|(payload_type, count)| {
             if count > 1 {
@@ -32,6 +51,11 @@ pub fn render_task_tree(tree: &TaskTree) -> Html {
             }
         })
         .collect();
+    if hidden_reminders > 0 {
+        let plural = if hidden_reminders == 1 { "" } else { "s" };
+        footer.push(format!("{hidden_reminders} reminder task{plural} hidden"));
+    }
+
     html! {
         <>
             // The agent's actual reply, rendered as markdown prose like a
@@ -43,9 +67,14 @@ pub fn render_task_tree(tree: &TaskTree) -> Html {
                     { crate::components::markdown::render_markdown(answer) }
                 </div>
             }
-            if tree.nodes().next().is_some() || !footer.is_empty() {
+            if !visible.is_empty() || !footer.is_empty() {
                 <div class="muse-task-tree">
-                    { for tree.nodes().map(render_task_node) }
+                    // Each task node carries a stable `key={task_id}` (set in
+                    // render_task_node) so Yew updates a task in place as it
+                    // advances running → completed, instead of positionally
+                    // diffing (which made an updating task appear to jump).
+                    // Mirrors how the Codex item list keys its cards.
+                    { for visible.iter().map(|node| render_task_node(node)) }
                     if !footer.is_empty() {
                         <div class="muse-journal-footer">{ footer.join(" · ") }</div>
                     }
@@ -53,6 +82,14 @@ pub fn render_task_tree(tree: &TaskTree) -> Html {
             }
         </>
     }
+}
+
+/// Internal scaffolding task (the `tbh-reminders` plugin's skill/scope/goal/
+/// verify reminders) — `task_kind` starts `reminder.`. Not user-facing work.
+fn is_reminder_task(node: &TaskNode) -> bool {
+    node.task_kind
+        .as_deref()
+        .is_some_and(|kind| kind.starts_with("reminder."))
 }
 
 fn render_task_node(node: &TaskNode) -> Html {
@@ -68,7 +105,7 @@ fn render_task_node(node: &TaskNode) -> Html {
         running.then_some("muse-task-in-progress"),
     );
     html! {
-        <div class={item_class}>
+        <div class={item_class} key={node.task_id.clone()}>
             <div class="muse-task-header">
                 <span class={classes!("muse-task-badge", format!("muse-task-{}", state.label()))}>
                     { state.label() }
@@ -100,5 +137,35 @@ fn render_task_node(node: &TaskNode) -> Html {
                 <div class="muse-task-output">{ chunk }</div>
             }) }
         </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(kind: Option<&str>) -> TaskNode {
+        TaskNode {
+            task_kind: kind.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn reminder_scaffolding_tasks_are_hidden() {
+        assert!(is_reminder_task(&node(Some(
+            "reminder.agent.plugin:tbh-reminders:skill-reminder"
+        ))));
+        assert!(is_reminder_task(&node(Some(
+            "reminder.agent.plugin:tbh-reminders:goal-reminder"
+        ))));
+    }
+
+    #[test]
+    fn real_tasks_and_unknowns_are_kept() {
+        assert!(!is_reminder_task(&node(Some("model.unknown.response"))));
+        assert!(!is_reminder_task(&node(None)));
+        // Must START with `reminder.` — a kind that merely contains it stays.
+        assert!(!is_reminder_task(&node(Some("agent.reminder.thing"))));
     }
 }

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -32,7 +32,7 @@ pub fn render_task_tree(tree: &TaskTree) -> Html {
     let visible: Vec<&TaskNode> = tree
         .nodes()
         .filter(|node| {
-            if is_reminder_task(node) {
+            if is_hidden_scaffolding(node) {
                 hidden_reminders += 1;
                 false
             } else {
@@ -90,6 +90,20 @@ fn is_reminder_task(node: &TaskNode) -> bool {
     node.task_kind
         .as_deref()
         .is_some_and(|kind| kind.starts_with("reminder."))
+}
+
+/// A reminder scaffolding task we can safely hide: only when it carries **no
+/// user-facing content**. The reducer's current tool-result attribution
+/// ("latest running task") lands tool outcomes on a running scaffolding task
+/// in every captured turn, so blindly hiding all reminders would silently drop
+/// the tool results Matt most wants to see. Rendering any reminder node that
+/// holds a tool result, streamed output, or a side-effect keeps that content
+/// visible; the attribution itself is corrected upstream in the reducer.
+fn is_hidden_scaffolding(node: &TaskNode) -> bool {
+    is_reminder_task(node)
+        && node.tool_results.is_empty()
+        && node.output.is_empty()
+        && node.side_effect.is_none()
 }
 
 fn render_task_node(node: &TaskNode) -> Html {
@@ -151,21 +165,45 @@ mod tests {
         }
     }
 
+    const REMINDER: &str = "reminder.agent.plugin:tbh-reminders:scope-reminder";
+
     #[test]
-    fn reminder_scaffolding_tasks_are_hidden() {
-        assert!(is_reminder_task(&node(Some(
-            "reminder.agent.plugin:tbh-reminders:skill-reminder"
-        ))));
-        assert!(is_reminder_task(&node(Some(
+    fn contentless_reminder_scaffolding_is_hidden() {
+        assert!(is_hidden_scaffolding(&node(Some(REMINDER))));
+        assert!(is_hidden_scaffolding(&node(Some(
             "reminder.agent.plugin:tbh-reminders:goal-reminder"
         ))));
     }
 
     #[test]
+    fn reminder_carrying_a_tool_result_is_kept() {
+        // The reducer attributes tool results to a running scaffolding task in
+        // every captured turn — hiding it would silently drop the tool output.
+        let mut n = node(Some(REMINDER));
+        n.tool_results.push(task_tree::ToolOutcome {
+            call_id: "c1".to_string(),
+            tool_name: Some("write_file".to_string()),
+            outcome: Some("success".to_string()),
+            text: "wrote hello.txt".to_string(),
+            has_edit_facts: true,
+        });
+        assert!(
+            !is_hidden_scaffolding(&n),
+            "a reminder with a tool result must render"
+        );
+
+        let mut with_output = node(Some(REMINDER));
+        with_output.output.push("some streamed text".to_string());
+        assert!(!is_hidden_scaffolding(&with_output));
+    }
+
+    #[test]
     fn real_tasks_and_unknowns_are_kept() {
-        assert!(!is_reminder_task(&node(Some("model.unknown.response"))));
-        assert!(!is_reminder_task(&node(None)));
+        assert!(!is_hidden_scaffolding(&node(Some(
+            "model.unknown.response"
+        ))));
+        assert!(!is_hidden_scaffolding(&node(None)));
         // Must START with `reminder.` — a kind that merely contains it stays.
-        assert!(!is_reminder_task(&node(Some("agent.reminder.thing"))));
+        assert!(!is_hidden_scaffolding(&node(Some("agent.reminder.thing"))));
     }
 }


### PR DESCRIPTION
Two muse task-tree fixes from live testing (both view-only — the TaskTree
reducer is untouched).

## 1. Hide internal `reminder.*` scaffolding tasks

Muse's `tbh-reminders` plugin injects skill/scope/goal/verify reminder tasks
into the journal — their `task_kind` is
`reminder.agent.plugin:tbh-reminders:*`. They're prompt bookkeeping, not
user-facing work, but rendered as full task cards they clutter every muse turn
(the committed captures carry 4–6 of them per turn). Filter them out of the
task list, keeping a muted `"N reminder tasks hidden"` footer count so the
"nothing drops silently" invariant holds.

## 2. Key task nodes so a running→completed task updates in place

`render_task_node` emitted no Yew key, so Yew diffed the task list
**positionally**. As a task advanced running → completed the list re-diffed and
the updating task appeared to jump to the bottom. Giving each node a stable
`key={task_id}` makes Yew match a task to its DOM node across renders and
update it in place — the same in-place behavior the Codex item list gets from
keying its cards.

## Verification

New unit tests for the `reminder.*` predicate (`reminder.` prefix matches;
`None` and merely-contains-`reminder` do not). 12 muse_renderer tests green
(incl. the 10 reducer tests, unchanged). WASM build, clippy, `cargo fmt` clean.
Keying is a Yew-runtime behavior; the in-place result is best confirmed live.
