### PR TITLE
Lower the frontend render cap to 100 (keep durable retention high)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -912,7 +912,7 @@ When making changes, verify:
 | `PORTAL_STT_VOCABULARY_NAME` | Pre-created custom-vocabulary resource | Optional (`aws`) |
 | `PORTAL_MAX_AUDIO_MB` | Per-recording cap for `POST /api/stt/transcribe` | Optional (default: 25) |
 | `PORTAL_MAX_IMAGE_MB` | Max image size for proxies (also the per-file cap for image `agent-portal show`) | Optional (default: 10) |
-| `PORTAL_MAX_VIDEO_MB` | Per-file cap for videos shown via `agent-portal show` | Optional (default: 100) |
+| `PORTAL_MAX_VIDEO_MB` | Per-file cap for videos shown via `agent-portal show` | Optional (default: 1000) |
 | `PORTAL_IMAGE_STORE_MAX_MB` | Backend served-image cache total-byte cap (LRU eviction past this) | Optional (default: 256) |
 | `PORTAL_MEDIA_STORE_MAX_MB` | Backend on-disk video store total-byte cap (oldest evicted past this); TTL reuses `PORTAL_IMAGE_STORE_TTL_SECS` | Optional (default: 1024) |
 | `PORTAL_IMAGE_STORE_TTL_SECS` | Backend served-image per-entry TTL in seconds | Optional (default: 3600) |

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -393,13 +393,15 @@ impl ServerConfig {
             );
         }
 
-        // Message retention settings. The default counts wire records, not
-        // turns: muse journals ~60–90 durable records per turn, so a default of
-        // 100 kept barely one muse turn and the per-session trim evicted the
-        // user's own earlier messages (and split older muse turns) on reload.
-        // 1000 holds ~10+ muse turns and is a no-op for Claude/Codex sessions,
-        // which rarely reach even the old cap. Kept in sync with the frontend
-        // live-buffer cap (`MAX_MESSAGES_PER_SESSION`).
+        // Durable per-session history budget (a DB row count) — deliberately a
+        // SEPARATE knob from the frontend render cap `MAX_MESSAGES_PER_SESSION`.
+        // The UI lag was the render cap (churning a big live buffer), not this;
+        // trimming durable history would only throw away muse scrollback for no
+        // perf gain. So it stays high (1000). Prod overrides this via env
+        // (`MESSAGE_RETENTION_COUNT=2000`), so this default only governs hosts
+        // without an override. The `reminder.*` classifier screen keeps junk
+        // out of what's retained; a bounded initial replay is the follow-up for
+        // the open-path cost (efficiency, not the felt lag).
         let message_retention_count: i64 = parse_or(&mut errors, "MESSAGE_RETENTION_COUNT", 1000);
         let message_retention_days: u32 = parse_or(&mut errors, "MESSAGE_RETENTION_DAYS", 30);
 

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -31,18 +31,22 @@ pub const SESSION_RAIL_GROUP_BY_HOST_STORAGE_KEY: &str = "claude-portal-session-
 /// Storage key for the opt-in vim editing mode in localStorage
 pub const VIM_MODE_STORAGE_KEY: &str = "claude-portal-vim-mode";
 
-/// Maximum number of messages to keep in the frontend live buffer.
+/// Maximum messages held in the frontend live buffer — a **render** budget,
+/// separate from durable history (`MESSAGE_RETENTION_COUNT`, a DB row count).
 ///
-/// This counts individual wire records, not conversational turns. Claude/Codex
-/// emit a handful of records per turn, but **muse journals ~60–90 durable
-/// records per turn** (each task lifecycle transition, tool result, etc. is its
-/// own record, later grouped into one task-tree card). At the old cap of 100 a
-/// single muse turn nearly filled the buffer and the next turn's flood evicted
-/// the oldest entries — the user's own prior messages — and left partial muse
-/// turns whose task-tree card rebuilt from a truncated record set. Sized to
-/// hold ~10+ muse turns so a turn's records never push the user's messages (or
-/// a neighbouring turn's records) out of view.
-pub const MAX_MESSAGES_PER_SESSION: usize = 1000;
+/// Every buffered record is grouped and re-parsed on each streamed frame and
+/// is a live DOM subtree, so this is what governs interactivity. 1000 (from
+/// #1581) was the laggy extreme; 100 keeps a long session responsive — this is
+/// the change that actually fixed the felt lag.
+///
+/// The tension with #1581 (a muse turn's ~60–90-record flood evicting the
+/// user's own earlier messages at a low cap) is resolved by cutting the flood
+/// at the source rather than by raising this budget: the muse classifier
+/// `Noop`s its `reminder.*` scaffolding (~41–47% of a turn) *before* the
+/// buffer, so those records never count here — a post-screen turn is ~30–40
+/// rendered records and 100 holds a couple of turns of real content. Durable
+/// history is unaffected (kept server-side under `MESSAGE_RETENTION_COUNT`).
+pub const MAX_MESSAGES_PER_SESSION: usize = 100;
 
 /// Type alias for WebSocket sender.
 ///


### PR DESCRIPTION
The felt UI lag was the **frontend live buffer** — grouping/re-parsing a large buffer on every streamed frame and holding it all as live DOM — not durable history. (Confirmed: prod pins `MESSAGE_RETENTION_COUNT=2000` in env, so the open-path replay was 2000 all along, before and after today's deploy; the speed-up came entirely from the render cap.)

## Change
- `MAX_MESSAGES_PER_SESSION` (frontend render budget): **1000 → 100** — the actual fix.
- `MESSAGE_RETENTION_COUNT` (durable DB history): **stays 1000** — a separate job. Trimming it would discard muse scrollback for zero perf gain. Prod overrides to 2000 via env; this default only governs non-override hosts.

## Why 100 is safe against #1581
Not by budgeting for the flood, but by cutting it at the source: the reminder classifier screen (#1587) `Noop`s muse's `reminder.*` scaffolding (~41–47% of a turn) before the buffer, so a post-screen turn is ~30–40 rendered records.

Supersedes the earlier both-knobs-to-100 approach (#1586) and the 200/three-knob-decouple proposal. A bounded initial-replay cap remains a worthwhile *efficiency* follow-up (stop shipping ~2000 rows to discard most), but it's not the felt lag. Can't merge until Actions recovers.