### PR TITLE
Forward launcher flags to the muse binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,9 +4523,8 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026276b49ac61ea3f9328b60a393bd448e355dfdf32e841c44300f87fd0e1b9e"
+version = "0.1.5"
+source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=6682946#6682946bd6871723ec54aac5ab235610201d3870"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = { version = "2.1.223", default-features = false, features = ["types"] }
 
 # Codex CLI integration
-muse-codes = { version = "0.1.4", default-features = false, features = ["async-client"] }
+# Temporary git pin: 0.1.5 (full `muse exec` flag parity + MuseExecBuilder::extra_args
+# raw passthrough) is unpublished pending a crates.io release. Flip back to a version
+# pin once 0.1.5 publishes — the API is identical branch→crates.
+muse-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "6682946", default-features = false, features = ["async-client"] }
 codex-codes = { version = "0.146.4", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the

--- a/muse-session-lib/src/io_task.rs
+++ b/muse-session-lib/src/io_task.rs
@@ -76,10 +76,7 @@ async fn run_turn(
     classifier: &mut MuseClassifier,
     event_tx: &mpsc::UnboundedSender<IoEvent>,
 ) -> Result<(), muse_codes::Error> {
-    let mut builder = MuseExecBuilder::new(text)
-        .provider(Provider::Meta)
-        .working_directory(&config.working_directory);
-    builder = builder.session_id(config.session_id.to_string());
+    let builder = build_exec_builder(config, text);
 
     let mut run = ExecRun::spawn(&builder).await?;
     let _ = event_tx.send(IoEvent::AgentStarted { pid: run.pid() });
@@ -94,6 +91,24 @@ async fn run_turn(
     Ok(())
 }
 
+/// Build the `muse exec` invocation for one turn. Extracted from [`run_turn`] so
+/// the argv is testable without spawning: it is the single place session config
+/// maps onto the muse CLI.
+///
+/// `config.extra_args` is forwarded verbatim (the launch dialog's model picker
+/// emits `--model <id>`, plus anything typed in the extra-args box). The
+/// passthrough sits after the typed flags and before the positional prompt, so
+/// raw tokens can never override structural args. Mirrors how claude
+/// (`args.extend`) and codex (`.extra_args`) pass the same field — muse was
+/// previously the lone agent that dropped it.
+fn build_exec_builder(config: &SessionConfig, text: &str) -> MuseExecBuilder {
+    MuseExecBuilder::new(text)
+        .provider(Provider::Meta)
+        .working_directory(&config.working_directory)
+        .session_id(config.session_id.to_string())
+        .extra_args(config.extra_args.clone())
+}
+
 fn emit(
     classifier: &mut MuseClassifier,
     record: &MuseRecord,
@@ -101,5 +116,60 @@ fn emit(
 ) {
     for decision in classifier.classify(record.clone()) {
         let _ = event_tx.send(IoEvent::Classified(decision));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// Live argv check: the launcher's `extra_args` must reach the spawned
+    /// `muse exec` argv (this is the exact seam muse previously dropped). It
+    /// resolves the real `muse` binary via `which`, so it's `#[ignore]`d —
+    /// run it on a host with muse installed via
+    /// `cargo test -p muse-session-lib -- --ignored`. muse-codes' own
+    /// `extra_args_sit_between_typed_flags_and_the_prompt` pins the argv
+    /// position in CI; wirecheck live-verifies the flag surface against the CLI.
+    #[test]
+    #[ignore = "requires the muse binary on PATH; run with --ignored"]
+    fn extra_args_reach_the_muse_argv() {
+        let config = SessionConfig {
+            working_directory: PathBuf::from("/tmp"),
+            extra_args: vec![
+                "--model".to_string(),
+                "test-model".to_string(),
+                "--yolo".to_string(),
+            ],
+            ..Default::default()
+        };
+        let cmd = build_exec_builder(&config, "hello")
+            .build_command()
+            .expect("muse binary should resolve on PATH");
+        let argv: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(argv.contains(&"exec".to_string()), "argv: {argv:?}");
+        for token in ["--model", "test-model", "--yolo"] {
+            assert!(
+                argv.iter().any(|a| a == token),
+                "expected {token:?} in argv: {argv:?}"
+            );
+        }
+        // Passthrough sits before the positional prompt, which stays last.
+        assert_eq!(
+            argv.last().map(String::as_str),
+            Some("hello"),
+            "argv: {argv:?}"
+        );
+        let session_pos = argv.iter().position(|a| a == "--session-id").unwrap();
+        let model_pos = argv.iter().position(|a| a == "--model").unwrap();
+        assert!(
+            session_pos < model_pos,
+            "typed flags precede the raw passthrough; argv: {argv:?}"
+        );
     }
 }


### PR DESCRIPTION
## What

The muse io-task built the `muse exec` command from `provider` / `session-id` / `working-directory` only and **never read `SessionConfig.extra_args`**, so the launch dialog's `--model` picker and anything typed in the extra-args box were silently dropped before reaching the muse process. Claude (`args.extend(extra_args)`) and Codex (`.extra_args(trailing)`) both forward that field — muse was the lone dropper.

## How

- Wire `config.extra_args` through `MuseExecBuilder::extra_args` (muse-codes 0.1.5), which appends the raw tokens **after** the typed flags and **before** the positional prompt, so passthrough can never override structural args. Same shape as claude/codex.
- Extract `build_exec_builder` as a small testable seam — the single place session config maps onto the muse CLI.
- Add an `#[ignore]`d live argv test (resolves the real `muse` binary via `which`, so it's opt-in with `--ignored`) confirming `--model`/`--yolo` land in the argv, positioned after `--session-id` and before the prompt. Verified locally against the installed binary. muse-codes' own `extra_args_sit_between_typed_flags_and_the_prompt` pins the position in CI, and the sdks `wirecheck` suite live-verifies the flag surface against the CLI.

## Build dependency (temporary)

`muse-codes 0.1.5` (full `muse exec` flag parity + the `extra_args` passthrough) is **git-pinned to an exact rev** pending a crates.io publish — that publish is Matt's explicit call, gated on the sdks branch merging to main. **Until the pin is flipped back to a version pin, this repo's builds depend on that rev staying fetchable on GitHub.** The sdks maintainer is holding `meawoppl/wirecheck-portal` (rev `6682946`) in place until the flip. Flip to a version pin the moment 0.1.5 lands on crates.io; the API is identical branch→crates.