### PR TITLE
Harden macOS self-update restart

### DIFF
--- a/launcher/src/service.rs
+++ b/launcher/src/service.rs
@@ -490,15 +490,36 @@ pub fn stop() -> Result<()> {
 
 #[cfg(target_os = "macos")]
 pub fn restart() -> Result<()> {
-    use anyhow::Context;
-    let plist = plist_path()?;
-    let _ = std::process::Command::new("launchctl")
-        .args(["unload", &plist.to_string_lossy()])
-        .output();
-    std::process::Command::new("launchctl")
-        .args(["load", &plist.to_string_lossy()])
+    use anyhow::{bail, Context};
+
+    // Do not unload the job from inside the process that job owns: launchd may
+    // terminate us before we can load it again. kickstart performs the
+    // kill-and-respawn transaction inside launchd instead.
+    let uid = std::process::Command::new("id")
+        .arg("-u")
         .output()
-        .context("Failed to run launchctl load")?;
+        .context("Failed to determine user id for launchctl")?;
+    if !uid.status.success() {
+        bail!(
+            "id -u failed: {}",
+            String::from_utf8_lossy(&uid.stderr).trim()
+        );
+    }
+    let domain = format!(
+        "gui/{}/{}",
+        String::from_utf8_lossy(&uid.stdout).trim(),
+        PLIST_LABEL
+    );
+    let output = std::process::Command::new("launchctl")
+        .args(["kickstart", "-k", &domain])
+        .output()
+        .context("Failed to run launchctl kickstart")?;
+    if !output.status.success() {
+        bail!(
+            "launchctl kickstart failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
     println!("Restarted {}", PLIST_LABEL);
     Ok(())
 }

--- a/portal-update/src/lib.rs
+++ b/portal-update/src/lib.rs
@@ -273,11 +273,66 @@ fn install_binary(self_path: &std::path::Path, new_binary: &[u8]) -> Result<()> 
 
     #[cfg(not(windows))]
     {
-        // Atomic rename on Unix
-        fs::rename(&temp_path, self_path).context("Failed to replace binary")?;
+        #[cfg(not(target_os = "macos"))]
+        {
+            // Atomic rename on Unix platforms without the macOS execution
+            // policy validation described below.
+            fs::rename(&temp_path, self_path).context("Failed to replace binary")?;
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            // Keep the previous executable available until the replacement has
+            // proved that the OS will execute it. This matters on macOS, where a
+            // freshly downloaded binary can pass the write/chmod steps but still
+            // be rejected by Gatekeeper on its first exec.
+            let old_path = self_path.with_extension("old");
+            let _ = fs::remove_file(&old_path);
+            fs::copy(self_path, &old_path).context("Failed to back up current binary")?;
+
+            fs::rename(&temp_path, self_path).context("Failed to replace binary")?;
+
+            if let Err(error) = validate_macos_executable(self_path) {
+                fs::rename(&old_path, self_path).context(
+                    "Replacement failed validation and old binary could not be restored",
+                )?;
+                return Err(error.context("Replacement failed validation; restored old binary"));
+            }
+        }
+
         info!("Update installed successfully");
         Ok(())
     }
+}
+
+/// Clear download provenance and prove launchd will be able to execute the
+/// replacement before the running launcher asks launchd to restart it.
+#[cfg(target_os = "macos")]
+fn validate_macos_executable(path: &std::path::Path) -> Result<()> {
+    let xattr = std::process::Command::new("xattr")
+        .arg("-c")
+        .arg(path)
+        .output()
+        .context("Failed to run xattr on replacement binary")?;
+    if !xattr.status.success() {
+        bail!(
+            "xattr -c failed: {}",
+            String::from_utf8_lossy(&xattr.stderr).trim()
+        );
+    }
+
+    let smoke = std::process::Command::new(path)
+        .arg("--help")
+        .output()
+        .context("Failed to execute replacement binary")?;
+    if !smoke.status.success() {
+        bail!(
+            "replacement --help smoke test failed with {}: {}",
+            smoke.status,
+            String::from_utf8_lossy(&smoke.stderr).trim()
+        );
+    }
+    Ok(())
 }
 
 /// How the Windows binary-swap dance failed

--- a/portal-update/src/lib.rs
+++ b/portal-update/src/lib.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::fs;
 use tracing::info;
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "macos"))]
 use tracing::warn;
 
 /// GitHub repository for releases
@@ -298,6 +298,13 @@ fn install_binary(self_path: &std::path::Path, new_binary: &[u8]) -> Result<()> 
                 )?;
                 return Err(error.context("Replacement failed validation; restored old binary"));
             }
+            if let Err(error) = fs::remove_file(&old_path) {
+                warn!(
+                    "Validated update installed, but failed to remove backup {}: {}",
+                    old_path.display(),
+                    error
+                );
+            }
         }
 
         info!("Update installed successfully");
@@ -309,7 +316,9 @@ fn install_binary(self_path: &std::path::Path, new_binary: &[u8]) -> Result<()> 
 /// replacement before the running launcher asks launchd to restart it.
 #[cfg(target_os = "macos")]
 fn validate_macos_executable(path: &std::path::Path) -> Result<()> {
-    let xattr = std::process::Command::new("xattr")
+    // launchd supplies a deliberately small PATH; use the platform's stable
+    // absolute path so command lookup cannot unnecessarily reject an update.
+    let xattr = std::process::Command::new("/usr/bin/xattr")
         .arg("-c")
         .arg(path)
         .output()


### PR DESCRIPTION
Closes #1589

## Summary
- keep a rollback copy of the current macOS executable during self-update
- clear extended attributes and smoke-test the installed binary before restarting
- restore the old binary when validation fails
- use checked `launchctl kickstart -k` instead of unloading the running job

## Verification
- `cargo test -p portal-update`
- `cargo check -p agent-portal`
- `cargo fmt --all -- --check`