### PR TITLE
Preserve launcher log severity in journald

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-journald",
  "tracing-subscriber",
  "uuid",
  "ws-bridge",
@@ -1192,6 +1193,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tracing",
+ "tracing-journald",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -8009,6 +8011,17 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-journald"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -53,6 +53,9 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 directories = { workspace = true }
 serde_json.workspace = true
 
+[target.'cfg(target_os = "linux")'.dependencies]
+tracing-journald = "0.3"
+
 [dev-dependencies]
 tempfile = "3.27.0"
 

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -19,6 +19,30 @@ use clap::{Parser, Subcommand};
 use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+fn init_tracing() {
+    let env_filter =
+        tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
+
+    #[cfg(target_os = "linux")]
+    {
+        // A journald layer preserves tracing levels as journal PRIORITY values
+        // and exposes structured fields to journalctl. Keep stdout formatting
+        // when the journal socket is unavailable (for example in a container).
+        let journald = tracing_journald::layer().ok();
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(journald.is_none().then(tracing_subscriber::fmt::layer))
+            .with(journald)
+            .init();
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "agent-portal")]
 #[command(about = "Persistent daemon that launches claude-portal sessions as in-process tasks")]
@@ -231,12 +255,7 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+    init_tracing();
 
     // Handle subcommands before the daemon startup path
     match args.command {

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -67,6 +67,9 @@ colored = "2.1"
 # Time
 chrono = { workspace = true, features = ["std", "clock"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+tracing-journald = "0.3"
+
 # Self-update
 portal-update = { path = "../portal-update" }
 session-lib = { path = "../session-lib" }

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -67,15 +67,15 @@ colored = "2.1"
 # Time
 chrono = { workspace = true, features = ["std", "clock"] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
-tracing-journald = "0.3"
-
 # Self-update
 portal-update = { path = "../portal-update" }
 session-lib = { path = "../session-lib" }
 claude-session-lib = { path = "../claude-session-lib" }
 portal-auth = { path = "../portal-auth" }
 base64 = "0.22"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tracing-journald = "0.3"
 
 # Unix system calls (for lock file process checking)
 [target.'cfg(unix)'.dependencies]

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -176,15 +176,36 @@ fn init_tracing(session_id_tag: Option<Uuid>, verbose: bool) {
         .unwrap_or_else(|_| default_level.into());
 
     if let Some(sid) = session_id_tag {
-        // Launched by daemon: JSON format with session_id field
-        let fmt_layer = tracing_subscriber::fmt::layer()
-            .json()
-            .with_target(false)
-            .with_span_list(false);
+        // A daemon-launched proxy should preserve tracing severity as journald
+        // PRIORITY and promote session_id to a queryable journal field. JSON on
+        // stdout remains the fallback when the journal socket is unavailable.
+        #[cfg(target_os = "linux")]
+        {
+            let journald = tracing_journald::layer().ok();
+            let fmt_layer = journald.is_none().then(|| {
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_target(false)
+                    .with_span_list(false)
+            });
+            tracing_subscriber::registry()
+                .with(env_filter)
+                .with(fmt_layer)
+                .with(journald)
+                .init();
+        }
+
+        #[cfg(not(target_os = "linux"))]
         tracing_subscriber::registry()
             .with(env_filter)
-            .with(fmt_layer)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_target(false)
+                    .with_span_list(false),
+            )
             .init();
+
         tracing::info!(session_id = %sid, "Proxy starting with session tag");
     } else {
         // Interactive: human-readable format


### PR DESCRIPTION
## Summary
- send launcher tracing events directly to journald on Linux
- preserve tracing levels as real journald priorities and expose structured fields
- use the same journald behavior for daemon-tagged proxy sessions while retaining stdout/JSON fallbacks
- keep non-Linux and interactive proxy logging unchanged

## Verification
- `cargo fmt --check`
- `cargo check -p agent-portal -p claude-portal`
- `cargo test -p agent-portal -p claude-portal`
- `cargo clippy -p agent-portal -p claude-portal -- -D warnings`

Closes #1597