### PR TITLE
Add Muse YOLO launch mode

### DIFF
--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -166,7 +166,10 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
             form.set(TaskForm {
                 timezone: detected_timezone(),
                 max_runtime_minutes: 30,
-                skip_permissions: true,
+                // Preserve the established auto-enabled setting for Claude and
+                // Codex schedules, but Muse's broader YOLO mode must be an
+                // explicit opt-in because it also disables the sandbox.
+                skip_permissions: session_agent_type != shared::AgentType::Muse,
                 ..Default::default()
             });
             error_msg.set(None);

--- a/frontend/src/components/skip_permissions.rs
+++ b/frontend/src/components/skip_permissions.rs
@@ -15,15 +15,14 @@ const CODEX_SKIP_PERMISSIONS_ARGS: &[&str] = &[
     "-c",
     "sandbox_mode=danger-full-access",
 ];
+const MUSE_SKIP_PERMISSIONS_ARGS: &[&str] = &["--yolo"];
 
 /// CLI arguments appended when the user checks the skip-permissions box.
 pub fn skip_permissions_args(agent_type: AgentType) -> &'static [&'static str] {
     match agent_type {
         AgentType::Claude => CLAUDE_SKIP_PERMISSIONS_ARGS,
         AgentType::Codex => CODEX_SKIP_PERMISSIONS_ARGS,
-        // Muse decides tool policy itself in headless runs and exposes no
-        // skip-permissions flag; the checkbox is hidden for it.
-        AgentType::Muse => &[],
+        AgentType::Muse => MUSE_SKIP_PERMISSIONS_ARGS,
     }
 }
 
@@ -32,7 +31,7 @@ pub fn skip_permissions_label(agent_type: AgentType) -> &'static str {
     match agent_type {
         AgentType::Claude => "--dangerously-skip-permissions",
         AgentType::Codex => "-c approval_policy=never -c sandbox_mode=danger-full-access",
-        AgentType::Muse => "(not applicable — Muse manages tool policy itself)",
+        AgentType::Muse => "YOLO mode (--yolo: disables approval and sandbox)",
     }
 }
 
@@ -47,6 +46,12 @@ pub fn strip_skip_permissions_args(args: &[String], agent_type: AgentType) -> (b
         let arg = args[i].as_str();
 
         if arg == "--dangerously-skip-permissions" {
+            has_skip = true;
+            i += 1;
+            continue;
+        }
+
+        if agent_type == AgentType::Muse && arg == "--yolo" {
             has_skip = true;
             i += 1;
             continue;
@@ -117,7 +122,7 @@ mod tests {
 
     #[test]
     fn strip_recognizes_exactly_what_skip_permissions_args_emits() {
-        for agent_type in [AgentType::Claude, AgentType::Codex] {
+        for agent_type in [AgentType::Claude, AgentType::Codex, AgentType::Muse] {
             let emitted: Vec<String> = skip_permissions_args(agent_type)
                 .iter()
                 .map(|a| a.to_string())

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -359,13 +359,31 @@ async fn run_session_task(
             None
         };
 
+        // The portal's established dangerous-permissions wire format is the
+        // agent argument list. Consume Muse's token here and carry it as typed
+        // config so the backend uses MuseExecBuilder::yolo rather than a raw
+        // passthrough argument.
+        let muse_yolo = config.agent_type == shared::AgentType::Muse
+            && config.claude_args.iter().any(|arg| arg == "--yolo");
+        let extra_args = if config.agent_type == shared::AgentType::Muse {
+            config
+                .claude_args
+                .iter()
+                .filter(|arg| arg.as_str() != "--yolo")
+                .cloned()
+                .collect()
+        } else {
+            config.claude_args.clone()
+        };
+
         let session_config = SessionConfig {
             session_id: config.session_id,
             working_directory: PathBuf::from(&config.working_directory),
             session_name: config.session_name.clone(),
             resume: config.resume,
             claude_path: None,
-            extra_args: config.claude_args.clone(),
+            extra_args,
+            muse_yolo,
             agent_type: config.agent_type,
             codex_thread_id,
         };

--- a/muse-session-lib/src/io_task.rs
+++ b/muse-session-lib/src/io_task.rs
@@ -110,6 +110,7 @@ fn build_exec_builder(config: &SessionConfig, text: &str) -> MuseExecBuilder {
         .provider(Provider::Meta)
         .working_directory(&config.working_directory)
         .session_id(config.session_id.to_string())
+        .yolo(config.muse_yolo)
         .extra_args(config.extra_args.clone())
 }
 
@@ -140,11 +141,8 @@ mod tests {
     fn extra_args_reach_the_muse_argv() {
         let config = SessionConfig {
             working_directory: PathBuf::from("/tmp"),
-            extra_args: vec![
-                "--model".to_string(),
-                "test-model".to_string(),
-                "--yolo".to_string(),
-            ],
+            extra_args: vec!["--model".to_string(), "test-model".to_string()],
+            muse_yolo: true,
             ..Default::default()
         };
         let cmd = build_exec_builder(&config, "hello")

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -796,7 +796,18 @@ async fn create_claude_session(config: &ProxySessionConfig) -> Result<ClaudeSess
         session_name: config.session_name.clone(),
         resume: config.resume,
         claude_path: None,
-        extra_args: config.claude_args.clone(),
+        extra_args: if config.agent_type == shared::AgentType::Muse {
+            config
+                .claude_args
+                .iter()
+                .filter(|arg| arg.as_str() != "--yolo")
+                .cloned()
+                .collect()
+        } else {
+            config.claude_args.clone()
+        },
+        muse_yolo: config.agent_type == shared::AgentType::Muse
+            && config.claude_args.iter().any(|arg| arg == "--yolo"),
         agent_type: config.agent_type,
         codex_thread_id,
     };

--- a/session-lib/src/snapshot.rs
+++ b/session-lib/src/snapshot.rs
@@ -23,6 +23,10 @@ pub struct SessionConfig {
     /// Extra arguments to pass to the claude CLI
     #[serde(default)]
     pub extra_args: Vec<String>,
+    /// Whether Muse should disable tool approval and sandboxing and trust the
+    /// workspace. Ignored by other agents and safe by default.
+    #[serde(default)]
+    pub muse_yolo: bool,
     /// Which agent CLI to use
     #[serde(default)]
     pub agent_type: shared::AgentType,
@@ -112,6 +116,7 @@ mod tests {
             resume: false,
             claude_path: None,
             extra_args: vec![],
+            muse_yolo: false,
             agent_type: Default::default(),
             codex_thread_id: None,
         }
@@ -128,6 +133,16 @@ mod tests {
         assert_eq!(config.session_name, restored.session_name);
         assert_eq!(config.resume, restored.resume);
         assert_eq!(config.claude_path, restored.claude_path);
+        assert!(!restored.muse_yolo);
+    }
+
+    #[test]
+    fn missing_muse_yolo_defaults_off() {
+        let mut value = serde_json::to_value(sample_config()).unwrap();
+        value.as_object_mut().unwrap().remove("muse_yolo");
+        let restored: SessionConfig = serde_json::from_value(value).unwrap();
+
+        assert!(!restored.muse_yolo);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a default-off Muse YOLO checkbox using the existing dangerous-permissions launch surface
- convert `--yolo` at the launcher/proxy boundary into typed `SessionConfig::muse_yolo`
- invoke `MuseExecBuilder::yolo(bool)` and keep raw passthrough args clean
- preserve safe defaults for Muse scheduled sessions and backward-compatible snapshots

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p frontend skip_permissions --lib`
- `cargo test -p session-lib snapshot --lib`
- `cargo check -p agent-portal -p muse-session-lib -p claude-portal`

Closes #1592