### PR TITLE
Standardize config dir to ~/.config/agent-portal on all platforms

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -260,7 +260,9 @@ chmod +x scripts/*.sh
 If everything is broken, try a full cleanup:
 ```bash
 ./scripts/clean.sh
-rm -rf ~/.config/agent-portal/  # Remove cached auth
+# Remove cached auth/config only — NOT the whole dir, which on an installed
+# machine also holds the `agent-portal` binary (#1591).
+rm -f ~/.config/agent-portal/launcher.json ~/.config/agent-portal/config.json
 cargo clean
 cd frontend && trunk clean && cd ..
 ./scripts/install-deps.sh

--- a/docs/VSCODE_SETUP.md
+++ b/docs/VSCODE_SETUP.md
@@ -32,7 +32,7 @@ Once authenticated, all future sessions (terminal and VS Code) reuse the stored 
 
 **Important**: The auth token is stored per-working-directory. The shim uses a cross-directory fallback, so authenticating from *any* directory is sufficient for VS Code sessions to work.
 
-**Config location on macOS**: `~/Library/Application Support/com.anthropic.agent-portal/config.json` (not `~/.config/`). The proxy uses the `directories` crate which follows OS-standard paths.
+**Config location**: `~/.config/agent-portal/config.json` on every platform (Linux and macOS alike; `%APPDATA%\agent-portal\config.json` on Windows). This matches the installer everywhere (#1591).
 
 ### 2. Create the shim script
 

--- a/launcher/src/config.rs
+++ b/launcher/src/config.rs
@@ -26,9 +26,7 @@ pub struct ExpectedSession {
 }
 
 fn config_dir() -> PathBuf {
-    directories::ProjectDirs::from("com", "anthropic", "agent-portal")
-        .map(|p| p.config_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/tmp/agent-portal"))
+    session_lib::paths::config_dir()
 }
 
 fn config_path() -> PathBuf {

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -238,6 +238,11 @@ async fn main() -> anyhow::Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
+    // Reconcile the pre-#1591 config location (macOS/Windows `ProjectDirs`)
+    // onto the standardized `~/.config/agent-portal` before anything reads
+    // config, so existing devices keep their auth token instead of logging out.
+    session_lib::paths::migrate_legacy_config_dir();
+
     // Handle subcommands before the daemon startup path
     match args.command {
         Some(Command::Login) => return cmd_login(&args).await,

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -24,13 +24,10 @@ use crate::path_policy;
 const CRASH_LOOP_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Path to the launcher's sidecar codex-thread map: `session_id -> thread_id`.
-/// Lives next to `launcher.json` in `ProjectDirs` so it ships with the same
+/// Lives next to `launcher.json` in the config dir so it ships with the same
 /// install/uninstall surface and survives across restarts.
 fn codex_threads_path() -> PathBuf {
-    directories::ProjectDirs::from("com", "anthropic", "agent-portal")
-        .map(|p| p.config_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/tmp/agent-portal"))
-        .join("codex_threads.json")
+    session_lib::paths::config_dir().join("codex_threads.json")
 }
 
 fn load_codex_threads() -> HashMap<Uuid, String> {

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -137,12 +137,7 @@ impl Drop for ConfigLock {
 
 impl ProxyConfig {
     pub fn config_path() -> Result<PathBuf> {
-        let config_dir = directories::ProjectDirs::from("com", "anthropic", "agent-portal")
-            .context("Failed to determine config directory")?
-            .config_dir()
-            .to_path_buf();
-
-        Ok(config_dir.join("config.json"))
+        Ok(session_lib::paths::config_dir().join("config.json"))
     }
 
     pub fn load() -> Result<Self> {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -238,6 +238,11 @@ async fn main() -> Result<()> {
 
     init_tracing(args.session_id_tag, args.verbose);
 
+    // Reconcile the pre-#1591 config location before reading config.json.
+    // Idempotent and best-effort; normally the launcher already did this, but a
+    // standalone proxy run must not read the stale macOS `ProjectDirs` path.
+    session_lib::paths::migrate_legacy_config_dir();
+
     // Skip update checks and UI output entirely in shim mode
     if !args.shim {
         // Apply any pending update, then auto-update before anything else —

--- a/session-lib/src/lib.rs
+++ b/session-lib/src/lib.rs
@@ -29,6 +29,7 @@ pub mod heartbeat;
 pub mod install;
 pub mod io;
 pub mod output_buffer;
+pub mod paths;
 pub mod probe;
 pub mod session;
 pub mod snapshot;

--- a/session-lib/src/output_buffer.rs
+++ b/session-lib/src/output_buffer.rs
@@ -111,13 +111,8 @@ impl PendingOutputBuffer {
 
     /// Get the path for a session's buffer file
     fn buffer_path(session_id: Uuid) -> Result<PathBuf> {
-        let config_dir = directories::ProjectDirs::from("com", "anthropic", "agent-portal")
-            .context("Failed to determine config directory")?
-            .config_dir()
-            .to_path_buf();
-
         // Create buffers subdirectory
-        let buffers_dir = config_dir.join("buffers");
+        let buffers_dir = crate::paths::config_dir().join("buffers");
         fs::create_dir_all(&buffers_dir).context("Failed to create buffers directory")?;
 
         Ok(buffers_dir.join(format!("{}.json", session_id)))

--- a/session-lib/src/paths.rs
+++ b/session-lib/src/paths.rs
@@ -1,0 +1,238 @@
+//! Single source of truth for the launcher/proxy on-disk config directory.
+//!
+//! Standardized to `~/.config/agent-portal` on Unix (Linux **and** macOS) and
+//! `%APPDATA%\agent-portal` on Windows. This matches the install script, which
+//! writes both the binary and `launcher.json` to `~/.config/agent-portal` on
+//! every platform (see `backend/src/handlers/downloads.rs`).
+//!
+//! Previously every call site built this from
+//! `ProjectDirs::from("com", "anthropic", "agent-portal")`, whose Unix impl
+//! follows the XDG spec and drops the qualifier/organization — so it resolved
+//! to `~/.config/agent-portal` on Linux but
+//! `~/Library/Application Support/com.anthropic.agent-portal` on macOS. That
+//! disagreed with the installer on macOS: the launcher read a directory the
+//! installer never wrote to, silently dropping the self-hosted `backend_url`
+//! (#1591). Collapsing the path into one helper — and dropping the reverse-DNS
+//! identifier that read as vendor attribution — makes the installer, the docs,
+//! and the code agree on every platform.
+
+use std::path::{Path, PathBuf};
+
+/// The config directory: `~/.config/agent-portal` on Unix, `%APPDATA%\agent-portal`
+/// on Windows. Holds `launcher.json`, the proxy's `config.json`, the machine-id
+/// file, `codex_threads.json`, the `buffers/` subdirectory, and (via the
+/// installer) the `agent-portal` binary itself.
+pub fn config_dir() -> PathBuf {
+    #[cfg(windows)]
+    {
+        // `BaseDirs::config_dir()` is `%APPDATA%` (Roaming) on Windows.
+        directories::BaseDirs::new()
+            .map(|b| b.config_dir().join("agent-portal"))
+            .unwrap_or_else(|| PathBuf::from("agent-portal"))
+    }
+    #[cfg(not(windows))]
+    {
+        // `~/.config/agent-portal` regardless of `$XDG_CONFIG_HOME`, matching
+        // the install script's hard-coded `${HOME}/.config/agent-portal`.
+        directories::BaseDirs::new()
+            .map(|b| b.home_dir().join(".config").join("agent-portal"))
+            .unwrap_or_else(|| PathBuf::from("/tmp/agent-portal"))
+    }
+}
+
+/// The pre-#1591 location, still produced by `ProjectDirs` for the migration.
+/// On Linux this resolves to the same path as [`config_dir`] (XDG drops the
+/// qualifier), so migration is a no-op there; macOS/Windows resolve it to the
+/// old per-OS directory that held the live config.
+fn legacy_config_dir() -> Option<PathBuf> {
+    directories::ProjectDirs::from("com", "anthropic", "agent-portal")
+        .map(|p| p.config_dir().to_path_buf())
+}
+
+/// One-time, best-effort migration from the legacy `ProjectDirs` location to
+/// [`config_dir`]. Idempotent; safe to call on every startup. It never fails
+/// startup — a migration error just means the user may need to run
+/// `agent-portal login` again, which is strictly better than crashing.
+///
+/// The legacy config is authoritative (it is what the running launcher has
+/// been using), so overlapping files overwrite the destination — in particular
+/// the installer's `launcher.json` stub, which on macOS held only `backend_url`
+/// and no auth token. The legacy directory never contains the binary (on macOS
+/// it is `Application Support`, and the installer puts the binary under
+/// `~/.config`), so overwriting can't clobber the executable.
+pub fn migrate_legacy_config_dir() {
+    let new = config_dir();
+    let Some(legacy) = legacy_config_dir() else {
+        return;
+    };
+    migrate_between(&legacy, &new);
+}
+
+/// Testable core of [`migrate_legacy_config_dir`] with explicit paths.
+fn migrate_between(legacy: &Path, new: &Path) {
+    if !legacy.exists() {
+        return;
+    }
+    // Same directory (the Linux case, or already migrated): nothing to do.
+    let same = std::fs::canonicalize(legacy)
+        .ok()
+        .zip(std::fs::canonicalize(new).ok())
+        .map(|(a, b)| a == b)
+        .unwrap_or(false);
+    if same {
+        return;
+    }
+    if let Err(e) = std::fs::create_dir_all(new) {
+        tracing::warn!("config migration: could not create {}: {e}", new.display());
+        return;
+    }
+    let entries = match std::fs::read_dir(legacy) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!("config migration: could not read {}: {e}", legacy.display());
+            return;
+        }
+    };
+    let mut moved = 0usize;
+    for entry in entries.flatten() {
+        let from = entry.path();
+        let dest = new.join(entry.file_name());
+        match move_path(&from, &dest) {
+            Ok(()) => moved += 1,
+            Err(e) => tracing::warn!(
+                "config migration: failed to move {} -> {}: {e}",
+                from.display(),
+                dest.display()
+            ),
+        }
+    }
+    if moved > 0 {
+        tracing::info!(
+            "Migrated {moved} config entr{} from {} to {} (#1591)",
+            if moved == 1 { "y" } else { "ies" },
+            legacy.display(),
+            new.display()
+        );
+    }
+    // The now-emptied legacy directory is left in place; removing it is
+    // unnecessary and risks deleting something we didn't create.
+}
+
+/// Move `from` onto `dest`, overwriting any existing destination. Tries a
+/// rename first (same-volume — the normal case, both live under `$HOME`) and
+/// falls back to a recursive copy + remove across volumes. Handles both files
+/// and directories (the `buffers/` subdirectory).
+fn move_path(from: &Path, dest: &Path) -> std::io::Result<()> {
+    // Clear any destination stub so a rename doesn't fail on a non-empty dir
+    // and files are replaced cleanly.
+    if dest.exists() {
+        if dest.is_dir() {
+            std::fs::remove_dir_all(dest)?;
+        } else {
+            std::fs::remove_file(dest)?;
+        }
+    }
+    match std::fs::rename(from, dest) {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            // Cross-device or other rename failure: deep copy, then remove.
+            copy_recursive(from, dest)?;
+            if from.is_dir() {
+                std::fs::remove_dir_all(from)
+            } else {
+                std::fs::remove_file(from)
+            }
+        }
+    }
+}
+
+fn copy_recursive(from: &Path, dest: &Path) -> std::io::Result<()> {
+    if from.is_dir() {
+        std::fs::create_dir_all(dest)?;
+        for entry in std::fs::read_dir(from)? {
+            let entry = entry?;
+            copy_recursive(&entry.path(), &dest.join(entry.file_name()))?;
+        }
+        Ok(())
+    } else {
+        std::fs::copy(from, dest).map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_dir_is_under_dot_config_on_unix() {
+        // On the CI/dev Unix hosts this must land at ~/.config/agent-portal,
+        // matching the installer — never Application Support.
+        #[cfg(not(windows))]
+        {
+            let dir = config_dir();
+            assert!(
+                dir.ends_with(".config/agent-portal"),
+                "expected ~/.config/agent-portal, got {}",
+                dir.display()
+            );
+            assert!(
+                !dir.to_string_lossy().contains("Application Support"),
+                "must not resolve to the macOS ProjectDirs path: {}",
+                dir.display()
+            );
+        }
+    }
+
+    #[test]
+    fn migration_moves_legacy_config_and_overwrites_stub() {
+        let tmp =
+            std::env::temp_dir().join(format!("agent-portal-mig-{}-{}", std::process::id(), "a"));
+        let legacy = tmp.join("legacy");
+        let new = tmp.join("new");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::create_dir_all(&new).unwrap();
+
+        // Legacy holds the live config (token) + a buffers subdir; new holds
+        // the installer stub (backend_url only) and the "binary".
+        std::fs::write(
+            legacy.join("launcher.json"),
+            r#"{"backend_url":"wss://real","auth_token":"tok"}"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(legacy.join("buffers")).unwrap();
+        std::fs::write(legacy.join("buffers").join("s.json"), "[]").unwrap();
+        std::fs::write(new.join("launcher.json"), r#"{"backend_url":"wss://real"}"#).unwrap();
+        std::fs::write(new.join("agent-portal"), b"ELF").unwrap();
+
+        migrate_between(&legacy, &new);
+
+        // Live config (with token) overwrote the stub; buffers came across; the
+        // binary is untouched.
+        assert_eq!(
+            std::fs::read_to_string(new.join("launcher.json")).unwrap(),
+            r#"{"backend_url":"wss://real","auth_token":"tok"}"#
+        );
+        assert!(new.join("buffers").join("s.json").exists());
+        assert_eq!(std::fs::read(new.join("agent-portal")).unwrap(), b"ELF");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn migration_is_noop_when_paths_are_the_same() {
+        // The Linux case: legacy and new canonicalize to the same dir.
+        let tmp = std::env::temp_dir().join(format!("agent-portal-mig-{}-b", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(tmp.join("launcher.json"), "keep").unwrap();
+
+        migrate_between(&tmp, &tmp);
+
+        assert_eq!(
+            std::fs::read_to_string(tmp.join("launcher.json")).unwrap(),
+            "keep"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}


### PR DESCRIPTION
Fixes #1591.

## Problem

The four config-path call sites each built their directory from `ProjectDirs::from("com", "anthropic", "agent-portal")`. On Linux that follows XDG and yields `~/.config/agent-portal`; on macOS it expands to `~/Library/Application Support/com.anthropic.agent-portal`. But the install script hardcodes `~/.config/agent-portal` on **every** platform (and drops the binary there too). So on macOS the launcher read a directory the installer never wrote to — **silently dropping the self-hosted `backend_url`**, leaving a fresh install pointed at `wss://txcl.io` instead of the user's backend. The `com.anthropic.*` name also read as vendor attribution for a repo Anthropic doesn't ship.

## Fix (standardize + migrate, per maintainer decision)

- **One helper.** `session_lib::paths::config_dir()` is now the single source of truth, standardized to `~/.config/agent-portal` on Unix (Linux + macOS) and `%APPDATA%\agent-portal` on Windows — matching the installer everywhere. The four duplicated `ProjectDirs` literals are gone, so this can't drift again.
- **No fleet-wide logout.** A best-effort, idempotent startup migration (`migrate_legacy_config_dir`, called from both `launcher` and `proxy` `main` before any config read) moves an existing legacy `ProjectDirs` config into the new location. The legacy config is authoritative for overlapping files (it overwrites the installer's `launcher.json` stub, which on macOS held only `backend_url` and no token). The legacy dir never contains the binary, so overwriting can't clobber the executable. On Linux legacy == new, so it's a no-op.
- **Docs.** The change makes the previously Linux-only doc paths correct on all platforms. Fixed the two that flipped: `VSCODE_SETUP.md`'s now-stale macOS special-case, and `TROUBLESHOOTING.md`'s `rm -rf ~/.config/agent-portal/` (which now also holds the installed binary) — narrowed to the auth/config files.
- **No installer change needed** — standardizing onto the path the installer already uses makes it correct by construction.

## Tests

`session-lib` unit tests cover the helper shape (never Application Support on Unix) and the migration core: it moves the live config over, overwrites the stub `launcher.json`, carries the `buffers/` subdir, leaves the binary untouched, and is a no-op when legacy == new.

## Verification note

The migration logic is fully unit-tested on Linux, but the macOS `ProjectDirs → ~/.config` move and the Windows path have not been exercised on a real device — worth a smoke test on one macOS device before broad rollout (an existing device should keep its login across the update).