### PR TITLE
Resolve current portal session after Claude /clear

### DIFF
--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -59,9 +59,10 @@ pub(crate) async fn spawn_claude(
     let mut cmd = Command::new(claude_path);
     cmd.args(&args);
     cmd.current_dir(&config.working_directory);
-    // Note: no need to inject a session-id env var — Claude Code already
-    // exports `CLAUDE_CODE_SESSION_ID` (equal to the `--session-id` we pass) to
-    // the tools it spawns, which `agent-portal message` reads for attribution.
+    // Claude exports `CLAUDE_CODE_SESSION_ID` to tools it spawns. This is the
+    // id passed here initially, but it is process-environment state and can go
+    // stale when `/clear` rolls Claude to another conversation. The launcher
+    // CLI therefore treats an explicit `PORTAL_SESSION_ID` as authoritative.
 
     // Log the full command for diagnostics.
     tracing::info!(

--- a/launcher/src/forward.rs
+++ b/launcher/src/forward.rs
@@ -28,10 +28,8 @@ fn api_base() -> Result<(String, String)> {
 
 /// The calling agent's own portal session id (reuses `message`'s resolver, so
 /// Claude / Codex / explicit-override all work).
-fn session_id() -> Result<String> {
-    crate::message::sender_session_id().ok_or_else(|| {
-        anyhow!("run this from inside an agent session (no portal session id found)")
-    })
+async fn session_id(client: &reqwest::Client, base: &str, token: &str) -> Result<String> {
+    crate::message::current_session_id(client, base, token).await
 }
 
 /// Outcome of a best-effort local probe of the origin the forward points at.
@@ -176,8 +174,8 @@ pub async fn open(port: u16) -> Result<()> {
         return Err(anyhow!("port must be 1-65535"));
     }
     let (base, token) = api_base()?;
-    let session = session_id()?;
     let client = reqwest::Client::new();
+    let session = session_id(&client, &base, &token).await?;
 
     // Probe the origin locally first (same host as the CLI) so we can report
     // exactly what the tunnel will see, before the round-trip to register.
@@ -216,8 +214,8 @@ pub async fn open(port: u16) -> Result<()> {
 /// `agent-portal forward list` — active forwards for this session.
 pub async fn list() -> Result<()> {
     let (base, token) = api_base()?;
-    let session = session_id()?;
     let client = reqwest::Client::new();
+    let session = session_id(&client, &base, &token).await?;
 
     let resp = client
         .get(format!("{base}/api/agent/sessions/{session}/forwards"))
@@ -250,8 +248,8 @@ pub async fn list() -> Result<()> {
 /// `agent-portal forward close` — revoke the session's forward.
 pub async fn close() -> Result<()> {
     let (base, token) = api_base()?;
-    let session = session_id()?;
     let client = reqwest::Client::new();
+    let session = session_id(&client, &base, &token).await?;
 
     let resp = client
         .delete(format!("{base}/api/agent/sessions/{session}/forwards"))

--- a/launcher/src/media.rs
+++ b/launcher/src/media.rs
@@ -109,15 +109,12 @@ pub async fn show(path_str: &str) -> Result<()> {
         ));
     }
 
-    let session_id = crate::message::sender_session_id().ok_or_else(|| {
-        anyhow!(
-            "could not determine the calling session — `agent-portal show` must be run \
-             from inside an agent session's shell"
-        )
-    })?;
     let (base, token) = crate::message::api_base()?;
 
     let client = reqwest::Client::new();
+    let session_id = crate::message::current_session_id(&client, &base, &token)
+        .await
+        .context("could not determine the calling session for `agent-portal show`")?;
     let resp = client
         .post(format!("{base}/api/agent/sessions/{session_id}/media"))
         .bearer_auth(&token)

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -237,7 +237,12 @@ pub async fn list() -> Result<()> {
         println!("No sessions found.");
         return Ok(());
     }
-    let self_id = sender_session_id(&data.sessions)?;
+    // Self-marking is cosmetic; a stale/ambiguous caller must still be able to
+    // inspect the session list and use an explicit id.
+    let self_id = sender_session_id(&data.sessions).unwrap_or_else(|error| {
+        eprintln!("warning: could not identify this session: {error}");
+        None
+    });
     for s in &data.sessions {
         let marker = if self_id.as_deref() == Some(&s.id.to_string()) {
             " (this session)"
@@ -281,7 +286,12 @@ pub async fn send(agent_id: &str, message: &str) -> Result<()> {
     let client = reqwest::Client::new();
     let sessions = fetch_sessions(&client, &base, &token).await?;
     let resolved_agent_id = resolve_session_id(agent_id, &sessions.sessions)?;
-    let from = sender_session_id(&sessions.sessions)?;
+    // Sender attribution is best-effort and must not block delivery when more
+    // than one live session shares this host and working directory.
+    let from = sender_session_id(&sessions.sessions).unwrap_or_else(|error| {
+        eprintln!("warning: could not attribute sender session: {error}");
+        None
+    });
     // Non-idempotent POST: retry the pre-delivery transient (404 target lookup
     // against a stale session index) and transport errors, but NOT 5xx — the
     // server may already have delivered, and a replay would double-send.

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -12,27 +12,96 @@ use shared::api::{AgentSessionsResponse, SendAgentMessageRequest, SendAgentMessa
 const SHORT_SESSION_ID_LEN: usize = 8;
 
 /// The calling agent's own portal session id, read from whatever the agent
-/// already exposes — no portal-side injection needed:
+/// already exposes:
 ///
-/// - Claude Code sets `CLAUDE_CODE_SESSION_ID` to the id we spawn it with
-///   (`--session-id <portal id>`), so it already *is* the portal session id.
+/// - `PORTAL_SESSION_ID` is the explicit portal-side override and therefore
+///   always wins. In particular, Claude keeps its process environment across
+///   `/clear`, so `CLAUDE_CODE_SESSION_ID` can still name the pre-clear
+///   conversation while a caller deliberately supplies the current portal id.
+/// - Claude Code sets `CLAUDE_CODE_SESSION_ID` to the id we spawn it with. It
+///   is a useful fallback, but is only a spawn-time value.
 /// - Codex sets `CODEX_THREAD_ID`, which is *not* the portal id, so we reverse
 ///   it through the launcher's `codex_threads.json` map to the portal session.
-/// - `PORTAL_SESSION_ID` is honored as a manual/explicit override.
 ///
 /// Returns `None` when none apply (e.g. a human shell), in which case the
 /// recipient falls back to user attribution.
-pub(crate) fn sender_session_id() -> Option<String> {
+pub(crate) fn sender_session_id(
+    sessions: &[shared::api::AgentSessionInfo],
+) -> Result<Option<String>> {
     let env = |key: &str| std::env::var(key).ok().filter(|v| !v.is_empty());
 
-    if let Some(id) = env("CLAUDE_CODE_SESSION_ID").or_else(|| env("PORTAL_SESSION_ID")) {
-        return Some(id);
+    if let Some(id) = env("PORTAL_SESSION_ID") {
+        return Ok(Some(id));
     }
     if let Some(thread_id) = env("CODEX_THREAD_ID") {
-        return crate::process_manager::session_id_for_codex_thread(&thread_id)
-            .map(|id| id.to_string());
+        return Ok(
+            crate::process_manager::session_id_for_codex_thread(&thread_id)
+                .map(|id| id.to_string()),
+        );
     }
-    None
+    let Some(claude_id) = env("CLAUDE_CODE_SESSION_ID") else {
+        return Ok(None);
+    };
+    let cwd = std::env::current_dir()
+        .context("could not determine the current working directory")?
+        .to_string_lossy()
+        .into_owned();
+    let hostname = claude_session_lib::hostname_or_unknown();
+    resolve_claude_session_id(&claude_id, &cwd, &hostname, sessions).map(Some)
+}
+
+/// Validate Claude's spawn-time id against the authenticated session list. If
+/// `/clear` replaced it, recover only when the caller's host + working
+/// directory identify exactly one live Claude session. Refusing ambiguity is
+/// important: guessing could mutate or attribute output to another session.
+fn resolve_claude_session_id(
+    claude_id: &str,
+    cwd: &str,
+    hostname: &str,
+    sessions: &[shared::api::AgentSessionInfo],
+) -> Result<String> {
+    if sessions
+        .iter()
+        .any(|session| session.id.to_string() == claude_id)
+    {
+        return Ok(claude_id.to_string());
+    }
+    let candidates: Vec<_> = sessions
+        .iter()
+        .filter(|session| {
+            session.agent_type == "claude"
+                && session.status == shared::SessionStatus::Active.as_str()
+                && session.working_directory == cwd
+                && session.hostname == hostname
+        })
+        .collect();
+    match candidates.as_slice() {
+        [session] => Ok(session.id.to_string()),
+        [] => Err(anyhow!(
+            "Claude's session id {claude_id} is stale and no active portal session matches this host and working directory; set PORTAL_SESSION_ID explicitly"
+        )),
+        _ => Err(anyhow!(
+            "Claude's session id {claude_id} is stale and {} active portal sessions match this host and working directory; set PORTAL_SESSION_ID explicitly",
+            candidates.len()
+        )),
+    }
+}
+
+pub(crate) async fn current_session_id(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+) -> Result<String> {
+    if let Some(id) = std::env::var("PORTAL_SESSION_ID")
+        .ok()
+        .filter(|v| !v.is_empty())
+    {
+        return Ok(id);
+    }
+    let sessions = fetch_sessions(client, base, token).await?;
+    sender_session_id(&sessions.sessions)?.ok_or_else(|| {
+        anyhow!("run this from inside an agent session (no portal session id found)")
+    })
 }
 
 /// Resolve the HTTP API base URL and auth token from the launcher config.
@@ -168,7 +237,7 @@ pub async fn list() -> Result<()> {
         println!("No sessions found.");
         return Ok(());
     }
-    let self_id = sender_session_id();
+    let self_id = sender_session_id(&data.sessions)?;
     for s in &data.sessions {
         let marker = if self_id.as_deref() == Some(&s.id.to_string()) {
             " (this session)"
@@ -212,7 +281,7 @@ pub async fn send(agent_id: &str, message: &str) -> Result<()> {
     let client = reqwest::Client::new();
     let sessions = fetch_sessions(&client, &base, &token).await?;
     let resolved_agent_id = resolve_session_id(agent_id, &sessions.sessions)?;
-    let from = sender_session_id();
+    let from = sender_session_id(&sessions.sessions)?;
     // Non-idempotent POST: retry the pre-delivery transient (404 target lookup
     // against a stale session index) and transport errors, but NOT 5xx — the
     // server may already have delivered, and a replay would double-send.
@@ -320,12 +389,53 @@ mod tests {
             id: Uuid::parse_str(id).expect("valid uuid"),
             session_name: "session".to_string(),
             working_directory: "/repo".to_string(),
-            agent_type: "codex".to_string(),
+            agent_type: "claude".to_string(),
             status: "active".to_string(),
             hostname: "host".to_string(),
             awaiting_permission: false,
             last_activity: String::new(),
         }
+    }
+
+    #[test]
+    fn stale_claude_id_resolves_to_unique_live_session_on_same_host_and_cwd() {
+        let sessions = vec![session("0c24805b-0000-0000-0000-000000000000")];
+        assert_eq!(
+            resolve_claude_session_id(
+                "80740e1d-0000-0000-0000-000000000000",
+                "/repo",
+                "host",
+                &sessions
+            )
+            .expect("unique replacement"),
+            sessions[0].id.to_string()
+        );
+    }
+
+    #[test]
+    fn existing_claude_id_wins_without_inference() {
+        let sessions = vec![session("80740e1d-0000-0000-0000-000000000000")];
+        assert_eq!(
+            resolve_claude_session_id(&sessions[0].id.to_string(), "/other", "other", &sessions)
+                .expect("existing id"),
+            sessions[0].id.to_string()
+        );
+    }
+
+    #[test]
+    fn stale_claude_id_refuses_ambiguous_live_sessions() {
+        let sessions = vec![
+            session("0c24805b-0000-0000-0000-000000000000"),
+            session("1c24805b-0000-0000-0000-000000000000"),
+        ];
+        let error = resolve_claude_session_id(
+            "80740e1d-0000-0000-0000-000000000000",
+            "/repo",
+            "host",
+            &sessions,
+        )
+        .expect_err("ambiguous sessions must not be guessed");
+        assert!(error.to_string().contains("2 active portal sessions"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- give explicit `PORTAL_SESSION_ID` precedence over Claude's spawn-time session ID
- validate `CLAUDE_CODE_SESSION_ID` against the caller's authenticated session list
- automatically recover a stale `/clear` id when exactly one active Claude session matches the current hostname and working directory
- refuse zero/ambiguous matches instead of risking attribution or mutation of the wrong session
- use the safe resolver across `forward`, `message`, and `show`
- document why Claude's exported id may become stale

## Verification
- `cargo fmt --check`
- `cargo test -p agent-portal message::tests` (11 passed)
- `cargo check -p agent-portal`

Closes #1505