### PR TITLE
Reconcile session status against live state

### DIFF
--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -92,6 +92,23 @@ pub fn spawn_stale_session_cleanup(
             .filter(|(id, _)| !connected_keys.contains(&id.to_string()))
             .collect();
 
+        // Re-read the live set right before the write and drop anything that
+        // reconnected during the query window. Registration is the only writer
+        // that sets Active, and it is one-shot — so a proxy that registered
+        // between the snapshot above and this UPDATE would otherwise have its
+        // Active write clobbered back to Disconnected permanently (#1605). The
+        // `status.eq(Active)` guard on the UPDATE closes the remaining sliver:
+        // a row a concurrent registration flips can't be demoted here.
+        let reconnected: std::collections::HashSet<String> = manager
+            .registered_session_keys()
+            .into_iter()
+            .map(|k| k.to_string())
+            .collect();
+        let stale: Vec<(uuid::Uuid, String)> = stale
+            .into_iter()
+            .filter(|(id, _)| !reconnected.contains(&id.to_string()))
+            .collect();
+
         if stale.is_empty() {
             tracing::info!("No stale sessions to clean up after reconnect grace period");
             return;
@@ -99,9 +116,13 @@ pub fn spawn_stale_session_cleanup(
 
         let stale_ids: Vec<uuid::Uuid> = stale.iter().map(|(id, _)| *id).collect();
 
-        match diesel::update(sessions::table.filter(sessions::id.eq_any(&stale_ids)))
-            .set(sessions::status.eq(shared::SessionStatus::Disconnected.as_str()))
-            .execute(&mut conn)
+        match diesel::update(
+            sessions::table
+                .filter(sessions::id.eq_any(&stale_ids))
+                .filter(sessions::status.eq(shared::SessionStatus::Active.as_str())),
+        )
+        .set(sessions::status.eq(shared::SessionStatus::Disconnected.as_str()))
+        .execute(&mut conn)
         {
             Ok(updated) => {
                 tracing::info!(
@@ -121,6 +142,62 @@ pub fn spawn_stale_session_cleanup(
             }
         }
     });
+}
+
+/// Periodically heal the `sessions.status` column against live truth (#1605).
+///
+/// `status` is written to `Disconnected` by five paths but back to `Active`
+/// only on proxy registration, which is one-shot — so a single spurious
+/// `Disconnected` write (a lost sweep race, a backend restart the proxy
+/// outran) strands a live session as greyed-out forever, since nothing sets it
+/// back. `SessionManager` holds the authoritative live set, so promote any row
+/// it says is connected but the column calls `Disconnected` back to `Active`.
+///
+/// Promote-only by design: the demote direction (Active → Disconnected) is
+/// already handled correctly by the generation-guarded socket teardown and the
+/// startup sweep, and running it on a tick would both race those paths and
+/// re-fire `SessionDisconnected` pushes. This side only ever moves a
+/// demonstrably-live session toward `Active`, so it cannot disturb `Replaced`
+/// or a genuinely-gone session.
+pub async fn reconcile_session_status(app_state: Arc<AppState>) {
+    let live: Vec<uuid::Uuid> = app_state
+        .session_manager
+        .registered_session_keys()
+        .into_iter()
+        .filter_map(|k| uuid::Uuid::parse_str(&k.to_string()).ok())
+        .collect();
+    if live.is_empty() {
+        return;
+    }
+
+    let pool = app_state.db_pool.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        use diesel::prelude::*;
+        use schema::sessions;
+
+        let mut conn = pool.get()?;
+        let updated = diesel::update(
+            sessions::table
+                .filter(sessions::status.eq(shared::SessionStatus::Disconnected.as_str()))
+                .filter(sessions::id.eq_any(&live)),
+        )
+        .set((
+            sessions::status.eq(shared::SessionStatus::Active.as_str()),
+            sessions::updated_at.eq(diesel::dsl::now),
+        ))
+        .execute(&mut conn)?;
+        anyhow::Ok(updated)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(n)) if n > 0 => {
+            tracing::info!("Reconciled {n} live session(s) from disconnected back to active");
+        }
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => tracing::error!("session status reconcile failed: {e}"),
+        Err(e) => tracing::error!("session status reconcile task panicked: {e}"),
+    }
 }
 
 /// Archive terminal sessions to long-term storage (#1258 phase 1).

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -260,6 +260,14 @@ pub async fn run() -> anyhow::Result<()> {
         app_state.clone(),
         background::run_retention_cleanup,
     );
+    // Heal sessions.status against live SessionManager truth so a live session
+    // can't stay greyed-out forever after a spurious disconnect write (#1605).
+    background::spawn_periodic(
+        "session status reconcile task (every 30 seconds)",
+        Duration::from_secs(30),
+        app_state.clone(),
+        background::reconcile_session_status,
+    );
     if app_state.session_max_age_days > 0 {
         background::spawn_periodic(
             &format!(


### PR DESCRIPTION
Fixes #1605 — session pills greyed out (status `disconnected`) while their connection dot is green and the agent is actively responding, stuck that way indefinitely.

## Root cause

`sessions.status` is event-sourced with a **5:1 writer asymmetry**: five paths write `disconnected`, but only proxy registration writes `active` — and registration is one-shot. So one spurious `disconnected` write (a lost sweep race, a backend restart the proxy outran) is **permanent**, because nothing reconciles the column against `SessionManager`, which holds the authoritative live state. The deployment in the issue showed a live muse child marked `disconnected`, rows stuck since July, and `last_activity` running days ahead of `updated_at` (the backend relaying traffic for sessions it had written off).

## Fix (issue's "1 + 2")

**1 — Guard the startup sweep** (`background.rs`). It snapshotted the live set at T0 and demoted at T2 with only `id = ANY(stale_ids)`, so a proxy registering in between had its `active` write clobbered back to `disconnected`. Now it re-reads the live set immediately before the write and drops anything that reconnected, and guards the UPDATE with `status = active` so a concurrent registration can't be demoted. **Stops new corruption.**

**2 — Periodic reconciler** (every 30s, `reconcile_session_status`). Projects `SessionManager` truth onto the column: promotes any row it reports as connected but the column calls `disconnected` back to `active`. Makes status **self-healing** and repairs rows already stuck.

Promote-only by design: the demote direction is already handled by the generation-guarded socket teardown (`proxy_socket.rs`) and the startup sweep; running it on a tick would race those and re-fire `SessionDisconnected` pushes. This side only ever moves a demonstrably-live session toward `active`, so it can't disturb `Replaced` or a genuinely-gone session.

## Verification

Backend builds, 296 lib tests pass. (Local clippy is blocked by a rustup-proxy toolchain-floor quirk on this box — CI will gate it.)

## Deliberately out of scope

- The optional per-message `status = active` band-aid (#1605 item 3): the 30s reconciler + guard already heal within a tick without touching the hot message path.
- `ServerToClient::SessionStatus` is dead protocol (never sent, never handled, carries no `session_id`). Once the column is correct the 5s `/api/sessions` poll delivers the right value; wiring a push (or removing the dead type) is a separate follow-up, not needed for this fix.