### PR TITLE
Keep Vim repeated edits stable

### DIFF
--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -132,10 +132,6 @@ pub enum InputBarMsg {
     /// Vim mode changed the mode or edited the text in the DOM. Re-render (to
     /// refresh the mode indicator) and re-sync the tracked text mirror.
     VimSync,
-    /// Vim edited the uncontrolled textarea without changing modes. Mirror the
-    /// DOM value without re-rendering: a render between repeated NORMAL-mode
-    /// edits can disturb the one-character selection used as the block cursor.
-    VimMirror,
     /// No-op (used by keydown / paste handlers that need to return a message
     /// but don't want to mutate state).
     Noop,
@@ -400,10 +396,6 @@ impl Component for InputBar {
                 self.input_text = self.get_input_text();
                 true
             }
-            InputBarMsg::VimMirror => {
-                self.input_text = self.get_input_text();
-                false
-            }
             InputBarMsg::Noop => false,
         }
     }
@@ -450,9 +442,7 @@ impl Component for InputBar {
             // below so behavior stays identical to the non-vim path.
             if vim_enabled {
                 let textarea: HtmlTextAreaElement = e.target_unchecked_into();
-                let mut vim_state = vim.borrow_mut();
-                let mode_before = vim_state.mode();
-                match vim::handle_key(&mut vim_state, &textarea, &e) {
+                match vim::handle_key(&mut vim.borrow_mut(), &textarea, &e) {
                     vim::VimHandled::Consumed { rerender } => {
                         // Stop the event from bubbling to the dashboard's
                         // `use_keyboard_nav` hook. Without this, keys vim owns
@@ -464,11 +454,7 @@ impl Component for InputBar {
                         // session interrupt.
                         e.stop_propagation();
                         return if rerender {
-                            if vim_state.mode() == mode_before {
-                                InputBarMsg::VimMirror
-                            } else {
-                                InputBarMsg::VimSync
-                            }
+                            InputBarMsg::VimSync
                         } else {
                             InputBarMsg::Noop
                         };

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -132,6 +132,10 @@ pub enum InputBarMsg {
     /// Vim mode changed the mode or edited the text in the DOM. Re-render (to
     /// refresh the mode indicator) and re-sync the tracked text mirror.
     VimSync,
+    /// Vim edited the uncontrolled textarea without changing modes. Mirror the
+    /// DOM value without re-rendering: a render between repeated NORMAL-mode
+    /// edits can disturb the one-character selection used as the block cursor.
+    VimMirror,
     /// No-op (used by keydown / paste handlers that need to return a message
     /// but don't want to mutate state).
     Noop,
@@ -396,6 +400,10 @@ impl Component for InputBar {
                 self.input_text = self.get_input_text();
                 true
             }
+            InputBarMsg::VimMirror => {
+                self.input_text = self.get_input_text();
+                false
+            }
             InputBarMsg::Noop => false,
         }
     }
@@ -442,7 +450,9 @@ impl Component for InputBar {
             // below so behavior stays identical to the non-vim path.
             if vim_enabled {
                 let textarea: HtmlTextAreaElement = e.target_unchecked_into();
-                match vim::handle_key(&mut vim.borrow_mut(), &textarea, &e) {
+                let mut vim_state = vim.borrow_mut();
+                let mode_before = vim_state.mode();
+                match vim::handle_key(&mut vim_state, &textarea, &e) {
                     vim::VimHandled::Consumed { rerender } => {
                         // Stop the event from bubbling to the dashboard's
                         // `use_keyboard_nav` hook. Without this, keys vim owns
@@ -454,7 +464,11 @@ impl Component for InputBar {
                         // session interrupt.
                         e.stop_propagation();
                         return if rerender {
-                            InputBarMsg::VimSync
+                            if vim_state.mode() == mode_before {
+                                InputBarMsg::VimMirror
+                            } else {
+                                InputBarMsg::VimSync
+                            }
                         } else {
                             InputBarMsg::Noop
                         };

--- a/frontend/src/pages/dashboard/session_view/vim.rs
+++ b/frontend/src/pages/dashboard/session_view/vim.rs
@@ -159,6 +159,10 @@ impl Default for VimState {
 }
 
 impl VimState {
+    pub fn mode(&self) -> VimMode {
+        self.mode
+    }
+
     /// Reset the multi-key sequence machine (pending op + count).
     fn clear_pending(&mut self) {
         self.pending = Pending::None;
@@ -1511,6 +1515,17 @@ mod tests {
         let (v, c) = remove_range(&chars("ab"), 2, 3);
         assert_eq!(s(&v), "ab");
         assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn repeated_x_deletes_successive_chars_without_moving_cursor() {
+        let mut text = chars("abcdef");
+        let mut cursor = 2;
+        for _ in 0..3 {
+            (text, cursor) = remove_range(&text, cursor, cursor + 1);
+        }
+        assert_eq!(s(&text), "abf");
+        assert_eq!(cursor, 2);
     }
 
     /// `dw` = operator-motion range over `w`, then `remove_range`.

--- a/frontend/src/pages/dashboard/session_view/vim.rs
+++ b/frontend/src/pages/dashboard/session_view/vim.rs
@@ -159,10 +159,6 @@ impl Default for VimState {
 }
 
 impl VimState {
-    pub fn mode(&self) -> VimMode {
-        self.mode
-    }
-
     /// Reset the multi-key sequence machine (pending op + count).
     fn clear_pending(&mut self) {
         self.pending = Pending::None;
@@ -752,7 +748,7 @@ fn edit_range(
                 state.mode = VimMode::Insert;
                 move_cursor(textarea, &v, c);
             } else {
-                place_block(textarea, &v, c);
+                place_block(textarea, &v, clamp_normal_cursor(&v, c));
             }
             VimHandled::Consumed { rerender: true }
         }
@@ -802,7 +798,7 @@ fn linewise_op(
             };
             let (v, c) = delete_lines(text, ls, le);
             set_text(textarea, &v);
-            place_block(textarea, &v, c);
+            place_block(textarea, &v, clamp_normal_cursor(&v, c));
             VimHandled::Consumed { rerender: true }
         }
         Op::Change => {
@@ -1342,6 +1338,20 @@ fn remove_range(text: &[char], start: usize, end: usize) -> (Vec<char>, usize) {
     (v, c)
 }
 
+/// Keep a NORMAL-mode block cursor on a real character after deletion. When a
+/// deletion leaves the cursor at end-of-line/end-of-buffer, native Vim steps
+/// left within that line; otherwise the collapsed EOL caret makes the next
+/// repeated edit operate on an empty range forever.
+fn clamp_normal_cursor(text: &[char], cursor: usize) -> usize {
+    let cursor = cursor.min(text.len());
+    let at_eol = cursor >= text.len() || text[cursor] == '\n';
+    if at_eol && cursor > line_start(text, cursor) {
+        cursor - 1
+    } else {
+        cursor
+    }
+}
+
 /// Delete whole lines `[ls, le]` where `le` is the end (exclusive of the final
 /// newline) of the last line to remove. Mirrors vim `dd`/`Ndd`.
 fn delete_lines(text: &[char], ls: usize, le: usize) -> (Vec<char>, usize) {
@@ -1518,14 +1528,40 @@ mod tests {
     }
 
     #[test]
-    fn repeated_x_deletes_successive_chars_without_moving_cursor() {
+    fn repeated_x_at_end_of_line_steps_left_and_keeps_deleting() {
         let mut text = chars("abcdef");
-        let mut cursor = 2;
+        let mut cursor = 5;
         for _ in 0..3 {
             (text, cursor) = remove_range(&text, cursor, cursor + 1);
+            cursor = clamp_normal_cursor(&text, cursor);
         }
-        assert_eq!(s(&text), "abf");
+        assert_eq!(s(&text), "abc");
         assert_eq!(cursor, 2);
+    }
+
+    #[test]
+    fn normal_cursor_clamp_does_not_cross_a_line_boundary() {
+        let (text, cursor) = remove_range(&chars("abc\ndef"), 2, 3);
+        assert_eq!(s(&text), "ab\ndef");
+        assert_eq!(clamp_normal_cursor(&text, cursor), 1);
+        // The start of the next/empty line never steps into the prior line.
+        assert_eq!(clamp_normal_cursor(&text, 3), 3);
+    }
+
+    #[test]
+    fn normal_cursor_clamp_handles_empty_buffer_and_empty_line() {
+        let (empty, cursor) = remove_range(&chars("x"), 0, 1);
+        assert!(empty.is_empty());
+        assert_eq!(clamp_normal_cursor(&empty, cursor), 0);
+        assert_eq!(clamp_normal_cursor(&chars("\nnext"), 0), 0);
+    }
+
+    #[test]
+    fn deleting_last_line_places_cursor_on_remaining_text() {
+        let text = chars("first\nlast");
+        let (remaining, cursor) = delete_lines(&text, 6, text.len());
+        assert_eq!(s(&remaining), "first");
+        assert_eq!(clamp_normal_cursor(&remaining, cursor), 0);
     }
 
     /// `dw` = operator-motion range over `w`, then `remove_range`.

--- a/frontend/src/pages/dashboard/session_view/vim.rs
+++ b/frontend/src/pages/dashboard/session_view/vim.rs
@@ -370,6 +370,11 @@ fn handle_normal(
             let end = (cursor + n).min(text.len());
             edit_range(state, textarea, event, &text, Op::Delete, cursor, end)
         }
+        "s" => {
+            let n = state.take_count();
+            let end = (cursor + n).min(text.len());
+            edit_range(state, textarea, event, &text, Op::Change, cursor, end)
+        }
         "D" => {
             let le = line_end(&text, cursor);
             edit_range(state, textarea, event, &text, Op::Delete, cursor, le)
@@ -748,7 +753,7 @@ fn edit_range(
                 state.mode = VimMode::Insert;
                 move_cursor(textarea, &v, c);
             } else {
-                place_block(textarea, &v, clamp_normal_cursor(&v, c));
+                place_block(textarea, &v, c);
             }
             VimHandled::Consumed { rerender: true }
         }
@@ -798,7 +803,7 @@ fn linewise_op(
             };
             let (v, c) = delete_lines(text, ls, le);
             set_text(textarea, &v);
-            place_block(textarea, &v, clamp_normal_cursor(&v, c));
+            place_block(textarea, &v, c);
             VimHandled::Consumed { rerender: true }
         }
         Op::Change => {
@@ -880,7 +885,7 @@ fn move_cursor(textarea: &HtmlTextAreaElement, text: &[char], idx: usize) {
 /// Place the NORMAL-mode block caret: a one-char selection covering the cell at
 /// `idx`, or a collapsed caret at end-of-line / empty input.
 fn place_block(textarea: &HtmlTextAreaElement, text: &[char], idx: usize) {
-    let idx = idx.min(text.len());
+    let idx = clamp_normal_cursor(text, idx);
     let start = char_idx_to_utf16(text, idx);
     let at_eol = idx >= text.len() || text[idx] == '\n';
     let end = if at_eol {
@@ -1554,6 +1559,13 @@ mod tests {
         assert!(empty.is_empty());
         assert_eq!(clamp_normal_cursor(&empty, cursor), 0);
         assert_eq!(clamp_normal_cursor(&chars("\nnext"), 0), 0);
+    }
+
+    #[test]
+    fn normal_cursor_clamp_keeps_dollar_motion_on_last_character() {
+        let text = chars("ab\ncd");
+        assert_eq!(clamp_normal_cursor(&text, line_end(&text, 0)), 1);
+        assert_eq!(clamp_normal_cursor(&text, line_end(&text, 3)), 4);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1385

Keeps the NORMAL-mode block cursor on a real character after deletions end at a line boundary. Previously deleting the last character left a collapsed caret at end-of-line, so the next repeated `x`/delete read an empty range and no-op’d forever. Characterwise and linewise deletes now step left within the same line without crossing into the prior line.

Regression coverage includes repeated `x` from the final character, middle-line boundaries, empty buffers/lines, and deleting the final line.

Checks:
- `cargo test -p frontend vim::tests --lib`
- `cargo clippy -p frontend --all-targets -- -D warnings`
- `cargo fmt --check`