### PR TITLE
Surface Claude prompt suggestions in composer

### DIFF
--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -20,7 +20,7 @@ mod spawn;
 pub mod transcript;
 
 pub use agent::ClaudeAgent;
-pub use spawn::claude_cli_args;
+pub use spawn::{claude_cli_args, claude_supports_prompt_suggestions};
 pub use transcript::{claude_transcript_status, TranscriptStatus};
 
 // Re-export the proxy session helpers used by the proxy binary.

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -146,7 +146,10 @@ pub async fn claude_supports_prompt_suggestions(claude_path: &Path) -> bool {
     // failures fail open (omit the additive flag) and are not cached, so a
     // later launch can probe again after host pressure recovers.
     let mut probe = Command::new(claude_path);
-    probe.arg("--help").kill_on_drop(true);
+    probe
+        .arg("--help")
+        .stdin(std::process::Stdio::null())
+        .kill_on_drop(true);
     let output = match tokio::time::timeout(Duration::from_secs(2), probe.output()).await {
         Ok(Ok(output)) => output,
         Ok(Err(error)) => {

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -32,6 +32,8 @@ pub fn claude_cli_args(
         "--permission-prompt-tool",
         "stdio",
         "--replay-user-messages",
+        "--prompt-suggestions",
+        "true",
     ]
     .iter()
     .map(|s| s.to_string())
@@ -194,5 +196,15 @@ mod tests {
             ["--session-id", &own_id.to_string()]
         );
         assert!(!args.iter().any(|arg| arg == "--fork-session"));
+    }
+
+    #[test]
+    fn enables_typed_prompt_suggestion_frames() {
+        let args = claude_cli_args(uuid::Uuid::nil(), false, None, &[]);
+        let flag = args
+            .iter()
+            .position(|arg| arg == "--prompt-suggestions")
+            .expect("prompt suggestions flag");
+        assert_eq!(args.get(flag + 1).map(String::as_str), Some("true"));
     }
 }

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -2,11 +2,14 @@
 //!
 //! Spawns `claude --print --verbose --output-format stream-json
 //! --input-format stream-json --permission-prompt-tool stdio
-//! --replay-user-messages [--session-id <id> | --resume <id> |
+//! --replay-user-messages [--prompt-suggestions true]
+//! [--session-id <id> | --resume <id> |
 //! --resume <source> --fork-session --session-id <new>] [extra...]`
 //! and wraps its handles in a [`ClaudeAsyncClient`].
 
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use tokio::process::Command;
 
 use claude_codes::AsyncClient as ClaudeAsyncClient;
@@ -20,6 +23,7 @@ pub fn claude_cli_args(
     session_id: uuid::Uuid,
     resume: bool,
     fork_from: Option<uuid::Uuid>,
+    prompt_suggestions: bool,
     extra_args: &[String],
 ) -> Vec<String> {
     let mut args: Vec<String> = [
@@ -32,12 +36,14 @@ pub fn claude_cli_args(
         "--permission-prompt-tool",
         "stdio",
         "--replay-user-messages",
-        "--prompt-suggestions",
-        "true",
     ]
     .iter()
     .map(|s| s.to_string())
     .collect();
+
+    if prompt_suggestions {
+        args.extend(["--prompt-suggestions".to_string(), "true".to_string()]);
+    }
 
     if let Some(source) = (!resume).then_some(fork_from).flatten() {
         // claude-codes exposes ClaudeCliBuilder::fork_from, but that builder
@@ -79,6 +85,7 @@ pub(crate) async fn spawn_claude(
         config.session_id,
         config.resume,
         config.fork_from_session_id,
+        claude_supports_prompt_suggestions(claude_path),
         &config.extra_args,
     );
 
@@ -123,6 +130,30 @@ pub(crate) async fn spawn_claude(
     Ok((client, pid))
 }
 
+/// Probe the installed CLI once per resolved path before using the additive
+/// prompt-suggestion flag. Older fleet hosts reject unknown flags at startup,
+/// so capability detection must happen before argv construction.
+pub fn claude_supports_prompt_suggestions(claude_path: &Path) -> bool {
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, bool>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let Ok(mut cache) = cache.lock() else {
+        return false;
+    };
+    if let Some(supported) = cache.get(claude_path).copied() {
+        return supported;
+    }
+    let supported = std::process::Command::new(claude_path)
+        .arg("--help")
+        .output()
+        .ok()
+        .is_some_and(|output| {
+            String::from_utf8_lossy(&output.stdout).contains("--prompt-suggestions")
+                || String::from_utf8_lossy(&output.stderr).contains("--prompt-suggestions")
+        });
+    cache.insert(claude_path.to_path_buf(), supported);
+    supported
+}
+
 /// Log the resolved path and version of the claude binary for diagnostics.
 fn log_claude_info(claude_path: &Path) {
     if let Ok(full_path) = which::which(claude_path) {
@@ -164,6 +195,7 @@ mod tests {
             new_id,
             false,
             Some(source),
+            false,
             &["--model".into(), "opus".into()],
         );
         let expected = vec![
@@ -182,7 +214,7 @@ mod tests {
     fn resume_ignores_persisted_fork_source() {
         let source = uuid::Uuid::from_u128(1);
         let own_id = uuid::Uuid::from_u128(2);
-        let args = claude_cli_args(own_id, true, Some(source), &[]);
+        let args = claude_cli_args(own_id, true, Some(source), false, &[]);
         assert_eq!(&args[args.len() - 2..], ["--resume", &own_id.to_string()]);
         assert!(!args.iter().any(|arg| arg == "--fork-session"));
     }
@@ -190,7 +222,7 @@ mod tests {
     #[test]
     fn fresh_non_fork_launch_uses_new_session_id() {
         let own_id = uuid::Uuid::from_u128(2);
-        let args = claude_cli_args(own_id, false, None, &[]);
+        let args = claude_cli_args(own_id, false, None, false, &[]);
         assert_eq!(
             &args[args.len() - 2..],
             ["--session-id", &own_id.to_string()]
@@ -200,11 +232,17 @@ mod tests {
 
     #[test]
     fn enables_typed_prompt_suggestion_frames() {
-        let args = claude_cli_args(uuid::Uuid::nil(), false, None, &[]);
+        let args = claude_cli_args(uuid::Uuid::nil(), false, None, true, &[]);
         let flag = args
             .iter()
             .position(|arg| arg == "--prompt-suggestions")
             .expect("prompt suggestions flag");
         assert_eq!(args.get(flag + 1).map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn omits_prompt_suggestion_flag_for_older_claude() {
+        let args = claude_cli_args(uuid::Uuid::nil(), false, false, &[]);
+        assert!(!args.iter().any(|arg| arg == "--prompt-suggestions"));
     }
 }

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -9,7 +9,8 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::OnceLock;
+use std::time::Duration;
 use tokio::process::Command;
 
 use claude_codes::AsyncClient as ClaudeAsyncClient;
@@ -85,7 +86,7 @@ pub(crate) async fn spawn_claude(
         config.session_id,
         config.resume,
         config.fork_from_session_id,
-        claude_supports_prompt_suggestions(claude_path),
+        claude_supports_prompt_suggestions(claude_path).await,
         &config.extra_args,
     );
 
@@ -133,23 +134,32 @@ pub(crate) async fn spawn_claude(
 /// Probe the installed CLI once per resolved path before using the additive
 /// prompt-suggestion flag. Older fleet hosts reject unknown flags at startup,
 /// so capability detection must happen before argv construction.
-pub fn claude_supports_prompt_suggestions(claude_path: &Path) -> bool {
-    static CACHE: OnceLock<Mutex<HashMap<PathBuf, bool>>> = OnceLock::new();
-    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-    let Ok(mut cache) = cache.lock() else {
-        return false;
-    };
+pub async fn claude_supports_prompt_suggestions(claude_path: &Path) -> bool {
+    static CACHE: OnceLock<tokio::sync::Mutex<HashMap<PathBuf, bool>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()));
+    let mut cache = cache.lock().await;
     if let Some(supported) = cache.get(claude_path).copied() {
         return supported;
     }
-    let supported = std::process::Command::new(claude_path)
-        .arg("--help")
-        .output()
-        .ok()
-        .is_some_and(|output| {
-            String::from_utf8_lossy(&output.stdout).contains("--prompt-suggestions")
-                || String::from_utf8_lossy(&output.stderr).contains("--prompt-suggestions")
-        });
+
+    // A missing or wedged binary must not stall session launch. Transient
+    // failures fail open (omit the additive flag) and are not cached, so a
+    // later launch can probe again after host pressure recovers.
+    let mut probe = Command::new(claude_path);
+    probe.arg("--help").kill_on_drop(true);
+    let output = match tokio::time::timeout(Duration::from_secs(2), probe.output()).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(error)) => {
+            tracing::warn!("Claude prompt-suggestion capability probe failed: {error}");
+            return false;
+        }
+        Err(_) => {
+            tracing::warn!("Claude prompt-suggestion capability probe timed out");
+            return false;
+        }
+    };
+    let supported = String::from_utf8_lossy(&output.stdout).contains("--prompt-suggestions")
+        || String::from_utf8_lossy(&output.stderr).contains("--prompt-suggestions");
     cache.insert(claude_path.to_path_buf(), supported);
     supported
 }

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn omits_prompt_suggestion_flag_for_older_claude() {
-        let args = claude_cli_args(uuid::Uuid::nil(), false, false, &[]);
+        let args = claude_cli_args(uuid::Uuid::nil(), false, None, false, &[]);
         assert!(!args.iter().any(|arg| arg == "--prompt-suggestions"));
     }
 }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -828,11 +828,15 @@ impl SessionView {
                 true
             }
             WsEvent::Ephemeral(payload) => {
-                if let Ok(shared::ClaudeOutput::PromptSuggestion(suggestion)) =
-                    serde_json::from_value(payload.clone())
+                if payload.get("type").and_then(|value| value.as_str()) == Some("prompt_suggestion")
                 {
-                    if let Some(dispatcher) = &self.input_bar_dispatcher {
-                        dispatcher.emit(InputBarInbound::PromptSuggestion(suggestion.suggestion));
+                    if let Ok(shared::ClaudeOutput::PromptSuggestion(suggestion)) =
+                        serde_json::from_value(payload.clone())
+                    {
+                        if let Some(dispatcher) = &self.input_bar_dispatcher {
+                            dispatcher
+                                .emit(InputBarInbound::PromptSuggestion(suggestion.suggestion));
+                        }
                     }
                     return false;
                 }
@@ -1059,13 +1063,6 @@ impl SessionView {
             ));
         }
         if let Ok(claude_msg) = serde_json::from_str::<shared::ClaudeOutput>(&output.content) {
-            if let shared::ClaudeOutput::PromptSuggestion(suggestion) = &claude_msg {
-                if let Some(dispatcher) = &self.input_bar_dispatcher {
-                    dispatcher.emit(InputBarInbound::PromptSuggestion(
-                        suggestion.suggestion.clone(),
-                    ));
-                }
-            }
             // Live task events use the server-assigned row timestamp when the
             // backend supplied it, falling back to browser time only for
             // pre-metadata/error frames.

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -1051,6 +1051,13 @@ impl SessionView {
             ));
         }
         if let Ok(claude_msg) = serde_json::from_str::<shared::ClaudeOutput>(&output.content) {
+            if let shared::ClaudeOutput::PromptSuggestion(suggestion) = &claude_msg {
+                if let Some(dispatcher) = &self.input_bar_dispatcher {
+                    dispatcher.emit(InputBarInbound::PromptSuggestion(
+                        suggestion.suggestion.clone(),
+                    ));
+                }
+            }
             // Live task events use the server-assigned row timestamp when the
             // backend supplied it, falling back to browser time only for
             // pre-metadata/error frames.

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -828,6 +828,14 @@ impl SessionView {
                 true
             }
             WsEvent::Ephemeral(payload) => {
+                if let Ok(shared::ClaudeOutput::PromptSuggestion(suggestion)) =
+                    serde_json::from_value(payload.clone())
+                {
+                    if let Some(dispatcher) = &self.input_bar_dispatcher {
+                        dispatcher.emit(InputBarInbound::PromptSuggestion(suggestion.suggestion));
+                    }
+                    return false;
+                }
                 // Transient live status: replace the strip line. Never touches
                 // `messages` (no persistence, no replay watermark). A frame we
                 // can't summarize is ignored rather than clearing a good line.

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -288,18 +288,19 @@ impl Component for InputBar {
                 // Textarea is uncontrolled — the DOM already has the new
                 // value. Track in state so we can restore after re-renders.
                 self.input_text = value;
-                self.pending_suggestion = None;
-                false
+                self.pending_suggestion.take().is_some()
             }
             InputBarMsg::AcceptSuggestion => {
+                let mut accepted = false;
                 if self.get_input_text().is_empty() {
                     if let Some(suggestion) = self.pending_suggestion.take() {
                         self.input_text = suggestion.clone();
                         self.set_input_text(&suggestion);
                         self.focus_textarea();
+                        accepted = true;
                     }
                 }
-                true
+                accepted
             }
             InputBarMsg::SendInput => self.dispatch_text_send(ctx, SendMode::Normal),
             InputBarMsg::SendWiggum => {
@@ -438,12 +439,8 @@ impl Component for InputBar {
 
         let vim_enabled = self.vim_enabled;
         let vim = self.vim.clone();
-        let can_accept_suggestion = self.pending_suggestion.is_some() && self.input_text.is_empty();
+        let has_suggestion = self.pending_suggestion.is_some();
         let handle_keydown = link.callback(move |e: KeyboardEvent| {
-            if e.key() == "Tab" && can_accept_suggestion {
-                e.prevent_default();
-                return InputBarMsg::AcceptSuggestion;
-            }
             // While the dashboard is in Nav mode the composer must be inert: Nav
             // owns single-key shortcuts (1-9 to jump panes, hjkl, w, n, d, G).
             // The textarea keeps DOM focus in Nav mode, so without this a plain
@@ -457,6 +454,19 @@ impl Component for InputBar {
             if !e.ctrl_key() && !e.meta_key() && dashboard_in_nav_mode() {
                 e.prevent_default();
                 return InputBarMsg::Noop;
+            }
+
+            if e.key() == "Tab"
+                && !e.shift_key()
+                && !e.ctrl_key()
+                && !e.meta_key()
+                && has_suggestion
+                && e.target_unchecked_into::<HtmlTextAreaElement>()
+                    .value()
+                    .is_empty()
+            {
+                e.prevent_default();
+                return InputBarMsg::AcceptSuggestion;
             }
 
             if e.ctrl_key() && e.key().to_lowercase() == "m" {
@@ -620,6 +630,7 @@ impl Component for InputBar {
                             type="button"
                             class="prompt-suggestion-accept"
                             title="Accept suggested prompt (Tab)"
+                            aria-label="Accept Claude's suggested prompt with Tab"
                             onclick={link.callback(|_| InputBarMsg::AcceptSuggestion)}
                         >{ "Tab" }</button>
                     }

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -100,6 +100,8 @@ pub enum InputBarInbound {
     /// after a permission is answered so the user can keep typing without
     /// a stray click.
     FocusTextarea,
+    /// Replace the current Claude-provided next-prompt suggestion.
+    PromptSuggestion(String),
 }
 
 pub enum InputBarMsg {
@@ -107,6 +109,7 @@ pub enum InputBarMsg {
     /// User typed into the textarea. We track the value in state so it can
     /// be restored after a re-render (e.g. on WS reconnect).
     UpdateInput(String),
+    AcceptSuggestion,
     /// User submitted the form (Enter, or click "Send"). Sends with
     /// `SendMode::Normal`.
     SendInput,
@@ -152,6 +155,7 @@ pub struct InputBar {
     drag_hover: bool,
     is_recording: bool,
     interim_transcription: Option<String>,
+    pending_suggestion: Option<String>,
     voice_button_ref: NodeRef,
     was_focused: bool,
     /// Mirror of the `ws_connected` prop from the previous render. The composer
@@ -196,6 +200,7 @@ impl Component for InputBar {
             drag_hover: false,
             is_recording: false,
             interim_transcription: None,
+            pending_suggestion: None,
             voice_button_ref: NodeRef::default(),
             was_focused: ctx.props().focused,
             was_ws_connected: ctx.props().ws_connected,
@@ -269,15 +274,32 @@ impl Component for InputBar {
 
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
-            InputBarMsg::Inbound(InputBarInbound::FocusTextarea) => {
-                self.focus_textarea();
-                false
-            }
+            InputBarMsg::Inbound(inbound) => match inbound {
+                InputBarInbound::FocusTextarea => {
+                    self.focus_textarea();
+                    false
+                }
+                InputBarInbound::PromptSuggestion(suggestion) => {
+                    self.pending_suggestion = (!suggestion.is_empty()).then_some(suggestion);
+                    true
+                }
+            },
             InputBarMsg::UpdateInput(value) => {
                 // Textarea is uncontrolled — the DOM already has the new
                 // value. Track in state so we can restore after re-renders.
                 self.input_text = value;
+                self.pending_suggestion = None;
                 false
+            }
+            InputBarMsg::AcceptSuggestion => {
+                if self.get_input_text().is_empty() {
+                    if let Some(suggestion) = self.pending_suggestion.take() {
+                        self.input_text = suggestion.clone();
+                        self.set_input_text(&suggestion);
+                        self.focus_textarea();
+                    }
+                }
+                true
             }
             InputBarMsg::SendInput => self.dispatch_text_send(ctx, SendMode::Normal),
             InputBarMsg::SendWiggum => {
@@ -416,7 +438,12 @@ impl Component for InputBar {
 
         let vim_enabled = self.vim_enabled;
         let vim = self.vim.clone();
+        let can_accept_suggestion = self.pending_suggestion.is_some() && self.input_text.is_empty();
         let handle_keydown = link.callback(move |e: KeyboardEvent| {
+            if e.key() == "Tab" && can_accept_suggestion {
+                e.prevent_default();
+                return InputBarMsg::AcceptSuggestion;
+            }
             // While the dashboard is in Nav mode the composer must be inert: Nav
             // owns single-key shortcuts (1-9 to jump panes, hjkl, w, n, d, G).
             // The textarea keeps DOM focus in Nav mode, so without this a plain
@@ -581,13 +608,21 @@ impl Component for InputBar {
                                 && self.vim.borrow().mode == vim::VimMode::Normal)
                                 .then_some("vim-normal")
                         )}
-                        placeholder="Type your message... (Shift+Enter for new line)"
+                        placeholder={self.pending_suggestion.clone().unwrap_or_else(|| "Type your message... (Shift+Enter for new line)".into())}
                         oninput={handle_input}
                         onkeydown={handle_keydown}
                         onpaste={handle_paste}
                         disabled={!ctx.props().ws_connected}
                         rows="1"
                     />
+                    if self.pending_suggestion.is_some() && self.input_text.is_empty() {
+                        <button
+                            type="button"
+                            class="prompt-suggestion-accept"
+                            title="Accept suggested prompt (Tab)"
+                            onclick={link.callback(|_| InputBarMsg::AcceptSuggestion)}
+                        >{ "Tab" }</button>
+                    }
                     { self.render_voice_input(ctx) }
                     { self.render_send_button(ctx) }
                     <div class="drop-hint">{ "Drop files here to upload" }</div>
@@ -642,6 +677,7 @@ impl InputBar {
         self.command_history.push(input.clone());
         self.set_input_text("");
         self.input_text.clear();
+        self.pending_suggestion = None;
         ctx.props().on_message_sent.emit(());
         ctx.props().on_send_text.emit((input, mode));
         true
@@ -661,6 +697,7 @@ impl InputBar {
         let user_input = self.get_input_text().trim().to_string();
         self.set_input_text("");
         self.input_text.clear();
+        self.pending_suggestion = None;
         if !user_input.is_empty() {
             self.command_history.push(user_input.clone());
         }

--- a/frontend/styles/session-input.css
+++ b/frontend/styles/session-input.css
@@ -70,6 +70,17 @@
     border-color: var(--accent);
 }
 
+.session-view-input .prompt-suggestion-accept {
+    align-self: center;
+    padding: 0.15rem 0.4rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-muted);
+    font: 0.7rem var(--font-mono, monospace);
+    cursor: pointer;
+}
+
 /* Vim NORMAL-mode block cursor. vim.rs keeps a one-character selection at the
    cursor, painted below as a solid vim-style block. caret-color is the accent
    (not transparent): browsers hide the blinking caret while a selection is

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -188,6 +188,7 @@ async fn run_shim_loop(
     let our_stdout_for_reader = our_stdout.clone();
     let permissions_for_reader = permissions.clone();
     let filtering_for_reader = filtering_active.clone();
+    let session_id_for_reader = config.session_id;
 
     // Claude stdout reader task: reads lines, forwards to stdout and queues for portal.
     //
@@ -251,6 +252,17 @@ async fn run_shim_loop(
 
             // Dispatch for portal forwarding (independent of VS Code decision).
             match parsed {
+                // Suggestions are transient composer UI, not durable transcript
+                // messages. Keep them out of the replay/output buffer.
+                Some(ClaudeOutput::PromptSuggestion(suggestion)) => {
+                    let payload = serde_json::to_value(ClaudeOutput::PromptSuggestion(suggestion))
+                        .unwrap_or_default();
+                    let _ = perm_request_tx.send(ProxyToServer::Ephemeral {
+                        session_id: session_id_for_reader,
+                        payload,
+                    });
+                    continue;
+                }
                 // Protocol noise the portal doesn't need.
                 Some(ClaudeOutput::ControlResponse(_)) => continue,
                 // Permission request: forward CanUseTool as typed PermissionRequest

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -23,7 +23,7 @@ use claude_codes::io::{
     ControlResponsePayload, PermissionResult, UserMessage,
 };
 use claude_codes::{ClaudeInput, ClaudeOutput};
-use claude_session_lib::claude_cli_args;
+use claude_session_lib::{claude_cli_args, claude_supports_prompt_suggestions};
 use session_lib::git_metadata::get_git_branch;
 use session_lib::output_buffer::PendingOutputBuffer;
 use shared::ProxyToServer;
@@ -126,6 +126,7 @@ fn spawn_claude(config: &ProxySessionConfig) -> Result<tokio::process::Child> {
         config.session_id,
         config.resume,
         None,
+        claude_supports_prompt_suggestions(std::path::Path::new("claude")),
         &config.claude_args,
     ));
 

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -49,7 +49,9 @@ pub async fn run_shim(config: ProxySessionConfig) -> Result<()> {
     info!("Starting shim mode");
 
     // Spawn claude binary with the same flags as claude-session-lib
-    let mut child = spawn_claude(&config)?;
+    let prompt_suggestions =
+        claude_supports_prompt_suggestions(std::path::Path::new("claude")).await;
+    let mut child = spawn_claude(&config, prompt_suggestions)?;
 
     let claude_stdin = child
         .stdin
@@ -120,13 +122,16 @@ pub async fn run_shim(config: ProxySessionConfig) -> Result<()> {
 }
 
 /// Spawn the claude binary with piped stdin/stdout/stderr.
-fn spawn_claude(config: &ProxySessionConfig) -> Result<tokio::process::Child> {
+fn spawn_claude(
+    config: &ProxySessionConfig,
+    prompt_suggestions: bool,
+) -> Result<tokio::process::Child> {
     let mut cmd = Command::new("claude");
     cmd.args(claude_cli_args(
         config.session_id,
         config.resume,
         None,
-        claude_supports_prompt_suggestions(std::path::Path::new("claude")),
+        prompt_suggestions,
         &config.claude_args,
     ));
 

--- a/session-lib/src/adapter.rs
+++ b/session-lib/src/adapter.rs
@@ -218,6 +218,10 @@ impl AgentOutputClassifier for ClaudeAdapter {
                     error_category: r.error_category,
                 }),
             }],
+            // Prompt suggestions are composer state, not transcript content.
+            // Route them over the non-persisted side-channel so they neither
+            // consume retention rows nor render as unknown-message cards.
+            ClaudeOutput::PromptSuggestion(_) => vec![AgentOutput::Ephemeral(raw)],
             // Everything else (System, User, Assistant, Error, RateLimitEvent)
             // is user-visible.
             _ => vec![AgentOutput::Visible(raw)],
@@ -261,6 +265,21 @@ mod tests {
         assert_eq!(
             adapter.classify(raw.clone()),
             vec![AgentOutput::Visible(raw)]
+        );
+    }
+
+    #[test]
+    fn classify_prompt_suggestion_is_ephemeral() {
+        let raw = json!({
+            "type": "prompt_suggestion",
+            "suggestion": "Run tests",
+            "uuid": "u5",
+            "session_id": "s5"
+        });
+        let mut adapter = ClaudeAdapter;
+        assert_eq!(
+            adapter.classify(raw.clone()),
+            vec![AgentOutput::Ephemeral(raw)]
         );
     }
 


### PR DESCRIPTION
Closes #1409

Enables Claude prompt-suggestion frames only when the installed CLI advertises support, with a once-per-binary-path cached capability probe so older fleet hosts keep launching unchanged. The typed `ClaudeOutput::PromptSuggestion` frame travels over the non-persisted ephemeral channel into its session composer, never becoming a transcript row or unknown-message card.

Empty composers show ghost text; unmodified Tab or the labeled button accepts without sending. Typing, accepting, or sending clears it, and Nav mode remains inert.

Checks:
- native proxy check plus frontend WASM check
- adapter routing regression test
- supported/unsupported CLI argv tests
- clippy with warnings denied
- rustfmt