### PR TITLE
Add Claude and Codex session fork plumbing

### DIFF
--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -15,7 +15,12 @@ use session_lib::snapshot::SessionConfig;
 /// Build the argument list for the `claude` CLI (everything after the binary
 /// path). Shared by the library spawn path and the proxy's shim mode so flag
 /// changes can't drift between the two.
-pub fn claude_cli_args(session_id: uuid::Uuid, resume: bool, extra_args: &[String]) -> Vec<String> {
+pub fn claude_cli_args(
+    session_id: uuid::Uuid,
+    resume: bool,
+    fork_from: Option<uuid::Uuid>,
+    extra_args: &[String],
+) -> Vec<String> {
     let mut args: Vec<String> = [
         "--print",
         "--verbose",
@@ -31,12 +36,21 @@ pub fn claude_cli_args(session_id: uuid::Uuid, resume: bool, extra_args: &[Strin
     .map(|s| s.to_string())
     .collect();
 
-    if resume {
+    if let Some(source) = fork_from {
+        args.extend([
+            "--resume".to_string(),
+            source.to_string(),
+            "--fork-session".to_string(),
+            "--session-id".to_string(),
+            session_id.to_string(),
+        ]);
+    } else if resume {
         args.push("--resume".to_string());
+        args.push(session_id.to_string());
     } else {
         args.push("--session-id".to_string());
+        args.push(session_id.to_string());
     }
-    args.push(session_id.to_string());
 
     args.extend(extra_args.iter().cloned());
     args
@@ -54,7 +68,12 @@ pub(crate) async fn spawn_claude(
 
     log_claude_info(claude_path);
 
-    let args = claude_cli_args(config.session_id, config.resume, &config.extra_args);
+    let args = claude_cli_args(
+        config.session_id,
+        config.resume,
+        config.fork_from_session_id,
+        &config.extra_args,
+    );
 
     let mut cmd = Command::new(claude_path);
     cmd.args(&args);
@@ -123,5 +142,25 @@ fn log_claude_info(claude_path: &Path) {
         Err(e) => {
             tracing::warn!("Failed to run claude --version: {}", e);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fork_args_keep_source_and_new_identity_distinct() {
+        let source = uuid::Uuid::from_u128(1);
+        let new_id = uuid::Uuid::from_u128(2);
+        let args = claude_cli_args(new_id, false, Some(source), &[]);
+        let expected = vec![
+            "--resume".to_string(),
+            source.to_string(),
+            "--fork-session".to_string(),
+            "--session-id".to_string(),
+            new_id.to_string(),
+        ];
+        assert_eq!(&args[args.len() - expected.len()..], expected.as_slice());
     }
 }

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -2,7 +2,8 @@
 //!
 //! Spawns `claude --print --verbose --output-format stream-json
 //! --input-format stream-json --permission-prompt-tool stdio
-//! --replay-user-messages [--session-id <id> | --resume <id>] [extra...]`
+//! --replay-user-messages [--session-id <id> | --resume <id> |
+//! --resume <source> --fork-session --session-id <new>] [extra...]`
 //! and wraps its handles in a [`ClaudeAsyncClient`].
 
 use std::path::Path;
@@ -36,7 +37,7 @@ pub fn claude_cli_args(
     .map(|s| s.to_string())
     .collect();
 
-    if let Some(source) = fork_from {
+    if let Some(source) = (!resume).then_some(fork_from).flatten() {
         args.extend([
             "--resume".to_string(),
             source.to_string(),
@@ -162,5 +163,25 @@ mod tests {
             new_id.to_string(),
         ];
         assert_eq!(&args[args.len() - expected.len()..], expected.as_slice());
+    }
+
+    #[test]
+    fn resume_ignores_persisted_fork_source() {
+        let source = uuid::Uuid::from_u128(1);
+        let own_id = uuid::Uuid::from_u128(2);
+        let args = claude_cli_args(own_id, true, Some(source), &[]);
+        assert_eq!(&args[args.len() - 2..], ["--resume", &own_id.to_string()]);
+        assert!(!args.iter().any(|arg| arg == "--fork-session"));
+    }
+
+    #[test]
+    fn fresh_non_fork_launch_uses_new_session_id() {
+        let own_id = uuid::Uuid::from_u128(2);
+        let args = claude_cli_args(own_id, false, None, &[]);
+        assert_eq!(
+            &args[args.len() - 2..],
+            ["--session-id", &own_id.to_string()]
+        );
+        assert!(!args.iter().any(|arg| arg == "--fork-session"));
     }
 }

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -38,6 +38,10 @@ pub fn claude_cli_args(
     .collect();
 
     if let Some(source) = (!resume).then_some(fork_from).flatten() {
+        // claude-codes exposes ClaudeCliBuilder::fork_from, but that builder
+        // cannot carry the portal's arbitrary user extra_args. Keep the SDK's
+        // documented flag recipe here until its builder supports passthrough;
+        // this function also remains the single argv seam shared with shim mode.
         args.extend([
             "--resume".to_string(),
             source.to_string(),
@@ -154,13 +158,20 @@ mod tests {
     fn fork_args_keep_source_and_new_identity_distinct() {
         let source = uuid::Uuid::from_u128(1);
         let new_id = uuid::Uuid::from_u128(2);
-        let args = claude_cli_args(new_id, false, Some(source), &[]);
+        let args = claude_cli_args(
+            new_id,
+            false,
+            Some(source),
+            &["--model".into(), "opus".into()],
+        );
         let expected = vec![
             "--resume".to_string(),
             source.to_string(),
             "--fork-session".to_string(),
             "--session-id".to_string(),
             new_id.to_string(),
+            "--model".to_string(),
+            "opus".to_string(),
         ];
         assert_eq!(&args[args.len() - expected.len()..], expected.as_slice());
     }

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -11,8 +11,8 @@ use std::time::Instant;
 use codex_codes::{
     AppServerBuilder, ApplyPatchApprovalResponse, AsyncClient as CodexAsyncClient,
     CommandExecutionRequestApprovalResponse, ExecCommandApprovalResponse, ServerMessage,
-    ServerRequest, ThreadResumeParams, ThreadStartParams, TurnInterruptParams, TurnStartParams,
-    TurnSteerParams, UserInput,
+    ServerRequest, ThreadForkParams, ThreadResumeParams, ThreadStartParams, TurnInterruptParams,
+    TurnStartParams, TurnSteerParams, UserInput,
 };
 use session_lib::error::SessionError;
 use session_lib::io::{IoCommand, IoEvent};
@@ -31,6 +31,14 @@ enum CodexApprovalResponseKind {
     AcceptDecline,
     ExecApprovedDenied,
     ApplyPatchApprovedDenied,
+}
+
+fn codex_fork_params(config: &SessionConfig) -> Option<ThreadForkParams> {
+    Some(ThreadForkParams {
+        thread_id: config.codex_fork_from_thread_id.clone()?,
+        last_turn_id: config.codex_fork_last_turn_id.clone(),
+        ..ThreadForkParams::default()
+    })
 }
 
 /// The rejection message Codex 0.143.5+ requires on a `denied` approval
@@ -271,7 +279,22 @@ pub(crate) async fn codex_io_task(
     // (`config.resume == true`) and the proxy persisted a thread id from
     // the previous incarnation.
     let mut resumed_thread: Option<(String, Option<String>)> = None;
-    if config.resume {
+    if let Some(fork_params) = codex_fork_params(&config) {
+        let source = fork_params.thread_id.clone();
+        match client.thread_fork(&fork_params).await {
+            Ok(resp) => {
+                let model = started_thread_model(resp.model, &configured_model_fallback);
+                tracing::info!("Codex thread {} forked as {}", source, resp.thread.id);
+                resumed_thread = Some((resp.thread.id, model));
+            }
+            Err(e) => {
+                let _ = event_tx.send(IoEvent::Error(SessionError::CommunicationError(format!(
+                    "Failed to fork Codex thread {source}: {e}"
+                ))));
+                return;
+            }
+        }
+    } else if config.resume {
         if let Some(prior) = config.codex_thread_id.as_ref() {
             let resume_params = ThreadResumeParams {
                 thread_id: prior.clone(),
@@ -1117,6 +1140,19 @@ mod tests {
 
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn fork_params_keep_parent_thread_and_optional_turn_cut() {
+        let config = SessionConfig {
+            codex_fork_from_thread_id: Some("parent-thread".into()),
+            codex_fork_last_turn_id: Some("turn-7".into()),
+            ..Default::default()
+        };
+        let params = codex_fork_params(&config).expect("fork params");
+        assert_eq!(params.thread_id, "parent-thread");
+        assert_eq!(params.last_turn_id.as_deref(), Some("turn-7"));
+        assert!(codex_fork_params(&SessionConfig::default()).is_none());
     }
 
     /// Neutral `PermissionDecision` → Codex approval response. Ported from the

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -34,9 +34,15 @@ enum CodexApprovalResponseKind {
 }
 
 fn codex_fork_params(config: &SessionConfig) -> Option<ThreadForkParams> {
+    if config.resume {
+        return None;
+    }
     Some(ThreadForkParams {
         thread_id: config.codex_fork_from_thread_id.clone()?,
         last_turn_id: config.codex_fork_last_turn_id.clone(),
+        // A fork commonly launches in a newly-created git worktree. Unlike a
+        // resume, it must not inherit the source thread's checkout.
+        cwd: Some(config.working_directory.to_string_lossy().into_owned()),
         ..ThreadForkParams::default()
     })
 }
@@ -279,6 +285,17 @@ pub(crate) async fn codex_io_task(
     // (`config.resume == true`) and the proxy persisted a thread id from
     // the previous incarnation.
     let mut resumed_thread: Option<(String, Option<String>)> = None;
+    if !config.resume
+        && config.fork_from_session_id.is_some()
+        && config.codex_fork_from_thread_id.is_none()
+    {
+        let _ = event_tx.send(IoEvent::Error(SessionError::CommunicationError(
+            "Codex fork requested but the launcher could not resolve the source thread id"
+                .to_string(),
+        )));
+        return;
+    }
+
     if let Some(fork_params) = codex_fork_params(&config) {
         let source = fork_params.thread_id.clone();
         match client.thread_fork(&fork_params).await {
@@ -1145,14 +1162,23 @@ mod tests {
     #[test]
     fn fork_params_keep_parent_thread_and_optional_turn_cut() {
         let config = SessionConfig {
+            fork_from_session_id: Some(uuid::Uuid::from_u128(1)),
             codex_fork_from_thread_id: Some("parent-thread".into()),
             codex_fork_last_turn_id: Some("turn-7".into()),
+            working_directory: "/tmp/fork-worktree".into(),
             ..Default::default()
         };
         let params = codex_fork_params(&config).expect("fork params");
         assert_eq!(params.thread_id, "parent-thread");
         assert_eq!(params.last_turn_id.as_deref(), Some("turn-7"));
+        assert_eq!(params.cwd.as_deref(), Some("/tmp/fork-worktree"));
         assert!(codex_fork_params(&SessionConfig::default()).is_none());
+
+        let resumed = SessionConfig {
+            resume: true,
+            ..config
+        };
+        assert!(codex_fork_params(&resumed).is_none());
     }
 
     /// Neutral `PermissionDecision` → Codex approval response. Ported from the

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -383,6 +383,9 @@ async fn run_session_task(
             muse_yolo,
             agent_type: config.agent_type,
             codex_thread_id,
+            fork_from_session_id: None,
+            codex_fork_from_thread_id: None,
+            codex_fork_last_turn_id: None,
         };
 
         let mut session = match AnySession::new(session_config).await {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -836,6 +836,9 @@ async fn create_claude_session(config: &ProxySessionConfig) -> Result<ClaudeSess
             && config.claude_args.iter().any(|arg| arg == "--yolo"),
         agent_type: config.agent_type,
         codex_thread_id,
+        fork_from_session_id: None,
+        codex_fork_from_thread_id: None,
+        codex_fork_last_turn_id: None,
     };
 
     if config.resume {

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -125,6 +125,7 @@ fn spawn_claude(config: &ProxySessionConfig) -> Result<tokio::process::Child> {
     cmd.args(claude_cli_args(
         config.session_id,
         config.resume,
+        None,
         &config.claude_args,
     ));
 

--- a/session-lib/src/snapshot.rs
+++ b/session-lib/src/snapshot.rs
@@ -40,7 +40,11 @@ pub struct SessionConfig {
     #[serde(default)]
     pub codex_thread_id: Option<String>,
     /// Source portal session for a fork. Fork metadata seeds only the first
-    /// launch (`resume == false`); relaunches resume the fork's own identity.
+    /// spawn attempt; the launcher must clear all three fork fields after that
+    /// attempt. `resume == false` alone is not a durable first-launch marker:
+    /// transcript rotation paths also set it false, while backend reconciliation
+    /// can set it true before a never-launched desired session first registers.
+    /// Muse does not implement fork semantics and must be capability-gated out.
     /// Claude emits this via `--resume <source> --fork-session --session-id
     /// <new>`. The launcher/API layer added by #1457 must preflight that the
     /// Claude source transcript exists before constructing this config.

--- a/session-lib/src/snapshot.rs
+++ b/session-lib/src/snapshot.rs
@@ -39,6 +39,18 @@ pub struct SessionConfig {
     /// directly via `--resume`).
     #[serde(default)]
     pub codex_thread_id: Option<String>,
+    /// Source portal session for a whole-history Claude fork. The new session
+    /// keeps `session_id` as its own identity; this id is emitted via
+    /// `--resume <source> --fork-session --session-id <new>`.
+    #[serde(default)]
+    pub fork_from_session_id: Option<Uuid>,
+    /// Source app-server thread for a Codex fork. Resolved launcher-side from
+    /// the source portal session because Codex thread ids are not backend data.
+    #[serde(default)]
+    pub codex_fork_from_thread_id: Option<String>,
+    /// Optional inclusive Codex fork cut. Claude only supports whole history.
+    #[serde(default)]
+    pub codex_fork_last_turn_id: Option<String>,
 }
 
 /// A pending permission request that hasn't been responded to
@@ -119,6 +131,9 @@ mod tests {
             muse_yolo: false,
             agent_type: Default::default(),
             codex_thread_id: None,
+            fork_from_session_id: None,
+            codex_fork_from_thread_id: None,
+            codex_fork_last_turn_id: None,
         }
     }
 
@@ -143,6 +158,19 @@ mod tests {
         let restored: SessionConfig = serde_json::from_value(value).unwrap();
 
         assert!(!restored.muse_yolo);
+    }
+
+    #[test]
+    fn missing_fork_fields_default_to_none() {
+        let mut value = serde_json::to_value(sample_config()).unwrap();
+        let object = value.as_object_mut().unwrap();
+        object.remove("fork_from_session_id");
+        object.remove("codex_fork_from_thread_id");
+        object.remove("codex_fork_last_turn_id");
+        let restored: SessionConfig = serde_json::from_value(value).unwrap();
+        assert!(restored.fork_from_session_id.is_none());
+        assert!(restored.codex_fork_from_thread_id.is_none());
+        assert!(restored.codex_fork_last_turn_id.is_none());
     }
 
     #[test]

--- a/session-lib/src/snapshot.rs
+++ b/session-lib/src/snapshot.rs
@@ -39,16 +39,20 @@ pub struct SessionConfig {
     /// directly via `--resume`).
     #[serde(default)]
     pub codex_thread_id: Option<String>,
-    /// Source portal session for a whole-history Claude fork. The new session
-    /// keeps `session_id` as its own identity; this id is emitted via
-    /// `--resume <source> --fork-session --session-id <new>`.
+    /// Source portal session for a fork. Fork metadata seeds only the first
+    /// launch (`resume == false`); relaunches resume the fork's own identity.
+    /// Claude emits this via `--resume <source> --fork-session --session-id
+    /// <new>`. The launcher/API layer added by #1457 must preflight that the
+    /// Claude source transcript exists before constructing this config.
     #[serde(default)]
     pub fork_from_session_id: Option<Uuid>,
     /// Source app-server thread for a Codex fork. Resolved launcher-side from
-    /// the source portal session because Codex thread ids are not backend data.
+    /// `fork_from_session_id` because Codex thread ids are not backend data.
+    /// Used only on the first launch; relaunches resume `codex_thread_id`.
     #[serde(default)]
     pub codex_fork_from_thread_id: Option<String>,
     /// Optional inclusive Codex fork cut. Claude only supports whole history.
+    /// Like the source thread, this is ignored on resume launches.
     #[serde(default)]
     pub codex_fork_last_turn_id: Option<String>,
 }


### PR DESCRIPTION
Closes #1537

Adds backward-compatible typed session config for runtime fork sources. Claude has a tested argv path that keeps source and new portal UUIDs distinct. Codex invokes the published `thread_fork` API, supports an optional `last_turn_id`, applies the configured fork worktree cwd, and fails explicitly when parent-thread resolution or the fork call fails.

Fork metadata seeds first launch only; crash/reconcile launches resume the fork’s own Claude session or persisted Codex thread instead of re-forking. This is the plumbing-only scope of #1537; API/UI/lineage remain #1457.

Checks:
- targeted cargo checks for all affected crates
- snapshot backward-compat tests
- Claude fresh/resume/fork argv tests
- Codex fork-parameter tests
- clippy with warnings denied
- rustfmt