### PR TITLE
Surface sub-agent type and retry state in live tool status

### DIFF
--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -458,6 +458,8 @@ fn handle_proxy_message(
             parent_tool_use_id,
             tool_name,
             elapsed_time_seconds,
+            subagent_type,
+            subagent_retry,
         } => {
             // Ephemeral live-status heartbeat: fan out to the session's web
             // clients only — deliberately NO DB write (unlike SequencedOutput).
@@ -471,6 +473,8 @@ fn handle_proxy_message(
                         parent_tool_use_id,
                         tool_name,
                         elapsed_time_seconds,
+                        subagent_type,
+                        subagent_retry,
                     },
                 );
             }

--- a/claude-session-lib/src/proxy_session/session_event.rs
+++ b/claude-session-lib/src/proxy_session/session_event.rs
@@ -105,6 +105,8 @@ pub(super) async fn handle_next_event<A: Agent>(
         parent_tool_use_id,
         tool_name,
         elapsed_time_seconds,
+        subagent_type,
+        subagent_retry,
     }) = event
     {
         let msg = ProxyToServer::ToolProgress {
@@ -113,6 +115,8 @@ pub(super) async fn handle_next_event<A: Agent>(
             parent_tool_use_id,
             tool_name,
             elapsed_time_seconds,
+            subagent_type,
+            subagent_retry,
         };
         let mut ws = state.ws_write.lock().await;
         if ws.send(msg).await.is_err() {

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -809,11 +809,22 @@ impl SessionView {
                 parent_tool_use_id,
                 tool_name,
                 elapsed_time_seconds,
+                subagent_type,
+                subagent_retry,
             } => {
                 // Ephemeral live status: refresh the running-tool strip. Never
                 // touches `messages` (no persistence, no replay watermark).
                 let key = running_tool_key(&tool_use_id, parent_tool_use_id.as_deref());
-                upsert_tool_progress(&mut self.active_tools, key, tool_name, elapsed_time_seconds);
+                upsert_tool_progress(
+                    &mut self.active_tools,
+                    ActiveToolProgress {
+                        key,
+                        tool_name,
+                        elapsed_seconds: elapsed_time_seconds,
+                        subagent_type,
+                        subagent_retry,
+                    },
+                );
                 true
             }
             WsEvent::Ephemeral(payload) => {
@@ -1086,9 +1097,24 @@ impl SessionView {
                         <div class="active-tool-pill" key={tool.key.clone()}>
                             <span class="active-tool-spinner" />
                             <span class="active-tool-name">{ tool.tool_name.clone() }</span>
+                            // Which Task sub-agent is running (#1474) — a long
+                            // `Task` otherwise reads as an anonymous stall.
+                            if let Some(subagent) = tool.subagent_type.as_deref() {
+                                <span class="active-tool-subagent">{ subagent }</span>
+                            }
                             <span class="active-tool-status">
                                 { format!("running — {}", format_tool_elapsed(tool.elapsed_seconds)) }
                             </span>
+                            // Only while the sub-agent is retrying: says the
+                            // turn is flaky-but-progressing, not hung.
+                            if let Some(retry) = tool.subagent_retry.as_ref() {
+                                <span class="active-tool-retry">
+                                    { format!(
+                                        "retrying {}/{} — {}",
+                                        retry.attempt, retry.max_retries, retry.error_category
+                                    ) }
+                                </span>
+                            }
                         </div>
                     }
                 }) }

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -510,6 +510,14 @@ pub(crate) struct ActiveToolProgress {
     pub key: String,
     pub tool_name: String,
     pub elapsed_seconds: f64,
+    /// The `Task` sub-agent behind this tool, when Claude reports one (#1474).
+    /// Renders as a qualifier on the pill so a long `Task` says *which* agent
+    /// is running.
+    pub subagent_type: Option<String>,
+    /// Retry state while the sub-agent is retrying after an error (#1474).
+    /// Present only mid-retry, so a flaky sub-agent turn is legible instead of
+    /// looking like an unexplained stall.
+    pub subagent_retry: Option<shared::SubagentRetryStatus>,
 }
 
 /// Derive the correlation key for a heartbeat: the *running* tool's id.
@@ -530,24 +538,31 @@ pub(crate) fn running_tool_key(tool_use_id: &str, parent_tool_use_id: Option<&st
     }
 }
 
-/// Upsert a heartbeat into the ordered active-tool list: refresh the elapsed
-/// time of an existing entry in place (preserving display order) or append a
-/// new one. Order-preserving so the strip doesn't reshuffle every 30s.
+/// Upsert a heartbeat into the ordered active-tool list: refresh an existing
+/// entry in place (preserving display order) or append a new one.
+/// Order-preserving so the strip doesn't reshuffle every 30s.
+///
+/// The two sub-agent fields (#1474) merge differently, on purpose:
+///
+/// - `subagent_type` is **sticky**. It identifies *which* `Task` agent is
+///   running, which cannot change for a given tool id, so a later frame that
+///   omits it keeps the known label rather than flickering it away.
+/// - `subagent_retry` is **replaced every frame**, including with `None`.
+///   It is transient state, and its absence is meaningful: it means the
+///   sub-agent is no longer retrying, so the badge must clear.
 pub(crate) fn upsert_tool_progress(
     list: &mut Vec<ActiveToolProgress>,
-    key: String,
-    tool_name: String,
-    elapsed_seconds: f64,
+    incoming: ActiveToolProgress,
 ) {
-    if let Some(existing) = list.iter_mut().find(|t| t.key == key) {
-        existing.tool_name = tool_name;
-        existing.elapsed_seconds = elapsed_seconds;
+    if let Some(existing) = list.iter_mut().find(|t| t.key == incoming.key) {
+        existing.tool_name = incoming.tool_name;
+        existing.elapsed_seconds = incoming.elapsed_seconds;
+        if incoming.subagent_type.is_some() {
+            existing.subagent_type = incoming.subagent_type;
+        }
+        existing.subagent_retry = incoming.subagent_retry;
     } else {
-        list.push(ActiveToolProgress {
-            key,
-            tool_name,
-            elapsed_seconds,
-        });
+        list.push(incoming);
     }
 }
 
@@ -1242,13 +1257,32 @@ mod tests {
         assert_eq!(running_tool_key("toolu_01abc", None), "toolu_01abc");
     }
 
+    /// A plain tool heartbeat (no sub-agent fields) — the common case.
+    fn progress(key: &str, tool_name: &str, elapsed_seconds: f64) -> ActiveToolProgress {
+        ActiveToolProgress {
+            key: key.into(),
+            tool_name: tool_name.into(),
+            elapsed_seconds,
+            subagent_type: None,
+            subagent_retry: None,
+        }
+    }
+
+    fn retry(attempt: u64, max_retries: u64) -> shared::SubagentRetryStatus {
+        shared::SubagentRetryStatus {
+            attempt,
+            max_retries,
+            error_category: "overloaded".into(),
+        }
+    }
+
     #[test]
     fn upsert_tool_progress_refreshes_in_place_preserving_order() {
         let mut list = Vec::new();
-        upsert_tool_progress(&mut list, "a".into(), "Bash".into(), 30.0);
-        upsert_tool_progress(&mut list, "b".into(), "Read".into(), 30.0);
+        upsert_tool_progress(&mut list, progress("a", "Bash", 30.0));
+        upsert_tool_progress(&mut list, progress("b", "Read", 30.0));
         // Refresh "a": elapsed updates, order stays [a, b].
-        upsert_tool_progress(&mut list, "a".into(), "Bash".into(), 60.0);
+        upsert_tool_progress(&mut list, progress("a", "Bash", 60.0));
         assert_eq!(list.len(), 2);
         assert_eq!(list[0].key, "a");
         assert_eq!(list[0].elapsed_seconds, 60.0);
@@ -1256,18 +1290,52 @@ mod tests {
     }
 
     #[test]
+    fn upsert_keeps_known_subagent_type_when_a_later_frame_omits_it() {
+        // `subagent_type` identifies which Task agent is running and cannot
+        // change for a tool id, so a frame without it must not blank the label.
+        let mut list = Vec::new();
+        let mut first = progress("a", "Task", 30.0);
+        first.subagent_type = Some("code-reviewer".into());
+        upsert_tool_progress(&mut list, first);
+        upsert_tool_progress(&mut list, progress("a", "Task", 60.0));
+        assert_eq!(list[0].subagent_type.as_deref(), Some("code-reviewer"));
+        assert_eq!(list[0].elapsed_seconds, 60.0);
+    }
+
+    #[test]
+    fn upsert_clears_retry_when_the_next_frame_is_not_retrying() {
+        // Retry state is transient: its ABSENCE means the sub-agent stopped
+        // retrying, so the badge has to clear or it would stick forever.
+        let mut list = Vec::new();
+        let mut retrying = progress("a", "Task", 30.0);
+        retrying.subagent_retry = Some(retry(2, 3));
+        upsert_tool_progress(&mut list, retrying);
+        assert!(list[0].subagent_retry.is_some());
+
+        upsert_tool_progress(&mut list, progress("a", "Task", 60.0));
+        assert!(
+            list[0].subagent_retry.is_none(),
+            "a non-retrying frame must clear the retry badge"
+        );
+    }
+
+    #[test]
+    fn upsert_advances_the_retry_attempt() {
+        let mut list = Vec::new();
+        let mut first = progress("a", "Task", 30.0);
+        first.subagent_retry = Some(retry(1, 3));
+        upsert_tool_progress(&mut list, first);
+        let mut second = progress("a", "Task", 60.0);
+        second.subagent_retry = Some(retry(2, 3));
+        upsert_tool_progress(&mut list, second);
+        assert_eq!(list[0].subagent_retry.as_ref().unwrap().attempt, 2);
+    }
+
+    #[test]
     fn clear_completed_tools_drops_matching_tool_result() {
         let mut list = vec![
-            ActiveToolProgress {
-                key: "toolu_01".into(),
-                tool_name: "Bash".into(),
-                elapsed_seconds: 90.0,
-            },
-            ActiveToolProgress {
-                key: "toolu_02".into(),
-                tool_name: "Read".into(),
-                elapsed_seconds: 30.0,
-            },
+            progress("toolu_01", "Bash", 90.0),
+            progress("toolu_02", "Read", 30.0),
         ];
         let user_result = serde_json::json!({
             "type": "user",
@@ -1289,11 +1357,7 @@ mod tests {
 
     #[test]
     fn clear_completed_tools_clears_all_on_turn_result() {
-        let mut list = vec![ActiveToolProgress {
-            key: "toolu_01".into(),
-            tool_name: "Bash".into(),
-            elapsed_seconds: 90.0,
-        }];
+        let mut list = vec![progress("toolu_01", "Bash", 90.0)];
         let result = serde_json::json!({
             "type": "result",
             "subtype": "success",
@@ -1311,11 +1375,7 @@ mod tests {
 
     #[test]
     fn clear_completed_tools_is_noop_for_unrelated_message() {
-        let mut list = vec![ActiveToolProgress {
-            key: "toolu_01".into(),
-            tool_name: "Bash".into(),
-            elapsed_seconds: 90.0,
-        }];
+        let mut list = vec![progress("toolu_01", "Bash", 90.0)];
         let assistant = serde_json::json!({
             "type": "assistant",
             "message": {

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -63,6 +63,10 @@ pub enum WsEvent {
         parent_tool_use_id: Option<String>,
         tool_name: String,
         elapsed_time_seconds: f64,
+        /// Which `Task` sub-agent is running, when this is sub-agent progress (#1474).
+        subagent_type: Option<String>,
+        /// Retry state, present only while the sub-agent is retrying (#1474).
+        subagent_retry: Option<shared::SubagentRetryStatus>,
     },
     /// Neutral ephemeral live-status frame (`ServerToClient::Ephemeral`).
     /// Drives a transient per-session live-status line (muse's streamed
@@ -250,12 +254,16 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
             parent_tool_use_id,
             tool_name,
             elapsed_time_seconds,
+            subagent_type,
+            subagent_retry,
         } => {
             on_event.emit(WsEvent::ToolProgress {
                 tool_use_id,
                 parent_tool_use_id,
                 tool_name,
                 elapsed_time_seconds,
+                subagent_type,
+                subagent_retry,
             });
         }
         ServerToClient::Ephemeral { payload } => {

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1593,6 +1593,20 @@
     color: var(--text-muted);
 }
 
+/* Which Task sub-agent is running (#1474) — a qualifier on the tool name, so
+   it reads as "Task code-reviewer running — 1m 30s". */
+.active-tool-subagent {
+    color: var(--accent);
+    font-weight: 500;
+}
+
+/* Sub-agent retry state (#1474). Only rendered mid-retry, and warning-colored
+   so a flaky turn is distinguishable at a glance from a healthy slow one. */
+.active-tool-retry {
+    color: var(--warning, #e0af68);
+    font-weight: 500;
+}
+
 /* Transient live-status line (neutral ephemeral channel; muse deltas/status). */
 .ephemeral-status-strip {
     display: flex;

--- a/session-lib/src/adapter.rs
+++ b/session-lib/src/adapter.rs
@@ -17,6 +17,8 @@
 //!
 //! See `docs/design/session-adapter.md` and `docs/design/agent-runtime.md`.
 
+use shared::SubagentRetryStatus;
+
 /// One unit of agent stdout, as opaque wire JSON. The classifier parses it.
 pub type RawUnit = serde_json::Value;
 
@@ -58,6 +60,12 @@ pub enum AgentOutput {
         parent_tool_use_id: Option<String>,
         tool_name: String,
         elapsed_time_seconds: f64,
+        /// The `Task` sub-agent this progress belongs to, when Claude reports
+        /// one (#1474) — e.g. which agent a long-running `Task` is running.
+        subagent_type: Option<String>,
+        /// Sub-agent retry state, present only while an attempt is being
+        /// retried after an error (#1474).
+        subagent_retry: Option<SubagentRetryStatus>,
     },
     /// Live-status output that must stream to the UI but must **never** be
     /// buffered or persisted.
@@ -198,6 +206,17 @@ impl AgentOutputClassifier for ClaudeAdapter {
                 parent_tool_use_id: tp.parent_tool_use_id,
                 tool_name: tp.tool_name,
                 elapsed_time_seconds: tp.elapsed_time_seconds,
+                subagent_type: tp.subagent_type,
+                // Map the SDK's retry struct onto the portal's wire shape,
+                // keeping only what the live pill renders (#1474). `heartbeat`
+                // is deliberately not carried: every frame on this channel is
+                // already a keepalive tick as far as the strip is concerned, so
+                // the flag has no user-facing meaning today.
+                subagent_retry: tp.subagent_retry.map(|r| SubagentRetryStatus {
+                    attempt: r.attempt,
+                    max_retries: r.max_retries,
+                    error_category: r.error_category,
+                }),
             }],
             // Everything else (System, User, Assistant, Error, RateLimitEvent)
             // is user-visible.
@@ -389,11 +408,16 @@ mod tests {
                 parent_tool_use_id,
                 tool_name,
                 elapsed_time_seconds,
+                subagent_type,
+                subagent_retry,
             } => {
                 assert_eq!(tool_use_id, "toolu_01abc-heartbeat-0");
                 assert_eq!(parent_tool_use_id.as_deref(), Some("toolu_01abc"));
                 assert_eq!(tool_name, "Bash");
                 assert_eq!(*elapsed_time_seconds, 30.0);
+                // An ordinary tool heartbeat carries neither sub-agent field.
+                assert_eq!(*subagent_type, None);
+                assert_eq!(*subagent_retry, None);
             }
             other => panic!("expected ToolProgress, got {other:?}"),
         }
@@ -402,6 +426,48 @@ mod tests {
             !matches!(&out[0], AgentOutput::Visible(_)),
             "tool_progress must never classify as Visible — it would be persisted"
         );
+    }
+
+    #[test]
+    fn classify_tool_progress_carries_subagent_type_and_retry() {
+        // A `Task` sub-agent mid-retry (#1474): the classifier maps the SDK's
+        // `subagent_type` / `subagent_retry` onto the portal's live-status
+        // shape so the strip can say which agent is running and that it is
+        // retrying rather than hung.
+        let raw = json!({
+            "type": "tool_progress",
+            "tool_name": "Task",
+            "elapsed_time_seconds": 90.0,
+            "parent_tool_use_id": "toolu_01abc",
+            "tool_use_id": "toolu_01abc-heartbeat-2",
+            "session_id": "01890000-0000-7000-8000-000000000001",
+            "uuid": "01890000-0000-7000-8000-000000000002",
+            "subagent_type": "code-reviewer",
+            "subagent_retry": {
+                "agent_id": "agent_1",
+                "attempt": 2,
+                "max_retries": 3,
+                "retry_delay_ms": 5000,
+                "error_status": 529,
+                "error_category": "overloaded"
+            }
+        });
+        let mut adapter = ClaudeAdapter;
+        let out = adapter.classify(raw);
+        match &out[0] {
+            AgentOutput::ToolProgress {
+                subagent_type,
+                subagent_retry,
+                ..
+            } => {
+                assert_eq!(subagent_type.as_deref(), Some("code-reviewer"));
+                let retry = subagent_retry.as_ref().expect("retry state");
+                assert_eq!(retry.attempt, 2);
+                assert_eq!(retry.max_retries, 3);
+                assert_eq!(retry.error_category, "overloaded");
+            }
+            other => panic!("expected ToolProgress, got {other:?}"),
+        }
     }
 
     #[test]

--- a/session-lib/src/io.rs
+++ b/session-lib/src/io.rs
@@ -159,6 +159,10 @@ pub enum SessionEvent {
         parent_tool_use_id: Option<String>,
         tool_name: String,
         elapsed_time_seconds: f64,
+        /// The `Task` sub-agent this progress belongs to, when there is one (#1474).
+        subagent_type: Option<String>,
+        /// Sub-agent retry state, present only mid-retry (#1474).
+        subagent_retry: Option<shared::SubagentRetryStatus>,
     },
 
     /// Claude reported a hard session limit with a reset time.

--- a/session-lib/src/session.rs
+++ b/session-lib/src/session.rs
@@ -284,12 +284,16 @@ impl<A: Agent> Session<A> {
                             parent_tool_use_id,
                             tool_name,
                             elapsed_time_seconds,
+                            subagent_type,
+                            subagent_retry,
                         } => {
                             return Some(SessionEvent::ToolProgress {
                                 tool_use_id,
                                 parent_tool_use_id,
                                 tool_name,
                                 elapsed_time_seconds,
+                                subagent_type,
+                                subagent_retry,
                             });
                         }
                         // Internal ack / nothing for the consumer — skip it and

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -4,7 +4,7 @@ use ws_bridge::WsEndpoint;
 
 use super::types::{
     FileUploadChunkFields, FileUploadResultFields, FileUploadStartFields, PermissionResponseFields,
-    RegisterFields,
+    RegisterFields, SubagentRetryStatus,
 };
 use crate::{AgentType, PermissionSuggestion, SendMode, SessionCost, SessionStatus, TurnMetrics};
 
@@ -341,6 +341,14 @@ pub enum ServerToClient {
         parent_tool_use_id: Option<String>,
         tool_name: String,
         elapsed_time_seconds: f64,
+        /// Which `Task` sub-agent is running, when this progress belongs to one
+        /// (#1474). Drives the sub-agent label on the live tool pill.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        subagent_type: Option<String>,
+        /// Present only while the sub-agent is retrying (#1474); drives the
+        /// "retrying n/m" badge.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        subagent_retry: Option<SubagentRetryStatus>,
     },
 
     /// Neutral ephemeral live-status, fanned out from

--- a/shared/src/endpoints/session.rs
+++ b/shared/src/endpoints/session.rs
@@ -5,8 +5,8 @@ use ws_bridge::WsEndpoint;
 use super::types::{
     FileDownloadRequestFields, FileDownloadResponseFields, FileUploadChunkFields,
     FileUploadResultFields, FileUploadStartFields, ForwardPortFields, ForwardStatusFields,
-    PermissionResponseFields, RegisterFields, SessionLimitContinuationFields, TunnelCloseFields,
-    TunnelDataFields, TunnelOpenFields, TunnelRefusedFields, TunnelStreamFields,
+    PermissionResponseFields, RegisterFields, SessionLimitContinuationFields, SubagentRetryStatus,
+    TunnelCloseFields, TunnelDataFields, TunnelOpenFields, TunnelRefusedFields, TunnelStreamFields,
     TunnelWindowFields,
 };
 use crate::{AgentType, PermissionSuggestion, SendMode, SessionStatus, TurnMetrics};
@@ -147,6 +147,15 @@ pub enum ProxyToServer {
         parent_tool_use_id: Option<String>,
         tool_name: String,
         elapsed_time_seconds: f64,
+        /// Which `Task` sub-agent this progress belongs to, when the running
+        /// tool is a sub-agent (#1474). `None` for ordinary tool calls. Older
+        /// proxies omit it, so it defaults rather than failing the frame.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        subagent_type: Option<String>,
+        /// Set only while a sub-agent's API call is being retried (#1474);
+        /// absent on a normal heartbeat.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        subagent_retry: Option<SubagentRetryStatus>,
     },
 
     /// A neutral ephemeral live-status frame — the agent-agnostic generalization

--- a/shared/src/endpoints/types.rs
+++ b/shared/src/endpoints/types.rs
@@ -345,6 +345,29 @@ pub struct FileDownloadResponseFields {
     pub error: Option<String>,
 }
 
+/// Retry state for a sub-agent whose API call is being retried after an error,
+/// carried on the live tool-progress side-channel (#1474).
+///
+/// Mapped from `claude_codes::SubagentRetry` at the classifier boundary rather
+/// than embedding the SDK struct: the portal's `ToolProgress` wire shape has
+/// always flattened the SDK's fields (it carries `tool_use_id` / `tool_name` /
+/// `elapsed_time_seconds`, not a `ToolProgressMessage`), and the SDK type
+/// derives no `PartialEq`, which the frontend's live-status state needs.
+///
+/// Only the display-relevant fields are carried. The SDK's `agent_id`,
+/// `retry_delay_ms` and `error_status` are deliberately dropped — nothing
+/// renders them, and this frame is emitted every ~30s per running tool.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubagentRetryStatus {
+    /// 1-based attempt number currently in flight.
+    pub attempt: u64,
+    /// Total attempts allowed before the sub-agent gives up.
+    pub max_retries: u64,
+    /// Coarse reason the previous attempt failed (e.g. `overloaded`), as
+    /// classified by the CLI. Rendered verbatim, so treat it as opaque.
+    pub error_category: String,
+}
+
 #[cfg(test)]
 mod continuation_reason_tests {
     use super::*;


### PR DESCRIPTION
Closes #1474.

## Problem

Claude's `tool_progress` frames carry `subagent_type` and `subagent_retry` (added in claude-codes 2.1.163), but the portal dropped both on the floor. A long-running `Task` therefore rendered as an anonymous "Task running — 4m 12s" with no indication of *which* sub-agent was working, and a sub-agent that was retrying after an overload looked identical to one that was hung.

## Change

Thread both fields through the **existing** ephemeral live-status path — no new channel, no persistence:

`ClaudeAdapter` → `AgentOutput::ToolProgress` → `SessionEvent::ToolProgress` → `ProxyToServer::ToolProgress` → backend fan-out → `ServerToClient::ToolProgress` → `WsEvent::ToolProgress` → active-tool strip.

The live pill now reads `Task code-reviewer running — 1m 30s` and, only while an attempt is in flight, adds a warning-colored `retrying 2/3 — overloaded`.

## Design notes

- **Portal-side `SubagentRetryStatus` rather than the SDK struct.** This wire shape has always flattened the SDK's fields (it carries `tool_use_id`/`tool_name`/`elapsed_time_seconds`, not a `ToolProgressMessage`), so the mapping happens at the classifier boundary like everything else here. It also keeps only the three fields that render — `agent_id`, `retry_delay_ms` and `error_status` are deliberately dropped, since this frame arrives every ~30s per running tool. (The SDK type also derives no `PartialEq`, which the frontend state needs.)
- **`subagent_type` merges sticky; `subagent_retry` is replaced every frame.** The type identifies *which* Task agent is running and cannot change for a tool id, so a later frame omitting it must not blank the label. Retry state is transient and its **absence is meaningful** — it means retrying stopped, so the badge has to clear. Both rules are unit-tested.
- **`heartbeat` deliberately not carried.** Every frame on this channel is already a keepalive tick as far as the strip is concerned, so the flag has no user-facing meaning today; threading it would add an unused wire field.
- Both new wire fields are `#[serde(default, skip_serializing_if = "Option::is_none")]`, so a mixed-version fleet (older proxy → newer backend) keeps working.

## Tests

- `adapter.rs`: a `Task` sub-agent mid-retry maps onto the portal shape; the existing plain-heartbeat test now also asserts both fields are `None`.
- `helpers.rs`: sticky `subagent_type` across an omitting frame, retry cleared when a non-retrying frame arrives, retry attempt advancing, plus the pre-existing order-preservation test.

Verified: `cargo test` (session-lib / shared / claude-session-lib / frontend), `cargo check -p frontend --target wasm32-unknown-unknown`, clippy, `cargo fmt --check`, stylelint.