### PR TITLE
Enlarge Muse pill watermark 30% keep centered

### DIFF
--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -272,7 +272,14 @@
 }
 .pill-watermark.claude { background-image: url('/anthropic-mark.svg'); }
 .pill-watermark.codex  { background-image: url('/openai-mark.png'); }
-.pill-watermark.muse   { background-image: url('/meta-mark.svg'); }
+
+/* Muse watermark 30% larger (64×1.3 = 83.2) — recentered so horizontal center stays at x=16 (left = 16 - 83.2/2 = -25.6) */
+.pill-watermark.muse {
+    background-image: url('/meta-mark.svg');
+    width: 83.2px;
+    height: 83.2px;
+    left: -25.6px;
+}
 
 /* Model-version watermark — the session's compact model number (e.g. "4.8")
    rendered in the same faint grey/opacity treatment as the agent logo. The


### PR DESCRIPTION
Muse (Meta) watermark was 64×64 at left -16px (center x=16). Now 83.2×83.2 (+30%) at left -25.6px so horizontal center stays at x=16. Vertical centering unchanged (top 50% + translateY(-50%)). Claude/Codex watermarks unchanged. CSS-only, no Rust.

- `frontend/styles/session-rail.css`: add `.pill-watermark.muse` size override with recentered left