### PR TITLE
Muse command results: shared card, styled like Claude/Codex

### DIFF
--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -55,31 +55,26 @@ fn parse_command_result(text: &str) -> Option<MuseCommandResult> {
         .filter(|c| !c.command.trim().is_empty())
 }
 
-/// Render a muse command result as a compact card — `$ command`, an optional
-/// description, and the output in a scrollable block — matching how the
-/// Claude/Codex renderers present a shell command, rather than printing the raw
-/// JSON muse packs into `text`.
+/// Render a muse command result via the shared [`CommandResultCard`] — the same
+/// green/collapsible treatment the Claude/Codex tool results use — rather than
+/// printing the raw JSON muse packs into `text`. Intent first, then the `$`
+/// command line, then the collapsible output.
 fn render_command_card(cmd: &MuseCommandResult) -> Html {
-    let exit = cmd.exit_code.unwrap_or(0);
+    use crate::components::tool_renderers::CommandResultCard;
+    // muse truncates long output itself and flags it; surface that as a note
+    // appended to the output so the card doesn't imply it saw everything.
+    let output = match (cmd.output.as_deref(), cmd.truncated) {
+        (Some(o), Some(true)) => Some(format!("{o}\n[output truncated]")),
+        (Some(o), _) => Some(o.to_string()),
+        (None, _) => None,
+    };
     html! {
-        <div class="muse-bash">
-            <div class="muse-bash-command-line">
-                <span class="muse-bash-prompt">{ "$" }</span>
-                <code class="muse-bash-command">{ &cmd.command }</code>
-                if exit != 0 {
-                    <span class="muse-bash-exit">{ format!("exit {exit}") }</span>
-                }
-            </div>
-            if let Some(desc) = cmd.description.as_deref().filter(|d| !d.trim().is_empty()) {
-                <div class="muse-bash-note">{ desc }</div>
-            }
-            if let Some(out) = cmd.output.as_deref().filter(|o| !o.is_empty()) {
-                <pre class="muse-bash-output">{ out }</pre>
-            }
-            if cmd.truncated.unwrap_or(false) {
-                <div class="muse-bash-note">{ "output truncated" }</div>
-            }
-        </div>
+        <CommandResultCard
+            command={AttrValue::from(cmd.command.clone())}
+            description={cmd.description.clone().map(AttrValue::from)}
+            output={output.map(AttrValue::from)}
+            exit_code={cmd.exit_code}
+        />
     }
 }
 

--- a/frontend/src/components/tool_renderers/command_result.rs
+++ b/frontend/src/components/tool_renderers/command_result.rs
@@ -1,0 +1,59 @@
+//! A self-contained card for a shell-command execution: intent, the command
+//! line, and its (collapsible) output — styled like the Claude/Codex tool
+//! results (green success / red failure). Extracted so any agent whose wire
+//! shape carries a command + its output in one place can render it the same
+//! way; muse's `bash`/command results are the first consumer.
+
+use super::super::expandable::ExpandableText;
+use crate::components::markdown::linkify_urls;
+use yew::prelude::*;
+
+/// How much output to show before the `ExpandableText` toggle collapses it —
+/// matches the "show a bit, click for the rest" behavior of the other agents'
+/// tool output.
+const OUTPUT_PREVIEW_CHARS: usize = 600;
+
+#[derive(Properties, PartialEq)]
+pub struct CommandResultCardProps {
+    pub command: AttrValue,
+    /// The agent's one-line rationale ("intent"), shown above the command.
+    #[prop_or_default]
+    pub description: Option<AttrValue>,
+    /// Combined stdout/stderr. Rendered as ANSI-styled, collapsible output.
+    #[prop_or_default]
+    pub output: Option<AttrValue>,
+    /// `None` treated as success (0). Non-zero flips the card to the failure
+    /// (red) treatment and shows an `exit N` badge.
+    #[prop_or_default]
+    pub exit_code: Option<i64>,
+}
+
+#[function_component(CommandResultCard)]
+pub fn command_result_card(props: &CommandResultCardProps) -> Html {
+    let exit = props.exit_code.unwrap_or(0);
+    let failed = exit != 0;
+    let card_class = classes!("command-result", failed.then_some("failed"));
+
+    html! {
+        <div class={card_class}>
+            if let Some(desc) = props.description.as_ref().filter(|d| !d.trim().is_empty()) {
+                <div class="command-result-intent">{ desc }</div>
+            }
+            <div class="command-result-command">
+                <span class="command-result-prompt">{ "$" }</span>
+                <code class="command-result-line">{ linkify_urls(&props.command) }</code>
+                if failed {
+                    <span class="command-result-exit">{ format!("exit {exit}") }</span>
+                }
+            </div>
+            if let Some(out) = props.output.as_ref().filter(|o| !o.is_empty()) {
+                <ExpandableText
+                    full_text={out.clone()}
+                    max_len={OUTPUT_PREVIEW_CHARS}
+                    class={classes!("command-result-output")}
+                    ansi={true}
+                />
+            }
+        </div>
+    }
+}

--- a/frontend/src/components/tool_renderers/mod.rs
+++ b/frontend/src/components/tool_renderers/mod.rs
@@ -1,8 +1,11 @@
 mod bash;
+mod command_result;
 mod edit;
 mod interactive;
 mod search;
 mod task;
+
+pub(crate) use self::command_result::CommandResultCard;
 
 use serde::de::DeserializeOwned;
 use serde_json::Value;

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1766,58 +1766,8 @@
     overflow-wrap: anywhere;
 }
 
-/* Command (bash) tool result rendered as a card rather than raw JSON — muse
-   packs a structured result into `tool.result.text` as JSON; the renderer
-   parses it and draws this. Reads like the Claude/Codex bash cards: a `$`
-   command line over a scrollable output block. */
 .muse-tool-command {
     margin: 0.2rem 0 0.2rem 0.5rem;
-}
-
-.muse-bash-command-line {
-    display: flex;
-    gap: 0.4rem;
-    align-items: baseline;
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-}
-
-.muse-bash-prompt {
-    color: var(--accent, #7aa2f7);
-    flex-shrink: 0;
-}
-
-.muse-bash-command {
-    color: var(--text-primary);
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-}
-
-.muse-bash-exit {
-    color: var(--error, #f7768e);
-    flex-shrink: 0;
-}
-
-.muse-bash-note {
-    color: var(--text-muted);
-    font-style: italic;
-    font-size: 0.72rem;
-    margin: 0.1rem 0 0 0.9rem;
-}
-
-.muse-bash-output {
-    margin: 0.2rem 0 0 0.9rem;
-    padding: 0.35rem 0.5rem;
-    color: var(--text-secondary);
-    background: var(--bg-darker, rgba(0, 0, 0, 0.25));
-    border-radius: 4px;
-    font-family: var(--font-mono);
-    font-size: 0.72rem;
-    line-height: 1.45;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-    max-height: 20rem;
-    overflow-y: auto;
 }
 
 .muse-task-card .message-body {

--- a/frontend/styles/tools/bash.css
+++ b/frontend/styles/tools/bash.css
@@ -47,3 +47,70 @@
     white-space: pre-wrap;
     word-break: break-all;
 }
+
+/* ==========================================================================
+   Command-result card (CommandResultCard) — a shell command + its output as
+   one card, styled like the Claude/Codex tool results: green success / red
+   failure, intent line on top, then `$ command`, then collapsible output.
+   Shared component; muse's bash/command results are the first consumer.
+   ========================================================================== */
+.command-result {
+    margin: 0.4rem 0 0.3rem 0.5rem;
+    padding: 0.45rem 0.6rem;
+    background: rgba(34, 197, 94, 0.1);
+    border-left: 3px solid var(--success);
+    border-radius: 0 4px 4px 0;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+}
+
+.command-result.failed {
+    background: rgba(239, 68, 68, 0.1);
+    border-left-color: var(--error);
+}
+
+.command-result-intent {
+    color: var(--text-secondary);
+    font-style: italic;
+    font-size: 0.78rem;
+    margin-bottom: 0.35rem;
+}
+
+.command-result-command {
+    display: flex;
+    gap: 0.4rem;
+    align-items: baseline;
+}
+
+.command-result-prompt {
+    color: var(--success);
+    flex-shrink: 0;
+}
+
+.command-result.failed .command-result-prompt {
+    color: var(--error);
+}
+
+.command-result-line {
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.command-result-exit {
+    color: var(--error);
+    flex-shrink: 0;
+    margin-left: auto;
+}
+
+.command-result-output {
+    margin: 0.4rem 0 0;
+    padding: 0.4rem 0.55rem;
+    color: var(--text-secondary);
+    background: rgba(0, 0, 0, 0.22);
+    border-radius: 4px;
+    font-size: 0.75rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}


### PR DESCRIPTION
Feedback on the muse bash card: make it look like the Claude/Codex tool results (green backdrop, intent, command, collapsible output), and extract the results renderer into its own component.

## Change

New shared **`CommandResultCard`** component (`frontend/src/components/tool_renderers/command_result.rs`) — a shell command + its output as one card:

- **Green success / red-on-failure** backdrop with a left accent, reusing the same green as Claude's `.tool-result`.
- **Intent** (the agent's one-line rationale) on top.
- **`$ command`** line below it.
- **Output via the shared `ExpandableText`** — the same char-based collapse-with-a-toggle + ANSI rendering the other tool cards use — instead of muse's bespoke fixed-height scroll box.

Muse's `render_command_card` now just parses its JSON-in-`text` (unchanged from #1596) into props and hands them to the component. Extracting it means any agent whose wire shape carries a command + output together can render identically; muse is the first consumer. `.command-result*` styles live with the other tool CSS (`styles/tools/bash.css`); the old `.muse-bash*` rules are removed.

## Before → after

| Before (#1596) | After |
|---|---|
| Bespoke muse card, plain scroll box | Shared green card: intent → `$ command` → collapsible ANSI output |

## Verification

Rendered against the real capture (the `git push --force-with-lease` example) in a harness with the built CSS — matches the spec (screenshot in the session). 21 muse tests pass, clippy clean on wasm32, stylelint clean, trunk build green.

Note: the `model.meta.response` bookkeeping card visible above these in the transcript is removed separately by #1607.