### PR TITLE
Drop cost from messages and top bar keep in telemetry

### DIFF
--- a/frontend/src/components/message_renderer/renderers/result.rs
+++ b/frontend/src/components/message_renderer/renderers/result.rs
@@ -2,7 +2,6 @@
 //! per-turn metrics footer, and the fast-mode labelling shared with the
 //! system init bar.
 
-use super::super::shorten_model_name;
 use super::errors::try_render_api_error;
 use shared::fmt::format_duration;
 use yew::prelude::*;
@@ -40,20 +39,10 @@ pub fn render_result_message(
     let api_ms = msg.duration_api_ms;
     let turns = msg.num_turns;
 
-    let mut timing_tooltip = format!(
+    let timing_tooltip = format!(
         "Total: {}ms | API: {}ms | Turns: {}",
         duration_ms, api_ms, turns
     );
-
-    if let Some(model_usage) = msg.model_usage.as_ref() {
-        for (model, entry) in model_usage {
-            timing_tooltip.push_str(&format!(
-                " | {}: ${:.4}",
-                shorten_model_name(model).unwrap_or_else(|| model.clone()),
-                entry.cost_usd
-            ));
-        }
-    }
 
     let errors_tooltip = if !msg.errors.is_empty() {
         msg.errors.join("\n")
@@ -73,17 +62,6 @@ pub fn render_result_message(
 
     let extra_badges = html! {
         <>
-            {
-                    if msg.total_cost_usd > 0.0 {
-                    html! {
-                        <span class="stat-item cost" title="Total cost">
-                            { format!("${:.2}", msg.total_cost_usd) }
-                        </span>
-                    }
-                } else {
-                    html! {}
-                }
-            }
             {
                 if msg.stop_reason.as_deref() == Some("max_tokens") {
                     html! {

--- a/frontend/src/components/message_renderer/turn_metrics_footer.rs
+++ b/frontend/src/components/message_renderer/turn_metrics_footer.rs
@@ -5,7 +5,7 @@
 //! `result-stats-bar` card, e.g.
 //!
 //! ```text
-//! 47.2 tok/s · TTFT 1.31s · 2.1k in / 547 out · cache 84% hit · max gap 0.4s · $0.014
+//! 47.2 tok/s · TTFT 1.31s · 2.1k in / 547 out · cache 84% hit · max gap 0.4s
 //! ```
 //!
 //! Each chip is a `<span class="turn-metric-chip">` so we can color the
@@ -42,14 +42,12 @@
 //!   decimal. Only rendered when the gap is `> 1000ms` — sub-1s gaps are
 //!   the steady-state hum and showing them would just clutter the chip
 //!   strip with `"max gap 0.2s"` on every successful turn.
-//! - **Cost**: `total_cost_usd` rendered as `$X.XXX` for values below $1.00
-//!   and `$X.XX` at $1.00 and above. Omitted when `None` (Codex turns).
 
 use shared::TurnMetrics;
 use yew::prelude::*;
 
 use crate::components::turn_metrics_display::{
-    compact_count, format_cache_hit, format_cost, format_max_gap, format_tok_per_sec, format_ttft,
+    compact_count, format_cache_hit, format_max_gap, format_tok_per_sec, format_ttft,
 };
 
 /// Build the full chip list for a `TurnMetrics` row, in render order. Each
@@ -81,9 +79,6 @@ pub fn build_chip_list(metrics: &TurnMetrics) -> Vec<String> {
         chips.push(s);
     }
     if let Some(s) = format_max_gap(metrics.max_inter_token_gap_ms) {
-        chips.push(s);
-    }
-    if let Some(s) = format_cost(metrics.total_cost_usd) {
         chips.push(s);
     }
     chips
@@ -296,29 +291,6 @@ mod tests {
         assert_eq!(format_max_gap(None), None);
     }
 
-    // ---- format_cost ----
-
-    #[test]
-    fn cost_none() {
-        // Codex turns: cost is None.
-        assert_eq!(format_cost(None), None);
-    }
-
-    #[test]
-    fn cost_sub_dollar_uses_three_decimals() {
-        assert_eq!(format_cost(Some(0.014)), Some("$0.014".to_string()));
-    }
-
-    #[test]
-    fn cost_at_dollar_uses_two_decimals() {
-        assert_eq!(format_cost(Some(1.00)), Some("$1.00".to_string()));
-    }
-
-    #[test]
-    fn cost_above_dollar_uses_two_decimals() {
-        assert_eq!(format_cost(Some(1.234)), Some("$1.23".to_string()));
-    }
-
     // ---- end-to-end chip-list builder ----
 
     fn sample_metrics() -> TurnMetrics {
@@ -361,7 +333,7 @@ mod tests {
     /// list is the exact order + content the spec calls out:
     ///
     /// ```text
-    /// 47.2 tok/s · TTFT 1.31s · 16 in / 547 out · cache 84% hit · max gap 1.5s · $0.014
+    /// 47.2 tok/s · TTFT 1.31s · 16 in / 547 out · cache 84% hit · max gap 1.5s
     /// ```
     #[test]
     fn end_to_end_full_chip_list() {
@@ -375,7 +347,6 @@ mod tests {
                 "16 in / 547 out".to_string(),
                 "cache 84% hit".to_string(),
                 "max gap 1.5s".to_string(),
-                "$0.014".to_string(),
             ],
         );
     }

--- a/frontend/src/components/turn_metrics_display.rs
+++ b/frontend/src/components/turn_metrics_display.rs
@@ -110,6 +110,9 @@ pub(crate) fn format_max_gap(max_inter_token_gap_ms: Option<i64>) -> Option<Stri
 }
 
 /// Cost chip text, e.g. `"$0.014"` for sub-$1 and `"$1.23"` for $1+.
+// Kept for telemetry/reporting screens (performance/admin/history) — not shown on
+// claude-code messages or the top bar.
+#[allow(dead_code)]
 pub(crate) fn format_cost(total_cost_usd: Option<f64>) -> Option<String> {
     let cost = total_cost_usd?;
     if cost.abs() < 1.0 {

--- a/frontend/src/hooks/use_client_websocket.rs
+++ b/frontend/src/hooks/use_client_websocket.rs
@@ -12,7 +12,8 @@ use yew::prelude::*;
 
 /// Return value from the use_client_websocket hook.
 pub struct UseClientWebSocket {
-    /// Total user spend across all sessions
+    /// Total user spend across all sessions (retained for telemetry/reporting screens; no longer shown in top bar)
+    #[allow(dead_code)]
     pub total_spend: f64,
     /// Server shutdown reason (if server is shutting down).
     /// Cleared automatically on the next successful (re)connect.

--- a/frontend/src/pages/dashboard/mod.rs
+++ b/frontend/src/pages/dashboard/mod.rs
@@ -9,7 +9,6 @@
 mod page;
 mod page_bootstrap;
 mod page_focus;
-mod page_spend;
 mod page_state;
 mod permission_dialog;
 mod session_order;

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -2,7 +2,6 @@
 
 use super::page_bootstrap::use_dashboard_bootstrap;
 use super::page_focus::use_dashboard_focus;
-use super::page_spend::use_spend_badge_animation;
 use super::page_state::{
     active_session_ids, DashboardSessionAction, DashboardSessionState, DashboardUiAction,
     DashboardUiState,
@@ -12,7 +11,7 @@ use super::session_rail::{ActivityRef, AgentMessageBroadcast, BroadcastRef, Sess
 use super::session_view::SessionView;
 use super::types::{
     load_group_by_host, load_hidden_sessions, load_inactive_hidden, load_rail_position,
-    load_show_cost, save_hidden_sessions, save_inactive_hidden, save_show_cost,
+    save_hidden_sessions, save_inactive_hidden,
 };
 use crate::components::{
     ConfirmModal, ConfirmModalStyle, HelpOverlay, LaunchDialog, TurnMetricsHeaderPill,
@@ -55,9 +54,7 @@ pub fn dashboard_page() -> Html {
     let sessions = sessions_hook.sessions.clone();
     let loading = sessions_hook.loading;
 
-    // Use the client websocket hook for spend updates
     let ws_hook = use_client_websocket();
-    let total_user_spend = ws_hook.total_spend;
     let server_shutdown_reason = ws_hook.shutdown_reason.clone();
     let update_available = ws_hook.update_available.clone();
     let bootstrap = use_dashboard_bootstrap();
@@ -93,7 +90,6 @@ pub fn dashboard_page() -> Html {
     let ui_state = use_reducer_eq(|| {
         DashboardUiState::new(
             load_inactive_hidden(),
-            load_show_cost(),
             load_rail_position(),
             load_group_by_host(),
         )
@@ -107,7 +103,6 @@ pub fn dashboard_page() -> Html {
     // SessionRail reads this on its own 100 ms tick instead.
     let activity_timestamps = use_memo((), |_| ActivityRef::default());
     let agent_message_broadcasts = use_memo((), |_| BroadcastRef::default());
-    let spend_animation = use_spend_badge_animation(total_user_spend);
 
     // Get DB-authoritative sessions in a total, deterministic display order
     // (see `session_order`). A disconnected, unpaused session is
@@ -520,15 +515,6 @@ pub fn dashboard_page() -> Html {
         })
     };
 
-    let on_toggle_show_cost = {
-        let ui_state = ui_state.clone();
-        Callback::from(move |_: MouseEvent| {
-            let new_val = !ui_state.show_cost;
-            save_show_cost(new_val);
-            ui_state.dispatch(DashboardUiAction::SetShowCost(new_val));
-        })
-    };
-
     let on_message_sent = {
         let session_state = session_state.clone();
         Callback::from(move |current_session_id: Uuid| {
@@ -676,33 +662,6 @@ pub fn dashboard_page() -> Html {
                 <h1>{ app_title.clone() }</h1>
                 <div class="header-actions">
                     <TurnMetricsHeaderPill metrics={ws_hook.recent_turn_metrics.clone()} />
-                    {
-                        if total_user_spend > 0.0 {
-                            let spend_class = classes!(
-                                "total-spend-badge",
-                                spend_animation.tier_class,
-                                if spend_animation.animating { Some("spend-animating") } else { None },
-                            );
-                            html! {
-                                <>
-                                    if ui_state.show_cost {
-                                        <span class={spend_class} title="Total spend across all sessions">
-                                            { utils::format_dollars(total_user_spend) }
-                                        </span>
-                                    }
-                                    <button
-                                        class="cost-toggle-btn"
-                                        onclick={on_toggle_show_cost.clone()}
-                                        title={if ui_state.show_cost { "Hide cost" } else { "Show cost" }}
-                                    >
-                                        { if ui_state.show_cost { "$" } else { "$?" } }
-                                    </button>
-                                </>
-                            }
-                        } else {
-                            html! {}
-                        }
-                    }
                     {
                         if waiting_count > 0 {
                             html! {

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -184,7 +184,6 @@ pub(super) struct DashboardUiState {
     pub show_settings: bool,
     pub show_help: bool,
     pub inactive_hidden: bool,
-    pub show_cost: bool,
     pub rail_position: RailPosition,
     /// Opt-in: group the session rail's pills into per-host sections.
     pub group_by_host: bool,
@@ -193,19 +192,13 @@ pub(super) struct DashboardUiState {
 }
 
 impl DashboardUiState {
-    pub fn new(
-        inactive_hidden: bool,
-        show_cost: bool,
-        rail_position: RailPosition,
-        group_by_host: bool,
-    ) -> Self {
+    pub fn new(inactive_hidden: bool, rail_position: RailPosition, group_by_host: bool) -> Self {
         Self {
             show_launch_dialog: false,
             show_admin: false,
             show_settings: false,
             show_help: false,
             inactive_hidden,
-            show_cost,
             rail_position,
             group_by_host,
             pending_leave: None,
@@ -225,7 +218,6 @@ pub(super) enum DashboardUiAction {
     ShowHelp,
     CloseHelp,
     SetInactiveHidden(bool),
-    SetShowCost(bool),
     SetRailPosition(RailPosition),
     SetGroupByHost(bool),
     RequestLeave(Uuid),
@@ -267,9 +259,6 @@ impl Reducible for DashboardUiState {
             }
             DashboardUiAction::SetInactiveHidden(hidden) => {
                 state.inactive_hidden = hidden;
-            }
-            DashboardUiAction::SetShowCost(show) => {
-                state.show_cost = show;
             }
             DashboardUiAction::SetRailPosition(position) => {
                 state.rail_position = position;
@@ -476,7 +465,7 @@ mod tests {
 
     #[test]
     fn ui_reducer_controls_modal_visibility() {
-        let state = DashboardUiState::new(false, false, RailPosition::Top, false);
+        let state = DashboardUiState::new(false, RailPosition::Top, false);
         let state = reduce_ui(state, DashboardUiAction::ToggleLaunchDialog);
         assert!(state.show_launch_dialog);
 
@@ -501,21 +490,19 @@ mod tests {
 
     #[test]
     fn ui_reducer_tracks_preferences() {
-        let state = DashboardUiState::new(false, false, RailPosition::Top, false);
+        let state = DashboardUiState::new(false, RailPosition::Top, false);
         let state = reduce_ui(state, DashboardUiAction::SetInactiveHidden(true));
-        let state = state.reduce(DashboardUiAction::SetShowCost(true));
         let state = state.reduce(DashboardUiAction::SetRailPosition(RailPosition::Left));
         let state = state.reduce(DashboardUiAction::SetGroupByHost(true));
 
         assert!(state.inactive_hidden);
-        assert!(state.show_cost);
         assert_eq!(state.rail_position, RailPosition::Left);
         assert!(state.group_by_host);
     }
 
     #[test]
     fn ui_reducer_tracks_pending_confirmations() {
-        let state = DashboardUiState::new(false, false, RailPosition::Top, false);
+        let state = DashboardUiState::new(false, RailPosition::Top, false);
         let state = reduce_ui(state, DashboardUiAction::RequestLeave(id(1)));
         let state = state.reduce(DashboardUiAction::RequestDelete(id(2)));
 

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -16,9 +16,6 @@ pub const HIDDEN_SESSIONS_STORAGE_KEY: &str = "claude-portal-hidden-sessions";
 /// Storage key for inactive hidden state in localStorage
 pub const INACTIVE_HIDDEN_STORAGE_KEY: &str = "claude-portal-inactive-hidden";
 
-/// Storage key for cost display visibility in localStorage
-pub const SHOW_COST_STORAGE_KEY: &str = "claude-portal-show-cost";
-
 /// Storage key for session rail orientation in localStorage
 pub const RAIL_ORIENTATION_STORAGE_KEY: &str = "claude-portal-rail-orientation";
 
@@ -141,16 +138,6 @@ pub fn load_inactive_hidden() -> bool {
 /// Save inactive hidden state to localStorage
 pub fn save_inactive_hidden(hidden: bool) {
     save_bool_pref(INACTIVE_HIDDEN_STORAGE_KEY, hidden);
-}
-
-/// Load cost display preference from localStorage (default: hidden)
-pub fn load_show_cost() -> bool {
-    load_bool_pref(SHOW_COST_STORAGE_KEY)
-}
-
-/// Save cost display preference to localStorage
-pub fn save_show_cost(show: bool) {
-    save_bool_pref(SHOW_COST_STORAGE_KEY, show);
 }
 
 /// Load whether vim editing mode is enabled from localStorage (default: off).


### PR DESCRIPTION
Remove $ display from claude-code messages and the dashboard top bar, keep it in telemetry/reporting screens.

**Removed from:**
- `frontend/src/components/message_renderer/renderers/result.rs`: dropped `<span class="stat-item cost">` badge (${:.2}) and model_usage cost from timing tooltip (${:.4}) — result card now shows only duration/tokens/turns/fast-mode/errors/denials.
- `frontend/src/components/message_renderer/turn_metrics_footer.rs`: dropped cost chip from `build_chip_list` ($0.014 etc.), updated docstring/example and tests. `format_cost` helper in `turn_metrics_display.rs` kept with `#[allow(dead_code)]` for telemetry use.

**Top bar:**
- `frontend/src/pages/dashboard/page.rs`: removed total-spend badge + $/$? toggle button and all spend-animation state (`total_user_spend`, `spend_animation`, `on_toggle_show_cost`, `use_spend_badge_animation` import, `load/show_cost` prefs).
- `frontend/src/pages/dashboard/page_state.rs`: removed `show_cost` field, `SetShowCost` variant/reducer, updated tests and `DashboardUiState::new` signature.
- `frontend/src/pages/dashboard/types.rs`: removed `SHOW_COST_STORAGE_KEY`, `load_show_cost`/`save_show_cost`.
- `frontend/src/pages/dashboard/mod.rs`: removed `mod page_spend` (hook still exists on disk but no longer compiled/used).
- `frontend/src/hooks/use_client_websocket.rs`: kept `total_spend` field but marked `\allow(dead_code)` — still populated for telemetry paths.

**Kept in telemetry/reporting:**
- Admin (`overview_tab`, `users_tab`, `sessions_tab`), History (`browser.rs`, `transcript.rs`), Performance panel cost-per-token, `utils::format_dollars` etc. untouched.

Verified: `cargo fmt`, `cargo clippy --workspace` (1 allow), `cargo test --workspace` (149 passed), `npm run lint:css` pass.