### PR TITLE
feat: fork agent sessions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 
 # Database
-diesel = { version = "2.2", features = ["postgres", "r2d2", "chrono", "uuid", "serde_json", "numeric"] }
+diesel = { version = "2.2", features = ["postgres", "r2d2", "chrono", "uuid", "serde_json", "numeric", "64-column-tables"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/archive-format/src/lib.rs
+++ b/archive-format/src/lib.rs
@@ -195,6 +195,12 @@ pub struct SessionArchiveManifest {
     /// auto-update does not refresh it. `None` for non-launcher sessions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub launcher_version: Option<String>,
+    /// Portal session whose agent-native history seeded this fork.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forked_from_session_id: Option<Uuid>,
+    /// Optional Codex native turn id used as the divergence point.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_point_turn_id: Option<String>,
     /// The scheduled (cron) task that spawned this session
     /// (`sessions.scheduled_task_id`), linking an archived session back to
     /// the automation that created it. `None` for interactively-launched
@@ -395,6 +401,8 @@ mod tests {
             media: None,
             launcher_id: None,
             launcher_version: None,
+            forked_from_session_id: None,
+            fork_point_turn_id: None,
             scheduled_task_id: None,
             claude_args: Vec::new(),
             archived_by_version: None,

--- a/archive-format/src/scan.rs
+++ b/archive-format/src/scan.rs
@@ -246,6 +246,8 @@ pub mod test_support {
             media: None,
             launcher_id: None,
             launcher_version: None,
+            forked_from_session_id: None,
+            fork_point_turn_id: None,
             scheduled_task_id: None,
             claude_args: Vec::new(),
             archived_by_version: None,

--- a/backend/migrations/2026-08-07-182044_add_session_fork_lineage/down.sql
+++ b/backend/migrations/2026-08-07-182044_add_session_fork_lineage/down.sql
@@ -1,0 +1,7 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX IF EXISTS sessions_forked_from_session_id_idx;
+ALTER TABLE sessions
+    DROP COLUMN IF EXISTS fork_create_worktree,
+    DROP COLUMN IF EXISTS fork_launch_pending,
+    DROP COLUMN IF EXISTS fork_point_turn_id,
+    DROP COLUMN IF EXISTS forked_from_session_id;

--- a/backend/migrations/2026-08-07-182044_add_session_fork_lineage/up.sql
+++ b/backend/migrations/2026-08-07-182044_add_session_fork_lineage/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+ALTER TABLE sessions
+    ADD COLUMN forked_from_session_id UUID REFERENCES sessions(id) ON DELETE SET NULL,
+    ADD COLUMN fork_point_turn_id TEXT,
+    ADD COLUMN fork_launch_pending BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN fork_create_worktree BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX sessions_forked_from_session_id_idx
+    ON sessions (forked_from_session_id);

--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -179,6 +179,8 @@ mod tests {
             media: None,
             launcher_id: None,
             launcher_version: None,
+            forked_from_session_id: None,
+            fork_point_turn_id: None,
             scheduled_task_id: None,
             claude_args: Vec::new(),
             archived_by_version: None,

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -483,6 +483,8 @@ fn archive_one_session(
             media,
             launcher_id: session.launcher_id,
             launcher_version: session.launcher_version.clone(),
+            forked_from_session_id: session.forked_from_session_id,
+            fork_point_turn_id: session.fork_point_turn_id.clone(),
             scheduled_task_id: session.scheduled_task_id,
             // `claude_args` is stored as a JSONB string array; recover it as
             // Vec<String>, tolerating a malformed/absent value as empty.

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -5,8 +5,9 @@ use axum::{
 use diesel::prelude::*;
 use serde::Deserialize;
 use shared::api::{
-    DirectoryListingResponse, InstallAgentResponse, LaunchRequest, ProbeAgentsResponse,
-    StartAgentLoginRequest, StartAgentLoginResponse, SubmitAgentLoginCodeRequest,
+    DirectoryListingResponse, ForkDirectoryMode, ForkSessionRequest, ForkSessionResponse,
+    InstallAgentResponse, LaunchRequest, ProbeAgentsResponse, StartAgentLoginRequest,
+    StartAgentLoginResponse, SubmitAgentLoginCodeRequest,
 };
 use shared::{
     AgentLoginOutcome, AgentType, LauncherInfo, LauncherToServer, ServerToLauncher, SessionRole,
@@ -99,6 +100,8 @@ pub async fn launch_session(
             client_version: Some(version),
             agent_type: req.agent_type,
             claude_args: req.claude_args.clone(),
+            forked_from_session_id: None,
+            fork_point_turn_id: None,
         },
     )?;
     app_state
@@ -120,6 +123,8 @@ pub async fn launch_session(
         resume: Some(false),
         create_worktree: req.create_worktree,
         worktree_branch,
+        fork_from_session_id: None,
+        fork_point_turn_id: None,
     };
 
     if !app_state
@@ -182,6 +187,8 @@ pub(crate) struct DesiredSessionDraft {
     client_version: Option<String>,
     agent_type: shared::AgentType,
     claude_args: Vec<String>,
+    forked_from_session_id: Option<Uuid>,
+    fork_point_turn_id: Option<String>,
 }
 
 pub(crate) fn create_desired_session(
@@ -222,6 +229,17 @@ pub(crate) fn create_desired_session(
         .values(&new_session)
         .execute(&mut conn)?;
 
+    if draft.forked_from_session_id.is_some() || draft.fork_point_turn_id.is_some() {
+        diesel::update(sessions::table.find(draft.session_id))
+            .set((
+                sessions::forked_from_session_id.eq(draft.forked_from_session_id),
+                sessions::fork_point_turn_id.eq(draft.fork_point_turn_id),
+                sessions::fork_launch_pending.eq(true),
+                sessions::fork_create_worktree.eq(false),
+            ))
+            .execute(&mut conn)?;
+    }
+
     diesel::insert_into(session_members::table)
         .values(NewSessionMember {
             session_id: draft.session_id,
@@ -231,6 +249,185 @@ pub(crate) fn create_desired_session(
         .execute(&mut conn)?;
 
     Ok(())
+}
+
+/// POST /api/sessions/:session_id/fork — create a divergent session on the
+/// source session's launcher, where the agent-native conversation state lives.
+pub async fn fork_session(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+    Path(source_id): Path<Uuid>,
+    Json(req): Json<ForkSessionRequest>,
+) -> Result<Json<ForkSessionResponse>, AppError> {
+    use crate::schema::sessions;
+
+    let mut conn = app_state.conn()?;
+    let source = sessions::table
+        .find(source_id)
+        .filter(sessions::user_id.eq(user_id))
+        .first::<crate::models::Session>(&mut conn)
+        .optional()?
+        .ok_or(AppError::NotFound("Source session not found"))?;
+
+    let launcher_id = source.launcher_id.ok_or(AppError::BadRequest(
+        "Proxy-direct sessions cannot be forked",
+    ))?;
+    if !app_state
+        .session_manager
+        .launcher_supports_capability(launcher_id, shared::LAUNCHER_CAPABILITY_FORK_SESSION)
+    {
+        return Err(AppError::BadRequest(
+            "Source launcher is offline or does not support session forking",
+        ));
+    }
+    let agent_type = source.agent_type.parse().unwrap_or(AgentType::Claude);
+    if agent_type == AgentType::Muse {
+        return Err(AppError::BadRequest("Muse sessions cannot be forked"));
+    }
+    if agent_type != AgentType::Codex && req.fork_point_turn_id.is_some() {
+        return Err(AppError::BadRequest(
+            "Fork-at-turn is only supported for Codex sessions",
+        ));
+    }
+
+    let create_worktree = req.directory_mode == ForkDirectoryMode::Worktree;
+    if create_worktree
+        && !app_state
+            .session_manager
+            .launcher_supports_capability(launcher_id, shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE)
+    {
+        return Err(AppError::BadRequest(
+            "Source launcher does not support git worktree launches",
+        ));
+    }
+    let working_directory = match req.directory_mode {
+        ForkDirectoryMode::Worktree | ForkDirectoryMode::Same => source.working_directory.clone(),
+        ForkDirectoryMode::Other => req
+            .working_directory
+            .filter(|path| !path.trim().is_empty())
+            .ok_or(AppError::BadRequest(
+                "working_directory is required for other-directory forks",
+            ))?,
+    };
+    let name = normalize_custom_name(Some(&req.name))
+        .unwrap_or_else(|| format!("{} (fork)", source.session_name));
+    let mut claude_args: Vec<String> =
+        serde_json::from_value(source.claude_args.clone()).unwrap_or_default();
+    if let Some(model) = req.model.filter(|model| !model.trim().is_empty()) {
+        claude_args = apply_model_override(claude_args, agent_type, model);
+    }
+
+    let (hostname, version) = {
+        let launcher = app_state
+            .session_manager
+            .launchers
+            .get(&launcher_id)
+            .ok_or(AppError::BadRequest("Source launcher is offline"))?;
+        (launcher.hostname.clone(), launcher.version.clone())
+    };
+    // Mint before persisting the desired row so an auth failure cannot leave
+    // behind an orphaned, never-launchable fork.
+    let auth_token = mint_launch_token(&app_state, user_id)?;
+    let request_id = Uuid::new_v4();
+    let session_id = Uuid::new_v4();
+    create_desired_session(
+        &app_state,
+        DesiredSessionDraft {
+            session_id,
+            user_id,
+            working_directory: working_directory.clone(),
+            session_name: name.clone(),
+            hostname,
+            launcher_id: Some(launcher_id),
+            client_version: Some(version),
+            agent_type,
+            claude_args: claude_args.clone(),
+            forked_from_session_id: Some(source_id),
+            fork_point_turn_id: req.fork_point_turn_id.clone(),
+        },
+    )?;
+    if create_worktree {
+        diesel::update(sessions::table.find(session_id))
+            .set(sessions::fork_create_worktree.eq(true))
+            .execute(&mut conn)?;
+    }
+    if let Some(prompt) = req
+        .divergence_prompt
+        .as_deref()
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+    {
+        app_state.session_manager.set_last_input_sender(
+            session_id,
+            user_id,
+            "Fork divergence prompt".to_string(),
+        );
+        app_state.session_manager.enqueue_input(
+            &app_state.db_pool,
+            &session_id.to_string(),
+            session_id,
+            serde_json::Value::String(prompt.to_string()),
+            None,
+            None,
+        );
+    }
+    app_state
+        .session_manager
+        .register_launch_session(request_id, session_id);
+    let launch = ServerToLauncher::LaunchSession {
+        request_id,
+        user_id,
+        auth_token,
+        working_directory,
+        session_name: Some(name.clone()),
+        claude_args,
+        agent_type,
+        scheduled_task_id: None,
+        resume_session_id: Some(session_id),
+        resume: Some(false),
+        create_worktree,
+        worktree_branch: create_worktree.then_some(name),
+        fork_from_session_id: Some(source_id),
+        fork_point_turn_id: req.fork_point_turn_id,
+    };
+    if !app_state
+        .session_manager
+        .send_to_launcher(&launcher_id, launch)
+    {
+        app_state.session_manager.cancel_launch_session(request_id);
+        diesel::delete(sessions::table.find(session_id)).execute(&mut conn)?;
+        return Err(AppError::Internal(
+            "Failed to send fork request to launcher".to_string(),
+        ));
+    }
+    Ok(Json(ForkSessionResponse {
+        request_id,
+        session_id,
+    }))
+}
+
+fn apply_model_override(args: Vec<String>, agent_type: AgentType, model: String) -> Vec<String> {
+    let mut next = Vec::with_capacity(args.len() + 2);
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--model"
+            || (arg == "-c"
+                && iter
+                    .as_slice()
+                    .first()
+                    .is_some_and(|value| value.starts_with("model=")))
+        {
+            let _ = iter.next();
+        } else {
+            next.push(arg);
+        }
+    }
+    match agent_type {
+        AgentType::Claude => next.extend(["--model".to_string(), model]),
+        AgentType::Codex => next.extend(["-c".to_string(), format!("model={model}")]),
+        AgentType::Muse => {}
+    }
+    next
 }
 
 fn resolve_launch_target(
@@ -783,5 +980,22 @@ mod tests {
         let ts = branch.trim_start_matches("session-");
         assert_eq!(ts.len(), 15, "unexpected timestamp in {branch}");
         assert!(ts.chars().all(|c| c.is_ascii_digit() || c == '-'));
+    }
+
+    #[test]
+    fn fork_model_override_replaces_agent_specific_model_only() {
+        let claude = apply_model_override(
+            vec!["--model".into(), "old".into(), "--verbose".into()],
+            AgentType::Claude,
+            "new".into(),
+        );
+        assert_eq!(claude, ["--verbose", "--model", "new"]);
+
+        let codex = apply_model_override(
+            vec!["-c".into(), "model=old".into(), "--yolo".into()],
+            AgentType::Codex,
+            "new".into(),
+        );
+        assert_eq!(codex, ["--yolo", "-c", "model=new"]);
     }
 }

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -355,6 +355,8 @@ pub async fn resume_session(
         resume: Some(true),
         create_worktree: false,
         worktree_branch: None,
+        fork_from_session_id: None,
+        fork_point_turn_id: None,
     };
 
     if !app_state
@@ -697,6 +699,10 @@ mod tests {
             archived_at: None,
             last_model: None,
             launcher_version: launcher_version.map(str::to_string),
+            forked_from_session_id: None,
+            fork_point_turn_id: None,
+            fork_launch_pending: false,
+            fork_create_worktree: false,
         }
     }
 

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -777,6 +777,8 @@ fn handle_launcher_message(
                         resume: Some(true),
                         create_worktree: false,
                         worktree_branch: None,
+                        fork_from_session_id: None,
+                        fork_point_turn_id: None,
                     };
                     if !app_state
                         .session_manager
@@ -1118,12 +1120,20 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
             .parse()
             .unwrap_or(shared::AgentType::Claude);
 
+        let pending_fork = session.fork_launch_pending;
+        let create_worktree = pending_fork && session.fork_create_worktree;
+
         info!(
-            "Reconcile relaunching session {} ({}) on launcher {}: resume, \
+            "Reconcile relaunching session {} ({}) on launcher {}: {}, \
              launch_failure_count={}, dir={}",
             session.id,
             session.session_name,
             launcher_id,
+            if pending_fork {
+                "initial fork"
+            } else {
+                "resume"
+            },
             session.launch_failure_count,
             session.working_directory
         );
@@ -1138,10 +1148,18 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
             agent_type,
             scheduled_task_id: None,
             resume_session_id: Some(session.id),
-            // Reconcile relaunch of an existing desired session: resume it.
-            resume: Some(true),
-            create_worktree: false,
-            worktree_branch: None,
+            // A desired fork may be reconciled before its first proxy registers
+            // (for example after a backend restart). Keep replaying the durable
+            // fork recipe until registration clears `fork_launch_pending`.
+            resume: Some(!pending_fork),
+            create_worktree,
+            worktree_branch: create_worktree.then(|| session.session_name.clone()),
+            fork_from_session_id: pending_fork
+                .then_some(session.forked_from_session_id)
+                .flatten(),
+            fork_point_turn_id: pending_fork
+                .then(|| session.fork_point_turn_id.clone())
+                .flatten(),
         };
 
         if !app_state

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -183,6 +183,7 @@ pub fn register_or_update_session(
                 sessions::hostname.eq(params.hostname),
                 sessions::repo_url.eq(params.repo_url),
                 sessions::launcher_id.eq(params.launcher_id),
+                sessions::fork_launch_pending.eq(false),
                 sessions::claude_args.eq(serde_json::to_value(params.claude_args)
                     .unwrap_or_else(|_| serde_json::Value::Array(Vec::new()))),
             ))

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -117,6 +117,12 @@ pub struct Session {
     /// at session-create time (see `NewSessionWithId::launcher_version`).
     /// `None` for proxy-direct (non-launcher) sessions.
     pub launcher_version: Option<String>,
+    pub forked_from_session_id: Option<Uuid>,
+    pub fork_point_turn_id: Option<String>,
+    /// True until the forked proxy first registers. Reconcile must replay the
+    /// fork recipe while this is true rather than resume the empty new id.
+    pub fork_launch_pending: bool,
+    pub fork_create_worktree: bool,
 }
 
 /// Insertable session that specifies the ID (so we can use Claude's session ID)

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -359,6 +359,10 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
         )
         .route("/api/launch", post(handlers::launchers::launch_session))
         .route(
+            "/api/sessions/{session_id}/fork",
+            post(handlers::launchers::fork_session),
+        )
+        .route(
             "/api/launchers/{launcher_id}/update",
             post(handlers::launchers::update_launcher),
         )

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -226,6 +226,10 @@ diesel::table! {
         last_model -> Nullable<Varchar>,
         #[max_length = 32]
         launcher_version -> Nullable<Varchar>,
+        forked_from_session_id -> Nullable<Uuid>,
+        fork_point_turn_id -> Nullable<Text>,
+        fork_launch_pending -> Bool,
+        fork_create_worktree -> Bool,
     }
 }
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -77,6 +77,10 @@ pub struct ProxySessionConfig {
     /// Persist-back closure for the codex app-server thread id; see
     /// [`CodexThreadIdSink`] doc.
     pub codex_thread_id_sink: Option<CodexThreadIdSink>,
+    /// First-spawn-only source session for Claude/Codex fork semantics.
+    pub fork_from_session_id: Option<Uuid>,
+    /// Optional Codex native turn id; `None` forks the latest turn.
+    pub fork_point_turn_id: Option<String>,
 }
 
 /// The local hostname, or `"unknown"` when the OS lookup fails.

--- a/frontend/src/components/fork_dialog.rs
+++ b/frontend/src/components/fork_dialog.rs
@@ -1,0 +1,165 @@
+use gloo_net::http::Request;
+use shared::api::{ForkDirectoryMode, ForkSessionRequest, ForkSessionResponse};
+use shared::SessionInfo;
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::{HtmlInputElement, HtmlTextAreaElement};
+use yew::prelude::*;
+
+use crate::components::ModelSelect;
+
+#[derive(Properties, PartialEq)]
+pub struct ForkDialogProps {
+    pub session: SessionInfo,
+    pub on_close: Callback<()>,
+    #[prop_or_default]
+    pub on_forked: Callback<Uuid>,
+}
+
+#[function_component(ForkDialog)]
+pub fn fork_dialog(props: &ForkDialogProps) -> Html {
+    let name = use_state(|| format!("{} (fork)", props.session.session_name));
+    let mode = use_state(|| {
+        if props.session.repo_url.is_some() {
+            ForkDirectoryMode::Worktree
+        } else {
+            ForkDirectoryMode::Same
+        }
+    });
+    let other_directory = use_state(String::new);
+    let model = use_state(|| {
+        props
+            .session
+            .claude_args
+            .windows(2)
+            .find_map(|pair| {
+                if pair[0] == "--model" {
+                    Some(pair[1].clone())
+                } else if pair[0] == "-c" {
+                    pair[1].strip_prefix("model=").map(str::to_string)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default()
+    });
+    let prompt = use_state(String::new);
+    let submitting = use_state(|| false);
+    let error = use_state(|| None::<String>);
+
+    let set_mode = |next: ForkDirectoryMode| {
+        let mode = mode.clone();
+        Callback::from(move |_| mode.set(next))
+    };
+    let submit = {
+        let source_id = props.session.id;
+        let name = name.clone();
+        let mode = mode.clone();
+        let other_directory = other_directory.clone();
+        let model = model.clone();
+        let prompt = prompt.clone();
+        let submitting = submitting.clone();
+        let error = error.clone();
+        let on_close = props.on_close.clone();
+        let on_forked = props.on_forked.clone();
+        Callback::from(move |_| {
+            if name.trim().is_empty() {
+                error.set(Some("Name is required".into()));
+                return;
+            }
+            if *mode == ForkDirectoryMode::Other && other_directory.trim().is_empty() {
+                error.set(Some("Choose the other working directory".into()));
+                return;
+            }
+            let body = ForkSessionRequest {
+                name: name.trim().to_string(),
+                directory_mode: *mode,
+                working_directory: (*mode == ForkDirectoryMode::Other)
+                    .then(|| other_directory.trim().to_string()),
+                model: (!model.trim().is_empty()).then(|| (*model).clone()),
+                divergence_prompt: (!prompt.trim().is_empty()).then(|| prompt.trim().to_string()),
+                fork_point_turn_id: None,
+            };
+            submitting.set(true);
+            error.set(None);
+            let submitting = submitting.clone();
+            let error = error.clone();
+            let on_close = on_close.clone();
+            let on_forked = on_forked.clone();
+            spawn_local(async move {
+                let request =
+                    match Request::post(&format!("/api/sessions/{source_id}/fork")).json(&body) {
+                        Ok(request) => request,
+                        Err(e) => {
+                            error.set(Some(format!("Could not encode fork request: {e}")));
+                            submitting.set(false);
+                            return;
+                        }
+                    };
+                let response = request.send().await;
+                match response {
+                    Ok(response) if response.ok() => {
+                        match response.json::<ForkSessionResponse>().await {
+                            Ok(result) => {
+                                on_forked.emit(result.session_id);
+                                on_close.emit(());
+                            }
+                            Err(e) => error.set(Some(format!("Fork response was malformed: {e}"))),
+                        }
+                    }
+                    Ok(response) => {
+                        let message = response
+                            .text()
+                            .await
+                            .unwrap_or_else(|_| "Fork failed".into());
+                        error.set(Some(message));
+                    }
+                    Err(e) => error.set(Some(format!("Fork request failed: {e}"))),
+                }
+                submitting.set(false);
+            });
+        })
+    };
+    let close = {
+        let on_close = props.on_close.clone();
+        Callback::from(move |_| on_close.emit(()))
+    };
+
+    html! {
+        <div class="launch-dialog-backdrop" onclick={close.clone()}>
+            <div class="launch-dialog fork-dialog" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
+                <h2>{ "Fork session" }</h2>
+                <p class="dialog-description">
+                    { format!("Create a new {} session from {}'s latest persisted turn.", props.session.agent_type, props.session.session_name) }
+                </p>
+                <label>{ "Name" }</label>
+                <input value={(*name).clone()} oninput={{ let name = name.clone(); Callback::from(move |e: InputEvent| name.set(e.target_unchecked_into::<HtmlInputElement>().value())) }} />
+
+                <fieldset class="fork-directory-options">
+                    <legend>{ "Working directory" }</legend>
+                    if props.session.repo_url.is_some() {
+                        <label><input type="radio" name="fork-dir" checked={*mode == ForkDirectoryMode::Worktree} onchange={set_mode(ForkDirectoryMode::Worktree)} /> { "New git worktree (recommended)" }</label>
+                    }
+                    <label><input type="radio" name="fork-dir" checked={*mode == ForkDirectoryMode::Same} onchange={set_mode(ForkDirectoryMode::Same)} /> { "Same directory" }</label>
+                    if *mode == ForkDirectoryMode::Same {
+                        <p class="warning-text">{ "Warning: both agents will share one checkout and may overwrite each other's work." }</p>
+                    }
+                    <label><input type="radio" name="fork-dir" checked={*mode == ForkDirectoryMode::Other} onchange={set_mode(ForkDirectoryMode::Other)} /> { "Other directory" }</label>
+                    if *mode == ForkDirectoryMode::Other {
+                        <input placeholder="/path/on/source/launcher" value={(*other_directory).clone()} oninput={{ let value = other_directory.clone(); Callback::from(move |e: InputEvent| value.set(e.target_unchecked_into::<HtmlInputElement>().value())) }} />
+                    }
+                </fieldset>
+
+                <label>{ "Model override" }</label>
+                <ModelSelect agent_type={props.session.agent_type} value={(*model).clone()} on_change={{ let model = model.clone(); Callback::from(move |value| model.set(value)) }} />
+                <label>{ "Divergence prompt (optional)" }</label>
+                <textarea value={(*prompt).clone()} oninput={{ let prompt = prompt.clone(); Callback::from(move |e: InputEvent| prompt.set(e.target_unchecked_into::<HtmlTextAreaElement>().value())) }} />
+                if let Some(message) = &*error { <div class="error-message">{ message }</div> }
+                <div class="dialog-actions">
+                    <button type="button" onclick={close}>{ "Cancel" }</button>
+                    <button type="button" class="primary" disabled={*submitting} onclick={submit}>{ if *submitting { "Forking…" } else { "Fork session" } }</button>
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -9,6 +9,7 @@ mod count_up;
 mod cron_describe;
 mod diff;
 pub mod expandable;
+mod fork_dialog;
 mod help_overlay;
 mod launch_dialog;
 pub(crate) mod markdown;
@@ -28,6 +29,7 @@ mod voice_input;
 pub use confirm_modal::{ConfirmModal, ConfirmModalStyle};
 pub use copy_command::CopyCommand;
 pub use count_up::CountUp;
+pub use fork_dialog::ForkDialog;
 pub use help_overlay::HelpOverlay;
 pub use launch_dialog::LaunchDialog;
 pub use message_renderer::{

--- a/frontend/src/pages/dashboard/session_order.rs
+++ b/frontend/src/pages/dashboard/session_order.rs
@@ -171,6 +171,8 @@ mod tests {
             paused: false,
             claude_args: Vec::new(),
             last_model: None,
+            forked_from_session_id: None,
+            fork_point_turn_id: None,
         }
     }
 

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -3,7 +3,7 @@
 //! Dropdown pattern matches the send button: always in DOM, toggled by .open class,
 //! parent page onclick closes it, toggle button uses stop_propagation.
 
-use crate::components::{ScheduleDialog, ShareDialog};
+use crate::components::{ForkDialog, ScheduleDialog, ShareDialog};
 use gloo::events::EventListener;
 use gloo::timers::callback::Interval;
 use shared::{PrRef, SessionInfo};
@@ -276,6 +276,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     let copied_id = use_state(|| false);
     let share_session_id = use_state(|| None::<Uuid>);
     let schedule_session = use_state(|| None::<SessionInfo>);
+    let fork_session = use_state(|| None::<SessionInfo>);
     let stop_has_tasks = use_scheduled_task_blocker(*menu_session, props.sessions.clone());
 
     // Independent 100 ms tick that drives sparkline redraws.
@@ -418,6 +419,10 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     let on_schedule = {
         let schedule_session = schedule_session.clone();
         Callback::from(move |session| schedule_session.set(Some(session)))
+    };
+    let on_fork = {
+        let fork_session = fork_session.clone();
+        Callback::from(move |session| fork_session.set(Some(session)))
     };
 
     let on_toggle_pill_menu = {
@@ -580,6 +585,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 on_delete={props.on_delete.clone()}
                 on_share={on_share}
                 on_schedule={on_schedule}
+                on_fork={on_fork}
             />
             {
                 if let Some(session_id) = *share_session_id {
@@ -595,6 +601,15 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                     let schedule_session = schedule_session.clone();
                     let on_close = Callback::from(move |_| schedule_session.set(None));
                     html! { <ScheduleDialog session={session.clone()} {on_close} /> }
+                } else {
+                    html! {}
+                }
+            }
+            {
+                if let Some(ref session) = *fork_session {
+                    let fork_session = fork_session.clone();
+                    let on_close = Callback::from(move |_| fork_session.set(None));
+                    html! { <ForkDialog session={session.clone()} {on_close} /> }
                 } else {
                     html! {}
                 }

--- a/frontend/src/pages/dashboard/session_rail/menu.rs
+++ b/frontend/src/pages/dashboard/session_rail/menu.rs
@@ -28,6 +28,7 @@ pub(super) struct SessionRailMenuProps {
     pub on_delete: Callback<Uuid>,
     pub on_share: Callback<Uuid>,
     pub on_schedule: Callback<SessionInfo>,
+    pub on_fork: Callback<SessionInfo>,
 }
 
 #[function_component(SessionRailMenu)]
@@ -89,6 +90,11 @@ fn render_menu_content(session: &SessionInfo, props: &SessionRailMenuProps) -> H
         let on_schedule = props.on_schedule.clone();
         let session = session.clone();
         move || on_schedule.emit(session.clone())
+    });
+    let open_fork = close_then(props.on_close.clone(), {
+        let on_fork = props.on_fork.clone();
+        let session = session.clone();
+        move || on_fork.emit(session.clone())
     });
 
     let on_hide = close_then(props.on_close.clone(), {
@@ -261,6 +267,19 @@ fn render_menu_content(session: &SessionInfo, props: &SessionRailMenuProps) -> H
     } else {
         html! {}
     };
+    let fork_option = if session.my_role == SessionRole::Owner
+        && session.launcher_id.is_some()
+        && session.agent_type != shared::AgentType::Muse
+    {
+        menu_option(
+            classes!("fork"),
+            "Fork Session…",
+            "Branch conversation and workspace",
+            open_fork,
+        )
+    } else {
+        html! {}
+    };
 
     html! {
         <>
@@ -271,6 +290,7 @@ fn render_menu_content(session: &SessionInfo, props: &SessionRailMenuProps) -> H
                 on_copy_id,
             ) }
             { share_option }
+            { fork_option }
             { schedule_option }
             { repo_option }
             { pause_option }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -10,7 +10,8 @@
 
 use crate::components::message_renderer::{MessageRenderer, RenderedMessage};
 use crate::components::{
-    group_is_turn_terminator, group_messages, thinking_chip_starts, MessageGroupRenderer,
+    group_is_turn_terminator, group_messages, thinking_chip_starts, ForkDialog,
+    MessageGroupRenderer,
 };
 use crate::utils::{self, On401};
 use gloo::timers::callback::Timeout;
@@ -187,6 +188,8 @@ pub enum SessionViewMsg {
     TurnMetricsReceived(Box<TurnMetrics>),
     ScheduleLimitContinuation(Uuid),
     ContinuationStatus(Uuid, String),
+    ShowForkDialog,
+    HideForkDialog,
 }
 
 /// SessionView - Main terminal view for a single session
@@ -274,6 +277,7 @@ pub struct SessionView {
     /// Monotonic tick bumped on every `ForwardsChanged` frame; passed to the
     /// forward-chip strip as a prop so it refetches (docs/PORT_FORWARDING.md).
     forwards_refresh: u32,
+    show_fork_dialog: bool,
 }
 
 impl Component for SessionView {
@@ -352,6 +356,7 @@ impl Component for SessionView {
             active_tools: Vec::new(),
             ephemeral_status: None,
             forwards_refresh: 0,
+            show_fork_dialog: false,
         }
     }
 
@@ -409,6 +414,14 @@ impl Component for SessionView {
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             SessionViewMsg::WsEvent(event) => self.handle_ws_event(ctx, event),
+            SessionViewMsg::ShowForkDialog => {
+                self.show_fork_dialog = true;
+                true
+            }
+            SessionViewMsg::HideForkDialog => {
+                self.show_fork_dialog = false;
+                true
+            }
             SessionViewMsg::LoadHistory(messages, last_timestamp) => {
                 self.handle_load_history(ctx, messages, last_timestamp);
                 true
@@ -668,9 +681,29 @@ impl Component for SessionView {
                         refresh={self.forwards_refresh}
                     />
                     <span class={status_class}>{ ctx.props().session.status.as_str() }</span>
+                    if ctx.props().session.my_role == shared::SessionRole::Owner
+                        && ctx.props().session.launcher_id.is_some()
+                        && ctx.props().session.agent_type != shared::AgentType::Muse
+                    {
+                        <button
+                            type="button"
+                            class="session-header-action"
+                            onclick={ctx.link().callback(|_| SessionViewMsg::ShowForkDialog)}
+                        >{ "Fork…" }</button>
+                    }
                 </div>
                 <div class="session-view-scroll-area">
                     <div class="session-view-messages" ref={self.messages_ref.clone()}>
+                        if let Some(source_id) = ctx.props().session.forked_from_session_id {
+                            <div class="fork-lineage-card">
+                                { "Forked from " }
+                                <a href={format!("/dashboard?session={source_id}")}>{ &source_id.to_string()[..8] }</a>
+                                if let Some(point) = &ctx.props().session.fork_point_turn_id {
+                                    <span>{ format!(" · turn {point}") }</span>
+                                }
+                                <span>{ " · shared agent history remains on the source launcher" }</span>
+                            </div>
+                        }
                         {
                             groups.into_iter().enumerate().map(|(i, group)| {
                                 let key = group.key(i);
@@ -699,6 +732,12 @@ impl Component for SessionView {
 
                 { self.render_permission_handler(ctx) }
                 { self.render_input_bar(ctx) }
+                if self.show_fork_dialog {
+                    <ForkDialog
+                        session={ctx.props().session.clone()}
+                        on_close={ctx.link().callback(|_| SessionViewMsg::HideForkDialog)}
+                    />
+                }
             </div>
         }
     }

--- a/frontend/src/pages/demo.rs
+++ b/frontend/src/pages/demo.rs
@@ -291,6 +291,8 @@ fn demo_session(spec: DemoSessionSpec) -> SessionInfo {
             spec.last_model.unwrap_or("demo").to_string(),
         ],
         last_model: spec.last_model.map(str::to_string),
+        forked_from_session_id: None,
+        fork_point_turn_id: None,
     }
 }
 

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -423,3 +423,16 @@
 .jump-to-live-pill:active {
     transform: translateX(-50%) translateY(0);
 }
+.fork-lineage-card {
+    margin: 0.75rem 1rem;
+    padding: 0.65rem 0.8rem;
+    border: 1px solid rgba(122, 162, 247, 0.35);
+    border-radius: 8px;
+    background: rgba(122, 162, 247, 0.08);
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.fork-lineage-card a {
+    color: var(--accent-blue);
+}

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -115,6 +115,7 @@ pub async fn run_launcher_loop(
                         .map(|p| p.to_string_lossy().to_string()),
                     capabilities: vec![
                         shared::LAUNCHER_CAPABILITY_CREATE_WORKTREE.to_string(),
+                        shared::LAUNCHER_CAPABILITY_FORK_SESSION.to_string(),
                         shared::LAUNCHER_CAPABILITY_RESTART.to_string(),
                         shared::LAUNCHER_CAPABILITY_HEARTBEAT_ACK.to_string(),
                     ],
@@ -633,6 +634,8 @@ async fn handle_message(
             resume,
             create_worktree,
             worktree_branch,
+            fork_from_session_id,
+            fork_point_turn_id,
             ..
         } => {
             // Check if this is a scheduler-owned launch.
@@ -667,6 +670,8 @@ async fn handle_message(
                     // backend leaves these fields at their defaults for them.
                     create_worktree,
                     worktree_branch,
+                    fork_from_session_id,
+                    fork_point_turn_id,
                 })
                 .await;
 

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -113,6 +113,8 @@ pub struct SpawnParams {
     /// Optional branch name for the worktree. When omitted a timestamped
     /// default (`session-<YYYYMMDD-HHMMSS>`) is derived.
     pub worktree_branch: Option<String>,
+    pub fork_from_session_id: Option<Uuid>,
+    pub fork_point_turn_id: Option<String>,
 }
 
 pub struct ProcessManager {
@@ -165,6 +167,26 @@ impl ProcessManager {
         // Resolve (and validate) the base directory the request targets. It
         // must exist and live under the launcher user's home directory.
         let base_dir = path_policy::ensure_existing_dir_under_home(&params.working_directory)?;
+
+        if let Some(source_id) = params.fork_from_session_id {
+            match params.agent_type {
+                shared::AgentType::Claude => {
+                    if claude_transcript_status(&base_dir, source_id) == TranscriptStatus::Missing {
+                        anyhow::bail!(
+                            "Cannot fork: source Claude transcript is missing on this launcher"
+                        );
+                    }
+                }
+                shared::AgentType::Codex => {
+                    if load_codex_thread_id(source_id).is_none() {
+                        anyhow::bail!(
+                            "Cannot fork: source Codex session has no persisted thread (it may have no turns yet)"
+                        );
+                    }
+                }
+                shared::AgentType::Muse => anyhow::bail!("Muse sessions cannot be forked"),
+            }
+        }
 
         // When the request opts into a worktree, create it from the repo that
         // contains `base_dir` and run the session there instead. Otherwise the
@@ -234,6 +256,8 @@ impl ProcessManager {
             // thread/resume. No-op for claude sessions (the codex io-task
             // is the only emitter).
             codex_thread_id_sink: Some(make_codex_thread_id_sink(session_id)),
+            fork_from_session_id: params.fork_from_session_id,
+            fork_point_turn_id: params.fork_point_turn_id,
         };
 
         let exit_tx = self.exit_tx.clone();
@@ -383,10 +407,15 @@ async fn run_session_task(
             muse_yolo,
             agent_type: config.agent_type,
             codex_thread_id,
-            fork_from_session_id: None,
-            codex_fork_from_thread_id: None,
-            codex_fork_last_turn_id: None,
+            fork_from_session_id: config.fork_from_session_id,
+            codex_fork_from_thread_id: config.fork_from_session_id.and_then(load_codex_thread_id),
+            codex_fork_last_turn_id: config.fork_point_turn_id.clone(),
         };
+
+        // Fork metadata seeds one spawn attempt only. Rotation/retry paths may
+        // set resume=false again and must never silently re-fork (#1537).
+        config.fork_from_session_id = None;
+        config.fork_point_turn_id = None;
 
         let mut session = match AnySession::new(session_config).await {
             Ok(s) => s,

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -425,6 +425,8 @@ async fn main() -> Result<()> {
         agent_type,
         scheduled_task_id: None,
         codex_thread_id_sink: Some(codex_thread_id_sink),
+        fork_from_session_id: None,
+        fork_point_turn_id: None,
     };
 
     // Branch: shim mode or normal proxy mode

--- a/shared/src/api/launch.rs
+++ b/shared/src/api/launch.rs
@@ -28,6 +28,35 @@ pub struct LaunchRequest {
     pub create_worktree: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForkDirectoryMode {
+    Worktree,
+    Same,
+    Other,
+}
+
+/// Request body for `POST /api/sessions/:id/fork`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForkSessionRequest {
+    pub name: String,
+    pub directory_mode: ForkDirectoryMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_directory: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub divergence_prompt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_point_turn_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForkSessionResponse {
+    pub request_id: uuid::Uuid,
+    pub session_id: uuid::Uuid,
+}
+
 /// Response from GET /api/launchers/:launcher_id/directories?path=…
 ///
 /// Envelope around the already-shared `DirectoryEntry` payload type.

--- a/shared/src/endpoints/launcher.rs
+++ b/shared/src/endpoints/launcher.rs
@@ -280,6 +280,13 @@ pub enum ServerToLauncher {
         /// derives a timestamped default.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         worktree_branch: Option<String>,
+        /// Source portal session whose local agent state should seed this
+        /// brand-new session. Additive and first-spawn-only.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fork_from_session_id: Option<Uuid>,
+        /// Codex-only optional native turn id. Claude ignores it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fork_point_turn_id: Option<String>,
     },
 
     /// Request to stop a session and remove the launcher's persisted

--- a/shared/src/endpoints/mod.rs
+++ b/shared/src/endpoints/mod.rs
@@ -513,6 +513,8 @@ mod tests {
             resume: None,
             create_worktree: false,
             worktree_branch: None,
+            fork_from_session_id: None,
+            fork_point_turn_id: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains(r#""type":"LaunchSession""#));

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -25,6 +25,9 @@ pub const BUILD_TIME: &str = env!("PORTAL_BUILD_TIME");
 /// Launcher capability advertised by versions that honor
 /// `ServerToLauncher::LaunchSession.create_worktree`.
 pub const LAUNCHER_CAPABILITY_CREATE_WORKTREE: &str = "launch.create_worktree";
+/// Launcher capability advertised by versions that can resolve local agent
+/// state and fork a session on the source host.
+pub const LAUNCHER_CAPABILITY_FORK_SESSION: &str = "launch.fork_session";
 
 /// Launcher capability advertised by versions that honor
 /// `ServerToLauncher::Restart` (restart the process without updating the binary).
@@ -628,6 +631,14 @@ pub struct SessionInfo {
     /// keeps older proxies/clients wire-compatible.
     #[serde(default)]
     pub last_model: Option<String>,
+    /// Source portal session for a fork. The agent history remains local to the
+    /// source launcher; this link provides durable portal-side provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forked_from_session_id: Option<Uuid>,
+    /// Agent-native turn id used as the fork point (Codex only). `None` means
+    /// the latest persisted turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_point_turn_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- add owner-only session forking for Claude and Codex on the source launcher
- support same directory, git worktree, or another directory plus model override and a persistent divergence prompt
- persist fork lineage and restart-safe first-launch state, surface provenance in the UI and archives
- gate unsupported launchers, proxy-direct sessions, and Muse with clear errors

## Verification
- fresh PostgreSQL migration + `diesel print-schema` matches checked-in schema
- `cargo check -p backend -p agent-portal -p claude-portal -p archive-format`
- `cargo check -p frontend --target wasm32-unknown-unknown`
- strict clippy for native targets and frontend WASM
- backend/archive/launcher/shared test compilation
- targeted Claude, Codex, and model-override tests
- migration-name and formatting checks

Closes #1457