### PR TITLE
feat: manage linked login identities

### DIFF
--- a/backend/src/handlers/identities.rs
+++ b/backend/src/handlers/identities.rs
@@ -1,0 +1,99 @@
+//! Self-service linked-login settings (#1535).
+
+use axum::{extract::Path, extract::State, Json};
+use diesel::prelude::*;
+use shared::api::{LinkedIdentitiesResponse, LinkedIdentity};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::auth::CurrentUserId;
+use crate::errors::AppError;
+use crate::handlers::responses::EmptyResponse;
+use crate::models::UserIdentity;
+use crate::schema::{user_identities, users};
+use crate::AppState;
+
+/// `GET /api/settings/identities` — list the caller's linked login methods.
+pub async fn list_identities(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+) -> Result<Json<LinkedIdentitiesResponse>, AppError> {
+    let mut conn = app_state.conn()?;
+    let identities = user_identities::table
+        .filter(user_identities::user_id.eq(user_id))
+        .order(user_identities::created_at.asc())
+        .select(UserIdentity::as_select())
+        .load::<UserIdentity>(&mut conn)?
+        .into_iter()
+        .map(|identity| LinkedIdentity {
+            id: identity.id,
+            provider: identity.provider,
+            email: identity.email,
+            linked_at: identity.created_at.and_utc().to_rfc3339(),
+        })
+        .collect();
+
+    Ok(Json(LinkedIdentitiesResponse { identities }))
+}
+
+/// `DELETE /api/settings/identities/:id` — unlink one login while preserving
+/// at least one way back into the account.
+pub async fn unlink_identity(
+    State(app_state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+    Path(identity_id): Path<Uuid>,
+) -> Result<EmptyResponse, AppError> {
+    let mut conn = app_state.conn()?;
+    conn.transaction::<_, AppError, _>(|conn| {
+        // Serialize concurrent unlink attempts for this account. Without the
+        // user-row lock, two requests could both observe a count of two and
+        // each delete one, leaving the account with no login method.
+        users::table
+            .find(user_id)
+            .select(users::id)
+            .for_update()
+            .first::<Uuid>(conn)?;
+
+        let identity_count = user_identities::table
+            .filter(user_identities::user_id.eq(user_id))
+            .count()
+            .get_result::<i64>(conn)?;
+        ensure_can_unlink(identity_count)?;
+
+        let deleted = diesel::delete(
+            user_identities::table
+                .find(identity_id)
+                .filter(user_identities::user_id.eq(user_id)),
+        )
+        .execute(conn)?;
+        if deleted == 0 {
+            return Err(AppError::NotFound("Linked identity not found"));
+        }
+        Ok(())
+    })?;
+
+    Ok(EmptyResponse::OK)
+}
+
+fn ensure_can_unlink(identity_count: i64) -> Result<(), AppError> {
+    if identity_count <= 1 {
+        Err(AppError::BadRequest("Cannot unlink the last login method"))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_can_unlink;
+    use crate::errors::AppError;
+
+    #[test]
+    fn last_login_method_cannot_be_unlinked() {
+        assert!(matches!(
+            ensure_can_unlink(1),
+            Err(AppError::BadRequest("Cannot unlink the last login method"))
+        ));
+        assert!(ensure_can_unlink(2).is_ok());
+    }
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -10,6 +10,7 @@ pub mod forward_proxy;
 pub mod forwards;
 pub mod helpers;
 pub mod history;
+pub mod identities;
 pub mod images;
 pub mod launchers;
 pub mod media_archive;

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -328,6 +328,14 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             "/api/settings/profile",
             put(handlers::profile::update_profile),
         )
+        .route(
+            "/api/settings/identities",
+            get(handlers::identities::list_identities),
+        )
+        .route(
+            "/api/settings/identities/{id}",
+            axum::routing::delete(handlers::identities::unlink_identity),
+        )
         .route(AUTH_ME, get(handlers::auth::me))
         .route(AUTH_REFRESH, post(handlers::auth::refresh_token))
         .route(AUTH_TOKEN_LOGIN, post(handlers::auth::token_login))

--- a/frontend/src/pages/settings/account_panel.rs
+++ b/frontend/src/pages/settings/account_panel.rs
@@ -1,0 +1,184 @@
+//! Account profile and linked login methods (#1535).
+
+use super::profile_panel::ProfilePanel;
+use crate::components::{ConfirmModal, ConfirmModalStyle};
+use crate::utils::{self, On401};
+use gloo_net::http::Request;
+use shared::api::{LinkedIdentitiesResponse, LinkedIdentity};
+use uuid::Uuid;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+fn provider_name(provider: &str) -> String {
+    match provider {
+        "google" => "Google".to_string(),
+        "github" => "GitHub".to_string(),
+        other => {
+            let mut chars = other.chars();
+            chars
+                .next()
+                .map(|first| first.to_uppercase().collect::<String>() + chars.as_str())
+                .unwrap_or_else(|| "Login".to_string())
+        }
+    }
+}
+
+#[function_component(AccountPanel)]
+pub fn account_panel() -> Html {
+    let identities = use_state(|| None::<Vec<LinkedIdentity>>);
+    let load_error = use_state(|| None::<String>);
+    let pending_unlink = use_state(|| None::<LinkedIdentity>);
+    let unlinking = use_state(|| None::<Uuid>);
+
+    {
+        let identities = identities.clone();
+        let load_error = load_error.clone();
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                match utils::fetch_json::<LinkedIdentitiesResponse>(
+                    "/api/settings/identities",
+                    On401::Logout,
+                )
+                .await
+                {
+                    Ok(response) => identities.set(Some(response.identities)),
+                    Err(error) => load_error.set(Some(error.to_string())),
+                }
+            });
+        });
+    }
+
+    let cancel_unlink = {
+        let pending_unlink = pending_unlink.clone();
+        Callback::from(move |_: MouseEvent| pending_unlink.set(None))
+    };
+    let confirm_unlink = {
+        let identities = identities.clone();
+        let pending_unlink = pending_unlink.clone();
+        let unlinking = unlinking.clone();
+        let load_error = load_error.clone();
+        Callback::from(move |_: MouseEvent| {
+            let Some(identity) = (*pending_unlink).clone() else {
+                return;
+            };
+            pending_unlink.set(None);
+            unlinking.set(Some(identity.id));
+            let identities = identities.clone();
+            let unlinking = unlinking.clone();
+            let load_error = load_error.clone();
+            spawn_local(async move {
+                let response = Request::delete(&utils::api_url(&format!(
+                    "/api/settings/identities/{}",
+                    identity.id
+                )))
+                .send()
+                .await;
+                match response {
+                    Ok(response) if response.ok() => {
+                        if let Some(current) = &*identities {
+                            identities.set(Some(
+                                current
+                                    .iter()
+                                    .filter(|item| item.id != identity.id)
+                                    .cloned()
+                                    .collect(),
+                            ));
+                        }
+                        load_error.set(None);
+                    }
+                    Ok(response) => load_error.set(Some(format!(
+                        "Couldn't unlink this login (HTTP {}).",
+                        response.status()
+                    ))),
+                    Err(error) => {
+                        load_error.set(Some(format!("Couldn't unlink this login: {error}")))
+                    }
+                }
+                unlinking.set(None);
+            });
+        })
+    };
+
+    html! {
+        <div class="section-stack account-settings">
+            <ProfilePanel />
+
+            <section class="section-stack linked-logins-section">
+                <div class="section-header">
+                    <h2>{ "Login methods" }</h2>
+                    <p class="section-description">
+                        { "External accounts you can use to sign in. Keep at least one login method linked." }
+                    </p>
+                </div>
+
+                if let Some(error) = &*load_error {
+                    <p class="settings-error" role="alert">{ error }</p>
+                }
+
+                if let Some(items) = &*identities {
+                    <div class="identity-list">
+                        { for items.iter().map(|identity| {
+                            let identity_for_click = identity.clone();
+                            let pending_unlink = pending_unlink.clone();
+                            let only_identity = items.len() == 1;
+                            let is_unlinking = *unlinking == Some(identity.id);
+                            let onclick = Callback::from(move |_: MouseEvent| {
+                                pending_unlink.set(Some(identity_for_click.clone()));
+                            });
+                            html! {
+                                <div class="identity-row" key={identity.id.to_string()}>
+                                    <span class={classes!("identity-provider", format!("provider-{}", identity.provider))}>
+                                        { provider_name(&identity.provider) }
+                                    </span>
+                                    <div class="identity-details">
+                                        <strong>{ identity.email.as_deref().unwrap_or("Linked account") }</strong>
+                                        <span>{ "Linked login" }</span>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        class="delete-button"
+                                        {onclick}
+                                        disabled={only_identity || is_unlinking}
+                                        title={only_identity.then_some("You cannot unlink your last login method")}
+                                    >
+                                        { if is_unlinking { "Unlinking…" } else { "Unlink" } }
+                                    </button>
+                                </div>
+                            }
+                        }) }
+                    </div>
+                } else if load_error.is_none() {
+                    <p class="setting-description">{ "Loading login methods…" }</p>
+                }
+            </section>
+
+            if let Some(identity) = &*pending_unlink {
+                <ConfirmModal
+                    title="Unlink login method"
+                    message={format!(
+                        "Unlink {}{} from this account?",
+                        provider_name(&identity.provider),
+                        identity.email.as_ref().map(|email| format!(" ({email})")).unwrap_or_default()
+                    )}
+                    warning="You will no longer be able to sign in with this identity."
+                    confirm_label="Unlink"
+                    style={ConfirmModalStyle::Panel}
+                    on_confirm={confirm_unlink}
+                    on_cancel={cancel_unlink}
+                />
+            }
+        </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::provider_name;
+
+    #[test]
+    fn provider_names_cover_known_and_generic_logins() {
+        assert_eq!(provider_name("google"), "Google");
+        assert_eq!(provider_name("github"), "GitHub");
+        assert_eq!(provider_name("gitlab"), "Gitlab");
+    }
+}

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -1,14 +1,17 @@
+mod account_panel;
 mod appearance_panel;
 mod forwarding_panel;
 mod health_timer_panel;
 mod launchers_panel;
 mod notifications_panel;
 mod performance_panel;
+mod profile_panel;
 mod sessions_panel;
 mod sounds_panel;
 mod tokens_panel;
 
 use crate::utils;
+use account_panel::AccountPanel;
 use appearance_panel::AppearancePanel;
 use forwarding_panel::ForwardingPanel;
 use health_timer_panel::HealthTimerPanel;
@@ -23,6 +26,7 @@ use yew::prelude::*;
 
 #[derive(Clone, Copy, PartialEq)]
 enum SettingsTab {
+    Account,
     Sessions,
     Tokens,
     Launchers,
@@ -41,7 +45,7 @@ pub struct SettingsPageProps {
 
 #[function_component(SettingsPage)]
 pub fn settings_page(props: &SettingsPageProps) -> Html {
-    let active_tab = use_state(|| SettingsTab::Sessions);
+    let active_tab = use_state(|| SettingsTab::Account);
 
     // Counts for tab badges (updated when panels load their data)
     let session_count = use_state(|| 0usize);
@@ -67,6 +71,7 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
         let active_tab = active_tab.clone();
         Callback::from(move |_: MouseEvent| active_tab.set(tab))
     };
+    let on_account_tab = make_tab_handler(SettingsTab::Account);
     let on_sessions_tab = make_tab_handler(SettingsTab::Sessions);
     let on_tokens_tab = make_tab_handler(SettingsTab::Tokens);
     let on_launchers_tab = make_tab_handler(SettingsTab::Launchers);
@@ -95,6 +100,12 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
             </header>
 
             <nav class="settings-tabs">
+                <button
+                    class={classes!("tab-button", (*active_tab == SettingsTab::Account).then_some("active"))}
+                    onclick={on_account_tab}
+                >
+                    { "Account" }
+                </button>
                 <button
                     class={classes!("tab-button", (*active_tab == SettingsTab::Sessions).then_some("active"))}
                     onclick={on_sessions_tab}
@@ -156,6 +167,9 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
             </nav>
 
             <main class="settings-content">
+                if *active_tab == SettingsTab::Account {
+                    <AccountPanel />
+                }
                 if *active_tab == SettingsTab::Tokens {
                     <TokensPanel on_tokens_loaded={on_tokens_loaded} />
                 }

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -91,6 +91,118 @@
     overflow-y: auto;
 }
 
+.account-settings {
+    max-width: 760px;
+}
+
+.profile-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.profile-setting {
+    padding: 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-darker);
+}
+
+.profile-setting h3 {
+    margin: 0 0 0.25rem;
+    color: var(--text-primary);
+}
+
+.profile-nickname-input {
+    width: min(100%, 28rem);
+    box-sizing: border-box;
+    margin-top: 0.75rem;
+    padding: 0.55rem 0.75rem;
+    color: var(--text-primary);
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+}
+
+.profile-nickname-input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.profile-save-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.linked-logins-section {
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+}
+
+.identity-list {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.identity-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+    background: var(--bg-darker);
+    border-bottom: 1px solid var(--border);
+}
+
+.identity-row:last-child {
+    border-bottom: 0;
+}
+
+.identity-provider {
+    min-width: 4.5rem;
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    background: var(--bg-dark);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-align: center;
+}
+
+.identity-details {
+    min-width: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.identity-details strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--text-primary);
+}
+
+.identity-details span {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+}
+
+.identity-row .delete-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+}
+
+.settings-error {
+    color: var(--error);
+    margin: 0;
+}
+
 /* Section shell — the vertical stack every settings/admin panel is built from.
    Its `gap` is the single source of spacing between the blocks inside it
    (header, cards, lists, loading/empty states).
@@ -669,6 +781,7 @@
 }
 
 .save-feedback {
+    color: var(--text-secondary);
     font-size: 0.85rem;
     font-weight: 500;
 }

--- a/shared/src/api/settings.rs
+++ b/shared/src/api/settings.rs
@@ -1,6 +1,24 @@
 //! Settings API request/response types.
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// One external login attached to the current portal account (#1535).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkedIdentity {
+    pub id: Uuid,
+    pub provider: String,
+    pub email: Option<String>,
+    /// ISO-8601 timestamp; kept as a string so the settings wire type stays
+    /// equally cheap on native and WASM targets.
+    pub linked_at: String,
+}
+
+/// Response for `GET /api/settings/identities`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkedIdentitiesResponse {
+    pub identities: Vec<LinkedIdentity>,
+}
 
 /// Response for GET /api/settings/sound
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- add an Account settings tab containing profile preferences and linked login methods
- list each Google, GitHub, or future provider identity without exposing provider subjects
- allow confirmed unlinking while atomically refusing removal of the final login method
- serialize concurrent unlink attempts with a user-row lock so an account cannot be stranded

## Verification
- `cargo check -p backend`
- `cargo check -p frontend --target wasm32-unknown-unknown`
- strict clippy for backend targets and frontend WASM
- backend last-identity guard test
- frontend provider-label test
- formatting and diff checks

Closes #1535