### PR TITLE
Collapse the muse work-log so the reply isn't buried

### DIFF
--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -131,19 +131,68 @@ pub fn render_task_tree(tree: &TaskTree) -> Html {
                 </div>
             }
             if !visible.is_empty() || !footer.is_empty() {
-                <div class="muse-task-tree">
+                // The task tree is the supporting WORK LOG, not the reply. A
+                // long turn stacks dozens of nodes that eclipse the answer
+                // above, so keep it collapsed behind a "N steps" toggle once an
+                // answer exists; when there's no answer yet (in progress, or a
+                // failed run with no reply), leave it open so the turn isn't
+                // an empty card (#muse-worklog-collapse).
+                <MuseWorkLog
+                    count={visible.len()}
+                    default_expanded={tree.answer().is_none()}
+                >
                     // Each task node carries a stable `key={task_id}` (set in
                     // render_task_node) so Yew updates a task in place as it
                     // advances running → completed, instead of positionally
-                    // diffing (which made an updating task appear to jump).
-                    // Mirrors how the Codex item list keys its cards.
+                    // diffing. Mirrors how the Codex item list keys its cards.
                     { for visible.iter().map(|node| render_task_node(node)) }
                     if !footer.is_empty() {
                         <div class="muse-journal-footer">{ footer.join(" · ") }</div>
                     }
-                </div>
+                </MuseWorkLog>
             }
         </>
+    }
+}
+
+/// Collapsible "work log" wrapper around a turn's task nodes. Muse emits many
+/// bookkeeping/tool tasks per turn; rendered inline they bury the actual reply,
+/// so this hides them behind a `▸ N steps` toggle. Defaults open when the turn
+/// has no answer yet (otherwise the card would be empty).
+#[derive(Properties, PartialEq)]
+struct MuseWorkLogProps {
+    count: usize,
+    default_expanded: bool,
+    children: Html,
+}
+
+#[function_component(MuseWorkLog)]
+fn muse_work_log(props: &MuseWorkLogProps) -> Html {
+    let expanded = use_state(|| props.default_expanded);
+    let toggle = {
+        let expanded = expanded.clone();
+        Callback::from(move |_: MouseEvent| expanded.set(!*expanded))
+    };
+    let label = if props.count == 1 {
+        "1 step".to_string()
+    } else {
+        format!("{} steps", props.count)
+    };
+    let header_class = if *expanded {
+        "muse-worklog-toggle expanded"
+    } else {
+        "muse-worklog-toggle"
+    };
+    html! {
+        <div class="muse-worklog">
+            <button type="button" class={header_class} onclick={toggle}>
+                <span class="muse-worklog-caret">{ if *expanded { "▾" } else { "▸" } }</span>
+                <span class="muse-worklog-count">{ label }</span>
+            </button>
+            if *expanded {
+                <div class="muse-task-tree">{ props.children.clone() }</div>
+            }
+        </div>
     }
 }
 

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1652,6 +1652,37 @@
     margin-bottom: 0;
 }
 
+/* Collapsible "work log" wrapper: keeps a turn's task nodes from burying the
+   reply above. The toggle is a quiet disclosure, not a control that competes
+   with the answer. */
+.muse-worklog {
+    margin: 0.35rem 0 0;
+}
+
+.muse-worklog-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.15rem 0.3rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.muse-worklog-toggle:hover {
+    color: var(--text-secondary);
+}
+
+.muse-worklog-caret {
+    font-size: 0.7rem;
+    line-height: 1;
+}
+
 .muse-task-tree {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Feedback: a muse turn's reply gets eclipsed by the wall of task cards that pile up below it.

## Diagnosis

The tasks already **dedupe in place** — one node per `task_id`, mutated through `started → completed` (no duplicate "completed" cards). So the problem isn't duplication; it's the **volume and position** of the work log: a turn's tasks stack below the answer and bury it.

## Fix

Wrap the task tree in a collapsible **`MuseWorkLog`**:
- The reply renders **prominently** at the top.
- The tasks sit behind a quiet **`▸ N steps`** disclosure below it, expandable on click.
- **Defaults collapsed** when the turn has an answer (the reply is the point); **defaults open** when there's no answer yet (in progress, or a failed run with no reply) so the card isn't empty.
- Toggle is local `use_state` — expanding one turn's log doesn't affect others and survives re-renders.

## Before → after

| Before | After |
|---|---|
| Answer, then a wall of task cards eclipsing it | Answer prominent; `▸ N steps` one click away |

## Verification

Both states (collapsed / expanded) rendered in a harness against the built CSS (screenshot in session). 21 muse tests pass, clippy clean on wasm32, stylelint clean, trunk build green.

Note: the reminder screen (merged) and #1607 (pending) already cut the *count* of those task nodes by hiding the bookkeeping tasks; this addresses the remaining position/prominence.