### PR TITLE
Extract shared test fixtures and builders

### DIFF
--- a/frontend/src/components/message_renderer/turn_metrics_footer.rs
+++ b/frontend/src/components/message_renderer/turn_metrics_footer.rs
@@ -148,9 +148,7 @@ pub fn render_turn_metrics_footer(metrics: Option<&TurnMetrics>) -> Html {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
     use shared::AgentType;
-    use uuid::Uuid;
 
     // ---- compact_count ----
 
@@ -294,38 +292,9 @@ mod tests {
     // ---- end-to-end chip-list builder ----
 
     fn sample_metrics() -> TurnMetrics {
-        TurnMetrics {
-            id: Some(Uuid::nil()),
-            session_id: Uuid::nil(),
-            user_message_id: None,
-            agent_type: AgentType::Claude,
-            model: Some("claude-opus-4-7".to_string()),
-            service_tier: Some("standard".to_string()),
-            started_at: Utc::now(),
-            first_token_at: None,
-            completed_at: None,
-            // 547 output / 11.59s gen ≈ 47.2 tok/s.
-            ttft_ms: Some(1310),
-            total_duration_ms: Some(12900),
-            generation_duration_ms: Some(11590),
-            // 1500ms — above the 1000ms threshold so the chip renders.
-            max_inter_token_gap_ms: Some(1500),
-            // 84% of 2100 = ~1764; pick numbers that give exactly 84%.
-            // (cache_read 84, fresh 16, cache_creation 0) → 84% of 100.
-            input_tokens: 16,
-            output_tokens: 547,
-            cache_creation_tokens: 0,
-            cache_read_tokens: 84,
-            thinking_tokens: 0,
-            subagent_tokens: 0,
-            stop_reason: Some("end_turn".to_string()),
-            is_error: false,
-            tool_call_count: 0,
-            stream_restarts: 0,
-            total_cost_usd: Some(0.014),
-            model_context_window: None,
-            context_snapshot_tokens: None,
-        }
+        // Builder defaults mirror this Claude-shaped sample (see
+        // `crate::test_fixtures::TurnMetricsBuilder`).
+        crate::test_fixtures::TurnMetricsBuilder::new().build()
     }
 
     /// End-to-end builder test: assemble a representative `TurnMetrics`
@@ -355,34 +324,20 @@ mod tests {
     /// chip list is just tok/s, TTFT, and the tokens chip.
     #[test]
     fn end_to_end_codex_shape_drops_chips() {
-        let m = TurnMetrics {
-            id: Some(Uuid::nil()),
-            session_id: Uuid::nil(),
-            user_message_id: None,
-            agent_type: AgentType::Codex,
-            model: None,
-            service_tier: None,
-            started_at: Utc::now(),
-            first_token_at: None,
-            completed_at: None,
-            ttft_ms: Some(800),
-            total_duration_ms: Some(4200),
-            generation_duration_ms: Some(3400),
-            max_inter_token_gap_ms: Some(200), // sub-1s → drops
-            input_tokens: 0,
-            output_tokens: 200,
-            cache_creation_tokens: 0,
-            cache_read_tokens: 0, // all zero → cache chip drops
-            thinking_tokens: 0,
-            subagent_tokens: 0,
-            stop_reason: None,
-            is_error: false,
-            tool_call_count: 0,
-            stream_restarts: 0,
-            total_cost_usd: None, // None → cost chip drops
-            model_context_window: None,
-            context_snapshot_tokens: None,
-        };
+        let m = crate::test_fixtures::TurnMetricsBuilder::new()
+            .agent_type(AgentType::Codex)
+            .model(None)
+            .service_tier(None)
+            .ttft_ms(Some(800))
+            .generation_duration_ms(Some(3400))
+            .max_gap_ms(Some(200)) // sub-1s → drops
+            .input_tokens(0)
+            .output_tokens(200)
+            .cache_creation(0)
+            .cache_read(0) // all zero → cache chip drops
+            .total_cost_usd(None) // None → cost chip drops
+            .stop_reason(None)
+            .build();
         let chips = build_chip_list(&m);
         assert_eq!(
             chips,

--- a/frontend/src/hooks/client_websocket_events.rs
+++ b/frontend/src/hooks/client_websocket_events.rs
@@ -99,41 +99,24 @@ pub(crate) fn insert_recent_metric(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{TimeZone, Utc};
-    use shared::AgentType;
+    use crate::test_fixtures::TurnMetricsBuilder;
     use uuid::Uuid;
 
     /// Build a minimal `TurnMetrics` with the fields the recent-buffer
     /// insertion path actually reads (`id`, `started_at`).
     fn sample(id: Option<Uuid>, started_secs: i64) -> TurnMetrics {
-        TurnMetrics {
-            id,
-            session_id: Uuid::nil(),
-            user_message_id: None,
-            agent_type: AgentType::Claude,
-            model: None,
-            service_tier: None,
-            started_at: Utc.timestamp_opt(started_secs, 0).unwrap(),
-            first_token_at: None,
-            completed_at: None,
-            ttft_ms: None,
-            total_duration_ms: None,
-            generation_duration_ms: None,
-            max_inter_token_gap_ms: None,
-            input_tokens: 0,
-            output_tokens: 0,
-            cache_creation_tokens: 0,
-            cache_read_tokens: 0,
-            thinking_tokens: 0,
-            subagent_tokens: 0,
-            context_snapshot_tokens: None,
-            stop_reason: None,
-            is_error: false,
-            tool_call_count: 0,
-            stream_restarts: 0,
-            total_cost_usd: None,
-            model_context_window: None,
-        }
+        TurnMetricsBuilder::new()
+            .id(id)
+            .started_secs(started_secs)
+            .model(None)
+            .service_tier(None)
+            .input_tokens(0)
+            .output_tokens(0)
+            .cache_read(0)
+            .cache_creation(0)
+            .total_cost_usd(None)
+            .stop_reason(None)
+            .build()
     }
 
     #[test]

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -3,6 +3,8 @@ mod components;
 mod health_timer;
 mod hooks;
 mod pages;
+#[cfg(test)]
+pub mod test_fixtures;
 pub mod utils;
 
 /// Application version — derived at build time from the git commit count

--- a/frontend/src/pages/dashboard/session_view/state.rs
+++ b/frontend/src/pages/dashboard/session_view/state.rs
@@ -54,39 +54,25 @@ pub(super) fn sort_turn_metrics_by_start(metrics: &mut [TurnMetrics]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{TimeZone, Utc};
-    use shared::AgentType;
+    use crate::test_fixtures::TurnMetricsBuilder;
     use uuid::Uuid;
 
     fn metric(id: Option<Uuid>, started_secs: i64, output_tokens: i64) -> TurnMetrics {
-        TurnMetrics {
-            id,
-            session_id: Uuid::nil(),
-            user_message_id: None,
-            agent_type: AgentType::Claude,
-            model: None,
-            service_tier: None,
-            started_at: Utc.timestamp_opt(started_secs, 0).unwrap(),
-            first_token_at: None,
-            completed_at: None,
-            ttft_ms: None,
-            total_duration_ms: None,
-            generation_duration_ms: None,
-            max_inter_token_gap_ms: None,
-            input_tokens: 0,
-            output_tokens,
-            cache_creation_tokens: 0,
-            cache_read_tokens: 0,
-            thinking_tokens: 0,
-            subagent_tokens: 0,
-            context_snapshot_tokens: None,
-            stop_reason: None,
-            is_error: false,
-            tool_call_count: 0,
-            stream_restarts: 0,
-            total_cost_usd: None,
-            model_context_window: None,
-        }
+        TurnMetricsBuilder::new()
+            .id(id)
+            .started_secs(started_secs)
+            .output_tokens(output_tokens)
+            .model(None)
+            .service_tier(None)
+            .ttft_ms(None)
+            .generation_duration_ms(None)
+            .max_gap_ms(None)
+            .input_tokens(0)
+            .cache_creation(0)
+            .cache_read(0)
+            .total_cost_usd(None)
+            .stop_reason(None)
+            .build()
     }
 
     #[test]

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -97,6 +97,7 @@ mod tests {
         build_auxiliary_token_series, build_cache_hit_series, build_cost_per_token_series,
         build_stop_reason_series,
     };
+    use crate::test_fixtures::MetricBucketBuilder;
 
     fn mk_bucket(
         ts: DateTime<Utc>,
@@ -105,31 +106,14 @@ mod tests {
         ttft_p50: Option<i64>,
         throughput_p50: Option<f64>,
         stop_counts: Vec<(&str, i64)>,
-    ) -> MetricBucket {
-        let mut counts = BTreeMap::new();
-        for (k, v) in stop_counts {
-            counts.insert(k.to_string(), v);
-        }
-        MetricBucket {
-            bucket_start: ts,
-            agent_type: AgentType::Claude,
-            model: model.map(|s| s.to_string()),
-            service_tier: tier.map(|s| s.to_string()),
-            turn_count: 1,
-            error_count: 0,
-            ttft_p50_ms: ttft_p50,
-            ttft_p95_ms: None,
-            throughput_p50_tps: throughput_p50,
-            throughput_p95_tps: None,
-            input_tokens_sum: 1000,
-            output_tokens_sum: 200,
-            cache_read_tokens_sum: 500,
-            cache_creation_tokens_sum: 100,
-            thinking_tokens_sum: 0,
-            subagent_tokens_sum: 0,
-            total_cost_usd_sum: Some(0.05),
-            stop_reason_counts: counts,
-        }
+    ) -> shared::api::MetricBucket {
+        MetricBucketBuilder::new(ts)
+            .model(model)
+            .service_tier(tier)
+            .ttft_p50(ttft_p50)
+            .throughput_p50(throughput_p50)
+            .stop_counts(stop_counts)
+            .build()
     }
 
     #[test]

--- a/frontend/src/test_fixtures.rs
+++ b/frontend/src/test_fixtures.rs
@@ -1,0 +1,274 @@
+//! Test fixtures and builders for frontend tests — per-crate helpers with
+//! sensible defaults and explicit overrides (see #924).
+//!
+//! Keep this module small and focused: one builder per shared shape that is
+//! repeatedly constructed in `#[cfg(test)]` code. Builders carry the real
+//! crate's types and default to a *valid* value so a test only spells out
+//! the field it cares about.
+
+use chrono::{DateTime, TimeZone, Utc};
+use shared::{api::MetricBucket, AgentType, TurnMetrics};
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+/// Builder for `shared::TurnMetrics` with builder-style overrides.
+///
+/// Defaults mirror the Claude-shaped `sample_metrics` that was previously
+/// copy-pasted across four test modules (footer, state, client_websocket,
+/// etc.): a started-at of `2026-05-01 00:00:00 UTC`, Claude agent, a known
+/// model, and zeroed counters. Callers override only the field under test.
+#[derive(Debug, Clone)]
+pub struct TurnMetricsBuilder {
+    inner: TurnMetrics,
+}
+
+impl Default for TurnMetricsBuilder {
+    fn default() -> Self {
+        Self {
+            inner: TurnMetrics {
+                id: Some(Uuid::nil()),
+                session_id: Uuid::nil(),
+                user_message_id: None,
+                agent_type: AgentType::Claude,
+                model: Some("claude-opus-4-7".to_string()),
+                service_tier: Some("standard".to_string()),
+                started_at: Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap(),
+                first_token_at: None,
+                completed_at: None,
+                ttft_ms: Some(1310),
+                total_duration_ms: Some(12900),
+                generation_duration_ms: Some(11590),
+                max_inter_token_gap_ms: Some(1500),
+                input_tokens: 16,
+                output_tokens: 547,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 84,
+                thinking_tokens: 0,
+                subagent_tokens: 0,
+                stop_reason: Some("end_turn".to_string()),
+                is_error: false,
+                tool_call_count: 0,
+                stream_restarts: 0,
+                total_cost_usd: Some(0.014),
+                model_context_window: None,
+                context_snapshot_tokens: None,
+            },
+        }
+    }
+}
+
+impl TurnMetricsBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn id(mut self, id: Option<Uuid>) -> Self {
+        self.inner.id = id;
+        self
+    }
+
+    pub fn session_id(mut self, id: Uuid) -> Self {
+        self.inner.session_id = id;
+        self
+    }
+
+    pub fn agent_type(mut self, agent: AgentType) -> Self {
+        self.inner.agent_type = agent;
+        self
+    }
+
+    pub fn model(mut self, model: Option<&str>) -> Self {
+        self.inner.model = model.map(|s| s.to_string());
+        self
+    }
+
+    pub fn service_tier(mut self, tier: Option<&str>) -> Self {
+        self.inner.service_tier = tier.map(|s| s.to_string());
+        self
+    }
+
+    pub fn started_at(mut self, ts: DateTime<Utc>) -> Self {
+        self.inner.started_at = ts;
+        self
+    }
+
+    /// Convenience: set `started_at` from whole seconds since epoch.
+    pub fn started_secs(mut self, secs: i64) -> Self {
+        self.inner.started_at = Utc.timestamp_opt(secs, 0).unwrap();
+        self
+    }
+
+    pub fn ttft_ms(mut self, v: Option<i64>) -> Self {
+        self.inner.ttft_ms = v;
+        self
+    }
+
+    pub fn generation_duration_ms(mut self, v: Option<i64>) -> Self {
+        self.inner.generation_duration_ms = v;
+        self
+    }
+
+    pub fn max_gap_ms(mut self, v: Option<i64>) -> Self {
+        self.inner.max_inter_token_gap_ms = v;
+        self
+    }
+
+    pub fn input_tokens(mut self, n: i64) -> Self {
+        self.inner.input_tokens = n;
+        self
+    }
+
+    pub fn output_tokens(mut self, n: i64) -> Self {
+        self.inner.output_tokens = n;
+        self
+    }
+
+    pub fn cache_read(mut self, n: i64) -> Self {
+        self.inner.cache_read_tokens = n;
+        self
+    }
+
+    pub fn cache_creation(mut self, n: i64) -> Self {
+        self.inner.cache_creation_tokens = n;
+        self
+    }
+
+    pub fn thinking_tokens(mut self, n: i64) -> Self {
+        self.inner.thinking_tokens = n;
+        self
+    }
+
+    pub fn subagent_tokens(mut self, n: i64) -> Self {
+        self.inner.subagent_tokens = n;
+        self
+    }
+
+    pub fn total_cost_usd(mut self, v: Option<f64>) -> Self {
+        self.inner.total_cost_usd = v;
+        self
+    }
+
+    pub fn is_error(mut self, v: bool) -> Self {
+        self.inner.is_error = v;
+        self
+    }
+
+    pub fn stop_reason(mut self, v: Option<&str>) -> Self {
+        self.inner.stop_reason = v.map(|s| s.to_string());
+        self
+    }
+
+    pub fn tool_call_count(mut self, n: i32) -> Self {
+        self.inner.tool_call_count = n;
+        self
+    }
+
+    pub fn stream_restarts(mut self, n: i32) -> Self {
+        self.inner.stream_restarts = n;
+        self
+    }
+
+    pub fn build(self) -> TurnMetrics {
+        self.inner
+    }
+}
+
+/// Builder for `shared::api::MetricBucket` with sensible defaults.
+///
+/// Defaults mirror the `mk_bucket` helper that was previously copy-pasted in
+/// `performance_panel::tests`: 1 turn, Claude, standard tier, 1000 in / 200 out
+/// etc., so a test only spells out the fields it varies.
+#[derive(Debug, Clone)]
+pub struct MetricBucketBuilder {
+    inner: MetricBucket,
+}
+
+impl MetricBucketBuilder {
+    pub fn new(bucket_start: DateTime<Utc>) -> Self {
+        Self {
+            inner: MetricBucket {
+                bucket_start,
+                agent_type: AgentType::Claude,
+                model: None,
+                service_tier: None,
+                turn_count: 1,
+                error_count: 0,
+                ttft_p50_ms: None,
+                ttft_p95_ms: None,
+                throughput_p50_tps: None,
+                throughput_p95_tps: None,
+                input_tokens_sum: 1000,
+                output_tokens_sum: 200,
+                cache_read_tokens_sum: 500,
+                cache_creation_tokens_sum: 100,
+                thinking_tokens_sum: 0,
+                subagent_tokens_sum: 0,
+                total_cost_usd_sum: Some(0.05),
+                stop_reason_counts: BTreeMap::new(),
+            },
+        }
+    }
+
+    pub fn agent_type(mut self, agent: AgentType) -> Self {
+        self.inner.agent_type = agent;
+        self
+    }
+
+    pub fn model(mut self, model: Option<&str>) -> Self {
+        self.inner.model = model.map(|s| s.to_string());
+        self
+    }
+
+    pub fn service_tier(mut self, tier: Option<&str>) -> Self {
+        self.inner.service_tier = tier.map(|s| s.to_string());
+        self
+    }
+
+    pub fn ttft_p50(mut self, v: Option<i64>) -> Self {
+        self.inner.ttft_p50_ms = v;
+        self
+    }
+
+    pub fn throughput_p50(mut self, v: Option<f64>) -> Self {
+        self.inner.throughput_p50_tps = v;
+        self
+    }
+
+    pub fn input_sum(mut self, n: i64) -> Self {
+        self.inner.input_tokens_sum = n;
+        self
+    }
+
+    pub fn output_sum(mut self, n: i64) -> Self {
+        self.inner.output_tokens_sum = n;
+        self
+    }
+
+    pub fn cache_read_sum(mut self, n: i64) -> Self {
+        self.inner.cache_read_tokens_sum = n;
+        self
+    }
+
+    pub fn cache_creation_sum(mut self, n: i64) -> Self {
+        self.inner.cache_creation_tokens_sum = n;
+        self
+    }
+
+    pub fn total_cost_sum(mut self, v: Option<f64>) -> Self {
+        self.inner.total_cost_usd_sum = v;
+        self
+    }
+
+    pub fn stop_counts(mut self, counts: Vec<(&str, i64)>) -> Self {
+        let mut m = BTreeMap::new();
+        for (k, v) in counts {
+            m.insert(k.to_string(), v);
+        }
+        self.inner.stop_reason_counts = m;
+        self
+    }
+
+    pub fn build(self) -> MetricBucket {
+        self.inner
+    }
+}


### PR DESCRIPTION
Part of #924 — first slice (frontend TurnMetrics/MetricBucket). Follow-up slices can extend to backend/shared.

**Problem:** Tests repeatedly defined local builders and verbose fixture setup for common shapes (`MetricBucket`, `TurnMetrics`, websocket messages), adding noise and making broad refactors harder.

**Solution:** Small per-crate helper modules with builders that have sensible defaults and explicit overrides (issue's requested shape), not a giant global fixture crate.

- **New `frontend/src/test_fixtures.rs` (`#[cfg(test)]`):**
  - `TurnMetricsBuilder` — defaults to the Claude-shaped `sample_metrics` previously copy-pasted across 4 test modules (footer, state, client_websocket); builder methods `id`/`started_secs`/`output_tokens`/`model`/`service_tier`/`ttft_ms`/…/`total_cost_usd`/`stop_reason` etc. + `build()`.
  - `MetricBucketBuilder` — defaults mirror `mk_bucket` (1 turn, Claude, 1000 in/200 out, 500 cache_read…), methods `model`/`service_tier`/`ttft_p50`/`throughput_p50`/`stop_counts`/`total_cost_sum` etc.

- **Refactored call sites to use builders (preserves existing coverage):**
  - `frontend/src/pages/settings/performance_panel.rs`: `mk_bucket` now delegates to `MetricBucketBuilder::new(ts)…build()` (+ re-added missing `MetricBucket` import).
  - `frontend/src/components/message_renderer/turn_metrics_footer.rs`: `sample_metrics()` → `TurnMetricsBuilder::new().build()`; Codex-shape test → builder chain; removed unused `chrono`/`uuid` imports.
  - `frontend/src/pages/dashboard/session_view/state.rs`: `metric()` → builder.
  - `frontend/src/hooks/client_websocket_events.rs`: `sample()` → builder (explicit `model(None)`/zeroed tokens to keep minimal fixture).

**Scope:** Test-code only, 6 files (+184), no production wire/behavior change. Future slices can add backend `test_fixtures` for sessions/users and Codex permission payloads.

Verified: `cargo fmt`, `cargo clippy --workspace` clean, `cargo test -p frontend --lib` 578 passed, `cargo test --workspace` pass.