### PR TITLE
fix: render Muse file tools with shared cards

### DIFF
--- a/frontend/src/components/diff.rs
+++ b/frontend/src/components/diff.rs
@@ -118,7 +118,7 @@ fn render_diff_html(lines: &[DiffLine<'_>]) -> Html {
 /// space on context lines).
 fn parse_unified_diff(diff: &str) -> Vec<DiffLine<'_>> {
     diff.lines()
-        .filter(|l| !l.starts_with("--- ") && !l.starts_with("+++ ") && !l.starts_with("@@ "))
+        .filter(|l| !l.starts_with("--- ") && !l.starts_with("+++ ") && !l.starts_with("@@"))
         .filter_map(|l| match l.as_bytes().first() {
             Some(b'+') => Some(DiffLine::Added(&l[1..])),
             Some(b'-') => Some(DiffLine::Removed(&l[1..])),
@@ -242,6 +242,12 @@ mod tests {
                 ("ctx", "line three"),
             ]
         );
+    }
+
+    #[test]
+    fn parses_muse_hunk_header_without_ranges() {
+        let parsed = parse_unified_diff("--- original\n+++ updated\n@@\n-old\n+new\n");
+        assert_eq!(classify(&parsed), vec![("rem", "old"), ("add", "new")]);
     }
 
     #[test]

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -78,6 +78,91 @@ fn render_command_card(cmd: &MuseCommandResult) -> Html {
     }
 }
 
+#[derive(Debug, PartialEq)]
+struct MuseReadResult<'a> {
+    path: &'a str,
+    content: &'a str,
+}
+
+/// Muse's read result is a provider-owned prose envelope around the file
+/// contents. Keep this tiny adapter here, then hand the normalized fields to
+/// the same Read card Claude uses. The tool-name gate prevents unrelated prose
+/// containing the same words from being misclassified.
+fn parse_read_result<'a>(tool_name: Option<&str>, text: &'a str) -> Option<MuseReadResult<'a>> {
+    if tool_name != Some("read_file") {
+        return None;
+    }
+    let rest = text.strip_prefix("Read text file `")?;
+    let (path, content) = rest
+        .split_once("`.\n")
+        .or_else(|| rest.split_once("`.\r\n"))
+        .or_else(|| rest.strip_suffix("`.").map(|path| (path, "")))?;
+    Some(MuseReadResult { path, content })
+}
+
+/// Extract the unified diff Muse places after its short edit summary. The
+/// path is carried separately in typed `edit_facts` and is never scraped from
+/// the prose result.
+fn parse_edit_diff(tool_name: Option<&str>, text: &str) -> Option<String> {
+    if tool_name != Some("edit_file") {
+        return None;
+    }
+    let lines: Vec<&str> = text.lines().collect();
+    let header = lines
+        .iter()
+        .position(|line| line.trim_start() == "--- original")?;
+    let indent = lines[header].len() - lines[header].trim_start().len();
+    Some(
+        lines[header..]
+            .iter()
+            .map(|line| line.get(indent..).unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
+fn render_muse_tool_result(result: &task_tree::ToolOutcome) -> Html {
+    use crate::components::diff::{DiffCard, DiffSource};
+    use crate::components::tool_renderers::ReadToolCard;
+
+    let outcome = result.outcome.as_deref().unwrap_or("unknown");
+    let tool = result.tool_name.as_deref().unwrap_or("tool");
+    if let Some(cmd) = parse_command_result(&result.text) {
+        return html! {
+            <div class={classes!("muse-tool-command", format!("muse-tool-{outcome}"))}>
+                { render_command_card(&cmd) }
+            </div>
+        };
+    }
+    if let Some(read) = parse_read_result(result.tool_name.as_deref(), &result.text) {
+        return html! {
+            <div class={classes!("muse-tool-card", format!("muse-tool-{outcome}"))}>
+                <ReadToolCard
+                    file_path={AttrValue::from(read.path.to_string())}
+                    content={AttrValue::from(read.content.to_string())}
+                />
+            </div>
+        };
+    }
+    if let Some(diff) = parse_edit_diff(result.tool_name.as_deref(), &result.text) {
+        return html! {
+            <div class={classes!("muse-tool-card", format!("muse-tool-{outcome}"))}>
+                <DiffCard
+                    source={DiffSource::Unified { text: diff }}
+                    file_path={result.edit_path.clone().map(AttrValue::from)}
+                    kind="update"
+                />
+            </div>
+        };
+    }
+    html! {
+        <div class={classes!("muse-tool-result", format!("muse-tool-{outcome}"))}>
+            <span class="muse-tool-name">{ tool }</span>
+            <span class="muse-tool-text">{ &result.text }</span>
+        </div>
+    }
+}
+
 /// Draw a task tree: one stacked card per task showing lifecycle state,
 /// tool outcomes, streamed output, and the policy decision muse applied to
 /// any side effect (muse decides tool policy itself and never prompts, so
@@ -255,24 +340,7 @@ fn render_task_node(node: &TaskNode) -> Html {
                     { format!("{op} — policy: {decision}") }
                 </div>
             }
-            { for node.tool_results.iter().map(|r| {
-                let outcome = r.outcome.as_deref().unwrap_or("unknown");
-                let tool = r.tool_name.as_deref().unwrap_or("tool");
-                if let Some(cmd) = parse_command_result(&r.text) {
-                    html! {
-                        <div class={classes!("muse-tool-command", format!("muse-tool-{outcome}"))}>
-                            { render_command_card(&cmd) }
-                        </div>
-                    }
-                } else {
-                    html! {
-                        <div class={classes!("muse-tool-result", format!("muse-tool-{outcome}"))}>
-                            <span class="muse-tool-name">{ tool }</span>
-                            <span class="muse-tool-text">{ &r.text }</span>
-                        </div>
-                    }
-                }
-            }) }
+            { for node.tool_results.iter().map(render_muse_tool_result) }
             { for node.output.iter().filter(|c| !shown_as_result.contains(c.as_str())).map(|chunk| {
                 // A surviving chunk that is itself a command payload still gets
                 // the card treatment rather than a raw dump.
@@ -338,6 +406,25 @@ mod tests {
     }
 
     #[test]
+    fn read_file_result_is_normalized_for_the_shared_read_card() {
+        let text =
+            "Read text file `frontend/src/lib.rs`.\n    (9 line(s) above)\n  10|fn main() {}";
+        let read = parse_read_result(Some("read_file"), text).expect("Muse read envelope");
+        assert_eq!(read.path, "frontend/src/lib.rs");
+        assert_eq!(read.content, "    (9 line(s) above)\n  10|fn main() {}");
+        assert!(parse_read_result(Some("write_file"), text).is_none());
+    }
+
+    #[test]
+    fn edit_file_result_yields_a_unified_diff_body() {
+        let text = "edit_file edited\n    changed lines: lines 3-4\n    --- original\n    +++ updated\n    @@\n    -old\n    +new";
+        let diff = parse_edit_diff(Some("edit_file"), text).expect("Muse edit diff");
+        assert!(diff.starts_with("--- original\n"));
+        assert!(diff.contains("-old\n+new"));
+        assert!(parse_edit_diff(Some("read_file"), text).is_none());
+    }
+
+    #[test]
     fn bash_output_chunk_duplicates_the_tool_result_so_dedup_fires() {
         // The de-dup in render_task_node keys on tool_result.text == output
         // chunk. This proves that equality holds on the real capture, so the
@@ -372,7 +459,7 @@ mod tests {
             tool_name: Some("write_file".to_string()),
             outcome: Some("success".to_string()),
             text: "wrote hello.txt".to_string(),
-            has_edit_facts: true,
+            edit_path: Some("hello.txt".to_string()),
         });
         assert!(
             !is_hidden_scaffolding(&n),

--- a/frontend/src/components/muse_renderer/task_tree.rs
+++ b/frontend/src/components/muse_renderer/task_tree.rs
@@ -87,8 +87,8 @@ pub struct ToolOutcome {
     /// `"success"` / `"failure"` as reported in `correlation_facts`.
     pub outcome: Option<String>,
     pub text: String,
-    /// Present for file-editing tools.
-    pub has_edit_facts: bool,
+    /// Typed path from Muse's `edit_facts`, when the tool changed a file.
+    pub edit_path: Option<String>,
 }
 
 /// A node in the task tree.
@@ -282,7 +282,9 @@ impl TaskTree {
             tool_name: facts.and_then(|f| str_field(f, "tool_name")),
             outcome: facts.and_then(|f| str_field(f, "outcome")),
             text: str_field(payload, "text").unwrap_or_default(),
-            has_edit_facts: payload.get("edit_facts").is_some_and(|v| !v.is_null()),
+            edit_path: payload
+                .get("edit_facts")
+                .and_then(|facts| str_field(facts, "path")),
         };
         if let Some(id) = self.tool_result_target(outcome.tool_name.as_deref()) {
             self.node_mut(&id).tool_results.push(outcome);
@@ -417,6 +419,28 @@ mod tests {
                 .any(|r| r.tool_name.is_some() && r.outcome.is_some()),
             "correlation_facts (tool_name/outcome) must survive into the model"
         );
+    }
+
+    #[test]
+    fn edit_facts_keep_the_typed_file_path() {
+        let mut tree = TaskTree::new();
+        tree.apply(&json!({
+            "payload_type": "task.lifecycle.proposed",
+            "payload": {"event": {
+                "kind": "proposed", "task_id": "edit-1", "task_kind": "tool.edit_file"
+            }}
+        }));
+        tree.apply(&json!({
+            "payload_type": "tool.result",
+            "payload": {
+                "call_id": "call-1",
+                "correlation_facts": {"tool_name": "edit_file", "outcome": "success"},
+                "edit_facts": {"path": "src/main.rs", "added": 1, "removed": 1},
+                "text": "edit_file edited\n--- original\n+++ updated\n@@\n-old\n+new"
+            }
+        }));
+        let result = &tree.get("edit-1").expect("edit task").tool_results[0];
+        assert_eq!(result.edit_path.as_deref(), Some("src/main.rs"));
     }
 
     /// Records arrive over two channels and can interleave out of order. A

--- a/frontend/src/components/tool_renderers/mod.rs
+++ b/frontend/src/components/tool_renderers/mod.rs
@@ -81,20 +81,41 @@ fn render_read_tool(input: &Value) -> Html {
         _ => None,
     };
 
+    html! { <ReadToolCard file_path={read.file_path} range={range_info} /> }
+}
+
+/// Shared Read card used by Claude's typed tool input and Muse's typed task
+/// result adapter. Agent-specific parsing stays at the edge; the visual shell,
+/// path treatment, range label, and expandable body stay identical.
+#[derive(Properties, PartialEq)]
+pub(crate) struct ReadToolCardProps {
+    pub file_path: AttrValue,
+    #[prop_or_default]
+    pub range: Option<AttrValue>,
+    #[prop_or_default]
+    pub content: Option<AttrValue>,
+}
+
+#[function_component(ReadToolCard)]
+pub(crate) fn read_tool_card(props: &ReadToolCardProps) -> Html {
     html! {
         <div class="tool-use read-tool">
             <div class="tool-use-header">
                 <span class="tool-icon">{ "📖" }</span>
                 <span class="tool-name">{ "Read" }</span>
-                <span class="read-file-path">{ read.file_path }</span>
-                {
-                    if let Some(range) = range_info {
-                        html! { <span class="tool-meta">{ range }</span> }
-                    } else {
-                        html! {}
-                    }
+                <span class="read-file-path">{ &props.file_path }</span>
+                if let Some(range) = &props.range {
+                    <span class="tool-meta">{ range }</span>
                 }
             </div>
+            if let Some(content) = &props.content {
+                <ExpandableText
+                    full_text={content.clone()}
+                    max_len={4000}
+                    class="read-tool-content"
+                    tag="pre"
+                />
+            }
         </div>
     }
 }

--- a/frontend/styles/tools/read.css
+++ b/frontend/styles/tools/read.css
@@ -5,6 +5,30 @@
     border-left-color: var(--accent);
 }
 
+.read-file-path {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.read-tool-content {
+    max-height: 400px;
+    margin: 0 0.75rem 0.5rem;
+    padding: 0.5rem 0.75rem;
+    overflow: auto;
+    color: var(--text-secondary);
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    line-height: 1.5;
+    white-space: pre;
+}
+
 .file-path {
     color: var(--accent);
     font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- adapt Muse `tool.read_file` results into the same reusable Read card used by Claude
- adapt Muse `tool.edit_file` results into the shared Claude/Codex `DiffCard`
- preserve Muse's typed `edit_facts.path` for the diff header
- normalize Muse's indentation and range-less `@@` hunk header while keeping agent-specific parsing at the renderer edge

## Verification
- frontend WASM check
- strict frontend WASM clippy
- 21 Muse renderer/reducer tests
- shared diff parser tests
- CSS lint, rustfmt, and diff checks