### PR TITLE
Rethread Muse live work into transcript cards

### DIFF
--- a/frontend/src/components/message_renderer/group_renderer.rs
+++ b/frontend/src/components/message_renderer/group_renderer.rs
@@ -32,6 +32,10 @@ pub struct MessageGroupRendererProps {
     /// tool call splits a thinking run instead of re-racing each chip from 0.
     #[prop_or(0)]
     pub thinking_start: i64,
+    /// Ephemeral records for this Muse turn. Replayed after persisted records
+    /// so the one card advances live without writing token deltas to history.
+    #[prop_or_default]
+    pub muse_live_events: Vec<serde_json::Value>,
 }
 
 #[function_component(MessageGroupRenderer)]
@@ -88,6 +92,13 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                     if let Ok(value) = serde_json::from_str::<serde_json::Value>(&message.content) {
                         tree.apply(&value);
                     }
+                }
+                // Muse's classifier routes each record to exactly one side:
+                // Durable → persisted messages, Ephemeral → this overlay.
+                // Applying both sets cannot double-count output chunks unless
+                // that classifier invariant changes.
+                for event in &props.muse_live_events {
+                    tree.apply(event);
                 }
                 // Nothing structural and nothing to footnote — a group of
                 // records the reducer consumed without visible effect (e.g.

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -64,6 +64,27 @@ pub enum MessageGroup {
 }
 
 impl MessageGroup {
+    pub(crate) fn muse_causation_id(&self) -> Option<String> {
+        let MessageGroup::IdentityGroup {
+            category: GroupCategory::Muse,
+            messages,
+            ..
+        } = self
+        else {
+            return None;
+        };
+        messages.iter().find_map(|message| {
+            serde_json::from_str::<serde_json::Value>(&message.content)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("causation_id")
+                        .and_then(|id| id.as_str())
+                        .map(str::to_string)
+                })
+        })
+    }
+
     /// Stable key for this group derived from the first message's identity.
     ///
     /// A positional index would change whenever an earlier group gets added

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -206,78 +206,24 @@ pub fn render_task_tree(tree: &TaskTree) -> Html {
 
     html! {
         <>
-            // The agent's actual reply, rendered as markdown prose like a
-            // Claude/Codex assistant message — the task tree below is the
-            // supporting work log, the same way tool-use cards sit under
-            // assistant text.
+            // Match Claude/Codex's transcript order: work appears where it
+            // happened, then the assistant's answer closes the turn. Tool
+            // cards keep their own focused expand/collapse controls; the
+            // whole execution trace is never hidden behind a second toggle.
+            if !visible.is_empty() || !footer.is_empty() {
+                <div class="muse-task-tree">
+                    { for visible.iter().map(|node| render_task_node(node)) }
+                    if !footer.is_empty() {
+                        <div class="muse-journal-footer">{ footer.join(" · ") }</div>
+                    }
+                </div>
+            }
             if let Some(answer) = tree.answer() {
                 <div class="muse-answer">
                     { crate::components::markdown::render_markdown(answer) }
                 </div>
             }
-            if !visible.is_empty() || !footer.is_empty() {
-                // The task tree is the supporting WORK LOG, not the reply. A
-                // long turn stacks dozens of nodes that eclipse the answer
-                // above, so keep it collapsed behind a "N steps" toggle once an
-                // answer exists; when there's no answer yet (in progress, or a
-                // failed run with no reply), leave it open so the turn isn't
-                // an empty card (#muse-worklog-collapse).
-                <MuseWorkLog
-                    count={visible.len()}
-                    default_expanded={tree.answer().is_none()}
-                >
-                    // Each task node carries a stable `key={task_id}` (set in
-                    // render_task_node) so Yew updates a task in place as it
-                    // advances running → completed, instead of positionally
-                    // diffing. Mirrors how the Codex item list keys its cards.
-                    { for visible.iter().map(|node| render_task_node(node)) }
-                    if !footer.is_empty() {
-                        <div class="muse-journal-footer">{ footer.join(" · ") }</div>
-                    }
-                </MuseWorkLog>
-            }
         </>
-    }
-}
-
-/// Collapsible "work log" wrapper around a turn's task nodes. Muse emits many
-/// bookkeeping/tool tasks per turn; rendered inline they bury the actual reply,
-/// so this hides them behind a `▸ N steps` toggle. Defaults open when the turn
-/// has no answer yet (otherwise the card would be empty).
-#[derive(Properties, PartialEq)]
-struct MuseWorkLogProps {
-    count: usize,
-    default_expanded: bool,
-    children: Html,
-}
-
-#[function_component(MuseWorkLog)]
-fn muse_work_log(props: &MuseWorkLogProps) -> Html {
-    let expanded = use_state(|| props.default_expanded);
-    let toggle = {
-        let expanded = expanded.clone();
-        Callback::from(move |_: MouseEvent| expanded.set(!*expanded))
-    };
-    let label = if props.count == 1 {
-        "1 step".to_string()
-    } else {
-        format!("{} steps", props.count)
-    };
-    let header_class = if *expanded {
-        "muse-worklog-toggle expanded"
-    } else {
-        "muse-worklog-toggle"
-    };
-    html! {
-        <div class="muse-worklog">
-            <button type="button" class={header_class} onclick={toggle}>
-                <span class="muse-worklog-caret">{ if *expanded { "▾" } else { "▸" } }</span>
-                <span class="muse-worklog-count">{ label }</span>
-            </button>
-            if *expanded {
-                <div class="muse-task-tree">{ props.children.clone() }</div>
-            }
-        </div>
     }
 }
 

--- a/frontend/src/components/muse_renderer/task_tree.rs
+++ b/frontend/src/components/muse_renderer/task_tree.rs
@@ -137,11 +137,11 @@ pub struct TaskTree {
     order: Vec<String>,
     /// Turn this tree belongs to (`causation_id`), set by the first record.
     pub causation_id: Option<String>,
-    /// The run's final answer text (`run.terminal.completed` → `payload.text`),
-    /// in markdown. This is the agent's actual reply — rendered as prose above
-    /// the task tree, the same way a Claude/Codex assistant message renders —
-    /// rather than being dropped into the footer as a bare count.
+    /// The run's answer text in markdown. Live `run.output.delta` chunks build
+    /// it while the turn runs; a durable `run.terminal.*` record replaces the
+    /// stream with the canonical final text.
     answer: Option<String>,
+    answer_is_terminal: bool,
     /// Count per `payload_type` of records the tree does not render
     /// structurally (`run.model.configured`, `command.received`, future
     /// vocabulary). Surfaced as a muted footer so nothing on the wire silently
@@ -203,6 +203,13 @@ impl TaskTree {
             }
             t if t.starts_with("task.lifecycle.") => self.apply_lifecycle(payload),
             "tool.result" => self.apply_tool_result(payload),
+            "run.output.delta" => {
+                if !self.answer_is_terminal {
+                    if let Some(chunk) = str_field(payload, "text") {
+                        self.answer.get_or_insert_default().push_str(&chunk);
+                    }
+                }
+            }
             // The run's final answer — the agent's actual reply. Match the whole
             // `run.terminal.*` family, not just `.completed`: the terminal state
             // is encoded in the suffix (completed / failed / cancelled / future
@@ -217,6 +224,7 @@ impl TaskTree {
                     .or_else(|| str_field(payload, "reason").filter(|r| !r.trim().is_empty()));
                 if answer.is_some() {
                     self.answer = answer;
+                    self.answer_is_terminal = true;
                 }
             }
             other => {
@@ -256,7 +264,10 @@ impl TaskTree {
         }
         match kind.as_str() {
             "proposed" => node.task_kind = str_field(ev, "task_kind"),
-            "status" => node.status = str_field(ev, "message"),
+            // A late ephemeral heartbeat must not resurrect progress UI on a
+            // task whose durable lifecycle has already reached a terminal
+            // state (notably after a reconnect/history replay).
+            "status" if !node.state.is_terminal() => node.status = str_field(ev, "message"),
             "output" => {
                 if let Some(chunk) = str_field(ev, "chunk") {
                     node.output.push(chunk);
@@ -496,6 +507,18 @@ mod tests {
             "live status must clear at terminal state"
         );
         assert!(node.reason.is_some(), "the failure reason must be kept");
+
+        tree.apply(&json!({
+            "payload_type": "task.lifecycle.status",
+            "causation_id": "turn-1",
+            "payload": {"task_id": "t1", "event": {
+                "kind": "status", "task_id": "t1", "message": "stale reconnect heartbeat"
+            }},
+        }));
+        assert!(
+            tree.get("t1").expect("node").status.is_none(),
+            "late status must not resurrect on a terminal task"
+        );
     }
 
     /// The run's final answer text is captured as prose, not dumped into the
@@ -519,6 +542,35 @@ mod tests {
         );
         // An answer-only turn (no tasks) is still a card worth rendering.
         assert!(!tree.is_empty(), "a tree with an answer is not empty");
+    }
+
+    #[test]
+    fn streamed_answer_accumulates_then_terminal_replaces_it() {
+        let mut tree = TaskTree::new();
+        tree.apply(&serde_json::json!({
+            "payload_type": "run.output.delta",
+            "causation_id": "turn-1",
+            "payload": {"text": "live "}
+        }));
+        tree.apply(&serde_json::json!({
+            "payload_type": "run.output.delta",
+            "causation_id": "turn-1",
+            "payload": {"text": "answer"}
+        }));
+        assert_eq!(tree.answer(), Some("live answer"));
+        assert!(tree.other_records().next().is_none());
+
+        tree.apply(&serde_json::json!({
+            "payload_type": "run.terminal.completed",
+            "causation_id": "turn-1",
+            "payload": {"text": "canonical answer"}
+        }));
+        tree.apply(&serde_json::json!({
+            "payload_type": "run.output.delta",
+            "causation_id": "turn-1",
+            "payload": {"text": " stale"}
+        }));
+        assert_eq!(tree.answer(), Some("canonical answer"));
     }
 
     /// A blank terminal text leaves no answer (and no empty prose block).

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -30,6 +30,7 @@ use super::helpers::{
     enrich_codex_file_change_permission, ephemeral_summary, format_tool_elapsed,
     is_claude_awaiting, parse_iso_ms_utc, reconcile_pending_sends, running_tool_key,
     update_pending_send_delivery, upsert_tool_progress, ActiveToolProgress, ActivityTag,
+    MuseLiveTurn,
 };
 use super::input_bar::{InputBar, InputBarInbound};
 use super::outbox::Outbox;
@@ -265,12 +266,13 @@ pub struct SessionView {
     /// ends. Kept out of the memoized message-render props on purpose (see the
     /// `helpers` tool-progress section).
     active_tools: Vec<ActiveToolProgress>,
-    /// Latest neutral ephemeral live-status line (`WsEvent::Ephemeral`), shown
-    /// as a transient strip at the transcript tail while a turn runs and
-    /// cleared when a durable message arrives. Never persisted. Muse's streamed
-    /// deltas / task status flow here; the rich per-agent view is layered on
-    /// top of this same stream separately.
+    /// Latest non-Muse neutral ephemeral status line, shown as a transient
+    /// transcript-tail strip and cleared by durable output. Muse owns the
+    /// richer turn-local overlay below instead.
     ephemeral_status: Option<String>,
+    /// Muse's current ephemeral turn, replayed over the matching persisted
+    /// task tree so live work updates the same card instead of a bottom bar.
+    muse_live_turn: MuseLiveTurn,
     /// Monotonic tick bumped on every `ForwardsChanged` frame; passed to the
     /// forward-chip strip as a prop so it refetches (docs/PORT_FORWARDING.md).
     forwards_refresh: u32,
@@ -351,6 +353,7 @@ impl Component for SessionView {
             continuation_statuses: HashMap::new(),
             active_tools: Vec::new(),
             ephemeral_status: None,
+            muse_live_turn: MuseLiveTurn::default(),
             forwards_refresh: 0,
         }
     }
@@ -629,6 +632,23 @@ impl Component for SessionView {
         // Seed each thinking chip's odometer with the prior burst's max in
         // its turn so tool-call splits don't re-race the count from 0.
         let thinking_starts = thinking_chip_starts(&groups);
+        let live_muse_group = self.muse_live_turn.causation_id.as_deref().and_then(|id| {
+            groups
+                .iter()
+                .rposition(|group| group.muse_causation_id().as_deref() == Some(id))
+        });
+        let unmatched_muse_tree = if ctx.props().session.agent_type == shared::AgentType::Muse
+            && !self.muse_live_turn.events.is_empty()
+            && live_muse_group.is_none()
+        {
+            let mut tree = crate::components::muse_renderer::TaskTree::default();
+            for event in &self.muse_live_turn.events {
+                tree.apply(event);
+            }
+            Some(tree)
+        } else {
+            None
+        };
         let launcher_version = ctx
             .props()
             .session
@@ -676,12 +696,23 @@ impl Component for SessionView {
                                 let key = group.key(i);
                                 let metrics = group_metrics.get(i).cloned().flatten();
                                 let thinking_start = thinking_starts.get(i).copied().unwrap_or(0);
-                                html! { <MessageGroupRenderer {key} group={group} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} {thinking_start} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
+                                let muse_live_events = if live_muse_group == Some(i) { self.muse_live_turn.events.clone() } else { Vec::new() };
+                                html! { <MessageGroupRenderer {key} group={group} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} turn_metrics={metrics} {thinking_start} {muse_live_events} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
                             }).collect::<Html>()
                         }
                         { for self.pending_sends.iter().enumerate().map(|(i, message)| {
                             html! { <MessageRenderer key={format!("p{}", i)} message={message.clone()} session_id={ctx.props().session.id} agent_type={ctx.props().session.agent_type} current_user_id={ctx.props().current_user_id.clone()} continuation_statuses={self.continuation_statuses.clone()} on_schedule_continuation={on_schedule_continuation.clone()} /> }
                         })}
+                        if let Some(tree) = unmatched_muse_tree {
+                            <div class="claude-message muse-message muse-task-card muse-live-card">
+                                <div class="message-header">
+                                    <span class="message-type-badge muse">{ "Muse" }</span>
+                                </div>
+                                <div class="message-body">
+                                    { crate::components::muse_renderer::render_task_tree(&tree) }
+                                </div>
+                            </div>
+                        }
                         { self.render_active_tools() }
                         { self.render_ephemeral_status() }
                     </div>
@@ -737,6 +768,12 @@ impl SessionView {
                 false
             }
             WsEvent::HistoryBatch(messages, last_created_at) => {
+                // A reconnect batch is the authoritative state since the last
+                // watermark. Discard pre-disconnect Muse ephemera before
+                // replaying it; a terminal record may have landed while this
+                // browser was offline and therefore never visited the normal
+                // live-output cleanup path.
+                self.muse_live_turn = MuseLiveTurn::default();
                 self.messages.extend(messages);
                 retain_newest_items(&mut self.messages, MAX_MESSAGES_PER_SESSION);
                 // Set the reconnect-replay watermark to the server-assigned
@@ -840,12 +877,16 @@ impl SessionView {
                     }
                     return false;
                 }
-                // Transient live status: replace the strip line. Never touches
+                if ctx.props().session.agent_type == shared::AgentType::Muse
+                    && payload.get("type").and_then(|value| value.as_str()) == Some("muse_record")
+                {
+                    self.muse_live_turn.push(payload);
+                    return true;
+                }
+                // Non-Muse transient status: replace the strip line. Never touches
                 // `messages` (no persistence, no replay watermark). A frame we
                 // can't summarize is ignored rather than clearing a good line.
-                // Durable muse structure renders as the transcript's task-tree
-                // card (`GroupCategory::Muse`); this strip carries only the
-                // between-records heartbeat.
+                // Muse was routed into its task-tree overlay above.
                 match ephemeral_summary(&payload) {
                     Some(summary) => {
                         self.ephemeral_status = Some(summary);
@@ -1085,8 +1126,11 @@ impl SessionView {
         // tool_result for the running tool, or a turn `result` that ends the
         // turn entirely. (The live heartbeat side-channel only adds entries.)
         clear_completed_tools(&mut self.active_tools, &output.content);
-        // A durable message supersedes the transient live-status line.
+        // Generic status is superseded by any durable message. Muse live
+        // records instead stay overlaid on their matching group until the
+        // durable terminal record makes the whole turn replayable.
         self.ephemeral_status = None;
+        self.muse_live_turn.clear_if_terminal(&output.content);
 
         push_message_with_limit(&mut self.messages, output, MAX_MESSAGES_PER_SESSION);
         true
@@ -1135,10 +1179,9 @@ impl SessionView {
     }
 
     /// Transient live-status strip fed by the neutral `WsEvent::Ephemeral`
-    /// channel (muse's streamed deltas / task status). One line, replaced per
+    /// channel for agents without a richer live renderer. One line, replaced per
     /// frame, cleared when a durable message arrives. Renders nothing when
-    /// idle. Deliberately minimal — a placeholder the per-agent live view
-    /// (muse's task tree) replaces, not a base to extend.
+    /// idle. Deliberately minimal rather than a second transcript model.
     fn render_ephemeral_status(&self) -> Html {
         let Some(status) = self.ephemeral_status.as_deref() else {
             return html! {};

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -641,8 +641,8 @@ pub(crate) fn format_tool_elapsed(seconds: f64) -> String {
 /// frame still names itself instead of showing nothing. Returns `None` only
 /// when the frame carries no usable signal at all.
 ///
-/// This is an interim, agent-neutral render; the rich per-agent view (muse's
-/// task tree) is built on top of this same live stream in a follow-up.
+/// Muse records bypass this summary and replay into their task tree; this is
+/// the conservative fallback for other ephemeral producers.
 pub(crate) fn ephemeral_summary(payload: &serde_json::Value) -> Option<String> {
     let inner = payload.get("payload");
     // Streaming output text (muse `run.output.delta`).
@@ -671,6 +671,106 @@ pub(crate) fn ephemeral_summary(payload: &serde_json::Value) -> Option<String> {
         .map(str::trim)
         .filter(|t| !t.is_empty())
         .map(str::to_string)
+}
+
+/// Transient Muse records for the currently-running turn. Durable journal
+/// records remain the source of truth; this buffer is only replayed over the
+/// matching durable tree so status and streamed answer text update in place.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct MuseLiveTurn {
+    pub(crate) causation_id: Option<String>,
+    pub(crate) events: Vec<serde_json::Value>,
+}
+
+impl MuseLiveTurn {
+    const MAX_EVENTS: usize = 256;
+
+    pub(crate) fn push(&mut self, event: serde_json::Value) {
+        let causation_id = event
+            .get("causation_id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string);
+        if causation_id.is_some() && causation_id != self.causation_id {
+            self.events.clear();
+            self.causation_id = causation_id;
+        }
+
+        let payload_type = event.get("payload_type").and_then(|value| value.as_str());
+        // Status is replacement state, not history. Keeping only the newest
+        // line per task avoids a heartbeat-heavy turn growing without bound.
+        if payload_type == Some("task.lifecycle.status") {
+            let task_id = muse_task_id(&event);
+            if let Some(existing) = self.events.iter_mut().rev().find(|candidate| {
+                candidate
+                    .get("payload_type")
+                    .and_then(|value| value.as_str())
+                    == Some("task.lifecycle.status")
+                    && muse_task_id(candidate) == task_id
+            }) {
+                *existing = event;
+                return;
+            }
+        }
+
+        // Output deltas are one logical assistant response. Coalesce adjacent
+        // chunks so rendering cost follows turns, not token count.
+        if payload_type == Some("run.output.delta") {
+            if let (Some(chunk), Some(previous)) = (
+                event
+                    .get("payload")
+                    .and_then(|payload| payload.get("text"))
+                    .and_then(|value| value.as_str()),
+                self.events.last_mut(),
+            ) {
+                if previous
+                    .get("payload_type")
+                    .and_then(|value| value.as_str())
+                    == Some("run.output.delta")
+                {
+                    if let Some(text) = previous
+                        .get_mut("payload")
+                        .and_then(|payload| payload.get_mut("text"))
+                        .and_then(|value| value.as_str())
+                    {
+                        let mut joined = text.to_string();
+                        joined.push_str(chunk);
+                        previous["payload"]["text"] = serde_json::Value::String(joined);
+                        return;
+                    }
+                }
+            }
+        }
+
+        self.events.push(event);
+        if self.events.len() > Self::MAX_EVENTS {
+            self.events.remove(0);
+        }
+    }
+
+    pub(crate) fn clear_if_terminal(&mut self, durable: &str) {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(durable) else {
+            return;
+        };
+        let terminal = value
+            .get("payload_type")
+            .and_then(|value| value.as_str())
+            .is_some_and(|kind| kind.starts_with("run.terminal."));
+        let same_turn = value.get("causation_id").and_then(|value| value.as_str())
+            == self.causation_id.as_deref();
+        if terminal && same_turn {
+            self.events.clear();
+            self.causation_id = None;
+        }
+    }
+}
+
+fn muse_task_id(value: &serde_json::Value) -> Option<&str> {
+    let payload = value.get("payload")?;
+    payload
+        .get("event")
+        .and_then(|event| event.get("task_id"))
+        .or_else(|| payload.get("task_id"))
+        .and_then(|value| value.as_str())
 }
 
 #[cfg(test)]
@@ -709,6 +809,63 @@ mod tests {
     #[test]
     fn ephemeral_summary_none_when_no_signal() {
         assert_eq!(ephemeral_summary(&json!({"payload": {}})), None);
+    }
+
+    #[test]
+    fn muse_live_turn_coalesces_output_and_replaces_task_status() {
+        let mut live = MuseLiveTurn::default();
+        live.push(json!({
+            "payload_type": "task.lifecycle.status",
+            "causation_id": "turn-1",
+            "payload": {"event": {"task_id": "task-1", "message": "starting"}}
+        }));
+        live.push(json!({
+            "payload_type": "task.lifecycle.status",
+            "causation_id": "turn-1",
+            "payload": {"event": {"task_id": "task-1", "message": "running"}}
+        }));
+        live.push(json!({
+            "payload_type": "run.output.delta",
+            "causation_id": "turn-1",
+            "payload": {"text": "hello "}
+        }));
+        live.push(json!({
+            "payload_type": "run.output.delta",
+            "causation_id": "turn-1",
+            "payload": {"text": "world"}
+        }));
+
+        assert_eq!(live.events.len(), 2);
+        assert_eq!(live.events[0]["payload"]["event"]["message"], "running");
+        assert_eq!(live.events[1]["payload"]["text"], "hello world");
+    }
+
+    #[test]
+    fn muse_live_turn_resets_on_new_causation_and_terminal() {
+        let mut live = MuseLiveTurn::default();
+        live.push(json!({
+            "payload_type": "run.output.delta",
+            "causation_id": "turn-1",
+            "payload": {"text": "old"}
+        }));
+        live.push(json!({
+            "payload_type": "run.output.delta",
+            "causation_id": "turn-2",
+            "payload": {"text": "new"}
+        }));
+        assert_eq!(live.events.len(), 1);
+        assert_eq!(live.causation_id.as_deref(), Some("turn-2"));
+
+        live.clear_if_terminal(
+            &json!({
+                "payload_type": "run.terminal.completed",
+                "causation_id": "turn-2",
+                "payload": {"text": "done"}
+            })
+            .to_string(),
+        );
+        assert!(live.events.is_empty());
+        assert!(live.causation_id.is_none());
     }
 
     #[test]

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1642,52 +1642,17 @@
    collapse and drop the status, since a finished task's last progress
    message is stale by definition. */
 
-/* The agent's actual reply, rendered as markdown prose — the primary content
-   of a muse turn, sitting above the task-tree work log. */
+/* The agent's actual reply closes the turn after its work, matching the
+   Claude/Codex tool-then-answer reading order. */
 .muse-answer {
-    margin-bottom: 0.5rem;
-}
-
-.muse-answer:last-child {
-    margin-bottom: 0;
-}
-
-/* Collapsible "work log" wrapper: keeps a turn's task nodes from burying the
-   reply above. The toggle is a quiet disclosure, not a control that competes
-   with the answer. */
-.muse-worklog {
-    margin: 0.35rem 0 0;
-}
-
-.muse-worklog-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.15rem 0.3rem;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.72rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.muse-worklog-toggle:hover {
-    color: var(--text-secondary);
-}
-
-.muse-worklog-caret {
-    font-size: 0.7rem;
-    line-height: 1;
+    margin-top: 0.5rem;
 }
 
 .muse-task-tree {
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
-    margin: 0.35rem 0;
+    margin: 0.35rem 0 0;
     font-size: 0.8rem;
 }
 


### PR DESCRIPTION
## Summary
- replay Muse ephemeral records over the matching durable turn card instead of a one-line bottom status bar
- stream answer deltas into the turn and replace them with the canonical terminal answer
- render execution steps inline before the final response, matching Claude/Codex transcript order
- remove the turn-wide work-log accordion while preserving focused expansion on shared tool cards
- coalesce output chunks and replace per-task statuses to bound live frontend state

## Verification
- cargo test -p frontend (585 passed)
- cargo clippy -p frontend -- -D warnings
- cargo fmt --all --check
- cargo check -p frontend
- cargo check -p frontend --target wasm32-unknown-unknown