### PR TITLE
Show full agent identity and live status in message list

### DIFF
--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -69,7 +69,7 @@ pub async fn list_agent_sessions(
     let user_id = resolve_user(&app_state, &headers, &cookies)?;
     let mut conn = app_state.conn()?;
 
-    use crate::schema::{pending_permission_requests, session_members, sessions};
+    use crate::schema::{messages, pending_permission_requests, session_members, sessions};
     let rows: Vec<Session> = sessions::table
         .inner_join(session_members::table.on(session_members::session_id.eq(sessions::id)))
         .filter(session_members::user_id.eq(user_id))
@@ -89,21 +89,79 @@ pub async fn list_agent_sessions(
         .into_iter()
         .collect();
 
+    // One row per session: the newest event capable of changing turn state.
+    // Portal/system chatter is deliberately excluded so a reconnect notice or
+    // heartbeat cannot turn an otherwise-busy session idle. PostgreSQL's
+    // DISTINCT ON keeps this a single batched query rather than N+1 lookups.
+    let latest_signals: std::collections::HashMap<Uuid, (String, String)> = messages::table
+        .filter(messages::session_id.eq_any(&session_ids))
+        .filter(messages::role.eq_any(["user", "assistant", "result", "unknown", "error"]))
+        .distinct_on(messages::session_id)
+        .select((
+            messages::session_id,
+            messages::agent_type,
+            messages::content,
+        ))
+        .order((messages::session_id, messages::created_at.desc()))
+        .load::<(Uuid, String, String)>(&mut conn)?
+        .into_iter()
+        .map(|(id, agent_type, content)| (id, (agent_type, content)))
+        .collect();
+
     let sessions = rows
         .into_iter()
-        .map(|s| AgentSessionInfo {
-            id: s.id,
-            awaiting_permission: awaiting.contains(&s.id),
-            last_activity: s.last_activity.and_utc().to_rfc3339(),
-            session_name: s.session_name,
-            working_directory: s.working_directory,
-            agent_type: s.agent_type,
-            status: s.status,
-            hostname: s.hostname,
+        .map(|s| {
+            let connected = app_state
+                .session_manager
+                .sessions
+                .contains_key(s.id.to_string().as_str());
+            let busy = connected
+                && latest_signals
+                    .get(&s.id)
+                    .is_some_and(|(agent_type, content)| turn_signal_is_busy(agent_type, content));
+            AgentSessionInfo {
+                connected: Some(connected),
+                busy: Some(busy),
+                id: s.id,
+                awaiting_permission: awaiting.contains(&s.id),
+                last_activity: s.last_activity.and_utc().to_rfc3339(),
+                session_name: s.session_name,
+                working_directory: s.working_directory,
+                agent_type: s.agent_type,
+                status: s.status,
+                hostname: s.hostname,
+                model: s.last_model,
+            }
         })
         .collect();
 
     Ok(Json(AgentSessionsResponse { sessions }))
+}
+
+/// Interpret the latest significant durable event as turn state. The wire
+/// protocols have different terminal vocabulary, but all three expose typed
+/// or stable top-level discriminators; malformed future frames fail safe to
+/// "busy" while connected instead of advertising an agent as idle mid-turn.
+fn turn_signal_is_busy(agent_type: &str, content: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(content) else {
+        return true;
+    };
+    let kind = value.get("type").and_then(|value| value.as_str());
+    match agent_type {
+        "claude" => kind != Some("result") && kind != Some("error"),
+        "codex" => !matches!(
+            kind,
+            Some("thread.started" | "turn.completed" | "turn.failed" | "error")
+        ),
+        "muse" => !value
+            .get("payload_type")
+            .and_then(|value| value.as_str())
+            .is_some_and(|kind| kind.starts_with("run.terminal.")),
+        _ => !matches!(
+            kind,
+            Some("result" | "turn.completed" | "turn.failed" | "error")
+        ),
+    }
 }
 
 /// POST /api/agent/sessions/{id}/message — inject a message into a session as
@@ -398,4 +456,37 @@ fn pending_input_count(
         .count()
         .get_result(conn)?;
     Ok(count.max(0) as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::turn_signal_is_busy;
+
+    #[test]
+    fn turn_state_covers_all_agent_terminal_shapes() {
+        assert!(turn_signal_is_busy("claude", r#"{"type":"assistant"}"#));
+        assert!(!turn_signal_is_busy("claude", r#"{"type":"result"}"#));
+        assert!(turn_signal_is_busy("codex", r#"{"type":"item.started"}"#));
+        assert!(!turn_signal_is_busy(
+            "codex",
+            r#"{"type":"thread.started"}"#
+        ));
+        assert!(!turn_signal_is_busy(
+            "codex",
+            r#"{"type":"turn.completed"}"#
+        ));
+        assert!(turn_signal_is_busy(
+            "muse",
+            r#"{"type":"muse_record","payload_type":"tool.result"}"#
+        ));
+        assert!(!turn_signal_is_busy(
+            "muse",
+            r#"{"type":"muse_record","payload_type":"run.terminal.completed"}"#
+        ));
+    }
+
+    #[test]
+    fn malformed_in_progress_signal_fails_busy() {
+        assert!(turn_signal_is_busy("codex", "not-json"));
+    }
 }

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -250,16 +250,45 @@ pub async fn list() -> Result<()> {
             ""
         };
         println!(
-            "{}  {}  [{}/{}]  {}{}",
+            "{}  {} / {} / {}  {}  {}{}",
             display_session_id(s, &data.sessions),
+            full_agent_name(s),
+            if session_is_connected(s) {
+                "connected"
+            } else {
+                "disconnected"
+            },
+            if s.busy.unwrap_or(false) {
+                "busy"
+            } else {
+                "idle"
+            },
             s.session_name,
-            s.agent_type,
-            s.status,
             s.working_directory,
             marker
         );
     }
     Ok(())
+}
+
+fn full_agent_name(session: &shared::api::AgentSessionInfo) -> String {
+    let Some(model) = session.model.as_deref().filter(|model| !model.is_empty()) else {
+        return session.agent_type.clone();
+    };
+    if model.starts_with(&session.agent_type) {
+        model.to_string()
+    } else {
+        format!("{}-{model}", session.agent_type)
+    }
+}
+
+/// New backends report live proxy presence explicitly. Falling back to the
+/// legacy status keeps a newly-updated CLI useful against an older backend
+/// during rolling deploys.
+fn session_is_connected(session: &shared::api::AgentSessionInfo) -> bool {
+    session
+        .connected
+        .unwrap_or_else(|| session.status == shared::SessionStatus::Active.as_str())
 }
 
 async fn fetch_sessions(
@@ -402,6 +431,9 @@ mod tests {
             agent_type: "claude".to_string(),
             status: "active".to_string(),
             hostname: "host".to_string(),
+            model: None,
+            connected: Some(true),
+            busy: Some(false),
             awaiting_permission: false,
             last_activity: String::new(),
         }
@@ -456,6 +488,28 @@ mod tests {
         ];
 
         assert_eq!(display_session_id(&sessions[0], &sessions), "12345678");
+    }
+
+    #[test]
+    fn full_agent_name_keeps_full_model_and_avoids_duplicate_prefix() {
+        let mut codex = session("12345678-0000-0000-0000-000000000000");
+        codex.agent_type = "codex".to_string();
+        codex.model = Some("gpt-5.4-sol".to_string());
+        assert_eq!(full_agent_name(&codex), "codex-gpt-5.4-sol");
+
+        let mut claude = codex;
+        claude.agent_type = "claude".to_string();
+        claude.model = Some("claude-opus-4-8".to_string());
+        assert_eq!(full_agent_name(&claude), "claude-opus-4-8");
+    }
+
+    #[test]
+    fn connection_presence_falls_back_to_legacy_status() {
+        let mut old_wire = session("12345678-0000-0000-0000-000000000000");
+        old_wire.connected = None;
+        assert!(session_is_connected(&old_wire));
+        old_wire.status = "disconnected".to_string();
+        assert!(!session_is_connected(&old_wire));
     }
 
     #[test]

--- a/shared/src/api/sessions.rs
+++ b/shared/src/api/sessions.rs
@@ -106,6 +106,18 @@ pub struct AgentSessionInfo {
     pub agent_type: String,
     pub status: String,
     pub hostname: String,
+    /// Full last-observed model identifier. `None` before the first turn that
+    /// reports one; callers fall back to `agent_type`.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Live proxy presence, independent of the eventually-consistent database
+    /// status string retained above for wire compatibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connected: Option<bool>,
+    /// True while the latest significant transcript event belongs to an
+    /// in-progress turn. Meaningful only while `connected` is true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub busy: Option<bool>,
     /// True when the session has a pending permission request waiting on the
     /// user — the "agent is blocked on you" signal mobile widgets surface.
     #[serde(default)]


### PR DESCRIPTION
## Summary
- show `full-agent-name / connected|disconnected / idle|busy` in `agent-portal message list`
- use the full last-observed model identifier, with an agent prefix when needed
- derive connection state from the live proxy registry instead of the lagging database status
- derive turn activity from the newest significant durable event across Claude, Codex, and Muse
- keep the existing session id, session name, working directory, and self marker

## Verification
- `cargo check -p backend -p agent-portal`
- `cargo test -p backend handlers::agent_comms::tests`
- `cargo test -p agent-portal message::tests`
- `cargo clippy -p backend -p agent-portal -- -D warnings`
- `cargo fmt --all --check`
