### PR TITLE
Contract long muse non-command tool results like other renderers

### DIFF
--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -12,6 +12,9 @@
 use serde::Deserialize;
 use yew::prelude::*;
 
+use super::expandable::ExpandableText;
+use super::tool_renderers::OUTPUT_PREVIEW_CHARS;
+
 pub mod task_tree;
 
 pub use task_tree::{TaskNode, TaskState, TaskTree};
@@ -155,10 +158,18 @@ fn render_muse_tool_result(result: &task_tree::ToolOutcome) -> Html {
             </div>
         };
     }
+    // Non-command tool results (search, list, …) contract past the shared
+    // preview threshold like the Claude/Codex tool output does — a bounded
+    // search alone can be 80 matches long (#1628).
     html! {
         <div class={classes!("muse-tool-result", format!("muse-tool-{outcome}"))}>
             <span class="muse-tool-name">{ tool }</span>
-            <span class="muse-tool-text">{ &result.text }</span>
+            <ExpandableText
+                full_text={result.text.clone()}
+                max_len={OUTPUT_PREVIEW_CHARS}
+                tag="span"
+                class={classes!("muse-tool-text")}
+            />
         </div>
     }
 }
@@ -293,7 +304,14 @@ fn render_task_node(node: &TaskNode) -> Html {
                 if let Some(cmd) = parse_command_result(chunk) {
                     html! { <div class="muse-tool-command">{ render_command_card(&cmd) }</div> }
                 } else {
-                    html! { <div class="muse-task-output">{ chunk }</div> }
+                    html! {
+                        <ExpandableText
+                            full_text={chunk.clone()}
+                            max_len={OUTPUT_PREVIEW_CHARS}
+                            tag="div"
+                            class={classes!("muse-task-output")}
+                        />
+                    }
                 }
             }) }
         </div>

--- a/frontend/src/components/tool_renderers/command_result.rs
+++ b/frontend/src/components/tool_renderers/command_result.rs
@@ -10,8 +10,9 @@ use yew::prelude::*;
 
 /// How much output to show before the `ExpandableText` toggle collapses it —
 /// matches the "show a bit, click for the rest" behavior of the other agents'
-/// tool output.
-const OUTPUT_PREVIEW_CHARS: usize = 600;
+/// tool output. Shared with the muse renderer so its non-command tool results
+/// contract at the same threshold (#1628).
+pub(crate) const OUTPUT_PREVIEW_CHARS: usize = 600;
 
 #[derive(Properties, PartialEq)]
 pub struct CommandResultCardProps {

--- a/frontend/src/components/tool_renderers/mod.rs
+++ b/frontend/src/components/tool_renderers/mod.rs
@@ -5,7 +5,7 @@ mod interactive;
 mod search;
 mod task;
 
-pub(crate) use self::command_result::CommandResultCard;
+pub(crate) use self::command_result::{CommandResultCard, OUTPUT_PREVIEW_CHARS};
 
 use serde::de::DeserializeOwned;
 use serde_json::Value;


### PR DESCRIPTION
Non-command muse tool results (`tool:search` and friends) and streamed `task.lifecycle.output` chunks rendered their full text inline — a single bounded search dumped ~80 grep matches into the transcript. Command results already got the collapsible card treatment; these two fallthrough paths did not.

Both now render through the shared `ExpandableText` at the same 600-char preview threshold the command cards use (`OUTPUT_PREVIEW_CHARS`, made `pub(crate)` and shared instead of duplicated). Short results render inline exactly as before; long ones show a preview with the standard "… N more chars" toggle. As a side effect the text is now URL-linkified, matching the other renderers.

Closes #1628.