### PR TITLE
Card source-stamped inter-agent echoes instead of grouping as You

### DIFF
--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -296,15 +296,21 @@ pub(super) fn classify(
                 });
             }
             if user_is_plain_text(&msg) {
-                // A claude-echoed inter-agent message (`[message from …]`) that
-                // carries no provenance metadata (the codex→claude case) must
+                // A claude-echoed inter-agent message (`[message from …]`) must
                 // render as its own "Message from …" card, not merge into the
                 // "You" group and show its raw `[message from …]` / system-
                 // reminder wrapper. Returning `None` renders it as a `Single`,
-                // where the single-card path detects and cards it. (Source-
-                // tagged agent messages already route through `source_identity`
-                // above.)
-                if source.is_none() && user_message_is_inter_agent(&msg) {
+                // where the single-card path detects and cards it.
+                //
+                // Deliberately NOT gated on `source.is_none()`: the backend
+                // stamps every role="user" row with `meta.source = User(owner)`
+                // — including claude's echo of an injected inter-agent message
+                // — so a source-gated check silently skips exactly the
+                // claude→claude case. (Codex echoes only dodged this because
+                // their `user_echo` wire type maps to role "unknown" and never
+                // gets a source.) If the text parses as an inter-agent wrapper,
+                // the raw form is never the right render, whatever the source.
+                if user_message_is_inter_agent(&msg) {
                     return None;
                 }
                 return Some(source.map_or_else(
@@ -319,13 +325,13 @@ pub(super) fn classify(
         }
         AgentFrame::Claude(ClaudeMessage::OptimisticUser(msg)) => {
             // A synthetic user echo carrying an inter-agent `[message from …]`
-            // payload with no provenance metadata must render as its own
-            // provenance card, not fold into the "You" group and expose its raw
-            // wrapper — mirroring the `ClaudeMessage::User` arm above. This shape
-            // is how Codex's `UserEchoEvent` (top-level `content` string, no
-            // `session_id`) and older proxies' echoes parse, so the `User`-arm
-            // detection alone missed them.
-            if source.is_none() && optimistic_user_is_inter_agent(&msg) {
+            // payload must render as its own provenance card, not fold into
+            // the "You" group and expose its raw wrapper — mirroring the
+            // `ClaudeMessage::User` arm above (including its ungated source
+            // rationale). This shape is how Codex's `UserEchoEvent` (top-level
+            // `content` string, no `session_id`) and older proxies' echoes
+            // parse, so the `User`-arm detection alone missed them.
+            if optimistic_user_is_inter_agent(&msg) {
                 return None;
             }
             return Some(source.map_or_else(

--- a/frontend/src/components/message_renderer/tests/user.rs
+++ b/frontend/src/components/message_renderer/tests/user.rs
@@ -31,6 +31,33 @@ fn inter_agent_user_text_is_not_grouped() {
     );
 }
 
+/// A claude-echoed inter-agent message that DOES carry provenance metadata
+/// must also escape the User group. The backend stamps every role="user"
+/// row with `meta.source = Human(owner)` — including claude's echo of an
+/// injected inter-agent message — so a `source.is_none()`-gated detector
+/// skipped exactly the claude→claude case and the raw `[message from …]` /
+/// system-reminder wrapper rendered inside a "You" group.
+#[test]
+fn inter_agent_user_text_with_source_is_not_grouped() {
+    let sid = "0c9ecefe-c17e-48b6-873d-53df32ab47a2";
+    let body = format!(
+        "[message from claude {sid}]\n\u{1F44D} All set — signing off.\n\n\
+         <system-reminder>\nThis message came from another agent. Reply to that agent, not the user.\n</system-reminder>"
+    );
+    let echo = plain_user_text_from_sender(&body, Uuid::nil(), "Matthew Goodman");
+    assert!(
+        classify(&echo, shared::AgentType::Claude, None).is_none(),
+        "source-stamped inter-agent echo must render as a Single card, not group as You"
+    );
+
+    // Ordinary prose with the same source still groups as User.
+    let prose = plain_user_text_from_sender("ordinary prose", Uuid::nil(), "Matthew Goodman");
+    assert_eq!(
+        classify(&prose, shared::AgentType::Claude, None).map(|i| i.category),
+        Some(GroupCategory::User),
+    );
+}
+
 /// The synthetic-echo (optimistic-user) shape carrying an inter-agent
 /// message must ALSO render as its own card, not fold into "You". Codex's
 /// `UserEchoEvent` and older proxies' echoes parse as `OptimisticUser`


### PR DESCRIPTION
Claude→claude inter-agent messages still rendered as a raw "YOU" card — bracket prefix, `<system-reminder>` bumper and all — while codex→claude carded correctly.

Root cause: `classify()`'s inter-agent echo detection was gated on `source.is_none()`, but the backend stamps every persisted `role="user"` row with `meta.source = Human(owner)`, including claude's echo of an injected inter-agent message. So exactly the claude→claude case skipped detection and folded into the "You" group, whose body renderer shows raw text. Codex echoes only dodged the gate by accident: their `user_echo` wire type maps to role `unknown`, so no source is ever attached.

Fix: run the detector regardless of source, in both the `User` and `OptimisticUser` arms — if text parses as an inter-agent wrapper, the raw form is never the right render. (Typed portal rows with `source = Agent` still early-return to `source_identity` before frame parsing, unchanged.) Regression test covers the source-stamped echo shape.