### PR TITLE
Attribute codex inter-agent sends via exported PORTAL_SESSION_ID

### DIFF
--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -253,7 +253,17 @@ pub(crate) async fn codex_io_task(
 
     let mut builder = AppServerBuilder::new()
         .command(codex_path)
-        .working_directory(&config.working_directory);
+        .working_directory(&config.working_directory)
+        // Exported so shell tools codex spawns inherit it — `agent-portal
+        // message send` reads this as its first sender-attribution arm.
+        // Without it, attribution depends on `CODEX_THREAD_ID` plus the
+        // launcher's persisted thread map, which goes stale across thread
+        // rotation (fork / new thread) and then sends silently degrade to the
+        // backend's untyped "[portal message from <user>]" fallback. The
+        // portal session id is stable for this app-server's whole life, so it
+        // can't go stale the way the thread mapping does. Mirrors the muse
+        // fix (#1635).
+        .env("PORTAL_SESSION_ID", config.session_id.to_string());
     for (k, v) in &overrides {
         builder = builder.config_override(k, v);
     }

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -316,11 +316,25 @@ pub async fn send(agent_id: &str, message: &str) -> Result<()> {
     let sessions = fetch_sessions(&client, &base, &token).await?;
     let resolved_agent_id = resolve_session_id(agent_id, &sessions.sessions)?;
     // Sender attribution is best-effort and must not block delivery when more
-    // than one live session shares this host and working directory.
-    let from = sender_session_id(&sessions.sessions).unwrap_or_else(|error| {
-        eprintln!("warning: could not attribute sender session: {error}");
-        None
-    });
+    // than one live session shares this host and working directory. But it
+    // must never degrade SILENTLY: an unattributed agent send falls back to
+    // the backend's plain "[portal message from <user>]" string and renders
+    // in the recipient's transcript as if the human typed it.
+    let from = match sender_session_id(&sessions.sessions) {
+        Ok(Some(id)) => Some(id),
+        Ok(None) => {
+            eprintln!(
+                "warning: sender session not identified (no PORTAL_SESSION_ID or \
+                 recognized agent env) — this message will be attributed to your \
+                 user account, not to this agent session"
+            );
+            None
+        }
+        Err(error) => {
+            eprintln!("warning: could not attribute sender session: {error}");
+            None
+        }
+    };
     // Non-idempotent POST: retry the pre-delivery transient (404 target lookup
     // against a stale session index) and transport errors, but NOT 5xx — the
     // server may already have delivered, and a replay would double-send.


### PR DESCRIPTION
An inter-agent design summary from the codex session rendered in the recipient's transcript as a plain "YOU" card with the `[portal message from Matthew Goodman]` fallback prefix — the same unattributed-sender class as the muse fix (#1635), via a different hole.

Codex attribution resolves `CODEX_THREAD_ID` through the launcher's persisted thread map. That mapping goes stale across thread rotation (fork / new thread — fresh paths from the fork plumbing), and when the lookup misses, `sender_session_id` returns `Ok(None)` — which the CLI treated as success, so the send degraded **silently** to the backend's untyped human-fallback string.

Two changes:
- `codex-session-lib`: export `PORTAL_SESSION_ID` into the app-server env at spawn (`AppServerBuilder::env` already existed). Shell tools codex spawns inherit it, and it's the CLI's first resolution arm — the portal session id is stable for the app-server's entire life, so it can't go stale the way the thread map does. Mirrors #1635.
- `launcher` CLI: `Ok(None)` from sender resolution now prints a warning ("message will be attributed to your user account, not this agent session") instead of silently proceeding — the sending agent sees it and can surface it.

Existing sessions pick this up on their next proxy restart; claude attribution (own resolver, working) is untouched.