### PR TITLE
Fix wire goldens after LaunchSession gained fork fields

### DIFF
--- a/shared/src/endpoints/wire_goldens_tests.rs
+++ b/shared/src/endpoints/wire_goldens_tests.rs
@@ -622,6 +622,8 @@ fn launcher_server_to_launcher_launch_roundtrip_golden() {
         resume: None,
         create_worktree: false,
         worktree_branch: None,
+        fork_from_session_id: None,
+        fork_point_turn_id: None,
     };
     let v = serde_json::to_value(&msg).unwrap();
     assert_eq!(v["type"], "LaunchSession");


### PR DESCRIPTION
Main is red: the fork plumbing added `fork_from_session_id` / `fork_point_turn_id` to `ServerToLauncher::LaunchSession` after the wire-goldens test (which initializes that variant exhaustively) merged. Each PR was green against its own base; together they don't compile (`E0063` in `wire_goldens_tests.rs`). Adds the two fields as `None` to the golden's initializer.