### PR TITLE
Style the fork dialog with the launch-dialog vocabulary

### DIFF
--- a/frontend/src/components/fork_dialog.rs
+++ b/frontend/src/components/fork_dialog.rs
@@ -128,36 +128,44 @@ pub fn fork_dialog(props: &ForkDialogProps) -> Html {
     html! {
         <div class="launch-dialog-backdrop" onclick={close.clone()}>
             <div class="launch-dialog fork-dialog" onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}>
-                <h2>{ "Fork session" }</h2>
-                <p class="dialog-description">
+                <h3>{ "Fork session" }</h3>
+                <p class="launch-info">
                     { format!("Create a new {} session from {}'s latest persisted turn.", props.session.agent_type, props.session.session_name) }
                 </p>
-                <label>{ "Name" }</label>
-                <input value={(*name).clone()} oninput={{ let name = name.clone(); Callback::from(move |e: InputEvent| name.set(e.target_unchecked_into::<HtmlInputElement>().value())) }} />
+                <div class="launch-field">
+                    <label>{ "Name" }</label>
+                    <input value={(*name).clone()} oninput={{ let name = name.clone(); Callback::from(move |e: InputEvent| name.set(e.target_unchecked_into::<HtmlInputElement>().value())) }} />
+                </div>
 
-                <fieldset class="fork-directory-options">
-                    <legend>{ "Working directory" }</legend>
-                    if props.session.repo_url.is_some() {
-                        <label><input type="radio" name="fork-dir" checked={*mode == ForkDirectoryMode::Worktree} onchange={set_mode(ForkDirectoryMode::Worktree)} /> { "New git worktree (recommended)" }</label>
-                    }
-                    <label><input type="radio" name="fork-dir" checked={*mode == ForkDirectoryMode::Same} onchange={set_mode(ForkDirectoryMode::Same)} /> { "Same directory" }</label>
-                    if *mode == ForkDirectoryMode::Same {
-                        <p class="warning-text">{ "Warning: both agents will share one checkout and may overwrite each other's work." }</p>
-                    }
-                    <label><input type="radio" name="fork-dir" checked={*mode == ForkDirectoryMode::Other} onchange={set_mode(ForkDirectoryMode::Other)} /> { "Other directory" }</label>
-                    if *mode == ForkDirectoryMode::Other {
-                        <input placeholder="/path/on/source/launcher" value={(*other_directory).clone()} oninput={{ let value = other_directory.clone(); Callback::from(move |e: InputEvent| value.set(e.target_unchecked_into::<HtmlInputElement>().value())) }} />
-                    }
-                </fieldset>
+                <div class="launch-field">
+                    <label>{ "Working directory" }</label>
+                    <div class="fork-directory-options">
+                        if props.session.repo_url.is_some() {
+                            <label><input type="radio" name="fork-dir" checked={*mode == ForkDirectoryMode::Worktree} onchange={set_mode(ForkDirectoryMode::Worktree)} /> { "New git worktree (recommended)" }</label>
+                        }
+                        <label><input type="radio" name="fork-dir" checked={*mode == ForkDirectoryMode::Same} onchange={set_mode(ForkDirectoryMode::Same)} /> { "Same directory" }</label>
+                        if *mode == ForkDirectoryMode::Same {
+                            <p class="launch-note launch-note-warn">{ "Warning: both agents will share one checkout and may overwrite each other's work." }</p>
+                        }
+                        <label><input type="radio" name="fork-dir" checked={*mode == ForkDirectoryMode::Other} onchange={set_mode(ForkDirectoryMode::Other)} /> { "Other directory" }</label>
+                        if *mode == ForkDirectoryMode::Other {
+                            <input placeholder="/path/on/source/launcher" value={(*other_directory).clone()} oninput={{ let value = other_directory.clone(); Callback::from(move |e: InputEvent| value.set(e.target_unchecked_into::<HtmlInputElement>().value())) }} />
+                        }
+                    </div>
+                </div>
 
-                <label>{ "Model override" }</label>
-                <ModelSelect agent_type={props.session.agent_type} value={(*model).clone()} on_change={{ let model = model.clone(); Callback::from(move |value| model.set(value)) }} />
-                <label>{ "Divergence prompt (optional)" }</label>
-                <textarea value={(*prompt).clone()} oninput={{ let prompt = prompt.clone(); Callback::from(move |e: InputEvent| prompt.set(e.target_unchecked_into::<HtmlTextAreaElement>().value())) }} />
-                if let Some(message) = &*error { <div class="error-message">{ message }</div> }
-                <div class="dialog-actions">
-                    <button type="button" onclick={close}>{ "Cancel" }</button>
-                    <button type="button" class="primary" disabled={*submitting} onclick={submit}>{ if *submitting { "Forking…" } else { "Fork session" } }</button>
+                <div class="launch-field">
+                    <label>{ "Model override" }</label>
+                    <ModelSelect agent_type={props.session.agent_type} value={(*model).clone()} on_change={{ let model = model.clone(); Callback::from(move |value| model.set(value)) }} />
+                </div>
+                <div class="launch-field">
+                    <label>{ "Divergence prompt (optional)" }</label>
+                    <textarea value={(*prompt).clone()} oninput={{ let prompt = prompt.clone(); Callback::from(move |e: InputEvent| prompt.set(e.target_unchecked_into::<HtmlTextAreaElement>().value())) }} />
+                </div>
+                if let Some(message) = &*error { <div class="launch-error">{ message }</div> }
+                <div class="launch-actions">
+                    <button type="button" class="launch-button-cancel" onclick={close}>{ "Cancel" }</button>
+                    <button type="button" class="launch-button" disabled={*submitting} onclick={submit}>{ if *submitting { "Forking…" } else { "Fork session" } }</button>
                 </div>
             </div>
         </div>

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -665,3 +665,52 @@
     outline: 2px solid var(--accent);
     outline-offset: 2px;
 }
+
+/* Fork dialog (shares the launch-dialog shell + field vocabulary). The
+   radio rows override .launch-field's block labels / full-width inputs,
+   so these rules must stay AFTER the .launch-field block above. */
+.fork-directory-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.fork-directory-options label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0;
+    cursor: pointer;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.fork-directory-options input[type="radio"] {
+    width: auto;
+    accent-color: var(--accent);
+    cursor: pointer;
+}
+
+.fork-directory-options input[type="radio"]:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.launch-field textarea {
+    width: 100%;
+    min-height: 5rem;
+    padding: 0.6rem 0.75rem;
+    background: var(--bg-dark);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-family: 'Courier New', Consolas, monospace;
+    box-sizing: border-box;
+    resize: vertical;
+}
+
+.launch-field textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+}


### PR DESCRIPTION
The fork-session dialog rendered with raw browser-default controls — white inputs, a native `<fieldset>` border, inline radio buttons, unstyled Cancel/Fork buttons — because it reused the `.launch-dialog` shell but none of the launch dialog's field vocabulary (`.launch-field`, `.launch-info`, `.launch-actions`, `.launch-button[-cancel]`), and its own classes (`dialog-description`, `dialog-actions`, `warning-text`, `fork-directory-options`) had no CSS at all.

Restructured the markup onto the existing launch-dialog classes (h3 title, `.launch-info` description, `.launch-field` wrappers, warn-note for the shared-checkout warning, shared action buttons), replaced the fieldset with a labeled radio group, and added the two things the launch dialog never needed: stacked radio-row rules (`.fork-directory-options`, with focus rings matching the checkbox treatment) and `.launch-field textarea` styling for the divergence prompt.

No behavior change; trunk build + 607 frontend tests green.