### PR TITLE
Stop KaTeX mutating Yew's DOM; typeset math per element

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,10 +36,12 @@
     <!-- KaTeX for rendering LaTeX math in messages -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"
           integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous" />
+    <!-- The `auto-render` contrib extension is deliberately NOT loaded: it
+         rewrites matching text nodes in place, which corrupted Yew's bundle
+         and panicked the app on re-render. katex-helper.js renders each math
+         region into its own element instead. -->
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"
             integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
-            integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>
 
     <!-- Loading spinner (inline so it renders before any external assets) -->
     <style>

--- a/frontend/katex-helper.js
+++ b/frontend/katex-helper.js
@@ -1,40 +1,63 @@
-// Helper exposed on window for Yew to call after rendering markdown.
-// Uses KaTeX's auto-render extension to find $...$ and $$...$$ in a DOM
-// element and replace them with rendered math.
+// Helper exposed on window for Yew to call for a single math region.
 //
-// The KaTeX library and its auto-render extension are loaded via deferred
-// <script> tags in index.html. On a cold page load, Yew may invoke this
-// helper before those scripts have finished evaluating. The original
-// implementation silently returned in that case, leaving math un-rendered
-// for the lifetime of the page (the Yew effect is keyed on props.text and
-// won't fire again for a message that doesn't change). We queue calls
-// until KaTeX is ready and flush them on first availability.
+// Yew calls this once per `MathSpan` element with that region's LaTeX source.
+// KaTeX renders INTO the supplied element and owns everything inside it; Yew
+// renders that element with no children of its own, so the two never touch the
+// same nodes.
+//
+// This deliberately does NOT use KaTeX's `auto-render` extension. That
+// extension scans a subtree and rewrites matching text nodes in place — when
+// pointed at Yew-rendered markdown it replaced nodes Yew's bundle still
+// referenced, so the next re-render (every streamed token) computed an insert
+// position against a detached node and panicked the WASM app with
+// "failed to insert node before next sibling". It also applied its own
+// delimiter heuristics, which disagreed with the Rust-side scanner that
+// already skips code spans and dollar amounts.
+//
+// KaTeX loads from a deferred <script>, so on a cold page load Yew can call
+// this before the library exists. Such calls leave the LaTeX source visible as
+// text and are queued, then flushed when KaTeX becomes available.
 
 (function () {
-    const KATEX_OPTIONS = {
-        delimiters: [
-            { left: '$$', right: '$$', display: true },
-            { left: '$', right: '$', display: false },
-            { left: '\\(', right: '\\)', display: false },
-            { left: '\\[', right: '\\]', display: true },
-        ],
-        ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
-        ignoredClasses: ['md-code-block', 'md-inline-code', 'tool-result-content', 'bash-command-inline'],
-        throwOnError: false,
-        errorColor: '#cc6666',
-    };
+    function options(displayMode) {
+        return {
+            displayMode: !!displayMode,
+            throwOnError: false,
+            errorColor: '#cc6666',
+            // `trust` stays false (the default): \href/\url and friends are
+            // refused, so agent-authored math cannot inject navigable links.
+            trust: false,
+        };
+    }
 
-    const pending = new Set();
+    // element -> {latex, displayMode} for calls that arrived before KaTeX did.
+    const pending = new Map();
     let pollHandle = null;
 
+    function ready() {
+        return typeof window.katex === 'object'
+            && window.katex !== null
+            && typeof window.katex.render === 'function';
+    }
+
+    function renderNow(element, latex, displayMode) {
+        try {
+            window.katex.render(latex, element, options(displayMode));
+            return true;
+        } catch (e) {
+            console.error('[katex] render failed:', e);
+            // Leave the source readable rather than an empty gap.
+            element.textContent = latex;
+            return false;
+        }
+    }
+
     function flush() {
-        if (typeof window.renderMathInElement !== 'function') return;
-        for (const element of pending) {
-            if (!element.isConnected) continue;
-            try {
-                window.renderMathInElement(element, KATEX_OPTIONS);
-            } catch (e) {
-                console.error('[katex] render failed:', e);
+        if (!ready()) return;
+        for (const [element, spec] of pending) {
+            // Elements Yew has since removed are skipped, not resurrected.
+            if (element.isConnected) {
+                renderNow(element, spec.latex, spec.displayMode);
             }
         }
         pending.clear();
@@ -46,44 +69,21 @@
 
     function schedulePoll() {
         if (pollHandle) return;
-        pollHandle = setInterval(function () {
-            if (typeof window.renderMathInElement === 'function') {
-                flush();
-            }
-        }, 50);
+        pollHandle = setInterval(flush, 50);
     }
 
-    window.renderMathInNode = function (element) {
+    window.renderMathIntoNode = function (element, latex, displayMode) {
         if (!element) {
-            console.warn('[katex] renderMathInNode called with no element');
+            console.warn('[katex] renderMathIntoNode called with no element');
             return;
         }
-        // Probe whether this subtree actually contains math delimiters. If
-        // it does, but KaTeX doesn't render, the log makes the failure mode
-        // visible in the browser console for diagnosis.
-        const text = (element.textContent || '');
-        const hasDollar = text.includes('$');
-        const hasParen = text.includes('\\(');
-        const hasBracket = text.includes('\\[');
-        if (typeof window.renderMathInElement === 'function') {
-            try {
-                window.renderMathInElement(element, KATEX_OPTIONS);
-                if (hasDollar || hasParen || hasBracket) {
-                    const after = element.querySelectorAll('.katex').length;
-                    if (after === 0) {
-                        console.warn(
-                            '[katex] no math rendered though delimiters present',
-                            { sample: text.slice(0, 200) }
-                        );
-                    }
-                }
-            } catch (e) {
-                console.error('[katex] render failed:', e);
-            }
-        } else {
-            console.warn('[katex] auto-render not yet loaded — queued');
-            pending.add(element);
-            schedulePoll();
+        if (ready()) {
+            pending.delete(element);
+            renderNow(element, latex, displayMode);
+            return;
         }
+        element.textContent = latex;
+        pending.set(element, { latex: latex, displayMode: displayMode });
+        schedulePoll();
     };
 })();

--- a/frontend/src/components/markdown/math.rs
+++ b/frontend/src/components/markdown/math.rs
@@ -1,8 +1,6 @@
 // TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use pulldown_cmark::Event;
-
 pub(super) const MATH_OPEN: char = '\u{E000}';
 pub(super) const MATH_CLOSE: char = '\u{E001}';
 
@@ -114,25 +112,74 @@ fn emit_placeholder(output: &mut String, math_blocks: &mut Vec<String>, math: &s
     output.push(MATH_CLOSE);
 }
 
-/// Walk the event stream and replace placeholders inside `Event::Text` with
-/// the original math literals so that KaTeX can find the delimiters.
-pub(super) fn restore_math_in_events<'a>(
-    events: Vec<Event<'a>>,
-    math_blocks: &[String],
-) -> Vec<Event<'a>> {
-    events
-        .into_iter()
-        .map(|e| match e {
-            Event::Text(t) => {
-                if t.contains(MATH_OPEN) {
-                    Event::Text(restore_math(&t, math_blocks).into())
-                } else {
-                    Event::Text(t)
-                }
+/// One piece of a parsed text run: literal prose, or a math region that must
+/// be typeset by KaTeX into its own element.
+pub(super) enum MathSegment {
+    Text(String),
+    Math { latex: String, display: bool },
+}
+
+/// Split a text run on math placeholders, resolving each back to its captured
+/// literal and classifying it as inline or display math.
+///
+/// The placeholders (not the restored literals) are what survive markdown
+/// parsing, which is why the split happens here at render time: it lets each
+/// math region become its own DOM element instead of loose text that a
+/// DOM-mutating auto-renderer would have to find and rewrite in place.
+pub(super) fn split_math_segments(text: &str, math_blocks: &[String]) -> Vec<MathSegment> {
+    let mut segments = Vec::new();
+    let mut buf = String::new();
+    let mut chars = text.chars();
+
+    while let Some(c) = chars.next() {
+        if c != MATH_OPEN {
+            buf.push(c);
+            continue;
+        }
+        let mut token = String::new();
+        for tc in chars.by_ref() {
+            if tc == MATH_CLOSE {
+                break;
             }
-            other => other,
-        })
-        .collect()
+            token.push(tc);
+        }
+        let resolved = token
+            .strip_prefix("MATH")
+            .and_then(|idx| idx.parse::<usize>().ok())
+            .and_then(|idx| math_blocks.get(idx))
+            .and_then(|literal| strip_math_delimiters(literal));
+        // A malformed placeholder is dropped, matching `restore_math`.
+        if let Some((latex, display)) = resolved {
+            if !buf.is_empty() {
+                segments.push(MathSegment::Text(std::mem::take(&mut buf)));
+            }
+            segments.push(MathSegment::Math { latex, display });
+        }
+    }
+
+    if !buf.is_empty() {
+        segments.push(MathSegment::Text(buf));
+    }
+    segments
+}
+
+/// Strip the delimiters off a captured literal, yielding the LaTeX source and
+/// whether it typesets in display mode. `$$` is tested before `$` so display
+/// math isn't mistaken for inline math wrapping a `$`-delimited body.
+fn strip_math_delimiters(literal: &str) -> Option<(String, bool)> {
+    for (open, close, display) in [
+        ("$$", "$$", true),
+        ("\\[", "\\]", true),
+        ("\\(", "\\)", false),
+        ("$", "$", false),
+    ] {
+        if let Some(rest) = literal.strip_prefix(open) {
+            if let Some(inner) = rest.strip_suffix(close) {
+                return Some((inner.to_string(), display));
+            }
+        }
+    }
+    None
 }
 
 pub(super) fn restore_math(text: &str, math_blocks: &[String]) -> String {

--- a/frontend/src/components/markdown/math_span.rs
+++ b/frontend/src/components/markdown/math_span.rs
@@ -1,0 +1,75 @@
+use wasm_bindgen::JsCast;
+use yew::prelude::*;
+
+/// A single typeset math region — a leaf whose interior belongs to KaTeX.
+///
+/// **Why this is a childless element.** KaTeX renders by mutating the DOM. The
+/// previous design pointed KaTeX's `auto-render` extension at the whole
+/// rendered-markdown subtree, where it rewrote matching text nodes into
+/// `<span class="katex">` trees *in place*. Those nodes were Yew's: its bundle
+/// still referenced the text nodes KaTeX had replaced, so the next re-render —
+/// and streamed messages re-render on every token — computed an insert
+/// position against a node that was no longer a child of its parent.
+/// `insertBefore` then threw `NotFoundError`, which Yew turns into a panic
+/// (`failed to insert node before next sibling`) that aborts the whole WASM
+/// app, taking the dashboard down.
+///
+/// Rendering `<span>` with **no Yew children** fixes that at the root: Yew's
+/// bundle for this element is a single childless node, so Yew owns the element
+/// and KaTeX owns everything inside it, and neither one ever walks into the
+/// other's territory. Removal still works because dropping the element takes
+/// KaTeX's subtree with it — no orphaned nodes.
+#[derive(Properties, PartialEq)]
+pub(super) struct MathSpanProps {
+    /// LaTeX source, delimiters already stripped.
+    pub latex: String,
+    /// Display (block) vs. inline math.
+    pub display: bool,
+}
+
+#[function_component(MathSpan)]
+pub(super) fn math_span(props: &MathSpanProps) -> Html {
+    let node_ref = use_node_ref();
+
+    {
+        let node_ref = node_ref.clone();
+        use_effect_with(
+            (props.latex.clone(), props.display),
+            move |(latex, display)| {
+                if let Some(element) = node_ref.cast::<web_sys::Element>() {
+                    render_math_into(&element, latex, *display);
+                }
+                || ()
+            },
+        );
+    }
+
+    let class = if props.display {
+        "md-math md-math-display"
+    } else {
+        "md-math"
+    };
+    html! { <span ref={node_ref} class={class} /> }
+}
+
+/// Hand one math region to the JS helper, which typesets it into `element`
+/// (queueing until KaTeX's deferred script has evaluated). Silently a no-op if
+/// the helper isn't present — the helper leaves the LaTeX source as readable
+/// text in that case rather than showing an empty gap.
+fn render_math_into(element: &web_sys::Element, latex: &str, display: bool) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Ok(func) = js_sys::Reflect::get(&window, &"renderMathIntoNode".into()) else {
+        return;
+    };
+    let Ok(func) = func.dyn_into::<js_sys::Function>() else {
+        return;
+    };
+    let _ = func.call3(
+        &window,
+        element,
+        &latex.into(),
+        &wasm_bindgen::JsValue::from_bool(display),
+    );
+}

--- a/frontend/src/components/markdown/mod.rs
+++ b/frontend/src/components/markdown/mod.rs
@@ -5,11 +5,11 @@
 //! inline code, blockquotes, lists, and tables.
 
 use uuid::Uuid;
-use wasm_bindgen::JsCast;
 use yew::prelude::*;
 
 mod links;
 mod math;
+mod math_span;
 mod parser;
 mod portal_file_link;
 mod renderer;
@@ -23,7 +23,8 @@ use renderer::render_events;
 use links::{find_next_url, is_valid_url};
 #[cfg(test)]
 use math::{
-    extract_math_placeholders, restore_math, restore_math_in_events, MATH_CLOSE, MATH_OPEN,
+    extract_math_placeholders, restore_math, split_math_segments, MathSegment, MATH_CLOSE,
+    MATH_OPEN,
 };
 #[cfg(test)]
 use pulldown_cmark::{Event, Options, Parser, Tag};
@@ -55,29 +56,13 @@ struct MarkdownViewProps {
 
 #[function_component(MarkdownView)]
 fn markdown_view(props: &MarkdownViewProps) -> Html {
-    let node_ref = use_node_ref();
-
-    // After render, call the JS helper to render math in this subtree
-    {
-        let node_ref = node_ref.clone();
-        use_effect_with(props.text.clone(), move |_| {
-            if let Some(node) = node_ref.cast::<web_sys::Element>() {
-                if let Some(window) = web_sys::window() {
-                    if let Ok(func) = js_sys::Reflect::get(&window, &"renderMathInNode".into()) {
-                        if let Ok(func) = func.dyn_into::<js_sys::Function>() {
-                            let _ = func.call1(&window, &node);
-                        }
-                    }
-                }
-            }
-            || ()
-        });
-    }
-
-    let events = parse_markdown_events(&props.text);
+    // Math is typeset per-region by `MathSpan`, not by walking this subtree
+    // after render: KaTeX mutates the DOM, and pointing it at nodes Yew owns
+    // corrupted Yew's bundle and panicked the app on the next re-render.
+    let (events, math) = parse_markdown_events(&props.text);
 
     html! {
-        <span ref={node_ref}>{ render_events(&events, props.session_id) }</span>
+        <span>{ render_events(&events, props.session_id, &math) }</span>
     }
 }
 
@@ -247,6 +232,62 @@ mod tests {
         assert_eq!(restore_math(&out, &blocks), input);
     }
 
+    /// Helper: describe segments compactly so the assertions below read as
+    /// the sequence the renderer will emit.
+    fn segments_of(input: &str) -> Vec<String> {
+        let (out, blocks) = extract_math_placeholders(input);
+        split_math_segments(&out, &blocks)
+            .into_iter()
+            .map(|segment| match segment {
+                MathSegment::Text(text) => format!("text:{text}"),
+                MathSegment::Math { latex, display } => {
+                    let kind = if display { "display" } else { "inline" };
+                    format!("{kind}:{latex}")
+                }
+            })
+            .collect()
+    }
+
+    /// Each math region becomes its own segment so the renderer can give it a
+    /// dedicated element — the property that keeps KaTeX's DOM mutations off
+    /// nodes Yew owns (the `insertBefore` panic).
+    #[test]
+    fn math_segments_split_text_from_math() {
+        assert_eq!(
+            segments_of("So $\\sigma_{1D}$ is small."),
+            vec!["text:So ", "inline:\\sigma_{1D}", "text: is small."]
+        );
+    }
+
+    #[test]
+    fn math_segments_classify_display_mode() {
+        assert_eq!(segments_of("$$a+b$$"), vec!["display:a+b"]);
+        assert_eq!(segments_of("\\[a+b\\]"), vec!["display:a+b"]);
+        assert_eq!(segments_of("\\(a+b\\)"), vec!["inline:a+b"]);
+        assert_eq!(segments_of("$a+b$"), vec!["inline:a+b"]);
+    }
+
+    /// Prose with no math must stay a single text run — the renderer relies on
+    /// this to skip the split entirely for the overwhelmingly common case.
+    #[test]
+    fn math_segments_leave_plain_text_intact() {
+        assert_eq!(segments_of("no math here"), vec!["text:no math here"]);
+        // Dollar amounts are not math, so they never become segments.
+        assert_eq!(
+            segments_of("I have $5 and $10 left."),
+            vec!["text:I have $5 and $10 left."]
+        );
+    }
+
+    /// Adjacent regions must not merge, and a trailing text run must survive.
+    #[test]
+    fn math_segments_handle_multiple_regions() {
+        assert_eq!(
+            segments_of("$a$ and $$b$$ done"),
+            vec!["inline:a", "text: and ", "display:b", "text: done"]
+        );
+    }
+
     #[test]
     fn test_extract_math_skips_dollar_amounts() {
         // "$5 and $10" looks like inline math to a naïve scanner but isn't.
@@ -294,20 +335,19 @@ Where:\n\
         options.insert(Options::ENABLE_STRIKETHROUGH);
         let parser = Parser::new_ext(&pre_processed, options);
         let events: Vec<Event> = parser.collect();
-        let restored = restore_math_in_events(events, &math_blocks);
 
-        // The math content (`\rho`) must land in plain Text events so KaTeX
-        // auto-render can find the delimiters. If it ends up in `Event::Html`
-        // or `Event::InlineHtml`, KaTeX cannot find the math reliably.
-        let math_in_text = restored.iter().any(|e| match e {
-            Event::Text(t) => t.contains("\\rho"),
+        // The placeholders must land in plain Text events, where the renderer
+        // can split them out into their own `MathSpan` elements. If they end
+        // up in `Event::Html`/`Event::InlineHtml` the math is never typeset.
+        let math_in_text = events.iter().any(|e| match e {
+            Event::Text(t) => t.contains(MATH_OPEN),
             _ => false,
         });
-        let math_in_html = restored.iter().any(|e| match e {
-            Event::Html(t) | Event::InlineHtml(t) => t.contains("\\rho"),
+        let math_in_html = events.iter().any(|e| match e {
+            Event::Html(t) | Event::InlineHtml(t) => t.contains(MATH_OPEN),
             _ => false,
         });
-        assert!(math_in_text, "math should reach Event::Text");
+        assert!(math_in_text, "math placeholders should reach Event::Text");
         assert!(!math_in_html, "math should not leak into Event::Html");
     }
 

--- a/frontend/src/components/markdown/parser.rs
+++ b/frontend/src/components/markdown/parser.rs
@@ -1,24 +1,26 @@
 use pulldown_cmark::{Event, Options, Parser};
 
-use super::math::{extract_math_placeholders, restore_math_in_events};
+use super::math::extract_math_placeholders;
 
 /// Parse markdown into owned pulldown-cmark events after protecting math
 /// regions from markdown emphasis/link parsing.
-pub(super) fn parse_markdown_events(text: &str) -> Vec<Event<'static>> {
+///
+/// The math placeholders are deliberately **left in place** in the returned
+/// events; the renderer resolves them against the returned literals so each
+/// math region becomes its own element (see [`MathSpan`](super::math_span)).
+pub(super) fn parse_markdown_events(text: &str) -> (Vec<Event<'static>>, Vec<String>) {
     // Protect math regions ($…$, $$…$$, \(…\), \[…\]) from pulldown-cmark by
     // replacing them with private-use placeholders BEFORE parsing. Otherwise
     // pulldown-cmark would interpret `_` inside an equation as emphasis (and
-    // `*`, etc.) which splits the math text across DOM elements and prevents
-    // KaTeX's auto-render from matching the surrounding delimiters.
+    // `*`, etc.), splitting one equation across several DOM elements.
     let (pre_processed, math_blocks) = extract_math_placeholders(text);
 
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
     options.insert(Options::ENABLE_STRIKETHROUGH);
 
-    let events: Vec<Event> = Parser::new_ext(&pre_processed, options).collect();
-    restore_math_in_events(events, &math_blocks)
-        .into_iter()
+    let events: Vec<Event<'static>> = Parser::new_ext(&pre_processed, options)
         .map(Event::into_static)
-        .collect()
+        .collect();
+    (events, math_blocks)
 }

--- a/frontend/src/components/markdown/renderer.rs
+++ b/frontend/src/components/markdown/renderer.rs
@@ -5,16 +5,18 @@ use yew::prelude::*;
 use crate::components::copy_button::copy_to_clipboard;
 
 use super::links::linkify_urls;
+use super::math::{restore_math, split_math_segments, MathSegment, MATH_OPEN};
+use super::math_span::MathSpan;
 use super::portal_file_link::PortalFileLink;
 use super::sanitizer::{classify_link_destination, sanitize_raw_html, LinkDestination};
 
 /// Convert pulldown-cmark events to Yew Html.
-pub(super) fn render_events(events: &[Event], session_id: Option<Uuid>) -> Html {
+pub(super) fn render_events(events: &[Event], session_id: Option<Uuid>, math: &[String]) -> Html {
     let mut html_parts: Vec<Html> = Vec::new();
     let mut i = 0;
 
     while i < events.len() {
-        let (html, consumed) = render_event(&events[i..], session_id);
+        let (html, consumed) = render_event(&events[i..], session_id, math);
         html_parts.push(html);
         i += consumed;
     }
@@ -24,14 +26,14 @@ pub(super) fn render_events(events: &[Event], session_id: Option<Uuid>) -> Html 
 
 /// Render a single event or a group of related events.
 /// Returns (Html, number of events consumed).
-fn render_event(events: &[Event], session_id: Option<Uuid>) -> (Html, usize) {
+fn render_event(events: &[Event], session_id: Option<Uuid>, math: &[String]) -> (Html, usize) {
     if events.is_empty() {
         return (html! {}, 0);
     }
 
     match &events[0] {
-        Event::Start(tag) => render_tag(tag, events, session_id),
-        Event::Text(text) => (linkify_urls(text), 1),
+        Event::Start(tag) => render_tag(tag, events, session_id, math),
+        Event::Text(text) => (render_text_run(text, math), 1),
         Event::Code(code) => (
             html! { <code class="md-inline-code">{ linkify_urls(code) }</code> },
             1,
@@ -47,11 +49,38 @@ fn render_event(events: &[Event], session_id: Option<Uuid>) -> (Html, usize) {
     }
 }
 
+/// Render one text run, turning any math placeholders it carries into their
+/// own [`MathSpan`] elements and linkifying the prose around them.
+///
+/// Splitting here — rather than letting a DOM-mutating auto-renderer find math
+/// in the finished DOM — is what keeps KaTeX out of Yew's nodes; see
+/// [`MathSpan`] for why that mattered.
+fn render_text_run(text: &str, math: &[String]) -> Html {
+    if !text.contains(MATH_OPEN) {
+        return linkify_urls(text);
+    }
+    let parts: Vec<Html> = split_math_segments(text, math)
+        .into_iter()
+        .map(|segment| match segment {
+            MathSegment::Text(text) => linkify_urls(&text),
+            MathSegment::Math { latex, display } => html! {
+                <MathSpan latex={latex} display={display} />
+            },
+        })
+        .collect();
+    html! { <>{ for parts }</> }
+}
+
 /// Render a tag and its contents.
-fn render_tag(tag: &Tag, events: &[Event], session_id: Option<Uuid>) -> (Html, usize) {
+fn render_tag(
+    tag: &Tag,
+    events: &[Event],
+    session_id: Option<Uuid>,
+    math: &[String],
+) -> (Html, usize) {
     let end_tag = get_end_tag(tag);
     let (inner_events, total_consumed) = collect_until_end(events, &end_tag);
-    let inner_html = render_events(&inner_events, session_id);
+    let inner_html = render_events(&inner_events, session_id, math);
 
     let html = match tag {
         Tag::Paragraph => html! { <p class="md-paragraph">{ inner_html }</p> },
@@ -109,7 +138,9 @@ fn render_tag(tag: &Tag, events: &[Event], session_id: Option<Uuid>) -> (Html, u
             dest_url, title, ..
         } => {
             let src = dest_url.to_string();
-            let alt = extract_text(&inner_events);
+            // Alt text is a plain attribute, so math can't be typeset into it —
+            // restore the literal source rather than leaking a placeholder.
+            let alt = restore_math(&extract_text(&inner_events), math);
             let title_attr = if title.is_empty() {
                 None
             } else {
@@ -117,7 +148,7 @@ fn render_tag(tag: &Tag, events: &[Event], session_id: Option<Uuid>) -> (Html, u
             };
             html! { <img src={src} alt={alt} title={title_attr} class="md-image" /> }
         }
-        Tag::Table(alignments) => render_table(&inner_events, alignments, session_id),
+        Tag::Table(alignments) => render_table(&inner_events, alignments, session_id, math),
         Tag::TableHead => html! { <thead class="md-table-head">{ inner_html }</thead> },
         Tag::TableRow => html! { <tr class="md-table-row">{ inner_html }</tr> },
         Tag::TableCell => html! { <td class="md-table-cell">{ inner_html }</td> },
@@ -259,6 +290,7 @@ fn render_table(
     events: &[Event],
     alignments: &[pulldown_cmark::Alignment],
     session_id: Option<Uuid>,
+    math: &[String],
 ) -> Html {
     // Tables have: TableHead (with TableRow and TableCells), then TableRows with TableCells.
     // We need to process the events to build proper thead/tbody structure.
@@ -271,14 +303,14 @@ fn render_table(
         match &events[i] {
             Event::Start(Tag::TableHead) => {
                 let (inner, consumed) = collect_until_end(&events[i..], &TagEnd::TableHead);
-                let head_html = render_table_head(&inner, &alignments, session_id);
+                let head_html = render_table_head(&inner, &alignments, session_id, math);
                 parts.push(head_html);
                 i += consumed;
                 head_processed = true;
             }
             Event::Start(Tag::TableRow) if head_processed => {
                 let (inner, consumed) = collect_until_end(&events[i..], &TagEnd::TableRow);
-                let row_html = render_table_row(&inner, &alignments, session_id);
+                let row_html = render_table_row(&inner, &alignments, session_id, math);
                 parts.push(row_html);
                 i += consumed;
             }
@@ -308,6 +340,7 @@ fn render_table_cells(
     events: &[Event],
     alignments: &[pulldown_cmark::Alignment],
     session_id: Option<Uuid>,
+    math: &[String],
     is_header: bool,
 ) -> Vec<Html> {
     let mut cells: Vec<Html> = Vec::new();
@@ -318,7 +351,7 @@ fn render_table_cells(
         match &events[i] {
             Event::Start(Tag::TableCell) => {
                 let (inner, consumed) = collect_until_end(&events[i..], &TagEnd::TableCell);
-                let inner_html = render_events(&inner, session_id);
+                let inner_html = render_events(&inner, session_id, math);
                 let align = alignments
                     .get(col)
                     .copied()
@@ -347,8 +380,9 @@ fn render_table_head(
     events: &[Event],
     alignments: &[pulldown_cmark::Alignment],
     session_id: Option<Uuid>,
+    math: &[String],
 ) -> Html {
-    let cells = render_table_cells(events, alignments, session_id, true);
+    let cells = render_table_cells(events, alignments, session_id, math, true);
     html! { <thead class="md-table-head"><tr class="md-table-row">{ for cells }</tr></thead> }
 }
 
@@ -357,8 +391,9 @@ fn render_table_row(
     events: &[Event],
     alignments: &[pulldown_cmark::Alignment],
     session_id: Option<Uuid>,
+    math: &[String],
 ) -> Html {
-    let cells = render_table_cells(events, alignments, session_id, false);
+    let cells = render_table_cells(events, alignments, session_id, math, false);
     html! { <tr class="md-table-row">{ for cells }</tr> }
 }
 

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -573,3 +573,12 @@
     border-top: 1px solid var(--border-color);
 }
 
+
+/* Math regions typeset by KaTeX. The element is rendered childless by Yew
+   (see markdown/math_span.rs) — KaTeX owns everything inside it, which is
+   what keeps its DOM mutations out of Yew's bundle. Display math gets a
+   block wrapper so KaTeX's own `.katex-display` margins lay out predictably
+   inside an inline context. */
+.md-math-display {
+    display: block;
+}


### PR DESCRIPTION
Fixes the WASM abort reported from the portal console:

```
failed to insert node before next sibling
NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which
the new node is to be inserted is not a child of this node.
  ... yew::dom_bundle::position::DomSlot::insert
  ... <VTag as Reconcilable>::attach   <li class="md-list-item">
panicked at yew-0.21.0/src/dom_bundle/position.rs:122:21
Uncaught RuntimeError: unreachable
```

**Root cause.** `MarkdownView` ran KaTeX's `auto-render` extension over its whole rendered subtree after every render. That extension finds text nodes containing math delimiters and **replaces them in place** with `<span class="katex">` trees — but those were nodes Yew created and still tracked in its bundle. On the next re-render Yew computed an insert position from a node KaTeX had detached, `insertBefore` threw, and Yew's panic aborted the entire WASM app (the dashboard dies, not just the message).

Streaming makes this reliable rather than rare: a message re-renders on every token, so a growing list plus any text auto-render decided looked like math (its heuristics have no dollar-amount guard, unlike ours) crashes the page.

**Fix.** Math regions now render as their own `MathSpan` — an element Yew renders with **no children**, which KaTeX renders *into* via `katex.render`. Yew's bundle for it is a single childless node, so Yew owns the element and KaTeX owns its interior; neither walks the other's nodes, and removal still takes KaTeX's subtree with the element (no orphans).

To get there, math placeholders now survive markdown parsing (instead of being restored to literals for auto-render to re-discover) and the renderer splits text runs on them. That also makes the Rust-side scanner — which already skips fenced/inline code and dollar amounts — the single delimiter authority; `auto-render.min.js` is no longer loaded at all.

- `math.rs`: `split_math_segments` + delimiter stripping w/ display-mode classification; `restore_math_in_events` deleted (its consumer is gone), `restore_math` still used for image alt text.
- `math_span.rs` (new): the leaf component, with the why documented so it isn't "simplified" back into a subtree walk.
- `katex-helper.js`: renders one region into one element, queues until the deferred KaTeX script evaluates, and leaves the LaTeX source visible as text meanwhile. `trust: false` kept explicit — agent-authored math can't inject links.
- 4 new tests over the segment splitting (mixed prose/math, display-vs-inline for all four delimiter pairs, dollar amounts staying prose, adjacent regions).

trunk build + 611 frontend tests green; clippy clean.