### PR TITLE
Let SVG previews use the column width

### DIFF
--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -371,13 +371,31 @@
    aspect ratio, so the shrink-to-fit frame above sizes to the image while the
    image's `max-width: 100%` sizes to the frame. Browsers resolve that cycle at
    zero and the diagram renders 0x0: invisible, with no `onerror` to trigger the
-   "media expired" fallback. `min-width` breaks the cycle with a definite basis
-   without capping SVGs that *do* carry a size (a matplotlib plot still renders
-   at its full natural width). `min(100%, ...)` keeps it from overflowing a
-   narrow phone column. Frame class is set by `needs_size_fallback` in
-   frontend/src/components/message_renderer/renderers.rs. */
+   "media expired" fallback.
+
+   A `min-width: min(100%, 320px)` floor used to break that cycle, but the floor
+   then became the *actual* width: on any viewport wider than 320px the `min()`
+   resolves to 320px, so a 1380-wide diagram arrived as a 320px sliver. Give the
+   frame a definite full-width basis instead and let the image fill it — the
+   same reasoning the lightbox rule below already applies: an SVG is vector, so
+   scaling one up stays crisp. SVGs that *do* carry a pixel size now scale to
+   the column rather than stopping at their natural width, which is the wanted
+   behavior for a figure in a transcript. Frame class is set by
+   `needs_size_fallback` in
+   frontend/src/components/message_renderer/renderers/media.rs. */
 .tool-result-image.svg {
-    min-width: min(100%, 320px);
+    width: 100%;
+}
+
+.tool-result-image.svg img {
+    width: 100%;
+    height: auto;
+    /* `height: auto` keeps the aspect ratio, so the 600px cap above (which
+       stops large raster screenshots dominating the transcript) would letterbox
+       a tall diagram inside a full-width box instead of shrinking it. Cap
+       against the viewport instead; the lightbox is one click away for
+       anything taller. */
+    max-height: 80vh;
 }
 
 /* Video shown via `agent-portal show`. Sizing mirrors `.tool-result-image`


### PR DESCRIPTION
An SVG shown with `agent-portal show` arrived as a narrow sliver in the transcript.

**Cause.** A `viewBox`-only SVG (no `width`/`height` — the normal shape for a hand-authored diagram) has an aspect ratio but no intrinsic size. `.tool-result-image` is `width: fit-content` and its `img` is `max-width: 100%`, so frame and image size against each other; browsers resolve that cycle at zero and the diagram used to render 0×0. The fix for *that* was a `min-width: min(100%, 320px)` floor — but with nothing else supplying a width, the floor became the **actual** width: `min()` picks 320px on any viewport wider than 320px, so a 1380×980 diagram displayed at 320px.

**Fix.** Give the frame a definite full-width basis and let the image fill it, which is what the lightbox rule right below has always done, for the reason it already documents: an SVG is vector, so scaling up stays crisp.

```css
.tool-result-image.svg     { width: 100%; }
.tool-result-image.svg img { width: 100%; height: auto; max-height: 80vh; }
```

`height: auto` preserves aspect, which is why the `max-height: 600px` from the shared rule is overridden — inside a now-full-width box it would letterbox a tall diagram (side bands) rather than shrink it. The cap moves to the viewport instead, and the lightbox is one click away for anything taller.

Note this also changes SVGs that *do* declare a pixel size (e.g. a matplotlib export): they now scale to the column instead of stopping at natural width. For a figure in a transcript that's the wanted behavior, and it's lossless. Raster images are untouched — they keep shrink-to-fit and the 600px cap.

Comment rewritten to record why the floor was wrong so it doesn't get reinstated. Trunk build green.