### PR TITLE
Fix CSS Lint on main: blank line before comment

### DIFF
--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -390,6 +390,7 @@
 .tool-result-image.svg img {
     width: 100%;
     height: auto;
+
     /* `height: auto` keeps the aspect ratio, so the 600px cap above (which
        stops large raster screenshots dominating the transcript) would letterbox
        a tall diagram inside a full-width box instead of shrinking it. Cap


### PR DESCRIPTION
`main` is red on CSS Lint: stylelint's `comment-empty-line-before` rejected the inner comment added in #1644. That check isn't in the required set, so auto-merge landed the PR with it failing.

One blank line. Verified with the exact CI command — `cd frontend/lint && npm run lint:css` — which now reports clean.

Worth knowing for next time: the CSS lint is runnable locally (`frontend/lint`, stylelint + stylelint-config-standard) and isn't in the CLAUDE.md pre-push checklist, which is how I missed it.