### PR TITLE
Use agent-reported context windows

### DIFF
--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -53,6 +53,26 @@ const SESSION_LIMIT_TEXT: &str = "You've hit your session limit";
 const SESSION_LIMIT_CONTINUE_PROMPT: &str =
     "Continue from where you stopped before the Claude session limit was reached.";
 
+fn reported_model_context_window(
+    entries: Option<&std::collections::BTreeMap<String, claude_codes::io::ModelUsageEntry>>,
+    model: Option<&str>,
+) -> Option<i64> {
+    let model = model?;
+    let entries = entries?;
+    entries
+        .get(model)
+        .or_else(|| {
+            entries
+                .iter()
+                .find_map(|(name, entry)| name.eq_ignore_ascii_case(model).then_some(entry))
+        })
+        .and_then(|entry| {
+            i64::try_from(entry.context_window)
+                .ok()
+                .filter(|window| *window > 0)
+        })
+}
+
 #[derive(Debug)]
 struct EchoDropMarker {
     expected_text: String,
@@ -637,6 +657,17 @@ pub(crate) async fn claude_io_task(
                             state.clear_stale_echo_markers();
                             let usage = r.usage.as_ref();
                             let model = current_model.clone();
+                            // `model_usage` is the CLI-resolved, provider-aware
+                            // source of truth for the window that actually
+                            // served this turn. Prefer it over the backend's
+                            // model-name approximation: it captures native-1M
+                            // capability, beta entitlement, and proxy-host
+                            // environment resolution without duplicating the
+                            // CLI's private capability table (#1529/#1533).
+                            let model_context_window = reported_model_context_window(
+                                r.model_usage.as_ref(),
+                                model.as_deref(),
+                            );
                             let outcome = TurnOutcome {
                                 agent_type: shared::AgentType::Claude,
                                 model,
@@ -671,10 +702,7 @@ pub(crate) async fn claude_io_task(
                                 stop_reason: r.stop_reason.clone(),
                                 is_error: r.is_error,
                                 total_cost_usd: Some(r.total_cost_usd),
-                                // Claude's stream-json carries no window size;
-                                // `TurnMetrics::context_window` derives it from
-                                // the model id instead.
-                                model_context_window: None,
+                                model_context_window,
                             };
                             if let Some(metrics) = turn_tracker.finalize(
                                 Instant::now(),
@@ -1228,6 +1256,48 @@ mod tests {
         let usage = asst.message.usage.as_ref().expect("usage");
         // 10 + 2 + 3 = 15; the output token is deliberately not counted.
         assert_eq!(context_snapshot_tokens(usage), 15);
+    }
+
+    #[test]
+    fn reported_window_uses_cli_resolved_model_usage() {
+        let mut entries = std::collections::BTreeMap::new();
+        entries.insert(
+            "claude-opus-4-8".to_string(),
+            claude_codes::io::ModelUsageEntry {
+                context_window: 1_000_000,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            reported_model_context_window(Some(&entries), Some("claude-opus-4-8")),
+            Some(1_000_000)
+        );
+        // Model identifiers originate at different frames; tolerate casing
+        // drift without guessing between genuinely different model keys.
+        assert_eq!(
+            reported_model_context_window(Some(&entries), Some("CLAUDE-OPUS-4-8")),
+            Some(1_000_000)
+        );
+    }
+
+    #[test]
+    fn reported_window_rejects_missing_or_zero_values() {
+        let mut entries = std::collections::BTreeMap::new();
+        entries.insert(
+            "claude-sonnet-4-6".to_string(),
+            claude_codes::io::ModelUsageEntry::default(),
+        );
+
+        assert_eq!(
+            reported_model_context_window(Some(&entries), Some("claude-sonnet-4-6")),
+            None
+        );
+        assert_eq!(
+            reported_model_context_window(Some(&entries), Some("claude-opus-4-8")),
+            None
+        );
+        assert_eq!(reported_model_context_window(Some(&entries), None), None);
     }
 
     /// CLI-injected frames must never anchor context: the synthetic model, and

--- a/frontend/src/components/codex_renderer/events.rs
+++ b/frontend/src/components/codex_renderer/events.rs
@@ -249,7 +249,7 @@ impl CodexUsage {
     }
 
     pub(super) fn thread_total_tokens(&self) -> Option<u64> {
-        self.total.as_ref().and_then(|u| u.total_tokens)
+        self.total.as_ref().and_then(|usage| usage.total_tokens)
     }
 }
 

--- a/frontend/src/components/codex_renderer/turns.rs
+++ b/frontend/src/components/codex_renderer/turns.rs
@@ -2,6 +2,21 @@ use super::events::{CodexError, CodexUsage};
 use shared::fmt::format_duration;
 use yew::prelude::*;
 
+fn context_snapshot(
+    input_tokens: u64,
+    cached_input_tokens: u64,
+    context_window: Option<u64>,
+) -> Option<(u64, u64)> {
+    // Codex reports uncached and cached prompt tokens as disjoint buckets
+    // (the same convention used by CodexUsage::total_tokens). Both occupy the
+    // active context window, so omitting cache hits badly understates normal,
+    // cache-heavy turns.
+    let occupied = input_tokens.saturating_add(cached_input_tokens);
+    (occupied > 0)
+        .then_some(occupied)
+        .zip(context_window.filter(|window| *window > 0))
+}
+
 pub(super) fn render_turn_completed(
     usage: Option<&CodexUsage>,
     duration_ms: Option<u64>,
@@ -16,16 +31,20 @@ pub(super) fn render_turn_completed(
     let total = usage.map(CodexUsage::total_tokens).unwrap_or(0);
     let thread_total = usage.and_then(CodexUsage::thread_total_tokens);
     let context_window = usage.and_then(|u| u.model_context_window);
+    let context_snapshot = context_snapshot(input, cached, context_window);
 
     let mut tooltip = format!(
         "Input: {} | Output: {} | Cached: {} | Reasoning: {} | Total: {}",
         input, output, cached, reasoning, total
     );
+    if let Some((context_tokens, context_window)) = context_snapshot {
+        tooltip.push_str(&format!(
+            " | Context snapshot: {} / {}",
+            context_tokens, context_window
+        ));
+    }
     if let Some(thread_total) = thread_total {
         tooltip.push_str(&format!(" | Thread total: {}", thread_total));
-    }
-    if let Some(context_window) = context_window {
-        tooltip.push_str(&format!(" | Context window: {}", context_window));
     }
     let status_title = turn_id.unwrap_or("Codex turn").to_string();
 
@@ -81,10 +100,10 @@ pub(super) fn render_turn_completed(
                     }
                 }
                 {
-                    if let (Some(thread_total), Some(context_window)) = (thread_total, context_window) {
+                    if let Some((context_tokens, context_window)) = context_snapshot {
                         html! {
-                            <span class="stat-item turns" title="Thread tokens / model context window">
-                                { format!("{} / {} ctx", thread_total, context_window) }
+                            <span class="stat-item turns" title="Current context tokens / model context window">
+                                { format!("{} / {} ctx", context_tokens, context_window) }
                             </span>
                         }
                     } else {
@@ -137,5 +156,20 @@ pub(super) fn render_turn_failed(
             </div>
             { metrics_footer }
         </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::context_snapshot;
+
+    #[test]
+    fn context_display_uses_current_snapshot_not_lifetime_total() {
+        assert_eq!(
+            context_snapshot(72_000, 18_000, Some(200_000)),
+            Some((90_000, 200_000))
+        );
+        assert_eq!(context_snapshot(0, 0, Some(200_000)), None);
+        assert_eq!(context_snapshot(72_000, 18_000, None), None);
     }
 }

--- a/shared/src/api/metrics.rs
+++ b/shared/src/api/metrics.rs
@@ -111,10 +111,10 @@ pub struct TurnMetrics {
     pub total_cost_usd: Option<f64>,
 
     /// The model's context window in tokens, when the agent reports it. Codex
-    /// sends `model_context_window` on its wire, so codex turns carry it here.
-    /// Claude does not report a window, so claude turns leave this `None` and
-    /// [`TurnMetrics::context_window`] derives a nominal size from the model id
-    /// instead. Powers the context-usage gauge.
+    /// sends `model_context_window` directly; Claude carries the CLI-resolved
+    /// value in `ResultMessage.model_usage`. Older proxies leave this `None`,
+    /// so [`TurnMetrics::context_window`] retains the model-id fallback.
+    /// Powers the context-usage gauge.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_context_window: Option<i64>,
     /// Context occupancy at the end of the turn, from the LAST real assistant


### PR DESCRIPTION
Refs #1529
Refs #1533

## Summary
- derive Claude context windows from typed `ResultMessage.model_usage` instead of relying only on model-name approximations
- render Codex context occupancy from the current input snapshot rather than cumulative thread totals
- retain the existing Claude model table as a compatibility fallback for older proxies or missing usage metadata

## Verification
- `cargo test -p claude-session-lib --lib` (64 passed)
- `cargo test -p frontend --lib` (612 passed)
- `cargo clippy -p claude-session-lib -p frontend --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`