### PR TITLE
Use typed Muse command results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2480,6 +2480,7 @@ dependencies = [
  "gloo-net 0.6.0",
  "js-sys",
  "log",
+ "muse-codes",
  "pulldown-cmark 0.13.3",
  "serde",
  "serde_json",
@@ -4525,8 +4526,8 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.1.5"
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=6682946#6682946bd6871723ec54aac5ab235610201d3870"
+version = "0.1.7"
+source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=2137be7#2137be743254668381a34a3aa97f9ec463d7b4d5"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,11 +78,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # Claude Code integration
 claude-codes = { version = "2.1.223", default-features = false, features = ["types"] }
 
-# Codex CLI integration
-# Temporary git pin: 0.1.5 (full `muse exec` flag parity + MuseExecBuilder::extra_args
-# raw passthrough) is unpublished pending a crates.io release. Flip back to a version
-# pin once 0.1.5 publishes — the API is identical branch→crates.
-muse-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "6682946", default-features = false, features = ["async-client"] }
+# Muse CLI integration
+# Temporary git pin: 0.1.7 carries the typed command-result binding used by
+# the frontend. Flip back to a crates.io version once 0.1.7 publishes.
+muse-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "2137be7", default-features = false }
 codex-codes = { version = "0.146.4", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -20,6 +20,9 @@ codex-codes = { workspace = true }
 # model picker (same types-only, WASM-compat configuration).
 claude-codes = { workspace = true }
 
+# Typed Muse journal payloads (types-only so the frontend remains WASM-safe).
+muse-codes = { workspace = true }
+
 # Yew framework
 yew = { workspace = true }
 yew-router = { workspace = true }

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -9,7 +9,7 @@
 //! renders it here — so a live turn's ~100 journal records read as one
 //! structural view instead of a hundred raw-JSON bubbles.
 
-use serde::Deserialize;
+use muse_codes::CommandResult;
 use yew::prelude::*;
 
 use super::expandable::ExpandableText;
@@ -19,41 +19,16 @@ pub mod task_tree;
 
 pub use task_tree::{TaskNode, TaskState, TaskTree};
 
-/// Muse's `bash`/command tools pack a structured result into the otherwise
-/// opaque `tool.result.text` as a JSON object (muse-codes models `text` as a
-/// provider string — see its `ToolResult` — so this shape is muse's own
-/// encoding, not a typed SDK variant we can match on). When `text`
-/// deserializes into this with a non-empty `command`, we render a command card
-/// like the Claude/Codex bash cards instead of dumping the JSON. Any other
-/// `text` (e.g. `write_file`'s prose summary) fails to parse and falls back to
-/// plain text, so non-command tools are unaffected.
-///
-/// TODO(SDK meawoppl/rust-code-agent-sdks#294): replace this local
-/// deserialize with the typed command-result binding once `muse-codes` exposes
-/// one — this struct mirrors the shape reported there. Adoption tracked in
-/// agent-portal#1595.
-#[derive(Deserialize)]
-struct MuseCommandResult {
-    command: String,
-    #[serde(default)]
-    description: Option<String>,
-    #[serde(default)]
-    output: Option<String>,
-    #[serde(default)]
-    exit_code: Option<i64>,
-    #[serde(default)]
-    truncated: Option<bool>,
-}
-
 /// Recognize a command-execution `text` payload. Cheap guard first (only a JSON
-/// object can be one), then require a non-empty `command` so a stray JSON blob
-/// from some other tool doesn't get drawn as a shell command.
-fn parse_command_result(text: &str) -> Option<MuseCommandResult> {
+/// object can be one), then use muse-codes' provider-owned typed binding. The
+/// non-empty command guard prevents a stray future JSON blob from being drawn
+/// as a shell command.
+fn parse_command_result(text: &str) -> Option<CommandResult> {
     let trimmed = text.trim_start();
     if !trimmed.starts_with('{') {
         return None;
     }
-    serde_json::from_str::<MuseCommandResult>(trimmed)
+    serde_json::from_str::<CommandResult>(trimmed)
         .ok()
         .filter(|c| !c.command.trim().is_empty())
 }
@@ -62,21 +37,21 @@ fn parse_command_result(text: &str) -> Option<MuseCommandResult> {
 /// green/collapsible treatment the Claude/Codex tool results use — rather than
 /// printing the raw JSON muse packs into `text`. Intent first, then the `$`
 /// command line, then the collapsible output.
-fn render_command_card(cmd: &MuseCommandResult) -> Html {
+fn render_command_card(cmd: &CommandResult) -> Html {
     use crate::components::tool_renderers::CommandResultCard;
     // muse truncates long output itself and flags it; surface that as a note
     // appended to the output so the card doesn't imply it saw everything.
-    let output = match (cmd.output.as_deref(), cmd.truncated) {
-        (Some(o), Some(true)) => Some(format!("{o}\n[output truncated]")),
-        (Some(o), _) => Some(o.to_string()),
-        (None, _) => None,
+    let output = if cmd.truncated {
+        format!("{}\n[output truncated]", cmd.output)
+    } else {
+        cmd.output.clone()
     };
     html! {
         <CommandResultCard
             command={AttrValue::from(cmd.command.clone())}
-            description={cmd.description.clone().map(AttrValue::from)}
-            output={output.map(AttrValue::from)}
-            exit_code={cmd.exit_code}
+            description={Some(AttrValue::from(cmd.description.clone()))}
+            output={Some(AttrValue::from(output))}
+            exit_code={Some(i64::from(cmd.exit_code))}
         />
     }
 }
@@ -374,9 +349,9 @@ mod tests {
         let cmd = parse_command_result(&node.tool_results[0].text)
             .expect("bash tool text is a command result, not opaque prose");
         assert!(cmd.command.starts_with("curl -s -X POST"));
-        assert_eq!(cmd.exit_code, Some(0));
-        assert_eq!(cmd.truncated, Some(false));
-        assert!(cmd.output.as_deref().unwrap().contains("d99dce066453"));
+        assert_eq!(cmd.exit_code, 0);
+        assert!(!cmd.truncated);
+        assert!(cmd.output.contains("d99dce066453"));
     }
 
     #[test]

--- a/muse-session-lib/Cargo.toml
+++ b/muse-session-lib/Cargo.toml
@@ -12,7 +12,7 @@ shared = { path = "../shared" }
 # claude-codes types for the Input variant — even Muse sessions read user
 # input through that channel.
 claude-codes = { workspace = true, features = ["async-client"] }
-muse-codes = { workspace = true }
+muse-codes = { workspace = true, features = ["async-client"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/session-lib/Cargo.toml
+++ b/session-lib/Cargo.toml
@@ -13,7 +13,7 @@ shared = { path = "../shared" }
 # agent-agnostic at the runtime level.
 claude-codes = { workspace = true, features = ["async-client"] }
 # Muse auth probe (credentials_present / AuthFile) for the agent matrix.
-muse-codes = { workspace = true }
+muse-codes = { workspace = true, features = ["async-client"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Closes #1595

## Summary
- pin `muse-codes` to merged SDK PR #304 / v0.1.7
- replace the frontend-local Muse command-result mirror with the SDK `CommandResult` type
- preserve the shared `CommandResultCard` rendering and task-output de-duplication
- add a types-only frontend dependency and verify it on wasm32

## Verification
- `cargo test -p frontend muse_renderer --lib` (24 passed)
- `cargo clippy -p frontend --all-targets -- -D warnings`
- `cargo check -p frontend --target wasm32-unknown-unknown`
- `cargo fmt --all -- --check`
- `git diff --check`