### PR TITLE
Send the portal reminder at session start, for every agent

### DIFF
--- a/claude-session-lib/src/proxy_session/input_delivery.rs
+++ b/claude-session-lib/src/proxy_session/input_delivery.rs
@@ -7,6 +7,8 @@
 //! the connection loop. Display-event echo synthesis now lives in the agent
 //! I/O task so it enters the replay buffer before proxy forwarding.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use tokio::sync::oneshot;
 use tracing::{debug, error};
 use uuid::Uuid;
@@ -27,6 +29,7 @@ pub(super) async fn handle_input<A: Agent>(
     session_id: Uuid,
     working_directory: &str,
     git_metadata: &GitMetadataState,
+    reminder_pending: &AtomicBool,
     claude_session: &mut Session<A>,
     input: PortalInput,
 ) -> Option<ConnectionResult> {
@@ -40,6 +43,19 @@ pub(super) async fn handle_input<A: Agent>(
 
     debug!("sending to agent process: {}", truncate(&input.text, 100));
 
+    // First input of this agent process carries the portal-features reminder.
+    // `swap` makes the claim atomic, so a burst of queued inputs prefixes
+    // exactly one of them.
+    let (text, display_event) = if reminder_pending.swap(false, Ordering::SeqCst) {
+        super::portal_reminder::fold_session_start_reminder(
+            input.text,
+            input.display_event,
+            session_id,
+        )
+    } else {
+        (input.text, input.display_event)
+    };
+
     // Delivery stage: the proxy has the input and is about to hand it to the
     // agent (#939).
     emit_input_progress(
@@ -51,7 +67,7 @@ pub(super) async fn handle_input<A: Agent>(
     .await;
 
     let delivered = match claude_session
-        .enqueue_input_with_display(serde_json::Value::String(input.text), input.display_event)
+        .enqueue_input_with_display(serde_json::Value::String(text), display_event)
     {
         Ok(delivered) => delivered,
         Err(e) => {

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use portal_reminder::inject_portal_reminder;
 pub use wiggum::wiggum_prompt;
 pub use ws_reader::{classify_portal_input, RoutedPortalInput};
 
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -251,6 +252,12 @@ pub struct SessionState<'a, A: Agent> {
     pub backoff: Backoff,
     /// Whether this is the first connection attempt
     pub first_connection: bool,
+    /// Whether the portal-features reminder still needs to ride along with the
+    /// next user input. Lives here, not on `ConnectionState`, because it is
+    /// scoped to the agent PROCESS: a WS reconnect must not re-send it, but a
+    /// respawned agent must get it again. Shared with the per-connection state
+    /// so the input arms can clear it without a write-back.
+    pub reminder_pending: Arc<AtomicBool>,
     /// When the last disconnect occurred (for reporting reconnect duration)
     pub disconnected_at: Option<Instant>,
     /// Wall-clock UTC paired with `disconnected_at` for the reconnect text
@@ -279,6 +286,7 @@ impl<'a, A: Agent> SessionState<'a, A> {
             output_buffer,
             backoff: Backoff::new(),
             first_connection: true,
+            reminder_pending: Arc::new(AtomicBool::new(true)),
             disconnected_at: None,
             disconnected_at_utc: None,
             last_disconnect_graceful: false,
@@ -351,6 +359,8 @@ struct ConnectionState {
     working_directory: String,
     /// Active file uploads being received in chunks
     active_uploads: std::collections::HashMap<String, FileReceiveState>,
+    /// Shared with `SessionState` — see the field there.
+    reminder_pending: Arc<AtomicBool>,
     /// Agent type for tagging per-message wire output (proxy emission side)
     agent_type: shared::AgentType,
     /// Shared git metadata state for branch / PR / repo refreshes.
@@ -878,6 +888,7 @@ async fn run_message_loop<A: Agent>(
         file_download_rx,
         working_directory: config.working_directory.clone(),
         active_uploads: std::collections::HashMap::new(),
+        reminder_pending: session.reminder_pending.clone(),
         agent_type: config.agent_type,
         git_metadata,
         git_refresh: GitRefreshTrigger::default(),
@@ -1000,6 +1011,7 @@ async fn run_main_loop<A: Agent>(
                     state.session_id,
                     &state.working_directory,
                     &state.git_metadata,
+                    &state.reminder_pending,
                     claude_session,
                     input,
                 )
@@ -1017,6 +1029,7 @@ async fn run_main_loop<A: Agent>(
                     &state.working_directory,
                     &state.git_metadata,
                     &mut state.wiggum_state,
+                    &state.reminder_pending,
                     &state.output_buffer,
                     state.agent_type,
                     claude_session,

--- a/claude-session-lib/src/proxy_session/portal_reminder.rs
+++ b/claude-session-lib/src/proxy_session/portal_reminder.rs
@@ -62,6 +62,36 @@ fn agent_facing(body: &str) -> String {
     )
 }
 
+/// Fold the reminder into the session's **first** user input rather than
+/// sending it as an input of its own.
+///
+/// Injecting it standalone at session start would make the agent answer it:
+/// every agent here treats an input as a turn (muse literally spawns a `muse
+/// exec` run per input), so the user would get a reply to a message they never
+/// sent, before they had said anything. Riding along on the first real input
+/// costs no extra turn and reaches every agent type through the one funnel
+/// they all share ([`handle_input`](super::input_delivery::handle_input)).
+///
+/// Returns the agent-facing text plus the display event that must accompany
+/// it. The display event is essential, not cosmetic: the prefixed text now
+/// starts with `<system-reminder>`, and both the claude and codex echo paths
+/// suppress synthesized echoes for exactly that prefix — without an explicit
+/// display event the user's own message would vanish from the transcript.
+pub(super) fn fold_session_start_reminder(
+    text: String,
+    display_event: Option<serde_json::Value>,
+    session_id: uuid::Uuid,
+) -> (String, Option<serde_json::Value>) {
+    let display_event = display_event.or_else(|| {
+        Some(crate::io_task::claude_user_echo_value(
+            text.clone(),
+            session_id,
+        ))
+    });
+    let prefixed = format!("{}\n\n{}", agent_facing(&load_reminder_body()), text);
+    (prefixed, display_event)
+}
+
 /// Inject the reminder into the agent's stdin only. The user-bound copy was
 /// removed (#692): it bloated the scrollback for content the user already
 /// knew, and the agent-side reminder is the part that actually does work
@@ -76,5 +106,61 @@ pub async fn inject_portal_reminder<A: Agent>(claude_session: &mut Session<A>) {
         .await
     {
         error!("Failed to inject portal reminder into agent stdin: {}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    /// The agent must receive the reminder AND the user's words, in that
+    /// order, from a single input — the point of folding rather than sending
+    /// the reminder as a turn of its own.
+    #[test]
+    fn fold_prefixes_the_reminder_and_keeps_the_prompt() {
+        let (text, _) = fold_session_start_reminder("do the thing".to_string(), None, Uuid::nil());
+
+        assert!(text.starts_with("<system-reminder>"));
+        assert!(text.contains("Agent Portal version"));
+        assert!(text.ends_with("do the thing"));
+        // The reminder body itself came along, not just the envelope.
+        assert!(text.contains("agent-portal show"));
+    }
+
+    /// Regression guard for the transcript: the folded text starts with
+    /// `<system-reminder>`, which both the claude and codex echo paths use as
+    /// their "suppress the synthesized echo" signal. Without a display event
+    /// carrying the user's own words, their message would silently vanish.
+    #[test]
+    fn fold_supplies_a_display_event_so_the_user_message_still_renders() {
+        let (_, display) =
+            fold_session_start_reminder("hello agent".to_string(), None, Uuid::nil());
+
+        let display = display.expect("a display event is required, not optional");
+        assert_eq!(display["type"], "user");
+        assert!(
+            display.to_string().contains("hello agent"),
+            "display event must echo the user's text, got {display}"
+        );
+        assert!(
+            !display.to_string().contains("system-reminder"),
+            "the reminder must not leak into the transcript: {display}"
+        );
+    }
+
+    /// An input that already has a display event (an inter-agent message card)
+    /// keeps it — folding must not overwrite provenance with a plain echo.
+    #[test]
+    fn fold_preserves_an_existing_display_event() {
+        let provenance = serde_json::json!({"type": "portal", "content": [{"agent": "codex"}]});
+        let (text, display) = fold_session_start_reminder(
+            "relayed".to_string(),
+            Some(provenance.clone()),
+            Uuid::nil(),
+        );
+
+        assert_eq!(display, Some(provenance));
+        assert!(text.ends_with("relayed"));
     }
 }

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -89,6 +89,7 @@ pub(super) async fn handle_wiggum_activation<A: Agent>(
     working_directory: &str,
     git_metadata: &GitMetadataState,
     wiggum_state: &mut Option<WiggumState>,
+    reminder_pending: &std::sync::atomic::AtomicBool,
     output_buffer: &Arc<Mutex<PendingOutputBuffer>>,
     agent_type: AgentType,
     claude_session: &mut Session<A>,
@@ -133,8 +134,27 @@ pub(super) async fn handle_wiggum_activation<A: Agent>(
     )
     .await;
     let original_prompt = wiggum_input.text.clone();
-    let prompt = wiggum_prompt(&original_prompt);
-    let display_event = claude_user_echo_value(original_prompt.clone(), session_id);
+    // Wiggum is the other way a user input reaches the agent, so it claims the
+    // session-start reminder too (see `fold_session_start_reminder`). The
+    // display event is already the user's own prompt, so it survives.
+    let (prompt, display_event) = {
+        let framed = wiggum_prompt(&original_prompt);
+        let display = claude_user_echo_value(original_prompt.clone(), session_id);
+        if reminder_pending.swap(false, std::sync::atomic::Ordering::SeqCst) {
+            let (text, display) = super::portal_reminder::fold_session_start_reminder(
+                framed,
+                Some(display),
+                session_id,
+            );
+            (
+                text,
+                display
+                    .unwrap_or_else(|| claude_user_echo_value(original_prompt.clone(), session_id)),
+            )
+        } else {
+            (framed, display)
+        }
+    };
     *wiggum_state = Some(WiggumState {
         original_prompt,
         iteration: 1,

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -928,7 +928,13 @@ fn emit_user_input_display(
     display_event: Option<Box<serde_json::Value>>,
     event_tx: &mpsc::UnboundedSender<IoEvent>,
 ) {
-    if prompt.starts_with("<system-reminder>") {
+    // Order matters: an explicit display event wins over the reminder-prefix
+    // suppression below. The session-start reminder rides along on the FIRST
+    // user input (see claude-session-lib's `fold_session_start_reminder`), so
+    // that prompt both starts with `<system-reminder>` and carries the user's
+    // own words as its display event — suppressing it here would delete the
+    // user's message from the transcript.
+    if display_event.is_none() && prompt.starts_with("<system-reminder>") {
         return;
     }
     match display_event {


### PR DESCRIPTION
The portal-features reminder had exactly two injection sites, both compaction-gated — claude's compact boundary (`wiggum.rs`) and codex's `thread/compacted` (`session_event.rs`). That means:

- **Muse never received it at all** — no call site exists for it.
- **No session-start injection existed for anyone**, despite the module doc ("injected at session start and after each compaction boundary") and the CHANGELOG entry both claiming one. A session that never compacted never learned that `agent-portal show` / `forward` / `message` exist.

## Approach

The reminder now **folds into the session's first user input** rather than being sent as an input of its own.

Sending it standalone was the obvious implementation and is the wrong one: every agent here treats an input as a turn — muse literally spawns a `muse exec` run per input — so a standalone reminder makes the agent produce a reply to a message the user never sent, before they've said anything. Folding costs no extra turn, and it lands in `input_delivery::handle_input`, the single funnel all three agent types already share, so muse is covered by construction rather than by a third bespoke call site.

Compaction injection is unchanged.

## Details worth flagging in review

- **Flag scope.** `reminder_pending` lives on `SessionState` (created outside the reconnect loop) rather than `ConnectionState`, so a WebSocket reconnect does *not* re-send it, while a respawned agent does get it again. It's an `Arc<AtomicBool>` shared into the per-connection state so the input arms can clear it with no write-back, and `swap` makes the claim atomic — a burst of queued inputs prefixes exactly one.
- **The transcript would have broken without a display event.** The folded text starts with `<system-reminder>`, and *both* echo paths use that prefix as their "suppress the synthesized echo" signal (`should_suppress_synthetic_user_echo` in claude, the early return in codex's `emit_user_input_display`). So the fold always supplies a display event carrying the user's own words, and codex's suppression now yields to an explicit display event. Without that pairing the user's first message of every session would silently disappear.
- An input that already carries a display event (an inter-agent provenance card) keeps it — folding never overwrites provenance with a plain echo.
- Wiggum activation is the other input entry point, so it claims the reminder too.

3 tests over the fold (prefix + prompt preserved, display event synthesized and reminder-free, existing display event preserved). fmt/clippy clean, `claude-session-lib` 65 and `codex-session-lib` 35 tests green, launcher builds.

Note this also makes the stale module doc true for the first time.