### PR TITLE
Collapse system-reminder blocks into a clickable bar

### DIFF
--- a/frontend/src/components/markdown/mod.rs
+++ b/frontend/src/components/markdown/mod.rs
@@ -14,10 +14,12 @@ mod parser;
 mod portal_file_link;
 mod renderer;
 mod sanitizer;
+mod system_reminder;
 
 pub use links::linkify_urls;
 use parser::parse_markdown_events;
 use renderer::render_events;
+use system_reminder::{has_system_reminder, split_system_reminders, Segment, SystemReminderBar};
 
 #[cfg(test)]
 use links::{find_next_url, is_valid_url};
@@ -56,13 +58,35 @@ struct MarkdownViewProps {
 
 #[function_component(MarkdownView)]
 fn markdown_view(props: &MarkdownViewProps) -> Html {
+    // `<system-reminder>` blocks collapse into a clickable bar. Doing it here
+    // rather than in each agent's renderer is the point: every session type's
+    // text already flows through this component, so claude, codex and muse all
+    // get the same treatment from one place.
+    if has_system_reminder(&props.text) {
+        let parts: Vec<Html> = split_system_reminders(&props.text)
+            .into_iter()
+            .map(|segment| match segment {
+                Segment::Text(text) => render_markdown_body(&text, props.session_id),
+                Segment::Reminder(body) => html! {
+                    <SystemReminderBar body={body} />
+                },
+            })
+            .collect();
+        return html! { <span>{ for parts }</span> };
+    }
+
+    render_markdown_body(&props.text, props.session_id)
+}
+
+/// Render one run of ordinary markdown prose (no reminder blocks).
+fn render_markdown_body(text: &str, session_id: Option<Uuid>) -> Html {
     // Math is typeset per-region by `MathSpan`, not by walking this subtree
     // after render: KaTeX mutates the DOM, and pointing it at nodes Yew owns
     // corrupted Yew's bundle and panicked the app on the next re-render.
-    let (events, math) = parse_markdown_events(&props.text);
+    let (events, math) = parse_markdown_events(text);
 
     html! {
-        <span>{ render_events(&events, props.session_id, &math) }</span>
+        <span>{ render_events(&events, session_id, &math) }</span>
     }
 }
 

--- a/frontend/src/components/markdown/system_reminder.rs
+++ b/frontend/src/components/markdown/system_reminder.rs
@@ -1,0 +1,171 @@
+//! `<system-reminder>` blocks, rendered as a collapsed bar you can click into.
+//!
+//! These blocks are out-of-band context for the agent — the portal-features
+//! reminder, the inter-agent "reply to that agent, not the user" bumper, the
+//! CLI's own injected notices. They are genuinely useful to *see* (they explain
+//! why an agent did something), but they are noise inline: several are longer
+//! than the message carrying them.
+//!
+//! Splitting happens in [`MarkdownView`](super::MarkdownView), which every
+//! session type's text already flows through, so claude, codex and muse all get
+//! this from one pathway rather than three per-renderer special cases.
+//!
+//! The bar deliberately reuses the `.portal-reminder*` classes rather than
+//! minting a parallel set: that treatment (subtle teal, collapsed by default,
+//! header toggles) is already the established "notice you can click into" idiom
+//! in the transcript, and its `#7dcfff` matches the portal tick color.
+
+use yew::prelude::*;
+
+const OPEN_TAG: &str = "<system-reminder>";
+const CLOSE_TAG: &str = "</system-reminder>";
+
+/// One piece of a message: ordinary prose, or a reminder to collapse.
+#[derive(Debug, PartialEq)]
+pub(super) enum Segment {
+    Text(String),
+    Reminder(String),
+}
+
+/// Split `text` on `<system-reminder>` blocks.
+///
+/// An unterminated open tag is treated as prose, not as a reminder running to
+/// the end of the message: a truncated or malformed block should read as the
+/// literal text it is rather than swallowing everything after it into a bar.
+pub(super) fn split_system_reminders(text: &str) -> Vec<Segment> {
+    let mut segments = Vec::new();
+    let mut rest = text;
+
+    while let Some(open) = rest.find(OPEN_TAG) {
+        let after_open = open + OPEN_TAG.len();
+        let Some(close_rel) = rest[after_open..].find(CLOSE_TAG) else {
+            break;
+        };
+        let close = after_open + close_rel;
+
+        let before = &rest[..open];
+        if !before.trim().is_empty() {
+            segments.push(Segment::Text(before.to_string()));
+        }
+        segments.push(Segment::Reminder(
+            rest[after_open..close].trim().to_string(),
+        ));
+        rest = &rest[close + CLOSE_TAG.len()..];
+    }
+
+    if !rest.trim().is_empty() {
+        segments.push(Segment::Text(rest.to_string()));
+    }
+    segments
+}
+
+/// True when `text` holds at least one complete reminder block — lets the
+/// caller skip the split entirely for the overwhelmingly common case.
+pub(super) fn has_system_reminder(text: &str) -> bool {
+    text.find(OPEN_TAG)
+        .is_some_and(|open| text[open + OPEN_TAG.len()..].contains(CLOSE_TAG))
+}
+
+#[derive(Properties, PartialEq)]
+pub(super) struct SystemReminderBarProps {
+    /// Reminder contents, tags already stripped.
+    pub body: AttrValue,
+}
+
+#[function_component(SystemReminderBar)]
+pub(super) fn system_reminder_bar(props: &SystemReminderBarProps) -> Html {
+    let expanded = use_state(|| false);
+    let on_toggle = {
+        let expanded = expanded.clone();
+        Callback::from(move |_: MouseEvent| expanded.set(!*expanded))
+    };
+    let header_class = if *expanded {
+        "portal-reminder-header expanded"
+    } else {
+        "portal-reminder-header"
+    };
+
+    html! {
+        <div class="portal-reminder system-reminder-bar">
+            <button type="button" class={header_class} onclick={on_toggle}>
+                <span class="portal-reminder-icon">{ "\u{24D8}" }</span>
+                <span class="portal-reminder-title">{ "System reminder" }</span>
+                <span class="portal-reminder-toggle">
+                    { if *expanded { "\u{25BE}" } else { "\u{25B8}" } }
+                </span>
+            </button>
+            if *expanded {
+                // The body is rendered as plain text, not markdown: reminders
+                // are machine-authored and often contain literal angle
+                // brackets, backticks and paths that markdown would mangle.
+                <div class="portal-reminder-body system-reminder-body">{ &props.body }</div>
+            }
+        </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_prose_from_reminder() {
+        let segments =
+            split_system_reminders("before\n<system-reminder>\nnote\n</system-reminder>");
+        assert_eq!(
+            segments,
+            vec![
+                Segment::Text("before\n".to_string()),
+                Segment::Reminder("note".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn keeps_trailing_prose_and_handles_several_blocks() {
+        let segments = split_system_reminders(
+            "a<system-reminder>one</system-reminder>b<system-reminder>two</system-reminder>c",
+        );
+        assert_eq!(
+            segments,
+            vec![
+                Segment::Text("a".to_string()),
+                Segment::Reminder("one".to_string()),
+                Segment::Text("b".to_string()),
+                Segment::Reminder("two".to_string()),
+                Segment::Text("c".to_string()),
+            ]
+        );
+    }
+
+    /// A truncated block must read as literal text. Treating an unterminated
+    /// open tag as "reminder to end of message" would silently swallow real
+    /// content into a collapsed bar.
+    #[test]
+    fn unterminated_block_stays_prose() {
+        let text = "visible <system-reminder> never closed";
+        assert!(!has_system_reminder(text));
+        assert_eq!(
+            split_system_reminders(text),
+            vec![Segment::Text(text.to_string())]
+        );
+    }
+
+    #[test]
+    fn plain_text_is_untouched() {
+        assert!(!has_system_reminder("just prose"));
+        assert_eq!(
+            split_system_reminders("just prose"),
+            vec![Segment::Text("just prose".to_string())]
+        );
+    }
+
+    /// A message that is nothing but a reminder yields no empty prose segment.
+    #[test]
+    fn reminder_only_message_has_no_empty_text_segment() {
+        assert_eq!(
+            split_system_reminders("<system-reminder>solo</system-reminder>"),
+            vec![Segment::Reminder("solo".to_string())]
+        );
+    }
+}

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -229,7 +229,12 @@ pub(crate) fn agent_message_event_from_agent_facing_text(text: &str) -> Option<A
         return None;
     }
 
-    let text = strip_agent_message_reminder(body).trim_end().to_string();
+    // The reminder bumper is deliberately NOT stripped here any more: it flows
+    // through `MarkdownView`, which collapses `<system-reminder>` blocks into a
+    // clickable bar. Dropping it hid the "reply to that agent" instruction the
+    // recipient was acting on, which made inter-agent behavior hard to explain
+    // from the transcript alone.
+    let text = body.trim_end().to_string();
     if text.is_empty() {
         return None;
     }
@@ -239,13 +244,6 @@ pub(crate) fn agent_message_event_from_agent_facing_text(text: &str) -> Option<A
         from_session_id,
         text,
     })
-}
-
-fn strip_agent_message_reminder(body: &str) -> &str {
-    body.split_once("\n\n<system-reminder>")
-        .or_else(|| body.split_once("\n<system-reminder>"))
-        .map(|(message, _)| message)
-        .unwrap_or(body)
 }
 
 pub(crate) fn render_agent_message_event(
@@ -445,7 +443,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_message_event_from_agent_facing_text_strips_reminder() {
+    fn agent_message_event_from_agent_facing_text_keeps_reminder_for_the_bar() {
         let event = agent_message_event_from_agent_facing_text(
             "[message from codex e2d342f5-68c6-4134-a5d8-63cb4afcee9e]\n\
 Will do.\n\n\
@@ -460,7 +458,11 @@ This message came from another agent.\n\
             event.from_session_id,
             "e2d342f5-68c6-4134-a5d8-63cb4afcee9e"
         );
-        assert_eq!(event.text, "Will do.");
+        // The bumper is retained, not stripped: `MarkdownView` collapses it
+        // into a clickable system-reminder bar, so keeping it preserves the
+        // instruction the recipient acted on instead of hiding it.
+        assert!(event.text.starts_with("Will do."));
+        assert!(event.text.contains("<system-reminder>"));
     }
 
     #[test]

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1776,3 +1776,17 @@
     font-size: 0.7rem;
     color: var(--text-muted);
 }
+
+/* `<system-reminder>` blocks lifted out of any agent's message text (see
+   markdown/system_reminder.rs). It reuses `.portal-reminder*` for the bar
+   itself so every collapsed notice in the transcript reads as one family;
+   only the body differs, because reminder text is machine-authored and holds
+   literal paths, tags and commands that want a monospace, pre-wrapped face
+   rather than prose treatment. */
+.system-reminder-body {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--text-muted);
+}


### PR DESCRIPTION
`<system-reminder>` blocks were being handled three inconsistent ways: **stripped outright** from inter-agent message bodies (frontend), **suppressed** at the proxy echo, or **leaked into the transcript as literal text** wherever neither filter applied. They're worth seeing — they're often the reason an agent did something — but they're noise inline, frequently longer than the message carrying them.

## One pathway

The split happens in `MarkdownView`, which every session type's text already flows through, so claude, codex and muse are covered by construction rather than by three per-renderer special cases. Anything rendered as markdown anywhere in the transcript — user text, assistant text, portal messages, tool cards — gets the same treatment.

The bar reuses the existing `.portal-reminder*` classes rather than minting a parallel visual: collapsed-by-default, header toggles open, subtle teal (`#7dcfff`, the same hue as the portal tick). Only the body styling differs — monospace and `pre-wrap` — because reminder text is machine-authored and carries literal tags, paths and commands that prose treatment mangles. For the same reason the body renders as plain text, not markdown.

## Behavior change worth calling out

`strip_agent_message_reminder` is gone. Inter-agent cards previously **discarded** the "reply to that agent, not the user" bumper; it now rides along as a collapsed bar. That bumper is the instruction the recipient acted on, so dropping it was exactly the thing that made inter-agent exchanges hard to explain after the fact. The test that pinned the stripping now pins retention.

Not addressed here: the proxy-side echo suppression (claude's `should_suppress_synthetic_user_echo`, codex's `emit_user_input_display`) still prevents reminder-only inputs from reaching the transcript at all. That's deliberate — those are whole-message suppressions, not block-level, and unsuppressing them is a separate call about transcript volume.

5 tests on the splitter (prose/reminder split, several blocks, trailing prose, reminder-only, and an unterminated block staying literal rather than swallowing the rest of the message). 617 frontend tests, clippy, stylelint and trunk build all green.