### PR TITLE
Style the Fork button as a header chip

### DIFF
--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -155,6 +155,11 @@
         padding: 0.15rem 0.35rem;
     }
 
+    .session-view-header .session-header-action {
+        font-size: 0.7rem;
+        padding: 0.15rem 0.4rem;
+    }
+
     .session-view-header .status {
         font-size: 0.7rem;
         padding: 0.2rem 0.5rem;

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -89,6 +89,34 @@
     white-space: nowrap;
 }
 
+/* Header actions (Fork…) — a button, but it sits in the chip row, so it takes
+   the same chip geometry as `.session-launcher-version` / `.forward-chip`
+   rather than the browser default. Without this it rendered as a raw
+   system-styled button: light background, square corners, wrong font. */
+.session-view-header .session-header-action {
+    font-size: 0.78rem;
+    font-family: inherit;
+    color: var(--text-secondary);
+    padding: 0.2rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: rgba(187, 154, 247, 0.1);
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.session-view-header .session-header-action:hover {
+    color: var(--text-primary);
+    border-color: var(--accent);
+    background: rgba(187, 154, 247, 0.18);
+}
+
+.session-view-header .session-header-action:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
 /* Port-forward chips (docs/PORT_FORWARDING.md) */
 .session-view-header .session-forwards {
     display: inline-flex;


### PR DESCRIPTION
The `Fork…` button in the session header rendered with raw browser defaults — light background, square corners, system font — sitting immediately beside the version, forward and status chips, all of which are styled.

Cause: `.session-header-action` was never given any CSS. The class is applied in `session_view/component.rs` but matches no rule in any stylesheet, so the element fell through to the UA stylesheet. Same omission as the fork dialog (#1642) — the fork feature landed with its markup classed but unstyled.

It now takes the same chip geometry as `.session-launcher-version` and `.forward-chip` (0.78rem, 1px border, 4px radius, tinted background, `white-space: nowrap`), tinted purple to read as an action rather than a status, plus:

- a hover state (brighter text, accent border) since unlike its neighbours it's clickable,
- a `:focus-visible` ring, matching the treatment the launch dialog's buttons got in #1384,
- a mobile size-down alongside the sibling chips in `session-mobile.css`, so it doesn't dominate a narrow header.

CSS-only; stylelint and trunk build green.