### PR TITLE
Move system-reminder splitting into shared

### DIFF
--- a/frontend/src/components/markdown/mod.rs
+++ b/frontend/src/components/markdown/mod.rs
@@ -19,7 +19,8 @@ mod system_reminder;
 pub use links::linkify_urls;
 use parser::parse_markdown_events;
 use renderer::render_events;
-use system_reminder::{has_system_reminder, split_system_reminders, Segment, SystemReminderBar};
+use shared::system_reminder::{has_system_reminder, split_system_reminders, Segment};
+use system_reminder::SystemReminderBar;
 
 #[cfg(test)]
 use links::{find_next_url, is_valid_url};

--- a/frontend/src/components/markdown/system_reminder.rs
+++ b/frontend/src/components/markdown/system_reminder.rs
@@ -6,6 +6,11 @@
 //! why an agent did something), but they are noise inline: several are longer
 //! than the message carrying them.
 //!
+//! The splitting itself lives in [`shared::system_reminder`] (#1654), because
+//! the backend has to strip the same blocks before classifying message text and
+//! a splitter that disagreed with itself across the wire would show the user one
+//! thing and feed the classifier another. This module is only the rendering half.
+//!
 //! Splitting happens in [`MarkdownView`](super::MarkdownView), which every
 //! session type's text already flows through, so claude, codex and muse all get
 //! this from one pathway rather than three per-renderer special cases.
@@ -16,55 +21,6 @@
 //! in the transcript, and its `#7dcfff` matches the portal tick color.
 
 use yew::prelude::*;
-
-const OPEN_TAG: &str = "<system-reminder>";
-const CLOSE_TAG: &str = "</system-reminder>";
-
-/// One piece of a message: ordinary prose, or a reminder to collapse.
-#[derive(Debug, PartialEq)]
-pub(super) enum Segment {
-    Text(String),
-    Reminder(String),
-}
-
-/// Split `text` on `<system-reminder>` blocks.
-///
-/// An unterminated open tag is treated as prose, not as a reminder running to
-/// the end of the message: a truncated or malformed block should read as the
-/// literal text it is rather than swallowing everything after it into a bar.
-pub(super) fn split_system_reminders(text: &str) -> Vec<Segment> {
-    let mut segments = Vec::new();
-    let mut rest = text;
-
-    while let Some(open) = rest.find(OPEN_TAG) {
-        let after_open = open + OPEN_TAG.len();
-        let Some(close_rel) = rest[after_open..].find(CLOSE_TAG) else {
-            break;
-        };
-        let close = after_open + close_rel;
-
-        let before = &rest[..open];
-        if !before.trim().is_empty() {
-            segments.push(Segment::Text(before.to_string()));
-        }
-        segments.push(Segment::Reminder(
-            rest[after_open..close].trim().to_string(),
-        ));
-        rest = &rest[close + CLOSE_TAG.len()..];
-    }
-
-    if !rest.trim().is_empty() {
-        segments.push(Segment::Text(rest.to_string()));
-    }
-    segments
-}
-
-/// True when `text` holds at least one complete reminder block — lets the
-/// caller skip the split entirely for the overwhelmingly common case.
-pub(super) fn has_system_reminder(text: &str) -> bool {
-    text.find(OPEN_TAG)
-        .is_some_and(|open| text[open + OPEN_TAG.len()..].contains(CLOSE_TAG))
-}
 
 #[derive(Properties, PartialEq)]
 pub(super) struct SystemReminderBarProps {
@@ -101,71 +57,5 @@ pub(super) fn system_reminder_bar(props: &SystemReminderBarProps) -> Html {
                 <div class="portal-reminder-body system-reminder-body">{ &props.body }</div>
             }
         </div>
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn splits_prose_from_reminder() {
-        let segments =
-            split_system_reminders("before\n<system-reminder>\nnote\n</system-reminder>");
-        assert_eq!(
-            segments,
-            vec![
-                Segment::Text("before\n".to_string()),
-                Segment::Reminder("note".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn keeps_trailing_prose_and_handles_several_blocks() {
-        let segments = split_system_reminders(
-            "a<system-reminder>one</system-reminder>b<system-reminder>two</system-reminder>c",
-        );
-        assert_eq!(
-            segments,
-            vec![
-                Segment::Text("a".to_string()),
-                Segment::Reminder("one".to_string()),
-                Segment::Text("b".to_string()),
-                Segment::Reminder("two".to_string()),
-                Segment::Text("c".to_string()),
-            ]
-        );
-    }
-
-    /// A truncated block must read as literal text. Treating an unterminated
-    /// open tag as "reminder to end of message" would silently swallow real
-    /// content into a collapsed bar.
-    #[test]
-    fn unterminated_block_stays_prose() {
-        let text = "visible <system-reminder> never closed";
-        assert!(!has_system_reminder(text));
-        assert_eq!(
-            split_system_reminders(text),
-            vec![Segment::Text(text.to_string())]
-        );
-    }
-
-    #[test]
-    fn plain_text_is_untouched() {
-        assert!(!has_system_reminder("just prose"));
-        assert_eq!(
-            split_system_reminders("just prose"),
-            vec![Segment::Text("just prose".to_string())]
-        );
-    }
-
-    /// A message that is nothing but a reminder yields no empty prose segment.
-    #[test]
-    fn reminder_only_message_has_no_empty_text_segment() {
-        assert_eq!(
-            split_system_reminders("<system-reminder>solo</system-reminder>"),
-            vec![Segment::Reminder("solo".to_string())]
-        );
     }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -107,6 +107,10 @@ pub mod fmt;
 // Timezone canonicalization (abbreviation -> IANA) shared across crates
 pub mod timezone;
 
+// `<system-reminder>` splitting, shared by the frontend renderer (collapse to
+// a bar) and backend text classification (strip before summarizing)
+pub mod system_reminder;
+
 // Compact model-version extraction for the session-pill watermark
 pub mod model_version;
 pub use model_version::{compact_model_version, context_window_for};

--- a/shared/src/system_reminder.rs
+++ b/shared/src/system_reminder.rs
@@ -1,0 +1,173 @@
+//! Splitting `<system-reminder>` blocks out of message text.
+//!
+//! These blocks are out-of-band context for the agent — the portal-features
+//! reminder, the inter-agent "reply to that agent, not the user" bumper, the
+//! CLI's own injected notices. Two consumers need to separate them from the
+//! surrounding prose, for opposite reasons:
+//!
+//! - the **frontend** collapses them into a clickable bar, because they are
+//!   useful to *see* (they explain why an agent did something) but are noise
+//!   inline — several are longer than the message carrying them;
+//! - the **backend** strips them before classifying or summarizing message
+//!   text, because since #1649 the portal reminder is folded into the *first
+//!   user input* of every session rather than sent standalone, so anything
+//!   that treats a user message as prose would otherwise ingest the whole
+//!   reminder body.
+//!
+//! This lives in `shared` so those two stay in lockstep: a splitter that
+//! disagrees with itself across the wire would show the user one thing and
+//! feed the classifier another.
+
+/// One piece of a message: ordinary prose, or a reminder to collapse.
+#[derive(Debug, PartialEq)]
+pub enum Segment {
+    Text(String),
+    Reminder(String),
+}
+
+const OPEN_TAG: &str = "<system-reminder>";
+const CLOSE_TAG: &str = "</system-reminder>";
+
+/// Split `text` on `<system-reminder>` blocks.
+///
+/// An unterminated open tag is treated as prose, not as a reminder running to
+/// the end of the message: a truncated or malformed block should read as the
+/// literal text it is rather than swallowing everything after it into a bar.
+pub fn split_system_reminders(text: &str) -> Vec<Segment> {
+    let mut segments = Vec::new();
+    let mut rest = text;
+
+    while let Some(open) = rest.find(OPEN_TAG) {
+        let after_open = open + OPEN_TAG.len();
+        let Some(close_rel) = rest[after_open..].find(CLOSE_TAG) else {
+            break;
+        };
+        let close = after_open + close_rel;
+
+        let before = &rest[..open];
+        if !before.trim().is_empty() {
+            segments.push(Segment::Text(before.to_string()));
+        }
+        segments.push(Segment::Reminder(
+            rest[after_open..close].trim().to_string(),
+        ));
+        rest = &rest[close + CLOSE_TAG.len()..];
+    }
+
+    if !rest.trim().is_empty() {
+        segments.push(Segment::Text(rest.to_string()));
+    }
+    segments
+}
+
+/// True when `text` holds at least one complete reminder block — lets the
+/// caller skip the split entirely for the overwhelmingly common case.
+pub fn has_system_reminder(text: &str) -> bool {
+    text.find(OPEN_TAG)
+        .is_some_and(|open| text[open + OPEN_TAG.len()..].contains(CLOSE_TAG))
+}
+
+/// The prose of `text` with every complete reminder block removed.
+///
+/// The classifier-side counterpart to [`split_system_reminders`]: callers that
+/// only want "what did the human/agent actually say" get it without walking
+/// segments themselves.
+pub fn strip_system_reminders(text: &str) -> String {
+    if !has_system_reminder(text) {
+        return text.to_string();
+    }
+    split_system_reminders(text)
+        .into_iter()
+        .filter_map(|segment| match segment {
+            Segment::Text(text) => Some(text),
+            Segment::Reminder(_) => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_prose_from_reminder() {
+        let segments =
+            split_system_reminders("before\n<system-reminder>\nnote\n</system-reminder>");
+        assert_eq!(
+            segments,
+            vec![
+                Segment::Text("before\n".to_string()),
+                Segment::Reminder("note".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn keeps_trailing_prose_and_handles_several_blocks() {
+        let segments = split_system_reminders(
+            "a<system-reminder>one</system-reminder>b<system-reminder>two</system-reminder>c",
+        );
+        assert_eq!(
+            segments,
+            vec![
+                Segment::Text("a".to_string()),
+                Segment::Reminder("one".to_string()),
+                Segment::Text("b".to_string()),
+                Segment::Reminder("two".to_string()),
+                Segment::Text("c".to_string()),
+            ]
+        );
+    }
+
+    /// A truncated block must read as literal text. Treating an unterminated
+    /// open tag as "reminder to end of message" would silently swallow real
+    /// content into a collapsed bar.
+    #[test]
+    fn unterminated_block_stays_prose() {
+        let text = "visible <system-reminder> never closed";
+        assert!(!has_system_reminder(text));
+        assert_eq!(
+            split_system_reminders(text),
+            vec![Segment::Text(text.to_string())]
+        );
+    }
+
+    #[test]
+    fn plain_text_is_untouched() {
+        assert!(!has_system_reminder("just prose"));
+        assert_eq!(
+            split_system_reminders("just prose"),
+            vec![Segment::Text("just prose".to_string())]
+        );
+    }
+
+    /// A message that is nothing but a reminder yields no empty prose segment.
+    #[test]
+    fn reminder_only_message_has_no_empty_text_segment() {
+        assert_eq!(
+            split_system_reminders("<system-reminder>solo</system-reminder>"),
+            vec![Segment::Reminder("solo".to_string())]
+        );
+    }
+
+    /// The shape #1649 actually produces: reminder folded onto the front of
+    /// the user's own first message. Stripping must leave the user's words.
+    #[test]
+    fn strip_leaves_the_users_words_from_a_folded_first_input() {
+        let folded = "<system-reminder>\nAgent Portal version 2.13.0.\n\nbody\n</system-reminder>\n\ndo the thing";
+        assert_eq!(strip_system_reminders(folded).trim(), "do the thing");
+    }
+
+    #[test]
+    fn strip_is_identity_without_a_reminder() {
+        assert_eq!(strip_system_reminders("just prose"), "just prose");
+    }
+
+    /// An unterminated block is prose, so stripping must not eat it.
+    #[test]
+    fn strip_keeps_an_unterminated_block() {
+        let text = "visible <system-reminder> never closed";
+        assert_eq!(strip_system_reminders(text), text);
+    }
+}


### PR DESCRIPTION
The `<system-reminder>` splitter lived in the frontend markdown renderer, but the backend needs the same logic to strip these blocks before classifying or summarizing message text — the `is_narratable` filter in #1407 being the first consumer.

This matters more than a tidy-up because of #1649: the portal reminder is now folded into the **first user input** of every session rather than sent standalone, so any backend consumer treating a user message as prose would ingest the entire reminder body.

- `Segment`, `split_system_reminders`, `has_system_reminder` and their tests move to `shared::system_reminder`. Pure string operations, WASM-safe as-is.
- The Yew `SystemReminderBar` stays in the frontend and imports the splitter from shared, so there is one implementation rather than two that can drift.
- Adds `strip_system_reminders` as the classifier-side counterpart, with a test using the exact folded shape #1649 produces.

Closes #1654