### PR TITLE
Share a git test fixture and drop the sleep from worktree tests

### DIFF
--- a/session-lib/Cargo.toml
+++ b/session-lib/Cargo.toml
@@ -27,11 +27,17 @@ which = "8.0.0"
 ws-bridge = { workspace = true, features = ["native-client"] }
 base64 = "0.22.1"
 listeners = "0.6.0"
+# Optional so `git_fixtures` can be shared with other crates' tests via the
+# `test-fixtures` feature without pulling tempfile into production builds.
+tempfile = { version = "3.27.0", optional = true }
 
 # Unix-only: signal the agent's process group on stop/drop so the agent
 # process can't be orphaned when `kill_on_drop` doesn't fire (#927).
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[features]
+test-fixtures = ["dep:tempfile"]
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/session-lib/src/git_fixtures.rs
+++ b/session-lib/src/git_fixtures.rs
@@ -1,0 +1,176 @@
+//! Throwaway git repositories for tests (#1656).
+//!
+//! Everything in [`git_metadata`](crate::git_metadata) shells out to real
+//! `git`, so testing it means having a real repository to point at. Pinning a
+//! branch of this repo would produce tests that drift as history moves, so
+//! instead each test builds the exact shape it needs in a tempdir and throws
+//! it away.
+//!
+//! This started as a helper local to one test and is shared because #1407's
+//! commit-walk harness needs the same thing.
+//!
+//! Two deliberate choices make this reproducible on any machine and in CI:
+//!
+//! - **The ambient git config is neutralized.** `GIT_CONFIG_GLOBAL` and
+//!   `GIT_CONFIG_SYSTEM` are pointed at `/dev/null` and identity comes from
+//!   `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env vars, so a developer's global
+//!   `commit.gpgsign`, `init.defaultBranch`, or hooks cannot reach in and fail
+//!   the run.
+//! - **mtimes are set explicitly, never slept for.** Worktree activity
+//!   ordering (#1067) is decided by the mtime of each worktree's `logs/HEAD`.
+//!   Sleeping past filesystem timestamp granularity would be both slow and
+//!   flaky, so [`GitFixture::age_head_log`] backdates a reflog directly.
+//!
+//! Available to other crates via the `test-fixtures` feature; on by default
+//! inside this crate's own `cfg(test)`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime};
+
+use tempfile::TempDir;
+
+/// A disposable git repository. Deleted when dropped, along with any linked
+/// worktrees created under it.
+pub struct GitFixture {
+    dir: TempDir,
+}
+
+impl GitFixture {
+    /// A repository on branch `main` with one commit.
+    ///
+    /// The initial commit matters: `git rev-parse --abbrev-ref HEAD` reports
+    /// the branch on an unborn HEAD too, but `git worktree add` refuses to run
+    /// until there is a commit to base one on.
+    pub fn new() -> Self {
+        let dir = TempDir::new().expect("create tempdir for git fixture");
+        std::fs::create_dir(dir.path().join("repo")).expect("create repo dir");
+        let fixture = Self { dir };
+        fixture.git(&fixture.root(), &["init", "-q", "-b", "main"]);
+        fixture.commit("initial");
+        fixture
+    }
+
+    /// Repository root — a `repo/` subdirectory of the tempdir, so linked
+    /// worktrees can be created as siblings rather than nested inside the
+    /// working tree they belong to.
+    pub fn root(&self) -> PathBuf {
+        self.dir.path().join("repo")
+    }
+
+    /// The tempdir containing [`root`](Self::root) and any linked worktrees.
+    pub fn base(&self) -> &Path {
+        self.dir.path()
+    }
+
+    /// Run `git` in `cwd`, panicking with git's own stderr on failure — a
+    /// fixture that fails silently produces a confusing downstream assertion
+    /// rather than a readable error.
+    pub fn git(&self, cwd: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env("GIT_AUTHOR_NAME", "Fixture")
+            .env("GIT_AUTHOR_EMAIL", "fixture@example.invalid")
+            .env("GIT_COMMITTER_NAME", "Fixture")
+            .env("GIT_COMMITTER_EMAIL", "fixture@example.invalid")
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run git {args:?}: {e}"));
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    /// An empty commit on the current branch — enough for branch and worktree
+    /// detection, which never look at trees.
+    pub fn commit(&self, message: &str) {
+        self.git(
+            &self.root(),
+            &[
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                message,
+                "--no-gpg-sign",
+            ],
+        );
+    }
+
+    /// Create and check out a new branch in the main checkout.
+    pub fn checkout_new_branch(&self, name: &str) {
+        self.git(&self.root(), &["checkout", "-q", "-b", name]);
+    }
+
+    /// Detach HEAD at the current commit.
+    pub fn detach_head(&self) {
+        self.git(&self.root(), &["checkout", "-q", "--detach"]);
+    }
+
+    /// Add a linked worktree on a new branch, as a sibling of the repo.
+    /// Returns its path.
+    pub fn add_worktree(&self, dir_name: &str, branch: &str) -> PathBuf {
+        let path = self.base().join(dir_name);
+        let path_str = path.to_string_lossy().to_string();
+        self.git(
+            &self.root(),
+            &["worktree", "add", "-q", "-b", branch, &path_str],
+        );
+        path
+    }
+
+    /// Backdate a checkout's reflog so another worktree reads as more recently
+    /// active.
+    ///
+    /// Worktree activity ranking keys on the mtime of `logs/HEAD` within each
+    /// worktree's git dir — a plain directory for the main checkout, and a
+    /// `gitdir:` pointer file for a linked one. Setting the timestamp directly
+    /// keeps the ordering exact instead of depending on filesystem timestamp
+    /// resolution.
+    pub fn age_head_log(&self, worktree_root: &Path, by: Duration) {
+        let dot_git = worktree_root.join(".git");
+        let git_dir = if dot_git.is_file() {
+            let contents = std::fs::read_to_string(&dot_git).expect("read gitdir pointer");
+            PathBuf::from(
+                contents
+                    .strip_prefix("gitdir:")
+                    .expect("gitdir pointer is well-formed")
+                    .trim(),
+            )
+        } else {
+            dot_git
+        };
+
+        // Mirror `head_mtime`'s own fallback: the per-worktree reflog when it
+        // exists, `HEAD` in reflog-disabled repos.
+        let log = git_dir.join("logs/HEAD");
+        let target = if log.exists() {
+            log
+        } else {
+            git_dir.join("HEAD")
+        };
+
+        let file = std::fs::File::options()
+            .write(true)
+            .open(&target)
+            .unwrap_or_else(|e| panic!("open {} for mtime update: {e}", target.display()));
+        let when = SystemTime::now() - by;
+        file.set_times(
+            std::fs::FileTimes::new()
+                .set_accessed(when)
+                .set_modified(when),
+        )
+        .expect("set reflog mtime");
+    }
+}
+
+impl Default for GitFixture {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/session-lib/src/git_metadata.rs
+++ b/session-lib/src/git_metadata.rs
@@ -279,31 +279,21 @@ pub fn get_open_prs(cwd: &str) -> Vec<PrRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let out = std::process::Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@t")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@t")
-            .output()
-            .expect("git runs");
-        assert!(out.status.success(), "git {args:?}: {out:?}");
-    }
+    use crate::git_fixtures::GitFixture;
+    use std::time::Duration;
 
     /// #1067: a sibling worktree with more recent HEAD activity surfaces as
     /// the active branch — in the display composite AND as the PR-lookup
     /// branch — and drops back out when the main checkout is active again.
+    ///
+    /// Activity ordering is set by backdating reflog mtimes rather than
+    /// sleeping past filesystem timestamp granularity: the ranking is exactly
+    /// what the assertions describe, and the test costs no wall-clock time.
     #[test]
     fn branch_info_surfaces_most_recently_active_worktree() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let repo = tmp.path().join("repo");
-        std::fs::create_dir(&repo).unwrap();
-        git(&repo, &["init", "-q", "-b", "main"]);
-        git(&repo, &["commit", "-q", "--allow-empty", "-m", "init"]);
-        let cwd = repo.to_str().unwrap();
+        let fixture = GitFixture::new();
+        let root = fixture.root();
+        let cwd = root.to_str().expect("utf-8 tempdir path");
 
         // Single worktree: plain branch, no composite.
         let info = get_branch_info(cwd).expect("in a repo");
@@ -312,32 +302,46 @@ mod tests {
         assert_eq!(info.display(), "main");
         assert_eq!(info.pr_branch(), "main");
 
-        // Add a worktree; its HEAD was just written, so it's the most
-        // recently active checkout.
-        let side = tmp.path().join("side");
-        git(
-            &repo,
-            &[
-                "worktree",
-                "add",
-                "-q",
-                side.to_str().unwrap(),
-                "-b",
-                "feature-side",
-            ],
-        );
+        // Add a worktree, then age the main checkout so the worktree is
+        // unambiguously the more recently active one.
+        let side = fixture.add_worktree("side", "feature-side");
+        fixture.age_head_log(&root, Duration::from_secs(60));
+
         let info = get_branch_info(cwd).expect("in a repo");
         assert_eq!(info.checkout, "main");
         assert_eq!(info.active_worktree.as_deref(), Some("feature-side"));
         assert_eq!(info.display(), "main (+ feature-side)");
         assert_eq!(info.pr_branch(), "feature-side");
 
-        // Activity moves back to the main checkout (HEAD rewritten):
-        // the composite drops away.
-        std::thread::sleep(std::time::Duration::from_millis(1100));
-        git(&repo, &["commit", "-q", "--allow-empty", "-m", "more"]);
+        // Activity moves back to the main checkout: the composite drops away.
+        fixture.age_head_log(&side, Duration::from_secs(120));
         let info = get_branch_info(cwd).expect("in a repo");
         assert_eq!(info.active_worktree, None, "cwd is the active checkout");
         assert_eq!(info.display(), "main");
+    }
+
+    /// A detached HEAD has no branch name to show, so the checkout reads as
+    /// `detached:<short sha>` rather than git's literal `HEAD`.
+    #[test]
+    fn detached_head_reports_a_short_sha() {
+        let fixture = GitFixture::new();
+        fixture.detach_head();
+        let root = fixture.root();
+        let info = get_branch_info(root.to_str().expect("utf-8 path")).expect("in a repo");
+
+        assert!(
+            info.checkout.starts_with("detached:"),
+            "expected a detached marker, got {}",
+            info.checkout
+        );
+        assert_ne!(info.checkout, "detached:", "the short sha must be present");
+    }
+
+    /// Outside a repository there is no branch info at all — the callers use
+    /// `None` to mean "not a git checkout", not "unknown branch".
+    #[test]
+    fn non_repository_has_no_branch_info() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(get_branch_info(tmp.path().to_str().expect("utf-8 path")).is_none());
     }
 }

--- a/session-lib/src/lib.rs
+++ b/session-lib/src/lib.rs
@@ -24,6 +24,11 @@ pub mod adapter;
 pub mod agent;
 pub mod buffer;
 pub mod error;
+/// Throwaway git repositories for tests. Behind a feature so consumers can opt
+/// in (`session-lib = { features = ["test-fixtures"] }`) without shipping
+/// `tempfile` into production builds; always on for this crate's own tests.
+#[cfg(any(test, feature = "test-fixtures"))]
+pub mod git_fixtures;
 pub mod git_metadata;
 pub mod heartbeat;
 pub mod install;


### PR DESCRIPTION
The issue as filed said nothing exercised git against a real repository; that was wrong — `branch_info_surfaces_most_recently_active_worktree` already did. The real problems with it were narrower, and are what this fixes:

1. **An 1100ms sleep** forced mtime ordering between two worktrees. Slow, and a guess at what the filesystem will round timestamps to.
2. **Ambient git config was not neutralized.** The local helper set `GIT_AUTHOR_*`/`GIT_COMMITTER_*` but not `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`, so a global `commit.gpgsign`, non-`main` `init.defaultBranch`, or hooks could fail it for reasons unrelated to the code.
3. **The helper was file-local**, so nothing else could reuse it — which is what #1407's commit-walk harness needs.

## Change

- `GitFixture` in `session-lib`, behind a `test-fixtures` feature so other crates can opt in. `tempfile` becomes an optional dependency, so production builds are unaffected; the module is always available inside this crate's own `cfg(test)`.
- Activity ordering comes from `age_head_log`, which backdates a reflog mtime directly — mirroring `head_mtime`'s own `logs/HEAD` → `HEAD` fallback, and handling both a plain `.git` directory and a linked worktree's `gitdir:` pointer file.
- The existing test migrates onto it unchanged in meaning. **1.1s → 0.04s.**
- New coverage: detached HEAD reports `detached:<short sha>` rather than git's literal `HEAD`, and a non-repository directory yields `None`.

Closes #1656