### PR TITLE
Restore agent install and login settings

### DIFF
--- a/frontend/src/pages/settings/agents_panel.rs
+++ b/frontend/src/pages/settings/agents_panel.rs
@@ -5,7 +5,7 @@
 //!
 //! A new user's first question is "what do I still need to set up, and where?".
 //! This pane answers it as a **computer × agent** grid: one row per launcher
-//! (host), one column per agent (Claude / Codex), each cell showing whether the
+//! (host), one column per agent (Claude / Codex / Muse), each cell showing whether the
 //! CLI is installed and whether it's signed in (+ the account label when the
 //! agent exposes one). Data comes from the existing per-launcher probe
 //! (`/api/launchers/{id}/probe-agents`), fanned across the user's launchers;
@@ -44,7 +44,11 @@ struct InstallTarget {
 }
 
 /// Columns of the matrix, in display order. Mirrors `AgentType`.
-const AGENTS: [(AgentType, &str); 2] = [(AgentType::Claude, "Claude"), (AgentType::Codex, "Codex")];
+const AGENTS: [(AgentType, &str); 3] = [
+    (AgentType::Claude, "Claude"),
+    (AgentType::Codex, "Codex"),
+    (AgentType::Muse, "Muse"),
+];
 
 /// Per-launcher probe outcome. The whole map is set once, after every probe
 /// resolves, so a launcher is either absent from the map (still loading, whole
@@ -294,7 +298,11 @@ fn sign_in_button(
     launcher_id: Uuid,
     on_sign_in: &Callback<LoginTarget>,
 ) -> Option<Html> {
-    if matches!(login, AgentLoginStatus::LoggedIn { .. }) {
+    // Muse can be installed and its credential state is probed, but the
+    // launcher-side interactive device-flow driver is not wired yet. Do not
+    // offer a button that can only fail; host/env login remains visible after
+    // Refresh and Claude/Codex retain the complete in-portal flow.
+    if agent == AgentType::Muse || matches!(login, AgentLoginStatus::LoggedIn { .. }) {
         return None;
     }
     let target = LoginTarget {
@@ -367,5 +375,19 @@ mod tests {
             login_summary(&AgentLoginStatus::Unknown).1,
             login_summary(&AgentLoginStatus::LoggedOut).1
         );
+    }
+
+    #[test]
+    fn matrix_covers_every_agent_without_offering_broken_muse_login() {
+        assert_eq!(AGENTS.len(), 3);
+        assert!(AGENTS.iter().any(|(agent, _)| *agent == AgentType::Muse));
+        assert!(sign_in_button(
+            &AgentLoginStatus::LoggedOut,
+            AgentType::Muse,
+            "Muse",
+            Uuid::nil(),
+            &Callback::noop(),
+        )
+        .is_none());
     }
 }

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -1,4 +1,7 @@
 mod account_panel;
+mod agent_install;
+mod agent_login;
+mod agents_panel;
 mod appearance_panel;
 mod forwarding_panel;
 mod health_timer_panel;
@@ -12,6 +15,7 @@ mod tokens_panel;
 
 use crate::utils;
 use account_panel::AccountPanel;
+use agents_panel::AgentsPanel;
 use appearance_panel::AppearancePanel;
 use forwarding_panel::ForwardingPanel;
 use health_timer_panel::HealthTimerPanel;
@@ -27,6 +31,7 @@ use yew::prelude::*;
 #[derive(Clone, Copy, PartialEq)]
 enum SettingsTab {
     Account,
+    Agents,
     Sessions,
     Tokens,
     Launchers,
@@ -72,6 +77,7 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
         Callback::from(move |_: MouseEvent| active_tab.set(tab))
     };
     let on_account_tab = make_tab_handler(SettingsTab::Account);
+    let on_agents_tab = make_tab_handler(SettingsTab::Agents);
     let on_sessions_tab = make_tab_handler(SettingsTab::Sessions);
     let on_tokens_tab = make_tab_handler(SettingsTab::Tokens);
     let on_launchers_tab = make_tab_handler(SettingsTab::Launchers);
@@ -105,6 +111,12 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                     onclick={on_account_tab}
                 >
                     { "Account" }
+                </button>
+                <button
+                    class={classes!("tab-button", (*active_tab == SettingsTab::Agents).then_some("active"))}
+                    onclick={on_agents_tab}
+                >
+                    { "Agents" }
                 </button>
                 <button
                     class={classes!("tab-button", (*active_tab == SettingsTab::Sessions).then_some("active"))}
@@ -169,6 +181,9 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
             <main class="settings-content">
                 if *active_tab == SettingsTab::Account {
                     <AccountPanel />
+                }
+                if *active_tab == SettingsTab::Agents {
+                    <AgentsPanel />
                 }
                 if *active_tab == SettingsTab::Tokens {
                     <TokensPanel on_tokens_loaded={on_tokens_loaded} />

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -1076,6 +1076,230 @@
 }
 
 /* ==========================================================================
+   Agent installation and login
+   ========================================================================== */
+
+/* Agent installation/login matrix and its shared confirmation modal. */
+.agents-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    overflow-x: auto;
+}
+
+.link-button {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--accent);
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.agents-matrix {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.agents-matrix th,
+.agents-matrix td {
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+    vertical-align: top;
+}
+
+.agents-matrix th,
+.agents-host-alias,
+.agents-cell.unreachable,
+.agents-cell.unknown,
+.agents-cell.loading {
+    color: var(--text-secondary);
+}
+
+.agents-host-name,
+.agent-install-command,
+.agent-login-device-code {
+    font-family: var(--font-mono, monospace);
+}
+
+.agents-host-alias {
+    margin-left: 0.4rem;
+    font-size: 0.8rem;
+}
+
+.agents-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.agents-badge {
+    width: fit-content;
+    padding: 0.05rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+}
+
+.agents-badge.installed,
+.agents-login.logged-in,
+.agent-login-status.success {
+    color: var(--success, #9ece6a);
+}
+
+.agents-badge.installed {
+    background: color-mix(in srgb, var(--success, #9ece6a) 20%, transparent);
+}
+
+.agents-badge.missing,
+.agents-login.logged-out,
+.agent-login-status.error {
+    color: var(--error, #f7768e);
+}
+
+.agents-badge.missing {
+    background: color-mix(in srgb, var(--error, #f7768e) 18%, transparent);
+}
+
+.agents-login {
+    font-size: 0.8rem;
+}
+
+.agents-login.unknown {
+    color: var(--text-secondary);
+}
+
+.agents-signin,
+.agent-login-submit {
+    width: fit-content;
+    padding: 0.25rem 0.65rem;
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--accent);
+    cursor: pointer;
+}
+
+.agents-signin {
+    margin-top: 0.15rem;
+    font-size: 0.75rem;
+}
+
+.agents-signin:hover,
+.agent-login-submit:hover {
+    background: color-mix(in srgb, var(--accent) 15%, transparent);
+}
+
+.agent-login-overlay {
+    position: fixed;
+    z-index: 1000;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgb(0 0 0 / 55%);
+}
+
+.agent-login-modal {
+    width: min(480px, 92vw);
+    max-height: 90vh;
+    padding: 1rem 1.25rem 1.25rem;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-secondary);
+    box-shadow: 0 12px 40px rgb(0 0 0 / 50%);
+}
+
+.agent-login-header,
+.agent-login-footer,
+.agent-login-code-row {
+    display: flex;
+    align-items: center;
+}
+
+.agent-login-header {
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
+}
+
+.agent-login-header h2,
+.agent-login-instr {
+    margin: 0;
+}
+
+.agent-login-close {
+    border: 0;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 1.4rem;
+    cursor: pointer;
+}
+
+.agent-login-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.agent-login-instr,
+.agent-login-status {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.agent-login-url {
+    color: var(--accent);
+    font-size: 0.85rem;
+    word-break: break-all;
+}
+
+.agent-login-device-code,
+.agent-install-command {
+    padding: 0.5rem 0.6rem;
+    border: 1px dashed var(--border);
+    border-radius: 6px;
+    background: var(--bg-primary);
+}
+
+.agent-login-device-code {
+    font-size: 1.4rem;
+    letter-spacing: 0.15rem;
+    text-align: center;
+}
+
+.agent-login-code-row {
+    gap: 0.5rem;
+}
+
+.agent-login-code-input {
+    flex: 1;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+}
+
+.agent-login-submit:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.agent-login-footer {
+    justify-content: flex-end;
+    margin-top: 1rem;
+}
+
+.agent-install-command {
+    display: block;
+    font-size: 0.85rem;
+    word-break: break-all;
+}
+
+/* ==========================================================================
    Appearance panel
    ========================================================================== */
 


### PR DESCRIPTION
Restores the Agents settings pane that was accidentally disconnected during the settings layout cleanup in #1572.

- reconnects the existing agent probe, install, and login components without replacing the newer Account pane
- restores the matrix/modal styling
- includes Claude, Codex, and Muse status/install support
- suppresses Muse interactive sign-in until its launcher-side login driver exists
- adds a regression test covering the complete agent matrix and unavailable Muse login action

Checks:
- cargo test -p frontend --lib
- cargo clippy -p frontend --all-targets -- -D warnings
- cargo check -p frontend --target wasm32-unknown-unknown
- cargo fmt --all -- --check
- npm --prefix frontend/lint run lint:css
- git diff --check