### PR TITLE
Stop diagram glyphs rendering as empty boxes

### DIFF
--- a/docs/prompts/illustrate-change.md
+++ b/docs/prompts/illustrate-change.md
@@ -134,14 +134,32 @@ vertical divider, and use the full x 32–1168 width. Do not invent a fake
 
 Technical:
 
-- Set `font-size` explicitly on **every** `<text>`. Use
-  `font-family="ui-monospace, SFMono-Regular, Menlo, monospace"` for code
-  identifiers and `font-family="system-ui, -apple-system, Segoe UI, sans-serif"`
-  for prose.
+- Set `font-size` explicitly on **every** `<text>`, and use exactly two font
+  families: `font-family="monospace"` for code identifiers and
+  `font-family="sans-serif"` for prose.
+
+  **Use the bare generics — do not write a CSS font stack.** A list like
+  `ui-monospace, SFMono-Regular, Menlo, monospace` works in a browser, which
+  walks it, but every fontconfig-based renderer (cairosvg, rsvg, Inkscape)
+  resolves the **first** name and stops. `ui-monospace` exists on no Linux
+  box, so those renderers land on the default sans: the text comes out
+  *proportional* when monospace was intended, and it loses the arrow and math
+  glyphs the monospace font would have had. The portal looks fine and every
+  export is quietly wrong.
+
 - **Size boxes to their text.** Monospace glyphs are about `0.6 × font-size`
   wide, so a 20-character label at 14px needs ~170px plus padding. Text
   overflowing its box is the most common way model-authored SVG looks broken;
-  budget at least 12px of padding on each side.
+  budget at least 12px of padding on each side. (This arithmetic only holds if
+  the font really is monospace — see above.)
+- **Draw arrows, never type them.** `→` `←` `⇒` are absent from the common
+  default sans, so they render as an empty box. An arrow between two things is
+  a `<line>` with a `<marker>`; it also lands where you aimed it, which a text
+  arrow does not.
+- **Stay near ASCII in text.** Safe everywhere: `— – · … ' " × ± ÷ µ § •`,
+  Greek letters, and superscripts. Unsafe: arrows, `≤ ≥ ≠ ≈ − ∂`, geometric
+  shapes (`▸ ▾`), `✓ ✗ ✕`, circled letters, and **emoji** — which belong in no
+  technical diagram regardless of whether they render.
 - **Prefix every `id` with the PR number** (`id="pr1643-arrow-green"`). These
   diagrams get merged into contact sheets, and bare ids like `arrow` collide
   silently — the first definition wins and later tiles draw the wrong marker.
@@ -155,12 +173,16 @@ Write the SVG to a file, then check it — do not trust it unseen:
 
 1. Confirm it parses (`python3 -c "import xml.etree.ElementTree as ET;
    ET.parse('out.svg')"`).
-2. If a rasterizer is available (`rsvg-convert`, `inkscape`, or `magick`),
-   convert to PNG and **read the image back so you can actually look at it**.
-   This is the only reliable way to catch text overflowing a box, elements
-   overlapping, or something drawn off-canvas. It is worth the extra step every
-   time.
-3. Fix what you find and look again.
+2. Run `scripts/check-svg-glyphs.py out.svg`. It resolves each `<text>`
+   element's font the way a rasterizer does and fails on any codepoint that
+   font lacks. A missing glyph raises no error — it silently draws an empty
+   box — so this is not something to eyeball.
+3. If a rasterizer is available (`cairosvg`, `rsvg-convert`, `inkscape`, or
+   `magick`), convert to PNG and **read the image back so you can actually look
+   at it**. This is the only reliable way to catch text overflowing a box,
+   elements overlapping, or something drawn off-canvas. It is worth the extra
+   step every time.
+4. Fix what you find and look again.
 
 Then display it with `agent-portal show out.svg`.
 

--- a/scripts/check-svg-glyphs.py
+++ b/scripts/check-svg-glyphs.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Fail on SVG text whose glyphs the rendering font does not have.
+
+A missing glyph does not error — it draws a "tofu" box, so a diagram can look
+finished in the writer's terminal and be unreadable everywhere else. This
+resolves each `<text>` element's font the way a rasterizer does and checks
+every codepoint against that font's cmap.
+
+Two findings this was written to catch, both from real diagrams:
+
+1. **Font stacks silently do not fall through.** CSS lists like
+   `ui-monospace, SFMono-Regular, Menlo, monospace` work in a browser, which
+   walks the list. fontconfig-based renderers (cairosvg, rsvg, Inkscape)
+   resolve the *first* name and stop — and since `ui-monospace` exists on no
+   Linux box, they land on the default sans. So the text renders proportionally
+   when monospace was intended, and any width arithmetic based on a fixed
+   advance is wrong.
+
+2. **The default sans lacks arrows and math.** Noto Sans has no `→` `⇒` `≤`
+   `≠` `✓`, while DejaVu Sans Mono has all of them. Whether a glyph survives
+   therefore depends on which font the stack accidentally resolved to.
+
+Usage:
+    check-svg-glyphs.py FILE.svg [FILE.svg ...]
+
+Exit status is non-zero if any glyph is missing, so this can gate a pipeline.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unicodedata
+import xml.etree.ElementTree as ET
+from functools import lru_cache
+
+SVG = "{http://www.w3.org/2000/svg}"
+
+# Characters that render as a box in at least one font a common renderer picks.
+# Arrows are the big one: they are the natural thing to type between two
+# labels, and they are exactly what the default sans is missing. Draw them as
+# a <line> with a <marker> instead — it survives every font.
+PREFER_DRAWN = {
+    0x2190: "←", 0x2192: "→", 0x2191: "↑", 0x2193: "↓",
+    0x21D2: "⇒", 0x21D0: "⇐",
+}
+
+
+@lru_cache(maxsize=None)
+def resolve(family: str) -> tuple[str, frozenset[int]]:
+    """Resolve one family name to (font file, covered codepoints)."""
+    path = subprocess.run(
+        ["fc-match", "-f", "%{file}", family],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    try:
+        from fontTools.ttLib import TTFont
+
+        font = TTFont(path, fontNumber=0, lazy=True)
+        covered: set[int] = set()
+        for table in font["cmap"].tables:
+            covered |= set(table.cmap.keys())
+        return path, frozenset(covered)
+    except Exception:
+        return path, frozenset()
+
+
+def first_family(font_family: str) -> str:
+    """The family a fontconfig renderer will actually use.
+
+    Deliberately mirrors the naive behavior rather than CSS semantics: taking
+    only the first entry is precisely the bug being detected.
+    """
+    return font_family.split(",")[0].strip().strip("'\"")
+
+
+def check(path: str) -> list[str]:
+    root = ET.parse(path).getroot()
+    problems: list[str] = []
+    for text in root.iter(SVG + "text"):
+        stack = text.get("font-family") or "sans-serif"
+        family = first_family(stack)
+        font_file, covered = resolve(family)
+        if not covered:
+            problems.append(f"  could not read font for {family!r} ({font_file})")
+            continue
+        content = "".join(text.itertext())
+        for ch in content:
+            if ord(ch) < 128 or ch.isspace():
+                continue
+            if ord(ch) not in covered:
+                try:
+                    name = unicodedata.name(ch)
+                except ValueError:
+                    name = "<unnamed>"
+                hint = ""
+                if ord(ch) in PREFER_DRAWN:
+                    hint = "  [draw this as <line>+<marker>, not text]"
+                problems.append(
+                    f"  U+{ord(ch):04X} {ch!r} ({name}) missing from "
+                    f"{font_file.split('/')[-1]} — resolved from {stack!r}{hint}"
+                )
+    return problems
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    failed = False
+    for path in sys.argv[1:]:
+        problems = sorted(set(check(path)))
+        if problems:
+            failed = True
+            print(f"{path}: {len(problems)} problem(s)")
+            for p in problems:
+                print(p)
+        else:
+            print(f"{path}: ok")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Symbols in generated diagrams were rendering as tofu boxes. Investigating found the cause is **not** "some fonts lack some characters" — it is that the font stacks never reached the font they named.

## Root cause

A CSS list like `ui-monospace, SFMono-Regular, Menlo, monospace` works in a browser, which walks it. Every fontconfig-based renderer — cairosvg, rsvg, Inkscape — resolves the **first** name and stops. `ui-monospace` exists on no Linux box, so they land on the default sans.

Two consequences, one of which I had not noticed at all:

1. Text intended as monospace renders **proportionally**, which invalidates the `0.6 × font-size` width arithmetic the prompt prescribes for sizing boxes.
2. The default sans (Noto Sans) has no arrows or math operators, while DejaVu Sans Mono — the font the stack *meant* to reach — has all of them.

So the portal renders fine (browser) and every export is quietly wrong.

Demonstrated by rendering `MMMMMMMMMM iiiiiiiiii` in both: the stack version is proportional, plain `monospace` is fixed-width.

## Scale

Across the 36 diagrams generated so far, **31 contain at least one glyph the resolved font cannot draw** — overwhelmingly `U+2192 RIGHTWARDS ARROW`. Only three characters are missing from *both* fonts: `ⓘ` and two emoji.

## Fix

- Bare generic families (`monospace` / `sans-serif`) rather than stacks.
- **Arrows are drawn** as `<line>` + `<marker>`, never typed — they are the character most likely to be missing, and a drawn arrow also lands where you aimed it.
- An explicit safe/unsafe punctuation list; emoji banned outright.
- `scripts/check-svg-glyphs.py` resolves each `<text>` element's font the way a rasterizer does and fails on any codepoint it lacks. A missing glyph raises no error and only shows as an empty box, so this has to be mechanical rather than eyeballed. The prompt's verification step now runs it.