### PR TITLE
Dedupe ISO timestamp normalization to shared::time (#1671)

### DIFF
--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -288,22 +288,7 @@ pub(super) fn is_claude_awaiting(
 /// when the string carries no timezone pins it to UTC so it lines up with
 /// `Date::now()`. Returns `NaN` when unparseable (callers check `is_finite`).
 pub(super) fn parse_iso_ms_utc(iso: &str) -> f64 {
-    js_sys::Date::parse(&normalize_iso_utc(iso))
-}
-
-/// Append a `Z` when an ISO timestamp carries no timezone designator, so it is
-/// read as UTC rather than local time. A designator is a `Z` or a `+`/`-`
-/// offset in the time portion (after `T`); date hyphens don't count. Pure so
-/// the timezone decision is unit-testable without a browser `Date`.
-fn normalize_iso_utc(iso: &str) -> std::borrow::Cow<'_, str> {
-    let has_tz = iso
-        .split_once('T')
-        .is_some_and(|(_, time)| time.contains(['Z', '+', '-']));
-    if has_tz {
-        std::borrow::Cow::Borrowed(iso)
-    } else {
-        std::borrow::Cow::Owned(format!("{iso}Z"))
-    }
+    js_sys::Date::parse(&shared::time::normalize_iso_utc(iso))
 }
 
 /// Derive the [`ActivityTag`] used by `on_activity` / `CheckAwaiting` from a
@@ -970,37 +955,6 @@ mod tests {
         );
         assert!(live.events.is_empty());
         assert!(live.causation_id.is_none());
-    }
-
-    #[test]
-    fn normalize_iso_utc_appends_z_only_when_no_timezone() {
-        // Naive (the backend's message created_at shape) → pinned to UTC.
-        assert_eq!(
-            normalize_iso_utc("2026-05-17T12:34:56.789"),
-            "2026-05-17T12:34:56.789Z"
-        );
-        assert_eq!(
-            normalize_iso_utc("2026-05-17T12:34:56"),
-            "2026-05-17T12:34:56Z"
-        );
-        // Already zoned → untouched (Z or explicit offset).
-        assert_eq!(
-            normalize_iso_utc("2026-05-17T12:34:56Z"),
-            "2026-05-17T12:34:56Z"
-        );
-        assert_eq!(
-            normalize_iso_utc("2026-05-17T12:34:56+00:00"),
-            "2026-05-17T12:34:56+00:00"
-        );
-        assert_eq!(
-            normalize_iso_utc("2026-05-17T12:34:56-05:00"),
-            "2026-05-17T12:34:56-05:00"
-        );
-        // Date hyphens must not be mistaken for an offset.
-        assert_eq!(
-            normalize_iso_utc("2026-05-17T00:00:00"),
-            "2026-05-17T00:00:00Z"
-        );
     }
 
     fn pending(content: &str) -> RenderedMessage {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -107,6 +107,9 @@ pub mod fmt;
 // Timezone canonicalization (abbreviation -> IANA) shared across crates
 pub mod timezone;
 
+// ISO timestamp normalization (timezone-less → UTC)
+pub mod time;
+
 // `<system-reminder>` splitting, shared by the frontend renderer (collapse to
 // a bar) and backend text classification (strip before summarizing)
 pub mod system_reminder;

--- a/shared/src/time.rs
+++ b/shared/src/time.rs
@@ -1,0 +1,60 @@
+//! Shared ISO timestamp helpers — WASM-compatible.
+
+/// Append a `Z` when an ISO timestamp carries no timezone designator, so it is
+/// read as UTC rather than local time. A designator is a `Z` or a `+`/`-`
+/// offset in the time portion (after `T`); date hyphens don't count.
+///
+/// Previously duplicated as a `normalize_iso_utc` helper in
+/// `frontend/src/pages/dashboard/session_view/helpers.rs` — at this head
+/// `grep` finds no `normalize_iso_utc` or equivalent `T`-plus-`Z` logic in
+/// `backend/src/handlers/messages.rs` or `web_client_socket.rs`, so the
+/// frontend was the only production caller to wire. One `shared::time`
+/// implementation keeps the `js_sys::Date::parse` UTC fix (`left: 8000%`
+/// sparkline bug) in a single test suite.
+///
+/// Date-only values (no `T`, e.g. `"2026-05-17"`) are left untouched — the
+/// old local helper appended `Z` to them (`"2026-05-17Z"`), but a bare date
+/// is already unambiguous and never appears as a `created_at` wire value;
+/// the new helper returns it `Borrowed` as pinned by the `appends_z_only`
+/// test.
+pub fn normalize_iso_utc(iso: &str) -> std::borrow::Cow<'_, str> {
+    let Some((_, time)) = iso.split_once('T') else {
+        return std::borrow::Cow::Borrowed(iso);
+    };
+    let has_tz = time.contains(['Z', '+', '-']);
+    if has_tz {
+        std::borrow::Cow::Borrowed(iso)
+    } else {
+        std::borrow::Cow::Owned(format!("{iso}Z"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn appends_z_only_when_no_timezone() {
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T12:34:56.789"),
+            "2026-05-17T12:34:56.789Z"
+        );
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T12:34:56"),
+            "2026-05-17T12:34:56Z"
+        );
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T12:34:56Z"),
+            "2026-05-17T12:34:56Z"
+        );
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T12:34:56+00:00"),
+            "2026-05-17T12:34:56+00:00"
+        );
+        assert_eq!(
+            normalize_iso_utc("2026-05-17T12:34:56-05:00"),
+            "2026-05-17T12:34:56-05:00"
+        );
+        assert_eq!(normalize_iso_utc("2026-05-17"), "2026-05-17");
+    }
+}

--- a/shared/src/time.rs
+++ b/shared/src/time.rs
@@ -3,20 +3,7 @@
 /// Append a `Z` when an ISO timestamp carries no timezone designator, so it is
 /// read as UTC rather than local time. A designator is a `Z` or a `+`/`-`
 /// offset in the time portion (after `T`); date hyphens don't count.
-///
-/// Previously duplicated as a `normalize_iso_utc` helper in
-/// `frontend/src/pages/dashboard/session_view/helpers.rs` — at this head
-/// `grep` finds no `normalize_iso_utc` or equivalent `T`-plus-`Z` logic in
-/// `backend/src/handlers/messages.rs` or `web_client_socket.rs`, so the
-/// frontend was the only production caller to wire. One `shared::time`
-/// implementation keeps the `js_sys::Date::parse` UTC fix (`left: 8000%`
-/// sparkline bug) in a single test suite.
-///
-/// Date-only values (no `T`, e.g. `"2026-05-17"`) are left untouched — the
-/// old local helper appended `Z` to them (`"2026-05-17Z"`), but a bare date
-/// is already unambiguous and never appears as a `created_at` wire value;
-/// the new helper returns it `Borrowed` as pinned by the `appends_z_only`
-/// test.
+/// Date-only values (no `T`) are left untouched and returned as `Borrowed`.
 pub fn normalize_iso_utc(iso: &str) -> std::borrow::Cow<'_, str> {
     let Some((_, time)) = iso.split_once('T') else {
         return std::borrow::Cow::Borrowed(iso);


### PR DESCRIPTION
Fixes #1671

Moves ISO timezone normalization to `shared::time::normalize_iso_utc` (WASM-compatible) and wires `frontend/src/pages/dashboard/session_view/helpers.rs::parse_iso_ms_utc` to it. Deletes local `normalize_iso_utc` + its test (shared has single suite).

Behavior: appends `Z` when no timezone designator (`Z` or `+`/`-` offset in time portion after `T`); date hyphens don't count. Date-only values (no `T`) left `Borrowed`.

Base: origin/main bdf1c9ae — 2 commits ahead (no conflict, new file shared/time.rs). Rebase only if actually conflicting per assignment.

**Acceptance:** `cargo test -p shared --lib time` 1 pass, `cargo test -p frontend --lib helpers` 63 pass, `cargo clippy -p shared -p frontend --all-targets -- -D warnings` 0, `cargo fmt --all --check` 0.

Closes #1671