### PR TITLE
Consolidate format_file_size / format_token_count to shared::fmt (#1672)

### DIFF
--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -176,27 +176,7 @@ pub fn storage_remove(key: &str) {
     }
 }
 
-/// Human-readable file size: `"512 B"`, `"1.5 KB"`, `"2.0 MB"`.
-pub fn format_file_size(bytes: u64) -> String {
-    if bytes < 1024 {
-        format!("{} B", bytes)
-    } else if bytes < 1024 * 1024 {
-        format!("{:.1} KB", bytes as f64 / 1024.0)
-    } else {
-        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
-    }
-}
-
-/// Format token count with K/M suffix for readability
-pub fn format_token_count(count: i64) -> String {
-    if count >= 1_000_000 {
-        format!("{:.1}M", count as f64 / 1_000_000.0)
-    } else if count >= 1_000 {
-        format!("{:.1}K", count as f64 / 1_000.0)
-    } else {
-        count.to_string()
-    }
-}
+pub use shared::fmt::{format_file_size, format_token_count};
 
 #[cfg(test)]
 mod tests {

--- a/launcher/src/media.rs
+++ b/launcher/src/media.rs
@@ -67,16 +67,7 @@ fn cap_mb(kind: MediaKind) -> u64 {
 }
 
 fn human_size(bytes: u64) -> String {
-    const KB: f64 = 1024.0;
-    const MB: f64 = KB * 1024.0;
-    let b = bytes as f64;
-    if b >= MB {
-        format!("{:.1} MB", b / MB)
-    } else if b >= KB {
-        format!("{:.1} KB", b / KB)
-    } else {
-        format!("{bytes} B")
-    }
+    shared::fmt::format_file_size(bytes)
 }
 
 /// `agent-portal show <file>` — upload and display media in this session.

--- a/shared/src/fmt.rs
+++ b/shared/src/fmt.rs
@@ -30,6 +30,32 @@ pub fn format_duration(ms: u64) -> String {
     }
 }
 
+/// Formats a byte count as a human-readable size (`"512 B"`, `"1.5 KB"`, `"2.0 MB"`).
+/// Single `B/KB/MB` implementation for the workspace — frontend and launcher
+/// use this via `shared` instead of ad-hoc formatting.
+pub fn format_file_size(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{} B", bytes)
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+/// Formats a token count with `K`/`M` suffixes for readability.
+/// Takes `i64` to match `usage` counts without casts at call sites (counts can
+/// be negative in tests; `u64` would require casts).
+pub fn format_token_count(count: i64) -> String {
+    if count < 1000 {
+        count.to_string()
+    } else if count < 1_000_000 {
+        format!("{:.1}K", count as f64 / 1000.0)
+    } else {
+        format!("{:.1}M", count as f64 / 1_000_000.0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,5 +102,22 @@ mod tests {
         assert_eq!(format_duration(60000), "1m 0s");
         assert_eq!(format_duration(197_000), "3m 17s");
         assert_eq!(format_duration(3_599_999), "59m 59s");
+    }
+
+    #[test]
+    fn format_file_size_bytes_and_kb_and_mb() {
+        assert_eq!(format_file_size(0), "0 B");
+        assert_eq!(format_file_size(512), "512 B");
+        assert_eq!(format_file_size(1024), "1.0 KB");
+        assert_eq!(format_file_size(1536), "1.5 KB");
+        assert_eq!(format_file_size(1024 * 1024), "1.0 MB");
+    }
+
+    #[test]
+    fn format_token_count_k_and_m() {
+        assert_eq!(format_token_count(999), "999");
+        assert_eq!(format_token_count(1000), "1.0K");
+        assert_eq!(format_token_count(1_500), "1.5K");
+        assert_eq!(format_token_count(1_000_000), "1.0M");
     }
 }


### PR DESCRIPTION
Fixes #1672

Consolidates the B/KB/MB and K/M ladders into `shared::fmt::format_file_size` / `format_token_count` (WASM-compatible, std-only). Single ladder for the workspace — `frontend` and `launcher` (`human_size` now delegates to `shared::fmt`) reuse this via `shared`.

`shared::fmt` docs now describe current API (`i64` token counts) without historical duplication narrative.

`cargo test -p shared --lib fmt` 8 pass; `cargo fmt` `cargo clippy -D warnings` clean.