### PR TITLE
Unify awaiting detection: introduce is_awaiting wrapper (#1676)

### DIFF
--- a/frontend/src/components/agent_frame.rs
+++ b/frontend/src/components/agent_frame.rs
@@ -52,7 +52,22 @@ pub enum AgentFrameKind {
     CodexReasoningTextDelta,
     CodexThreadCompacted,
     MuseRecord,
+    MuseRunTerminalCompleted,
+    MuseRunTerminalFailed,
     RawJson,
+}
+
+impl AgentFrameKind {
+    pub fn is_terminator(self) -> bool {
+        matches!(
+            self,
+            Self::ClaudeResult
+                | Self::CodexTurnCompleted
+                | Self::CodexTurnFailed
+                | Self::MuseRunTerminalCompleted
+                | Self::MuseRunTerminalFailed
+        )
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -121,7 +136,14 @@ impl AgentFrame {
         match self {
             Self::Claude(message) => message.kind(),
             Self::Codex(event) => event.kind(),
-            Self::Muse(_) => AgentFrameKind::MuseRecord,
+            Self::Muse(value) => {
+                let pt = value.get("payload_type").and_then(|v| v.as_str());
+                match pt {
+                    Some("run.terminal.completed") => AgentFrameKind::MuseRunTerminalCompleted,
+                    Some("run.terminal.failed") => AgentFrameKind::MuseRunTerminalFailed,
+                    _ => AgentFrameKind::MuseRecord,
+                }
+            }
             Self::RawJson => AgentFrameKind::RawJson,
         }
     }
@@ -153,7 +175,9 @@ impl FrameRenderer {
             | AgentFrameKind::CodexReasoningSummaryPartAdded
             | AgentFrameKind::CodexReasoningTextDelta
             | AgentFrameKind::CodexThreadCompacted => Self::Codex,
-            AgentFrameKind::MuseRecord => Self::Muse,
+            AgentFrameKind::MuseRecord
+            | AgentFrameKind::MuseRunTerminalCompleted
+            | AgentFrameKind::MuseRunTerminalFailed => Self::Muse,
             AgentFrameKind::RawJson => Self::RawJson,
         }
     }

--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -11,7 +11,7 @@ mod tests;
 mod tool_calls;
 mod tool_card;
 mod turns;
-pub use events::{codex_event_item_id, is_codex_terminal_event, CodexEvent, CodexItem};
+pub use events::{codex_event_item_id, CodexEvent, CodexItem};
 use lifecycle::{render_context_compacted, render_context_compaction_item, render_turn_plan};
 use messages::{
     render_agent_message, render_agent_message_content, render_error_block, render_reasoning,

--- a/frontend/src/components/codex_renderer/events.rs
+++ b/frontend/src/components/codex_renderer/events.rs
@@ -312,25 +312,3 @@ pub fn codex_event_item_id(json: &str) -> Option<String> {
         _ => None,
     }
 }
-
-/// Check if a Codex message indicates "awaiting" (turn complete or turn failed)
-pub fn is_codex_terminal_event(json: &str) -> Option<bool> {
-    let event: CodexEvent = serde_json::from_str(json).ok()?;
-    match event {
-        CodexEvent::TurnCompleted { .. } | CodexEvent::TurnFailed { .. } => Some(true),
-        CodexEvent::ItemStarted { .. }
-        | CodexEvent::ItemUpdated { .. }
-        | CodexEvent::ItemCompleted { .. }
-        | CodexEvent::TurnStarted { .. }
-        | CodexEvent::ThreadStarted { .. } => Some(false),
-        CodexEvent::Error { .. }
-        | CodexEvent::TurnDiffUpdated { .. }
-        | CodexEvent::FileChangePatchUpdated { .. }
-        | CodexEvent::TurnPlanUpdated { .. }
-        | CodexEvent::ThreadCompacted { .. }
-        | CodexEvent::PlanDelta { .. }
-        | CodexEvent::ReasoningSummaryPartAdded { .. }
-        | CodexEvent::ReasoningTextDelta { .. }
-        | CodexEvent::Unknown => None,
-    }
-}

--- a/frontend/src/components/codex_renderer/tests/wire_events.rs
+++ b/frontend/src/components/codex_renderer/tests/wire_events.rs
@@ -2,7 +2,8 @@
 //! detection, and the turn-level / streaming-delta variants.
 
 use super::super::events::CodexUsage;
-use super::super::{codex_event_item_id, is_codex_terminal_event, CodexEvent, CodexItem};
+use super::super::{codex_event_item_id, CodexEvent, CodexItem};
+use crate::components::agent_frame::{AgentFrameKind, AgentFrameRegistry};
 use codex_codes::io::items::{PatchChangeKind, ThreadItem};
 use codex_codes::protocol::ThreadItem as AppServerThreadItem;
 
@@ -204,30 +205,38 @@ fn round_trip_codex_event() {
     );
 }
 
-// --- Terminal event detection ---
+// --- Terminal event detection via AgentFrameKind::is_terminator ---
 
 #[test]
 fn terminal_event_turn_completed() {
     let json = r#"{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":20}}"#;
-    assert_eq!(is_codex_terminal_event(json), Some(true));
+    let kind = AgentFrameRegistry::parse(json, shared::AgentType::Codex).kind();
+    assert!(kind.is_terminator());
+    assert_eq!(kind, AgentFrameKind::CodexTurnCompleted);
 }
 
 #[test]
 fn terminal_event_turn_failed() {
     let json = r#"{"type":"turn.failed","error":{"message":"oops"}}"#;
-    assert_eq!(is_codex_terminal_event(json), Some(true));
+    let kind = AgentFrameRegistry::parse(json, shared::AgentType::Codex).kind();
+    assert!(kind.is_terminator());
+    assert_eq!(kind, AgentFrameKind::CodexTurnFailed);
 }
 
 #[test]
 fn terminal_event_item_completed_is_not_terminal() {
     let json = r#"{"type":"item.completed","item":{"type":"agent_message","id":"m1","text":"hi"}}"#;
-    assert_eq!(is_codex_terminal_event(json), Some(false));
+    let kind = AgentFrameRegistry::parse(json, shared::AgentType::Codex).kind();
+    assert!(!kind.is_terminator());
+    assert_eq!(kind, AgentFrameKind::CodexItemCompleted);
 }
 
 #[test]
 fn terminal_event_unknown_returns_none() {
     let json = r#"{"type":"something.else"}"#;
-    assert_eq!(is_codex_terminal_event(json), None);
+    let kind = AgentFrameRegistry::parse(json, shared::AgentType::Codex).kind();
+    assert!(!kind.is_terminator());
+    assert_eq!(kind, AgentFrameKind::RawJson);
 }
 
 // --- Streaming-delta / plan / diff variants ---

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -441,12 +441,9 @@ fn group_label(
 /// stays `None` on the proxy-emit side until a future PR wires up the
 /// per-turn linkage, so a key-based join would fail on every row today.
 pub fn is_turn_terminator(message: &RenderedMessage) -> bool {
-    matches!(
-        AgentFrameRegistry::parse(&message.content, shared::AgentType::Codex).kind(),
-        AgentFrameKind::ClaudeResult
-            | AgentFrameKind::CodexTurnCompleted
-            | AgentFrameKind::CodexTurnFailed
-    )
+    AgentFrameRegistry::parse(&message.content, shared::AgentType::Codex)
+        .kind()
+        .is_terminator()
 }
 
 /// True iff the group is a `Single` carrying a turn terminator. Identity

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -440,8 +440,8 @@ fn group_label(
 /// pair-by-ordering join is the agreed PR 2 strategy — `user_message_id`
 /// stays `None` on the proxy-emit side until a future PR wires up the
 /// per-turn linkage, so a key-based join would fail on every row today.
-pub fn is_turn_terminator(message: &RenderedMessage) -> bool {
-    AgentFrameRegistry::parse(&message.content, shared::AgentType::Codex)
+pub fn is_turn_terminator(message: &RenderedMessage, agent_type: shared::AgentType) -> bool {
+    AgentFrameRegistry::parse(&message.content, agent_type)
         .kind()
         .is_terminator()
 }
@@ -450,9 +450,9 @@ pub fn is_turn_terminator(message: &RenderedMessage) -> bool {
 /// groups never contain terminators (Result / TurnCompleted / TurnFailed
 /// don't classify into any identity category — see `classify`), so this
 /// helper only needs to inspect the `Single` arm.
-pub fn group_is_turn_terminator(group: &MessageGroup) -> bool {
+pub fn group_is_turn_terminator(group: &MessageGroup, agent_type: shared::AgentType) -> bool {
     match group {
-        MessageGroup::Single(json) => is_turn_terminator(json),
+        MessageGroup::Single(json) => is_turn_terminator(json, agent_type),
         MessageGroup::IdentityGroup { .. } => false,
     }
 }
@@ -472,7 +472,7 @@ pub fn group_is_turn_terminator(group: &MessageGroup) -> bool {
 /// starts from 0 again. Callers clamp the seed to the chip's own target,
 /// so a marker stream that ever restarts low degrades to a static display
 /// rather than a backwards animation.
-pub fn thinking_chip_starts(groups: &[MessageGroup]) -> Vec<i64> {
+pub fn thinking_chip_starts(groups: &[MessageGroup], agent_type: shared::AgentType) -> Vec<i64> {
     let mut running_max = 0i64;
     groups
         .iter()
@@ -487,7 +487,7 @@ pub fn thinking_chip_starts(groups: &[MessageGroup]) -> Vec<i64> {
                 start
             }
             _ => {
-                if group_is_turn_terminator(group) {
+                if group_is_turn_terminator(group, agent_type) {
                     running_max = 0;
                 }
                 0

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -432,8 +432,9 @@ fn group_label(
 }
 
 /// True iff `json` parses as a per-turn terminator: Claude's
-/// `ClaudeMessage::Result` or one of Codex's terminator events
-/// (`TurnCompleted` / `TurnFailed`).
+/// `ClaudeMessage::Result`, Codex's `TurnCompleted`/`TurnFailed`, or
+/// Muse's `run.terminal.completed`/`run.terminal.failed` (via
+/// `AgentFrameKind::is_terminator`).
 ///
 /// Used by `SessionView::view()` to pair the Nth terminator card in the
 /// rendered transcript with the Nth row in `SessionView.turn_metrics`. The
@@ -447,9 +448,9 @@ pub fn is_turn_terminator(message: &RenderedMessage, agent_type: shared::AgentTy
 }
 
 /// True iff the group is a `Single` carrying a turn terminator. Identity
-/// groups never contain terminators (Result / TurnCompleted / TurnFailed
-/// don't classify into any identity category — see `classify`), so this
-/// helper only needs to inspect the `Single` arm.
+/// groups never contain terminators (Result / TurnCompleted / TurnFailed /
+/// run.terminal.completed|failed don't classify into any identity category
+/// — see `classify`), so this helper only needs to inspect the `Single` arm.
 pub fn group_is_turn_terminator(group: &MessageGroup, agent_type: shared::AgentType) -> bool {
     match group {
         MessageGroup::Single(json) => is_turn_terminator(json, agent_type),

--- a/frontend/src/components/message_renderer/tests/classifier.rs
+++ b/frontend/src/components/message_renderer/tests/classifier.rs
@@ -22,21 +22,47 @@ fn turn_terminator_detection_covers_claude_and_codex() {
     })
     .to_string();
 
-    for json in [claude_result, codex_completed, codex_failed] {
+    for (json, agent_type) in [
+        (claude_result, shared::AgentType::Claude),
+        (codex_completed, shared::AgentType::Codex),
+        (codex_failed, shared::AgentType::Codex),
+    ] {
         assert!(
-            group_is_turn_terminator(&MessageGroup::Single(rendered(json))),
+            group_is_turn_terminator(&MessageGroup::Single(rendered(json)), agent_type),
             "single terminator frame should be recognized"
         );
     }
-    assert!(!group_is_turn_terminator(&MessageGroup::Single(rendered(
-        plain_user_text("hello")
-    ))));
-    assert!(!group_is_turn_terminator(&MessageGroup::IdentityGroup {
-        category: GroupCategory::User,
-        label: "You".to_string(),
-        badge_class: "user".to_string(),
-        messages: vec![rendered(plain_user_text("hello"))],
-    }));
+    // Muse terminal also terminates, but only when parsed as Muse.
+    let muse_completed = serde_json::json!({
+        "type": "muse_record",
+        "payload_type": "run.terminal.completed",
+        "payload": { "status": "completed" },
+    })
+    .to_string();
+    assert!(group_is_turn_terminator(
+        &MessageGroup::Single(rendered(muse_completed.clone())),
+        shared::AgentType::Muse
+    ));
+    assert!(
+        !group_is_turn_terminator(
+            &MessageGroup::Single(rendered(muse_completed)),
+            shared::AgentType::Claude
+        ),
+        "Muse terminal should not be terminator when parsed as Claude"
+    );
+    assert!(!group_is_turn_terminator(
+        &MessageGroup::Single(rendered(plain_user_text("hello"))),
+        shared::AgentType::Claude
+    ));
+    assert!(!group_is_turn_terminator(
+        &MessageGroup::IdentityGroup {
+            category: GroupCategory::User,
+            label: "You".to_string(),
+            badge_class: "user".to_string(),
+            messages: vec![rendered(plain_user_text("hello"))],
+        },
+        shared::AgentType::Claude
+    ));
 }
 
 /// One canonical wire shape per realistic message kind paired with the

--- a/frontend/src/components/message_renderer/tests/thinking.rs
+++ b/frontend/src/components/message_renderer/tests/thinking.rs
@@ -71,7 +71,7 @@ fn thinking_chip_starts_seed_across_splits_and_reset_on_terminator() {
         thinking_tokens_message(60),
     ];
     let groups = group_for_tests(&messages);
-    let starts = grouping::thinking_chip_starts(&groups);
+    let starts = grouping::thinking_chip_starts(&groups, shared::AgentType::Claude);
     assert_eq!(starts.len(), groups.len());
     // Burst 1 starts at 0; burst 2 is seeded with burst 1's peak; the
     // turn-2 burst starts at 0 again after the Result terminator.

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -276,6 +276,7 @@ impl Component for SessionView {
     fn create(ctx: &Context<Self>) -> Self {
         let link = ctx.link().clone();
         let session_id = ctx.props().session.id;
+        let agent_type = ctx.props().session.agent_type;
         let on_awaiting_change = ctx.props().on_awaiting_change.clone();
 
         // Fetch existing messages via REST, then connect WebSocket
@@ -288,7 +289,7 @@ impl Component for SessionView {
             )
             .await
             {
-                let is_awaiting = is_awaiting(data.messages.iter().map(|m| &m.content));
+                let is_awaiting = is_awaiting(data.messages.iter().map(|m| &m.content), agent_type);
                 on_awaiting_change.emit((session_id, is_awaiting));
 
                 last_message_time = data.messages.last().map(|m| m.created_at.clone());
@@ -463,7 +464,10 @@ impl Component for SessionView {
                 false
             }
             SessionViewMsg::CheckAwaiting => {
-                let is_result_awaiting = is_awaiting(self.messages.iter().map(|m| &m.content));
+                let is_result_awaiting = is_awaiting(
+                    self.messages.iter().map(|m| &m.content),
+                    ctx.props().session.agent_type,
+                );
                 let is_awaiting = is_result_awaiting || self.has_pending_permission;
                 let session_id = ctx.props().session.id;
                 ctx.props()
@@ -609,7 +613,7 @@ impl Component for SessionView {
         let group_metrics: Vec<Option<TurnMetrics>> = groups
             .iter()
             .map(|g| {
-                if group_is_turn_terminator(g) {
+                if group_is_turn_terminator(g, ctx.props().session.agent_type) {
                     metrics_iter.next().cloned()
                 } else {
                     None
@@ -618,7 +622,7 @@ impl Component for SessionView {
             .collect();
         // Seed each thinking chip's odometer with the prior burst's max in
         // its turn so tool-call splits don't re-race the count from 0.
-        let thinking_starts = thinking_chip_starts(&groups);
+        let thinking_starts = thinking_chip_starts(&groups, ctx.props().session.agent_type);
         let live_muse_group = self.muse_live_turn.causation_id.as_deref().and_then(|id| {
             groups
                 .iter()

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -28,10 +28,9 @@ use yew::prelude::*;
 use super::forward_chips::ForwardChips;
 use super::helpers::{
     autoscroll_transition, classify_output_msg_type, clear_completed_tools,
-    enrich_codex_file_change_permission, ephemeral_summary, format_tool_elapsed,
-    is_claude_awaiting, parse_iso_ms_utc, reconcile_pending_sends, running_tool_key,
-    update_pending_send_delivery, upsert_tool_progress, ActiveToolProgress, ActivityTag,
-    MuseLiveTurn,
+    enrich_codex_file_change_permission, ephemeral_summary, format_tool_elapsed, is_awaiting,
+    parse_iso_ms_utc, reconcile_pending_sends, running_tool_key, update_pending_send_delivery,
+    upsert_tool_progress, ActiveToolProgress, ActivityTag, MuseLiveTurn,
 };
 use super::input_bar::{InputBar, InputBarInbound};
 use super::outbox::Outbox;
@@ -289,7 +288,7 @@ impl Component for SessionView {
             )
             .await
             {
-                let is_awaiting = is_claude_awaiting(data.messages.iter().map(|m| &m.content));
+                let is_awaiting = is_awaiting(data.messages.iter().map(|m| &m.content));
                 on_awaiting_change.emit((session_id, is_awaiting));
 
                 last_message_time = data.messages.last().map(|m| m.created_at.clone());
@@ -464,20 +463,7 @@ impl Component for SessionView {
                 false
             }
             SessionViewMsg::CheckAwaiting => {
-                let is_codex = ctx.props().session.agent_type == shared::AgentType::Codex;
-                let is_result_awaiting = if is_codex {
-                    // For Codex: search backwards for terminal events
-                    // turn.completed / turn.failed = awaiting, item.* = working
-                    self.messages
-                        .iter()
-                        .rev()
-                        .find_map(|msg| {
-                            crate::components::codex_renderer::is_codex_terminal_event(&msg.content)
-                        })
-                        .unwrap_or(false)
-                } else {
-                    is_claude_awaiting(self.messages.iter().map(|m| &m.content))
-                };
+                let is_result_awaiting = is_awaiting(self.messages.iter().map(|m| &m.content));
                 let is_awaiting = is_result_awaiting || self.has_pending_permission;
                 let session_id = ctx.props().session.id;
                 ctx.props()

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -251,29 +251,50 @@ pub(super) fn autoscroll_transition(current: bool, new_at_bottom: bool) -> Optio
     }
 }
 
-/// Check if a Claude session is awaiting user input by scanning messages
-/// backwards. Skips noise types (portal, error, system, rate_limit_event)
-/// and returns true if `Result` is found before `User` or `Assistant`.
-pub(super) fn is_claude_awaiting(
-    messages: impl DoubleEndedIterator<Item = impl AsRef<str>>,
-) -> bool {
-    messages
-        .rev()
-        .find_map(|msg| {
-            ClaudeMessage::parse(msg.as_ref())
-                .ok()
-                .filter(|m| {
-                    matches!(
-                        m,
-                        ClaudeMessage::Result(_)
-                            | ClaudeMessage::Assistant(_)
-                            | ClaudeMessage::User(_)
-                            | ClaudeMessage::OptimisticUser(_)
-                    )
-                })
-                .map(|m| message_type_tag(&m))
-        })
-        .is_some_and(|t| t == ActivityTag::Result)
+/// Check if a session is awaiting user input by scanning messages
+/// backwards. Uses `AgentFrameKind::is_terminator()` so every agent's
+/// turn-end drives the same awaiting logic: Claude `Result`,
+/// Codex `turn.completed`/`turn.failed`, Muse `run.terminal.completed`/
+/// `run.terminal.failed`. The last meaningful signal determines the
+/// pill color — a terminator means awaiting (orange), an assistant/user
+/// or live item means working. Noise types are skipped.
+pub(crate) fn is_awaiting(messages: impl DoubleEndedIterator<Item = impl AsRef<str>>) -> bool {
+    use crate::components::agent_frame::AgentFrame;
+
+    for msg in messages.rev() {
+        let s = msg.as_ref();
+
+        // Try Claude shape first.
+        if let Ok(m) = ClaudeMessage::parse(s) {
+            match m {
+                ClaudeMessage::Result(_) => return true,
+                ClaudeMessage::Assistant(_)
+                | ClaudeMessage::User(_)
+                | ClaudeMessage::OptimisticUser(_) => return false,
+                _ => {}
+            }
+        }
+        // Try Codex event.
+        let codex = crate::components::codex_renderer::is_codex_terminal_event(s);
+
+        if let Some(is_term) = codex {
+            return is_term;
+        }
+        // Try Muse record.
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(s) {
+            if val.get("type").and_then(|v| v.as_str()) == Some("muse_record") {
+                let frame = AgentFrame::Muse(val);
+                let kind = frame.kind();
+
+                if kind.is_terminator() {
+                    return true;
+                }
+                // Any other muse record is a working signal.
+                return false;
+            }
+        }
+    }
+    false
 }
 
 /// Parse a server ISO timestamp to epoch-ms, treating a timezone-less string
@@ -1409,7 +1430,7 @@ mod tests {
         assert_eq!(pending.len(), 1);
     }
 
-    // --- is_claude_awaiting ---
+    // --- is_awaiting ---
 
     #[test]
     fn is_claude_awaiting_true_when_last_signal_is_result() {
@@ -1418,7 +1439,7 @@ mod tests {
             r#"{"type":"assistant","message":{"id":"msg_1","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[]},"session_id":"01890000-0000-7000-8000-000000000001"}"#.to_string(),
             r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":1,"duration_api_ms":1,"num_turns":1,"session_id":"01890000-0000-7000-8000-000000000001","total_cost_usd":0.0}"#.to_string(),
         ];
-        assert!(is_claude_awaiting(msgs.iter()));
+        assert!(is_awaiting(msgs.iter()));
     }
 
     #[test]
@@ -1427,7 +1448,7 @@ mod tests {
             r#"{"type":"user","content":"q"}"#.to_string(),
             r#"{"type":"assistant","message":{"id":"msg_1","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[]},"session_id":"01890000-0000-7000-8000-000000000001"}"#.to_string(),
         ];
-        assert!(!is_claude_awaiting(msgs.iter()));
+        assert!(!is_awaiting(msgs.iter()));
     }
 
     #[test]
@@ -1439,13 +1460,46 @@ mod tests {
             r#"{"type":"portal","content":[{"type":"text","text":"x"}]}"#.to_string(),
             r#"{"type":"error","error":{"type":"api_error","message":"y"}}"#.to_string(),
         ];
-        assert!(is_claude_awaiting(msgs.iter()));
+        assert!(is_awaiting(msgs.iter()));
     }
 
     #[test]
     fn is_claude_awaiting_false_for_empty_history() {
         let msgs: Vec<String> = vec![];
-        assert!(!is_claude_awaiting(msgs.iter()));
+        assert!(!is_awaiting(msgs.iter()));
+    }
+
+    #[test]
+    fn is_awaiting_true_for_muse_terminal_completed() {
+        let msgs = [
+            r#"{"type":"muse_record","payload_type":"run.terminal.completed","payload":{"status":"completed"}}"#.to_string(),
+        ];
+        assert!(is_awaiting(msgs.iter()));
+    }
+
+    #[test]
+    fn is_awaiting_true_for_muse_terminal_failed() {
+        let msgs = [
+            r#"{"type":"muse_record","payload_type":"run.terminal.failed","payload":{"status":"failed"}}"#.to_string(),
+        ];
+        assert!(is_awaiting(msgs.iter()));
+    }
+
+    #[test]
+    fn is_awaiting_false_for_muse_working_record() {
+        let msgs = [
+            r#"{"type":"muse_record","payload_type":"task.started","payload":{"task_id":"1"}}"#
+                .to_string(),
+        ];
+        assert!(!is_awaiting(msgs.iter()));
+    }
+
+    #[test]
+    fn is_awaiting_true_for_codex_turn_completed() {
+        let msgs = [
+            r#"{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}"#.to_string(),
+        ];
+        assert!(is_awaiting(msgs.iter()));
     }
 
     // --- extract_user_text ---

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -258,40 +258,31 @@ pub(super) fn autoscroll_transition(current: bool, new_at_bottom: bool) -> Optio
 /// `run.terminal.failed`. The last meaningful signal determines the
 /// pill color — a terminator means awaiting (orange), an assistant/user
 /// or live item means working. Noise types are skipped.
-pub(crate) fn is_awaiting(messages: impl DoubleEndedIterator<Item = impl AsRef<str>>) -> bool {
-    use crate::components::agent_frame::AgentFrame;
+pub(crate) fn is_awaiting(
+    messages: impl DoubleEndedIterator<Item = impl AsRef<str>>,
+    agent_type: shared::AgentType,
+) -> bool {
+    use crate::components::agent_frame::{AgentFrameKind, AgentFrameRegistry};
 
     for msg in messages.rev() {
-        let s = msg.as_ref();
-
-        // Try Claude shape first.
-        if let Ok(m) = ClaudeMessage::parse(s) {
-            match m {
-                ClaudeMessage::Result(_) => return true,
-                ClaudeMessage::Assistant(_)
-                | ClaudeMessage::User(_)
-                | ClaudeMessage::OptimisticUser(_) => return false,
-                _ => {}
-            }
+        let frame = AgentFrameRegistry::parse(msg.as_ref(), agent_type);
+        let kind = frame.kind();
+        if kind.is_terminator() {
+            return true;
         }
-        // Try Codex event.
-        let codex = crate::components::codex_renderer::is_codex_terminal_event(s);
-
-        if let Some(is_term) = codex {
-            return is_term;
-        }
-        // Try Muse record.
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(s) {
-            if val.get("type").and_then(|v| v.as_str()) == Some("muse_record") {
-                let frame = AgentFrame::Muse(val);
-                let kind = frame.kind();
-
-                if kind.is_terminator() {
-                    return true;
-                }
-                // Any other muse record is a working signal.
-                return false;
-            }
+        if matches!(
+            kind,
+            AgentFrameKind::ClaudeAssistant
+                | AgentFrameKind::ClaudeUser
+                | AgentFrameKind::OptimisticUser
+                | AgentFrameKind::CodexThreadStarted
+                | AgentFrameKind::CodexTurnStarted
+                | AgentFrameKind::CodexItemStarted
+                | AgentFrameKind::CodexItemUpdated
+                | AgentFrameKind::CodexItemCompleted
+                | AgentFrameKind::MuseRecord
+        ) {
+            return false;
         }
     }
     false
@@ -1439,7 +1430,7 @@ mod tests {
             r#"{"type":"assistant","message":{"id":"msg_1","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[]},"session_id":"01890000-0000-7000-8000-000000000001"}"#.to_string(),
             r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":1,"duration_api_ms":1,"num_turns":1,"session_id":"01890000-0000-7000-8000-000000000001","total_cost_usd":0.0}"#.to_string(),
         ];
-        assert!(is_awaiting(msgs.iter()));
+        assert!(is_awaiting(msgs.iter(), shared::AgentType::Claude));
     }
 
     #[test]
@@ -1448,7 +1439,7 @@ mod tests {
             r#"{"type":"user","content":"q"}"#.to_string(),
             r#"{"type":"assistant","message":{"id":"msg_1","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[]},"session_id":"01890000-0000-7000-8000-000000000001"}"#.to_string(),
         ];
-        assert!(!is_awaiting(msgs.iter()));
+        assert!(!is_awaiting(msgs.iter(), shared::AgentType::Claude));
     }
 
     #[test]
@@ -1460,13 +1451,13 @@ mod tests {
             r#"{"type":"portal","content":[{"type":"text","text":"x"}]}"#.to_string(),
             r#"{"type":"error","error":{"type":"api_error","message":"y"}}"#.to_string(),
         ];
-        assert!(is_awaiting(msgs.iter()));
+        assert!(is_awaiting(msgs.iter(), shared::AgentType::Claude));
     }
 
     #[test]
     fn is_claude_awaiting_false_for_empty_history() {
         let msgs: Vec<String> = vec![];
-        assert!(!is_awaiting(msgs.iter()));
+        assert!(!is_awaiting(msgs.iter(), shared::AgentType::Claude));
     }
 
     #[test]
@@ -1474,7 +1465,7 @@ mod tests {
         let msgs = [
             r#"{"type":"muse_record","payload_type":"run.terminal.completed","payload":{"status":"completed"}}"#.to_string(),
         ];
-        assert!(is_awaiting(msgs.iter()));
+        assert!(is_awaiting(msgs.iter(), shared::AgentType::Muse));
     }
 
     #[test]
@@ -1482,7 +1473,7 @@ mod tests {
         let msgs = [
             r#"{"type":"muse_record","payload_type":"run.terminal.failed","payload":{"status":"failed"}}"#.to_string(),
         ];
-        assert!(is_awaiting(msgs.iter()));
+        assert!(is_awaiting(msgs.iter(), shared::AgentType::Muse));
     }
 
     #[test]
@@ -1491,7 +1482,7 @@ mod tests {
             r#"{"type":"muse_record","payload_type":"task.started","payload":{"task_id":"1"}}"#
                 .to_string(),
         ];
-        assert!(!is_awaiting(msgs.iter()));
+        assert!(!is_awaiting(msgs.iter(), shared::AgentType::Muse));
     }
 
     #[test]
@@ -1499,7 +1490,7 @@ mod tests {
         let msgs = [
             r#"{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}"#.to_string(),
         ];
-        assert!(is_awaiting(msgs.iter()));
+        assert!(is_awaiting(msgs.iter(), shared::AgentType::Codex));
     }
 
     // --- extract_user_text ---

--- a/frontend/src/pages/demo.rs
+++ b/frontend/src/pages/demo.rs
@@ -116,7 +116,7 @@ pub fn demo_page() -> Html {
         scenario.session.agent_type,
         Some(current_user_id.as_str()),
     );
-    let thinking_starts = thinking_chip_starts(&groups);
+    let thinking_starts = thinking_chip_starts(&groups, scenario.session.agent_type);
 
     html! {
         <main class="focus-flow-container demo-portal-page">

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -107,7 +107,6 @@ pub mod fmt;
 // Timezone canonicalization (abbreviation -> IANA) shared across crates
 pub mod timezone;
 
-// ISO timestamp normalization (timezone-less → UTC)
 pub mod time;
 
 // `<system-reminder>` splitting, shared by the frontend renderer (collapse to

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -107,6 +107,7 @@ pub mod fmt;
 // Timezone canonicalization (abbreviation -> IANA) shared across crates
 pub mod timezone;
 
+// ISO timestamp normalization (timezone-less → UTC)
 pub mod time;
 
 // `<system-reminder>` splitting, shared by the frontend renderer (collapse to


### PR DESCRIPTION
Fixes #1676

Promotes `grouping::is_turn_terminator` to `AgentFrameKind::is_terminator()` covering Claude `Result`, Codex `turn.completed`/`turn.failed`, and Muse `run.terminal.completed`/`run.terminal.failed`. Wires `helpers::is_awaiting` through `is_terminator` so every agent's turn-end drives the same awaiting orange border (Muse history now lights up). Simplifies `SessionView::CheckAwaiting` to single `is_awaiting` call, deleting `is_codex_terminal_event` branching. Adds Muse/Codex cases to helpers tests.

Base: origin/main 55133056 — single commit ahead, MERGEABLE, no new file.

**Acceptance:** `cargo test -p frontend --lib helpers` 67 pass (+4 Muse/Codex), `cargo test -p frontend --lib` 643 pass, `cargo clippy -p frontend --all-targets -- -D warnings` 0, `cargo fmt --all --check` 0.

Closes #1676