### PR TITLE
Stop git metadata refreshes stalling codex sessions

### DIFF
--- a/claude-session-lib/src/proxy_session/git_metadata.rs
+++ b/claude-session-lib/src/proxy_session/git_metadata.rs
@@ -123,14 +123,77 @@ pub(super) fn muse_output_has_git_signal(value: &serde_json::Value) -> bool {
     text_has_git_signal(&command.command) || text_has_git_signal(&command.output)
 }
 
+/// Does this text indicate a command that may have moved the branch or PR?
+///
+/// Deliberately narrower than "mentions git". The previous form matched the
+/// bare substrings `branch`, `checkout`, `merge`, `rebase` and `commit`
+/// anywhere in a command *or its output*, so ordinary prose — a commit message
+/// being echoed, a test name containing "merge", any diff mentioning a branch —
+/// marked a signal. Every match costs a metadata refresh, and on the codex path
+/// that refresh used to run inline on the connection loop, so an over-eager
+/// predicate was directly responsible for stalls.
+///
+/// Now a match needs an actual `git`/`gh` invocation *and* a subcommand that
+/// can change what we display, or an unambiguous git output line for the case
+/// where the branch moved without us seeing the command.
 fn text_has_git_signal(text: &str) -> bool {
-    text.contains("git ")
-        || text.contains("gh ")
-        || text.contains("branch")
-        || text.contains("checkout")
-        || text.contains("merge")
-        || text.contains("rebase")
-        || text.contains("commit")
+    const STATE_CHANGING: [&str; 8] = [
+        "checkout", "switch", "commit", "merge", "rebase", "push", "branch", " pr ",
+    ];
+
+    let invoked = text.contains("git ") || text.contains("gh ");
+    if invoked && STATE_CHANGING.iter().any(|sub| text.contains(sub)) {
+        return true;
+    }
+
+    // Case-insensitive: git prints "Switched to branch", but this also sees
+    // aggregated output that has been through a shell or a logger.
+    [
+        "switched to branch",
+        "switched to a new branch",
+        "head is now at",
+    ]
+    .iter()
+    .any(|phrase| contains_ignore_ascii_case(text, phrase))
+}
+
+/// `str::contains`, ignoring ASCII case, without allocating a lowercased copy
+/// of every output frame this runs against.
+fn contains_ignore_ascii_case(haystack: &str, needle_lower: &str) -> bool {
+    let (h, n) = (haystack.as_bytes(), needle_lower.as_bytes());
+    n.len() <= h.len() && h.windows(n.len()).any(|w| w.eq_ignore_ascii_case(n))
+}
+
+/// Refresh git metadata in the background, without making the caller wait.
+///
+/// The codex/muse output arm runs inline in the connection's `select!` loop
+/// (unlike claude, whose forwarder owns a task of its own), so awaiting a
+/// refresh there blocks *everything* that loop services — output forwarding,
+/// input delivery, acks, heartbeats — for the length of up to three `gh`
+/// network calls. That is the session-appears-hung-then-floods symptom: the
+/// user's own message is queued behind the same stall, so when `gh` finally
+/// returns the loop drains the backlog and the reply in one wake-up, and the
+/// flood looks like a response to having typed.
+///
+/// Overlapping triggers collapse via [`GitMetadataState::try_begin_refresh`]
+/// rather than queueing one refresh per frame.
+pub(super) fn spawn_branch_update(
+    ws_write: &SharedWsWrite,
+    session_id: Uuid,
+    working_directory: &str,
+    state: &GitMetadataState,
+) {
+    let Some(guard) = state.try_begin_refresh() else {
+        debug!("git metadata refresh already in flight; skipping");
+        return;
+    };
+    let ws_write = ws_write.clone();
+    let working_directory = working_directory.to_string();
+    let state = state.clone();
+    tokio::spawn(async move {
+        check_and_send_branch_update(&ws_write, session_id, &working_directory, &state).await;
+        drop(guard);
+    });
 }
 
 /// Check and send git branch, PR URL, or repo URL update if changed.
@@ -140,15 +203,26 @@ pub(super) async fn check_and_send_branch_update(
     working_directory: &str,
     state: &GitMetadataState,
 ) {
-    let info = get_branch_info(working_directory);
-    let new_branch = info.as_ref().map(|i| i.display());
-    // PR lookup keys on the branch the work ships from — the active
-    // worktree's when one exists (#1067), never the composite display form.
-    let new_pr_url = info
-        .as_ref()
-        .and_then(|i| get_pr_url(working_directory, i.pr_branch()));
-    let new_repo_url = get_repo_url(working_directory);
-    let new_open_prs = get_open_prs(working_directory);
+    // These four shell out to `git` and `gh` with blocking
+    // `std::process::Command`, and three of them are GitHub network round
+    // trips. Run them on the blocking pool: on an async worker thread they
+    // stall every other task sharing it for the duration of the network call.
+    let cwd = working_directory.to_string();
+    let Ok((new_branch, new_pr_url, new_repo_url, new_open_prs)) =
+        tokio::task::spawn_blocking(move || {
+            let info = get_branch_info(&cwd);
+            let branch = info.as_ref().map(|i| i.display());
+            // PR lookup keys on the branch the work ships from — the active
+            // worktree's when one exists (#1067), never the composite display
+            // form.
+            let pr_url = info.as_ref().and_then(|i| get_pr_url(&cwd, i.pr_branch()));
+            (branch, pr_url, get_repo_url(&cwd), get_open_prs(&cwd))
+        })
+        .await
+    else {
+        error!("git metadata refresh task failed to run");
+        return;
+    };
 
     let mut branch_guard = state.current_branch.lock().await;
     let mut pr_guard = state.current_pr_url.lock().await;
@@ -345,6 +419,58 @@ mod tests {
         });
 
         assert!(codex_output_has_git_signal(&value));
+    }
+
+    /// The predicate gates a metadata refresh that makes up to three `gh`
+    /// network calls, so a false positive is not free. These are the shapes
+    /// that used to match on a bare substring and should not.
+    #[test]
+    fn git_signal_ignores_prose_that_merely_mentions_git_words() {
+        for text in [
+            "cargo test --workspace",
+            "test result: ok. 12 passed",
+            "fn merge_sorted(a: &[u8], b: &[u8])",
+            "the commit message explains why",
+            "error: cannot borrow `branch` as mutable",
+            "rebasing the argument is not the point",
+        ] {
+            assert!(
+                !text_has_git_signal(text),
+                "should not signal a refresh: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_signal_matches_real_invocations() {
+        for text in [
+            "git checkout -b feature/x",
+            "git commit -m 'fix'",
+            "git push --force-with-lease",
+            "gh pr create --draft",
+            "git switch main",
+            "git rebase -i main",
+        ] {
+            assert!(text_has_git_signal(text), "should signal: {text:?}");
+        }
+    }
+
+    /// The branch can move without us seeing the command — a script, or a
+    /// command whose text was truncated — so git's own output still counts.
+    #[test]
+    fn git_signal_matches_git_output_in_any_case() {
+        assert!(text_has_git_signal("Switched to branch 'main'"));
+        assert!(text_has_git_signal("switched to a new branch 'x'"));
+        assert!(text_has_git_signal("HEAD is now at 1a2b3c4"));
+    }
+
+    /// A bare mention of `git` with no state-changing subcommand is a read,
+    /// and reads cannot change what the pill displays.
+    #[test]
+    fn git_signal_ignores_read_only_git_commands() {
+        assert!(!text_has_git_signal("git status"));
+        assert!(!text_has_git_signal("git diff --stat"));
+        assert!(!text_has_git_signal("gh run watch"));
     }
 
     #[test]

--- a/claude-session-lib/src/proxy_session/session_event.rs
+++ b/claude-session-lib/src/proxy_session/session_event.rs
@@ -23,7 +23,7 @@ use shared::ProxyToServer;
 use tracing::error;
 
 use super::git_metadata::{
-    check_and_send_branch_update, codex_output_has_git_signal, muse_output_has_git_signal,
+    codex_output_has_git_signal, muse_output_has_git_signal, spawn_branch_update,
 };
 use super::wiggum::handle_session_event_with_wiggum;
 use super::{inject_portal_reminder, is_codex_compaction_event, ConnectionResult, ConnectionState};
@@ -40,14 +40,18 @@ pub(super) async fn handle_next_event<A: Agent>(
     // for its image/git/wiggum side-effects.
     if state.agent_type != shared::AgentType::Claude {
         if let Some(SessionEvent::RawOutput(ref value)) = event {
+            // Fire-and-forget: this arm runs inline in the connection's
+            // `select!`, so awaiting a refresh here stalls output forwarding,
+            // input delivery, acks and heartbeats behind up to three `gh`
+            // network calls. The update is emitted as its own `SessionUpdate`
+            // when it completes, so nothing is lost by not waiting.
             if state.git_refresh.should_check_before_message() {
-                check_and_send_branch_update(
+                spawn_branch_update(
                     &state.ws_write,
                     state.session_id,
                     &state.working_directory,
                     &state.git_metadata,
-                )
-                .await;
+                );
             }
             // This arm carries codex *and* muse, whose wire shapes have
             // nothing in common — so the detector is chosen by agent rather

--- a/scripts/illustrator/README.md
+++ b/scripts/illustrator/README.md
@@ -1,0 +1,77 @@
+# Illustrator pipeline
+
+Tooling around [`docs/prompts/illustrate-change.md`](../../docs/prompts/illustrate-change.md),
+which has a Fable session read a PR and compose an SVG explaining what the
+change does. These scripts are the parts worth automating: checking that the
+output follows the canonical layout, and assembling many diagrams into one
+sheet.
+
+The diagram itself is deliberately **not** automated. An earlier attempt
+generated diagrams from git statistics and could only ever draw where bytes
+moved — file-churn treemaps that explained nothing. Deciding what a change
+*means* is the whole job, and it is the part a script cannot do.
+
+## Generate
+
+Run the prompt in a Fable session per PR, writing each SVG to a directory:
+
+```
+/tmp/diagrams/pr-1643.svg
+/tmp/diagrams/pr-1659.svg
+...
+```
+
+## Check
+
+```sh
+./check-layout.py '/tmp/diagrams/pr-*.svg'
+```
+
+Verifies the canonical layout mechanically — canvas, background rect, header
+and subtitle baselines, `PR #n · title` heading format, the rule, the dashed
+divider, that content actually fills the panel band, and that every `id` is
+prefixed with its PR number. Prints a table and a failure tally.
+
+Sessions are independent and cannot see each other's output, so "they all
+looked consistent" is not something to take on faith across a dozen of them.
+
+Pair it with [`../check-svg-glyphs.py`](../check-svg-glyphs.py), which catches
+characters the rendering font cannot draw — those appear as empty boxes rather
+than raising an error.
+
+## Assemble
+
+```sh
+./make-contact-sheet.py 1643,1659,1611,1639,1649,1650,1576,1568,1613,1612,1661,1660 \
+    /tmp/diagrams /tmp/diagrams/contact-sheet.svg
+```
+
+Tiles twelve diagrams 3×4 with rules between them.
+
+**It namespaces every `id` per tile**, which is the non-obvious part. Bare ids
+like `arrow-green` collide across files — three of twelve diagrams defined
+exactly that — and on collision the first definition in document order wins, so
+later tiles silently draw the wrong marker. Nothing errors; the arrowheads are
+just the wrong colour.
+
+## Export
+
+```sh
+cairosvg contact-sheet.svg -o sheet-4k.png --output-width 3840
+```
+
+Verify opacity by rendering over white and sampling a corner — on a dark
+viewer a transparent background and an opaque one look identical:
+
+```sh
+cairosvg sheet.svg -o /tmp/check.png --background "#ffffff"
+python3 -c "from PIL import Image; print(Image.open('/tmp/check.png').convert('RGB').getpixel((3,3)))"
+# expect (26, 27, 38)
+```
+
+## One caution
+
+These sessions write a draft, rasterize it, look at it, and revise. A file
+appearing on disk does **not** mean the session is finished, so assembling on
+file existence can capture a superseded tile. Wait for the session to report
+completion; this bit twice, and only comparing mtimes afterwards caught it.

--- a/scripts/illustrator/check-layout.py
+++ b/scripts/illustrator/check-layout.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Check generated diagrams against the canonical layout.
+
+Usage: check-layout.py '/tmp/diagrams/pr-*.svg'
+
+Sessions run independently and cannot see each other's output, so consistency
+across a dozen diagrams is not something to eyeball. Prints a table plus a
+failure tally; exit status is informational.
+"""
+import xml.etree.ElementTree as ET, glob, os, re, sys
+
+NS='{http://www.w3.org/2000/svg}'
+def check(f):
+    pr = re.search(r'pr-(\d+)', f).group(1)
+    r = ET.parse(f).getroot()
+    kids = list(r)
+    out = {}
+    out['viewBox'] = r.get('viewBox') == '0 0 1200 720'
+    # <defs>/<title>/<desc>/<style> paint nothing, so a background rect that
+    # follows them is still behind every visible element.
+    NONRENDER = {NS+'defs', NS+'title', NS+'desc', NS+'style', NS+'metadata'}
+    rest = [k for k in kids if k.tag not in NONRENDER]
+    bg = rest[0] if rest else None
+    out['bg_first'] = (bg is not None and bg.tag==NS+'rect'
+                       and (bg.get('fill') or '').lower()=='#1a1b26'
+                       and bg.get('width')=='1200')
+    ys = lambda v: [e for e in r.iter(NS+'text') if e.get('y')==v]
+    out['head_y36'] = bool(ys('36'))
+    out['sub_y66'] = bool(ys('66'))
+    heads = ys('36')
+    txt = ''.join(heads[0].itertext()) if heads else ''
+    out['head_fmt'] = txt.startswith(f'PR #{pr}') and '·' in txt
+    out['rule_y96'] = any(e.get('y1')=='96' and e.get('y2')=='96' for e in r.iter(NS+'line'))
+    div = [e for e in r.iter(NS+'line') if e.get('x1')=='600' and e.get('x2')=='600']
+    out['divider'] = (not div) or any(e.get('stroke-dasharray') for e in div)
+    # deepest drawn y
+    maxy=0
+    for e in r.iter():
+        for a in ('y','y1','y2','cy'):
+            v=e.get(a)
+            if v:
+                try:
+                    n=float(v)
+                    if n<=760: maxy=max(maxy,n)
+                except ValueError: pass
+        if e.tag==NS+'rect' and e.get('y') and e.get('height') and e.get('fill','').lower()!='#1a1b26':
+            try: maxy=max(maxy,float(e.get('y'))+float(e.get('height')))
+            except ValueError: pass
+    out['fills_band'] = maxy >= 600
+    ids=[e.get('id') for e in r.iter() if e.get('id')]
+    out['ids_prefixed'] = all(i.startswith(f'pr{pr}') for i in ids) if ids else True
+    return pr, out, round(maxy)
+
+files = sorted(glob.glob(sys.argv[1]))
+keys = ['viewBox','bg_first','head_y36','sub_y66','head_fmt','rule_y96','divider','fills_band','ids_prefixed']
+print(f"{'PR':6}" + ''.join(f'{k[:9]:>11}' for k in keys) + '   maxY')
+fails={k:0 for k in keys}
+for f in files:
+    pr,o,my = check(f)
+    print(f"{pr:6}" + ''.join(f"{'ok' if o[k] else 'FAIL':>11}" for k in keys) + f"   {my}")
+    for k in keys:
+        if not o[k]: fails[k]+=1
+print(f"\n{len(files)} file(s). failures:", {k:v for k,v in fails.items() if v} or 'none')

--- a/scripts/illustrator/make-contact-sheet.py
+++ b/scripts/illustrator/make-contact-sheet.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Merge PR diagrams into a tiled contact sheet.
+
+Namespaces every `id` per tile: bare ids like `arrow-green` collide across
+files, and on collision the first definition in document order wins, so later
+tiles silently draw the wrong marker.
+"""
+import re, sys, pathlib
+
+order = [int(x) for x in sys.argv[1].split(",")]
+src = pathlib.Path(sys.argv[2]); dest = pathlib.Path(sys.argv[3])
+COLS, ROWS = 3, 4
+BG, MUTED = "#1a1b26", "#565f89"
+
+first = (src / f"pr-{order[0]}.svg").read_text()
+TW = int(re.search(r'viewBox="0 0 (\d+) (\d+)"', first).group(1))
+TH = int(re.search(r'viewBox="0 0 (\d+) (\d+)"', first).group(2))
+
+tiles = []
+for idx, pr in enumerate(order):
+    t = (src / f"pr-{pr}.svg").read_text()
+    inner = t[t.index(">", t.index("<svg")) + 1 : t.rindex("</svg>")]
+    for i in sorted(set(re.findall(r'id="([^"]+)"', inner)), key=len, reverse=True):
+        new = f"t{pr}-{i}"
+        inner = (inner.replace(f'id="{i}"', f'id="{new}"')
+                      .replace(f"url(#{i})", f"url(#{new})")
+                      .replace(f'href="#{i}"', f'href="#{new}"'))
+    c, r = idx % COLS, idx // COLS
+    tiles.append(f'<svg x="{c*TW}" y="{r*TH}" width="{TW}" height="{TH}" viewBox="0 0 {TW} {TH}">{inner}</svg>')
+
+W, H = COLS * TW, ROWS * TH
+rules = "".join(
+    [f'<line x1="{c*TW}" y1="0" x2="{c*TW}" y2="{H}" stroke="{MUTED}" stroke-opacity="0.55" stroke-width="2"/>' for c in range(1, COLS)]
+    + [f'<line x1="0" y1="{r*TH}" x2="{W}" y2="{r*TH}" stroke="{MUTED}" stroke-opacity="0.55" stroke-width="2"/>' for r in range(1, ROWS)]
+)
+dest.write_text(
+    f'<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" viewBox="0 0 {W} {H}">'
+    f'<rect x="0" y="0" width="{W}" height="{H}" fill="{BG}"/>' + "".join(tiles) + rules + "</svg>"
+)
+print(f"{dest.name}: {W}x{H}, {len(tiles)} tiles, {dest.stat().st_size//1024} KB")

--- a/session-lib/src/git_metadata.rs
+++ b/session-lib/src/git_metadata.rs
@@ -12,6 +12,11 @@ pub struct GitMetadataState {
     pub current_pr_url: Arc<Mutex<Option<String>>>,
     pub current_repo_url: Arc<Mutex<Option<String>>>,
     pub current_open_prs: Arc<Mutex<Vec<PrRef>>>,
+    /// Set while a refresh is running, so overlapping triggers collapse into
+    /// one. A refresh makes up to three `gh` network calls; without this, a
+    /// burst of git-signal frames would queue a refresh per frame and each
+    /// would re-run the same lookups.
+    refresh_in_flight: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl GitMetadataState {
@@ -21,7 +26,34 @@ impl GitMetadataState {
             current_pr_url: Arc::new(Mutex::new(None)),
             current_repo_url: Arc::new(Mutex::new(None)),
             current_open_prs: Arc::new(Mutex::new(Vec::new())),
+            refresh_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
+    }
+
+    /// Claim the refresh slot, or `None` if one is already running.
+    ///
+    /// The returned guard releases the slot on drop, so a refresh that panics
+    /// or returns early cannot wedge the flag on and disable refreshes for the
+    /// rest of the session.
+    pub fn try_begin_refresh(&self) -> Option<RefreshGuard> {
+        use std::sync::atomic::Ordering;
+        self.refresh_in_flight
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| RefreshGuard {
+                flag: self.refresh_in_flight.clone(),
+            })
+    }
+}
+
+/// Releases [`GitMetadataState`]'s refresh slot on drop.
+pub struct RefreshGuard {
+    flag: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl Drop for RefreshGuard {
+    fn drop(&mut self) {
+        self.flag.store(false, std::sync::atomic::Ordering::Release);
     }
 }
 


### PR DESCRIPTION
Codex sessions would appear hung, then flood the frontend the moment you sent a message. **The message did not unblock anything** — it was queued behind the same stall and released with the backlog in one wake-up, which is why the causality looks reversed.

## Mechanism

The non-Claude output arm runs **inline in the connection's `select!` loop** (`mod.rs:1077`), while Claude's forwarder owns a `tokio::spawn`ed task of its own (`output_forwarder.rs:40`). Awaiting a git metadata refresh there blocks everything that loop services — output forwarding, input delivery, acks, heartbeats.

The refresh shells out to `gh` three times (`pr view`, `repo view`, `pr list`) via blocking `std::process::Command`, so each stall lasted a GitHub round trip. That asymmetry is why this was codex-only and never reproduced on Claude.

The trigger made it frequent: `text_has_git_signal` matched the bare substrings `branch`, `checkout`, `merge`, `rebase`, `commit` anywhere in a command **or its aggregated output**, so echoed commit messages, test names and diffs all marked a signal — and the next frame paid a refresh.

## Changes

- **The codex/muse arm spawns the refresh instead of awaiting it.** The update still arrives as its own `SessionUpdate`, so nothing is lost by not waiting.
- **The `git`/`gh` lookups move onto `spawn_blocking`.** On an async worker thread they stalled every other task sharing it for the length of the network call — so even off the critical path they were harmful.
- **The predicate now requires a real `git`/`gh` invocation plus a state-changing subcommand**, or an unambiguous git output line (case-insensitively, since aggregated output may have been through a shell). `git status` and `git diff` no longer trigger refreshes.
- Overlapping triggers collapse through a refresh-in-flight guard, released via `Drop` so an early return or panic cannot wedge it off.

## Tests

Four new cases pin both directions: prose mentioning git words does **not** signal, real invocations do, git output lines match in any case, and read-only commands are ignored. All 16 tests in the module pass, including the pre-existing ones — the tightening did not break real detection.

## Caveat

Diagnosed by reading the code paths rather than reproducing a live stall, so I have not directly observed the fix eliminate it. The mechanism accounts for all three observed properties: codex-only, hangs then floods, and appears to unblock on input.

Also worth noting this had started affecting muse as of #1659, which gave muse a working detector using the same loose predicate; before that muse only ever hit the 100-message fallback and so rarely stalled.