### PR TITLE
Drop Muse run setup bookkeeping before frontend delivery

### DIFF
--- a/muse-session-lib/src/classifier.rs
+++ b/muse-session-lib/src/classifier.rs
@@ -202,11 +202,25 @@ pub fn classify_record(record: &MuseRecord) -> AgentOutput {
     }
 }
 
-/// Route on the wire's own durability flag. Deliberately not a match on
-/// payload types: muse is a days-old beta and will add ephemeral kinds, and
-/// an unlisted one must not default into the transcript — persisting
-/// live-status is expensive to unwind (a migration, not a code change).
-fn classify_payload(record: &MuseRecord, _payload: &MusePayload) -> AgentOutput {
+/// Drop typed run-setup bookkeeping that has no user-facing renderer before it
+/// reaches the buffer, database, or frontend socket. Unknown payloads still
+/// fail open through the durability branch below; only SDK-modeled shapes are
+/// eligible for suppression.
+fn classify_payload(record: &MuseRecord, payload: &MusePayload) -> AgentOutput {
+    if matches!(
+        payload,
+        MusePayload::CommandAccepted(_)
+            | MusePayload::SessionRunLinked(_)
+            | MusePayload::ModelConfigured(_)
+            | MusePayload::RunStarted(_)
+    ) {
+        return AgentOutput::Noop;
+    }
+
+    // Route every remaining record on the wire's own durability flag. Muse is
+    // a young protocol and will add kinds; an unlisted ephemeral type must not
+    // default into the transcript, while an unknown durable type must remain
+    // visible so schema drift is diagnosable.
     match record.durability {
         muse_codes::Durability::Ephemeral => AgentOutput::Ephemeral(to_event(record)),
         muse_codes::Durability::Durable => AgentOutput::Visible(to_event(record)),
@@ -408,9 +422,10 @@ mod tests {
     #[test]
     fn event_carries_composite_identity() {
         let r = env(
-            "run.lifecycle.started",
+            "run.terminal.completed",
             "durable",
-            json!({"kind": "run_started", "command_id": "c", "prompt": "p",
+            json!({"kind": "run_terminal", "command_id": "c", "terminal": "completed",
+                   "reason": null, "text": "done",
                    "run_stream": {"kind": "run", "id": "r"}}),
         );
         let AgentOutput::Visible(v) = classify_record(&r) else {
@@ -426,14 +441,10 @@ mod tests {
     /// classifier is exercised against the actual wire and not only
     /// hand-built envelopes.
     #[test]
-    fn real_captured_line_classifies() {
+    fn real_captured_command_acceptance_is_suppressed() {
         let line = r#"{"schema_version":1,"id":"018f0000-0000-7000-8000-00000000c350","stream":{"kind":"session","id":"34c4f817-8c19-4778-a6fc-a9399ac4d034"},"sequence":1,"recorded_at":1780531400000000,"record_type":"reconciliation","durability":"durable","causation_id":"7af312fb-ae7d-40f7-bd79-21cd328c4583","payload_type":"runtime.command.accepted","payload_schema_version":1,"payload":{"client_id":null,"command_id":"7af312fb-ae7d-40f7-bd79-21cd328c4583","command_kind":"turn.submit","kind":"command_accepted"}}"#;
         let r = record(line);
-        let AgentOutput::Visible(v) = classify_record(&r) else {
-            panic!("command acceptance is durable transcript material");
-        };
-        assert_eq!(v["payload_type"], "runtime.command.accepted");
-        assert_eq!(v["durability"], "durable");
+        assert!(matches!(classify_record(&r), AgentOutput::Noop));
     }
 }
 

--- a/muse-session-lib/tests/corpus_replay.rs
+++ b/muse-session-lib/tests/corpus_replay.rs
@@ -11,6 +11,17 @@ use muse_session_lib::{classify_record, MuseClassifier};
 use session_lib::adapter::{AgentOutput, AgentOutputClassifier};
 use std::collections::HashSet;
 
+const SUPPRESSED_BOOKKEEPING: [&str; 4] = [
+    "runtime.command.accepted",
+    "session.run.linked",
+    "run.model.configured",
+    "run.lifecycle.started",
+];
+
+fn is_suppressed_bookkeeping(payload_type: &str) -> bool {
+    SUPPRESSED_BOOKKEEPING.contains(&payload_type)
+}
+
 fn load(name: &str) -> Vec<MuseRecord> {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
@@ -38,6 +49,7 @@ fn every_captured_record_classifies_with_identity() {
             // buffered. Both carry the same identity fields.
             let v = match classify_record(r) {
                 AgentOutput::Visible(v) | AgentOutput::Ephemeral(v) => v,
+                AgentOutput::Noop if is_suppressed_bookkeeping(&r.payload_type) => continue,
                 other => panic!("{fixture}: unexpected classification {other:?}"),
             };
             {
@@ -122,15 +134,15 @@ fn live_capture_covers_provider_only_payloads() {
     }
 }
 
-/// The routing contract on real data: every record the wire marks
-/// `ephemeral` lands on the non-persisting channel, and every durable one
-/// persists. This is the assertion that stops live-status ever reaching
-/// `messages` — a mistake that would take a migration to unwind.
+/// The routing contract on real data: setup bookkeeping is suppressed, while
+/// every other record follows the wire's durability bit. This is the assertion
+/// that stops both useless setup rows and live-status from reaching `messages`.
 #[test]
 fn wire_durability_decides_routing_on_real_captures() {
     let records = load("corpus_meta_tool_use.jsonl");
     let mut ephemeral = 0usize;
     let mut durable = 0usize;
+    let mut suppressed = HashSet::new();
     for r in &records {
         match (r.durability, classify_record(r)) {
             (muse_codes::Durability::Ephemeral, AgentOutput::Ephemeral(v)) => {
@@ -141,12 +153,20 @@ fn wire_durability_decides_routing_on_real_captures() {
                 assert_eq!(v["durability"], "durable");
                 durable += 1;
             }
+            (_, AgentOutput::Noop) if is_suppressed_bookkeeping(&r.payload_type) => {
+                suppressed.insert(r.payload_type.as_str());
+            }
             (d, other) => panic!("{d:?} record mis-routed to {other:?}: {}", r.payload_type),
         }
     }
     assert!(
         ephemeral > 0 && durable > 0,
         "a live turn should exercise both channels (got {ephemeral} ephemeral, {durable} durable)"
+    );
+    assert_eq!(
+        suppressed,
+        SUPPRESSED_BOOKKEEPING.into_iter().collect(),
+        "every typed setup record should be removed before persistence"
     );
 }
 
@@ -244,11 +264,7 @@ fn reminder_scaffolding_screens_to_noop_on_real_captures() {
         );
 
         // Real work survives untouched.
-        for expected in [
-            "run.terminal.completed",
-            "tool.result",
-            "run.model.configured",
-        ] {
+        for expected in ["run.terminal.completed", "tool.result"] {
             assert!(
                 emitted_types.iter().any(|t| t == expected),
                 "{fixture}: screening must not touch {expected}"


### PR DESCRIPTION
Muse currently persists and sends four typed run-setup records that the frontend can only render as dotted labels in the journal footer.

Suppress these at the classifier boundary:
- `runtime.command.accepted`
- `session.run.linked`
- `run.model.configured`
- `run.lifecycle.started`

Unknown records still fail open according to their durability, and real task/tool/terminal records are unchanged. `session.workspace_branch.observed` is deliberately retained because it carries potentially useful branch provenance and does not yet have a typed SDK shape.

Real-capture replay tests assert all four setup types become `Noop`, while remaining durable and ephemeral records retain their routing and identity.

Checks:
- cargo test -p muse-session-lib
- cargo clippy -p muse-session-lib --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check