### PR TITLE
Take muse-codes from crates.io instead of a git rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4528,7 +4528,8 @@ dependencies = [
 [[package]]
 name = "muse-codes"
 version = "0.1.7"
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=2137be7#2137be743254668381a34a3aa97f9ec463d7b4d5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6dadbdd5c75d3a4402924e2a26051be89a986daaa26c5234aa945467067bccd"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ claude-codes = { version = "2.1.223", default-features = false, features = ["typ
 # Muse CLI integration
 # Temporary git pin: 0.1.7 carries the typed command-result binding used by
 # the frontend. Flip back to a crates.io version once 0.1.7 publishes.
-muse-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "2137be7", default-features = false }
+muse-codes = { version = "0.1.7", default-features = false }
 codex-codes = { version = "0.146.4", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the


### PR DESCRIPTION
muse-codes was pinned to a git rev while 0.1.5+ was unpublished. **0.1.7 is now on crates.io and is the same version the pinned rev already resolved to**, so this is a source change rather than a version bump.

```
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=2137be7#2137be74..."
+source = "registry+https://github.com/rust-lang/crates.io-index"
```

The whole lock delta is that line plus a checksum — no collateral dependency movement, which I checked deliberately since dropping a git source can trigger a broad re-resolution.

This also releases an upstream commitment: the pinned rev is not an ancestor of that repo's squashed main, so the `meawoppl/wirecheck-portal` branch had to stay alive or portal builds would break. It can be deleted once this lands.

## Verification

Built every consumer — `shared`, `session-lib`, `claude-session-lib`, `muse-session-lib`, `codex-session-lib`, launcher, proxy, and `frontend` on wasm32. **151 tests pass** across the crates that use it, including the typed `ToolResult` / `CommandResult` path the muse git-signal detector added in #1659 depends on.

Note: `cargo build --workspace` fails locally on rustc 1.93.0 because an AWS-feature crate now wants 1.94.1. I confirmed that reproduces identically on unmodified `main`, so it is pre-existing and unrelated.