### PR TITLE
Resume the conversation claude is actually in after /clear

### DIFF
--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -54,6 +54,10 @@ pub type WsRead = ws_bridge::WsReceiver<ServerToProxy>;
 /// `SessionEvent::CodexThreadId` arm. `None` is a no-op (the codex
 /// io-task still emits the event, the loop just doesn't persist it).
 pub type CodexThreadIdSink = Arc<dyn Fn(String) + Send + Sync>;
+/// Learns claude's *current* conversation id, which `/clear` rolls away from
+/// the portal's session id. The launcher persists it so the next `--resume`
+/// re-opens the live transcript instead of the pre-clear one.
+pub type ClaudeConversationIdSink = Arc<dyn Fn(uuid::Uuid) + Send + Sync>;
 
 /// Configuration for a proxy session
 #[derive(Clone)]
@@ -78,6 +82,8 @@ pub struct ProxySessionConfig {
     /// Persist-back closure for the codex app-server thread id; see
     /// [`CodexThreadIdSink`] doc.
     pub codex_thread_id_sink: Option<CodexThreadIdSink>,
+    /// Claude counterpart to `codex_thread_id_sink` (see the type docs).
+    pub claude_conversation_id_sink: Option<ClaudeConversationIdSink>,
     /// First-spawn-only source session for Claude/Codex fork semantics.
     pub fork_from_session_id: Option<Uuid>,
     /// Optional Codex native turn id; `None` forks the latest turn.
@@ -847,6 +853,7 @@ async fn run_message_loop<A: Agent>(
         git_metadata.clone(),
         session.output_buffer.clone(),
         config.agent_type,
+        config.claude_conversation_id_sink.clone(),
     );
 
     // Spawn WebSocket reader task

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -14,7 +14,7 @@ use claude_codes::io::{ContentBlock, ControlRequestPayload, ToolUseBlock};
 use claude_codes::ClaudeOutput;
 use shared::{AgentType, ProxyToServer};
 use tokio::sync::mpsc;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use session_lib::output_buffer::PendingOutputBuffer;
@@ -28,6 +28,10 @@ use super::{format_duration, truncate, SharedWsWrite};
 /// Spawn the output forwarder task
 ///
 /// Forwards Claude outputs to WebSocket with sequence numbers for reliable delivery.
+// One `tokio::spawn` fed by the connection loop's own locals; bundling them into
+// a struct would exist only to satisfy the lint, since there is no second caller
+// to share it with.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_output_forwarder(
     mut output_rx: mpsc::UnboundedReceiver<serde_json::Value>,
     ws_write: SharedWsWrite,
@@ -36,9 +40,13 @@ pub fn spawn_output_forwarder(
     git_metadata: GitMetadataState,
     output_buffer: std::sync::Arc<tokio::sync::Mutex<PendingOutputBuffer>>,
     agent_type: AgentType,
+    claude_conversation_id_sink: Option<super::ClaudeConversationIdSink>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut git_refresh = GitRefreshTrigger::default();
+        // Last conversation id we reported, so a steady stream of frames
+        // carrying the same id costs one comparison rather than a disk write.
+        let mut reported_conversation: Option<Uuid> = None;
 
         while let Some(value) = output_rx.recv().await {
             // `Session` is now agent-neutral and forwards raw wire JSON. Re-parse
@@ -63,6 +71,29 @@ pub fn spawn_output_forwarder(
 
             if let Some(ref output) = parsed {
                 log_claude_output(output);
+
+                // Claude stamps its current conversation on every frame. It
+                // equals `session_id` until `/clear` rolls claude onto a new
+                // conversation; from then on the portal id names the pre-clear
+                // transcript, so resuming it would silently reinstate the
+                // conversation as it was before the clear. Report the change so
+                // the launcher can persist it and resume the live one.
+                if let Some(current) = output
+                    .session_id()
+                    .and_then(|id| Uuid::parse_str(id).ok())
+                    .filter(|id| *id != session_id)
+                {
+                    if reported_conversation != Some(current) {
+                        reported_conversation = Some(current);
+                        info!(
+                            "Claude conversation diverged from portal session {}: now {}",
+                            session_id, current
+                        );
+                        if let Some(sink) = claude_conversation_id_sink.as_ref() {
+                            sink(current);
+                        }
+                    }
+                }
 
                 // The CLI's own PR-published signal: refresh PR metadata NOW
                 // rather than deferring, since the PR already exists in `gh`

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -20,13 +20,24 @@ use session_lib::snapshot::SessionConfig;
 /// Build the argument list for the `claude` CLI (everything after the binary
 /// path). Shared by the library spawn path and the proxy's shim mode so flag
 /// changes can't drift between the two.
+/// Build the `claude` argv.
+///
+/// `conversation_id` is claude's own current conversation, when it has diverged
+/// from the portal's `session_id` — which `/clear` causes. It is what `--resume`
+/// and a fork's source must key on: resuming the portal id after a clear
+/// re-opens the pre-clear transcript, and forking it branches from that stale
+/// history rather than from what the user can see. `--session-id` still gets the
+/// portal id, since that is the identity the backend and the dashboard hold.
 pub fn claude_cli_args(
     session_id: uuid::Uuid,
     resume: bool,
+    conversation_id: Option<uuid::Uuid>,
     fork_from: Option<uuid::Uuid>,
     prompt_suggestions: bool,
     extra_args: &[String],
 ) -> Vec<String> {
+    // Where claude's history actually lives right now.
+    let transcript_id = conversation_id.unwrap_or(session_id);
     let mut args: Vec<String> = [
         "--print",
         "--verbose",
@@ -51,6 +62,8 @@ pub fn claude_cli_args(
         // cannot carry the portal's arbitrary user extra_args. Keep the SDK's
         // documented flag recipe here until its builder supports passthrough;
         // this function also remains the single argv seam shared with shim mode.
+        // `source` is the source session's conversation id, resolved
+        // launcher-side — not its portal id, for the same reason as below.
         args.extend([
             "--resume".to_string(),
             source.to_string(),
@@ -60,7 +73,7 @@ pub fn claude_cli_args(
         ]);
     } else if resume {
         args.push("--resume".to_string());
-        args.push(session_id.to_string());
+        args.push(transcript_id.to_string());
     } else {
         args.push("--session-id".to_string());
         args.push(session_id.to_string());
@@ -85,7 +98,10 @@ pub(crate) async fn spawn_claude(
     let args = claude_cli_args(
         config.session_id,
         config.resume,
-        config.fork_from_session_id,
+        config.claude_conversation_id,
+        config
+            .claude_fork_from_conversation_id
+            .or(config.fork_from_session_id),
         claude_supports_prompt_suggestions(claude_path).await,
         &config.extra_args,
     );
@@ -207,6 +223,7 @@ mod tests {
         let args = claude_cli_args(
             new_id,
             false,
+            None,
             Some(source),
             false,
             &["--model".into(), "opus".into()],
@@ -223,11 +240,69 @@ mod tests {
         assert_eq!(&args[args.len() - expected.len()..], expected.as_slice());
     }
 
+    /// The bug this exists to prevent: `/clear` rolls claude onto a new
+    /// conversation, so resuming the portal session id re-opens the *pre-clear*
+    /// transcript and silently discards everything since.
+    #[test]
+    fn resume_uses_claude_conversation_once_it_has_diverged() {
+        let portal_id = uuid::Uuid::from_u128(2);
+        let after_clear = uuid::Uuid::from_u128(99);
+        let args = claude_cli_args(portal_id, true, Some(after_clear), None, false, &[]);
+
+        assert_eq!(
+            &args[args.len() - 2..],
+            ["--resume", &after_clear.to_string()],
+            "resume must open the live conversation, not the portal id"
+        );
+        assert!(
+            !args.contains(&portal_id.to_string()),
+            "the pre-clear transcript id must not appear at all"
+        );
+    }
+
+    /// The overwhelmingly common case: never cleared, so the portal id still
+    /// names claude's conversation and nothing changes.
+    #[test]
+    fn resume_falls_back_to_session_id_when_not_diverged() {
+        let portal_id = uuid::Uuid::from_u128(2);
+        let args = claude_cli_args(portal_id, true, None, None, false, &[]);
+        assert_eq!(
+            &args[args.len() - 2..],
+            ["--resume", &portal_id.to_string()]
+        );
+    }
+
+    /// A fork's source is resolved to the source's conversation by the caller,
+    /// for the same reason: forking a cleared session by its portal id branches
+    /// from history the user can no longer see. The new session still gets the
+    /// portal id as its own `--session-id`.
+    #[test]
+    fn fork_source_is_taken_verbatim_and_new_identity_is_the_portal_id() {
+        let new_portal_id = uuid::Uuid::from_u128(2);
+        let source_conversation = uuid::Uuid::from_u128(77);
+        let args = claude_cli_args(
+            new_portal_id,
+            false,
+            None,
+            Some(source_conversation),
+            false,
+            &[],
+        );
+
+        let resume_at = args.iter().position(|a| a == "--resume").expect("--resume");
+        assert_eq!(args[resume_at + 1], source_conversation.to_string());
+        let session_at = args
+            .iter()
+            .position(|a| a == "--session-id")
+            .expect("--session-id");
+        assert_eq!(args[session_at + 1], new_portal_id.to_string());
+    }
+
     #[test]
     fn resume_ignores_persisted_fork_source() {
         let source = uuid::Uuid::from_u128(1);
         let own_id = uuid::Uuid::from_u128(2);
-        let args = claude_cli_args(own_id, true, Some(source), false, &[]);
+        let args = claude_cli_args(own_id, true, None, Some(source), false, &[]);
         assert_eq!(&args[args.len() - 2..], ["--resume", &own_id.to_string()]);
         assert!(!args.iter().any(|arg| arg == "--fork-session"));
     }
@@ -235,7 +310,7 @@ mod tests {
     #[test]
     fn fresh_non_fork_launch_uses_new_session_id() {
         let own_id = uuid::Uuid::from_u128(2);
-        let args = claude_cli_args(own_id, false, None, false, &[]);
+        let args = claude_cli_args(own_id, false, None, None, false, &[]);
         assert_eq!(
             &args[args.len() - 2..],
             ["--session-id", &own_id.to_string()]
@@ -245,7 +320,7 @@ mod tests {
 
     #[test]
     fn enables_typed_prompt_suggestion_frames() {
-        let args = claude_cli_args(uuid::Uuid::nil(), false, None, true, &[]);
+        let args = claude_cli_args(uuid::Uuid::nil(), false, None, None, true, &[]);
         let flag = args
             .iter()
             .position(|arg| arg == "--prompt-suggestions")
@@ -255,7 +330,7 @@ mod tests {
 
     #[test]
     fn omits_prompt_suggestion_flag_for_older_claude() {
-        let args = claude_cli_args(uuid::Uuid::nil(), false, None, false, &[]);
+        let args = claude_cli_args(uuid::Uuid::nil(), false, None, None, false, &[]);
         assert!(!args.iter().any(|arg| arg == "--prompt-suggestions"));
     }
 }

--- a/codex-session-lib/src/io_task.rs
+++ b/codex-session-lib/src/io_task.rs
@@ -1181,6 +1181,8 @@ mod tests {
             fork_from_session_id: Some(uuid::Uuid::from_u128(1)),
             codex_fork_from_thread_id: Some("parent-thread".into()),
             codex_fork_last_turn_id: Some("turn-7".into()),
+            claude_conversation_id: None,
+            claude_fork_from_conversation_id: None,
             working_directory: "/tmp/fork-worktree".into(),
             ..Default::default()
         };

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -5,7 +5,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use claude_session_lib::proxy_session::CodexThreadIdSink;
+use claude_session_lib::proxy_session::{ClaudeConversationIdSink, CodexThreadIdSink};
 use claude_session_lib::{
     claude_transcript_status, run_connection_loop, ClaudeAgent, LoopResult, PortalInput,
     ProxySessionConfig, TranscriptStatus,
@@ -49,6 +49,60 @@ fn save_codex_threads(map: &HashMap<Uuid, String>) -> std::io::Result<()> {
 
 fn load_codex_thread_id(session_id: Uuid) -> Option<String> {
     load_codex_threads().get(&session_id).cloned()
+}
+
+/// Sidecar map of claude's *current* conversation per portal session, the
+/// claude counterpart to `codex_threads.json`.
+///
+/// `/clear` rolls claude onto a new conversation while the portal session id
+/// stays put, so from that point `--resume <portal id>` re-opens the pre-clear
+/// transcript. Persisting the divergence lets a relaunch resume what the user
+/// can actually see. Deliberately a separate file rather than a field in
+/// `launcher.json`: it is derived cache, rewritten from the output stream, and
+/// losing it degrades to the old behavior rather than corrupting config.
+fn claude_conversations_path() -> PathBuf {
+    session_lib::paths::config_dir().join("claude_conversations.json")
+}
+
+fn load_claude_conversations() -> HashMap<Uuid, Uuid> {
+    std::fs::read_to_string(claude_conversations_path())
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn load_claude_conversation_id(session_id: Uuid) -> Option<Uuid> {
+    load_claude_conversations().get(&session_id).copied()
+}
+
+fn make_claude_conversation_id_sink(session_id: Uuid) -> ClaudeConversationIdSink {
+    std::sync::Arc::new(move |conversation_id: Uuid| {
+        let mut map = load_claude_conversations();
+        if map.get(&session_id) == Some(&conversation_id) {
+            return;
+        }
+        map.insert(session_id, conversation_id);
+        let path = claude_conversations_path();
+        let write = path
+            .parent()
+            .map(std::fs::create_dir_all)
+            .unwrap_or(Ok(()))
+            .and_then(|()| {
+                serde_json::to_string_pretty(&map)
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            })
+            .and_then(|body| std::fs::write(&path, body));
+        match write {
+            Ok(()) => info!(
+                "Claude conversation for session {} recorded as {}",
+                session_id, conversation_id
+            ),
+            Err(e) => warn!(
+                "Failed to persist claude conversation id for session {}: {}",
+                session_id, e
+            ),
+        }
+    })
 }
 
 /// Reverse of the persisted map: given a codex thread id (which a codex agent
@@ -256,6 +310,10 @@ impl ProcessManager {
             // thread/resume. No-op for claude sessions (the codex io-task
             // is the only emitter).
             codex_thread_id_sink: Some(make_codex_thread_id_sink(session_id)),
+            // Claude counterpart: learn the conversation id `/clear` rolls
+            // to, so the next resume opens the live transcript (not the
+            // pre-clear one).
+            claude_conversation_id_sink: Some(make_claude_conversation_id_sink(session_id)),
             fork_from_session_id: params.fork_from_session_id,
             fork_point_turn_id: params.fork_point_turn_id,
         };
@@ -409,6 +467,10 @@ async fn run_session_task(
             codex_thread_id,
             fork_from_session_id: config.fork_from_session_id,
             codex_fork_from_thread_id: config.fork_from_session_id.and_then(load_codex_thread_id),
+            claude_conversation_id: load_claude_conversation_id(config.session_id),
+            claude_fork_from_conversation_id: config
+                .fork_from_session_id
+                .and_then(load_claude_conversation_id),
             codex_fork_last_turn_id: config.fork_point_turn_id.clone(),
         };
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -412,6 +412,7 @@ async fn main() -> Result<()> {
 
     // Build session config
     let session_config = ProxySessionConfig {
+        claude_conversation_id_sink: None,
         backend_url,
         session_id,
         session_name,
@@ -841,6 +842,10 @@ async fn create_claude_session(config: &ProxySessionConfig) -> Result<ClaudeSess
         fork_from_session_id: None,
         codex_fork_from_thread_id: None,
         codex_fork_last_turn_id: None,
+        // Standalone proxy mode has no launcher sidecar persisting claude's
+        // conversation id, so resume keeps the historical session-id behavior.
+        claude_conversation_id: None,
+        claude_fork_from_conversation_id: None,
     };
 
     if config.resume {

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -127,9 +127,12 @@ fn spawn_claude(
     prompt_suggestions: bool,
 ) -> Result<tokio::process::Child> {
     let mut cmd = Command::new("claude");
+    // Shim mode wraps claude directly and keeps no conversation sidecar, so
+    // there is no learned conversation id or fork source to pass.
     cmd.args(claude_cli_args(
         config.session_id,
         config.resume,
+        None,
         None,
         prompt_suggestions,
         &config.claude_args,

--- a/session-lib/src/snapshot.rs
+++ b/session-lib/src/snapshot.rs
@@ -35,10 +35,25 @@ pub struct SessionConfig {
     /// Consumed by the codex io-task: when `resume == true` and this is
     /// `Some`, call `thread/resume` to re-attach to the app-server's
     /// existing thread context rather than starting a fresh one.
-    /// Ignored by the claude path (claude's resume keys off `session_id`
-    /// directly via `--resume`).
+    /// Ignored by the claude path, which has its own equivalent in
+    /// [`claude_conversation_id`](Self::claude_conversation_id).
     #[serde(default)]
     pub codex_thread_id: Option<String>,
+    /// Claude's *current* conversation id, learned from its output stream and
+    /// persisted by the launcher — the claude-side counterpart to
+    /// [`codex_thread_id`](Self::codex_thread_id).
+    ///
+    /// Resume used to pass `session_id` straight to `--resume`, which is only
+    /// correct while claude's conversation id still equals the portal's. `/clear`
+    /// rolls claude onto a new conversation, so from that point the portal id
+    /// names the *pre-clear* transcript and every later resume — crash recovery,
+    /// launcher reconcile, pause/resume, a service restart — silently reinstated
+    /// the conversation as it was before the clear, discarding everything since.
+    ///
+    /// When set, this is what `--resume` gets. `None` means the session has not
+    /// diverged (or predates this field), and `session_id` remains correct.
+    #[serde(default)]
+    pub claude_conversation_id: Option<Uuid>,
     /// Source portal session for a fork. Fork metadata seeds only the first
     /// spawn attempt; the launcher must clear all three fork fields after that
     /// attempt. `resume == false` alone is not a durable first-launch marker:
@@ -55,6 +70,12 @@ pub struct SessionConfig {
     /// Used only on the first launch; relaunches resume `codex_thread_id`.
     #[serde(default)]
     pub codex_fork_from_thread_id: Option<String>,
+    /// Source *conversation* for a claude fork, resolved launcher-side from
+    /// `fork_from_session_id`. Same reason as `claude_conversation_id`: if the
+    /// source was `/clear`ed, its portal id names the pre-clear transcript, so
+    /// forking it branches from history the user can no longer see.
+    #[serde(default)]
+    pub claude_fork_from_conversation_id: Option<Uuid>,
     /// Optional inclusive Codex fork cut. Claude only supports whole history.
     /// Like the source thread, this is ignored on resume launches.
     #[serde(default)]
@@ -142,6 +163,8 @@ mod tests {
             fork_from_session_id: None,
             codex_fork_from_thread_id: None,
             codex_fork_last_turn_id: None,
+            claude_conversation_id: None,
+            claude_fork_from_conversation_id: None,
         }
     }
 


### PR DESCRIPTION
Resume passed the portal session id straight to `claude --resume` (`spawn.rs:61-63`). That is correct only while claude's conversation id still equals the portal's. **`/clear` rolls claude onto a new conversation**, so from that point the portal id names the *pre-clear* transcript — and every later resume (crash recovery, launcher reconcile, pause/resume, a service restart) silently reinstated the conversation as it was before the clear, discarding everything since.

Fork had the same root cause: `--resume <source> --fork-session` used the source's portal id, so forking a cleared session branched from history the user could no longer see.

## Why claude and not codex

Codex already solved this shape. `CodexThreadIdSink` persists the app-server thread id so the next resume re-attaches to the live thread (`process_manager.rs`, `session_event.rs`). Claude had no equivalent — even though every claude frame carries `session_id`, and `spawn.rs` already documented the staleness hazard in a comment while acting on it only for the CLI's `PORTAL_SESSION_ID` path, never for resume. `SessionConfig::codex_thread_id`'s own doc comment asserted the broken premise: *"claude's resume keys off `session_id` directly."*

## Change, mirroring the codex pattern

- The output forwarder watches claude's `session_id` and reports divergence from the portal id — once per change, not per frame.
- The launcher persists it to a `claude_conversations.json` sidecar beside `codex_threads.json`. Deliberately derived cache: losing it degrades to the old behavior rather than corrupting config.
- Resume passes the learned conversation to `--resume`; fork resolves its source the same way. `--session-id` still gets the portal id, which is the identity the backend and dashboard hold.
- Standalone proxy and shim modes have no sidecar and keep the previous behavior explicitly.

## Tests

Three new cases pin the behavior in both directions — diverged resume opens the live conversation and the pre-clear id appears nowhere in the argv; undiverged resume still uses the session id (the overwhelmingly common path); fork takes its source verbatim while the new session keeps the portal id. 168 tests pass across the affected crates.

## Not verified

Diagnosed and fixed from the code paths; I have not reproduced a `/clear`-then-restart cycle end to end. The mechanism is deterministic and the argv is now directly asserted, but the real confirmation is a cleared session surviving a launcher restart with its post-clear history intact.