### PR TITLE
Gate claude transcript checks on the conversation id, not the portal id

### DIFF
--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -21,7 +21,7 @@ pub mod transcript;
 
 pub use agent::ClaudeAgent;
 pub use spawn::{claude_cli_args, claude_supports_prompt_suggestions};
-pub use transcript::{claude_transcript_status, TranscriptStatus};
+pub use transcript::{claude_transcript_id, claude_transcript_status, TranscriptStatus};
 
 // Re-export the proxy session helpers used by the proxy binary.
 pub use proxy_session::{

--- a/claude-session-lib/src/spawn.rs
+++ b/claude-session-lib/src/spawn.rs
@@ -36,8 +36,10 @@ pub fn claude_cli_args(
     prompt_suggestions: bool,
     extra_args: &[String],
 ) -> Vec<String> {
-    // Where claude's history actually lives right now.
-    let transcript_id = conversation_id.unwrap_or(session_id);
+    // Where claude's history actually lives right now. Shared with the
+    // launcher's transcript-existence gates so the file they check is always the
+    // file this resumes.
+    let transcript_id = crate::transcript::claude_transcript_id(session_id, conversation_id);
     let mut args: Vec<String> = [
         "--print",
         "--verbose",
@@ -106,13 +108,7 @@ pub(crate) async fn spawn_claude(
         &config.extra_args,
     );
 
-    let mut cmd = Command::new(claude_path);
-    cmd.args(&args);
-    cmd.current_dir(&config.working_directory);
-    // Claude exports `CLAUDE_CODE_SESSION_ID` to tools it spawns. This is the
-    // id passed here initially, but it is process-environment state and can go
-    // stale when `/clear` rolls Claude to another conversation. The launcher
-    // CLI therefore treats an explicit `PORTAL_SESSION_ID` as authoritative.
+    let mut cmd = build_claude_command(claude_path, &args, config);
 
     // Log the full command for diagnostics.
     tracing::info!(
@@ -120,6 +116,30 @@ pub(crate) async fn spawn_claude(
         claude_path.to_string_lossy(),
         args.join(" ")
     );
+
+    let child = cmd.spawn().map_err(SessionError::SpawnFailed)?;
+    let pid = child.id();
+
+    let client = ClaudeAsyncClient::new(child).map_err(|e| {
+        SessionError::CommunicationError(format!("Failed to create ClaudeAsyncClient: {}", e))
+    })?;
+    Ok((client, pid))
+}
+
+/// Build the fully-configured `claude` [`Command`], short of spawning it.
+/// Factored out of [`spawn_claude`] so the environment and stdio wiring are
+/// assertable in tests without launching a process.
+fn build_claude_command(claude_path: &Path, args: &[String], config: &SessionConfig) -> Command {
+    let mut cmd = Command::new(claude_path);
+    cmd.args(args);
+    cmd.current_dir(&config.working_directory);
+    // Claude exports `CLAUDE_CODE_SESSION_ID` to the tools it spawns, but that
+    // is process-environment state naming claude's *conversation*: `/clear`
+    // rolls it onto an id that is not a portal session at all. Export the portal
+    // id explicitly — `launcher::message` treats it as authoritative and only
+    // falls back to matching on host + working directory, which is ambiguous the
+    // moment two sessions share a directory. Codex and Muse already do this.
+    cmd.env("PORTAL_SESSION_ID", config.session_id.to_string());
 
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -138,13 +158,7 @@ pub(crate) async fn spawn_claude(
     #[cfg(unix)]
     cmd.process_group(0);
 
-    let child = cmd.spawn().map_err(SessionError::SpawnFailed)?;
-    let pid = child.id();
-
-    let client = ClaudeAsyncClient::new(child).map_err(|e| {
-        SessionError::CommunicationError(format!("Failed to create ClaudeAsyncClient: {}", e))
-    })?;
-    Ok((client, pid))
+    cmd
 }
 
 /// Probe the installed CLI once per resolved path before using the additive
@@ -332,5 +346,55 @@ mod tests {
     fn omits_prompt_suggestion_flag_for_older_claude() {
         let args = claude_cli_args(uuid::Uuid::nil(), false, None, None, false, &[]);
         assert!(!args.iter().any(|arg| arg == "--prompt-suggestions"));
+    }
+
+    /// The property the launcher's transcript gates depend on: the id
+    /// `--resume` opens is exactly `claude_transcript_id`. If these ever drift,
+    /// a gate checks the existence of a different file than the spawn uses —
+    /// which is the bug class this whole seam exists to close.
+    #[test]
+    fn resume_target_is_the_shared_transcript_id() {
+        for conversation in [None, Some(uuid::Uuid::from_u128(99))] {
+            let portal_id = uuid::Uuid::from_u128(2);
+            let args = claude_cli_args(portal_id, true, conversation, None, false, &[]);
+            let expected = crate::transcript::claude_transcript_id(portal_id, conversation);
+            assert_eq!(
+                &args[args.len() - 2..],
+                ["--resume", &expected.to_string()],
+                "argv and the gates' transcript id must agree (conversation={conversation:?})"
+            );
+        }
+    }
+
+    /// Tools claude spawns must inherit the *portal* session id. Claude's own
+    /// `CLAUDE_CODE_SESSION_ID` names its conversation, which `/clear` rolls
+    /// onto an id that is not a portal session at all — leaving
+    /// `agent-portal message send` to guess from host + working directory.
+    #[test]
+    fn exports_portal_session_id_to_the_claude_child() {
+        let config = SessionConfig {
+            session_id: uuid::Uuid::from_u128(42),
+            working_directory: std::env::temp_dir(),
+            // A cleared session: claude's own env var would name this instead.
+            claude_conversation_id: Some(uuid::Uuid::from_u128(4242)),
+            ..Default::default()
+        };
+        let cmd = build_claude_command(Path::new("claude"), &[], &config);
+
+        let envs: Vec<(String, String)> = cmd
+            .as_std()
+            .get_envs()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.to_string_lossy().into_owned(),
+                    v?.to_string_lossy().into_owned(),
+                ))
+            })
+            .collect();
+        assert!(
+            envs.iter()
+                .any(|(k, v)| k == "PORTAL_SESSION_ID" && *v == config.session_id.to_string()),
+            "PORTAL_SESSION_ID must be the portal id, not the conversation; envs: {envs:?}"
+        );
     }
 }

--- a/claude-session-lib/src/transcript.rs
+++ b/claude-session-lib/src/transcript.rs
@@ -29,6 +29,22 @@ pub enum TranscriptStatus {
     Unknown,
 }
 
+/// Which id names claude's transcript on disk: the conversation it has diverged
+/// onto, else the portal session id.
+///
+/// `/clear` rolls claude to a new conversation while the portal session id stays
+/// put, so from that point the two differ. This is the single rule for resolving
+/// that — [`claude_cli_args`](crate::claude_cli_args) applies it to pick the
+/// `--resume` target, and every "does the transcript exist?" gate must apply it
+/// too. Callers that gate on the portal id while the spawn opens the
+/// conversation id get a check of a *different file than the one about to be
+/// used*, and both directions of that mismatch hurt: `Missing` on a stale
+/// pre-clear file rotates away a live, resumable conversation, while `Present`
+/// on one suppresses the rotation that breaks a doomed `--resume` crash-loop.
+pub fn claude_transcript_id(session_id: Uuid, conversation_id: Option<Uuid>) -> Uuid {
+    conversation_id.unwrap_or(session_id)
+}
+
 /// Encode a working directory the way the `claude` CLI names its project dir:
 /// every `/` and `.` becomes `-`.
 fn encode_project_dir(working_directory: &Path) -> String {

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -7,8 +7,8 @@ use uuid::Uuid;
 
 use claude_session_lib::proxy_session::{ClaudeConversationIdSink, CodexThreadIdSink};
 use claude_session_lib::{
-    claude_transcript_status, run_connection_loop, ClaudeAgent, LoopResult, PortalInput,
-    ProxySessionConfig, TranscriptStatus,
+    claude_transcript_id, claude_transcript_status, run_connection_loop, ClaudeAgent, LoopResult,
+    PortalInput, ProxySessionConfig, TranscriptStatus,
 };
 use codex_session_lib::CodexAgent;
 use muse_session_lib::MuseAgent;
@@ -73,6 +73,16 @@ fn load_claude_conversations() -> HashMap<Uuid, Uuid> {
 
 fn load_claude_conversation_id(session_id: Uuid) -> Option<Uuid> {
     load_claude_conversations().get(&session_id).copied()
+}
+
+/// The id naming claude's transcript on disk for `session_id` right now, from
+/// the launcher's persisted view of the divergence.
+///
+/// Thin wrapper that feeds the sidecar into the shared rule the argv builder
+/// uses, so a gate and the spawn it guards can never check different files —
+/// see [`claude_session_lib::claude_transcript_id`] for why that matters.
+fn resolved_transcript_id(session_id: Uuid) -> Uuid {
+    claude_transcript_id(session_id, load_claude_conversation_id(session_id))
 }
 
 fn make_claude_conversation_id_sink(session_id: Uuid) -> ClaudeConversationIdSink {
@@ -225,7 +235,13 @@ impl ProcessManager {
         if let Some(source_id) = params.fork_from_session_id {
             match params.agent_type {
                 shared::AgentType::Claude => {
-                    if claude_transcript_status(&base_dir, source_id) == TranscriptStatus::Missing {
+                    // Validate the transcript the fork will actually branch from
+                    // — the source's *conversation* — not its portal id, which
+                    // names the pre-clear transcript once the source has been
+                    // `/clear`ed. See `resolved_transcript_id`.
+                    if claude_transcript_status(&base_dir, resolved_transcript_id(source_id))
+                        == TranscriptStatus::Missing
+                    {
                         anyhow::bail!(
                             "Cannot fork: source Claude transcript is missing on this launcher"
                         );
@@ -410,11 +426,14 @@ async fn run_session_task(
         // one step, instead of crash-looping until claude happens to emit
         // "No conversation found". Claude-only (codex has no transcript file);
         // `Unknown` (path-encoding uncertainty) falls through to a normal spawn.
+        // Asks about the id the spawn below will actually `--resume` (see
+        // `resolved_transcript_id`) — gating on the portal id would rotate away a
+        // live post-`/clear` conversation whose pre-clear file had been cleaned up.
         if config.resume
             && config.agent_type == shared::AgentType::Claude
             && claude_transcript_status(
                 std::path::Path::new(&config.working_directory),
-                config.session_id,
+                resolved_transcript_id(config.session_id),
             ) == TranscriptStatus::Missing
         {
             let old_id = config.session_id;
@@ -554,11 +573,15 @@ async fn run_session_task(
                     // the rotation only when the transcript is confirmed Present:
                     // then the early exit is some other fault, and discarding the
                     // resume would needlessly lose conversation continuity.
+                    // Same id discipline as the pre-flight gate above: ask about
+                    // the conversation we actually resumed, or a stale pre-clear
+                    // file reading `Present` suppresses the rotation and we
+                    // crash-loop on exactly the case this exists to break.
                     if config.resume
                         && config.agent_type == shared::AgentType::Claude
                         && claude_transcript_status(
                             std::path::Path::new(&config.working_directory),
-                            config.session_id,
+                            resolved_transcript_id(config.session_id),
                         ) != TranscriptStatus::Present
                     {
                         let old_id = config.session_id;


### PR DESCRIPTION
Follow-up audit after #1695 found three more places where the portal session id was used to address Claude-side state.

`claude_transcript_status` resolves `~/.claude/projects/<cwd>/<id>.jsonl` — a file keyed by Claude's **conversation** id. All three call sites passed the **portal** id:

- `process_manager.rs` pre-flight resume gate
- `process_manager.rs` crash-loop rotation gate
- `process_manager.rs` fork preflight

This was harmless while the spawn also used the portal id. #1695 taught `--resume` to open the learned conversation after a `/clear` but didn't teach the gates, so from then on a gate could check a different file than the spawn was about to open. Both directions of that mismatch are harmful:

- **`Missing` on a stale pre-clear file** → rotates to a fresh session id and drops resume, discarding a live, resumable conversation. Silent data loss.
- **`Present` on one** → suppresses the rotation that exists to break a doomed `--resume` crash-loop.

Reaching the first only takes Claude's own transcript housekeeping removing the pre-clear `.jsonl` while the post-clear one lives.

## Approach

Make the resolution structural rather than a convention. The rule moves to `claude_transcript_id` in `claude-session-lib`; `claude_cli_args` picks its `--resume` target through it, and the launcher's `resolved_transcript_id` feeds the sidecar into the same function. The gate and the argv now call one function, so they cannot drift. A test pins the equivalence.

## Also

Export `PORTAL_SESSION_ID` to the Claude child, matching codex and muse. Claude only sets `CLAUDE_CODE_SESSION_ID`, which names its conversation — after a `/clear` that is not a portal session at all, leaving `agent-portal message send` to fall back to matching on host + working directory, which is ambiguous the moment two sessions share a directory. Spawn command construction is factored into `build_claude_command` so the export is assertable without launching a process.

## Verification

162 tests pass across both crates, clippy clean. Not reproduced end-to-end through a `/clear`-then-cleanup cycle — the gate/argv equivalence is covered by unit test rather than integration.