### PR TITLE
Display images an agent reads, again

### DIFF
--- a/claude-session-lib/src/proxy_session/media_display.rs
+++ b/claude-session-lib/src/proxy_session/media_display.rs
@@ -1,0 +1,190 @@
+//! Auto-display of images an agent reads.
+//!
+//! Reading an image used to render it inline; #1450 removed that in favor of the
+//! explicit `agent-portal show` CLI. `show` is still the right tool when an
+//! agent *generates* something it wants seen, but it does nothing for the common
+//! case of an agent reading a screenshot or a diagram — the user watches it
+//! reason about a picture they cannot see. This restores the implicit path on
+//! top of the current media stack rather than the chunked uploader #1451 deleted:
+//! detection lives here, and the launcher does the upload through the same
+//! `POST /api/agent/sessions/{id}/media` endpoint `show` uses, so archiving,
+//! replay, SVG sanitization (#1530) and eviction behavior are shared.
+//!
+//! Claude and Codex need separate detectors for the same reason their git
+//! signals do (#1653): Claude has a typed `Read` tool, Codex shells out.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use claude_codes::ClaudeOutput;
+
+/// Displays a local media file inline in the session transcript.
+///
+/// The detection half lives here; the launcher supplies the side effect because
+/// only it holds the session's upload credentials. Same split — and same reason
+/// — as [`ClaudeConversationIdSink`](super::ClaudeConversationIdSink). A
+/// standalone proxy passes `None` and simply doesn't auto-display.
+pub type MediaDisplaySink = Arc<dyn Fn(PathBuf) + Send + Sync>;
+
+/// Extensions the portal can render inline. Deliberately the image half of
+/// `shared::media`'s supported set: video is never auto-displayed, since nothing
+/// an agent does to a video file reads as "look at this".
+const DISPLAYABLE: [&str; 6] = ["png", "jpg", "jpeg", "gif", "webp", "svg"];
+
+fn is_displayable_image(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            DISPLAYABLE
+                .iter()
+                .any(|known| ext.eq_ignore_ascii_case(known))
+        })
+}
+
+/// The image Claude's `Read` tool is opening in this frame, if any.
+///
+/// Keyed off the typed [`ToolInput::Read`](claude_codes::tool_inputs::ToolInput)
+/// rather than `input["file_path"]`, so an upstream field rename is a compile
+/// error here instead of a detector that silently stops matching.
+pub(super) fn claude_output_image_read(output: &ClaudeOutput) -> Option<PathBuf> {
+    let read = output.as_tool_use("Read")?;
+    let Some(claude_codes::tool_inputs::ToolInput::Read(input)) = read.typed_input() else {
+        return None;
+    };
+    let path = PathBuf::from(input.file_path);
+    is_displayable_image(&path).then_some(path)
+}
+
+/// Best-effort Codex counterpart.
+///
+/// Codex has no typed read tool — it shells out — so this parses command argv
+/// and is honestly weaker than the Claude path: it sees `cat diagram.png` but
+/// not an image opened by a script or a shell function. Gated to `item.completed`
+/// so the file exists by the time we upload it, and to a read-ish allowlist so
+/// that `rm logo.png` never displays anything.
+pub(super) fn codex_output_image_read(value: &serde_json::Value) -> Option<PathBuf> {
+    if value.get("type").and_then(|t| t.as_str()) != Some("item.completed") {
+        return None;
+    }
+    let item = value.get("item")?;
+    let item_type = item.get("type").and_then(|t| t.as_str())?;
+    if item_type != "commandExecution" && item_type != "command_execution" {
+        return None;
+    }
+    image_path_from_read_command(item.get("command")?.as_str()?)
+}
+
+/// Commands that mean "look at this file". `cat` earns its place because it is
+/// what an agent reaches for reflexively, even though the bytes are useless to
+/// it — that reflex is exactly the case worth rendering for the human.
+const READ_COMMANDS: [&str; 6] = ["cat", "open", "xdg-open", "imgcat", "display", "qlmanage"];
+
+fn image_path_from_read_command(command: &str) -> Option<PathBuf> {
+    let mut tokens = command.split_whitespace();
+    let program = tokens.next()?;
+    let program = Path::new(program).file_name()?.to_str()?;
+    if !READ_COMMANDS.contains(&program) {
+        return None;
+    }
+    tokens
+        .filter(|token| !token.starts_with('-'))
+        .map(PathBuf::from)
+        .find(|path| is_displayable_image(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn claude_read(file_path: &str) -> ClaudeOutput {
+        serde_json::from_value(json!({
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-opus-5",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "Read",
+                    "input": { "file_path": file_path }
+                }],
+                "stop_reason": null,
+                "stop_sequence": null,
+                "usage": { "input_tokens": 1, "output_tokens": 1 }
+            },
+            "session_id": "00000000-0000-0000-0000-000000000001"
+        }))
+        .expect("valid claude assistant frame")
+    }
+
+    #[test]
+    fn detects_a_claude_image_read() {
+        assert_eq!(
+            claude_output_image_read(&claude_read("/tmp/shot.png")),
+            Some(PathBuf::from("/tmp/shot.png"))
+        );
+    }
+
+    #[test]
+    fn extension_match_is_case_insensitive() {
+        assert!(claude_output_image_read(&claude_read("/tmp/Diagram.SVG")).is_some());
+    }
+
+    /// The overwhelmingly common Read: source files must not upload anything.
+    #[test]
+    fn ignores_claude_reads_of_non_images() {
+        assert!(claude_output_image_read(&claude_read("/src/main.rs")).is_none());
+        assert!(claude_output_image_read(&claude_read("/notes/pngs.md")).is_none());
+    }
+
+    fn codex_command(command: &str) -> serde_json::Value {
+        json!({
+            "type": "item.completed",
+            "item": { "type": "commandExecution", "command": command }
+        })
+    }
+
+    #[test]
+    fn detects_a_codex_shell_image_read() {
+        assert_eq!(
+            codex_output_image_read(&codex_command("cat out/chart.png")),
+            Some(PathBuf::from("out/chart.png"))
+        );
+        assert_eq!(
+            codex_output_image_read(&codex_command("/usr/bin/open -a Preview a.jpeg")),
+            Some(PathBuf::from("a.jpeg"))
+        );
+    }
+
+    /// Destructive and unrelated commands that merely mention an image must not
+    /// trigger an upload.
+    #[test]
+    fn ignores_codex_commands_that_are_not_reads() {
+        assert!(codex_output_image_read(&codex_command("rm logo.png")).is_none());
+        assert!(codex_output_image_read(&codex_command("cp a.png b.png")).is_none());
+        assert!(codex_output_image_read(&codex_command("cat main.rs")).is_none());
+    }
+
+    /// Only completed commands: uploading on `item.started` races the file into
+    /// existence and would display a truncated or absent image.
+    #[test]
+    fn ignores_codex_commands_still_running() {
+        let mut started = codex_command("cat out/chart.png");
+        started["type"] = json!("item.started");
+        assert!(codex_output_image_read(&started).is_none());
+    }
+
+    /// A muse journal record must not be read by the codex detector (#1653).
+    #[test]
+    fn ignores_muse_records() {
+        let muse = json!({
+            "type": "muse_record",
+            "payload_type": "tool.result",
+            "payload": { "output": "cat shot.png" }
+        });
+        assert!(codex_output_image_read(&muse).is_none());
+    }
+}

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -3,6 +3,7 @@
 mod git_metadata;
 mod heartbeat_watchdog;
 mod input_delivery;
+mod media_display;
 mod output_forwarder;
 mod permission_bridge;
 mod portal_reminder;
@@ -30,6 +31,7 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 pub use git_metadata::{get_git_branch, get_repo_url};
+pub use media_display::MediaDisplaySink;
 
 use git_metadata::{get_open_prs, get_pr_url, GitMetadataState, GitRefreshTrigger};
 use output_forwarder::spawn_output_forwarder;
@@ -84,6 +86,8 @@ pub struct ProxySessionConfig {
     pub codex_thread_id_sink: Option<CodexThreadIdSink>,
     /// Claude counterpart to `codex_thread_id_sink` (see the type docs).
     pub claude_conversation_id_sink: Option<ClaudeConversationIdSink>,
+    /// Displays an image the agent read; see [`MediaDisplaySink`].
+    pub media_display_sink: Option<MediaDisplaySink>,
     /// First-spawn-only source session for Claude/Codex fork semantics.
     pub fork_from_session_id: Option<Uuid>,
     /// Optional Codex native turn id; `None` forks the latest turn.
@@ -377,6 +381,9 @@ struct ConnectionState {
     /// [`CodexThreadIdSink`] doc. Cloned out of `ProxySessionConfig` so
     /// the per-connection state doesn't need to carry a config reference.
     codex_thread_id_sink: Option<CodexThreadIdSink>,
+    /// Displays images the agent reads; see [`MediaDisplaySink`]. Used by the
+    /// non-Claude arm — Claude's detection runs in the output forwarder.
+    media_display_sink: Option<MediaDisplaySink>,
 }
 
 /// Run the WebSocket connection loop with auto-reconnect
@@ -854,6 +861,7 @@ async fn run_message_loop<A: Agent>(
         session.output_buffer.clone(),
         config.agent_type,
         config.claude_conversation_id_sink.clone(),
+        config.media_display_sink.clone(),
     );
 
     // Spawn WebSocket reader task
@@ -900,6 +908,7 @@ async fn run_message_loop<A: Agent>(
         git_metadata,
         git_refresh: GitRefreshTrigger::default(),
         codex_thread_id_sink: config.codex_thread_id_sink.clone(),
+        media_display_sink: config.media_display_sink.clone(),
     };
 
     // On the very first connection of this session, inject the portal

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -23,6 +23,7 @@ use super::git_metadata::{
     check_and_send_branch_update, claude_output_code_change_published,
     claude_output_has_git_signal, GitMetadataState, GitRefreshTrigger,
 };
+use super::media_display::{claude_output_image_read, MediaDisplaySink};
 use super::{format_duration, truncate, SharedWsWrite};
 
 /// Spawn the output forwarder task
@@ -41,6 +42,7 @@ pub fn spawn_output_forwarder(
     output_buffer: std::sync::Arc<tokio::sync::Mutex<PendingOutputBuffer>>,
     agent_type: AgentType,
     claude_conversation_id_sink: Option<super::ClaudeConversationIdSink>,
+    media_display_sink: Option<MediaDisplaySink>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut git_refresh = GitRefreshTrigger::default();
@@ -111,6 +113,15 @@ pub fn spawn_output_forwarder(
                         &git_metadata,
                     )
                     .await;
+                }
+
+                // Reading an image displays it: the user otherwise watches the
+                // agent reason about a picture they cannot see.
+                if let Some(sink) = media_display_sink.as_ref() {
+                    if let Some(path) = claude_output_image_read(output) {
+                        debug!("← Read of displayable image: {}", path.display());
+                        sink(path);
+                    }
                 }
 
                 // Is THIS message a git-related bash command (for next iteration)?

--- a/claude-session-lib/src/proxy_session/session_event.rs
+++ b/claude-session-lib/src/proxy_session/session_event.rs
@@ -25,6 +25,7 @@ use tracing::error;
 use super::git_metadata::{
     codex_output_has_git_signal, muse_output_has_git_signal, spawn_branch_update,
 };
+use super::media_display::codex_output_image_read;
 use super::wiggum::handle_session_event_with_wiggum;
 use super::{inject_portal_reminder, is_codex_compaction_event, ConnectionResult, ConnectionState};
 
@@ -64,6 +65,17 @@ pub(super) async fn handle_next_event<A: Agent>(
             };
             if has_git_signal {
                 state.git_refresh.mark_git_signal();
+            }
+
+            // Codex counterpart to the Claude Read-triggered display. Muse is
+            // excluded deliberately: its journal has no command-execution record
+            // this could key on, so a detector here would be dead code.
+            if state.agent_type == shared::AgentType::Codex {
+                if let Some(sink) = state.media_display_sink.as_ref() {
+                    if let Some(path) = codex_output_image_read(value) {
+                        sink(path);
+                    }
+                }
             }
 
             let is_codex_compaction = is_codex_compaction_event(value);

--- a/launcher/src/media.rs
+++ b/launcher/src/media.rs
@@ -81,7 +81,38 @@ fn human_size(bytes: u64) -> String {
 
 /// `agent-portal show <file>` — upload and display media in this session.
 pub async fn show(path_str: &str) -> Result<()> {
-    let path = Path::new(path_str);
+    let client = reqwest::Client::new();
+    let (base, token) = crate::message::api_base()?;
+    let session_id = crate::message::current_session_id(&client, &base, &token)
+        .await
+        .context("could not determine the calling session for `agent-portal show`")?;
+
+    let (data, filename, size, kind) = upload_media(&session_id, Path::new(path_str)).await?;
+    let kind_word = match kind {
+        MediaKind::Image => "image",
+        MediaKind::Video => "video",
+    };
+    println!(
+        "Displayed {kind_word} {filename} ({}) in session {}.",
+        human_size(size),
+        data.session_name
+    );
+    if !data.persisted {
+        println!("warning: media was shown live but not durably persisted for replay");
+    }
+    Ok(())
+}
+
+/// Upload a local file as media for an explicit session.
+///
+/// Split out of [`show`] because the Read-triggered auto-display runs inside the
+/// launcher daemon, which manages many sessions at once and therefore cannot use
+/// `show`'s "resolve the calling session from my own environment" step.
+pub(crate) async fn upload_media(
+    session_id: &str,
+    path: &Path,
+) -> Result<(ShowMediaResponse, String, u64, MediaKind)> {
+    let path_str = path.display().to_string();
     let bytes = std::fs::read(path).with_context(|| format!("could not read file `{path_str}`"))?;
     if bytes.is_empty() {
         return Err(anyhow!("`{path_str}` is empty"));
@@ -112,9 +143,6 @@ pub async fn show(path_str: &str) -> Result<()> {
     let (base, token) = crate::message::api_base()?;
 
     let client = reqwest::Client::new();
-    let session_id = crate::message::current_session_id(&client, &base, &token)
-        .await
-        .context("could not determine the calling session for `agent-portal show`")?;
     let resp = client
         .post(format!("{base}/api/agent/sessions/{session_id}/media"))
         .bearer_auth(&token)
@@ -132,19 +160,7 @@ pub async fn show(path_str: &str) -> Result<()> {
     }
 
     let data: ShowMediaResponse = resp.json().await.context("malformed response")?;
-    let kind_word = match kind {
-        MediaKind::Image => "image",
-        MediaKind::Video => "video",
-    };
-    println!(
-        "Displayed {kind_word} {filename} ({}) in session {}.",
-        human_size(size),
-        data.session_name
-    );
-    if !data.persisted {
-        println!("warning: media was shown live but not durably persisted for replay");
-    }
-    Ok(())
+    Ok((data, filename, size, kind))
 }
 
 #[cfg(test)]

--- a/launcher/src/process_manager.rs
+++ b/launcher/src/process_manager.rs
@@ -2,10 +2,12 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use claude_session_lib::proxy_session::{ClaudeConversationIdSink, CodexThreadIdSink};
+use claude_session_lib::proxy_session::{
+    ClaudeConversationIdSink, CodexThreadIdSink, MediaDisplaySink,
+};
 use claude_session_lib::{
     claude_transcript_id, claude_transcript_status, run_connection_loop, ClaudeAgent, LoopResult,
     PortalInput, ProxySessionConfig, TranscriptStatus,
@@ -83,6 +85,33 @@ fn load_claude_conversation_id(session_id: Uuid) -> Option<Uuid> {
 /// see [`claude_session_lib::claude_transcript_id`] for why that matters.
 fn resolved_transcript_id(session_id: Uuid) -> Uuid {
     claude_transcript_id(session_id, load_claude_conversation_id(session_id))
+}
+
+/// Upload images the agent reads so they render inline in the transcript.
+///
+/// The detection half lives in `claude_session_lib::proxy_session::media_display`;
+/// the upload lands here because only the launcher holds the session credentials.
+/// Fire-and-forget by construction: the sink is called from the connection's
+/// output path, so it must not block, and a failed display is never worth
+/// interrupting a session over — it is logged and dropped. Deliberately quiet
+/// about the common benign failures (file already moved, oversize, unsupported
+/// container), which are `debug!` rather than `warn!`.
+fn make_media_display_sink(session_id: Uuid) -> MediaDisplaySink {
+    std::sync::Arc::new(move |path: PathBuf| {
+        tokio::spawn(async move {
+            match crate::media::upload_media(&session_id.to_string(), &path).await {
+                Ok((_, filename, _, _)) => {
+                    info!("Displayed {} read by session {}", filename, session_id)
+                }
+                Err(e) => debug!(
+                    "Not displaying {} for session {}: {}",
+                    path.display(),
+                    session_id,
+                    e
+                ),
+            }
+        });
+    })
 }
 
 fn make_claude_conversation_id_sink(session_id: Uuid) -> ClaudeConversationIdSink {
@@ -330,6 +359,7 @@ impl ProcessManager {
             // to, so the next resume opens the live transcript (not the
             // pre-clear one).
             claude_conversation_id_sink: Some(make_claude_conversation_id_sink(session_id)),
+            media_display_sink: Some(make_media_display_sink(session_id)),
             fork_from_session_id: params.fork_from_session_id,
             fork_point_turn_id: params.fork_point_turn_id,
         };

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -413,6 +413,9 @@ async fn main() -> Result<()> {
     // Build session config
     let session_config = ProxySessionConfig {
         claude_conversation_id_sink: None,
+        // Auto-display needs the launcher's upload credentials; a standalone
+        // proxy simply doesn't display images the agent reads.
+        media_display_sink: None,
         backend_url,
         session_id,
         session_name,


### PR DESCRIPTION
Restores the Read-triggered inline image display that #1450 replaced with `agent-portal show`.

`show` is right when an agent *generates* something it wants seen, but it does nothing for the common case of an agent reading a screenshot or a diagram — the user watches it reason about a picture they can't see.

## What's here (backend/proxy — complete)

Built on the current media stack, not the chunked uploader #1451 deleted. Detection lives in a new `media_display` module; the launcher uploads through the same `POST /api/agent/sessions/{id}/media` endpoint `show` uses, so archiving, replay, SVG sanitization (#1530) and eviction are all shared. The detect/side-effect split follows `ClaudeConversationIdSink` — only the launcher holds session credentials, so a standalone proxy passes `None` and doesn't auto-display.

Claude and Codex need separate detectors for the same reason their git signals do (#1653):

- **Claude** keys off the typed `ToolInput::Read`, so an upstream field rename is a compile error rather than a silently-dead detector.
- **Codex** has no typed read tool — it shells out — so its detector parses command argv and is honestly weaker. Gated to `item.completed` (file exists by then) and to a read-ish allowlist, so `rm logo.png` never displays anything.
- **Muse** is excluded: its journal has no command-execution record to key on.

Also extracts `upload_media` from `show`, which resolved the session from its own environment — wrong for the launcher, which manages many sessions at once.

## What's NOT here yet — why this is a draft

The agreed presentation is a **matrix of thumbnails you can click into as a carousel**. That isn't built. Right now each auto-displayed image arrives as its own portal message and renders stacked, one per message.

That matters, because "every read displays" was chosen on the assumption the matrix would contain the noise. Merging this as-is gives the flooding without the mitigation — a directory sweep would stack 30 full-size images down the transcript. **Recommend not merging until the matrix/carousel lands.**

The grouping is the real work: `ImageViewer` already has a single-image lightbox with Escape handling to build the carousel on, but grouping *across* consecutive messages is a transcript-level change, since auto-display produces one message per image.

## Verification

88 tests in claude-session-lib (7 new covering both detectors), 81 in the launcher. Clippy clean. All three binaries build. Not exercised end-to-end against a live session.