### PR TITLE
Require documentation to describe current system state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -710,6 +710,18 @@ fn custom_answer_input(props: &CustomAnswerInputProps) -> Html {
 See `frontend/src/pages/dashboard/permission_dialog.rs` (`CustomAnswerInput`) for
 the live example.
 
+### Documentation Describes the Current System
+
+Reference documentation and code comments must describe the system as it works
+now. Do not preserve superseded behavior, implementation history, migration
+narratives, or "previously..." commentary merely for context; Git history is
+the archive for that information.
+
+Historical context belongs in current documentation only when it is necessary
+to explain a present-day invariant, compatibility constraint, operational
+hazard, or migration that users still need to perform. Keep that context as
+short as possible and state the current behavior first.
+
 ### Dead Code
 
 **Remove dead code aggressively.** Do not:


### PR DESCRIPTION
## Summary
- require reference docs and code comments to describe current behavior
- reserve historical context for active invariants, compatibility constraints, operational hazards, and migrations users still perform
- identify Git history as the archive for superseded implementation narratives

## Validation
- `git diff --check`

Docs-only change; shipping without review per request.