### PR TITLE
Render /clear as a conversation-reset seam, not a raw bubble

### DIFF
--- a/frontend/src/components/agent_frame.rs
+++ b/frontend/src/components/agent_frame.rs
@@ -154,6 +154,10 @@ impl ClaudeMessage {
             Self::Error(_) => AgentFrameKind::ClaudeError,
             Self::Portal(_) => AgentFrameKind::Portal,
             Self::RateLimitEvent(_) => AgentFrameKind::ClaudeRateLimitEvent,
+            // A `/clear` seam is a session-level event, so it routes and groups
+            // with system frames; `dispatch` still selects its own renderer off
+            // the message variant, not this kind.
+            Self::ConversationReset(_) => AgentFrameKind::ClaudeSystem,
             Self::OptimisticUser(_) => AgentFrameKind::OptimisticUser,
             Self::Unknown => AgentFrameKind::RawJson,
         }

--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -81,6 +81,9 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
             AgentFrame::Claude(ClaudeMessage::RateLimitEvent(msg)) => {
                 renderers::render_rate_limit_event(&msg, ctx.timestamp)
             }
+            AgentFrame::Claude(ClaudeMessage::ConversationReset(msg)) => {
+                renderers::render_conversation_reset(&msg)
+            }
             AgentFrame::Claude(ClaudeMessage::Unknown)
             | AgentFrame::Codex(_)
             | AgentFrame::Muse(_)
@@ -210,7 +213,11 @@ fn render_raw_json(json: &str) -> Html {
 
 /// Base repo for unrecognized-frame reports: the SDK repo, since an unrendered
 /// frame is a typed-model gap there, not a portal bug.
-const REPORT_REPO: &str = "https://github.com/meawoppl/rust-code-agent-sdks";
+// Raw bubbles are overwhelmingly a *portal* render gap — a frame claude-codes
+// already types that `ClaudeMessage` never mapped — so reports belong here, not
+// against the SDK. Pointing this at the SDK repo misrouted at least one report
+// (rust-code-agent-sdks#315, which was a missing `ConversationReset` arm).
+const REPORT_REPO: &str = "https://github.com/meawoppl/agent-portal";
 
 /// Largest raw-JSON snippet to inline in the issue body. GitHub 414s on
 /// over-long URLs and percent-encoding a JSON blob roughly triples its size, so

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -20,7 +20,7 @@ pub(crate) use portal::{
     render_portal_message_content,
 };
 pub use result::render_result_message;
-pub use system::render_system_message;
+pub use system::{render_conversation_reset, render_system_message};
 pub use user::{
     render_optimistic_user_message, render_optimistic_user_message_content, render_user_message,
     render_user_message_content,

--- a/frontend/src/components/message_renderer/renderers/system.rs
+++ b/frontend/src/components/message_renderer/renderers/system.rs
@@ -268,6 +268,24 @@ fn render_task_notification(msg: &shared::SystemMessage, timestamp: Option<&str>
     }
 }
 
+/// `/clear` — the seam between two conversations inside one portal session.
+///
+/// Rendered rather than left to fall through to a raw `Unknown` bubble: it is
+/// the one frame that explains why the transcript above it stops being
+/// referenced. It is also where claude's conversation id rotates, which is why
+/// the portal keys resume on the *next* system-init `session_id` rather than on
+/// this frame's `new_conversation_id` — that field matches no session and no
+/// transcript on disk (claude-codes #316), so it is deliberately not shown.
+pub fn render_conversation_reset(_msg: &shared::ConversationResetMessage) -> Html {
+    html! {
+        <div class="claude-message compaction-message compact">
+            <div class="message-header">
+                <span class="message-type-badge compaction">{ "Conversation Reset" }</span>
+            </div>
+        </div>
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/frontend/src/components/message_renderer/tests/classifier.rs
+++ b/frontend/src/components/message_renderer/tests/classifier.rs
@@ -115,3 +115,24 @@ fn classifier_exhaustive_over_realistic_messages() {
         );
     }
 }
+
+/// `/clear` used to fall through the `_ => Unknown` wildcard and render as a
+/// raw "Unrecognized Message" bubble even though claude-codes has typed it for
+/// months (rust-code-agent-sdks#315).
+#[test]
+fn conversation_reset_parses_to_its_own_variant() {
+    use super::super::types::ClaudeMessage;
+    let json = r#"{
+        "type": "conversation_reset",
+        "new_conversation_id": "11111111-1111-1111-1111-111111111111",
+        "uuid": "22222222-2222-2222-2222-222222222222",
+        "session_id": "33333333-3333-3333-3333-333333333333"
+    }"#;
+    assert!(
+        matches!(
+            ClaudeMessage::parse(json),
+            Ok(ClaudeMessage::ConversationReset(_))
+        ),
+        "conversation_reset must not fall through to Unknown"
+    );
+}

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -40,6 +40,10 @@ pub enum ClaudeMessage {
     Error(shared::AnthropicError),
     Portal(PortalMessage),
     RateLimitEvent(shared::RateLimitEvent),
+    /// `/clear`. Worth its own variant rather than falling to `Unknown`: it is
+    /// the visible seam between two conversations in one session, and it also
+    /// marks where claude's conversation id rotates (see the render).
+    ConversationReset(shared::ConversationResetMessage),
     OptimisticUser(OptimisticUserMessage),
     Unknown,
 }
@@ -65,6 +69,7 @@ impl ClaudeMessage {
                 shared::ClaudeOutput::Result(msg) => Self::Result(msg),
                 shared::ClaudeOutput::Error(msg) => Self::Error(msg),
                 shared::ClaudeOutput::RateLimitEvent(msg) => Self::RateLimitEvent(msg),
+                shared::ClaudeOutput::ConversationReset(msg) => Self::ConversationReset(msg),
                 // Wildcard: control frames plus the 2.1.160 wire additions
                 // (stream_event, tool_progress, transcript variants, …) that
                 // have no dedicated renderer yet.
@@ -90,6 +95,7 @@ impl<'de> Deserialize<'de> for ClaudeMessage {
                 shared::ClaudeOutput::Result(msg) => Self::Result(msg),
                 shared::ClaudeOutput::Error(msg) => Self::Error(msg),
                 shared::ClaudeOutput::RateLimitEvent(msg) => Self::RateLimitEvent(msg),
+                shared::ClaudeOutput::ConversationReset(msg) => Self::ConversationReset(msg),
                 // Wildcard: control frames plus the 2.1.160 wire additions
                 // (stream_event, tool_progress, transcript variants, …) that
                 // have no dedicated renderer yet.

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -205,6 +205,7 @@ pub(super) fn message_type_tag(m: &ClaudeMessage) -> ActivityTag {
         ClaudeMessage::Error(_) => ActivityTag::Error,
         ClaudeMessage::Portal(_) => ActivityTag::Portal,
         ClaudeMessage::RateLimitEvent(_) => ActivityTag::RateLimit,
+        ClaudeMessage::ConversationReset(_) => ActivityTag::System,
         ClaudeMessage::Unknown => ActivityTag::Unknown,
     }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -142,9 +142,10 @@ pub use claude_codes::io::{
 
 // Re-export claude-codes output types for typed parsing.
 pub use claude_codes::io::{
-    AnthropicError, AssistantMessage, AssistantUsage, MessageContent, RateLimitEvent,
-    ResultMessage, ServerToolUse, SystemMessage, SystemSubtype, TaskNotificationMessage,
-    TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType, TaskUsage, UserMessage,
+    AnthropicError, AssistantMessage, AssistantUsage, ConversationResetMessage, MessageContent,
+    RateLimitEvent, ResultMessage, ServerToolUse, SystemMessage, SystemSubtype,
+    TaskNotificationMessage, TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType,
+    TaskUsage, UserMessage,
 };
 pub use claude_codes::CacheCreationDetails;
 pub use claude_codes::ClaudeOutput;


### PR DESCRIPTION
Reported from the rust-code-agent-sdks session; all three claims independently verified against this tree before fixing.

## Render gap

claude-codes has typed `ConversationReset` for months, but the frontend `ClaudeMessage` wrapper never mapped it — so every `/clear` rendered as an "Unrecognized Message" raw bubble. Adds the variant, maps it at both parse sites, and renders it as a compact seam chip alongside the compaction markers it resembles. It's the one frame that explains why the transcript above it stops being referenced.

Adding the variant made two further matches non-exhaustive — the payoff of a typed arm over the `_ => Unknown` wildcard. Frame-kind routing and the activity tag now both classify a reset as a session-level system event instead of silently as `Unknown`.

## `new_conversation_id` is deliberately not shown

Measured live in claude-codes #316: that field matches no session id and no transcript on disk, and is never referenced again. The successor identity is the **next** system-init `session_id`.

Worth noting this repo already keys on the right thing — the proxy captures the successor from subsequent frames' `session_id` for resume (#1695), and the launcher's transcript gates resolve through the same rule (#1696). No behavior change needed there; this PR just makes sure the UI doesn't start advertising the misleading field.

## Report-link misroute

The raw-bubble "Report this issue" link pointed at `rust-code-agent-sdks`. A raw bubble is overwhelmingly a *portal* render gap — a frame the SDK already types that `ClaudeMessage` never mapped — so reports belong here. The old target misrouted at least one (rust-code-agent-sdks#315, which was exactly this missing arm).

## Verification

635 frontend tests pass, including a new regression test asserting `conversation_reset` parses to its own variant rather than `Unknown`. Clippy clean, native and `wasm32-unknown-unknown` both build.