### PR TITLE
Report oversized uploads as too large, and render portal errors

### DIFF
--- a/backend/src/handlers/websocket/uploads.rs
+++ b/backend/src/handlers/websocket/uploads.rs
@@ -56,25 +56,37 @@ pub(super) fn handle_file_upload_start(
     total_size: u64,
     max_image_mb: u32,
 ) {
+    // Server-side hard cap on total decoded bytes, derived from
+    // `PORTAL_MAX_IMAGE_MB`. Saturating to avoid overflow on absurd configs.
+    let effective_max_total_bytes = (max_image_mb as u64).saturating_mul(1024 * 1024);
+
+    // Size is checked BEFORE the chunk-count sanity guard, and the order is the
+    // whole point. `total_chunks` is derived from the file size by the sender
+    // (`size / UPLOAD_CHUNK_SIZE`), so an oversized file trips *both* — and
+    // whichever runs first is the error the user sees. Chunk count is an
+    // anti-abuse guard against pathological values; size is the limit a person
+    // can actually act on. Checking chunks first meant anyone uploading a file
+    // past the ceiling got "invalid chunk count", an internal protocol detail
+    // that reads as a portal bug rather than "your file is too big".
+    if total_size > effective_max_total_bytes {
+        warn!(
+            "Upload {} declared total_size {} > server cap {} bytes; rejecting",
+            upload_id, total_size, effective_max_total_bytes
+        );
+        send_upload_failure(
+            tx,
+            upload_id,
+            &format!("file is too large (limit {max_image_mb} MB)"),
+        );
+        return;
+    }
+
     if total_chunks == 0 || total_chunks > MAX_UPLOAD_TOTAL_CHUNKS {
         warn!(
             "Invalid total_chunks {} for upload {}",
             total_chunks, upload_id
         );
         send_upload_failure(tx, upload_id, "invalid chunk count");
-        return;
-    }
-
-    // Server-side hard cap on total decoded bytes, derived from
-    // `PORTAL_MAX_IMAGE_MB`. Saturating to avoid overflow on absurd configs.
-    let effective_max_total_bytes = (max_image_mb as u64).saturating_mul(1024 * 1024);
-
-    if total_size > effective_max_total_bytes {
-        warn!(
-            "Upload {} declared total_size {} > server cap {} bytes; rejecting",
-            upload_id, total_size, effective_max_total_bytes
-        );
-        send_upload_failure(tx, upload_id, "file exceeds server size limit");
         return;
     }
 

--- a/frontend/src/components/agent_frame.rs
+++ b/frontend/src/components/agent_frame.rs
@@ -77,10 +77,25 @@ impl AgentFrameRegistry {
 
 impl AgentFrame {
     pub fn parse(json: &str, agent_type: shared::AgentType) -> Self {
-        if let Ok(message) = ClaudeMessage::parse(json) {
-            if !matches!(message, ClaudeMessage::Unknown) {
-                return Self::Claude(message);
+        match ClaudeMessage::parse(json) {
+            // A portal-generated error (`{type:"error", message}`) is
+            // agent-agnostic — any session can fail an upload — and its shape
+            // collides with Codex's own error frame. Let the agent-specific
+            // parser win when there is one, and fall back to the portal error
+            // otherwise, so a failed upload renders as an error everywhere
+            // without stealing a frame Codex owns.
+            Ok(ClaudeMessage::LocalError(error)) => {
+                if agent_type == shared::AgentType::Codex {
+                    if let Ok(event) = serde_json::from_str::<CodexEvent>(json) {
+                        if !matches!(event, CodexEvent::Unknown) {
+                            return Self::Codex(event);
+                        }
+                    }
+                }
+                return Self::Claude(ClaudeMessage::LocalError(error));
             }
+            Ok(ClaudeMessage::Unknown) | Err(_) => {}
+            Ok(message) => return Self::Claude(message),
         }
 
         if agent_type == shared::AgentType::Codex {
@@ -158,6 +173,9 @@ impl ClaudeMessage {
             // with system frames; `dispatch` still selects its own renderer off
             // the message variant, not this kind.
             Self::ConversationReset(_) => AgentFrameKind::ClaudeSystem,
+            // Portal-generated errors group with agent errors: same meaning to
+            // the reader, only a different wire shape.
+            Self::LocalError(_) => AgentFrameKind::ClaudeError,
             Self::OptimisticUser(_) => AgentFrameKind::OptimisticUser,
             Self::Unknown => AgentFrameKind::RawJson,
         }

--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -81,6 +81,9 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
             AgentFrame::Claude(ClaudeMessage::RateLimitEvent(msg)) => {
                 renderers::render_rate_limit_event(&msg, ctx.timestamp)
             }
+            AgentFrame::Claude(ClaudeMessage::LocalError(msg)) => {
+                renderers::render_local_error(&msg, ctx.timestamp)
+            }
             AgentFrame::Claude(ClaudeMessage::ConversationReset(msg)) => {
                 renderers::render_conversation_reset(&msg)
             }

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -13,7 +13,7 @@ pub(crate) use assistant::assistant_label;
 pub use assistant::{
     render_assistant_message, render_assistant_message_content, render_content_blocks,
 };
-pub use errors::{render_error_message, render_rate_limit_event};
+pub use errors::{render_error_message, render_local_error, render_rate_limit_event};
 pub(crate) use portal::{
     agent_message_event_from_agent_facing_text, portal_text, render_agent_message_body,
     render_agent_message_event, render_agent_message_from_source, render_portal_message,

--- a/frontend/src/components/message_renderer/renderers/errors.rs
+++ b/frontend/src/components/message_renderer/renderers/errors.rs
@@ -206,3 +206,21 @@ fn format_error_type(error_type: &str) -> String {
         other => other.replace('_', " ").to_string(),
     }
 }
+
+/// A portal-generated error ([`shared::ErrorMessage`]) — a failed upload, say.
+///
+/// Rendered with the same treatment as an Anthropic error because to the reader
+/// it is the same thing: something went wrong and the turn did not happen. The
+/// two differ only in wire shape (flat vs. nested), which is an implementation
+/// detail nobody staring at a failed upload cares about.
+pub fn render_local_error(msg: &shared::ErrorMessage, timestamp: Option<&str>) -> Html {
+    html! {
+        <div class="claude-message error-message-display">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
+                <span class="message-type-badge result error">{ "Error" }</span>
+                <CopyButton text={msg.message.clone()} title="Copy error" />
+            </div>
+            <div class="error-content">{ &msg.message }</div>
+        </div>
+    }
+}

--- a/frontend/src/components/message_renderer/tests/classifier.rs
+++ b/frontend/src/components/message_renderer/tests/classifier.rs
@@ -136,3 +136,56 @@ fn conversation_reset_parses_to_its_own_variant() {
         "conversation_reset must not fall through to Unknown"
     );
 }
+
+/// The portal's own error envelope is flat (`{type:"error", message:"…"}`),
+/// unlike Anthropic's nested `{type:"error", error:{…}}`. It matched neither
+/// `ClaudeOutput` nor the local-frame fallback, so every failed file upload
+/// rendered as an "Unrecognized Message" raw bubble — the portal reporting its
+/// own errors as frames it did not recognize.
+#[test]
+fn portal_error_envelope_renders_as_an_error_not_an_unknown_frame() {
+    use super::super::types::ClaudeMessage;
+    let json = r#"{"type":"error","message":"File upload failed: file is too large (limit 10 MB) — your message was not sent"}"#;
+    match ClaudeMessage::parse(json) {
+        Ok(ClaudeMessage::LocalError(e)) => {
+            assert!(e.message.contains("too large"), "message preserved: {e:?}")
+        }
+        other => panic!("expected LocalError, got {other:?}"),
+    }
+}
+
+/// Anthropic's nested envelope must keep routing to the existing error arm —
+/// the new flat variant must not shadow it.
+#[test]
+fn anthropic_nested_error_still_parses_as_error() {
+    use super::super::types::ClaudeMessage;
+    let json = r#"{"type":"error","error":{"type":"api_error","message":"boom"}}"#;
+    assert!(
+        matches!(ClaudeMessage::parse(json), Ok(ClaudeMessage::Error(_))),
+        "nested Anthropic errors must not regress to LocalError"
+    );
+}
+
+/// The portal error must render as an error on non-Codex agents too — but
+/// without stealing Codex's own `{type:"error"}` frame, which the exhaustive
+/// sweep above pins. Same JSON, different agent, different owner.
+#[test]
+fn portal_error_routes_to_claude_but_leaves_codex_frames_alone() {
+    use super::super::types::ClaudeMessage;
+    use crate::components::agent_frame::{AgentFrame, AgentFrameRegistry};
+    let json = r#"{"type":"error","message":"File upload failed"}"#;
+    assert!(
+        matches!(
+            AgentFrameRegistry::parse(json, shared::AgentType::Claude),
+            AgentFrame::Claude(ClaudeMessage::LocalError(_))
+        ),
+        "a Claude session must render the portal's own error"
+    );
+    assert!(
+        matches!(
+            AgentFrameRegistry::parse(json, shared::AgentType::Codex),
+            AgentFrame::Codex(_)
+        ),
+        "Codex owns this shape and must keep it"
+    );
+}

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -44,6 +44,12 @@ pub enum ClaudeMessage {
     /// the visible seam between two conversations in one session, and it also
     /// marks where claude's conversation id rotates (see the render).
     ConversationReset(shared::ConversationResetMessage),
+    /// A portal-generated error ([`shared::ErrorMessage`]) — a failed file
+    /// upload, say. Distinct from [`Self::Error`], which is Anthropic's nested
+    /// `{type:"error", error:{…}}` envelope: this one is flat, so it never
+    /// matched `ClaudeOutput` and fell through to a raw `Unknown` bubble. The
+    /// portal was rendering its own errors as unrecognized frames.
+    LocalError(shared::ErrorMessage),
     OptimisticUser(OptimisticUserMessage),
     Unknown,
 }
@@ -115,6 +121,11 @@ enum LocalMessage {
     Portal(PortalMessage),
     #[serde(rename = "user")]
     OptimisticUser(OptimisticUserMessage),
+    // Only the payload: `LocalMessage` is internally tagged on `type`, so
+    // serde consumes that key for the discriminant and a nested
+    // `shared::ErrorMessage` (which also declares `type`) can never see it.
+    #[serde(rename = "error")]
+    LocalError { message: String },
     #[serde(other)]
     Unknown,
 }
@@ -124,6 +135,9 @@ impl From<LocalMessage> for ClaudeMessage {
         match value {
             LocalMessage::Portal(msg) => Self::Portal(msg),
             LocalMessage::OptimisticUser(msg) => Self::OptimisticUser(msg),
+            LocalMessage::LocalError { message } => {
+                Self::LocalError(shared::ErrorMessage::new(message))
+            }
             LocalMessage::Unknown => Self::Unknown,
         }
     }

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -206,6 +206,7 @@ pub(super) fn message_type_tag(m: &ClaudeMessage) -> ActivityTag {
         ClaudeMessage::Portal(_) => ActivityTag::Portal,
         ClaudeMessage::RateLimitEvent(_) => ActivityTag::RateLimit,
         ClaudeMessage::ConversationReset(_) => ActivityTag::System,
+        ClaudeMessage::LocalError(_) => ActivityTag::Error,
         ClaudeMessage::Unknown => ActivityTag::Unknown,
     }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -118,9 +118,9 @@ pub use model_version::{compact_model_version, context_window_for};
 // API client types and trait
 pub mod api;
 pub use api::{
-    AgentSessionInfo, AgentSessionsResponse, CodexPermissionInput, ModelUsage, ModelUsageEntry,
-    SendAgentMessageRequest, SendAgentMessageResponse, SoundSettingsResponse, TurnMetrics,
-    TurnMetricsResponse,
+    AgentSessionInfo, AgentSessionsResponse, CodexPermissionInput, ErrorMessage, ModelUsage,
+    ModelUsageEntry, SendAgentMessageRequest, SendAgentMessageResponse, SoundSettingsResponse,
+    TurnMetrics, TurnMetricsResponse,
 };
 
 /// Default backend URL based on build profile.

--- a/shared/src/protocol.rs
+++ b/shared/src/protocol.rs
@@ -35,8 +35,12 @@ pub const UPLOAD_CHUNK_SIZE: usize = 1024;
 pub const MAX_UPLOAD_CHUNK_BYTES: usize = 64 * 1024; // 64 KiB
 
 /// Hard ceiling on the number of chunks per upload, enforced by the
-/// backend at `FileUploadStart` time. With `MAX_UPLOAD_CHUNK_BYTES = 64
-/// KiB` this caps any single upload at 4 GiB, but the **binding** limit
+/// backend at `FileUploadStart` time.
+///
+/// The ceiling this implies depends on the *sender's* chunk size, not on
+/// `MAX_UPLOAD_CHUNK_BYTES`: our frontend sends `UPLOAD_CHUNK_SIZE`
+/// (1 KiB) chunks, so 65 536 of them is 64 MiB, not the 4 GiB you get by
+/// assuming maximum-size chunks. Either way the **binding** limit
 /// is the per-server `PORTAL_MAX_IMAGE_MB` byte cap — this constant only
 /// stops obviously-pathological `total_chunks` values from being accepted.
 pub const MAX_UPLOAD_TOTAL_CHUNKS: u32 = 65_536;


### PR DESCRIPTION
Two bugs, both visible in one screenshot of a failed large-PDF upload.

## 1. The wrong error won

The upload failed with **"invalid chunk count"**. `total_chunks` is derived from the file size by the sender (`size / UPLOAD_CHUNK_SIZE`), so an oversized file trips *both* the size cap and the chunk-count guard — and whichever runs first is the error the user sees.

Chunk count ran first. It's an anti-abuse guard against pathological values; **size** is the limit a person can actually act on. Reordered, and the message now states the limit: `file is too large (limit 10 MB)`.

While measuring this: `MAX_UPLOAD_TOTAL_CHUNKS`'s doc claimed a 4 GiB ceiling, reasoning from maximum-size 64 KiB chunks. Our frontend sends **1 KiB** chunks (`UPLOAD_CHUNK_SIZE`), so the real ceiling is 64 MiB — off by 64×. Corrected to describe what the sender actually does.

## 2. The error rendered as an Unrecognized Message

`shared::ErrorMessage` is flat — `{type:"error", message}` — while `ClaudeOutput::Error` is Anthropic's nested `{type:"error", error:{…}}`. It matched neither that nor the local-frame fallback, so **the portal was reporting its own errors as frames it didn't recognize**. Same class as the `ConversationReset` gap in #1701.

Two things this turned up that a naive fix would have gotten wrong:

- `LocalMessage` is internally tagged on `type`, so serde consumes that key for the discriminant and a nested `ErrorMessage` (which also declares `type`) can never see it. The variant carries just the payload. The test caught this — without it the variant would have silently never matched.
- That flat shape is agent-agnostic and **collides with Codex's own error frame**, and `AgentFrame::parse` tries Claude first. Left naive, the new variant stole every Codex error (an existing exhaustive-sweep test caught it). The agent-specific parser now wins with the portal error as fallback.

## What this does not do

It does not make the large PDF uploadable. The binding limit is `PORTAL_MAX_IMAGE_MB` (default 10 MB), a deploy config knob. Worth noting that variable is named for *images* but gates every file upload, including PDFs — a naming/semantics wart, flagged not fixed.

## Verification

638 frontend tests, 99 backend websocket tests, clippy clean, native + `wasm32-unknown-unknown` both build.