### PR TITLE
Stop relabelling planned restarts as unexpected disconnects

### DIFF
--- a/backend/src/handlers/websocket/uploads.rs
+++ b/backend/src/handlers/websocket/uploads.rs
@@ -56,25 +56,37 @@ pub(super) fn handle_file_upload_start(
     total_size: u64,
     max_image_mb: u32,
 ) {
+    // Server-side hard cap on total decoded bytes, derived from
+    // `PORTAL_MAX_IMAGE_MB`. Saturating to avoid overflow on absurd configs.
+    let effective_max_total_bytes = (max_image_mb as u64).saturating_mul(1024 * 1024);
+
+    // Size is checked BEFORE the chunk-count sanity guard, and the order is the
+    // whole point. `total_chunks` is derived from the file size by the sender
+    // (`size / UPLOAD_CHUNK_SIZE`), so an oversized file trips *both* — and
+    // whichever runs first is the error the user sees. Chunk count is an
+    // anti-abuse guard against pathological values; size is the limit a person
+    // can actually act on. Checking chunks first meant anyone uploading a file
+    // past the ceiling got "invalid chunk count", an internal protocol detail
+    // that reads as a portal bug rather than "your file is too big".
+    if total_size > effective_max_total_bytes {
+        warn!(
+            "Upload {} declared total_size {} > server cap {} bytes; rejecting",
+            upload_id, total_size, effective_max_total_bytes
+        );
+        send_upload_failure(
+            tx,
+            upload_id,
+            &format!("file is too large (limit {max_image_mb} MB)"),
+        );
+        return;
+    }
+
     if total_chunks == 0 || total_chunks > MAX_UPLOAD_TOTAL_CHUNKS {
         warn!(
             "Invalid total_chunks {} for upload {}",
             total_chunks, upload_id
         );
         send_upload_failure(tx, upload_id, "invalid chunk count");
-        return;
-    }
-
-    // Server-side hard cap on total decoded bytes, derived from
-    // `PORTAL_MAX_IMAGE_MB`. Saturating to avoid overflow on absurd configs.
-    let effective_max_total_bytes = (max_image_mb as u64).saturating_mul(1024 * 1024);
-
-    if total_size > effective_max_total_bytes {
-        warn!(
-            "Upload {} declared total_size {} > server cap {} bytes; rejecting",
-            upload_id, total_size, effective_max_total_bytes
-        );
-        send_upload_failure(tx, upload_id, "file exceeds server size limit");
         return;
     }
 

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -386,6 +386,28 @@ struct ConnectionState {
     media_display_sink: Option<MediaDisplaySink>,
 }
 
+/// Record the start of an outage, classifying it **once**.
+///
+/// Both the "connection dropped" and "reconnect attempt failed" paths report
+/// `ConnectionResult::Disconnected`, and every retry during a backend restart
+/// takes the latter. Classifying on each call let those retries overwrite a
+/// graceful classification, so any restart outlasting the first backoff — i.e.
+/// every real redeploy — was reported to the user as an "unexpected
+/// disconnect". Only the first call after a live connection is lost decides
+/// what kind of outage this is; later calls just keep waiting.
+fn note_disconnect(
+    disconnected_at: &mut Option<Instant>,
+    disconnected_at_utc: &mut Option<chrono::DateTime<chrono::Utc>>,
+    last_disconnect_graceful: &mut bool,
+    graceful: bool,
+) {
+    if disconnected_at.is_none() {
+        *disconnected_at = Some(Instant::now());
+        *disconnected_at_utc = Some(chrono::Utc::now());
+        *last_disconnect_graceful = graceful;
+    }
+}
+
 /// Run the WebSocket connection loop with auto-reconnect
 pub async fn run_connection_loop<A: Agent>(
     config: &ProxySessionConfig,
@@ -416,11 +438,12 @@ pub async fn run_connection_loop<A: Agent>(
                 return Ok(LoopResult::SessionNotFound);
             }
             ConnectionResult::Disconnected(duration) => {
-                if session.disconnected_at.is_none() {
-                    session.disconnected_at = Some(Instant::now());
-                    session.disconnected_at_utc = Some(chrono::Utc::now());
-                }
-                session.last_disconnect_graceful = false;
+                note_disconnect(
+                    &mut session.disconnected_at,
+                    &mut session.disconnected_at_utc,
+                    &mut session.last_disconnect_graceful,
+                    false,
+                );
                 session.backoff.reset_if_stable(duration);
                 session.persist_buffer().await;
 
@@ -435,11 +458,12 @@ pub async fn run_connection_loop<A: Agent>(
                 session.backoff.advance();
             }
             ConnectionResult::ServerShutdown(delay) => {
-                if session.disconnected_at.is_none() {
-                    session.disconnected_at = Some(Instant::now());
-                    session.disconnected_at_utc = Some(chrono::Utc::now());
-                }
-                session.last_disconnect_graceful = true;
+                note_disconnect(
+                    &mut session.disconnected_at,
+                    &mut session.disconnected_at_utc,
+                    &mut session.last_disconnect_graceful,
+                    true,
+                );
                 // Graceful shutdown - reset backoff and use server's suggested delay
                 session.backoff.reset();
                 session.persist_buffer().await;
@@ -561,6 +585,17 @@ async fn run_single_connection<A: Agent>(session: &mut SessionState<'_, A>) -> C
     {
         let hostname = hostname_or_unknown();
 
+        // A reconnect the server announced. `first_connection` is never one.
+        let expected_cycle = !session.first_connection && session.last_disconnect_graceful;
+        let reconnect_duration = session.disconnected_at.map(|t| {
+            let secs = t.elapsed().as_secs();
+            if secs < 60 {
+                format!("{}s", secs)
+            } else {
+                format!("{}m {}s", secs / 60, secs % 60)
+            }
+        });
+
         let status_line = if session.first_connection {
             "**Session started**".to_string()
         } else {
@@ -601,18 +636,28 @@ async fn run_single_connection<A: Agent>(session: &mut SessionState<'_, A>) -> C
             }
         };
 
-        let short_id = &session.config.session_id.to_string()[..8];
-        let text = format!(
-            "{} — `{}` on `{}` in `{}` ({} `{}…`)",
-            status_line,
-            session.config.session_name,
-            hostname,
-            session.config.working_directory,
-            config_with_branch.agent_type,
-            short_id,
-        );
-
-        let portal_content = shared::PortalMessage::text(text).to_json();
+        // An expected cycle — the backend told us it was restarting — is
+        // routine and gets a one-line seam chip instead of a full card with
+        // host, cwd and agent id. An unexpected drop keeps the card: that one
+        // is worth interrupting the reader for.
+        let portal_content = if expected_cycle {
+            shared::PortalMessage::with_content(vec![shared::PortalContent::ConnectionCycle {
+                duration: reconnect_duration,
+            }])
+            .to_json()
+        } else {
+            let short_id = &session.config.session_id.to_string()[..8];
+            let text = format!(
+                "{} — `{}` on `{}` in `{}` ({} `{}…`)",
+                status_line,
+                session.config.session_name,
+                hostname,
+                session.config.working_directory,
+                config_with_branch.agent_type,
+                short_id,
+            );
+            shared::PortalMessage::text(text).to_json()
+        };
         let seq = {
             let mut buf = session.output_buffer.lock().await;
             buf.push(portal_content.clone())
@@ -1415,6 +1460,37 @@ pub(crate) use shared::fmt::{format_duration, truncate_str as truncate};
 
 #[cfg(test)]
 mod tests {
+    /// The redeploy bug: the backend announces a restart (graceful), then every
+    /// reconnect attempt fails while it is coming back up. Those retries must
+    /// not relabel the outage — a planned redeploy that takes longer than one
+    /// backoff was being reported to the user as an "unexpected disconnect".
+    #[test]
+    fn retries_during_a_restart_do_not_relabel_a_graceful_outage() {
+        let (mut at, mut at_utc, mut graceful) = (None, None, false);
+
+        note_disconnect(&mut at, &mut at_utc, &mut graceful, true);
+        assert!(graceful, "the server told us it was restarting");
+        let first_seen = at;
+
+        // 35 seconds of failed reconnect attempts, each reporting Disconnected.
+        for _ in 0..8 {
+            note_disconnect(&mut at, &mut at_utc, &mut graceful, false);
+        }
+
+        assert!(graceful, "retries must not turn a restart into a surprise");
+        assert_eq!(at, first_seen, "the outage clock starts at the first drop");
+    }
+
+    /// The converse still has to work: a genuinely unexpected drop stays
+    /// unexpected, and keeps the louder card.
+    #[test]
+    fn an_unannounced_drop_stays_unexpected() {
+        let (mut at, mut at_utc, mut graceful) = (None, None, false);
+        note_disconnect(&mut at, &mut at_utc, &mut graceful, false);
+        assert!(!graceful);
+        assert!(at.is_some());
+    }
+
     use super::*;
     use uuid::Uuid;
 

--- a/frontend/src/components/agent_frame.rs
+++ b/frontend/src/components/agent_frame.rs
@@ -77,10 +77,25 @@ impl AgentFrameRegistry {
 
 impl AgentFrame {
     pub fn parse(json: &str, agent_type: shared::AgentType) -> Self {
-        if let Ok(message) = ClaudeMessage::parse(json) {
-            if !matches!(message, ClaudeMessage::Unknown) {
-                return Self::Claude(message);
+        match ClaudeMessage::parse(json) {
+            // A portal-generated error (`{type:"error", message}`) is
+            // agent-agnostic — any session can fail an upload — and its shape
+            // collides with Codex's own error frame. Let the agent-specific
+            // parser win when there is one, and fall back to the portal error
+            // otherwise, so a failed upload renders as an error everywhere
+            // without stealing a frame Codex owns.
+            Ok(ClaudeMessage::LocalError(error)) => {
+                if agent_type == shared::AgentType::Codex {
+                    if let Ok(event) = serde_json::from_str::<CodexEvent>(json) {
+                        if !matches!(event, CodexEvent::Unknown) {
+                            return Self::Codex(event);
+                        }
+                    }
+                }
+                return Self::Claude(ClaudeMessage::LocalError(error));
             }
+            Ok(ClaudeMessage::Unknown) | Err(_) => {}
+            Ok(message) => return Self::Claude(message),
         }
 
         if agent_type == shared::AgentType::Codex {
@@ -158,6 +173,9 @@ impl ClaudeMessage {
             // with system frames; `dispatch` still selects its own renderer off
             // the message variant, not this kind.
             Self::ConversationReset(_) => AgentFrameKind::ClaudeSystem,
+            // Portal-generated errors group with agent errors: same meaning to
+            // the reader, only a different wire shape.
+            Self::LocalError(_) => AgentFrameKind::ClaudeError,
             Self::OptimisticUser(_) => AgentFrameKind::OptimisticUser,
             Self::Unknown => AgentFrameKind::RawJson,
         }

--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -81,6 +81,9 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
             AgentFrame::Claude(ClaudeMessage::RateLimitEvent(msg)) => {
                 renderers::render_rate_limit_event(&msg, ctx.timestamp)
             }
+            AgentFrame::Claude(ClaudeMessage::LocalError(msg)) => {
+                renderers::render_local_error(&msg, ctx.timestamp)
+            }
             AgentFrame::Claude(ClaudeMessage::ConversationReset(msg)) => {
                 renderers::render_conversation_reset(&msg)
             }

--- a/frontend/src/components/message_renderer/renderers.rs
+++ b/frontend/src/components/message_renderer/renderers.rs
@@ -13,7 +13,7 @@ pub(crate) use assistant::assistant_label;
 pub use assistant::{
     render_assistant_message, render_assistant_message_content, render_content_blocks,
 };
-pub use errors::{render_error_message, render_rate_limit_event};
+pub use errors::{render_error_message, render_local_error, render_rate_limit_event};
 pub(crate) use portal::{
     agent_message_event_from_agent_facing_text, portal_text, render_agent_message_body,
     render_agent_message_event, render_agent_message_from_source, render_portal_message,

--- a/frontend/src/components/message_renderer/renderers/errors.rs
+++ b/frontend/src/components/message_renderer/renderers/errors.rs
@@ -206,3 +206,21 @@ fn format_error_type(error_type: &str) -> String {
         other => other.replace('_', " ").to_string(),
     }
 }
+
+/// A portal-generated error ([`shared::ErrorMessage`]) — a failed upload, say.
+///
+/// Rendered with the same treatment as an Anthropic error because to the reader
+/// it is the same thing: something went wrong and the turn did not happen. The
+/// two differ only in wire shape (flat vs. nested), which is an implementation
+/// detail nobody staring at a failed upload cares about.
+pub fn render_local_error(msg: &shared::ErrorMessage, timestamp: Option<&str>) -> Html {
+    html! {
+        <div class="claude-message error-message-display">
+            <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
+                <span class="message-type-badge result error">{ "Error" }</span>
+                <CopyButton text={msg.message.clone()} title="Copy error" />
+            </div>
+            <div class="error-content">{ &msg.message }</div>
+        </div>
+    }
+}

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -56,6 +56,21 @@ fn render_portal_content(
 ) -> Html {
     match content {
         shared::PortalContent::Text { text } => render_markdown_for_session(text, session_id),
+        shared::PortalContent::ConnectionCycle { duration } => {
+            // One line, no badge, no host/cwd/agent id. A planned redeploy is
+            // routine — it should read as a seam in the transcript, not as an
+            // event competing with the conversation for attention.
+            let label = match duration {
+                Some(d) => format!("reconnected after {d}"),
+                None => "reconnected".to_string(),
+            };
+            html! {
+                <div class="connection-cycle">
+                    <span class="connection-cycle-dot" />
+                    { label }
+                </div>
+            }
+        }
         shared::PortalContent::Image {
             media_type,
             data,

--- a/frontend/src/components/message_renderer/tests/classifier.rs
+++ b/frontend/src/components/message_renderer/tests/classifier.rs
@@ -136,3 +136,56 @@ fn conversation_reset_parses_to_its_own_variant() {
         "conversation_reset must not fall through to Unknown"
     );
 }
+
+/// The portal's own error envelope is flat (`{type:"error", message:"…"}`),
+/// unlike Anthropic's nested `{type:"error", error:{…}}`. It matched neither
+/// `ClaudeOutput` nor the local-frame fallback, so every failed file upload
+/// rendered as an "Unrecognized Message" raw bubble — the portal reporting its
+/// own errors as frames it did not recognize.
+#[test]
+fn portal_error_envelope_renders_as_an_error_not_an_unknown_frame() {
+    use super::super::types::ClaudeMessage;
+    let json = r#"{"type":"error","message":"File upload failed: file is too large (limit 10 MB) — your message was not sent"}"#;
+    match ClaudeMessage::parse(json) {
+        Ok(ClaudeMessage::LocalError(e)) => {
+            assert!(e.message.contains("too large"), "message preserved: {e:?}")
+        }
+        other => panic!("expected LocalError, got {other:?}"),
+    }
+}
+
+/// Anthropic's nested envelope must keep routing to the existing error arm —
+/// the new flat variant must not shadow it.
+#[test]
+fn anthropic_nested_error_still_parses_as_error() {
+    use super::super::types::ClaudeMessage;
+    let json = r#"{"type":"error","error":{"type":"api_error","message":"boom"}}"#;
+    assert!(
+        matches!(ClaudeMessage::parse(json), Ok(ClaudeMessage::Error(_))),
+        "nested Anthropic errors must not regress to LocalError"
+    );
+}
+
+/// The portal error must render as an error on non-Codex agents too — but
+/// without stealing Codex's own `{type:"error"}` frame, which the exhaustive
+/// sweep above pins. Same JSON, different agent, different owner.
+#[test]
+fn portal_error_routes_to_claude_but_leaves_codex_frames_alone() {
+    use super::super::types::ClaudeMessage;
+    use crate::components::agent_frame::{AgentFrame, AgentFrameRegistry};
+    let json = r#"{"type":"error","message":"File upload failed"}"#;
+    assert!(
+        matches!(
+            AgentFrameRegistry::parse(json, shared::AgentType::Claude),
+            AgentFrame::Claude(ClaudeMessage::LocalError(_))
+        ),
+        "a Claude session must render the portal's own error"
+    );
+    assert!(
+        matches!(
+            AgentFrameRegistry::parse(json, shared::AgentType::Codex),
+            AgentFrame::Codex(_)
+        ),
+        "Codex owns this shape and must keep it"
+    );
+}

--- a/frontend/src/components/message_renderer/tests/portal.rs
+++ b/frontend/src/components/message_renderer/tests/portal.rs
@@ -68,3 +68,25 @@ fn portal_run_breaks_on_intervening_assistant() {
         ]
     );
 }
+
+/// An expected cycle must survive the wire as its own typed variant rather
+/// than a prose card — the whole point is that the frontend can render it
+/// thin. Round-tripped because the proxy serializes it and the frontend
+/// deserializes it, with a backend and a DB in between.
+#[test]
+fn connection_cycle_round_trips_as_its_own_variant() {
+    let json = serde_json::to_string(&shared::PortalContent::ConnectionCycle {
+        duration: Some("35s".to_string()),
+    })
+    .expect("serializes");
+    assert!(
+        json.contains("connection_cycle"),
+        "tagged for the frontend: {json}"
+    );
+    match serde_json::from_str::<shared::PortalContent>(&json).expect("round trips") {
+        shared::PortalContent::ConnectionCycle { duration } => {
+            assert_eq!(duration.as_deref(), Some("35s"))
+        }
+        other => panic!("expected ConnectionCycle, got {other:?}"),
+    }
+}

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -44,6 +44,12 @@ pub enum ClaudeMessage {
     /// the visible seam between two conversations in one session, and it also
     /// marks where claude's conversation id rotates (see the render).
     ConversationReset(shared::ConversationResetMessage),
+    /// A portal-generated error ([`shared::ErrorMessage`]) — a failed file
+    /// upload, say. Distinct from [`Self::Error`], which is Anthropic's nested
+    /// `{type:"error", error:{…}}` envelope: this one is flat, so it never
+    /// matched `ClaudeOutput` and fell through to a raw `Unknown` bubble. The
+    /// portal was rendering its own errors as unrecognized frames.
+    LocalError(shared::ErrorMessage),
     OptimisticUser(OptimisticUserMessage),
     Unknown,
 }
@@ -115,6 +121,11 @@ enum LocalMessage {
     Portal(PortalMessage),
     #[serde(rename = "user")]
     OptimisticUser(OptimisticUserMessage),
+    // Only the payload: `LocalMessage` is internally tagged on `type`, so
+    // serde consumes that key for the discriminant and a nested
+    // `shared::ErrorMessage` (which also declares `type`) can never see it.
+    #[serde(rename = "error")]
+    LocalError { message: String },
     #[serde(other)]
     Unknown,
 }
@@ -124,6 +135,9 @@ impl From<LocalMessage> for ClaudeMessage {
         match value {
             LocalMessage::Portal(msg) => Self::Portal(msg),
             LocalMessage::OptimisticUser(msg) => Self::OptimisticUser(msg),
+            LocalMessage::LocalError { message } => {
+                Self::LocalError(shared::ErrorMessage::new(message))
+            }
             LocalMessage::Unknown => Self::Unknown,
         }
     }

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -206,6 +206,7 @@ pub(super) fn message_type_tag(m: &ClaudeMessage) -> ActivityTag {
         ClaudeMessage::Portal(_) => ActivityTag::Portal,
         ClaudeMessage::RateLimitEvent(_) => ActivityTag::RateLimit,
         ClaudeMessage::ConversationReset(_) => ActivityTag::System,
+        ClaudeMessage::LocalError(_) => ActivityTag::Error,
         ClaudeMessage::Unknown => ActivityTag::Unknown,
     }
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1790,3 +1790,29 @@
     font-size: 0.78rem;
     color: var(--text-muted);
 }
+
+/* Expected connection cycle (planned redeploy): a seam, not an event.
+   Deliberately has none of the `.claude-message` chrome — no badge, no
+   left accent stripe, no card padding — because a planned restart is
+   routine and a full card for it crowds out the conversation. An
+   *unexpected* disconnect still renders as a normal portal card. */
+.connection-cycle {
+    align-items: center;
+    color: var(--text-muted);
+    display: flex;
+    font-size: 0.78rem;
+    gap: 0.45rem;
+    justify-content: center;
+    letter-spacing: 0.02em;
+    opacity: 0.75;
+    padding: 0.15rem 0;
+}
+
+.connection-cycle-dot {
+    background: var(--text-muted);
+    border-radius: 50%;
+    display: inline-block;
+    flex: none;
+    height: 4px;
+    width: 4px;
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -888,6 +888,20 @@ pub enum PortalContent {
         #[serde(default = "default_continuation_reason")]
         reason: String,
     },
+    /// A proxy reconnect, as a typed event rather than a prose line.
+    ///
+    /// Emitted only for an **expected** cycle (the backend told us it was
+    /// restarting). A genuinely unexpected drop stays a full `Text` card,
+    /// because that one is worth interrupting the reader for; a planned
+    /// redeploy is routine and should cost a single line. The frontend renders
+    /// this as a compact seam chip.
+    #[serde(rename = "connection_cycle")]
+    ConnectionCycle {
+        /// Human-readable outage length, e.g. `"35s"`. `None` when the proxy
+        /// had no recorded disconnect instant to measure from.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        duration: Option<String>,
+    },
     /// Typed event for an inter-agent message. This replaces UI parsing of
     /// the agent-facing `[message from ...]` text prefix for new messages.
     #[serde(rename = "agent_message")]
@@ -902,6 +916,10 @@ impl std::fmt::Debug for PortalContent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Text { text } => f.debug_struct("Text").field("text", text).finish(),
+            Self::ConnectionCycle { duration } => f
+                .debug_struct("ConnectionCycle")
+                .field("duration", duration)
+                .finish(),
             Self::Image {
                 media_type,
                 data,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -118,9 +118,9 @@ pub use model_version::{compact_model_version, context_window_for};
 // API client types and trait
 pub mod api;
 pub use api::{
-    AgentSessionInfo, AgentSessionsResponse, CodexPermissionInput, ModelUsage, ModelUsageEntry,
-    SendAgentMessageRequest, SendAgentMessageResponse, SoundSettingsResponse, TurnMetrics,
-    TurnMetricsResponse,
+    AgentSessionInfo, AgentSessionsResponse, CodexPermissionInput, ErrorMessage, ModelUsage,
+    ModelUsageEntry, SendAgentMessageRequest, SendAgentMessageResponse, SoundSettingsResponse,
+    TurnMetrics, TurnMetricsResponse,
 };
 
 /// Default backend URL based on build profile.

--- a/shared/src/protocol.rs
+++ b/shared/src/protocol.rs
@@ -35,8 +35,12 @@ pub const UPLOAD_CHUNK_SIZE: usize = 1024;
 pub const MAX_UPLOAD_CHUNK_BYTES: usize = 64 * 1024; // 64 KiB
 
 /// Hard ceiling on the number of chunks per upload, enforced by the
-/// backend at `FileUploadStart` time. With `MAX_UPLOAD_CHUNK_BYTES = 64
-/// KiB` this caps any single upload at 4 GiB, but the **binding** limit
+/// backend at `FileUploadStart` time.
+///
+/// The ceiling this implies depends on the *sender's* chunk size, not on
+/// `MAX_UPLOAD_CHUNK_BYTES`: our frontend sends `UPLOAD_CHUNK_SIZE`
+/// (1 KiB) chunks, so 65 536 of them is 64 MiB, not the 4 GiB you get by
+/// assuming maximum-size chunks. Either way the **binding** limit
 /// is the per-server `PORTAL_MAX_IMAGE_MB` byte cap — this constant only
 /// stops obviously-pathological `total_chunks` values from being accepted.
 pub const MAX_UPLOAD_TOTAL_CHUNKS: u32 = 65_536;


### PR DESCRIPTION
A planned redeploy showed up in the transcript as **"Proxy reconnected after 35s (unexpected disconnect)"**, in a full card.

## Why it was mislabelled

The classification was correct at the moment of the drop — a server restart arrives as `ConnectionResult::ServerShutdown` and sets `last_disconnect_graceful = true`.

The problem is what happens next. A **failed reconnect attempt** reports `ConnectionResult::Disconnected` through the same match arm as a lost live connection, and that arm reassigned the flag on every pass. So every retry against a backend still coming up overwrote the graceful classification.

That makes the bug systematic rather than occasional: any restart outlasting the first backoff gets relabelled, which is every real redeploy. The 35s in the screenshot is roughly eight failed attempts, each one stamping "unexpected" over the truth.

Only the connected→disconnected transition classifies an outage now. Extracted as `note_disconnect` so both arms share one implementation and the regression is testable — the two arms had duplicated the bookkeeping anyway.

## The thin element

An expected cycle now emits a typed `PortalContent::ConnectionCycle`, rendered as a one-line seam chip — muted, centered, no badge, no left accent, no card padding:

```
· reconnected after 35s
```

instead of a full portal card carrying host, cwd, agent id and two UTC timestamps.

An **unexpected** drop deliberately keeps the full card. That one is worth interrupting the reader for; the point of the split is that a planned restart isn't.

## Rollout note

`PortalContent` has no unknown-variant fallback, so a new proxy emitting `ConnectionCycle` to an older backend/frontend renders it as a raw bubble until both sides update. Same tradeoff `Video` and `AgentMessage` took when they were added, and it only affects the expected-cycle case.

## Verification

92 tests in claude-session-lib (2 new, covering both the retry-relabel regression and the converse), 639 frontend tests (1 new round-trip), clippy clean, native + `wasm32-unknown-unknown`, and both dependent binaries build.