### PR TITLE
Give portal-authored transcript frames one definition and one door

### DIFF
--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -173,7 +173,7 @@ fn message_text(message: &RenderedMessage) -> String {
         match value {
             Value::String(text) => return text,
             Value::Object(_) => {
-                if let Ok(portal) = serde_json::from_value::<super::types::PortalMessage>(value) {
+                if let Ok(portal) = serde_json::from_value::<shared::PortalMessage>(value) {
                     return renderers::portal_text(&portal);
                 }
             }

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -232,7 +232,7 @@ fn user_message_is_inter_agent(msg: &shared::UserMessage) -> bool {
 
 /// True iff a synthetic optimistic-user echo is actually an inter-agent
 /// message. See [`is_inter_agent_text`].
-fn optimistic_user_is_inter_agent(msg: &super::types::OptimisticUserMessage) -> bool {
+fn optimistic_user_is_inter_agent(msg: &shared::UserFrame) -> bool {
     is_inter_agent_text(&msg.content)
 }
 

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -1,7 +1,7 @@
-use super::super::types::PortalMessage;
 use super::media::{render_image_source, render_video_source};
 use crate::components::copy_button::CopyButton;
 use crate::components::markdown::render_markdown_for_session;
+use shared::PortalMessage;
 use std::collections::HashMap;
 use uuid::Uuid;
 use yew::prelude::*;
@@ -432,9 +432,7 @@ mod tests {
 
     #[test]
     fn agent_message_event_reads_typed_portal_event_content() {
-        let msg = PortalMessage {
-            content: agent_message_content(),
-        };
+        let msg = PortalMessage::with_content(agent_message_content());
 
         let event = agent_message_event(&msg).expect("event");
 
@@ -448,11 +446,9 @@ mod tests {
 
     #[test]
     fn agent_message_event_ignores_plain_portal_text() {
-        let msg = PortalMessage {
-            content: vec![shared::PortalContent::Text {
-                text: "[message from claude 1111]\nbody".to_string(),
-            }],
-        };
+        let msg = PortalMessage::with_content(vec![shared::PortalContent::Text {
+            text: "[message from claude 1111]\nbody".to_string(),
+        }]);
 
         assert!(agent_message_event(&msg).is_none());
     }

--- a/frontend/src/components/message_renderer/renderers/user.rs
+++ b/frontend/src/components/message_renderer/renderers/user.rs
@@ -1,7 +1,6 @@
 //! User-message renderers: the real Claude `user` wire shape, the synthetic
 //! optimistic echo, and the delivery-progress chip that rides on both.
 
-use super::super::types::OptimisticUserMessage;
 use super::{
     agent_message_event_from_agent_facing_text, render_agent_message_event, render_content_blocks,
 };
@@ -10,6 +9,7 @@ use crate::components::markdown::render_markdown_for_session;
 use crate::components::tool_renderers::{
     has_askuserquestion_answers, render_askuserquestion_result,
 };
+use shared::UserFrame as OptimisticUserMessage;
 use uuid::Uuid;
 use yew::prelude::*;
 

--- a/frontend/src/components/message_renderer/tests/classifier.rs
+++ b/frontend/src/components/message_renderer/tests/classifier.rs
@@ -189,3 +189,35 @@ fn portal_error_routes_to_claude_but_leaves_codex_frames_alone() {
         "Codex owns this shape and must keep it"
     );
 }
+
+/// The invariant that makes the single injection door worth having: **anything
+/// the portal can author, the portal can render.**
+///
+/// `RenderedMessage::local` is the only way a portal-authored frame enters a
+/// transcript, so the set of shapes the renderer must understand is exactly the
+/// set of `LocalFrame` variants. Each one must parse to a real `ClaudeMessage`
+/// variant — never `Unknown`, which is the raw-bubble fallback reserved for
+/// *foreign* agent frames. Add a `LocalFrame` variant without teaching
+/// `parse_local_frame` about it and this fails.
+#[test]
+fn every_local_frame_the_portal_can_author_renders() {
+    use super::super::types::ClaudeMessage;
+
+    let frames = [
+        shared::LocalFrame::Portal(shared::PortalMessage::text("hi".into())),
+        shared::LocalFrame::user("hi"),
+        shared::LocalFrame::error("boom"),
+    ];
+
+    for frame in frames {
+        let tag = frame.message_type();
+        let json = frame.to_json();
+        let parsed = ClaudeMessage::parse(&json)
+            .unwrap_or_else(|e| panic!("{tag} frame must parse: {e} ({json})"));
+        assert!(
+            !matches!(parsed, ClaudeMessage::Unknown),
+            "{tag} frame fell through to Unknown — it would render as a raw \
+             \"Unrecognized Message\" bubble: {json}"
+        );
+    }
+}

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -14,8 +14,26 @@ pub struct RenderedMessage {
 }
 
 impl RenderedMessage {
+    /// Wrap an already-serialized frame. Use this for **foreign** frames only
+    /// — agent JSON off the wire or replayed from the database, which is opaque
+    /// by nature. For a frame the portal itself authors, use [`Self::local`],
+    /// which cannot produce a shape the renderer does not understand.
     pub fn new(content: String, meta: Option<shared::PortalMeta>) -> Self {
         Self { content, meta }
+    }
+
+    /// The single door for portal-authored frames.
+    ///
+    /// Everything the portal writes into a transcript goes through here, so the
+    /// set of shapes the renderer must handle is exactly the set of
+    /// [`shared::LocalFrame`] variants — closed, and enumerable by a test.
+    /// Hand-rolling `serde_json::to_string` at a call site is what previously
+    /// let `{"type":"error"}` ship from three sites with no renderer at all.
+    pub fn local(frame: shared::LocalFrame, meta: Option<shared::PortalMeta>) -> Self {
+        Self {
+            content: frame.to_json(),
+            meta,
+        }
     }
 
     pub fn raw_iso(&self) -> Option<&str> {
@@ -38,7 +56,7 @@ pub enum ClaudeMessage {
     Result(shared::ResultMessage),
     User(shared::UserMessage),
     Error(shared::AnthropicError),
-    Portal(PortalMessage),
+    Portal(shared::PortalMessage),
     RateLimitEvent(shared::RateLimitEvent),
     /// `/clear`. Worth its own variant rather than falling to `Unknown`: it is
     /// the visible seam between two conversations in one session, and it also
@@ -50,19 +68,8 @@ pub enum ClaudeMessage {
     /// matched `ClaudeOutput` and fell through to a raw `Unknown` bubble. The
     /// portal was rendering its own errors as unrecognized frames.
     LocalError(shared::ErrorMessage),
-    OptimisticUser(OptimisticUserMessage),
+    OptimisticUser(shared::UserFrame),
     Unknown,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct PortalMessage {
-    #[serde(default)]
-    pub content: Vec<shared::PortalContent>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct OptimisticUserMessage {
-    pub content: String,
 }
 
 impl ClaudeMessage {
@@ -83,7 +90,8 @@ impl ClaudeMessage {
             });
         }
 
-        serde_json::from_str::<LocalMessage>(json).map(Into::into)
+        let value: serde_json::Value = serde_json::from_str(json)?;
+        Ok(parse_local_frame(&value).unwrap_or(Self::Unknown))
     }
 }
 
@@ -108,37 +116,29 @@ impl<'de> Deserialize<'de> for ClaudeMessage {
                 _ => Self::Unknown,
             });
         }
-        serde_json::from_value::<LocalMessage>(value)
-            .map(Into::into)
-            .map_err(serde::de::Error::custom)
+        Ok(parse_local_frame(&value).unwrap_or(Self::Unknown))
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
-enum LocalMessage {
-    #[serde(rename = "portal")]
-    Portal(PortalMessage),
-    #[serde(rename = "user")]
-    OptimisticUser(OptimisticUserMessage),
-    // Only the payload: `LocalMessage` is internally tagged on `type`, so
-    // serde consumes that key for the discriminant and a nested
-    // `shared::ErrorMessage` (which also declares `type`) can never see it.
-    #[serde(rename = "error")]
-    LocalError { message: String },
-    #[serde(other)]
-    Unknown,
-}
-
-impl From<LocalMessage> for ClaudeMessage {
-    fn from(value: LocalMessage) -> Self {
-        match value {
-            LocalMessage::Portal(msg) => Self::Portal(msg),
-            LocalMessage::OptimisticUser(msg) => Self::OptimisticUser(msg),
-            LocalMessage::LocalError { message } => {
-                Self::LocalError(shared::ErrorMessage::new(message))
-            }
-            LocalMessage::Unknown => Self::Unknown,
-        }
+/// Parse a frame the **portal itself** authored, dispatching on its `"type"`
+/// tag into the shared [`shared::LocalFrame`] vocabulary.
+///
+/// Dispatching on the tag rather than deserializing an internally-tagged
+/// wrapper is what lets each payload keep its own `type` field: serde would
+/// otherwise consume that key for the discriminant, leaving the nested struct
+/// unable to see its own tag. Every arm here parses a type defined once in
+/// `shared` — there is no frontend-local copy to drift from.
+fn parse_local_frame(value: &serde_json::Value) -> Option<ClaudeMessage> {
+    match value.get("type").and_then(|t| t.as_str())? {
+        shared::PortalMessage::MESSAGE_TYPE => serde_json::from_value(value.clone())
+            .ok()
+            .map(ClaudeMessage::Portal),
+        shared::UserFrame::MESSAGE_TYPE => serde_json::from_value(value.clone())
+            .ok()
+            .map(ClaudeMessage::OptimisticUser),
+        shared::ERROR_MESSAGE_TYPE => serde_json::from_value(value.clone())
+            .ok()
+            .map(ClaudeMessage::LocalError),
+        _ => None,
     }
 }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -15,7 +15,7 @@ use crate::components::{
 };
 use crate::utils::{self, On401};
 use gloo::timers::callback::Timeout;
-use shared::api::{ErrorMessage, TurnMetricsResponse};
+use shared::api::TurnMetricsResponse;
 use shared::{ClientToServer, DeliveryMeta, PortalMeta, SendMode, SessionInfo, TurnMetrics};
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -86,20 +86,8 @@ fn optimistic_user_message(
     created_at: &str,
     client_msg_id: Uuid,
 ) -> RenderedMessage {
-    #[derive(serde::Serialize)]
-    struct OptimisticUserMessage<'a> {
-        #[serde(rename = "type")]
-        message_type: &'static str,
-        content: &'a str,
-    }
-
-    let content = serde_json::to_string(&OptimisticUserMessage {
-        message_type: "user",
-        content,
-    })
-    .unwrap_or_default();
-    RenderedMessage::new(
-        content,
+    RenderedMessage::local(
+        shared::LocalFrame::user(content),
         Some(PortalMeta {
             created_at: Some(created_at.to_string()),
             source: None,
@@ -1019,11 +1007,10 @@ impl SessionView {
     /// referencing the file is deliberately NOT sent — the agent must never
     /// be told about a file that isn't fully on disk.
     fn push_upload_error(&mut self, err: &str) {
-        let error_msg = ErrorMessage::new(format!(
-            "File upload failed: {err} — your message was not sent"
-        ));
-        self.messages.push(RenderedMessage::new(
-            serde_json::to_string(&error_msg).unwrap_or_default(),
+        self.messages.push(RenderedMessage::local(
+            shared::LocalFrame::error(format!(
+                "File upload failed: {err} — your message was not sent"
+            )),
             None,
         ));
     }
@@ -1257,9 +1244,8 @@ impl SessionView {
                 link.send_message(SessionViewMsg::AttemptReconnect);
             }));
         } else {
-            let error_msg = ErrorMessage::new(format!("Connection lost: {}", err));
-            self.messages.push(RenderedMessage::new(
-                serde_json::to_string(&error_msg).unwrap_or_default(),
+            self.messages.push(RenderedMessage::local(
+                shared::LocalFrame::error(format!("Connection lost: {}", err)),
                 None,
             ));
         }

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -2,7 +2,6 @@
 
 use crate::utils;
 use futures_util::StreamExt;
-use shared::api::ErrorMessage;
 use shared::{
     ClientEndpoint, ClientToServer, InputDeliveryStage, ServerToClient, TurnMetrics, WsEndpoint,
 };
@@ -200,11 +199,12 @@ fn handle_proxy_message(msg: ServerToClient, on_event: &Callback<WsEvent>) {
             on_event.emit(WsEvent::UploadResult(fields));
         }
         ServerToClient::Error { message } => {
-            let error_msg = ErrorMessage::new(message);
-            let error_json = serde_json::to_string(&error_msg).unwrap_or_default();
             // Error envelopes don't go through the DB so they have no
             // server-assigned `created_at` — leave the watermark unchanged.
-            on_event.emit(WsEvent::Output(RenderedMessage::new(error_json, None)));
+            on_event.emit(WsEvent::Output(RenderedMessage::local(
+                shared::LocalFrame::error(message),
+                None,
+            )));
         }
         ServerToClient::SessionUpdate {
             session_id: _,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -117,11 +117,13 @@ pub use model_version::{compact_model_version, context_window_for};
 
 // API client types and trait
 pub mod api;
+pub mod local_frame;
 pub use api::{
     AgentSessionInfo, AgentSessionsResponse, CodexPermissionInput, ErrorMessage, ModelUsage,
     ModelUsageEntry, SendAgentMessageRequest, SendAgentMessageResponse, SoundSettingsResponse,
     TurnMetrics, TurnMetricsResponse,
 };
+pub use local_frame::{LocalFrame, UserFrame, ERROR_MESSAGE_TYPE};
 
 /// Default backend URL based on build profile.
 /// Release builds point to `wss://txcl.io`, debug builds to `ws://localhost:3000`.

--- a/shared/src/local_frame.rs
+++ b/shared/src/local_frame.rs
@@ -1,0 +1,144 @@
+//! Frames the **portal itself** authors into a session transcript.
+//!
+//! Everything else in the transcript is *foreign*: agent JSON forwarded
+//! verbatim from the wire or replayed from the database. Foreign frames are
+//! necessarily opaque — we can't type arbitrary agent output — so the renderer
+//! falls back to a raw bubble when it doesn't recognize one. That fallback is
+//! correct there and **wrong here**: a frame the portal wrote itself should
+//! never be unrenderable.
+//!
+//! It was, though. `{"type":"error","message":…}` was produced at three sites
+//! and understood at none, so every failed upload, every server-pushed
+//! `ServerToClient::Error`, and every exhausted-reconnect notice rendered as
+//! "Unrecognized Message". The wire types were not at fault — the frames were
+//! typed right up until they were serialized into the transcript's
+//! `content: String` and re-parsed by a consumer that had never been told the
+//! shape existed.
+//!
+//! The rule this module exists to enforce: **one definition per local frame,
+//! and one door in.** Producers construct a [`LocalFrame`]; the renderer parses
+//! into the same three types. Neither side can drift, because there is nothing
+//! to drift from.
+
+use serde::{Deserialize, Serialize};
+
+use crate::api::ErrorMessage;
+use crate::PortalMessage;
+
+/// An optimistic user echo, rendered before the agent's own user frame arrives.
+///
+/// Carries its `"type"` tag as a field — matching [`PortalMessage`] — rather
+/// than relying on an enclosing serde tag. That is deliberate: an internally
+/// tagged wrapper consumes `type` for its discriminant, so a nested struct
+/// declaring `type` can never see it. That exact collision is why the first
+/// attempt at rendering portal errors silently matched nothing.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct UserFrame {
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub content: String,
+}
+
+impl UserFrame {
+    /// The invariant `"type"` tag value.
+    pub const MESSAGE_TYPE: &'static str = "user";
+
+    pub fn new(content: String) -> Self {
+        Self {
+            message_type: Self::MESSAGE_TYPE.to_string(),
+            content,
+        }
+    }
+}
+
+/// The closed set of frames the portal writes into a transcript.
+///
+/// Deliberately **not** `#[serde(tag = "type")]`: each variant's payload
+/// already carries its own tag field, and stacking a second one collides. The
+/// enum exists to make the set closed and the serialization single-sourced, not
+/// to add a layer of tagging.
+#[derive(Debug, Clone)]
+pub enum LocalFrame {
+    Portal(PortalMessage),
+    User(UserFrame),
+    Error(ErrorMessage),
+}
+
+impl LocalFrame {
+    /// Convenience for the overwhelmingly common case.
+    pub fn error(message: impl Into<String>) -> Self {
+        Self::Error(ErrorMessage::new(message.into()))
+    }
+
+    pub fn user(content: impl Into<String>) -> Self {
+        Self::User(UserFrame::new(content.into()))
+    }
+
+    /// The wire `type` tag this frame serializes with. Kept next to
+    /// [`Self::to_json`] so the producer's tag and the consumer's dispatch are
+    /// read off one list.
+    pub fn message_type(&self) -> &'static str {
+        match self {
+            Self::Portal(_) => PortalMessage::MESSAGE_TYPE,
+            Self::User(_) => UserFrame::MESSAGE_TYPE,
+            Self::Error(_) => ERROR_MESSAGE_TYPE,
+        }
+    }
+
+    /// Serialize for the transcript. The **only** supported way to put a
+    /// portal-authored frame into a session's message buffer — hand-rolling
+    /// `serde_json::to_string` at a call site is what let a shape ship that no
+    /// renderer understood.
+    pub fn to_json(&self) -> String {
+        let serialized = match self {
+            Self::Portal(msg) => serde_json::to_string(msg),
+            Self::User(msg) => serde_json::to_string(msg),
+            Self::Error(msg) => serde_json::to_string(msg),
+        };
+        serialized.unwrap_or_default()
+    }
+}
+
+/// The `"type"` tag [`ErrorMessage`] serializes with.
+pub const ERROR_MESSAGE_TYPE: &str = "error";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The invariant the module exists for: every frame the portal can author
+    /// serializes with a tag, and that tag is the one the renderer dispatches
+    /// on. If a variant is added without a tag, this fails.
+    #[test]
+    fn every_local_frame_serializes_with_its_declared_tag() {
+        let frames = [
+            LocalFrame::Portal(PortalMessage::text("hi".into())),
+            LocalFrame::user("hi"),
+            LocalFrame::error("boom"),
+        ];
+        for frame in frames {
+            let json = frame.to_json();
+            let value: serde_json::Value =
+                serde_json::from_str(&json).expect("local frames are valid json");
+            assert_eq!(
+                value.get("type").and_then(|t| t.as_str()),
+                Some(frame.message_type()),
+                "frame {frame:?} serialized without its declared tag: {json}"
+            );
+        }
+    }
+
+    /// A tag is only useful if the payload survives with it.
+    #[test]
+    fn payloads_round_trip() {
+        let json = LocalFrame::error("disk on fire").to_json();
+        let back: ErrorMessage = serde_json::from_str(&json).expect("round trips");
+        assert_eq!(back.message, "disk on fire");
+        assert_eq!(back.error_type, ERROR_MESSAGE_TYPE);
+
+        let json = LocalFrame::user("hello").to_json();
+        let back: UserFrame = serde_json::from_str(&json).expect("round trips");
+        assert_eq!(back.content, "hello");
+        assert_eq!(back.message_type, UserFrame::MESSAGE_TYPE);
+    }
+}


### PR DESCRIPTION
Follow-up to #1703, fixing the cause rather than the instance.

## What actually failed

The upload-error bug was **not** a wire-typing failure. `ServerToClient::Error` arrived correctly typed over its ws-bridge endpoint. The frontend then serialized it into the transcript's `content: String` and re-parsed it at render time with a consumer that had never been told the shape existed.

Type safety was lost at a *second* seam, downstream of the endpoint types — one with a producer side and a consumer side and nothing forcing them to agree.

## Why that seam was unprotected

The local-frame vocabulary was defined **twice**:

- producers — `ErrorMessage` (shared/api), a private `OptimisticUserMessage` (component.rs)
- consumers — the `LocalMessage` enum, with its own `PortalMessage` and `OptimisticUserMessage`, in the frontend

They agreed only because someone kept them in sync by hand. `"user"` happened to match. `"error"` didn't, so three producers shipped a shape no renderer knew — every server-pushed error, every failed upload, every exhausted-reconnect notice.

## The fix

**One definition each.** `shared::LocalFrame` is the closed set of frames the portal authors, wrapping `PortalMessage`, the new `shared::UserFrame`, and `ErrorMessage` — each defined exactly once, in `shared`. The frontend's duplicates and the `LocalMessage` enum are deleted; parsing dispatches on the tag into those same types.

**One door.** `RenderedMessage::local(frame, meta)` is the only supported way to put a portal-authored frame in a transcript. All four producers converted.

`RenderedMessage::new` survives and is now documented for what it's actually for: **foreign** frames — agent JSON off the wire or replayed from the DB. Those are opaque by nature and the raw-bubble fallback is *correct* there. The bug was applying that permissive fallback to frames we wrote ourselves. Every remaining `new` call site is a foreign frame (wire output, history batch, archived transcript, demo fixtures).

## One design note

`LocalFrame` is deliberately **not** `#[serde(tag = "type")]`. Each payload carries its own tag field, and an internally-tagged wrapper consumes that key for its discriminant, so the nested struct can never see it. That collision is what made the first attempt at rendering portal errors match nothing — it fails as "variant never matches", not as an error.

## Tests

Two invariants, both of which fail if a variant is added without wiring:

- every `LocalFrame` serializes with the tag the parser dispatches on
- every `LocalFrame` parses to a real `ClaudeMessage`, never `Unknown`

640 frontend tests, 177 shared, clippy clean, native + `wasm32-unknown-unknown`, backend/proxy/launcher all build.

## Upstream

Filed meawoppl/ws-bridge#7 — a typed message vocabulary independent of an endpoint. ws-bridge wasn't at fault here, but the failure is the same shape it exists to prevent, for messages at rest rather than in flight. Reasonable for it to be closed as out of scope.