### PR TITLE
Serve history's archive scan stale rather than rescanning inline

### DIFF
--- a/backend/src/archive.rs
+++ b/backend/src/archive.rs
@@ -62,10 +62,17 @@ pub const ARCHIVE_SWEEP_BATCH: i64 = 25;
 // Store
 // ---------------------------------------------------------------------------
 
-/// How long a `/api/history` manifest scan is served from cache before
-/// rescanning. Bounds S3 list/GET cost while keeping a local archive
-/// effectively live; per-session reads (manifest/messages/media) never cache.
-pub const HISTORY_SCAN_TTL: std::time::Duration = std::time::Duration::from_secs(10);
+/// How long a `/api/history` manifest scan is served before a refresh is
+/// triggered. Bounds S3 list/GET cost; per-session reads (manifest/messages/
+/// media) never cache.
+///
+/// This is **not** how long a page can be stale, and it is not a latency
+/// budget: [`ArchiveRuntime::scan_rows_cached`] serves the previous scan
+/// immediately and refreshes behind the request, so expiry costs a background
+/// rescan rather than a user-visible wait. Sessions only enter the archive when
+/// the retention sweep runs — minutes apart — so a window measured in seconds
+/// is already far finer than the data changes.
+pub const HISTORY_SCAN_TTL: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Store plus the settings the archival sweep needs at write time.
 pub struct ArchiveRuntime {
@@ -75,6 +82,9 @@ pub struct ArchiveRuntime {
     /// `/api/history` scan cache: the flattened manifest rows and when they
     /// were collected. Shared across requests; see [`HISTORY_SCAN_TTL`].
     scan_cache: std::sync::Mutex<Option<(std::time::Instant, std::sync::Arc<Vec<scan::FlatRow>>)>>,
+    /// Set while a background rescan is in flight, so a burst of requests
+    /// against an expired cache triggers one scan rather than one per request.
+    scan_refreshing: std::sync::atomic::AtomicBool,
 }
 
 impl ArchiveRuntime {
@@ -89,6 +99,7 @@ impl ArchiveRuntime {
             config,
             stats: ArchiveStats::default(),
             scan_cache: std::sync::Mutex::new(None),
+            scan_refreshing: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -112,6 +123,66 @@ impl ArchiveRuntime {
         *self.scan_cache.lock().expect("scan cache lock poisoned") =
             Some((std::time::Instant::now(), rows.clone()));
         Ok(rows)
+    }
+
+    /// The rows to answer a `/api/history` request with, **without making the
+    /// caller wait for a rescan**.
+    ///
+    /// `/api/history` used to call [`Self::scan_rows`] directly, so every
+    /// request that happened to land on an expired cache paid a full archive
+    /// scan — a list plus a GET per manifest on S3 — before a single row could
+    /// render. With a short window and a user clicking through pages and
+    /// filters, that is a large fraction of requests, and it is why the first
+    /// paint took seconds.
+    ///
+    /// Serve the previous scan immediately and refresh behind the request
+    /// instead. Only a genuinely cold cache blocks, which after
+    /// [`Self::warm_scan_cache`] means only a request that beats startup.
+    pub fn scan_rows_cached(
+        self: &std::sync::Arc<Self>,
+    ) -> std::io::Result<std::sync::Arc<Vec<scan::FlatRow>>> {
+        let cached = self
+            .scan_cache
+            .lock()
+            .expect("scan cache lock poisoned")
+            .clone();
+
+        match cached {
+            Some((at, rows)) => {
+                if at.elapsed() >= HISTORY_SCAN_TTL {
+                    self.spawn_scan_refresh();
+                }
+                Ok(rows)
+            }
+            // Nothing to serve stale: this one has to block.
+            None => self.scan_rows(),
+        }
+    }
+
+    /// Rescan on the blocking pool, at most one at a time.
+    fn spawn_scan_refresh(self: &std::sync::Arc<Self>) {
+        use std::sync::atomic::Ordering;
+        if self
+            .scan_refreshing
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return; // a refresh is already running
+        }
+        let runtime = self.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = runtime.scan_rows() {
+                // Keep serving the stale rows; the next request retries.
+                tracing::warn!("history archive scan refresh failed: {e}");
+            }
+            runtime.scan_refreshing.store(false, Ordering::Release);
+        });
+    }
+
+    /// Populate the cache off the request path at startup, so the first user to
+    /// open history doesn't pay the cold scan.
+    pub fn warm_scan_cache(self: &std::sync::Arc<Self>) {
+        self.spawn_scan_refresh();
     }
 }
 
@@ -144,6 +215,66 @@ impl ArchiveStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn local_runtime(root: &Path) -> std::sync::Arc<ArchiveRuntime> {
+        std::sync::Arc::new(
+            ArchiveRuntime::new(ArchiveConfig {
+                backend: ArchiveBackendConfig::Local {
+                    root: root.to_path_buf(),
+                },
+                transcripts: true,
+                media: false,
+            })
+            .expect("local archive runtime"),
+        )
+    }
+
+    /// The whole point of `scan_rows_cached`: an expired cache must not make
+    /// the caller wait. `/api/history` used to call `scan_rows` directly, so a
+    /// request landing on an expired cache paid a full archive scan — a list
+    /// plus a GET per manifest on S3 — before rendering a single row.
+    ///
+    /// Asserts the stale rows come back *identically* (same `Arc`), which is
+    /// only possible if no rescan happened inline.
+    #[tokio::test]
+    async fn an_expired_cache_is_served_stale_rather_than_rescanned_inline() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime = local_runtime(dir.path());
+
+        let first = runtime.scan_rows().expect("cold scan");
+
+        // Force expiry without waiting out the TTL.
+        {
+            let mut cache = runtime.scan_cache.lock().expect("lock");
+            let (_, rows) = cache.take().expect("primed");
+            *cache = Some((
+                std::time::Instant::now() - HISTORY_SCAN_TTL - std::time::Duration::from_secs(1),
+                rows,
+            ));
+        }
+
+        let served = runtime.scan_rows_cached().expect("served");
+        assert!(
+            std::sync::Arc::ptr_eq(&first, &served),
+            "an expired cache must serve the previous scan, not rescan inline"
+        );
+    }
+
+    /// A cold cache has nothing to serve, so it is the one case that blocks.
+    #[tokio::test]
+    async fn a_cold_cache_still_populates() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime = local_runtime(dir.path());
+        assert!(runtime.scan_cache.lock().expect("lock").is_none());
+
+        runtime.scan_rows_cached().expect("cold scan");
+
+        assert!(
+            runtime.scan_cache.lock().expect("lock").is_some(),
+            "a cold call must leave the cache primed for everyone after it"
+        );
+    }
+
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
     use uuid::Uuid;

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -254,6 +254,15 @@ pub async fn run_archive_sweep(app_state: Arc<AppState>) {
                     failed
                 );
             }
+            if archived > 0 {
+                // The sweep is the only thing that adds sessions to the
+                // archive, so refresh here rather than waiting for
+                // `HISTORY_SCAN_TTL` to notice. Freshness follows the event
+                // that changed the data; the TTL is just the backstop.
+                if let Some(runtime) = app_state.archive.as_ref() {
+                    runtime.warm_scan_cache();
+                }
+            }
         }
         Ok(Err(e)) => tracing::error!("{ARCHIVE_SWEEP_FAILED}: {e}"),
         Err(e) => tracing::error!("archive sweep task panicked: {e}"),

--- a/backend/src/handlers/history.rs
+++ b/backend/src/handlers/history.rs
@@ -172,7 +172,7 @@ pub async fn list_history_sessions(
     };
 
     let scan_runtime = runtime.clone();
-    let rows = on_blocking(move || scan_runtime.scan_rows()).await?;
+    let rows = on_blocking(move || scan_runtime.scan_rows_cached()).await?;
     let live_member_ids = live_member_session_ids(&app_state, user.id)?;
 
     // Visibility first: everything below operates on rows this caller may see.

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -291,7 +291,12 @@ pub async fn run() -> anyhow::Result<()> {
         app_state.clone(),
         background::run_liveness_sweep,
     );
-    if app_state.archive.is_some() {
+    if let Some(archive) = app_state.archive.as_ref() {
+        // Populate the `/api/history` scan cache off the request path. Without
+        // this the first person to open history after a deploy pays the full
+        // archive scan — an S3 list plus a GET per manifest — before a single
+        // row renders.
+        archive.warm_scan_cache();
         background::spawn_periodic(
             "session archive sweep (every 5 minutes)",
             Duration::from_secs(archive::ARCHIVE_SWEEP_INTERVAL_SECS),


### PR DESCRIPTION
Opening history took seconds before anything rendered. The page already shows a loading state and already paginates — the wait was a full archive scan sitting on the request path.

## What was happening

`/api/history` called `scan_rows`, which rescans whenever the cache is older than `HISTORY_SCAN_TTL`. That TTL was **10 seconds**.

So a user clicking through pages and changing filters landed on an expired cache constantly, and each time paid a full scan — an S3 list plus a GET per manifest — before a single row could render.

Pagination was never going to help, either: the handler materializes every visible session, sorts, and *then* slices the page. Page 1 costs exactly what page 10 costs. The paging made the result usable; it didn't touch the cost.

## The fix

**Serve stale, refresh behind.** `scan_rows_cached` returns the previous scan immediately and kicks the rescan off the request path, with a compare-exchange guard so a burst against an expired cache triggers one rescan rather than one per request. Only a genuinely cold cache blocks.

**Warm at startup**, so the first person to open history after a deploy doesn't pay the cold scan either.

**Refresh when the sweep archives something.** The sweep is the only thing that adds sessions to the archive, so freshness now follows the event that changes the data rather than a timer guessing at it.

With staleness bounded by an event instead of a wait, the TTL becomes a backstop rather than the mechanism — so it moves 10s → 30s to cut S3 list/GET churn. That's still far finer than the data changes, since sessions only enter the archive when the retention sweep runs, minutes apart.

## Tests

- an expired cache returns the *same `Arc`* it already had — only possible if nothing rescanned inline
- a cold cache still populates, priming it for every request behind it

## What this does not do

It doesn't make the cold scan itself faster, and it doesn't stream partial results — the first request against a truly empty cache still waits. Startup warming means that should only ever be a request that beats the warm task. If the archive grows large enough that even the background scan is slow, the next step is an index object rather than a full manifest walk; flagging that rather than pre-building it.