### PR TITLE
Keep context status stable during agent broadcasts

### DIFF
--- a/backend/src/handlers/turn_metrics.rs
+++ b/backend/src/handlers/turn_metrics.rs
@@ -58,7 +58,10 @@ pub async fn list_turn_metrics(
         .load(&mut conn)?;
 
     let metrics = rows.into_iter().map(TurnMetric::into_wire).collect();
-    Ok(Json(TurnMetricsResponse { metrics }))
+    Ok(Json(TurnMetricsResponse {
+        metrics,
+        latest_by_session: Vec::new(),
+    }))
 }
 
 /// Window size for `GET /api/metrics/recent`. Picked to comfortably cover a
@@ -98,7 +101,33 @@ pub async fn list_recent_user_turn_metrics(
     rows.reverse();
 
     let metrics = rows.into_iter().map(TurnMetric::into_wire).collect();
-    Ok(Json(TurnMetricsResponse { metrics }))
+
+    // The 50-row trend is intentionally global and bounded, but context bars
+    // need one durable latest value per session. Fetch that independently so
+    // traffic in one session cannot make quiet sessions lose their gauges.
+    // Inner-joining sessions excludes archived/orphaned metric rows and limits
+    // this overlay to sessions the dashboard can actually render.
+    use crate::schema::sessions;
+    let latest_rows: Vec<TurnMetric> = turn_metrics::table
+        .inner_join(sessions::table)
+        .filter(turn_metrics::user_id.eq(current_user_id))
+        // Return the newest row that can plausibly drive context/model status,
+        // not a newer bookkeeping row with no model or reported window.
+        .filter(
+            turn_metrics::model_context_window
+                .gt(0)
+                .or(turn_metrics::model.is_not_null()),
+        )
+        .distinct_on(turn_metrics::session_id)
+        .order((turn_metrics::session_id, turn_metrics::started_at.desc()))
+        .select(TurnMetric::as_select())
+        .load(&mut conn)?;
+    let latest_by_session = latest_rows.into_iter().map(TurnMetric::into_wire).collect();
+
+    Ok(Json(TurnMetricsResponse {
+        metrics,
+        latest_by_session,
+    }))
 }
 
 // =============================================================================

--- a/frontend/src/components/turn_metrics_pill.rs
+++ b/frontend/src/components/turn_metrics_pill.rs
@@ -50,9 +50,9 @@ impl SparklineMetric {
     }
 }
 
-/// Pick the (model, service_tier) pair of the *most recent* turn in the
-/// buffer. Returns `None` when the buffer is empty or the newest turn has
-/// neither field populated.
+/// Pick the newest usable `(model, service_tier)` pair in the buffer. Turns
+/// from an agent that reports neither field are skipped instead of making the
+/// whole header status disappear.
 ///
 /// The buffer is sorted oldest → newest, so the newest turn is the last
 /// element. The pair is the (model, tier) tuple — both `Option` because
@@ -61,11 +61,10 @@ impl SparklineMetric {
 pub(crate) fn pick_most_recent_model_tier(
     buf: &[TurnMetrics],
 ) -> Option<(Option<String>, Option<String>)> {
-    let last = buf.last()?;
-    if last.model.is_none() && last.service_tier.is_none() {
-        return None;
-    }
-    Some((last.model.clone(), last.service_tier.clone()))
+    buf.iter()
+        .rev()
+        .find(|metric| metric.model.is_some() || metric.service_tier.is_some())
+        .map(|metric| (metric.model.clone(), metric.service_tier.clone()))
 }
 
 /// Build a human-readable label from a (model, tier) pair. The model name
@@ -315,6 +314,17 @@ mod tests {
     fn pick_pair_returns_none_when_newest_has_no_model_or_tier() {
         let buf = vec![mk(None, None, 0)];
         assert!(pick_most_recent_model_tier(&buf).is_none());
+    }
+
+    #[test]
+    fn pick_pair_skips_newest_row_without_model_metadata() {
+        let buf = vec![
+            mk(Some("claude-opus-4-8"), Some("priority"), 0),
+            mk(None, None, 1),
+        ];
+        let pair = pick_most_recent_model_tier(&buf).unwrap();
+        assert_eq!(pair.0.as_deref(), Some("claude-opus-4-8"));
+        assert_eq!(pair.1.as_deref(), Some("priority"));
     }
 
     #[test]

--- a/frontend/src/hooks/client_websocket_events.rs
+++ b/frontend/src/hooks/client_websocket_events.rs
@@ -1,4 +1,6 @@
 use shared::{ServerToClient, TurnMetrics};
+use std::collections::HashMap;
+use uuid::Uuid;
 use yew::UseStateHandle;
 
 /// Cap for the dashboard's recent-turn ring buffer. Matches the server-side
@@ -12,6 +14,7 @@ pub(crate) fn handle_server_message(
     total_spend: &UseStateHandle<f64>,
     shutdown_reason: &UseStateHandle<Option<String>>,
     recent_turn_metrics: &UseStateHandle<Vec<TurnMetrics>>,
+    latest_session_metrics: &UseStateHandle<HashMap<Uuid, TurnMetrics>>,
     launch_event_counter: &UseStateHandle<u32>,
     launcher_event_counter: &UseStateHandle<u32>,
 ) {
@@ -34,12 +37,16 @@ pub(crate) fn handle_server_message(
             shutdown_reason.set(Some(reason));
         }
         ServerToClient::TurnMetrics(metrics) => {
+            let metrics = *metrics;
             let next = insert_recent_metric(
                 (**recent_turn_metrics).clone(),
-                *metrics,
+                metrics.clone(),
                 RECENT_TURN_BUFFER_CAP,
             );
             recent_turn_metrics.set(next);
+            let mut latest = (**latest_session_metrics).clone();
+            insert_latest_session_metric(&mut latest, metrics);
+            latest_session_metrics.set(latest);
         }
         ServerToClient::LaunchSessionResult { success, error, .. } => {
             // Push signal from the backend that the launcher finished registering
@@ -59,6 +66,23 @@ pub(crate) fn handle_server_message(
             launcher_event_counter.set(launcher_event_counter.wrapping_add(1));
         }
         _ => {}
+    }
+}
+
+pub(crate) fn insert_latest_session_metric(
+    latest: &mut HashMap<Uuid, TurnMetrics>,
+    incoming: TurnMetrics,
+) {
+    // An agent/version that cannot report a context window must not erase the
+    // last usable gauge. The bounded trend ring still retains that raw turn.
+    if incoming.context_fraction().is_none() {
+        return;
+    }
+    let replace = latest
+        .get(&incoming.session_id)
+        .is_none_or(|existing| incoming.started_at >= existing.started_at);
+    if replace {
+        latest.insert(incoming.session_id, incoming);
     }
 }
 
@@ -160,5 +184,47 @@ mod tests {
         assert_eq!(buf.len(), 3);
         let secs: Vec<i64> = buf.iter().map(|m| m.started_at.timestamp()).collect();
         assert_eq!(secs, vec![30, 40, 50]);
+    }
+
+    #[test]
+    fn latest_per_session_survives_unrelated_ring_eviction() {
+        let quiet = Uuid::new_v4();
+        let busy = Uuid::new_v4();
+        let mut latest = HashMap::new();
+        let mut quiet_metric = sample(Some(Uuid::new_v4()), 10);
+        quiet_metric.session_id = quiet;
+        quiet_metric.model_context_window = Some(200_000);
+        quiet_metric.context_snapshot_tokens = Some(50_000);
+        insert_latest_session_metric(&mut latest, quiet_metric);
+
+        let mut ring = Vec::new();
+        for t in 20..=80 {
+            let mut metric = sample(Some(Uuid::new_v4()), t);
+            metric.session_id = busy;
+            metric.model_context_window = Some(200_000);
+            metric.context_snapshot_tokens = Some(t * 100);
+            insert_latest_session_metric(&mut latest, metric.clone());
+            ring = insert_recent_metric(ring, metric, 50);
+        }
+
+        assert!(ring.iter().all(|metric| metric.session_id != quiet));
+        assert_eq!(latest.get(&quiet).unwrap().started_at.timestamp(), 10);
+    }
+
+    #[test]
+    fn unknown_context_does_not_erase_last_usable_status() {
+        let session_id = Uuid::new_v4();
+        let mut latest = HashMap::new();
+        let mut usable = sample(Some(Uuid::new_v4()), 10);
+        usable.session_id = session_id;
+        usable.model_context_window = Some(200_000);
+        usable.context_snapshot_tokens = Some(50_000);
+        insert_latest_session_metric(&mut latest, usable);
+
+        let mut unknown = sample(Some(Uuid::new_v4()), 20);
+        unknown.session_id = session_id;
+        insert_latest_session_metric(&mut latest, unknown);
+
+        assert_eq!(latest.get(&session_id).unwrap().started_at.timestamp(), 10);
     }
 }

--- a/frontend/src/hooks/use_client_websocket.rs
+++ b/frontend/src/hooks/use_client_websocket.rs
@@ -7,6 +7,8 @@ use crate::utils::{self, On401};
 use client_websocket_events::handle_server_message;
 use shared::api::TurnMetricsResponse;
 use shared::{AppConfig, ClientEndpoint, TurnMetrics, WsEndpoint};
+use std::collections::HashMap;
+use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
@@ -31,6 +33,10 @@ pub struct UseClientWebSocket {
     /// this buffer ticks live without the dashboard having to subscribe to
     /// individual session WS streams. Capped by the websocket event helper.
     pub recent_turn_metrics: Vec<TurnMetrics>,
+    /// Newest context-capable row per session, independent of the bounded
+    /// trend ring. Context status must not disappear when another session is
+    /// busy or emits a newer row without context metadata.
+    pub latest_session_metrics: HashMap<Uuid, TurnMetrics>,
     /// Monotonic counter that ticks every time the backend broadcasts a
     /// `ServerToClient::LaunchSessionResult` frame (proxy registered, or
     /// the launch failed). Consumers can hang a `use_effect_with` on this
@@ -89,6 +95,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
     let shutdown_reason = use_state(|| None::<String>);
     let update_available = use_state(|| None::<String>);
     let recent_turn_metrics = use_state(Vec::<TurnMetrics>::new);
+    let latest_session_metrics = use_state(HashMap::<Uuid, TurnMetrics>::new);
     let launch_event_counter = use_state(|| 0u32);
     let launcher_event_counter = use_state(|| 0u32);
 
@@ -97,13 +104,35 @@ pub fn use_client_websocket() -> UseClientWebSocket {
     // has any prior turns, and the WS path keeps it fresh once it lands.
     {
         let recent_turn_metrics = recent_turn_metrics.clone();
+        let latest_session_metrics = latest_session_metrics.clone();
         use_effect_with((), move |_| {
             spawn_local(async move {
                 if let Ok(parsed) =
                     utils::fetch_json::<TurnMetricsResponse>("/api/metrics/recent", On401::Ignore)
                         .await
                 {
-                    recent_turn_metrics.set(parsed.metrics);
+                    let mut ring = (*recent_turn_metrics).clone();
+                    let mut latest = (*latest_session_metrics).clone();
+                    for metric in parsed.metrics {
+                        client_websocket_events::insert_latest_session_metric(
+                            &mut latest,
+                            metric.clone(),
+                        );
+                        ring = client_websocket_events::insert_recent_metric(
+                            ring,
+                            metric,
+                            client_websocket_events::RECENT_TURN_BUFFER_CAP,
+                        );
+                    }
+                    recent_turn_metrics.set(ring);
+
+                    // New backends include each session's newest usable context
+                    // row explicitly. Seeding from the trend rows above keeps
+                    // the prior best-effort behavior against an old backend.
+                    for metric in parsed.latest_by_session {
+                        client_websocket_events::insert_latest_session_metric(&mut latest, metric);
+                    }
+                    latest_session_metrics.set(latest);
                 }
             });
             || ()
@@ -115,6 +144,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
         let shutdown_reason = shutdown_reason.clone();
         let update_available = update_available.clone();
         let recent_turn_metrics = recent_turn_metrics.clone();
+        let latest_session_metrics = latest_session_metrics.clone();
         let launch_event_counter = launch_event_counter.clone();
         let launcher_event_counter = launcher_event_counter.clone();
 
@@ -123,6 +153,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
             let shutdown_reason = shutdown_reason.clone();
             let update_available = update_available.clone();
             let recent_turn_metrics = recent_turn_metrics.clone();
+            let latest_session_metrics = latest_session_metrics.clone();
             let launch_event_counter = launch_event_counter.clone();
             let launcher_event_counter = launcher_event_counter.clone();
 
@@ -168,6 +199,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
                                         &total_spend,
                                         &shutdown_reason,
                                         &recent_turn_metrics,
+                                        &latest_session_metrics,
                                         &launch_event_counter,
                                         &launcher_event_counter,
                                     ),
@@ -207,6 +239,7 @@ pub fn use_client_websocket() -> UseClientWebSocket {
         shutdown_reason: (*shutdown_reason).clone(),
         update_available: (*update_available).clone(),
         recent_turn_metrics: (*recent_turn_metrics).clone(),
+        latest_session_metrics: (*latest_session_metrics).clone(),
         launch_event_counter: *launch_event_counter,
         launcher_event_counter: *launcher_event_counter,
     }

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -107,26 +107,19 @@ pub fn dashboard_page() -> Html {
     // Get DB-authoritative sessions in a total, deterministic display order
     // (see `session_order`). A disconnected, unpaused session is
     // desired-running and should stay visible while the launcher reconciles it.
-    // Live model overlay for the pill's model watermark. The dashboard already
-    // receives every session's per-turn `TurnMetrics` (which carries `model`)
-    // on the user channel, so a mid-session model change — e.g. a Fable 5
-    // session falling back to Opus 4.8 — flips the pill's watermark instantly,
-    // before the next `/api/sessions` poll reads the persisted `last_model`
-    // back. Latest turn wins: the buffer is ordered oldest→newest, so a plain
-    // `collect` lets later entries overwrite earlier ones per session.
+    // Live model overlay for the pill's model watermark. The persisted
+    // `last_model` remains the durable fallback when this trend window rolls.
     let live_models: HashMap<Uuid, String> = ws_hook
         .recent_turn_metrics
         .iter()
         .filter_map(|m| m.model.clone().map(|model| (m.session_id, model)))
         .collect();
 
-    // Per-session context-window fill, same source and "latest turn wins"
-    // ordering as `live_models` above. Feeds each pill's top context bar; a
-    // turn whose window is unknown (e.g. an unrecognized model) is skipped, so
-    // that session simply shows no bar.
+    // Per-session context-window fill from the dedicated durable latest-value
+    // map. Rows without a usable window never erase a prior known gauge.
     let context_fractions: HashMap<Uuid, f64> = ws_hook
-        .recent_turn_metrics
-        .iter()
+        .latest_session_metrics
+        .values()
         .filter_map(|m| m.context_fraction().map(|frac| (m.session_id, frac)))
         .collect();
 

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -1117,6 +1117,7 @@
     pointer-events: none;
     background: rgba(192, 202, 245, 0.06);
     overflow: hidden;
+
     /* Broadcast plasma is z-index:1. Keep status readable while the effect
        crosses a pill instead of letting its glow paint over the gauge. */
     z-index: 2;

--- a/frontend/styles/session-rail.css
+++ b/frontend/styles/session-rail.css
@@ -1117,6 +1117,9 @@
     pointer-events: none;
     background: rgba(192, 202, 245, 0.06);
     overflow: hidden;
+    /* Broadcast plasma is z-index:1. Keep status readable while the effect
+       crosses a pill instead of letting its glow paint over the gauge. */
+    z-index: 2;
 }
 
 .pill-context-fill {

--- a/shared/src/api/metrics.rs
+++ b/shared/src/api/metrics.rs
@@ -194,14 +194,18 @@ impl TurnMetrics {
     }
 }
 
-/// Response from `GET /api/sessions/{id}/turn-metrics`.
-///
-/// Rows are ordered `started_at ASC` so the SessionView's join walk (pair Nth
-/// terminator message with Nth metrics row) works without a second sort.
+/// Turn-metrics response shared by the per-session and dashboard endpoints.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TurnMetricsResponse {
+    /// Trend/history rows. The per-session endpoint returns the whole session;
+    /// the dashboard endpoint returns its bounded newest-turn window.
     #[serde(default)]
     pub metrics: Vec<TurnMetrics>,
+    /// Newest context-capable row for every existing session owned by the user.
+    /// Kept separate from `metrics` so a busy session cannot evict a quiet
+    /// session's current context gauge from the bounded trend window.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub latest_by_session: Vec<TurnMetrics>,
 }
 
 /// One bucket in the `GET /api/metrics/turns` response. Aggregates `turn_metrics`


### PR DESCRIPTION
## Summary
- keep the bounded 50-turn trend ring, but hydrate and maintain a separate newest context-capable metric per session
- merge REST hydration with live WebSocket metrics so a late fetch cannot overwrite a newer turn
- preserve the last usable context gauge when a newer agent/version omits context metadata
- make the header select the newest usable model/tier instead of disappearing on a metadata-free newest turn
- layer context gauges above the plasma effect

## Root cause
Agent-to-agent sends generate turn metrics. The dashboard used the global 50-turn trend ring as per-session status storage, so busy broadcast traffic evicted quiet sessions and removed their context bars. Plasma also painted above the gauge, and a newest turn without model metadata hid the header pill.

## Validation
- `cargo check -p backend`
- `cargo test -p frontend client_websocket_events --lib`
- `cargo test -p frontend turn_metrics_pill --lib`
- `cargo clippy -p backend -p frontend --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`