### PR TITLE
Pin where a muse rejection without correlation_facts renders

### DIFF
--- a/frontend/src/components/muse_renderer/task_tree.rs
+++ b/frontend/src/components/muse_renderer/task_tree.rs
@@ -659,6 +659,58 @@ mod tests {
         );
     }
 
+    /// Muse 0.2.1 omits `correlation_facts` on a **pre-execution rejection** —
+    /// a tool call refused before it runs, e.g. the stringified-scalar rejects
+    /// seen on meawoppl-fc (`invalid type: string "false", expected a
+    /// boolean`). With no `tool_name` there is nothing to kind-match, so the
+    /// fallback decides where the failure is rendered, and the preference for
+    /// a non-reminder task is what keeps it on the visible work rather than on
+    /// scaffolding the view hides.
+    ///
+    /// Covered here because that fallback became load-bearing on 0.2.1 rather
+    /// than theoretical (rust-code-agent-sdks#325). The existing fallback test
+    /// only exercises the degenerate case where a reminder is the *sole*
+    /// running task.
+    #[test]
+    fn a_rejection_without_correlation_facts_lands_on_real_work_not_scaffolding() {
+        let mut tree = TaskTree::new();
+        for (id, kind) in [
+            ("r1", "reminder.agent.plugin:tbh-reminders:scope-reminder"),
+            ("t1", "tool.bash"),
+        ] {
+            tree.apply(&json!({
+                "payload_type": "task.lifecycle.proposed",
+                "payload": {"task_id": id, "event": {
+                    "kind": "proposed", "task_id": id, "task_kind": kind
+                }},
+            }));
+            tree.apply(&json!({
+                "payload_type": "task.lifecycle.started",
+                "payload": {"task_id": id, "event": {"kind": "started", "task_id": id}},
+            }));
+        }
+
+        // No `correlation_facts`: the 0.2.1 pre-execution rejection shape.
+        tree.apply(&json!({
+            "payload_type": "tool.result",
+            "payload": {
+                "call_id": "c1",
+                "text": "invalid type: string \"false\", expected a boolean at line 1 column 102"
+            },
+        }));
+
+        assert_eq!(
+            tree.get("t1").expect("tool task").tool_results.len(),
+            1,
+            "a rejection with no correlation_facts must attach to the running \
+             tool task, not the reminder scaffolding the view hides"
+        );
+        assert!(
+            tree.get("r1").expect("reminder").tool_results.is_empty(),
+            "scaffolding must not absorb the rejection"
+        );
+    }
+
     /// A frame the model cannot interpret must not break the tree built by
     /// the rest of the turn.
     #[test]


### PR DESCRIPTION
No behavior change — this pins a fallback that just became load-bearing.

## Why now

Muse 0.2.1 omits `correlation_facts` on a **pre-execution rejection**: a tool call refused before it runs. That's the shape behind the rejects currently filling a session on `meawoppl-fc` (`invalid type: string "false", expected a boolean`), and it's now pinned by a committed capture upstream in rust-code-agent-sdks#325.

With no `tool_name` there's nothing to kind-match, so `tool_result_target` falls through to its fallback — and the preference for a running **non-reminder** task is what keeps the failure attached to visible work rather than to reminder scaffolding, which `is_hidden_scaffolding` hides.

The fallback already does the right thing, so there's no fix here. What changed is that it went from theoretical to load-bearing when that host's CLI moved to 0.2.1.

## The gap

Existing coverage (`tool_results_fall_back_to_a_reminder_task_when_nothing_else_runs`) exercises absent `correlation_facts` only in the degenerate case where a reminder is the *sole* running task. The branch that actually fires on 0.2.1 — a rejection arriving while real work is also running — was untested.

This adds that: both a reminder and a `tool.bash` task running, a `tool.result` with no `correlation_facts`, asserting it lands on the tool task and that scaffolding doesn't absorb it.

## Note

I verified the upstream claim that "no portal change is needed" against the code rather than taking it on trust — `tool_result_target` does take `Option<&str>` and does prefer non-reminder running tasks. It holds. The test exists so it keeps holding.

641 frontend tests pass, clippy clean.