### PR TITLE
Stop git metadata refreshes stalling claude sessions too

### DIFF
--- a/claude-session-lib/src/proxy_session/git_metadata.rs
+++ b/claude-session-lib/src/proxy_session/git_metadata.rs
@@ -137,12 +137,30 @@ pub(super) fn muse_output_has_git_signal(value: &serde_json::Value) -> bool {
 /// can change what we display, or an unambiguous git output line for the case
 /// where the branch moved without us seeing the command.
 fn text_has_git_signal(text: &str) -> bool {
-    const STATE_CHANGING: [&str; 8] = [
-        "checkout", "switch", "commit", "merge", "rebase", "push", "branch", " pr ",
+    const STATE_CHANGING: [&str; 7] = [
+        "checkout", "switch", "commit", "merge", "rebase", "push", "branch",
+    ];
+
+    /// PR subcommands that change something worth re-reading. Deliberately not
+    /// a bare `" pr "`: that also matched every read-only `gh pr checks` /
+    /// `view` / `list` / `diff` / `status`, so browsing PR state triggered a
+    /// refresh — three `gh` round trips — that could not have found anything
+    /// new. `gh pr checks <n> --watch` is the worst of it, re-emitting output
+    /// every interval and marking a signal on each frame.
+    const PR_STATE_CHANGING: [&str; 6] = [
+        "pr create",
+        "pr merge",
+        "pr edit",
+        "pr close",
+        "pr reopen",
+        "pr ready",
     ];
 
     let invoked = text.contains("git ") || text.contains("gh ");
-    if invoked && STATE_CHANGING.iter().any(|sub| text.contains(sub)) {
+    if invoked
+        && (STATE_CHANGING.iter().any(|sub| text.contains(sub))
+            || PR_STATE_CHANGING.iter().any(|sub| text.contains(sub)))
+    {
         return true;
     }
 
@@ -333,6 +351,44 @@ mod tests {
                 "correlation_facts": { "tool_name": "bash" },
             }
         })
+    }
+
+    /// The command that exposed the stall: `gh pr checks <n> --watch` re-emits
+    /// output every interval and changes nothing, so it must not mark a git
+    /// signal. A bare `" pr "` match did, turning a CI watch into a refresh
+    /// per frame — three `gh` round trips each, which the claude arm awaited
+    /// inline in the output forwarder.
+    #[test]
+    fn read_only_gh_pr_commands_are_not_git_signals() {
+        for cmd in [
+            "gh pr checks 1788 --watch --interval 15",
+            "/bin/bash -lc 'gh pr checks 1788 --watch --interval 15'",
+            "gh pr view 42",
+            "gh pr list --state open",
+            "gh pr diff 7",
+        ] {
+            assert!(
+                !text_has_git_signal(cmd),
+                "read-only PR browsing must not trigger a refresh: {cmd:?}"
+            );
+        }
+    }
+
+    /// Narrowing the PR match must not lose the case it existed for: creating
+    /// or merging a PR genuinely changes what the pill should show.
+    #[test]
+    fn state_changing_gh_pr_commands_are_still_git_signals() {
+        for cmd in [
+            "gh pr create --fill",
+            "gh pr merge 1788 --squash --auto",
+            "gh pr ready 1788",
+            "gh pr close 1788",
+        ] {
+            assert!(
+                text_has_git_signal(cmd),
+                "PR mutation must still trigger a refresh: {cmd:?}"
+            );
+        }
     }
 
     #[test]

--- a/claude-session-lib/src/proxy_session/output_forwarder.rs
+++ b/claude-session-lib/src/proxy_session/output_forwarder.rs
@@ -20,8 +20,8 @@ use uuid::Uuid;
 use session_lib::output_buffer::PendingOutputBuffer;
 
 use super::git_metadata::{
-    check_and_send_branch_update, claude_output_code_change_published,
-    claude_output_has_git_signal, GitMetadataState, GitRefreshTrigger,
+    claude_output_code_change_published, claude_output_has_git_signal, spawn_branch_update,
+    GitMetadataState, GitRefreshTrigger,
 };
 use super::media_display::{claude_output_image_read, MediaDisplaySink};
 use super::{format_duration, truncate, SharedWsWrite};
@@ -61,14 +61,22 @@ pub fn spawn_output_forwarder(
 
             // Branch/PR update from the PREVIOUS message's git command (deferred
             // so the command has finished). Runs each frame regardless of parse.
+            //
+            // Fire-and-forget, for the same reason the codex arm is (#1690):
+            // awaiting here stalls *this* task, and this task is the one
+            // forwarding output to the backend. The refresh shells out to `git`
+            // and `gh` — three GitHub round trips, none of them with a timeout —
+            // so a slow network turned every claude output frame into a
+            // serialized wait, which reads as a frozen session that dumps a
+            // burst of messages the moment something else nudges the loop.
+            //
+            // `gh pr checks <n> --watch` is the pathological case: it re-emits
+            // output every interval, and every frame contains both `gh ` and
+            // ` pr `, so the git-signal predicate fires on all of them. The
+            // in-flight guard inside `spawn_branch_update` coalesces that flood
+            // into one refresh instead of one per frame.
             if git_refresh.should_check_before_message() {
-                check_and_send_branch_update(
-                    &ws_write,
-                    session_id,
-                    &working_directory,
-                    &git_metadata,
-                )
-                .await;
+                spawn_branch_update(&ws_write, session_id, &working_directory, &git_metadata);
             }
 
             if let Some(ref output) = parsed {
@@ -104,13 +112,12 @@ pub fn spawn_output_forwarder(
                         "← code_change_published: {} {} ({})",
                         published.provider, published.url, published.repo
                     );
-                    check_and_send_branch_update(
-                        &ws_write,
-                        session_id,
-                        &working_directory,
-                        &git_metadata,
-                    )
-                    .await;
+                    spawn_branch_update(&ws_write, session_id, &working_directory, &git_metadata);
+                    // The refresh above is coalesced away if one is already in
+                    // flight, and that one may have started before the PR
+                    // existed. Mark a signal so the next frame retries rather
+                    // than leaving the just-published PR unreported.
+                    git_refresh.mark_git_signal();
                 }
 
                 // Reading an image displays it: the user otherwise watches the


### PR DESCRIPTION
Reported still happening on a launcher already carrying #1690, with the stalled command being `/bin/bash -lc 'gh pr checks 1788 --watch --interval 15'`.

## What #1690 missed

It made the refresh fire-and-forget — but only on the **codex/muse** arm (`session_event.rs`). The **claude** arm still did:

```rust
check_and_send_branch_update(&ws_write, session_id, &working_directory, &git_metadata).await;
```

inline in the output forwarder — the task whose job is forwarding output to the backend. The helper offloads the subprocesses to the blocking pool, so the runtime is fine, but the forwarder task still *awaits* the result. Message delivery pauses for the duration: three `gh` GitHub round trips, none with a timeout.

That is the original symptom exactly — session looks frozen, then dumps a burst once something else nudges the loop — surviving on the path #1690 didn't convert.

## Why that command in particular

`gh pr checks <n> --watch` re-emits output every interval, and every frame contains both `gh ` and ` pr `, so the git-signal predicate fired on **each one**. On the claude arm each signal became an awaited three-call refresh before the next frame could be forwarded.

Two fixes, one per layer:

- **`spawn_branch_update` on both arms.** Its in-flight guard coalesces a flood into one refresh instead of one per frame, and nothing awaits it.
- **Narrow the PR predicate.** A bare `" pr "` matched every read-only `gh pr checks` / `view` / `list` / `diff` / `status` — refreshes that could not possibly find anything new. Now matches state-changing subcommands: create, merge, edit, close, reopen, ready.

Also, on `code_change_published` the spawn can now be coalesced away by a refresh that started *before* the PR existed, so it marks a signal alongside; the next frame retries rather than leaving a just-published PR unreported.

## Tests

Both directions of the predicate: read-only PR browsing (including the exact reported command, with and without the `bash -lc` wrapper) marks no signal; PR mutations still do. 95 tests in claude-session-lib, 81 in the launcher, clippy clean.

## Known gap, not fixed here

None of the seven `git`/`gh` lookups in `session-lib/src/git_metadata.rs` has a timeout — they are bare `std::process::Command::output()`. With the refresh now fire-and-forget, a hung `gh` no longer stalls output; it means metadata stops updating for that session while the in-flight guard stays held. Worth bounding separately.