### PR TITLE
Key codex cards by item id so expanded previews stay open

### DIFF
--- a/frontend/src/components/message_renderer/group_renderer.rs
+++ b/frontend/src/components/message_renderer/group_renderer.rs
@@ -132,7 +132,8 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
             // item that the body's `gap` still spaces into a blank row.
             let parts: Vec<Html> = visible
                 .iter()
-                .filter_map(|&i| {
+                .filter_map(|(i, item_id)| {
+                    let i = *i;
                     let message = &messages[i];
                     let content = dispatch::render_identity_group_part(
                         message,
@@ -141,10 +142,16 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                         &props.continuation_statuses,
                         props.on_schedule_continuation.clone(),
                     )?;
-                    let key = message
-                        .raw_iso()
-                        .map(|iso| format!("m-{}", iso))
-                        .unwrap_or_else(|| format!("m{}", i));
+                    // Prefer the codex item id: it is stable across the
+                    // item's whole lifecycle, whereas the surviving message's
+                    // timestamp changes each time a later frame wins the dedup
+                    // — recreating the card and collapsing anything expanded
+                    // inside it.
+                    let key = item_id
+                        .as_ref()
+                        .map(|id| format!("i-{id}"))
+                        .or_else(|| message.raw_iso().map(|iso| format!("m-{iso}")))
+                        .unwrap_or_else(|| format!("m{i}"));
                     Some(html! { <div {key} class="grouped-message-part">{ content }</div> })
                 })
                 .collect();

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -571,12 +571,23 @@ pub fn group_messages(
 /// Events that don't carry an `item_id` (turn-level events, deltas, errors)
 /// always pass through — they're standalone signals, not lifecycle stages of
 /// a per-item card.
+/// Returns each surviving index paired with the codex `item_id` it renders,
+/// when it has one.
+///
+/// The id is handed back rather than recomputed by the caller for two reasons.
+/// It avoids a second parse of every message on the hot render path (#967) —
+/// and, more importantly, it is the card's **stable identity**. Keying the
+/// rendered card on the surviving message's timestamp instead means the key
+/// changes every time a later lifecycle frame for the same item wins the
+/// dedup, so Yew tears the card down and rebuilds it — resetting every
+/// expandable inside, which is how an expanded bash-output preview closed
+/// itself as a turn progressed.
 pub(super) fn visible_group_indices(
     category: GroupCategory,
     messages: &[RenderedMessage],
-) -> Vec<usize> {
+) -> Vec<(usize, Option<String>)> {
     if !matches!(category, GroupCategory::Codex) {
-        return (0..messages.len()).collect();
+        return (0..messages.len()).map(|i| (i, None)).collect();
     }
     use crate::components::codex_renderer::codex_event_item_id;
     use std::collections::HashMap;
@@ -599,6 +610,6 @@ pub(super) fn visible_group_indices(
             Some(id) => last_idx.get(id.as_str()) == Some(i),
             None => true,
         })
-        .map(|(i, _)| i)
+        .map(|(i, id)| (i, id.clone()))
         .collect()
 }

--- a/frontend/src/components/message_renderer/tests/codex.rs
+++ b/frontend/src/components/message_renderer/tests/codex.rs
@@ -7,6 +7,12 @@ use super::fixtures::{
     group_for_codex_tests, portal_text_message, rendered_vec,
 };
 
+/// The surviving indices only — most assertions here are about *which*
+/// messages render, not the ids that key them.
+fn indices(visible: &[(usize, Option<String>)]) -> Vec<usize> {
+    visible.iter().map(|(i, _)| *i).collect()
+}
+
 #[test]
 fn codex_event_classifies_into_codex_group() {
     let msg = codex_item_started_agent_message("hi");
@@ -71,7 +77,10 @@ fn codex_command_lifecycle_dedupes_to_completed() {
         codex_command_event("item.started", "cmd_1", "in_progress"),
         codex_command_event("item.completed", "cmd_1", "completed"),
     ];
-    let visible = visible_group_indices(GroupCategory::Codex, &rendered_vec(&messages));
+    let visible = indices(&visible_group_indices(
+        GroupCategory::Codex,
+        &rendered_vec(&messages),
+    ));
     assert_eq!(
         visible,
         vec![1],
@@ -90,7 +99,10 @@ fn codex_command_started_updated_completed_dedupes_to_completed() {
         codex_command_event("item.updated", "cmd_1", "in_progress"),
         codex_command_event("item.completed", "cmd_1", "completed"),
     ];
-    let visible = visible_group_indices(GroupCategory::Codex, &rendered_vec(&messages));
+    let visible = indices(&visible_group_indices(
+        GroupCategory::Codex,
+        &rendered_vec(&messages),
+    ));
     assert_eq!(visible, vec![2]);
 }
 
@@ -104,7 +116,10 @@ fn codex_two_distinct_items_each_keep_one_card() {
         codex_command_event("item.started", "cmd_b", "in_progress"),
         codex_command_event("item.completed", "cmd_b", "completed"),
     ];
-    let visible = visible_group_indices(GroupCategory::Codex, &rendered_vec(&messages));
+    let visible = indices(&visible_group_indices(
+        GroupCategory::Codex,
+        &rendered_vec(&messages),
+    ));
     // Indices 1 (cmd_a completed) and 3 (cmd_b completed) remain.
     assert_eq!(visible, vec![1, 3]);
 }
@@ -124,7 +139,10 @@ fn codex_non_item_events_always_visible() {
         turn_completed.clone(),
         codex_command_event("item.completed", "cmd_1", "completed"),
     ];
-    let visible = visible_group_indices(GroupCategory::Codex, &rendered_vec(&messages));
+    let visible = indices(&visible_group_indices(
+        GroupCategory::Codex,
+        &rendered_vec(&messages),
+    ));
     // turn.completed (index 1) is kept; the started (index 0) drops in
     // favor of the completed (index 2).
     assert_eq!(visible, vec![1, 2]);
@@ -145,7 +163,7 @@ fn visible_group_indices_is_codex_only() {
         GroupCategory::Portal,
         GroupCategory::User,
     ] {
-        let visible = visible_group_indices(cat, &rendered_vec(&messages));
+        let visible = indices(&visible_group_indices(cat, &rendered_vec(&messages)));
         assert_eq!(
             visible,
             vec![0, 1],
@@ -171,6 +189,49 @@ fn codex_items_without_id_do_not_collapse() {
         "item": {"type": "agent_message", "text": "second"},
     })
     .to_string();
-    let visible = visible_group_indices(GroupCategory::Codex, &rendered_vec(&[no_id_a, no_id_b]));
+    let visible = indices(&visible_group_indices(
+        GroupCategory::Codex,
+        &rendered_vec(&[no_id_a, no_id_b]),
+    ));
     assert_eq!(visible, vec![0, 1]);
+}
+
+/// The reported bug: an expanded bash-output preview closed itself as new
+/// messages arrived, on codex sessions but not claude ones.
+///
+/// Codex re-emits one tool call as `item.started` → `item.updated` →
+/// `item.completed`, and the dedup keeps only the newest. Keying the rendered
+/// card on the surviving message's timestamp therefore changed the key at
+/// every stage, so Yew tore the card down and rebuilt it — resetting the
+/// `ExpandableText` inside. Claude has no progressive re-emission, which is
+/// why it never churned.
+///
+/// The `item_id` is stable across the whole lifecycle, so the surviving entry
+/// must carry it and it must not change stage to stage.
+#[test]
+fn a_codex_card_keeps_one_identity_across_its_lifecycle() {
+    let stages = ["item.started", "item.updated", "item.completed"];
+    let mut keys = Vec::new();
+
+    // Replay the turn as it actually arrives: one more frame each time.
+    for upto in 1..=stages.len() {
+        let messages: Vec<_> = stages[..upto]
+            .iter()
+            .map(|stage| codex_command_event(stage, "cmd_1", "in_progress"))
+            .collect();
+        let visible = visible_group_indices(GroupCategory::Codex, &rendered_vec(&messages));
+        assert_eq!(visible.len(), 1, "one card per item at stage {upto}");
+        keys.push(
+            visible[0]
+                .1
+                .clone()
+                .unwrap_or_else(|| panic!("surviving codex card must carry its item id")),
+        );
+    }
+
+    assert!(
+        keys.windows(2).all(|w| w[0] == w[1]),
+        "the card's identity must not move as its lifecycle advances \
+         (an expanded preview would collapse): {keys:?}"
+    );
 }


### PR DESCRIPTION
Reported: an expanded collapsed-bash-output preview closes itself as new messages come in — on codex sessions, and seemingly not claude ones. Both halves of that observation were right, and they're the clue.

## Mechanism

Codex re-emits one tool call as `item.started` → `item.updated` → `item.completed`. `visible_group_indices` dedupes those to the **newest frame per `item_id`** (#776), so the message backing a card is replaced at every stage.

The card was keyed on the surviving message's `created_at`. New stage → new surviving message → new timestamp → **new key**. Yew treats that as a different child, destroys the old component and mounts a fresh one, and `ExpandableText`'s `expanded` state goes with it.

Claude never re-emits one item progressively, so its keys don't churn — which is why the bug looked agent-specific. It is.

## Fix

Key on `item_id`, which is the card's actual identity and stable across its whole lifecycle.

`visible_group_indices` already parses the id to do the dedup, so it now returns it alongside each surviving index. The renderer uses it directly rather than re-parsing every message — #967 specifically removed a double parse from this path and I didn't want to put one back.

Falls back to the timestamp, then the index, exactly as before, for frames with no item id (turn-level events, deltas, errors).

## Worth noting

`MessageGroup::key` already carried a comment warning about this exact failure — *"reset internal state of every expandable/collapsible inside it (bash command toggle, `ExpandableText`, image viewer, etc.)"* — and solved it correctly at the **group** level. The per-item level nested below it still used the timestamp. The reasoning was right and just hadn't been carried one level down.

## Tests

A new test replays a turn the way it actually arrives — one more frame each time — and asserts the surviving card's identity does not move across `started → updated → completed`. Existing dedup tests keep asserting the surviving indices via a small helper.

645 frontend tests pass, clippy clean, native and `wasm32-unknown-unknown`.