### PR TITLE
Render ANSI on the tool-output surfaces that were still literal

### DIFF
--- a/frontend/src/components/ansi.rs
+++ b/frontend/src/components/ansi.rs
@@ -555,6 +555,31 @@ mod tests {
         assert!(segs[1].style.bg.is_none());
     }
 
+    /// Clippy's diagnostics, which is what most CI output in this portal is.
+    /// It emits bold + **bright** blue for the `-->` location arrow
+    /// (`ESC[1m ESC[94m --> ESC[0m`). Bright *backgrounds* were covered; bright
+    /// foregrounds — the half that actually shows up — were not.
+    #[test]
+    fn clippy_bold_bright_foreground_renders() {
+        let segs = styled("\x1b[1m\x1b[94m--> \x1b[0msrc/main.rs:1:1");
+
+        assert!(segs[0].style.bold, "bold must survive");
+        assert_eq!(
+            segs[0].style.fg,
+            // 94 is bright blue: 8 + (94 - 90).
+            Some(AnsiColor::Standard(12)),
+            "bright foreground must map into the bright half of the palette"
+        );
+        assert_eq!(segs[0].text, "--> ");
+
+        let tail = segs.last().expect("text after the reset");
+        assert!(
+            tail.style.is_default(),
+            "ESC[0m must clear both the weight and the colour"
+        );
+        assert_eq!(tail.text, "src/main.rs:1:1");
+    }
+
     #[test]
     fn incomplete_csi_at_eof_is_dropped() {
         let segs = styled("ok\x1b[31");

--- a/frontend/src/components/message_renderer/renderers/assistant.rs
+++ b/frontend/src/components/message_renderer/renderers/assistant.rs
@@ -257,7 +257,7 @@ fn render_block(block: &ContentBlock, session_id: Uuid) -> Option<Html> {
                 Some(ToolResultContent::Text(s)) => {
                     html! {
                         <div class={class}>
-                            <ExpandableText full_text={s.clone()} max_len={500} class="tool-result-content" />
+                            <ExpandableText full_text={s.clone()} max_len={500} class="tool-result-content" ansi=true />
                         </div>
                     }
                 }

--- a/frontend/src/components/message_renderer/renderers/tools.rs
+++ b/frontend/src/components/message_renderer/renderers/tools.rs
@@ -43,7 +43,7 @@ pub(super) fn render_code_execution_result(content: &Value) -> Html {
             <div class="tool-use-header">
                 <span class="tool-badge code-exec">{ "Code Execution" }</span>
             </div>
-            <ExpandableText full_text={preview} max_len={500} class="tool-result-content" />
+            <ExpandableText full_text={preview} max_len={500} class="tool-result-content" ansi=true />
         </div>
     }
 }
@@ -83,7 +83,7 @@ pub(super) fn render_mcp_tool_result(content: &Value, is_error: bool) -> Html {
                     { if is_error { "MCP Error" } else { "MCP Result" } }
                 </span>
             </div>
-            <ExpandableText full_text={preview} max_len={500} class="tool-result-content" />
+            <ExpandableText full_text={preview} max_len={500} class="tool-result-content" ansi=true />
         </div>
     }
 }

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -144,6 +144,7 @@ fn render_muse_tool_result(result: &task_tree::ToolOutcome) -> Html {
                 max_len={OUTPUT_PREVIEW_CHARS}
                 tag="span"
                 class={classes!("muse-tool-text")}
+                ansi=true
             />
         </div>
     }
@@ -304,6 +305,7 @@ fn render_task_node(node: &TaskNode) -> Html {
                             max_len={OUTPUT_PREVIEW_CHARS}
                             tag="div"
                             class={classes!("muse-task-output")}
+                            ansi=true
                         />
                     }
                 }


### PR DESCRIPTION
`ExpandableText` takes ANSI opt-in per call site (#1496). The three main command paths already had it — `CommandResultCard` (which serves **both** claude Bash results and muse command cards), codex's `aggregated_output`, and the claude text block — which is why most terminal output already looked right.

Five other surfaces carry output that can be colorized and were rendering escapes as literal `[1m` text:

- code-execution results
- MCP tool results (MCP servers routinely shell out)
- muse non-command tool results — search and list, and ripgrep colorizes
- muse task-output chunks that didn't parse as a command payload
- the generic string tool-result block

## Left off deliberately

These aren't terminal output and shouldn't be interpreted as such:

- codex's command string and prompt — *inputs*, not results
- web-search results — prose
- the Read tool's **file contents**. A file that happens to contain `ESC[` should show you those bytes, not hide them behind a style. That one's a correctness call, not an oversight.

## Test

Bright *backgrounds* were covered; bright *foregrounds* weren't — and 94 (bright blue) is exactly what clippy emits for the `-->` arrow in every diagnostic, which is the most common colorized output in this portal. The new test walks the real sequence `ESC[1m ESC[94m--> ESC[0m` and asserts bold survives, 94 maps into the bright half of the palette (index 12), and `ESC[0m` clears both weight and colour.

646 frontend tests, clippy clean, native and `wasm32-unknown-unknown`.

## Not fixed by this

If an `ESC` byte was already stripped upstream — as happens with some GitHub Actions log-fetch paths — the remainder is literal text by the time it arrives and no renderer can recover it. This only helps output that reaches the portal with escapes intact, which the working paths prove it does.