### PR TITLE
Close a session by clicking twice, not through a modal

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -210,10 +210,27 @@ pub fn dashboard_page() -> Html {
 
     // Request deletion of a session (shows the confirm modal). Shared by the
     // rail context menu and the nav-mode `d` shortcut.
+    // The rail menu confirms this itself (click once to arm, again to fire), so
+    // there is no modal round-trip: delete straight away and let the pill leave
+    // the rail when the refresh lands.
     let on_delete = {
-        let ui_state = ui_state.clone();
+        let refresh = sessions_hook.refresh.clone();
         Callback::from(move |session_id: Uuid| {
-            ui_state.dispatch(DashboardUiAction::RequestDelete(session_id));
+            let refresh = refresh.clone();
+            spawn_local(async move {
+                let api_endpoint = utils::api_url(&format!("/api/sessions/{}", session_id));
+                match Request::delete(&api_endpoint).send().await {
+                    Ok(response) if response.status() == 204 => {
+                        refresh.emit(());
+                    }
+                    Ok(response) => {
+                        log::error!("Failed to delete session: status {}", response.status());
+                    }
+                    Err(e) => {
+                        log::error!("Failed to delete session: {:?}", e);
+                    }
+                }
+            });
         })
     };
 
@@ -353,39 +370,6 @@ pub fn dashboard_page() -> Html {
                         log::error!("Failed to get current user ID for leave");
                     }
                     ui_state.dispatch(DashboardUiAction::ClearPendingLeave);
-                });
-            }
-        })
-    };
-
-    let on_cancel_delete = {
-        let ui_state = ui_state.clone();
-        Callback::from(move |_| {
-            ui_state.dispatch(DashboardUiAction::ClearPendingDelete);
-        })
-    };
-
-    let on_confirm_delete = {
-        let ui_state = ui_state.clone();
-        let refresh = sessions_hook.refresh.clone();
-        Callback::from(move |_| {
-            if let Some(session_id) = ui_state.pending_delete {
-                let refresh = refresh.clone();
-                let ui_state = ui_state.clone();
-                spawn_local(async move {
-                    let api_endpoint = utils::api_url(&format!("/api/sessions/{}", session_id));
-                    match Request::delete(&api_endpoint).send().await {
-                        Ok(response) if response.status() == 204 => {
-                            refresh.emit(());
-                        }
-                        Ok(response) => {
-                            log::error!("Failed to delete session: status {}", response.status());
-                        }
-                        Err(e) => {
-                            log::error!("Failed to delete session: {:?}", e);
-                        }
-                    }
-                    ui_state.dispatch(DashboardUiAction::ClearPendingDelete);
                 });
             }
         })
@@ -763,6 +747,7 @@ pub fn dashboard_page() -> Html {
                         on_select={focus.on_select_session.clone()}
                         on_leave={on_leave.clone()}
                         on_delete={on_delete.clone()}
+                        archive_enabled={archive_enabled}
                         on_toggle_hidden={on_toggle_hidden.clone()}
                         on_toggle_inactive_hidden={on_toggle_inactive_hidden.clone()}
                         on_stop={on_stop.clone()}
@@ -876,37 +861,6 @@ pub fn dashboard_page() -> Html {
                         </div>
                     </div>
                 </>
-            }
-
-            // Close confirmation modal. With the archive enabled a close is
-            // archive-then-delete (the transcript stays readable in History);
-            // without it, the old permanent-delete warning still applies.
-            {
-                if let Some(session_id) = ui_state.pending_delete {
-                    let session_name = sessions.iter()
-                        .find(|s| s.id == session_id)
-                        .map(|s| s.session_name.as_str())
-                        .unwrap_or("this session");
-                    let warning = if archive_enabled {
-                        "The session is removed from your dashboard; its transcript stays available in History."
-                    } else {
-                        "History archiving is disabled: all message history and session metadata will be permanently removed."
-                    };
-
-                    html! {
-                        <ConfirmModal
-                            title="Close Session?"
-                            message={format!("Are you sure you want to close \"{}\"?", session_name)}
-                            {warning}
-                            confirm_label="Close"
-                            style={ConfirmModalStyle::Danger}
-                            on_confirm={on_confirm_delete.clone()}
-                            on_cancel={on_cancel_delete.clone()}
-                        />
-                    }
-                } else {
-                    html! {}
-                }
             }
 
             // Admin modal — full-page overlay preserves dashboard state

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -188,7 +188,6 @@ pub(super) struct DashboardUiState {
     /// Opt-in: group the session rail's pills into per-host sections.
     pub group_by_host: bool,
     pub pending_leave: Option<Uuid>,
-    pub pending_delete: Option<Uuid>,
 }
 
 impl DashboardUiState {
@@ -202,7 +201,6 @@ impl DashboardUiState {
             rail_position,
             group_by_host,
             pending_leave: None,
-            pending_delete: None,
         }
     }
 }
@@ -222,8 +220,6 @@ pub(super) enum DashboardUiAction {
     SetGroupByHost(bool),
     RequestLeave(Uuid),
     ClearPendingLeave,
-    RequestDelete(Uuid),
-    ClearPendingDelete,
 }
 
 impl Reducible for DashboardUiState {
@@ -271,12 +267,6 @@ impl Reducible for DashboardUiState {
             }
             DashboardUiAction::ClearPendingLeave => {
                 state.pending_leave = None;
-            }
-            DashboardUiAction::RequestDelete(session_id) => {
-                state.pending_delete = Some(session_id);
-            }
-            DashboardUiAction::ClearPendingDelete => {
-                state.pending_delete = None;
             }
         }
 
@@ -501,18 +491,14 @@ mod tests {
     }
 
     #[test]
+    /// Leave still routes through a modal, so the reducer still tracks it.
+    /// Closing a session does not: the rail menu arms and fires it locally.
     fn ui_reducer_tracks_pending_confirmations() {
         let state = DashboardUiState::new(false, RailPosition::Top, false);
         let state = reduce_ui(state, DashboardUiAction::RequestLeave(id(1)));
-        let state = state.reduce(DashboardUiAction::RequestDelete(id(2)));
-
         assert_eq!(state.pending_leave, Some(id(1)));
-        assert_eq!(state.pending_delete, Some(id(2)));
 
         let state = state.reduce(DashboardUiAction::ClearPendingLeave);
-        let state = state.reduce(DashboardUiAction::ClearPendingDelete);
-
         assert_eq!(state.pending_leave, None);
-        assert_eq!(state.pending_delete, None);
     }
 }

--- a/frontend/src/pages/dashboard/session_rail.rs
+++ b/frontend/src/pages/dashboard/session_rail.rs
@@ -257,6 +257,10 @@ pub struct SessionRailProps {
     /// Server version string for comparing against client versions
     #[prop_or_default]
     pub server_version: String,
+    /// Threaded through to the close-session confirm hint: with archiving off,
+    /// closing a session destroys its transcript rather than filing it.
+    #[prop_or_default]
+    pub archive_enabled: bool,
     pub on_select: Callback<usize>,
     pub on_leave: Callback<Uuid>,
     pub on_delete: Callback<Uuid>,
@@ -273,6 +277,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     let menu_session = use_state(|| None::<Uuid>);
     let menu_pos = use_state(|| (0i32, 0i32));
     let stop_confirm = use_state(|| false);
+    let delete_confirm = use_state(|| false);
     let copied_id = use_state(|| false);
     let share_session_id = use_state(|| None::<Uuid>);
     let schedule_session = use_state(|| None::<SessionInfo>);
@@ -359,6 +364,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     {
         let menu_session = menu_session.clone();
         let stop_confirm = stop_confirm.clone();
+        let delete_confirm = delete_confirm.clone();
         let rail_ref = rail_ref.clone();
         let is_open = (*menu_session).is_some();
         use_effect_with(is_open, move |is_open| {
@@ -373,6 +379,7 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                                 if !container.contains(Some(&target)) {
                                     menu_session.set(None);
                                     stop_confirm.set(false);
+                                    delete_confirm.set(false);
                                 }
                             }
                         }
@@ -406,6 +413,11 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         Callback::from(move |value| stop_confirm.set(value))
     };
 
+    let set_delete_confirm = {
+        let delete_confirm = delete_confirm.clone();
+        Callback::from(move |value| delete_confirm.set(value))
+    };
+
     let set_copied_id = {
         let copied_id = copied_id.clone();
         Callback::from(move |value| copied_id.set(value))
@@ -429,10 +441,12 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
         let menu_session = menu_session.clone();
         let menu_pos = menu_pos.clone();
         let stop_confirm = stop_confirm.clone();
+        let delete_confirm = delete_confirm.clone();
         let copied_id = copied_id.clone();
         Callback::from(move |(session_id, e): (Uuid, MouseEvent)| {
             e.stop_propagation();
             stop_confirm.set(false);
+            delete_confirm.set(false);
             copied_id.set(false);
             if *menu_session == Some(session_id) {
                 menu_session.set(None);
@@ -504,10 +518,12 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
     let on_container_click = {
         let menu_session = menu_session.clone();
         let stop_confirm = stop_confirm.clone();
+        let delete_confirm = delete_confirm.clone();
         Callback::from(move |_: MouseEvent| {
             if (*menu_session).is_some() {
                 menu_session.set(None);
                 stop_confirm.set(false);
+                delete_confirm.set(false);
             }
         })
     };
@@ -574,9 +590,12 @@ pub fn session_rail(props: &SessionRailProps) -> Html {
                 is_connected={is_menu_session_connected}
                 stop_has_tasks={stop_has_tasks}
                 confirming_stop={*stop_confirm}
+                confirming_delete={*delete_confirm}
+                archive_enabled={props.archive_enabled}
                 copied_id={*copied_id}
                 on_close={close_menu}
                 on_set_stop_confirm={set_stop_confirm}
+                on_set_delete_confirm={set_delete_confirm}
                 on_set_copied_id={set_copied_id}
                 on_stop={props.on_stop.clone()}
                 on_toggle_hidden={props.on_toggle_hidden.clone()}

--- a/frontend/src/pages/dashboard/session_rail/menu.rs
+++ b/frontend/src/pages/dashboard/session_rail/menu.rs
@@ -17,9 +17,14 @@ pub(super) struct SessionRailMenuProps {
     pub is_connected: bool,
     pub stop_has_tasks: bool,
     pub confirming_stop: bool,
+    pub confirming_delete: bool,
+    /// Drives the armed close hint: with archiving off, closing a session is
+    /// destructive rather than a dashboard tidy-up.
+    pub archive_enabled: bool,
     pub copied_id: bool,
     pub on_close: Callback<()>,
     pub on_set_stop_confirm: Callback<bool>,
+    pub on_set_delete_confirm: Callback<bool>,
     pub on_set_copied_id: Callback<bool>,
     pub on_stop: Callback<Uuid>,
     pub on_toggle_hidden: Callback<Uuid>,
@@ -112,10 +117,25 @@ fn render_menu_content(session: &SessionInfo, props: &SessionRailMenuProps) -> H
         move || on_leave.emit(session_id)
     });
 
-    let on_delete = close_then(props.on_close.clone(), {
+    // Two-click confirm rather than a modal, matching Stop directly above.
+    // The second click fires the close and dismisses the menu immediately —
+    // the pill then leaves the rail on its own when the refresh lands, so
+    // there is nothing to wait on and nothing to dismiss.
+    let on_delete = {
         let on_delete = props.on_delete.clone();
-        move || on_delete.emit(session_id)
-    });
+        let on_close = props.on_close.clone();
+        let on_set_delete_confirm = props.on_set_delete_confirm.clone();
+        let confirming_delete = props.confirming_delete;
+        Callback::from(move |_: MouseEvent| {
+            if confirming_delete {
+                on_delete.emit(session_id);
+                on_set_delete_confirm.emit(false);
+                on_close.emit(());
+            } else {
+                on_set_delete_confirm.emit(true);
+            }
+        })
+    };
 
     let hide_label = if is_hidden {
         "Show Session"
@@ -247,10 +267,22 @@ fn render_menu_content(session: &SessionInfo, props: &SessionRailMenuProps) -> H
     };
 
     let delete_option = if session.my_role == SessionRole::Owner {
+        // The armed hint carries what the confirm modal used to: with archiving
+        // on this is a dashboard tidy-up, with it off the transcript is gone.
+        let (delete_label, delete_hint) = if props.confirming_delete {
+            let hint = if props.archive_enabled {
+                "Transcript stays in History"
+            } else {
+                "Archiving is off — history is deleted permanently"
+            };
+            ("Click again to confirm", hint)
+        } else {
+            ("Close Session", "Remove from dashboard")
+        };
         menu_option(
-            classes!("stop"),
-            "Close Session",
-            "Remove from dashboard",
+            classes!("stop", props.confirming_delete.then_some("confirming")),
+            delete_label,
+            delete_hint,
             on_delete,
         )
     } else {


### PR DESCRIPTION
Closing a session opened a confirm modal. Now it's the same two-click gesture **Stop** already uses, one row above it in the same menu:

1. first click arms the option — label becomes "Click again to confirm"
2. second click fires the delete, dismisses the menu immediately, and the pill leaves the rail on its own when the refresh lands

Nothing to wait on, nothing to dismiss.

## Reusing the idiom rather than adding one

The menu already had `confirming_stop` / `on_set_stop_confirm` plumbing and a `.pill-menu-option.stop.confirming` style. The armed close reuses both, so it inherits the existing danger treatment with **no new CSS**, and the two destructive options in this menu now behave identically instead of one being a modal and one not.

Arming resets at the same three dismissal points the stop confirm does: click outside the rail, toggle the menu, click the container.

## Keeping the warning that mattered

The modal's warning changed with `archive_enabled` — with archiving on, a close is a dashboard tidy-up and the transcript stays readable in History; with it off, **the history is destroyed permanently**. Dropping that silently would be the one real regression here.

It moves into the armed option's hint line instead:

- archiving on → `Transcript stays in History`
- archiving off → `Archiving is off — history is deleted permanently`

Arguably better placed than before: it appears at the moment of the decision, on the control being clicked. `archive_enabled` is threaded page → rail → menu to do it.

## Cleanup

`pending_delete` and its `RequestDelete` / `ClearPendingDelete` reducer actions go with the modal. The reducer still tracks `pending_leave` — leaving a session is still a modal — and its test is narrowed to that with a note saying why close no longer appears.

646 frontend tests pass, clippy clean, native and `wasm32-unknown-unknown`.