### PR TITLE
Finish storage_get adoption in health_timer (#1722)

### DIFF
--- a/frontend/src/health_timer.rs
+++ b/frontend/src/health_timer.rs
@@ -66,10 +66,7 @@ impl HealthTimerSettings {
 }
 
 pub fn load_health_timer_settings() -> HealthTimerSettings {
-    let Some(storage) = local_storage() else {
-        return HealthTimerSettings::default();
-    };
-    let Ok(Some(raw)) = storage.get_item(STORAGE_KEY) else {
+    let Some(raw) = crate::utils::storage_get(STORAGE_KEY) else {
         return HealthTimerSettings::default();
     };
     serde_json::from_str::<HealthTimerSettings>(&raw)
@@ -78,10 +75,8 @@ pub fn load_health_timer_settings() -> HealthTimerSettings {
 }
 
 pub fn save_health_timer_settings(settings: &HealthTimerSettings) {
-    if let Some(storage) = local_storage() {
-        if let Ok(raw) = serde_json::to_string(&settings.clone().normalized()) {
-            let _ = storage.set_item(STORAGE_KEY, &raw);
-        }
+    if let Ok(raw) = serde_json::to_string(&settings.clone().normalized()) {
+        crate::utils::storage_set(STORAGE_KEY, &raw);
     }
     notify_settings_changed();
 }
@@ -92,10 +87,6 @@ pub fn save_health_timer_settings_reset(settings: &HealthTimerSettings) {
 
 fn default_cadence_minutes() -> u32 {
     DEFAULT_CADENCE_MINUTES
-}
-
-fn local_storage() -> Option<web_sys::Storage> {
-    web_sys::window().and_then(|w| w.local_storage().ok().flatten())
 }
 
 #[cfg(not(test))]


### PR DESCRIPTION
Closes #1722

Migrates `frontend/src/health_timer.rs` from raw `local_storage()->get_item/set_item` to typed `crate::utils::storage_get/set`, matching `meawoppl/storage-get-adopt` 8b636c93 for `launch_dialog.rs`. Removes `local_storage()` helper (now unused).

**Acceptance:** `grep -rn get_item health_timer.rs` empty, `cargo clippy -p frontend --all-targets -- -D warnings` 0 (verified 20.45s), `cargo fmt --all --check` 0.

**Risk:** trivial, no behavior change (storage_get/set already wraps same window.local_storage with silent None on unavailable).

**Testing:** `cargo clippy` 0, `cargo test -p frontend --lib` will be checked by CI (previous 640 ok).

Agent-to-agent review requested from 218343e5.