### PR TITLE
Collapse remaining ExpandableText literals to limits:: (#1723)

### DIFF
--- a/frontend/src/components/codex_renderer/tool_calls.rs
+++ b/frontend/src/components/codex_renderer/tool_calls.rs
@@ -69,7 +69,7 @@ pub(super) fn render_command_execution(it: &CommandExecutionItem, completed: boo
                         <div class={class}>
                             <ExpandableText
                                 full_text={out.to_string()}
-                                max_len=500
+                                max_len={crate::components::expandable::limits::TOOL_OUTPUT}
                                 tag="pre"
                                 class={classes!("tool-result-content")}
                                 ansi=true
@@ -192,7 +192,7 @@ pub(super) fn render_collab_agent_tool_call(
                     html! {
                         <ExpandableText
                             full_text={prompt.to_string()}
-                            max_len=500
+                            max_len={crate::components::expandable::limits::AGENT_PROMPT}
                             tag="pre"
                             class={classes!("tool-input-content")}
                         />

--- a/frontend/src/components/expandable.rs
+++ b/frontend/src/components/expandable.rs
@@ -13,6 +13,8 @@ pub mod limits {
     /// Raw JSON fallback (Codex unrecognized event dump) — reserved for follow-up (#1731)
     #[allow(dead_code)]
     pub const RAW_JSON: usize = 800;
+    /// Collab agent prompt (prose input, preserved at 500 to avoid truncating prompts)
+    pub const AGENT_PROMPT: usize = 500;
 }
 
 #[derive(Properties, PartialEq)]

--- a/frontend/src/components/expandable.rs
+++ b/frontend/src/components/expandable.rs
@@ -10,11 +10,12 @@ pub mod limits {
     pub const TOOL_OUTPUT: usize = 500;
     /// Short prose / user prompts
     pub const PROSE: usize = 300;
-    /// Raw JSON fallback (Codex unrecognized event dump) — reserved for follow-up (#1731)
-    #[allow(dead_code)]
+    /// Raw JSON fallback (unrecognized event and structured payload dumps)
     pub const RAW_JSON: usize = 800;
     /// Collab agent prompt (prose input, preserved at 500 to avoid truncating prompts)
     pub const AGENT_PROMPT: usize = 500;
+    /// Compact WebFetch prompt preview shown beside the fetched URL
+    pub const WEBFETCH_PROMPT: usize = 100;
 }
 
 #[derive(Properties, PartialEq)]

--- a/frontend/src/components/message_renderer/renderers/assistant.rs
+++ b/frontend/src/components/message_renderer/renderers/assistant.rs
@@ -257,7 +257,7 @@ fn render_block(block: &ContentBlock, session_id: Uuid) -> Option<Html> {
                 Some(ToolResultContent::Text(s)) => {
                     html! {
                         <div class={class}>
-                            <ExpandableText full_text={s.clone()} max_len={500} class="tool-result-content" ansi=true />
+                            <ExpandableText full_text={s.clone()} max_len={crate::components::expandable::limits::TOOL_OUTPUT} class="tool-result-content" ansi=true />
                         </div>
                     }
                 }

--- a/frontend/src/components/message_renderer/renderers/tools.rs
+++ b/frontend/src/components/message_renderer/renderers/tools.rs
@@ -107,7 +107,7 @@ pub(super) fn render_unknown_block(value: &Value) -> Html {
             <div class="tool-use-header">
                 <span class="tool-badge unknown">{ "Unknown Block" }</span>
             </div>
-            <ExpandableText full_text={preview} max_len={300} class="tool-result-content" />
+            <ExpandableText full_text={preview} max_len={crate::components::expandable::limits::RAW_JSON} class="tool-result-content" />
         </div>
     }
 }

--- a/frontend/src/components/message_renderer/renderers/tools.rs
+++ b/frontend/src/components/message_renderer/renderers/tools.rs
@@ -95,7 +95,7 @@ pub(super) fn render_container_upload(data: &Value) -> Html {
             <div class="tool-use-header">
                 <span class="tool-badge container">{ "Container Upload" }</span>
             </div>
-            <ExpandableText full_text={preview} max_len={300} class="tool-result-content" />
+            <ExpandableText full_text={preview} max_len={crate::components::expandable::limits::RAW_JSON} class="tool-result-content" />
         </div>
     }
 }
@@ -145,7 +145,7 @@ pub(super) fn render_structured_block(block: &shared::ContentBlock) -> Html {
             // Tool/command output can carry ANSI SGR color (cargo, git, test
             // runners, …); render it styled rather than as raw escape bytes
             // (#1496). Non-ANSI text is unaffected — it parses to one plain run.
-            html! { <ExpandableText full_text={t.text.clone()} max_len={500} class="tool-result-content" ansi=true /> }
+            html! { <ExpandableText full_text={t.text.clone()} max_len={crate::components::expandable::limits::TOOL_OUTPUT} class="tool-result-content" ansi=true /> }
         }
         other => {
             let json = serde_json::to_string_pretty(other).unwrap_or_default();

--- a/frontend/src/components/tool_renderers/search.rs
+++ b/frontend/src/components/tool_renderers/search.rs
@@ -108,7 +108,7 @@ pub fn render_webfetch_tool(input: &Value) -> Html {
             </div>
             {
                 if let Some(p) = prompt {
-                    html! { <ExpandableText full_text={p.to_string()} max_len={100} class="webfetch-prompt" tag="div" /> }
+                    html! { <ExpandableText full_text={p.to_string()} max_len={crate::components::expandable::limits::WEBFETCH_PROMPT} class="webfetch-prompt" tag="div" /> }
                 } else {
                     html! {}
                 }


### PR DESCRIPTION
Closes #1723

Completes the context-specific ExpandableText policy introduced by #1688:
- tool and command output uses TOOL_OUTPUT=500 while preserving ANSI rendering;
- prose uses PROSE=300;
- structured and unknown JSON fallbacks use RAW_JSON=800;
- collab prompts retain their existing 500-character preview via AGENT_PROMPT;
- the intentionally compact WebFetch prompt uses the named WEBFETCH_PROMPT=100 limit.

All remaining numeric preview limits are now either named by context or are separate component-specific policies (the 40-character inline summary, 4000-character generic input, and Muse CommandResult preview).

Verified: cargo fmt --all --check, cargo test -p frontend --lib (649 passed), and cargo clippy -p frontend --all-targets -- -D warnings.