### PR TITLE
Fix 1688 follow-up: revert unknown_block to 300 and reserve RAW_JSON

### DIFF
--- a/frontend/src/components/expandable.rs
+++ b/frontend/src/components/expandable.rs
@@ -10,7 +10,8 @@ pub mod limits {
     pub const TOOL_OUTPUT: usize = 500;
     /// Short prose / user prompts
     pub const PROSE: usize = 300;
-    /// Raw JSON fallback (Codex unrecognized event dump)
+    /// Raw JSON fallback (Codex unrecognized event dump) — reserved for follow-up (#1731)
+    #[allow(dead_code)]
     pub const RAW_JSON: usize = 800;
 }
 

--- a/frontend/src/components/message_renderer/renderers/tools.rs
+++ b/frontend/src/components/message_renderer/renderers/tools.rs
@@ -107,7 +107,7 @@ pub(super) fn render_unknown_block(value: &Value) -> Html {
             <div class="tool-use-header">
                 <span class="tool-badge unknown">{ "Unknown Block" }</span>
             </div>
-            <ExpandableText full_text={preview} max_len={crate::components::expandable::limits::RAW_JSON} class="tool-result-content" />
+            <ExpandableText full_text={preview} max_len={300} class="tool-result-content" />
         </div>
     }
 }


### PR DESCRIPTION
Fixes follow-up to #1688 (a5cddd64→573f9e48): reverts unknown_block 300→RAW_JSON 800 change that violated 'No rendered-output change, just naming' — leave literal 300 for #1731. Keeps RAW_JSON as #[allow(dead_code)] reserved for follow-up, fixes PR body Muse→Claude. No rendered-output change, just naming. 649/179 green.