### PR TITLE
Fix the Agents matrix collapsing into one column

### DIFF
--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -1130,10 +1130,15 @@
     font-size: 0.8rem;
 }
 
-.agents-cell {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
+/* Stack the badge/label/button without `display: flex` — flex on a <td>
+   takes it out of table layout, so the per-agent cells stop forming columns
+   and pile into the first one. */
+.agents-cell > * {
+    display: block;
+}
+
+.agents-cell > * + * {
+    margin-top: 0.25rem;
 }
 
 .agents-badge {


### PR DESCRIPTION
`.agents-cell` set `display: flex` on a `<td>`. That takes the element out of table layout — it stops being a table-cell, so the three per-agent cells no longer form columns and pile into the first one. The `<th>`s are unaffected, which is why the header showed Claude/Codex/Muse over a body with a single stacked column.

Stacks the badge/label/button with block children plus a margin instead. Both already have `width: fit-content`, so nothing stretches and the cell looks the same — just inside a real table cell.

CSS-only.