### PR TITLE
Stop health-timer edits restarting the countdown

### DIFF
--- a/frontend/src/pages/settings/health_timer_panel.rs
+++ b/frontend/src/pages/settings/health_timer_panel.rs
@@ -1,5 +1,6 @@
 use crate::health_timer::{
-    load_health_timer_settings, save_health_timer_settings_reset, HealthTimerSettings,
+    load_health_timer_settings, save_health_timer_settings, save_health_timer_settings_reset,
+    HealthTimerSettings,
 };
 use yew::prelude::*;
 
@@ -7,22 +8,30 @@ use yew::prelude::*;
 pub fn health_timer_panel() -> Html {
     let settings = use_state(load_health_timer_settings);
 
+    // Save without touching `last_confirmed_at`. Editing the message fires per
+    // keystroke, and resetting here pushed the next reminder further away on
+    // every character typed.
     let persist = {
         let settings = settings.clone();
         Callback::from(move |next: HealthTimerSettings| {
-            save_health_timer_settings_reset(&next);
+            save_health_timer_settings(&next);
             settings.set(next.normalized());
         })
     };
 
+    // Switching the timer on is the one edit that should start the clock.
     let on_enabled_change = {
         let settings = settings.clone();
-        let persist = persist.clone();
         Callback::from(move |e: Event| {
             let input: web_sys::HtmlInputElement = e.target_unchecked_into();
             let mut next = (*settings).clone();
             next.enabled = input.checked();
-            persist.emit(next);
+            if next.enabled {
+                save_health_timer_settings_reset(&next);
+            } else {
+                save_health_timer_settings(&next);
+            }
+            settings.set(next.normalized());
         })
     };
 
@@ -40,10 +49,9 @@ pub fn health_timer_panel() -> Html {
     let on_message_change = {
         let settings = settings.clone();
         let persist = persist.clone();
-        Callback::from(move |e: web_sys::InputEvent| {
-            let textarea: web_sys::HtmlTextAreaElement = e.target_unchecked_into();
+        Callback::from(move |message: String| {
             let mut next = (*settings).clone();
-            next.message = textarea.value();
+            next.message = message;
             persist.emit(next);
         })
     };
@@ -83,14 +91,59 @@ pub fn health_timer_panel() -> Html {
 
                 <label class="health-setting-field">
                     <span>{ "Reminder message" }</span>
-                    <textarea
-                        rows="4"
-                        placeholder="Stop/stretch and take a break"
-                        value={settings.message.clone()}
-                        oninput={on_message_change}
+                    <MessageInput
+                        initial={settings.message.clone()}
+                        on_input={on_message_change}
                     />
                 </label>
             </div>
         </section>
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct MessageInputProps {
+    initial: String,
+    on_input: Callback<String>,
+}
+
+/// The message box owns its own draft.
+///
+/// Binding `value` straight to parent state round-trips every keystroke through
+/// a re-render, which tears down and rebuilds the DOM node and bounces the caret
+/// out — see the focus-stable input note in CLAUDE.md. Re-seed only when the
+/// stored value changes from outside (another tab), which is a no-op while typing.
+#[function_component(MessageInput)]
+fn message_input(props: &MessageInputProps) -> Html {
+    let draft = use_state(|| props.initial.clone());
+
+    {
+        let draft = draft.clone();
+        use_effect_with(props.initial.clone(), move |initial| {
+            if *draft != *initial {
+                draft.set(initial.clone());
+            }
+            || ()
+        });
+    }
+
+    let oninput = {
+        let draft = draft.clone();
+        let on_input = props.on_input.clone();
+        Callback::from(move |e: web_sys::InputEvent| {
+            let textarea: web_sys::HtmlTextAreaElement = e.target_unchecked_into();
+            let value = textarea.value();
+            draft.set(value.clone());
+            on_input.emit(value);
+        })
+    };
+
+    html! {
+        <textarea
+            rows="4"
+            placeholder="Stop/stretch and take a break"
+            value={(*draft).clone()}
+            {oninput}
+        />
     }
 }


### PR DESCRIPTION
Two bugs in the health-timer settings, both reachable by just configuring it.

**The countdown restarted on every edit.** `persist` called `save_health_timer_settings_reset`, which moves `last_confirmed_at` to now. The message field is `oninput`, so it fires per keystroke — typing a reminder message pushed the next reminder further out with every character. Now saves without touching `last_confirmed_at`, and resets only when the timer is switched **on**, which is the one edit that should start the clock.

**Typing in the message box lost focus.** It bound `value` straight to parent state, so each keystroke round-tripped through a re-render that tore down and rebuilt the DOM node — the exact case CLAUDE.md documents under focus-stable text inputs. Now a small `MessageInput` owns its draft locally and re-seeds only when the stored value changes from outside (another tab).

The timer machinery itself checks out: mounted at app root so it survives navigation, storage round-trip is symmetric, and `delay_until_due_ms` is covered by tests.

648 tests, clippy clean.