### PR TITLE
Open history as an overlay instead of a route

### DIFF
--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -20,6 +20,7 @@ use crate::hooks::{
     use_client_websocket, use_interrupt_hotkey, use_keyboard_nav, use_sessions, KeyboardNavConfig,
 };
 use crate::pages::admin::AdminPage;
+use crate::pages::history::{HistoryBrowserPage, HistoryTranscriptPage};
 use crate::pages::settings::SettingsPage;
 use crate::utils;
 use gloo_net::http::Request;
@@ -294,19 +295,32 @@ pub fn dashboard_page() -> Html {
 
     // Separate `use_navigator` handle: the one above is moved into the
     // deep-link effect closure.
-    let history_navigator = use_navigator();
+    // Overlay, not a route push: navigating away unmounts the dashboard, and
+    // coming back refetches every session and reconnects the WS. Same reason
+    // Settings and Admin are overlays.
     let go_to_history = {
-        let navigator = history_navigator;
-        Callback::from(move |_| {
-            if let Some(navigator) = &navigator {
-                navigator.push(&crate::Route::History);
-            }
-        })
+        let ui_state = ui_state.clone();
+        Callback::from(move |_| ui_state.dispatch(DashboardUiAction::ShowHistory))
     };
 
     let close_admin = {
         let ui_state = ui_state.clone();
         Callback::from(move |_: ()| ui_state.dispatch(DashboardUiAction::CloseAdmin))
+    };
+
+    let close_history = {
+        let ui_state = ui_state.clone();
+        Callback::from(move |_| ui_state.dispatch(DashboardUiAction::CloseHistory))
+    };
+    let open_history_session = {
+        let ui_state = ui_state.clone();
+        Callback::from(move |(user, session): (String, String)| {
+            ui_state.dispatch(DashboardUiAction::OpenHistorySession(user, session))
+        })
+    };
+    let close_history_session = {
+        let ui_state = ui_state.clone();
+        Callback::from(move |_| ui_state.dispatch(DashboardUiAction::CloseHistorySession))
     };
 
     let close_settings = {
@@ -874,6 +888,26 @@ pub fn dashboard_page() -> Html {
             if ui_state.show_settings {
                 <div class="full-page-modal">
                     <SettingsPage on_close={close_settings.clone()} />
+                </div>
+            }
+
+            // History overlay — same full-page treatment as Settings, and it
+            // hosts the transcript view too so opening one never leaves the
+            // dashboard.
+            if ui_state.show_history {
+                <div class="full-page-modal">
+                    if let Some((user, session)) = ui_state.history_session.clone() {
+                        <HistoryTranscriptPage
+                            {user}
+                            {session}
+                            on_back={close_history_session.clone()}
+                        />
+                    } else {
+                        <HistoryBrowserPage
+                            on_close={close_history.clone()}
+                            on_open_session={open_history_session.clone()}
+                        />
+                    }
                 </div>
             }
 

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -182,6 +182,10 @@ pub(super) struct DashboardUiState {
     pub show_launch_dialog: bool,
     pub show_admin: bool,
     pub show_settings: bool,
+    /// History browser, shown as an overlay so the dashboard stays mounted.
+    /// `Some((user, session))` when a transcript is open inside it.
+    pub show_history: bool,
+    pub history_session: Option<(String, String)>,
     pub show_help: bool,
     pub inactive_hidden: bool,
     pub rail_position: RailPosition,
@@ -196,6 +200,8 @@ impl DashboardUiState {
             show_launch_dialog: false,
             show_admin: false,
             show_settings: false,
+            show_history: false,
+            history_session: None,
             show_help: false,
             inactive_hidden,
             rail_position,
@@ -213,6 +219,10 @@ pub(super) enum DashboardUiAction {
     CloseAdmin,
     ShowSettings,
     CloseSettings,
+    ShowHistory,
+    CloseHistory,
+    OpenHistorySession(String, String),
+    CloseHistorySession,
     ShowHelp,
     CloseHelp,
     SetInactiveHidden(bool),
@@ -246,6 +256,19 @@ impl Reducible for DashboardUiState {
             }
             DashboardUiAction::CloseSettings => {
                 state.show_settings = false;
+            }
+            DashboardUiAction::ShowHistory => {
+                state.show_history = true;
+            }
+            DashboardUiAction::CloseHistory => {
+                state.show_history = false;
+                state.history_session = None;
+            }
+            DashboardUiAction::OpenHistorySession(user, session) => {
+                state.history_session = Some((user, session));
+            }
+            DashboardUiAction::CloseHistorySession => {
+                state.history_session = None;
             }
             DashboardUiAction::ShowHelp => {
                 state.show_help = true;
@@ -451,6 +474,24 @@ mod tests {
 
     fn reduce_ui(state: DashboardUiState, action: DashboardUiAction) -> Rc<DashboardUiState> {
         Rc::new(state).reduce(action)
+    }
+
+    /// Closing history drops the open transcript too, so reopening lands on
+    /// the list rather than whatever was last viewed.
+    #[test]
+    fn ui_reducer_tracks_the_history_overlay() {
+        let state = DashboardUiState::new(false, RailPosition::Top, false);
+        let state = reduce_ui(state, DashboardUiAction::ShowHistory);
+        let state = state.reduce(DashboardUiAction::OpenHistorySession(
+            "u".into(),
+            "s".into(),
+        ));
+        assert!(state.show_history);
+        assert_eq!(state.history_session, Some(("u".into(), "s".into())));
+
+        let state = state.reduce(DashboardUiAction::CloseHistory);
+        assert!(!state.show_history);
+        assert_eq!(state.history_session, None);
     }
 
     #[test]

--- a/frontend/src/pages/history/browser.rs
+++ b/frontend/src/pages/history/browser.rs
@@ -22,8 +22,20 @@ const PAGE_SIZE: usize = DEFAULT_HISTORY_PAGE_SIZE;
 /// requests. Short enough to feel immediate on a page-turn click.
 const FETCH_DEBOUNCE_MS: u32 = 250;
 
+/// Embedding hooks. Both default to `None`, which keeps the standalone
+/// `/history` route behaving exactly as before; the dashboard overlay supplies
+/// them so opening history never unmounts the dashboard.
+#[derive(Properties, PartialEq, Default)]
+pub struct HistoryBrowserProps {
+    #[prop_or_default]
+    pub on_close: Option<Callback<()>>,
+    /// Intercepts a row click as `(user_id, session_id)` instead of navigating.
+    #[prop_or_default]
+    pub on_open_session: Option<Callback<(String, String)>>,
+}
+
 #[function_component(HistoryBrowserPage)]
-pub fn history_browser_page() -> Html {
+pub fn history_browser_page(props: &HistoryBrowserProps) -> Html {
     let response = use_state(|| None as Load<HistorySessionsResponse>);
     let filter = use_state(SessionFilter::default);
     let page = use_state(|| 0usize);
@@ -78,7 +90,7 @@ pub fn history_browser_page() -> Html {
                     // would silently describe this page instead.
                     { stats_strip(resp, &filter) }
                     { filter_controls(resp, &filter, &on_filter) }
-                    { session_table(&resp.sessions, resp.is_admin) }
+                    { session_table(&resp.sessions, resp.is_admin, &props.on_open_session) }
                     { pagination_controls(&window, resp.sessions.len(), &page) }
                 </>
             }
@@ -88,7 +100,13 @@ pub fn history_browser_page() -> Html {
     html! {
         <div class="history-root">
             <nav class="history-nav">
-                <Link<Route> to={Route::Dashboard}>{ "← Dashboard" }</Link<Route>>
+                if let Some(on_close) = props.on_close.clone() {
+                    <button class="link-button" onclick={Callback::from(move |_| on_close.emit(()))}>
+                        { "← Dashboard" }
+                    </button>
+                } else {
+                    <Link<Route> to={Route::Dashboard}>{ "← Dashboard" }</Link<Route>>
+                }
             </nav>
             <header class="history-header">
                 <h1>{ "Session History" }</h1>
@@ -322,7 +340,11 @@ fn pagination_controls(window: &PageWindow, total: usize, page: &UseStateHandle<
     }
 }
 
-fn session_table(rows: &[HistorySessionSummary], is_admin: bool) -> Html {
+fn session_table(
+    rows: &[HistorySessionSummary],
+    is_admin: bool,
+    on_open_session: &Option<Callback<(String, String)>>,
+) -> Html {
     if rows.is_empty() {
         return html! {
             <div class="history-empty">{ "No archived sessions match these filters." }</div>
@@ -344,7 +366,7 @@ fn session_table(rows: &[HistorySessionSummary], is_admin: bool) -> Html {
                 </tr>
             </thead>
             <tbody>
-                { for rows.iter().map(|s| html! { <SessionRow session={s.clone()} {is_admin} /> }) }
+                { for rows.iter().map(|s| html! { <SessionRow session={s.clone()} {is_admin} on_open_session={on_open_session.clone()} /> }) }
             </tbody>
         </table>
     }
@@ -354,6 +376,8 @@ fn session_table(rows: &[HistorySessionSummary], is_admin: bool) -> Html {
 struct SessionRowProps {
     session: HistorySessionSummary,
     is_admin: bool,
+    #[prop_or_default]
+    on_open_session: Option<Callback<(String, String)>>,
 }
 
 #[function_component(SessionRow)]
@@ -369,11 +393,19 @@ fn session_row(props: &SessionRowProps) -> Html {
     // handled (`default_prevented`) is left alone.
     let onclick = {
         let route = route.clone();
+        let embed = props.on_open_session.clone();
+        let ids = (s.user_id.clone(), s.session_id.clone());
         Callback::from(move |e: MouseEvent| {
             if e.default_prevented() || e.ctrl_key() || e.meta_key() || e.shift_key() {
                 return;
             }
-            if let Some(navigator) = &navigator {
+            // Embedded: open in place. Standalone: navigate as before. A
+            // modified click still falls through to the anchor either way, so
+            // cmd-click keeps opening a real tab.
+            if let Some(embed) = &embed {
+                e.prevent_default();
+                embed.emit(ids.clone());
+            } else if let Some(navigator) = &navigator {
                 navigator.push(&route);
             }
         })

--- a/frontend/src/pages/history/transcript.rs
+++ b/frontend/src/pages/history/transcript.rs
@@ -19,6 +19,10 @@ use crate::Route;
 pub struct HistoryTranscriptProps {
     pub user: String,
     pub session: String,
+    /// Set when embedded in the dashboard overlay: goes back to the list in
+    /// place instead of navigating. `None` keeps the standalone route's link.
+    #[prop_or_default]
+    pub on_back: Option<Callback<()>>,
 }
 
 #[function_component(HistoryTranscriptPage)]
@@ -67,7 +71,13 @@ pub fn history_transcript_page(props: &HistoryTranscriptProps) -> Html {
     html! {
         <div class="history-root history-transcript">
             <nav class="history-nav">
-                <Link<Route> to={Route::History}>{ "← All sessions" }</Link<Route>>
+                if let Some(on_back) = props.on_back.clone() {
+                    <button class="link-button" onclick={Callback::from(move |_| on_back.emit(()))}>
+                        { "← All sessions" }
+                    </button>
+                } else {
+                    <Link<Route> to={Route::History}>{ "← All sessions" }</Link<Route>>
+                }
             </nav>
             { header_card(&manifest) }
             { transcript_body(&messages, &props.user, &props.session, agent_type, session_id) }


### PR DESCRIPTION
Clicking History pushed `Route::History`, which unmounts `DashboardPage` — so coming back refetched every session and reconnected the client WebSocket. Settings and Admin already avoid this by rendering as `full-page-modal` overlays (their comments say so outright); history now does the same.

The overlay hosts the **transcript** view as well, not just the list — otherwise clicking into a session would leave the dashboard anyway and just move the problem one click later. `HistoryTranscriptPage` already took `user`/`session` as plain props, so embedding it was straightforward.

Both history pages gained optional embed props — `on_close`, `on_open_session`, `on_back` — all defaulting to `None`. So the standalone `/history` and `/history/:user/:session` routes still work unchanged for deep links, and a modified click (cmd/ctrl/shift) still falls through to the real anchor and opens a genuine new tab.

649 tests, clippy clean, both targets.