### PR TITLE
Show the health timer's state as a green/red toggle button

### DIFF
--- a/frontend/src/pages/settings/health_timer_panel.rs
+++ b/frontend/src/pages/settings/health_timer_panel.rs
@@ -22,10 +22,9 @@ pub fn health_timer_panel() -> Html {
     // Switching the timer on is the one edit that should start the clock.
     let on_enabled_change = {
         let settings = settings.clone();
-        Callback::from(move |e: Event| {
-            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+        Callback::from(move |_: MouseEvent| {
             let mut next = (*settings).clone();
-            next.enabled = input.checked();
+            next.enabled = !next.enabled;
             if next.enabled {
                 save_health_timer_settings_reset(&next);
             } else {
@@ -66,14 +65,20 @@ pub fn health_timer_panel() -> Html {
             </div>
 
             <div class="health-settings-card">
-                <label class="toggle-label health-toggle">
-                    <input
-                        type="checkbox"
-                        checked={settings.enabled}
-                        onchange={on_enabled_change}
-                    />
-                    <span>{ if settings.enabled { "Enabled" } else { "Disabled" } }</span>
-                </label>
+                <button
+                    type="button"
+                    class={classes!(
+                        "health-toggle-button",
+                        if settings.enabled { "on" } else { "off" }
+                    )}
+                    aria-pressed={settings.enabled.to_string()}
+                    onclick={on_enabled_change}
+                >
+                    <span class="health-toggle-glyph">
+                        { if settings.enabled { "\u{2713}" } else { "\u{2715}" } }
+                    </span>
+                    { if settings.enabled { "Enabled" } else { "Disabled" } }
+                </button>
 
                 <label class="health-setting-field">
                     <span>{ "Reminder interval" }</span>

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -868,8 +868,31 @@
     gap: 1.25rem;
 }
 
-.health-toggle {
+.health-toggle-button {
     align-self: flex-start;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.8rem;
+    border: 1px solid currentcolor;
+    border-radius: 6px;
+    background: transparent;
+    font-size: 0.95rem;
+    cursor: pointer;
+}
+
+.health-toggle-button.on {
+    color: var(--success);
+}
+
+.health-toggle-button.off {
+    color: var(--error);
+}
+
+/* Sized up so the state reads at a glance rather than from the word. */
+.health-toggle-glyph {
+    font-size: 1.05rem;
+    line-height: 1;
 }
 
 .health-setting-field {


### PR DESCRIPTION
The checkbox carried its state in the word beside it, so you had to read to know which way it was set.

Now a button: green ✓ **Enabled** or red ✗ **Disabled**, colored by state via the existing `--success`/`--error` vars, with `aria-pressed` so it reads correctly as a toggle rather than an action.

Clicking flips it, and the existing behaviour is unchanged — switching **on** still resets the countdown, everything else saves without touching it.

651 tests, clippy clean, stylelint clean.