### PR TITLE
Fix conditional-hook panic when the health timer fires

### DIFF
--- a/frontend/src/health_timer.rs
+++ b/frontend/src/health_timer.rs
@@ -130,6 +130,49 @@ fn notify_settings_changed() {
     let _ = window.dispatch_event(&event);
 }
 
+#[derive(Properties, PartialEq)]
+struct HealthTimerDialogProps {
+    message: AttrValue,
+    on_confirm: Callback<MouseEvent>,
+}
+
+/// The modal itself, in its own component so that its hooks (`use_node_ref` +
+/// `use_focus_trap`) are only reached when the modal is actually rendered.
+///
+/// They must **not** live in `HealthTimerReminder`: that component returns early
+/// while the reminder is hidden, so hooks placed after the early return run on
+/// some renders and not others — Yew's `assert_hook_context` then panics with
+/// "Hooks are called conditionally" the moment the timer fires and flips the
+/// component onto the visible path. Conditionally rendering a *child component*
+/// is the supported way to express this; a conditional hook never is.
+#[function_component(HealthTimerDialog)]
+fn health_timer_dialog(props: &HealthTimerDialogProps) -> Html {
+    let dialog_ref = use_node_ref();
+    use_focus_trap(dialog_ref.clone());
+
+    html! {
+        <div class="health-timer-overlay" role="presentation">
+            <section
+                ref={dialog_ref}
+                class="health-timer-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="health-timer-title"
+            >
+                <h2 id="health-timer-title">{ "Health timer" }</h2>
+                <p>{ props.message.clone() }</p>
+                <button
+                    type="button"
+                    class="health-timer-confirm"
+                    onclick={props.on_confirm.clone()}
+                >
+                    { "Confirm" }
+                </button>
+            </section>
+        </div>
+    }
+}
+
 #[function_component(HealthTimerReminder)]
 pub fn health_timer_reminder() -> Html {
     let settings = use_state(load_health_timer_settings);
@@ -192,7 +235,7 @@ pub fn health_timer_reminder() -> Html {
         return html! {};
     }
 
-    let message = settings.reminder_message().to_string();
+    let message = AttrValue::from(settings.reminder_message().to_string());
     let on_confirm = {
         let settings = settings.clone();
         let showing = showing.clone();
@@ -203,26 +246,8 @@ pub fn health_timer_reminder() -> Html {
             showing.set(false);
         })
     };
-    let dialog_ref = use_node_ref();
-    use_focus_trap(dialog_ref.clone());
 
-    html! {
-        <div class="health-timer-overlay" role="presentation">
-            <section
-                ref={dialog_ref}
-                class="health-timer-dialog"
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby="health-timer-title"
-            >
-                <h2 id="health-timer-title">{ "Health timer" }</h2>
-                <p>{ message }</p>
-                <button type="button" class="health-timer-confirm" onclick={on_confirm}>
-                    { "Confirm" }
-                </button>
-            </section>
-        </div>
-    }
+    html! { <HealthTimerDialog {message} {on_confirm} /> }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

`HealthTimerReminder` returned early while the reminder was hidden, but called `use_node_ref` and `use_focus_trap` (which is itself 2 `use_effect_with`s) *after* that early return.

That makes the hook count render-dependent: 4 hooks on the hidden path, 7 on the visible one. The moment the health timer's `Timeout` fired and flipped `showing` to `true`, Yew's `assert_hook_context` panicked —

```
Hooks are called conditionally.
  left: 4
 right: 7
```

— and since a Rust panic in WASM aborts, this took down the *entire* dashboard app, not just the reminder.

## Why it only bit now

Nothing renders the modal until the cadence elapses, so the app boots fine and dies later, mid-session, for anyone who has the health timer enabled.

## Fix

Move the modal into its own `HealthTimerDialog` function component that owns `use_node_ref` + `use_focus_trap`. The parent's hook order becomes unconditional, and the dialog's hooks are reached only when the dialog is actually rendered — conditionally rendering a child *component* is the supported way to express this.

This also matches how the other two `use_focus_trap` callers (`FloatingPane`, `LaunchDialog`) are already structured: dedicated dialog components that a parent renders conditionally. A doc comment on the new component records why the hooks must not move back up.

Behavior is unchanged: same markup, same focus trap, same confirm path.