### PR TITLE
Collapse a run of reconnect notices to one line

### DIFF
--- a/frontend/src/components/message_renderer/group_renderer.rs
+++ b/frontend/src/components/message_renderer/group_renderer.rs
@@ -38,6 +38,61 @@ pub struct MessageGroupRendererProps {
     pub muse_live_events: Vec<serde_json::Value>,
 }
 
+/// The reconnect durations in a group whose members are *all* connection
+/// cycles, or `None` if any member is something else.
+///
+/// An idle session reconnects on a slow loop, so these arrive as a long run of
+/// otherwise-identical one-liners. Collapsing the run to a single line is the
+/// whole point of the frame being typed.
+pub(super) fn connection_cycle_run(
+    messages: &[super::types::RenderedMessage],
+) -> Option<Vec<String>> {
+    let mut durations = Vec::with_capacity(messages.len());
+    for message in messages {
+        let portal: shared::PortalMessage = serde_json::from_str(&message.content).ok()?;
+        match portal.content.as_slice() {
+            [shared::PortalContent::ConnectionCycle { duration }] => {
+                durations.push(duration.clone().unwrap_or_default())
+            }
+            _ => return None,
+        }
+    }
+    (!durations.is_empty()).then_some(durations)
+}
+
+/// One line for a whole run: `reconnected 4x (36-38s)`.
+pub(super) fn render_connection_cycle_run(durations: &[String]) -> Html {
+    let label = match durations {
+        [] => return html! {},
+        [only] if only.is_empty() => "reconnected".to_string(),
+        [only] => format!("reconnected after {only}"),
+        many => {
+            // Durations arrive newest-last and are near-identical; show the
+            // span rather than repeating one value N times.
+            let mut seen: Vec<&str> = many
+                .iter()
+                .map(String::as_str)
+                .filter(|d| !d.is_empty())
+                .collect();
+            seen.sort_unstable();
+            seen.dedup();
+            match (seen.first(), seen.last()) {
+                (Some(lo), Some(hi)) if lo == hi => {
+                    format!("reconnected {}x after {lo}", many.len())
+                }
+                (Some(lo), Some(hi)) => format!("reconnected {}x ({lo}-{hi})", many.len()),
+                _ => format!("reconnected {}x", many.len()),
+            }
+        }
+    };
+    html! {
+        <div class="connection-cycle">
+            <span class="connection-cycle-dot" />
+            { label }
+        </div>
+    }
+}
+
 #[function_component(MessageGroupRenderer)]
 pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
     match &props.group {
@@ -116,6 +171,19 @@ pub fn message_group_renderer(props: &MessageGroupRendererProps) -> Html {
                         </div>
                     </div>
                 };
+            }
+
+            // A run of reconnect notices collapses to one line.
+            if *category == GroupCategory::Portal {
+                if let Some(durations) = connection_cycle_run(messages) {
+                    return html! {
+                        <div class="claude-message portal-message" title={ts.unwrap_or_default()}>
+                            <div class="message-body">
+                                { render_connection_cycle_run(&durations) }
+                            </div>
+                        </div>
+                    };
+                }
             }
 
             let wrapper_class = match category {

--- a/frontend/src/components/message_renderer/tests/portal.rs
+++ b/frontend/src/components/message_renderer/tests/portal.rs
@@ -3,7 +3,7 @@
 
 use super::super::grouping::{GroupCategory, MessageGroup};
 use super::fixtures::{
-    assistant_with_tool_use, classify_category, group_for_tests, portal_text_message,
+    assistant_with_tool_use, classify_category, group_for_tests, portal_text_message, rendered,
 };
 
 #[test]
@@ -89,4 +89,38 @@ fn connection_cycle_round_trips_as_its_own_variant() {
         }
         other => panic!("expected ConnectionCycle, got {other:?}"),
     }
+}
+
+/// An idle session reconnects on a loop, so these arrive as a run of
+/// near-identical one-liners. The run must collapse to a single summary.
+#[test]
+fn a_run_of_reconnects_collapses_to_one_line() {
+    use super::super::group_renderer::{connection_cycle_run, render_connection_cycle_run};
+
+    let cycles: Vec<_> = ["38s", "38s", "38s", "36s"]
+        .iter()
+        .map(|d| {
+            rendered(
+                shared::PortalMessage::with_content(vec![shared::PortalContent::ConnectionCycle {
+                    duration: Some((*d).to_string()),
+                }])
+                .to_json()
+                .to_string(),
+            )
+        })
+        .collect();
+
+    let durations = connection_cycle_run(&cycles).expect("all members are connection cycles");
+    assert_eq!(durations.len(), 4);
+    // Renders at all, and as one node rather than four.
+    let _ = render_connection_cycle_run(&durations);
+
+    // A group carrying anything else must not collapse.
+    let mut mixed = cycles.clone();
+    mixed.push(rendered(
+        shared::PortalMessage::text("hello".into())
+            .to_json()
+            .to_string(),
+    ));
+    assert!(connection_cycle_run(&mixed).is_none());
 }


### PR DESCRIPTION
An idle session reconnects on a slow loop, so the transcript accumulated one line per cycle — four near-identical `reconnected after 38s` rows stacked under a single portal card.

A portal group whose members are **all** `ConnectionCycle` frames now renders one summary line instead:

- `reconnected 4x after 38s` when every duration matches
- `reconnected 4x (36s-38s)` when they differ

If the group contains anything else, it doesn't collapse — a real portal message can never get swallowed by a run of reconnects. That's the case the test pins alongside the happy path.

This is the follow-on to #1704, which made each notice thin; being typed is what makes the run detectable at all.

652 tests, clippy clean, both targets.