### PR TITLE
Merge the launchers and agents tables into one row per computer

### DIFF
--- a/frontend/src/pages/settings/agents_panel.rs
+++ b/frontend/src/pages/settings/agents_panel.rs
@@ -15,36 +15,32 @@
 //! that opens [`AgentLoginModal`], which drives the launcher-side login flow; a
 //! successful sign-in re-probes the matrix.
 
-use crate::pages::settings::agent_install::{host_label, AgentInstallModal};
-use crate::pages::settings::agent_login::AgentLoginModal;
-use crate::utils::{self, On401};
-use shared::api::ProbeAgentsResponse;
+use crate::pages::settings::agent_install::host_label;
 use shared::{AgentInstall, AgentLoginStatus, AgentType, LauncherInfo};
 use std::collections::HashMap;
 use uuid::Uuid;
-use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
 /// Which cell's sign-in modal is open: (launcher, agent, agent display name).
 #[derive(Clone, PartialEq)]
-struct LoginTarget {
-    launcher_id: Uuid,
-    agent_type: AgentType,
-    agent_name: String,
+pub(super) struct LoginTarget {
+    pub(super) launcher_id: Uuid,
+    pub(super) agent_type: AgentType,
+    pub(super) agent_name: String,
 }
 
 /// Which cell's install modal is open, plus the host label so the modal can
 /// say *where* the install runs.
 #[derive(Clone, PartialEq)]
-struct InstallTarget {
-    launcher_id: Uuid,
-    agent_type: AgentType,
-    agent_name: String,
-    host: String,
+pub(super) struct InstallTarget {
+    pub(super) launcher_id: Uuid,
+    pub(super) agent_type: AgentType,
+    pub(super) agent_name: String,
+    pub(super) host: String,
 }
 
 /// Columns of the matrix, in display order. Mirrors `AgentType`.
-const AGENTS: [(AgentType, &str); 3] = [
+pub(super) const AGENTS: [(AgentType, &str); 3] = [
     (AgentType::Claude, "Claude"),
     (AgentType::Codex, "Codex"),
     (AgentType::Muse, "Muse"),
@@ -54,184 +50,14 @@ const AGENTS: [(AgentType, &str); 3] = [
 /// resolves, so a launcher is either absent from the map (still loading, whole
 /// pane shows "Loading…") or in one of these terminal states.
 #[derive(Clone, PartialEq)]
-enum ProbeState {
+pub(super) enum ProbeState {
     /// Launcher is offline (not connected) — can't be probed.
     Unreachable,
     /// Probe returned; agents keyed by type for O(1) cell lookup.
     Loaded(HashMap<AgentType, AgentInstall>),
 }
 
-#[function_component(AgentsPanel)]
-pub fn agents_panel() -> Html {
-    let launchers = use_state(|| None::<Vec<LauncherInfo>>);
-    let probes = use_state(HashMap::<Uuid, ProbeState>::new);
-    // Bumped by the refresh button (and a successful sign-in) to re-run the fan-out.
-    let refresh = use_state(|| 0u32);
-    // The open sign-in modal, if any.
-    let login_target = use_state(|| None::<LoginTarget>);
-    // The open install modal, if any.
-    let install_target = use_state(|| None::<InstallTarget>);
-
-    {
-        let launchers = launchers.clone();
-        let probes = probes.clone();
-        use_effect_with(*refresh, move |_| {
-            launchers.set(None);
-            probes.set(HashMap::new());
-            spawn_local(async move {
-                let list = utils::fetch_json::<Vec<LauncherInfo>>("/api/launchers", On401::Ignore)
-                    .await
-                    .unwrap_or_default();
-
-                // Probe sequentially — a settings pane has a handful of hosts,
-                // and this keeps the state update race-free (one set at the end)
-                // without pulling in a join_all.
-                let mut collected: HashMap<Uuid, ProbeState> = HashMap::new();
-                for l in &list {
-                    if !l.connected {
-                        collected.insert(l.launcher_id, ProbeState::Unreachable);
-                        continue;
-                    }
-                    let path = format!("/api/launchers/{}/probe-agents", l.launcher_id);
-                    let state = match utils::fetch_json::<ProbeAgentsResponse>(&path, On401::Ignore)
-                        .await
-                    {
-                        Ok(resp) => ProbeState::Loaded(
-                            resp.agents.into_iter().map(|a| (a.agent_type, a)).collect(),
-                        ),
-                        // A connected launcher that fails to answer (dropped
-                        // mid-probe, timeout) is unreachable for our purposes.
-                        Err(_) => ProbeState::Unreachable,
-                    };
-                    collected.insert(l.launcher_id, state);
-                }
-
-                launchers.set(Some(list));
-                probes.set(collected);
-            });
-            || ()
-        });
-    }
-
-    let on_refresh = {
-        let refresh = refresh.clone();
-        Callback::from(move |_: MouseEvent| refresh.set(*refresh + 1))
-    };
-
-    let on_sign_in = {
-        let login_target = login_target.clone();
-        Callback::from(move |target: LoginTarget| login_target.set(Some(target)))
-    };
-
-    let on_install = {
-        let install_target = install_target.clone();
-        Callback::from(move |target: InstallTarget| install_target.set(Some(target)))
-    };
-
-    let body = match (*launchers).clone() {
-        None => html! { <p class="setting-description">{ "Loading…" }</p> },
-        Some(list) if list.is_empty() => html! {
-            <p class="setting-description">
-                { "No computers connected yet. Install the agent-portal launcher on a \
-                   machine and it'll appear here." }
-            </p>
-        },
-        Some(list) => html! {
-            <table class="agents-matrix">
-                <thead>
-                    <tr>
-                        <th>{ "Computer" }</th>
-                        { for AGENTS.iter().map(|(_, name)| html! { <th>{ *name }</th> }) }
-                    </tr>
-                </thead>
-                <tbody>
-                    { for list.iter().map(|l| render_row(l, &probes, &on_sign_in, &on_install)) }
-                </tbody>
-            </table>
-        },
-    };
-
-    let login_modal = (*login_target).clone().map(|target| {
-        let on_close = {
-            let login_target = login_target.clone();
-            Callback::from(move |_| login_target.set(None))
-        };
-        let on_success = {
-            let refresh = refresh.clone();
-            Callback::from(move |_| refresh.set(*refresh + 1))
-        };
-        html! {
-            <AgentLoginModal
-                launcher_id={target.launcher_id}
-                agent_type={target.agent_type}
-                agent_name={target.agent_name}
-                {on_close}
-                {on_success}
-            />
-        }
-    });
-
-    let install_modal = (*install_target).clone().map(|target| {
-        let on_close = {
-            let install_target = install_target.clone();
-            Callback::from(move |_| install_target.set(None))
-        };
-        let on_success = {
-            let refresh = refresh.clone();
-            Callback::from(move |_| refresh.set(*refresh + 1))
-        };
-        html! {
-            <AgentInstallModal
-                launcher_id={target.launcher_id}
-                agent_type={target.agent_type}
-                agent_name={target.agent_name}
-                host={target.host}
-                {on_close}
-                {on_success}
-            />
-        }
-    });
-
-    html! {
-        <section class="agents-section">
-            <div class="section-header">
-                <h2>{ "Agents" }</h2>
-                <p class="section-description">
-                    { "Install and sign-in state for each agent on every connected \
-                       computer. " }
-                    <button class="link-button" onclick={on_refresh}>{ "Refresh" }</button>
-                </p>
-            </div>
-            { body }
-            { for login_modal }
-            { for install_modal }
-        </section>
-    }
-}
-
-fn render_row(
-    launcher: &LauncherInfo,
-    probes: &HashMap<Uuid, ProbeState>,
-    on_sign_in: &Callback<LoginTarget>,
-    on_install: &Callback<InstallTarget>,
-) -> Html {
-    let state = probes.get(&launcher.launcher_id);
-    html! {
-        <tr>
-            <td class="agents-host">
-                <span class="agents-host-name">{ &launcher.hostname }</span>
-                if launcher.launcher_name != launcher.hostname {
-                    <span class="agents-host-alias">{ format!("({})", launcher.launcher_name) }</span>
-                }
-            </td>
-            { for AGENTS.iter().map(|(agent, name)| {
-                render_cell(state, *agent, name, launcher, on_sign_in, on_install)
-            }) }
-        </tr>
-    }
-}
-
-fn render_cell(
+pub(super) fn render_cell(
     state: Option<&ProbeState>,
     agent: AgentType,
     agent_name: &str,

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -1,3 +1,8 @@
+use crate::pages::settings::agent_install::AgentInstallModal;
+use crate::pages::settings::agent_login::AgentLoginModal;
+use crate::pages::settings::agents_panel::{
+    render_cell, InstallTarget, LoginTarget, ProbeState, AGENTS,
+};
 use crate::utils::{self, On401};
 use gloo_net::http::Request;
 use shared::{AppConfig, LauncherInfo};
@@ -240,6 +245,10 @@ struct LauncherRowProps {
     phase: Option<UpdatePhase>,
     /// Which lifecycle the in-flight phase belongs to (drives the status text).
     mode: Option<LifecycleMode>,
+    /// Agent install/sign-in probe for this machine; `None` while loading.
+    probe: Option<ProbeState>,
+    on_sign_in: Callback<LoginTarget>,
+    on_install: Callback<InstallTarget>,
 }
 
 #[function_component(LauncherRow)]
@@ -366,7 +375,7 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
     let status = match &props.phase {
         Some(UpdatePhase::Succeeded { new_version, .. }) => Some(html! {
             <tr class="launcher-update-status">
-                <td colspan="5">
+                <td colspan="7">
                     <div class="launcher-status launcher-status--success">
                         { format!("Back online — v{new_version}") }
                     </div>
@@ -375,7 +384,7 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
         }),
         Some(UpdatePhase::SameVersion { version }) => Some(html! {
             <tr class="launcher-update-status">
-                <td colspan="5">
+                <td colspan="7">
                     <div class="launcher-status launcher-status--warning">
                         { format!(
                             "Came back on the same version (v{version}) — update may have failed."
@@ -392,7 +401,7 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
             };
             Some(html! {
                 <tr class="launcher-update-status">
-                    <td colspan="5">
+                    <td colspan="7">
                         <div class="launcher-status launcher-status--waiting">
                             <span class="spinner-small"></span>
                             { msg }
@@ -407,8 +416,12 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
     html! {
         <>
             <tr class="token-row">
-                <td class="token-name">{ &l.launcher_name }</td>
-                <td>{ &l.hostname }</td>
+                <td class="token-name">
+                    <span class="agents-host-name">{ &l.hostname }</span>
+                    if l.launcher_name != l.hostname {
+                        <span class="agents-host-alias">{ format!("({})", l.launcher_name) }</span>
+                    }
+                </td>
                 <td>{ format!("v{}", &l.version) }</td>
                 <td>{ l.running_sessions }</td>
                 <td class="token-actions">
@@ -440,6 +453,16 @@ fn launcher_row(props: &LauncherRowProps) -> Html {
                         </button>
                     </div>
                 </td>
+                { for AGENTS.iter().map(|(agent, name)| {
+                    render_cell(
+                        props.probe.as_ref(),
+                        *agent,
+                        name,
+                        l,
+                        &props.on_sign_in,
+                        &props.on_install,
+                    )
+                }) }
             </tr>
             { status.unwrap_or_default() }
         </>
@@ -503,7 +526,7 @@ fn phantom_launcher_row(props: &PhantomLauncherRowProps) -> Html {
                 <td class="token-actions">{ "—" }</td>
             </tr>
             <tr class="launcher-update-status">
-                <td colspan="5">
+                <td colspan="7">
                     <div class={classes!("launcher-status", status_class)}>
                         { status_body }
                     </div>
@@ -516,6 +539,12 @@ fn phantom_launcher_row(props: &PhantomLauncherRowProps) -> Html {
 #[function_component(LaunchersPanel)]
 pub fn launchers_panel() -> Html {
     let launchers = use_state(Vec::<LauncherInfo>::new);
+    // Agent install/sign-in state per launcher. Merged in here (rather than a
+    // second panel) because both are facts about the same machine, and both
+    // were separately fetching /api/launchers to list it.
+    let probes = use_state(std::collections::HashMap::<Uuid, ProbeState>::new);
+    let login_target = use_state(|| None::<LoginTarget>);
+    let install_target = use_state(|| None::<InstallTarget>);
     let loading = use_state(|| true);
     // Global banner reserved for the POST request itself failing (a live
     // launcher can't be reached). Success/progress is shown per-row.
@@ -523,6 +552,48 @@ pub fn launchers_panel() -> Html {
     // Per-launcher update lifecycle, keyed by launcher id (#710 follow-up).
     let update_states = use_state(HashMap::<Uuid, UpdateEntry>::new);
     // Backend's published target version, for the same-version detection.
+    {
+        let probes = probes.clone();
+        let launchers = launchers.clone();
+        use_effect_with((*launchers).clone(), move |list| {
+            let list = list.clone();
+            spawn_local(async move {
+                let mut collected = std::collections::HashMap::new();
+                for l in &list {
+                    if !l.connected {
+                        collected.insert(l.launcher_id, ProbeState::Unreachable);
+                        continue;
+                    }
+                    let path = format!("/api/launchers/{}/probe-agents", l.launcher_id);
+                    let state = match utils::fetch_json::<shared::api::ProbeAgentsResponse>(
+                        &path,
+                        On401::Ignore,
+                    )
+                    .await
+                    {
+                        Ok(resp) => ProbeState::Loaded(
+                            resp.agents.into_iter().map(|a| (a.agent_type, a)).collect(),
+                        ),
+                        Err(_) => ProbeState::Unreachable,
+                    };
+                    collected.insert(l.launcher_id, state);
+                }
+                probes.set(collected);
+            });
+            || ()
+        });
+    }
+    let _ = &launchers;
+
+    let on_sign_in = {
+        let login_target = login_target.clone();
+        Callback::from(move |t: LoginTarget| login_target.set(Some(t)))
+    };
+    let on_install = {
+        let install_target = install_target.clone();
+        Callback::from(move |t: InstallTarget| install_target.set(Some(t)))
+    };
+
     let server_version = use_state(|| None::<String>);
     // 1s heartbeat driving elapsed-time display and timeout/auto-clear checks.
     let tick = use_state(|| 0u32);
@@ -722,11 +793,11 @@ pub fn launchers_panel() -> Html {
                     <table class="tokens-table">
                         <thead>
                             <tr>
-                                <th>{ "Name" }</th>
-                                <th>{ "Host" }</th>
+                                <th>{ "Computer" }</th>
                                 <th>{ "Version" }</th>
                                 <th>{ "Sessions" }</th>
                                 <th>{ "Actions" }</th>
+                                { for AGENTS.iter().map(|(_, name)| html! { <th>{ *name }</th> }) }
                             </tr>
                         </thead>
                         <tbody>
@@ -747,6 +818,9 @@ pub fn launchers_panel() -> Html {
                                         restart_supported={restart_supported}
                                         phase={phase}
                                         mode={mode}
+                                        probe={probes.get(&l.launcher_id).cloned()}
+                                        on_sign_in={on_sign_in.clone()}
+                                        on_install={on_install.clone()}
                                     />
                                 }
                             }) }
@@ -762,6 +836,37 @@ pub fn launchers_panel() -> Html {
                         </tbody>
                     </table>
                 </div>
+            }
+            if let Some(target) = (*login_target).clone() {
+                <AgentLoginModal
+                    launcher_id={target.launcher_id}
+                    agent_type={target.agent_type}
+                    agent_name={target.agent_name}
+                    on_close={{
+                        let login_target = login_target.clone();
+                        Callback::from(move |_| login_target.set(None))
+                    }}
+                    on_success={{
+                        let tick = tick.clone();
+                        Callback::from(move |_| tick.set(tick.wrapping_add(1)))
+                    }}
+                />
+            }
+            if let Some(target) = (*install_target).clone() {
+                <AgentInstallModal
+                    launcher_id={target.launcher_id}
+                    agent_type={target.agent_type}
+                    agent_name={target.agent_name}
+                    host={target.host}
+                    on_close={{
+                        let install_target = install_target.clone();
+                        Callback::from(move |_| install_target.set(None))
+                    }}
+                    on_success={{
+                        let tick = tick.clone();
+                        Callback::from(move |_| tick.set(tick.wrapping_add(1)))
+                    }}
+                />
             }
         </section>
     }

--- a/frontend/src/pages/settings/mod.rs
+++ b/frontend/src/pages/settings/mod.rs
@@ -15,7 +15,6 @@ mod tokens_panel;
 
 use crate::utils;
 use account_panel::AccountPanel;
-use agents_panel::AgentsPanel;
 use appearance_panel::AppearancePanel;
 use forwarding_panel::ForwardingPanel;
 use health_timer_panel::HealthTimerPanel;
@@ -176,7 +175,6 @@ pub fn settings_page(props: &SettingsPageProps) -> Html {
                 }
                 if *active_tab == SettingsTab::Computers {
                     <LaunchersPanel />
-                    <AgentsPanel />
                 }
                 if *active_tab == SettingsTab::Tokens {
                     <TokensPanel on_tokens_loaded={on_tokens_loaded} />


### PR DESCRIPTION
Follow-up to #1751, which put the two panels on one tab. This actually merges them.

They were two tables listing the same machines — launcher name/host/version/sessions/actions in one, the per-agent install and sign-in matrix in the other, keyed by the same `launcher_id`. Both were separately fetching `/api/launchers` to build that list.

Now one table:

```
Computer | Version | Sessions | Actions | Claude | Codex | Muse
```

Name and Host collapse into a single **Computer** cell — hostname, with the launcher name as an alias when they differ — which is how the agents matrix already labelled the same machine.

`agents_panel` keeps what's still needed (cell renderers, `ProbeState`, the modal targets); its own component, row renderer and duplicate launcher fetch are deleted, about 200 lines. The launchers panel owns the probe state and hosts the install/login modals.

**Worth eyeballing:** it's seven columns now, and I can't see the result. If it's too wide on a narrow window, the easiest trim is Sessions — it's the least load-bearing of the launcher columns.

652 tests, clippy clean, both targets.