### PR TITLE
Improve performance plots and add session seppuku

### DIFF
--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -300,6 +300,10 @@ fn can_anchor_context(msg: &claude_codes::io::AssistantMessage) -> bool {
     }
     true
 }
+
+fn is_reportable_model(model: &str) -> bool {
+    !model.is_empty() && model != SYNTHETIC_MODEL
+}
 const MAX_RATE_LIMIT_RETRIES: u32 = 30;
 const RATE_LIMIT_BACKOFF_CAP_SECS: u64 = 60;
 
@@ -611,7 +615,7 @@ pub(crate) async fn claude_io_task(
                                 }
                                 // Refresh per-turn model + service tier from
                                 // the most recent assistant frame.
-                                if !asst.message.model.is_empty() {
+                                if is_reportable_model(&asst.message.model) {
                                     current_model = Some(asst.message.model.clone());
                                 }
                                 if let Some(usage) = &asst.message.usage {
@@ -1380,6 +1384,13 @@ mod tests {
                 "should not anchor: {text}"
             );
         }
+    }
+
+    #[test]
+    fn synthetic_model_cannot_replace_turn_model() {
+        assert!(is_reportable_model("claude-opus-4-8"));
+        assert!(!is_reportable_model(""));
+        assert!(!is_reportable_model(SYNTHETIC_MODEL));
     }
 
     /// The exclusion only inspects the FIRST content block, matching the CLI —

--- a/frontend/src/components/turn_metrics_display.rs
+++ b/frontend/src/components/turn_metrics_display.rs
@@ -22,6 +22,9 @@ pub(crate) fn compact_metric_count(value: f64) -> String {
 /// Strip a vendor prefix and trailing dated suffix so a model name fits a
 /// compact dashboard chip.
 pub(crate) fn compact_model_label(model: &str) -> String {
+    if !is_displayable_model(model) {
+        return "unknown".to_string();
+    }
     let trimmed = model
         .strip_prefix("claude-")
         .or_else(|| model.strip_prefix("gpt-"))
@@ -34,6 +37,10 @@ pub(crate) fn compact_model_label(model: &str) -> String {
         }
     }
     parts.join("-")
+}
+
+pub(crate) fn is_displayable_model(model: &str) -> bool {
+    !model.trim().is_empty() && model != "<synthetic>"
 }
 
 /// Build the compact dashboard label for a model/tier pair.
@@ -55,9 +62,13 @@ pub(crate) fn format_agent_model_tier_label(
     tier: &Option<String>,
 ) -> String {
     let base = match (agent_type, model.as_deref()) {
+        (AgentType::Claude, None) => "Claude".to_string(),
         (AgentType::Codex, None) => "Codex".to_string(),
-        (_, Some(model)) => model.to_string(),
-        (agent, None) => format!("{agent} unknown"),
+        (AgentType::Muse, None) => "Muse".to_string(),
+        (_, Some(model)) if is_displayable_model(model) => model.to_string(),
+        (AgentType::Claude, Some(_)) => "Claude".to_string(),
+        (AgentType::Codex, Some(_)) => "Codex".to_string(),
+        (AgentType::Muse, Some(_)) => "Muse".to_string(),
     };
     append_nonstandard_tier(base, tier.as_deref())
 }

--- a/frontend/src/components/turn_metrics_pill.rs
+++ b/frontend/src/components/turn_metrics_pill.rs
@@ -334,6 +334,7 @@ mod tests {
         assert_eq!(compact_model_label("gpt-5-mini"), "5-mini");
         // No prefix, no suffix → unchanged.
         assert_eq!(compact_model_label("haiku-4-5"), "haiku-4-5");
+        assert_eq!(compact_model_label("<synthetic>"), "unknown");
     }
 
     #[test]

--- a/frontend/src/pages/history/browser.rs
+++ b/frontend/src/pages/history/browser.rs
@@ -10,6 +10,7 @@ use shared::api::{HistorySessionSummary, HistorySessionsResponse, DEFAULT_HISTOR
 
 use super::fetch::{fetch_json, Load};
 use super::filters::SessionFilter;
+use crate::components::turn_metrics_display::is_displayable_model;
 use crate::Route;
 
 /// Rows requested per page. Must not exceed `MAX_HISTORY_PAGE_SIZE`, which the
@@ -433,8 +434,21 @@ fn session_row(props: &SessionRowProps) -> Html {
             <td class="cell-date">{ short_date(&s.last_activity) }</td>
             <td class="num">{ s.message_count }</td>
             <td class="num">{ format!("${:.2}", s.total_cost_usd) }</td>
-            <td class="cell-models">{ s.models.join(", ") }</td>
+            <td class="cell-models">{ visible_models(&s.models) }</td>
         </tr>
+    }
+}
+
+fn visible_models(models: &[String]) -> String {
+    let visible = models
+        .iter()
+        .filter(|model| is_displayable_model(model))
+        .cloned()
+        .collect::<Vec<_>>();
+    if visible.is_empty() {
+        "—".to_string()
+    } else {
+        visible.join(", ")
     }
 }
 
@@ -500,6 +514,13 @@ mod tests {
         let w = PageWindow::resolve(7, 0, 50);
         assert_eq!(w.page_count, 1);
         assert_eq!(w.shown(), 7);
+    }
+
+    #[test]
+    fn synthetic_models_are_hidden_from_history() {
+        let models = vec!["<synthetic>".to_string(), "claude-opus-4-8".to_string()];
+        assert_eq!(visible_models(&models), "claude-opus-4-8");
+        assert_eq!(visible_models(&["<synthetic>".to_string()]), "—");
     }
 
     #[test]

--- a/frontend/src/pages/settings/performance_panel.rs
+++ b/frontend/src/pages/settings/performance_panel.rs
@@ -30,6 +30,7 @@ pub fn performance_panel() -> Html {
     let window = use_state(|| TimeWindow::Days30);
     let group_by = use_state(|| GroupBy::All);
     let axis_scale = use_state(|| AxisScale::Linear);
+    let show_p95 = use_state(|| true);
     let metrics = use_performance_metrics(*window);
 
     let pairs = distinct_pairs(&metrics.buckets);
@@ -58,6 +59,11 @@ pub fn performance_panel() -> Html {
         })
     };
 
+    let on_show_p95_change = {
+        let show_p95 = show_p95.clone();
+        Callback::from(move |_| show_p95.set(!*show_p95))
+    };
+
     html! {
         <section class="section-stack">
             <div class="section-header">
@@ -72,13 +78,22 @@ pub fn performance_panel() -> Html {
                 window: *window,
                 group_by: &group_by,
                 axis_scale: *axis_scale,
+                show_p95: *show_p95,
                 pairs: &pairs,
                 on_window_change,
                 on_group_change,
                 on_axis_scale_change,
+                on_show_p95_change,
             }) }
 
-            { render_performance_body(&metrics, &group_by, &pairs, *window, *axis_scale) }
+            { render_performance_body(
+                &metrics,
+                &group_by,
+                &pairs,
+                *window,
+                *axis_scale,
+                *show_p95,
+            ) }
         </section>
     }
 }
@@ -90,6 +105,7 @@ mod tests {
     use shared::{api::MetricBucket, AgentType};
     use std::collections::BTreeMap;
 
+    use super::charts::apply_percentile_visibility;
     use super::model::{
         bucket_group_key, bucket_param, distinct_bucket_starts, pair_color, pair_label, GroupKey,
     };
@@ -97,6 +113,7 @@ mod tests {
         build_auxiliary_token_series, build_cache_hit_series, build_cost_per_token_series,
         build_stop_reason_series,
     };
+    use crate::components::charts::LineSeries;
     use crate::test_fixtures::MetricBucketBuilder;
 
     fn mk_bucket(
@@ -176,9 +193,37 @@ mod tests {
     }
 
     #[test]
-    fn pair_label_unknown_when_no_claude_model() {
+    fn pair_label_uses_agent_when_no_claude_model() {
         let label = pair_label(&(AgentType::Claude, None, None));
-        assert_eq!(label, "claude unknown");
+        assert_eq!(label, "Claude");
+    }
+
+    #[test]
+    fn synthetic_model_is_folded_into_agent_group() {
+        let ts = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+        let bucket = mk_bucket(ts, Some("<synthetic>"), None, None, None, vec![]);
+        assert_eq!(bucket_group_key(&bucket), (AgentType::Claude, None, None));
+    }
+
+    #[test]
+    fn p95_toggle_removes_only_dashed_series() {
+        let mut series = vec![
+            LineSeries {
+                label: "model p50".to_string(),
+                color: "blue".to_string(),
+                dashed: false,
+                values: vec![Some(1.0)],
+            },
+            LineSeries {
+                label: "model p95".to_string(),
+                color: "blue".to_string(),
+                dashed: true,
+                values: vec![Some(2.0)],
+            },
+        ];
+        apply_percentile_visibility(&mut series, false);
+        assert_eq!(series.len(), 1);
+        assert_eq!(series[0].label, "model p50");
     }
 
     #[test]

--- a/frontend/src/pages/settings/performance_panel/body.rs
+++ b/frontend/src/pages/settings/performance_panel/body.rs
@@ -14,6 +14,7 @@ pub(super) fn render_performance_body(
     pairs: &[GroupKey],
     window: TimeWindow,
     axis_scale: AxisScale,
+    show_p95: bool,
 ) -> Html {
     if metrics.loading {
         html! {
@@ -30,6 +31,13 @@ pub(super) fn render_performance_body(
             </div>
         }
     } else {
-        render_charts(&metrics.buckets, group_by, pairs, window, axis_scale)
+        render_charts(
+            &metrics.buckets,
+            group_by,
+            pairs,
+            window,
+            axis_scale,
+            show_p95,
+        )
     }
 }

--- a/frontend/src/pages/settings/performance_panel/charts.rs
+++ b/frontend/src/pages/settings/performance_panel/charts.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use shared::api::MetricBucket;
 use yew::prelude::*;
 
-use crate::components::charts::{AxisScale, BucketKind, LinePlot, StackedArea};
+use crate::components::charts::{AxisScale, BucketKind, LinePlot, LineSeries, StackedArea};
 
 use super::model::{
     bucket_group_key, bucket_param, distinct_bucket_starts, GroupBy, GroupKey, TimeWindow,
@@ -23,6 +23,7 @@ pub(super) fn render_charts(
     pairs: &[GroupKey],
     window: TimeWindow,
     axis_scale: AxisScale,
+    show_p95: bool,
 ) -> Html {
     let bucket_axis = distinct_bucket_starts(buckets);
     // Resolve the bucket-kind from the same wire param we sent on the request,
@@ -43,7 +44,7 @@ pub(super) fn render_charts(
     }
 
     // ------------ a) Throughput trend: p50 (solid) + p95 (dashed) ------------
-    let throughput_series = build_p50_p95_series(
+    let mut throughput_series = build_p50_p95_series(
         &indexed,
         &bucket_axis,
         &active_pairs,
@@ -52,13 +53,15 @@ pub(super) fn render_charts(
     );
 
     // ------------ b) TTFT trend: p50 (solid) + p95 (dashed) seconds ----------
-    let ttft_series = build_p50_p95_series(
+    let mut ttft_series = build_p50_p95_series(
         &indexed,
         &bucket_axis,
         &active_pairs,
         |r| r.ttft_p50_ms.map(|ms| ms as f64 / 1000.0),
         |r| r.ttft_p95_ms.map(|ms| ms as f64 / 1000.0),
     );
+    apply_percentile_visibility(&mut throughput_series, show_p95);
+    apply_percentile_visibility(&mut ttft_series, show_p95);
 
     // ------------ c) Stop-reason stacked area ---------------------------------
     let stop_reason_series = build_stop_reason_series(buckets, &bucket_axis, &active_pairs);
@@ -124,5 +127,11 @@ pub(super) fn render_charts(
                 axis_scale={axis_scale}
             />
         </div>
+    }
+}
+
+pub(super) fn apply_percentile_visibility(series: &mut Vec<LineSeries>, show_p95: bool) {
+    if !show_p95 {
+        series.retain(|series| !series.dashed);
     }
 }

--- a/frontend/src/pages/settings/performance_panel/controls.rs
+++ b/frontend/src/pages/settings/performance_panel/controls.rs
@@ -10,10 +10,12 @@ pub(super) struct PerformanceControlsProps<'a> {
     pub window: TimeWindow,
     pub group_by: &'a GroupBy,
     pub axis_scale: AxisScale,
+    pub show_p95: bool,
     pub pairs: &'a [GroupKey],
     pub on_window_change: Callback<TimeWindow>,
     pub on_group_change: Callback<Event>,
     pub on_axis_scale_change: Callback<AxisScale>,
+    pub on_show_p95_change: Callback<MouseEvent>,
 }
 
 pub(super) fn render_performance_controls(props: PerformanceControlsProps<'_>) -> Html {
@@ -85,6 +87,21 @@ pub(super) fn render_performance_controls(props: PerformanceControlsProps<'_>) -
                         </button>
                     }
                 }) }
+            </div>
+
+            <div class="performance-percentile-group">
+                <span class="performance-control-label">{ "Traces:" }</span>
+                <button
+                    type="button"
+                    class={classes!(
+                        "performance-window-button",
+                        props.show_p95.then_some("active"),
+                    )}
+                    aria-pressed={props.show_p95.to_string()}
+                    onclick={props.on_show_p95_change}
+                >
+                    { "p95" }
+                </button>
             </div>
         </div>
     }

--- a/frontend/src/pages/settings/performance_panel/model.rs
+++ b/frontend/src/pages/settings/performance_panel/model.rs
@@ -4,7 +4,9 @@ use chrono::{DateTime, Utc};
 use shared::api::MetricBucket;
 use shared::AgentType;
 
-use crate::components::turn_metrics_display::format_agent_model_tier_label;
+use crate::components::turn_metrics_display::{
+    format_agent_model_tier_label, is_displayable_model,
+};
 
 /// (agent_type, model, service_tier) tuple used as the group-by key. Codex
 /// currently reports no model or tier; keeping the agent in the key lets the
@@ -25,9 +27,15 @@ pub(super) fn distinct_pairs(buckets: &[MetricBucket]) -> Vec<GroupKey> {
 pub(super) fn bucket_group_key(bucket: &MetricBucket) -> GroupKey {
     (
         bucket.agent_type,
-        bucket.model.clone(),
+        visible_model(bucket.model.as_deref()).map(str::to_string),
         bucket.service_tier.clone(),
     )
+}
+
+/// Claude labels its own injected bookkeeping frames with `<synthetic>`.
+/// Those frames are not model executions and must not become a chart group.
+fn visible_model(model: Option<&str>) -> Option<&str> {
+    model.filter(|model| is_displayable_model(model))
 }
 
 /// Format an (agent, model, tier) group as a human-readable label for the

--- a/frontend/styles/performance.css
+++ b/frontend/styles/performance.css
@@ -25,7 +25,8 @@
 }
 
 .performance-window-group,
-.performance-scale-group {
+.performance-scale-group,
+.performance-percentile-group {
     display: flex;
     align-items: center;
     gap: 0.25rem;

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -12,6 +12,7 @@ mod pastebin;
 mod path_policy;
 mod process_manager;
 mod scheduler;
+mod seppuku;
 mod service;
 mod worktree;
 
@@ -115,6 +116,8 @@ enum Command {
         /// A port number, `list`, or `close`.
         target: String,
     },
+    /// Terminate the agent session this command is running inside.
+    Seppuku,
 }
 
 #[derive(Subcommand, Debug)]
@@ -301,6 +304,7 @@ async fn main() -> anyhow::Result<()> {
                 },
             };
         }
+        Some(Command::Seppuku) => return seppuku::run().await,
         None => {}
     }
 

--- a/launcher/src/seppuku.rs
+++ b/launcher/src/seppuku.rs
@@ -1,0 +1,30 @@
+//! Self-termination command for an agent session.
+//!
+//! There is deliberately no target argument: the session id is resolved from
+//! the environment injected into this agent process, then the normal backend
+//! stop lifecycle disconnects the proxy and asks its launcher to stop it.
+
+use anyhow::{Context, Result};
+
+pub async fn run() -> Result<()> {
+    let (base, token) = crate::message::api_base()?;
+    let client = reqwest::Client::new();
+    let session_id = crate::message::current_session_id(&client, &base, &token).await?;
+
+    println!("Terminating this portal session ({session_id})…");
+    let response = client
+        .post(format!("{base}/api/sessions/{session_id}/stop"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .context("could not reach the portal backend")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("backend returned {status}: {}", body.trim());
+    }
+
+    println!("Session termination requested.");
+    Ok(())
+}

--- a/shared/src/api/metrics.rs
+++ b/shared/src/api/metrics.rs
@@ -129,13 +129,14 @@ pub struct TurnMetrics {
 
 impl TurnMetrics {
     /// True when `model` is usable telemetry: present, non-blank, and not the
-    /// literal placeholder `"unknown"`. All three ingest points (Claude
+    /// literal placeholders `"unknown"` and `"<synthetic>"`. The latter is
+    /// Claude's label for CLI-injected bookkeeping, not an executing model. All three ingest points (Claude
     /// proxy, Codex proxy, backend persist) warn-and-drop turn metrics that
     /// fail this check, so the rule must stay identical everywhere.
     pub fn has_known_model(&self) -> bool {
         self.model.as_deref().is_some_and(|value| {
             let value = value.trim();
-            !value.is_empty() && !value.eq_ignore_ascii_case("unknown")
+            !value.is_empty() && !value.eq_ignore_ascii_case("unknown") && value != "<synthetic>"
         })
     }
 

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -362,6 +362,7 @@ mod tests {
             Some("   "),
             Some("unknown"),
             Some("UNKNOWN"),
+            Some("<synthetic>"),
         ] {
             metrics.model = bad.map(str::to_string);
             assert!(!metrics.has_known_model(), "expected {:?} rejected", bad);


### PR DESCRIPTION
## Summary
- add a p95 trace toggle to Performance charts
- prevent Claude internal `<synthetic>` frames from replacing real model telemetry and hide legacy synthetic labels in Performance and History
- add `agent-portal seppuku` to terminate the current session through the normal authenticated stop lifecycle

## Verification
- cargo test -p shared
- cargo test -p frontend
- cargo test -p claude-session-lib synthetic_model
- cargo test -p agent-portal
- cargo clippy -p shared -p frontend -p claude-session-lib -p agent-portal --all-targets -- -D warnings
- cargo build -p frontend --target wasm32-unknown-unknown